### PR TITLE
Coupons administration tab: manage Store coupon codes from Settings

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -873,6 +873,9 @@ public static class MemexConfiguration
                         // Plugin Catalog tab (platform admins only) — browse the registry's modules
                         // and Install / Update them onto this instance. Replaces the old Plugins Space.
                         .AddPluginCatalogSettingsTab()
+                        // Coupons tab (platform admins only) — the Store's typed coupon codes at
+                        // Admin/Coupons: live list, redemption tallies, create/open.
+                        .AddCouponAdminSettingsTab()
                         // Instance Sync lives in the "Synchronizations" NODE-menu item (not a
                         // settings tab) — wired via AddInstanceSyncTypes on the mesh builder.
                         // Code workspace tab — on-disk working-tree editor (checkout/edit/commit/push).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-coupons-administration-tab.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-coupons-administration-tab.md
@@ -1,0 +1,14 @@
+---
+Name: Coupons administration tab
+Category: What's New
+Description: Platform admins manage the Store's coupon codes from Settings ▸ Administration ▸ Coupons.
+Icon: Sparkle
+---
+
+# Coupons administration tab
+
+Platform administrators get a new **Coupons** tab under Settings ▸ Administration, next to the
+Plugin Catalog. It lists every coupon code live — what each unlocks, its price, validity window,
+and how often it has been redeemed — with one click to open a coupon for editing or deletion and
+a button to create a new code with the standard form. No more hand-crafting nodes under
+`Admin/Coupons` to run a promotion.

--- a/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
@@ -173,11 +173,10 @@ public static class CouponAdminSettingsTab
     private static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
     {
         stack = stack
-            .WithView(Controls.Html(
-                "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);margin-bottom:8px;\">" +
-                "Typed coupon codes at <code>Admin/Coupons/{CODE}</code>. A free coupon unlocks its " +
-                "whole plugin list in one redemption; a priced one applies at payment. Open a coupon " +
-                "to edit or delete it with the standard node actions.</p>"))
+            .WithView(Controls.Markdown(
+                "Typed coupon codes at `Admin/Coupons/{CODE}`. A free coupon unlocks its whole " +
+                "plugin list in one redemption; a priced one applies at payment. Open a coupon " +
+                "to edit or delete it with the standard node actions."))
             .WithView(Controls.Button("＋ New coupon")
                 .WithAppearance(Appearance.Accent)
                 .WithNavigateToHref("/Store/Coupon/Create?type=Store%2FCoupon"), "NewCoupon")
@@ -231,10 +230,9 @@ public static class CouponAdminSettingsTab
             .Select(n => ToRow(n, options))
             .ToImmutableArray();
 
-        var id = Guid.NewGuid().ToString();
-        host.RegisterForDisposal(Observable.Return(rows).Subscribe(data => host.UpdateData(id, data)));
-
-        var grid = Controls.DataGrid(new JsonPointerReference(LayoutAreaReference.GetDataPointer(id)))
+        // Rows bind INLINE — a per-render UpdateData under a fresh id would accumulate orphaned
+        // data entries for the host's lifetime (each snapshot re-renders this grid).
+        var grid = Controls.DataGrid(rows)
             .WithColumn(new PropertyColumnControl<string>
                 { Property = nameof(CouponRow.Code).ToCamelCase() }.WithTitle("Code"))
             .WithColumn(new PropertyColumnControl<string>
@@ -262,9 +260,7 @@ public static class CouponAdminSettingsTab
 
         return Controls.Stack
             .WithView(grid)
-            .WithView(Controls.Html(
-                "<p style=\"font-size:0.8rem;color:var(--neutral-foreground-hint);margin:8px 0 0 0;\">" +
-                "Open a coupon:</p>"))
+            .WithView(Controls.Markdown("Open a coupon:"))
             .WithView(openRow);
     }
 }

