### PR TITLE
Align materialized C# defaults in the installer's unchanged-check — root-churn class fix

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -297,7 +297,7 @@ public static class PackageInstaller
                 && (curDef.Sources ?? []).SequenceEqual(inDef.Sources ?? [], StringComparer.Ordinal);
         // Otherwise compare the full content, applying the incoming over current so an omitted field
         // does not read as a change — with the incoming ALIGNED to the current content's TYPE first
-        // (see AsCurrentType): the persisted side is often typed and materializes C# property
+        // (see AlignedIncoming): the persisted side is often typed and materializes C# property
         // defaults the repo file legitimately omits.
         return ContentSignature(AlignedIncoming(current.Content, incoming.Content, options) ?? current.Content, options)
             == ContentSignature(current.Content, options);
@@ -321,22 +321,45 @@ public static class PackageInstaller
     /// </summary>
     private static object? AlignedIncoming(object? current, object? incoming, JsonSerializerOptions options)
     {
-        if (incoming is not JsonElement el
+        if (incoming is not JsonElement { ValueKind: JsonValueKind.Object } el
             || current is null or JsonElement)
             return incoming;
         try
         {
-            if (el.ValueKind == JsonValueKind.Object
-                && el.TryGetProperty("$type", out var incomingType)
-                && JsonSerializer.SerializeToNode(current, options) is System.Text.Json.Nodes.JsonObject curNode
-                && curNode.TryGetPropertyValue("$type", out var currentType)
-                && !string.Equals(incomingType.GetString(), currentType?.GetValue<string>(), StringComparison.Ordinal))
-                return incoming;                    // a REAL type change — compare raw, signatures differ
-            return JsonSerializer.Deserialize(el, current.GetType(), options) ?? incoming;
+            // A differing $type IS a real change — never mask it by coercing into the wrong type.
+            // Both discriminators read defensively: a non-string $type on either side skips
+            // alignment (raw compare → change detected).
+            var incomingType = el.TryGetProperty("$type", out var it) && it.ValueKind == JsonValueKind.String
+                ? it.GetString()
+                : null;
+            var currentType = JsonSerializer.SerializeToNode(current, options)
+                    is System.Text.Json.Nodes.JsonObject curNode
+                && curNode.TryGetPropertyValue("$type", out var ct)
+                && ct is System.Text.Json.Nodes.JsonValue cv
+                && cv.TryGetValue<string>(out var cts)
+                ? cts
+                : null;
+            if (incomingType is not null
+                && !string.Equals(incomingType, currentType, StringComparison.Ordinal))
+                return incoming;
+
+            // Deserialize WITHOUT tolerating unknown members: with the ambient Skip handling, a
+            // property the file ADDS but the current type lacks would be silently dropped and a
+            // real change read as unchanged. Disallow makes that case throw → the catch below →
+            // raw compare → change detected (worst case an idempotent rewrite, never a miss).
+            // The $type discriminator is stripped first — deserializing to the CONCRETE type
+            // treats it as an unmapped member.
+            var strict = new JsonSerializerOptions(options)
+            {
+                UnmappedMemberHandling = System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow
+            };
+            var withoutDiscriminator = System.Text.Json.Nodes.JsonObject.Create(el)!;
+            withoutDiscriminator.Remove("$type");
+            return withoutDiscriminator.Deserialize(current.GetType(), strict) ?? incoming;
         }
         catch (JsonException)
         {
-            return incoming;                        // schema drift — raw compare, worst case a rewrite
+            return incoming;                        // schema drift / unknown member — raw compare
         }
     }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -282,7 +282,8 @@ public static class PackageInstaller
     /// fields (LastModified/Version). This is the content-checksum that makes an update touch only what
     /// really changed.
     /// </summary>
-    private static bool IsUnchanged(MeshNode current, MeshNode incoming, JsonSerializerOptions options)
+    // Internal for the InstallSignatureAlignmentTest pin (InternalsVisibleTo).
+    internal static bool IsUnchanged(MeshNode current, MeshNode incoming, JsonSerializerOptions options)
     {
         if (!ScalarsUnchanged(current, incoming))
             return false;
@@ -295,9 +296,48 @@ public static class PackageInstaller
             return string.Equals(curDef.Configuration, inDef.Configuration, StringComparison.Ordinal)
                 && (curDef.Sources ?? []).SequenceEqual(inDef.Sources ?? [], StringComparer.Ordinal);
         // Otherwise compare the full content, applying the incoming over current so an omitted field
-        // does not read as a change.
-        return ContentSignature(incoming.Content ?? current.Content, options)
+        // does not read as a change — with the incoming ALIGNED to the current content's TYPE first
+        // (see AsCurrentType): the persisted side is often typed and materializes C# property
+        // defaults the repo file legitimately omits.
+        return ContentSignature(AlignedIncoming(current.Content, incoming.Content, options) ?? current.Content, options)
             == ContentSignature(current.Content, options);
+    }
+
+    /// <summary>
+    /// Materialized-default alignment for the content compare. The persisted side is often TYPED —
+    /// the owning hub re-serialized it, materializing C# property defaults (the diagnosed case:
+    /// <c>PluginContent.Currency = "CHF"</c>) — while the incoming side is the repo file's raw
+    /// <c>JsonElement</c>, which legitimately OMITS defaulted properties. Signing them as-is reads
+    /// every materialized default as a change: the NONDETERMINISTIC "re-install of the unchanged
+    /// snapshot wrote 1 node(s)" root churn behind the plugins gate's flapping idempotence check
+    /// (~14 packages allow-listed) — nondeterministic because it fires only once the hub happens to
+    /// have re-serialized the node before the re-install's read. Deserializing the incoming element
+    /// to the CURRENT content's type makes both sides materialize the same defaults.
+    ///
+    /// <para>Guards: alignment happens only when the element's <c>$type</c> matches the current
+    /// content's serialized discriminator (a differing <c>$type</c> IS a real change and must never
+    /// be masked by coercing into the wrong type), and a failed deserialize falls back to the raw
+    /// element — worst case an idempotent rewrite, never a missed change.</para>
+    /// </summary>
+    private static object? AlignedIncoming(object? current, object? incoming, JsonSerializerOptions options)
+    {
+        if (incoming is not JsonElement el
+            || current is null or JsonElement)
+            return incoming;
+        try
+        {
+            if (el.ValueKind == JsonValueKind.Object
+                && el.TryGetProperty("$type", out var incomingType)
+                && JsonSerializer.SerializeToNode(current, options) is System.Text.Json.Nodes.JsonObject curNode
+                && curNode.TryGetPropertyValue("$type", out var currentType)
+                && !string.Equals(incomingType.GetString(), currentType?.GetValue<string>(), StringComparison.Ordinal))
+                return incoming;                    // a REAL type change — compare raw, signatures differ
+            return JsonSerializer.Deserialize(el, current.GetType(), options) ?? incoming;
+        }
+        catch (JsonException)
+        {
+            return incoming;                        // schema drift — raw compare, worst case a rewrite
+        }
     }
 
     // The node's scalar fields, applying the incoming's non-null values over the current (mirrors

--- a/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
@@ -76,4 +76,22 @@ public class InstallSignatureAlignmentTest(ITestOutputHelper output) : MonolithM
         PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
             .Should().BeFalse("a differing $type IS a real change — alignment only applies same-type");
     }
