### PR TITLE
Fix the advisories at source: delete an unused package, drop all four overrides

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -157,24 +157,20 @@
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <!-- Override vulnerable transitive dependencies. Forced as direct PackageReference so
-       the version pin in Directory.Packages.props actually applies (transitive deps
-       otherwise resolve to whatever a higher-up package requested).
-       - System.Security.Cryptography.Xml: CVE in 10.0.0 chain
-       - OpenTelemetry.Api: GHSA-g94r-2vxg-569j (1.13.1 vulnerable)
-       - Microsoft.AspNetCore.DataProtection: GHSA-9mv3-2cwr-p262 (10.0.0 vulnerable)
-       - AngleSharp: GHSA-pgww-w46g-26qg (1.4.0 vulnerable — transitive via bUnit); pinned 1.5.2.
-         The Directory.Packages.props pin was inert without a direct ref (no transitive pinning),
-         so AngleSharp resolved to the vulnerable 1.4.0 and tripped NU1902 as an error under
-         -warnaserror (WarningsNotAsErrors does not exempt NuGet audit advisories from the gate).
-       Conditioned on net10.0 because netstandard2.0 projects (e.g. BusinessRules.Generator)
-       opt out of CPM and don't need these packages. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="System.Security.Cryptography.Xml" />
-    <PackageReference Include="OpenTelemetry.Api" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
-    <PackageReference Include="AngleSharp" />
-  </ItemGroup>
+  <!-- No transitive-dependency overrides are needed any more, and that is deliberate.
+       This block used to force patched versions of System.Security.Cryptography.Xml,
+       Microsoft.AspNetCore.DataProtection, OpenTelemetry.Api and AngleSharp. Every one of those
+       advisories came from something we could fix at SOURCE instead:
+         - Microsoft.Identity.Web 4.9.0 dragged in System.Security.Cryptography.Xml 10.0.7;
+           4.14.2 depends on the patched 10.0.10 and cleared three of the four.
+         - AngleSharp 1.4.0 arrived via EPS.Extensions.YamlMarkdown -> Html2Markdown, a package
+           referenced by two csprojs and NEVER used by a single line of code. Deleting the
+           reference removed the last advisory outright.
+       If a future advisory needs an override, add it here WITH PrivateAssets="all": an override is
+       not a dependency this code uses, and without PrivateAssets it is exported into every
+       published package's nuspec - which is how MeshWeaver.Domain, a domain-model package, came to
+       declare an HTML parser and two crypto packages and pushed a High advisory onto every
+       downstream consumer. Prefer fixing the source package over adding one. -->
   <!-- Bake the git commit SHA into every assembly as AssemblyMetadata("CommitHash") so the About
        page can show EXACTLY which build is running and link to the GitHub commit. This is kept
        SEPARATE from InformationalVersion on purpose: CI overrides InformationalVersion to

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
+    <!-- Used DIRECTLY by MeshWeaver.AI (skill/agent front matter) and MeshWeaver.Hosting
+         (MarkdownFileParser). It used to arrive only TRANSITIVELY via EPS.Extensions.YamlMarkdown,
+         so removing that unused package broke the build - an accidental dependency, now explicit. -->
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Appium.WebDriver" Version="8.3.0" />
     <PackageVersion Include="AspectCore.Extensions.Reflection" Version="2.4.0" />
     <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="10.0.0" />
@@ -70,9 +74,9 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
     <!-- Microsoft.AspNetCore.DataProtection pinned to override transitive 10.0.0 (CVE-2026-40372 / GHSA-9mv3-2cwr-p262) -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.24" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
@@ -114,8 +118,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Graph" Version="6.1.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.9.0" />
-    <PackageVersion Include="Microsoft.Identity.Web.Ui" Version="4.9.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />
+    <PackageVersion Include="Microsoft.Identity.Web.Ui" Version="4.14.2" />
     <PackageVersion Include="Microsoft.Orleans.BroadcastChannel" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.2.0" />

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -16,6 +16,7 @@
                  CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="YamlDotNet" />
         <PackageReference Include="Azure.AI.OpenAI" />
         <PackageReference Include="Azure.Core" />
         <PackageReference Include="HtmlAgilityPack" />