--- a/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
@@ -1,0 +1,270 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The platform-admin "Coupons" Settings tab — the administration surface for the Store's typed
+/// coupons at <c>Admin/Coupons/{CODE}</c>. Lists every coupon LIVE (what it unlocks, its price,
+/// validity window and redemption tally), links each to its node page (where the Store/Coupon
+/// type's own Edit / Delete actions live), and offers the standard Create flow for a new code.
+///
+/// <para>The coupon TYPE is a dynamic node type (the Store plugin's <c>Store/Coupon</c>), so this
+/// tab reads content by SHAPE — typed, <c>JsonElement</c> or <c>JsonNode</c>, whatever arrives —
+/// and never references the plugin's compiled types.</para>
+///
+/// <para>Gated exactly like the Plugin Catalog tab — visible only when the viewer is a global
+/// admin AND on their own settings page — and grouped under "Administration" beside it.</para>
+/// </summary>
+public static class CouponAdminSettingsTab
+{
+    /// <summary>The settings-menu item id for the Coupons tab.</summary>
+    public const string TabId = "Coupons";
+
+    /// <summary>Where the Store's coupons live — the node id is the code.</summary>
+    public const string CouponsNamespace = "Admin/Coupons";
+
+    /// <summary>Registers the Coupons settings tab provider (global admins only).</summary>
+    public static MessageHubConfiguration AddCouponAdminSettingsTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetTab));
+
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>> GetTab(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
+
+        // Same home as the Global Administration tab: the admin's own settings page.
+        var hubPath = host.Hub.Address.ToString();
+        var nodeOwnerId = hubPath.StartsWith("User/", StringComparison.OrdinalIgnoreCase)
+            ? hubPath["User/".Length..]
+            : hubPath;
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var viewerId = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
+        if (string.IsNullOrEmpty(viewerId)
+            || !string.Equals(viewerId, nodeOwnerId, StringComparison.OrdinalIgnoreCase))
+            return Observable.Return(none);
+
+        var tab = new SettingsMenuItemDefinition(
+            Id: TabId,
+            Label: "Coupons",
+            ContentBuilder: BuildContent,
+            Group: "Administration",
+            Icon: FluentIcons.TicketDiagonal(),
+            GroupIcon: FluentIcons.Shield(),
+            Order: 330,
+            Keywords: ["coupons", "coupon codes", "discount", "redeem", "redemption", "store",
+                "entitlement", "unlock", "voucher", "promo"]);
+
+        // Wait for the POSITIVE admin confirmation with a bounded timeout; StartWith(none) so the
+        // menu renders immediately (mirrors PluginCatalogSettingsTab / the Global Administration tab).
+        return host.Hub.IsGlobalAdmin(viewerId)
+            .Where(isAdmin => isAdmin)
+            .Take(1)
+            .Select(_ => (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab })
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+
+    // ── Row model (pure — unit-tested) ─────────────────────────────────────────
+
+    /// <summary>Plain row record bound into the coupon <see cref="DataGridControl"/>.</summary>
+    public sealed record CouponRow
+    {
+        /// <summary>The coupon code (the node id).</summary>
+        public string Code { get; init; } = string.Empty;
+        /// <summary>The plugin allow-list, comma-joined; "any plugin" when the list is empty
+        /// (an empty list is valid everywhere and grants the redeemed-on plugin).</summary>
+        public string Unlocks { get; init; } = string.Empty;
+        /// <summary>The effective price: "free" when the coupon carries none (or 0), else the
+        /// discounted amount with currency.</summary>
+        public string Price { get; init; } = string.Empty;
+        /// <summary>The validity window, or "always" when unbounded.</summary>
+        public string Valid { get; init; } = string.Empty;
+        /// <summary>Redemption tally: "used / cap" with a capped budget, else just the count.</summary>
+        public string Redeemed { get; init; } = string.Empty;
+        /// <summary>The admin notes (may be empty).</summary>
+        public string Notes { get; init; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Projects a coupon node into its grid row — by SHAPE, whatever form the content arrives in
+    /// (the Store/Coupon type is dynamically compiled, so this assembly never sees it typed as its
+    /// own class; a foreign hub may still deliver it typed, a query a <c>JsonElement</c>, a
+    /// builder a <c>JsonNode</c>). Pure.
+    /// </summary>
+    public static CouponRow ToRow(MeshNode node, JsonSerializerOptions options)
+    {
+        var content = ElementOf(node, options);
+        var plugins = content is { } c && c.TryGetProperty("plugins", out var p)
+                      && p.ValueKind == JsonValueKind.Array
+            ? p.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String)
+                .Select(e => e.GetString()!).ToArray()
+            : [];
+        var price = ReadDecimal(content, "price");
+        var currency = ReadString(content, "currency") ?? "CHF";
+        var validFrom = ReadString(content, "validFrom");
+        var validUntil = ReadString(content, "validUntil");
+        var redeemed = ReadDecimal(content, "redeemed") ?? 0m;
+        var cap = ReadDecimal(content, "maxRedemptions");
+
+        return new CouponRow
+        {
+            Code = node.Id,
+            Unlocks = plugins.Length == 0 ? "any plugin" : string.Join(", ", plugins),
+            Price = price is null or 0m ? "free" : $"{currency} {price:0.##}",
+            Valid = (validFrom, validUntil) switch
+            {
+                (null, null) => "always",
+                (null, { } u) => $"until {DatePart(u)}",
+                ({ } f, null) => $"from {DatePart(f)}",
+                ({ } f, { } u) => $"{DatePart(f)} – {DatePart(u)}",
+            },
+            Redeemed = cap is { } budget ? $"{redeemed:0} / {budget:0}" : $"{redeemed:0}",
+            Notes = ReadString(content, "notes") ?? "",
+        };
+    }
+
+    private static string DatePart(string isoTimestamp) =>
+        isoTimestamp.Length >= 10 ? isoTimestamp[..10] : isoTimestamp;
+
+    private static string? ReadString(JsonElement? content, string name) =>
+        content is { } c && c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static decimal? ReadDecimal(JsonElement? content, string name) =>
+        content is { } c && c.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetDecimal()
+            : null;
+
+    /// <summary>
+    /// The node's content as a <see cref="JsonElement"/> object, whatever shape it arrived in.
+    /// Typed content serializes with its CONCRETE runtime type — never the <c>object</c> overload,
+    /// whose polymorphic path adopts foreign types into the registry as a read side effect.
+    /// </summary>
+    private static JsonElement? ElementOf(MeshNode node, JsonSerializerOptions options)
+    {
+        var element = node.Content switch
+        {
+            null => (JsonElement?)null,
+            JsonElement je => je,
+            System.Text.Json.Nodes.JsonNode jn => JsonSerializer.SerializeToElement(jn, options),
+            var typed => JsonSerializer.SerializeToElement(typed, typed.GetType(), options),
+        };
+        return element is { ValueKind: JsonValueKind.Object } ? element : null;
+    }
+
+    // ── Tab content ────────────────────────────────────────────────────────────
+
+    private static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
+    {
+        stack = stack
+            .WithView(Controls.Html(
+                "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);margin-bottom:8px;\">" +
+                "Typed coupon codes at <code>Admin/Coupons/{CODE}</code>. A free coupon unlocks its " +
+                "whole plugin list in one redemption; a priced one applies at payment. Open a coupon " +
+                "to edit or delete it with the standard node actions.</p>"))
+            .WithView(Controls.Button("＋ New coupon")
+                .WithAppearance(Appearance.Accent)
+                .WithNavigateToHref("/Store/Coupon/Create?type=Store%2FCoupon"), "NewCoupon")
+            .WithView((h, _) => LiveCouponList(h), "CouponList");
+        return stack;
+    }
+
+    /// <summary>
+    /// The LIVE coupon list: accumulates the chunked query over <see cref="CouponsNamespace"/>
+    /// (creates, edits and deletes all land) and re-renders the grid per snapshot. The viewer is
+    /// a confirmed global admin, so the query runs under their own identity — no impersonation.
+    /// </summary>
+    private static IObservable<UiControl?> LiveCouponList(LayoutAreaHost host)
+    {
+        var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return<UiControl?>(Controls.Markdown("*The mesh service is not available.*"));
+        var options = host.Hub.JsonSerializerOptions;
+
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{CouponsNamespace} scope:children"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, Accumulate)
+            // Let the chunked first snapshot settle instead of re-rendering per chunk.
+            .Throttle(TimeSpan.FromMilliseconds(300))
+            .StartWith(ImmutableDictionary<string, MeshNode>.Empty)
+            .Select(map => (UiControl?)BuildGrid(host, map, options));
+    }
+
+    /// <summary>One accumulation step over the chunked query — pure: Reset restarts, Removed
+    /// deletes, everything else upserts by path.</summary>
+    public static ImmutableDictionary<string, MeshNode> Accumulate(
+        ImmutableDictionary<string, MeshNode> map, QueryResultChange<MeshNode> change)
+    {
+        if (change.ChangeType == QueryChangeType.Reset)
+            map = ImmutableDictionary<string, MeshNode>.Empty;
+        foreach (var item in change.Items)
+            map = change.ChangeType == QueryChangeType.Removed
+                ? map.Remove(item.Path)
+                : map.SetItem(item.Path, item);
+        return map;
+    }
+
+    private static UiControl BuildGrid(
+        LayoutAreaHost host, ImmutableDictionary<string, MeshNode> coupons, JsonSerializerOptions options)
+    {
+        if (coupons.IsEmpty)
+            return Controls.Markdown("*No coupons yet — create the first one above.*");
+
+        var rows = coupons.Values
+            .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(n => ToRow(n, options))
+            .ToImmutableArray();
+
+        var id = Guid.NewGuid().ToString();
+        host.RegisterForDisposal(Observable.Return(rows).Subscribe(data => host.UpdateData(id, data)));
+
+        var grid = Controls.DataGrid(new JsonPointerReference(LayoutAreaReference.GetDataPointer(id)))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Code).ToCamelCase() }.WithTitle("Code"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Unlocks).ToCamelCase() }.WithTitle("Unlocks"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Price).ToCamelCase() }.WithTitle("Price"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Valid).ToCamelCase() }.WithTitle("Valid"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Redeemed).ToCamelCase() }.WithTitle("Redeemed"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(CouponRow.Notes).ToCamelCase() }.WithTitle("Notes"))
+            .Resizable();
+
+        // DataGrid has no row-click — one Open button per coupon navigates to its node page,
+        // where the Store/Coupon type's own Edit / Delete actions live.
+        var openRow = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("flex-wrap: wrap; margin-top: 8px;");
+        foreach (var row in rows)
+            openRow = openRow.WithView(Controls.Button(row.Code)
+                .WithAppearance(Appearance.Outline)
+                .WithNavigateToHref($"/{CouponsNamespace}/{row.Code}"));
+
+        return Controls.Stack
+            .WithView(grid)
+            .WithView(Controls.Html(
+                "<p style=\"font-size:0.8rem;color:var(--neutral-foreground-hint);margin:8px 0 0 0;\">" +
+                "Open a coupon:</p>"))
+            .WithView(openRow);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/CouponAdminSettingsTabTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CouponAdminSettingsTabTest.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the Coupons administration tab's row projection and live-list accumulation. The coupon
+/// type (<c>Store/Coupon</c>) is DYNAMIC — this assembly never sees it as a compiled class — so
+/// <see cref="CouponAdminSettingsTab.ToRow"/> must read the content by shape, in every form it
+/// arrives: a query's <c>JsonElement</c>, a builder's <c>JsonNode</c>, or absent.
+/// </summary>
+public class CouponAdminSettingsTabTest
+{
+    private static readonly JsonSerializerOptions Options =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private static MeshNode Coupon(string code, string json) =>
+        new(code, CouponAdminSettingsTab.CouponsNamespace)
+        {
+            Name = code,
+            NodeType = "Store/Coupon",
+            Content = JsonDocument.Parse(json).RootElement.Clone(),
+        };
+
+    [Fact]
+    public void ToRow_FreeMultiPluginCoupon_TheTypicalStoredShape()
+    {
+        var row = CouponAdminSettingsTab.ToRow(Coupon("UNLOCKALL",
+            """
+            {"$type":"CouponContent","currency":"CHF",
+             "plugins":["Chess","Claims","Edu"],
+             "redeemed":3,"redeemedBy":["a","b","c"],"redemptions":[],
+             "notes":"unlock everything"}
+            """), Options);
+        Assert.Equal("UNLOCKALL", row.Code);
+        Assert.Equal("Chess, Claims, Edu", row.Unlocks);
+        Assert.Equal("free", row.Price);
+        Assert.Equal("always", row.Valid);
+        Assert.Equal("3", row.Redeemed);
+        Assert.Equal("unlock everything", row.Notes);
+    }
+
+    [Fact]
+    public void ToRow_PricedWindowedCappedCoupon()
+    {
+        var row = CouponAdminSettingsTab.ToRow(Coupon("HALFOFF",
+            """
+            {"$type":"CouponContent","currency":"CHF","price":450,
+             "plugins":["DataModeling"],
+             "validFrom":"2026-08-01T00:00:00+00:00","validUntil":"2026-09-01T00:00:00+00:00",
+             "maxRedemptions":10,"redeemed":4}
+            """), Options);
+        Assert.Equal("CHF 450", row.Price);
+        Assert.Equal("2026-08-01 – 2026-09-01", row.Valid);
+        Assert.Equal("4 / 10", row.Redeemed);
+    }
+
+    [Fact]
+    public void ToRow_EmptyAllowList_ReadsAsAnyPlugin_AndZeroPriceIsFree()
+    {
+        var row = CouponAdminSettingsTab.ToRow(Coupon("OPEN",
+            """{"$type":"CouponContent","price":0,"validUntil":"2026-12-31T00:00:00+00:00"}"""), Options);
+        Assert.Equal("any plugin", row.Unlocks);
+        Assert.Equal("free", row.Price);
+        Assert.Equal("until 2026-12-31", row.Valid);
+        Assert.Equal("0", row.Redeemed);
+        Assert.Equal("", row.Notes);
+    }
+
+    [Fact]
+    public void ToRow_ReadsEveryContentShape()
+    {
+        // JsonNode (a builder's shape).
+        var asNode = new MeshNode("N1", CouponAdminSettingsTab.CouponsNamespace)
+        {
+            NodeType = "Store/Coupon",
+            Content = JsonNode.Parse("""{"plugins":["Chess"],"redeemed":1}""")!.AsObject(),
+        };
+        Assert.Equal("Chess", CouponAdminSettingsTab.ToRow(asNode, Options).Unlocks);
+
+        // Absent / non-object content degrades to an empty row, never a throw.
+        var empty = new MeshNode("N2", CouponAdminSettingsTab.CouponsNamespace)
+            { NodeType = "Store/Coupon", Content = null };
+        var row = CouponAdminSettingsTab.ToRow(empty, Options);
+        Assert.Equal("N2", row.Code);
+        Assert.Equal("any plugin", row.Unlocks);
+        Assert.Equal("free", row.Price);
+    }
+
+    [Fact]
+    public void Accumulate_UpsertsRemovesAndResets()
+    {
+        var a = Coupon("A", """{"plugins":[]}""");
+        var b = Coupon("B", """{"plugins":[]}""");
+
+        var map = CouponAdminSettingsTab.Accumulate(
+            ImmutableDictionary<string, MeshNode>.Empty,
+            new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Initial, Items = [a, b] });
+        Assert.Equal(2, map.Count);
+
+        map = CouponAdminSettingsTab.Accumulate(map,
+            new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Removed, Items = [a] });
+        Assert.Single(map);
+        Assert.True(map.ContainsKey(b.Path));
+
+        map = CouponAdminSettingsTab.Accumulate(map,
+            new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Reset, Items = [a] });
+        Assert.Single(map);
+        Assert.True(map.ContainsKey(a.Path));
+    }
+}


### PR DESCRIPTION
Adds **Settings ▸ Administration ▸ Coupons** (global admins only, gated and grouped exactly like the Plugin Catalog tab):

- **Live coupon list** over `Admin/Coupons/{CODE}` — code, what it unlocks (an empty allow-list reads "any plugin"), price ("free" for null/0), validity window, redemption tally (`used / cap` when capped), notes. The chunked query is accumulated (creates/edits/deletes all land) and the grid re-renders per settled snapshot.
- **Open** buttons per coupon → the node page, where the `Store/Coupon` type's own Edit / Delete actions live.
- **New coupon** → the standard Create flow (`/Store/Coupon/Create?type=Store%2FCoupon`; the type's `defaultNamespace` places it under `Admin/Coupons`).

The coupon type is **dynamic** (Store plugin), so the tab reads content strictly by shape — typed, `JsonElement`, or `JsonNode` — and never references the plugin's compiled types (`ToRow` + `Accumulate` are pure and unit-tested across all three shapes, plus priced/windowed/capped variants).

Registered in the memex portal config beside `AddPluginCatalogSettingsTab`. What's New entry included.

Verification: 5 new unit tests green, full solution `-c Release -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)