+
+    /// <summary>
+    /// A property the file ADDS but the current type lacks must read as a change: with the ambient
+    /// Skip unmapped-member handling, the alignment deserialize would silently drop it and mask a
+    /// real difference — the strict Disallow clone routes this to the raw compare instead.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void UnknownIncomingProperty_IsStillDetected()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" });
+        var incoming = Node(Element(
+            """{"$type":"PluginCatalogContent","sourceRepoPath":"/repo","brandNewProperty":"x"}"""));
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse(
+                "an unknown incoming member means the file carries something the persisted shape " +
+                "does not — alignment must fall back to the raw compare, never silently drop it");
+    }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
@@ -1,0 +1,79 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Text.Json;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the MATERIALIZED-DEFAULT alignment in the installer's unchanged-check
+/// (<see cref="PackageInstaller.IsUnchanged"/> → <c>AlignedIncoming</c>): the persisted side of a
+/// re-install compare is often TYPED — the owning hub re-serialized it, materializing C# property
+/// defaults (<c>PluginCatalogContent.SourceRef = "HEAD"</c> here; <c>PluginContent.Currency =
+/// "CHF"</c> in the diagnosed plugins-gate case) — while the incoming side is the repo file's raw
+/// <c>JsonElement</c>, which legitimately omits defaulted properties. Without alignment every
+/// materialized default reads as a change and the root rewrites on every re-install ONCE the hub
+/// happens to have re-serialized it: the nondeterministic "re-install wrote 1 node(s)" idempotence
+/// flap behind ~14 allow-listed packages in the plugins repo's gate.
+/// </summary>
+public class InstallSignatureAlignmentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
+
+    private MeshNode Node(object content) => new("cat", "Store")
+    {
+        NodeType = "PluginCatalog",
+        Name = "Catalog",
+        State = MeshNodeState.Active,
+        Content = content,
+    };
+
+    private JsonElement Element(string json) =>
+        JsonSerializer.Deserialize<JsonElement>(json, Mesh.JsonSerializerOptions);
+
+    /// <summary>The diagnosed churn shape: typed current with a materialized default vs a repo file
+    /// omitting that property — MUST read as unchanged.</summary>
+    [Fact(Timeout = 30000)]
+    public void TypedCurrentWithMaterializedDefault_VsFileOmittingIt_IsUnchanged()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" });
+        // The repo file's shape: $type + the authored property only — no sourceRef, which the
+        // typed side materializes as "HEAD".
+        var incoming = Node(Element("""{"$type":"PluginCatalogContent","sourceRepoPath":"/repo"}"""));
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeTrue(
+                "a property the file omits and the type defaults is NOT a change — comparing the " +
+                "raw element against the typed content is the root-churn idempotence flap");
+    }
+
+    /// <summary>An authored value differing from the persisted one is still a change.</summary>
+    [Fact(Timeout = 30000)]
+    public void RealValueChange_IsStillDetected()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" });
+        var incoming = Node(Element(
+            """{"$type":"PluginCatalogContent","sourceRepoPath":"/repo","sourceRef":"v2"}"""));
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse("sourceRef HEAD → v2 is a real change the alignment must not mask");
+    }
+
+    /// <summary>A $type change must never be masked by coercing the element into the wrong type.</summary>
+    [Fact(Timeout = 30000)]
+    public void ContentTypeChange_IsStillDetected()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" });
+        var incoming = Node(Element("""{"$type":"SomeOtherContent","sourceRepoPath":"/repo"}"""));
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse("a differing $type IS a real change — alignment only applies same-type");
+    }
+}