--- a/src/MeshWeaver.Hosting/MeshWeaver.Hosting.csproj
+++ b/src/MeshWeaver.Hosting/MeshWeaver.Hosting.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{93595120-3ccf-45c6-8783-4829a1120166}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EPS.Extensions.YamlMarkdown" />
+    <PackageReference Include="YamlDotNet" />
     <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MeshWeaver.Markdown/MeshWeaver.Markdown.csproj
+++ b/src/MeshWeaver.Markdown/MeshWeaver.Markdown.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" />
-    <PackageReference Include="EPS.Extensions.YamlMarkdown" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Started from a downstream symptom: `Systemorph/Memex` resolved **six vulnerable packages transitively** (one Critical), and bare `MeshWeaver.Domain` — a domain-model package — declared an HTML parser, a telemetry API and two crypto packages as its dependencies. Both traced back here.

## 1. The overrides were exported

`Directory.Build.props` force-referenced four packages to override somebody else's transitive resolution. Without `PrivateAssets`, those land in **every published nuspec**, so every consumer inherits them pinned to whatever we happened to build with. That is how `MeshWeaver.Domain 3.0.0-preview1` shipped `System.Security.Cryptography.Xml 10.0.6` as its **only** dependency and pushed a High advisory onto every downstream repo.

## 2. The overrides were treating symptoms

Tracing each one to its actual source:

| Advisory | Real cause | Fix |
|---|---|---|
| `System.Security.Cryptography.Xml` (High), `Microsoft.AspNetCore.DataProtection` (Critical), `OpenTelemetry.Api` | `Microsoft.Identity.Web` **4.9.0** → TokenCache → crypto **10.0.7** | bump Identity.Web → **4.14.2**, which depends on the patched **10.0.10** — cleared **three** advisories at once |
| `AngleSharp 1.4.0` (Moderate) | `EPS.Extensions.YamlMarkdown` → `Html2Markdown` — a package referenced by two csprojs and used by **zero lines of code** | delete the reference |

**Result: no overrides left at all**, and `dotnet restore` reports **zero advisories** — clean at source rather than patched over. The comment left in place says to use `PrivateAssets="all"` if one is ever needed again, and to prefer fixing the source package first.

## 3. YamlDotNet is now honest

Removing the unused package broke the build with `CS0246`. `MeshWeaver.AI` (skill/agent front matter) and `MeshWeaver.Hosting` (`MarkdownFileParser` — Markdig `UseYamlFrontMatter` + YamlDotNet `Deserializer`/`Serializer`, i.e. the mesh's `.md` → MeshNode reader) both use **YamlDotNet directly** but neither declared it: it arrived only as a transitive of the unused package.

Now pinned at `16.3.0` and referenced by exactly those two projects. Worth noting how it surfaced — grepping for the removed package's own namespace found nothing; the **build** is what caught the dependency it was really supplying.

(Unrelated to this PR: XML doc comments come from `Namotion.Reflection`, untouched.)

## Verification

- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → **0 warnings, 0 errors**
- `dotnet restore` → **0 NU issues**; `--vulnerable --include-transitive` → none
- Packing `MeshWeaver.Domain` before/after: 4 declared dependencies → **0**
- Tests: Security **345**, Persistence **421**, Graph **779**, Content **245**, Markdown **120**, Auth **116** (the Identity.Web bump's main risk), Hosting **95**, Documentation **19** — all green

## Follow-up

Once these packages are republished, the pins I added in `Systemorph/Memex#18` for `System.Security.Cryptography.Xml` and `Microsoft.AspNetCore.DataProtection` become removable — that PR's comments say so explicitly.

A broad "update Aspire and everything to latest" is deliberately **not** in here: major bumps across Aspire/Orleans/Fluent can break APIs and need a full test run, and mixing that into a security fix makes both harder to review and to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)