### PR DESCRIPTION
Round 2 of the plugins-gate idempotence flap (after #751 fixed the placeholder-persist race and the flap survived). `MW_INSTALL_DIFF=1` against the real gate image caught the field, identical across runs:

```
[DIFF] Claims scalars=True lens=4437/4420 firstDiff@4000
  cur(PluginContent): …"currency":"CHF","dependsOn":["Reinsurance"]…
  inc(JsonElement):   …"dependsOn":["Reinsurance"]…
```

The persisted side is TYPED (the owning hub re-serialized it, materializing `PluginContent.Currency = "CHF"`); the repo file legitimately omits the defaulted property. The signature compare read every materialized default as a change → the ROOT rewrote on unchanged re-install — but only once the hub happened to re-serialize before the re-install's read, hence the per-package per-run flap that whiplashed the allow-ratchet (~14 packages listed as debt).

**Fix**: `AlignedIncoming` deserializes the incoming element to the current content's type before signing, so both sides materialize the same defaults. Guards: a differing `$type` is never masked (raw compare → change detected); failed deserialize falls back to raw (worst case an idempotent rewrite, never a missed change).

**Pins** (`InstallSignatureAlignmentTest`, real mesh options via `InternalsVisibleTo`, using core's own materialized default `PluginCatalogContent.SourceRef = "HEAD"`): omitted-default = unchanged; real value change = detected; `$type` change = detected.

Full `MeshWeaver.PluginCatalog.Test` suite 58/58 green; builds `-c Release -warnaserror`. After merge + `mw-plugin-test:latest` rebuild, the plugins gate's idempotence check becomes deterministic and its allow list can drain (MeshWeaver.Plugins#295 finishes the drain).

No What's New — internal installer determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)