### PR TITLE
Roslyn autocomplete in Code-node editors — overlay completions + the kernel's script environment

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeCompletionRequest.cs
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeCompletionRequest.cs
@@ -1,0 +1,10 @@
+namespace MeshWeaver.Blazor.Components.Monaco;
+
+/// <summary>
+/// One code-completion request from the Monaco editor: the FULL in-flight buffer text and the
+/// caret position, already converted to the LSP convention (0-based line and character — Monaco
+/// is 1-based; <c>MonacoEditorView.GetCodeCompletions</c> converts at the boundary). Distinct
+/// from the trigger-token completion path (<c>CompletionCallback</c>), which matches a typed
+/// <c>@</c>-reference query and knows nothing about positions.
+/// </summary>
+public readonly record struct CodeCompletionRequest(string Text, int Line, int Character);

--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -23,7 +23,8 @@
                   CodeEditMode="true"
                   ValueChanged="@OnValueChanged"
                   DiagnosticsCallback="@diagnosticsCallback"
-                  DiagnosticSourcePath="@diagnosticSourcePath" />
+                  DiagnosticSourcePath="@diagnosticSourcePath"
+                  CodeCompletionCallback="@codeCompletionCallback" />
 
 @code {
     private MonacoEditorView? editorRef;
@@ -41,6 +42,7 @@
     // different Code node in the same component lifetime) picks up the new paths.
     private Func<string, IObservable<IReadOnlyList<DiagnosticInfo>>>? diagnosticsCallback;
     private string? diagnosticSourcePath;
+    private Func<CodeCompletionRequest, IObservable<IReadOnlyList<CompletionEntry>>>? codeCompletionCallback;
 
     // Store the data pointer for two-way binding
     private JsonPointerReference? ValuePointer;
@@ -149,11 +151,19 @@
                 diagnosticsCallback = text =>
                     languageService.CheckSpeculative(nodeTypePath, sourcePath, text ?? string.Empty);
                 diagnosticSourcePath = sourcePath;
+                // Roslyn code completions over the SAME language service: the editor's
+                // in-flight text plus the caret, answered from the NodeType's compilation —
+                // or, for a standalone script Code node (a lesson cell), from the kernel's
+                // script environment. Monaco filters client-side, so ask for a generous slice.
+                codeCompletionCallback = request => languageService.GetCompletions(
+                    nodeTypePath, sourcePath, request.Text,
+                    new SourcePosition(request.Line, request.Character), maxResults: 200);
             }
             else
             {
                 diagnosticsCallback = null;
                 diagnosticSourcePath = null;
+                codeCompletionCallback = null;
             }
         }
         else if (ViewModel.Diagnostics is { Count: > 0 } staticDiags)
@@ -176,11 +186,13 @@
                 .ToList();
             diagnosticsCallback = _ => Observable.Return(infos);
             diagnosticSourcePath = null; // already this file's diagnostics — no filtering
+            codeCompletionCallback = null;
         }
         else
         {
             diagnosticsCallback = null;
             diagnosticSourcePath = null;
+            codeCompletionCallback = null;
         }
     }
 

--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -24,7 +24,8 @@
                   ValueChanged="@OnValueChanged"
                   DiagnosticsCallback="@diagnosticsCallback"
                   DiagnosticSourcePath="@diagnosticSourcePath"
-                  CodeCompletionCallback="@codeCompletionCallback" />
+                  CodeCompletionCallback="@codeCompletionCallback"
+                  CodeCompletionAccepted="@codeCompletionAccepted" />
 
 @code {
     private MonacoEditorView? editorRef;
@@ -43,6 +44,7 @@
     private Func<string, IObservable<IReadOnlyList<DiagnosticInfo>>>? diagnosticsCallback;
     private string? diagnosticSourcePath;
     private Func<CodeCompletionRequest, IObservable<IReadOnlyList<CompletionEntry>>>? codeCompletionCallback;
+    private Action<string, int, string>? codeCompletionAccepted;
 
     // Store the data pointer for two-way binding
     private JsonPointerReference? ValuePointer;
@@ -158,12 +160,17 @@
                 codeCompletionCallback = request => languageService.GetCompletions(
                     nodeTypePath, sourcePath, request.Text,
                     new SourcePosition(request.Line, request.Character), maxResults: 200);
+                // Acceptances feed this user's suggest memory (persisted per user), which
+                // preselects the same choice next time they are in the same situation.
+                codeCompletionAccepted = (label, kind, typed) =>
+                    languageService.RecordCompletionAccepted(typed, label, (CompletionKind)kind);
             }
             else
             {
                 diagnosticsCallback = null;
                 diagnosticSourcePath = null;
                 codeCompletionCallback = null;
+                codeCompletionAccepted = null;
             }
         }
         else if (ViewModel.Diagnostics is { Count: > 0 } staticDiags)
@@ -187,12 +194,14 @@
             diagnosticsCallback = _ => Observable.Return(infos);
             diagnosticSourcePath = null; // already this file's diagnostics — no filtering
             codeCompletionCallback = null;
+            codeCompletionAccepted = null;
         }
         else
         {
             diagnosticsCallback = null;
             diagnosticSourcePath = null;
             codeCompletionCallback = null;
+            codeCompletionAccepted = null;
         }
     }
 

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
@@ -108,6 +108,17 @@
     public Func<string, IObservable<IReadOnlyList<CompletionItem>>>? CompletionCallback { get; set; }
 
     /// <summary>
+    /// Optional POSITION-BASED code completions (Roslyn over the mesh language service) —
+    /// distinct from <see cref="CompletionCallback"/>, whose trigger-token model matches a
+    /// typed <c>@</c>-reference query and cannot express "complete C# at line/column". Called
+    /// with the full in-flight buffer and the caret (LSP convention, 0-based — converted from
+    /// Monaco's 1-based positions at the boundary); the emitted entries feed Monaco's suggest
+    /// widget, which filters and ranks client-side against the current word.
+    /// </summary>
+    [Parameter]
+    public Func<CodeCompletionRequest, IObservable<IReadOnlyList<MeshWeaver.Mesh.Services.LanguageServer.CompletionEntry>>>? CodeCompletionCallback { get; set; }
+
+    /// <summary>
     /// Optional reactive callback that supplies live diagnostics (squiggles) for the
     /// current editor content. Called with the editor's full text on every debounced
     /// content change. Each emission is converted to Monaco markers and rendered via
@@ -264,6 +275,14 @@
 
             // Register completion provider if configured
             await TryRegisterCompletionProvider();
+
+            // Position-based code completions (the Roslyn path) — independent of the
+            // trigger-token provider above; a code editor may carry both.
+            if (CodeCompletionCallback != null)
+            {
+                await jsModule.InvokeVoidAsync("registerCodeCompletionProvider", EditorId,
+                    new { language = Language });
+            }
 
             // Enable LSP-style live diagnostics if the consumer wired a callback.
             // JS side debounces onDidChangeModelContent and invokes back to RequestDiagnostics.
@@ -455,6 +474,44 @@
         }
 
         return Task.FromResult(MapCompletionsToJs(_currentCompletions));
+    }
+
+    /// <summary>
+    /// Called from the JS code-completion provider on every suggest request: the full buffer
+    /// plus Monaco's 1-based caret, answered with LSP-shaped entries. Bounded — a language
+    /// service that stalls yields an empty list after the timeout instead of hanging the
+    /// suggest widget; errors are logged and swallowed the same way (suggest must never throw
+    /// into the circuit).
+    /// </summary>
+    [JSInvokable]
+    public async Task<object[]> GetCodeCompletions(string? text, int lineNumber, int column)
+    {
+        if (CodeCompletionCallback == null)
+            return [];
+        try
+        {
+            var request = new CodeCompletionRequest(
+                text ?? string.Empty, Math.Max(0, lineNumber - 1), Math.Max(0, column - 1));
+            var entries = await CodeCompletionCallback(request)
+                .Timeout(TimeSpan.FromSeconds(5))
+                .FirstOrDefaultAsync();
+            if (entries is not { Count: > 0 })
+                return [];
+            return entries.Select(e => (object)new
+            {
+                label = e.Label,
+                insertText = e.InsertText,
+                kind = (int)e.Kind,
+                detail = e.Detail ?? "",
+                documentation = e.Documentation ?? "",
+                sortText = e.SortText ?? "",
+            }).ToArray();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Code completions failed for editor {EditorId}", EditorId);
+            return [];
+        }
     }
 
     private static object[] MapCompletionsToJs(IReadOnlyList<CompletionItem> items)

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
@@ -505,6 +505,7 @@
                 detail = e.Detail ?? "",
                 documentation = e.Documentation ?? "",
                 sortText = e.SortText ?? "",
+                preselect = e.Preselect,
             }).ToArray();
         }
         catch (Exception ex)
@@ -512,6 +513,21 @@
             Logger.LogDebug(ex, "Code completions failed for editor {EditorId}", EditorId);
             return [];
         }
+    }
+
+    /// <summary>
+    /// Optional callback invoked when the user ACCEPTS a code completion — carries the chosen
+    /// label, its LSP kind, and the word that had been typed. Backs the per-user suggest memory.
+    /// </summary>
+    [Parameter]
+    public Action<string, int, string>? CodeCompletionAccepted { get; set; }
+
+    /// <summary>Called from JS once Monaco has inserted an accepted code completion.</summary>
+    [JSInvokable]
+    public void HandleCodeCompletionAccepted(string? label, int kind, string? typed)
+    {
+        if (!string.IsNullOrEmpty(label))
+            CodeCompletionAccepted?.Invoke(label!, kind, typed ?? string.Empty);
     }
 
     private static object[] MapCompletionsToJs(IReadOnlyList<CompletionItem> items)

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -841,6 +841,18 @@ export function registerCodeCompletionProvider(editorId, config) {
         state.codeCompletionDisposable = null;
     }
     const language = config?.language || 'csharp';
+    // Command invoked by Monaco AFTER an item is inserted — the acceptance signal the per-user
+    // suggest memory is built from (same mechanism the @-reference provider uses).
+    if (!state.codeCompletionCommandId && state.editorInstance) {
+        state.codeCompletionCommandId = state.editorInstance.addCommand(0, (_, label, kind, typed) => {
+            const currentState = editorState.get(editorId);
+            if (currentState?.dotNetRef && label) {
+                currentState.dotNetRef
+                    .invokeMethodAsync('HandleCodeCompletionAccepted', label, kind ?? 0, typed ?? '')
+                    .catch(err => console.debug('HandleCodeCompletionAccepted failed (editor disposed?):', err));
+            }
+        });
+    }
     state.codeCompletionDisposable = monaco.languages.registerCompletionItemProvider(language, {
         triggerCharacters: ['.'],
         provideCompletionItems: async (model, position) => {
@@ -864,6 +876,9 @@ export function registerCodeCompletionProvider(editorId, config) {
                 startColumn: word.startColumn,
                 endColumn: word.endColumn,
             };
+            // The word being completed — recorded with the acceptance so the memory can key on
+            // "what I had typed", exactly like VS Code's recentlyUsedByPrefix.
+            const typed = word.word || '';
             return {
                 suggestions: items.map(i => ({
                     label: i.label,
@@ -872,7 +887,13 @@ export function registerCodeCompletionProvider(editorId, config) {
                     detail: i.detail || undefined,
                     documentation: i.documentation || undefined,
                     sortText: i.sortText || undefined,
+                    // The one item this user accepted last time in this situation. Monaco
+                    // highlights it without disturbing the order we returned.
+                    preselect: i.preselect === true,
                     range,
+                    command: current.codeCompletionCommandId
+                        ? { id: current.codeCompletionCommandId, title: '', arguments: [i.label, i.kind, typed] }
+                        : undefined,
                 })),
             };
         },

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -790,6 +790,95 @@ export function registerCompletionProvider(editorId, config) {
     });
 }
 
+
+// ————————————————————————————————————————————————————————————— code completions
+// LSP CompletionKind (wire values, see IMeshLanguageService.CompletionKind) → Monaco
+// languages.CompletionItemKind. Distinct enums with different numbering — mapped here at the
+// boundary so the .NET side stays LSP-pure.
+const LSP_TO_MONACO_KIND = {
+    1: 18,  // Text
+    2: 0,   // Method
+    3: 1,   // Function
+    4: 2,   // Constructor
+    5: 3,   // Field
+    6: 4,   // Variable
+    7: 5,   // Class
+    8: 7,   // Interface
+    9: 8,   // Module
+    10: 9,  // Property
+    11: 12, // Unit
+    12: 13, // Value
+    13: 15, // Enum
+    14: 17, // Keyword
+    15: 27, // Snippet
+    16: 19, // Color
+    17: 20, // File
+    18: 21, // Reference
+    19: 23, // Folder
+    20: 16, // EnumMember
+    21: 14, // Constant
+    22: 6,  // Struct
+    23: 10, // Event
+    24: 11, // Operator
+    25: 24, // TypeParameter
+};
+
+/**
+ * Registers the POSITION-BASED code-completion provider (Roslyn over the mesh language
+ * service) — distinct from registerCompletionProvider, whose trigger-token model matches a
+ * typed @-reference query and cannot express "complete C# at line/column". Each suggest
+ * request round-trips the full buffer + caret to .NET (GetCodeCompletions), which answers
+ * with LSP-shaped entries; Monaco filters and ranks client-side against the current word.
+ */
+export function registerCodeCompletionProvider(editorId, config) {
+    const state = editorState.get(editorId);
+    if (!state) {
+        console.debug('Monaco editor state not available:', editorId);
+        return;
+    }
+    if (state.codeCompletionDisposable) {
+        state.codeCompletionDisposable.dispose();
+        state.codeCompletionDisposable = null;
+    }
+    const language = config?.language || 'csharp';
+    state.codeCompletionDisposable = monaco.languages.registerCompletionItemProvider(language, {
+        triggerCharacters: ['.'],
+        provideCompletionItems: async (model, position) => {
+            // Providers register globally per language — serve only our own editor's model.
+            const current = editorState.get(editorId);
+            const instance = current?.editorInstance;
+            if (!instance || instance.getModel() !== model || !current.dotNetRef) return null;
+            let items;
+            try {
+                items = await current.dotNetRef.invokeMethodAsync(
+                    'GetCodeCompletions', model.getValue(), position.lineNumber, position.column);
+            } catch (err) {
+                console.debug('GetCodeCompletions failed (editor disposed?):', err);
+                return null;
+            }
+            if (!items || items.length === 0) return { suggestions: [] };
+            const word = model.getWordUntilPosition(position);
+            const range = {
+                startLineNumber: position.lineNumber,
+                endLineNumber: position.lineNumber,
+                startColumn: word.startColumn,
+                endColumn: word.endColumn,
+            };
+            return {
+                suggestions: items.map(i => ({
+                    label: i.label,
+                    insertText: i.insertText || i.label,
+                    kind: LSP_TO_MONACO_KIND[i.kind] ?? 18,
+                    detail: i.detail || undefined,
+                    documentation: i.documentation || undefined,
+                    sortText: i.sortText || undefined,
+                    range,
+                })),
+            };
+        },
+    });
+}
+
 export function isAutocompleteVisible(editorId) {
     // Check if async completion is pending
     const state = editorState.get(editorId);
@@ -1242,6 +1331,9 @@ export function dispose(editorId) {
     if (state) {
         if (state.completionDisposable) {
             state.completionDisposable.dispose();
+        }
+        if (state.codeCompletionDisposable) {
+            state.codeCompletionDisposable.dispose();
         }
         if (state._diagnosticsChangeDisposable) {
             state._diagnosticsChangeDisposable.dispose();

--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -628,16 +628,27 @@ public static class CodeLayoutAreas
 
         stack = stack.WithView(languageRow);
 
-        // Monaco editor. LSP opt-in: when this Code node sits under a NodeType's Source/
-        // subtree, enable live Roslyn diagnostics (Stage-1 IMeshLanguageService). The
-        // Edit view's hub address IS the Code MeshNode path, so we can derive both the
-        // NodeType path and the source path from it. For Code nodes outside a Source/
-        // subtree (rare — typically standalone scripts), skip LSP wiring.
+        // Monaco editor. LSP opt-in for EVERY C# Code node — live Roslyn diagnostics AND
+        // completions (IMeshLanguageService). The Edit view's hub address IS the Code
+        // MeshNode path, so both the owner path and the source path derive from it:
+        //   • under a NodeType's Source/ subtree → the owner is that NodeType, and the
+        //     language service works in its compilation (siblings in scope);
+        //   • anywhere else (a standalone script cell — e.g. a course lesson's
+        //     {lesson}/Source/{cell}, whose owner is a Markdown page, or a bare Code node)
+        //     → the owner is simply the parent, which is not a NodeType, and the language
+        //     service answers from the KERNEL'S SCRIPT ENVIRONMENT instead (script parsing,
+        //     the kernel's imports/references, the script globals in scope).
+        // Either way the editor completes exactly what that cell can actually compile, so
+        // there is no longer a reason to leave standalone scripts without language services.
         var sourcePath = host.Hub.Address.ToString();
         var sourceMarkerIdx = sourcePath.IndexOf("/Source/", StringComparison.Ordinal);
-        CodeEditorLanguageServerConfig? lspConfig = sourceMarkerIdx > 0 && language == "csharp"
+        var lastSlashIdx = sourcePath.LastIndexOf('/');
+        var ownerPath = sourceMarkerIdx > 0
+            ? sourcePath.Substring(0, sourceMarkerIdx)
+            : lastSlashIdx > 0 ? sourcePath.Substring(0, lastSlashIdx) : sourcePath;
+        CodeEditorLanguageServerConfig? lspConfig = language == "csharp"
             ? new CodeEditorLanguageServerConfig(
-                NodeTypePath: sourcePath.Substring(0, sourceMarkerIdx),
+                NodeTypePath: ownerPath,
                 SourcePath: sourcePath)
             : null;
 

--- a/src/MeshWeaver.Graph/Configuration/CompletionMemoryNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompletionMemoryNodeType.cs
@@ -1,0 +1,37 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The <b>CompletionMemory</b> node — a user's completion acceptance history, one singleton node
+/// per user at <c>{userId}/_Settings/Completions</c> (see
+/// <see cref="CompletionMemoryStore.PathFor"/>). System-managed and user-owned, exactly like the
+/// notification settings next to it: excluded from search / create / autocomplete, written only by
+/// the editor's acceptance path.
+/// </summary>
+public static class CompletionMemoryNodeType
+{
+    /// <summary>The NodeType value used to identify completion-memory nodes.</summary>
+    public const string NodeType = "CompletionMemory";
+
+    /// <summary>Registers the built-in "CompletionMemory" MeshNode on the mesh builder.</summary>
+    public static TBuilder AddCompletionMemoryType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.ConfigureHub(config => config.WithType<CompletionMemory>(nameof(CompletionMemory)));
+        return builder;
+    }
+
+    /// <summary>Creates a MeshNode definition for the CompletionMemory node type.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Completion Memory",
+        Icon = "/static/NodeTypeIcons/code.svg",
+        IsSatelliteType = true,
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<CompletionMemory>())
+    };
+}

--- a/src/MeshWeaver.Graph/Configuration/CompletionMemoryStore.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompletionMemoryStore.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Per-user completion acceptance memory — loaded from and saved to
+/// <c>{userId}/_Settings/Completions</c>, the same per-user settings-node shape the notification
+/// preferences use.
+///
+/// <para><b>Write discipline.</b> Acceptances arrive one keystroke apart; a node write per
+/// acceptance is exactly the write storm this codebase has been burned by. So writes are
+/// COALESCED: each acceptance updates memory in-process and nudges a per-user throttle, and only
+/// a quiet window later does one write persist whatever the memory has become. A user who accepts
+/// twenty completions in a burst costs one write.</para>
+///
+/// <para><b>Never on the critical path.</b> Loading is a one-shot, empty-on-absent query behind a
+/// timeout; a user whose memory has not loaded (or cannot) simply gets no preselection. Nothing
+/// here can fail a completion request.</para>
+/// </summary>
+internal sealed class CompletionMemoryStore : IDisposable
+{
+    private static readonly TimeSpan SaveDebounce = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan LoadTimeout = TimeSpan.FromSeconds(15);
+
+    private readonly IMessageHub hub;
+    private readonly ILogger logger;
+    private readonly ConcurrentDictionary<string, CompletionMemory> memories = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> loading = new(StringComparer.Ordinal);
+    private readonly Subject<string> dirty = new();
+    private readonly IDisposable saveSubscription;
+
+    public CompletionMemoryStore(IMessageHub hub, ILogger logger)
+    {
+        this.hub = hub;
+        this.logger = logger;
+        // One save per user per quiet window — the coalescing that keeps acceptance recording
+        // from becoming a write storm.
+        saveSubscription = dirty
+            .GroupBy(viewer => viewer, StringComparer.Ordinal)
+            .SelectMany(group => group.Throttle(SaveDebounce))
+            .Subscribe(Save, ex => logger.LogDebug(ex, "Completion memory save pipeline faulted"));
+    }
+
+    /// <summary>The signed-in viewer, or null when there is nobody to remember for.</summary>
+    public string? Viewer()
+    {
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        foreach (var candidate in new[] { access?.Context?.ObjectId, access?.CircuitContext?.ObjectId })
+            if (!string.IsNullOrEmpty(candidate)
+                && candidate != WellKnownUsers.System
+                && !string.Equals(candidate, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase))
+                return candidate;
+        return null;
+    }
+
+    /// <summary>
+    /// The viewer's memory as currently known in-process, kicking off a one-time load when it has
+    /// not been read yet. Returns empty (never blocks) until that load lands.
+    /// </summary>
+    public CompletionMemory For(string viewer)
+    {
+        if (memories.TryGetValue(viewer, out var memory))
+            return memory;
+        BeginLoad(viewer);
+        return new CompletionMemory();
+    }
+
+    /// <summary>Records an acceptance and schedules the coalesced save. Never throws.</summary>
+    public void Record(string viewer, string? prefix, string label, int kind)
+    {
+        try
+        {
+            memories.AddOrUpdate(
+                viewer,
+                _ => new CompletionMemory().Record(prefix, label, kind),
+                (_, existing) => existing.Record(prefix, label, kind));
+            dirty.OnNext(viewer);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Recording completion acceptance failed for {Viewer}", viewer);
+        }
+    }
+
+    /// <summary>The per-user settings node holding the memory.</summary>
+    public static string PathFor(string viewer) => $"{viewer}/_Settings/Completions";
+
+    private void BeginLoad(string viewer)
+    {
+        if (!loading.TryAdd(viewer, 0))
+            return;
+
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+        {
+            memories.TryAdd(viewer, new CompletionMemory());
+            return;
+        }
+
+        var path = PathFor(viewer);
+        // Empty-on-absent query — never a point read of a maybe-absent path (that is the probe
+        // this mesh fast-fails and logs as a defect).
+        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}"))
+            .Scan(ImmutableList<MeshNode>.Empty, (list, change) => change.ChangeType switch
+            {
+                QueryChangeType.Removed => ImmutableList<MeshNode>.Empty,
+                _ => change.Items.ToImmutableList(),
+            })
+            .Throttle(TimeSpan.FromMilliseconds(500))
+            .Take(1)
+            .Timeout(LoadTimeout)
+            .Catch(Observable.Return(ImmutableList<MeshNode>.Empty))
+            .Subscribe(
+                nodes =>
+                {
+                    var stored = nodes.FirstOrDefault()
+                        ?.ContentAs<CompletionMemory>(hub.JsonSerializerOptions);
+                    // A load must never clobber acceptances recorded while it was in flight.
+                    memories.TryAdd(viewer, stored ?? new CompletionMemory());
+                },
+                ex => logger.LogDebug(ex, "Completion memory load failed for {Viewer}", viewer));
+    }
+
+    private void Save(string viewer)
+    {
+        if (!memories.TryGetValue(viewer, out var memory))
+            return;
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return;
+
+        var path = PathFor(viewer);
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Completion memory",
+            NodeType = CompletionMemoryNodeType.NodeType,
+            MainNode = viewer,
+            State = MeshNodeState.Active,
+            Content = memory,
+        };
+        mesh.CreateOrUpdateNode(node)
+            .Take(1)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogDebug(ex, "Completion memory save failed for {Viewer}", viewer));
+    }
+
+    public void Dispose()
+    {
+        saveSubscription.Dispose();
+        dirty.Dispose();
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/CompletionUsageIndex.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompletionUsageIndex.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.RegularExpressions;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// How often each identifier actually appears in the code THIS MESH already contains — the
+/// "likely usage" prior behind completion ranking.
+///
+/// <para><b>Why.</b> Roslyn returns every symbol in scope alphabetically, so a bare member list
+/// (<c>Controls.</c>) leads with <c>Badge</c> while every real cell wants <c>Stack</c>,
+/// <c>Markdown</c> or <c>DataGrid</c>. Editors solve this with a learned prior: VS Code keeps
+/// per-user acceptance history plus a locality bonus, and Visual Studio's IntelliCode re-ranks
+/// with a model trained on a large code corpus. The mesh has a BETTER corpus for its own API than
+/// any public one — the Code nodes it is already running — so the prior is simply how often each
+/// identifier occurs in them.</para>
+///
+/// <para><b>Safety — this can never break or slow a completion.</b> The index is built ONCE,
+/// lazily, in the background, from a BOUNDED query, behind a timeout; until it is ready (and
+/// forever, if the query never answers) completions serve with an empty prior and are merely
+/// ordered as before. A global <c>nodeType:</c> query is exactly the shape that has wedged this
+/// mesh before, so it is never awaited on the request path and every failure resolves to "no
+/// prior" rather than an error.</para>
+/// </summary>
+internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger)
+{
+    /// <summary>How many Code nodes the corpus scan reads at most.</summary>
+    private const int MaxNodes = 400;
+
+    /// <summary>How many distinct identifiers are kept — the long tail carries no ranking signal.</summary>
+    private const int MaxIdentifiers = 4000;
+
+    /// <summary>How long a built index is served before the next request triggers a rebuild.</summary>
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+
+    /// <summary>The corpus scan's ceiling — a wedged query must degrade to "no prior", not hang.</summary>
+    private static readonly TimeSpan QueryTimeout = TimeSpan.FromSeconds(30);
+
+    // Identifiers only: what a completion label can be. Deliberately not a C# parse — this is a
+    // frequency prior, and a tokenizer that is 99% right costs microseconds instead of a compile.
+    private static readonly Regex IdentifierPattern =
+        new(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
+
+    // The C# keywords and the handful of ubiquitous noise words that would otherwise top every
+    // ranking without ever being the thing a user is choosing from a member list.
+    private static readonly ImmutableHashSet<string> Ignored = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "var", "new", "return", "using", "public", "private", "protected", "internal", "static",
+        "class", "record", "struct", "interface", "enum", "void", "null", "true", "false", "if",
+        "else", "for", "foreach", "while", "do", "switch", "case", "break", "continue", "in",
+        "out", "ref", "this", "base", "get", "set", "init", "string", "int", "double", "bool",
+        "object", "long", "decimal", "float", "byte", "char", "short", "async", "await", "try",
+        "catch", "finally", "throw", "namespace", "readonly", "const", "params", "default",
+        "is", "as", "when", "where", "select", "from", "let", "into", "yield", "global");
+
+    private volatile ImmutableDictionary<string, int> frequencies =
+        ImmutableDictionary<string, int>.Empty;
+    private DateTimeOffset builtAt = DateTimeOffset.MinValue;
+    private int building;
+
+    /// <summary>
+    /// The corpus count for <paramref name="identifier"/> (0 when unknown or the index is not
+    /// built yet). Pure and allocation-free — safe to call once per candidate per keystroke.
+    /// </summary>
+    public int Frequency(string identifier)
+        => frequencies.TryGetValue(identifier, out var count) ? count : 0;
+
+    /// <summary>
+    /// Kicks off a background (re)build when the index is stale and no build is already running.
+    /// Returns immediately — the CALLER NEVER WAITS. Completions that arrive before the first
+    /// build finishes are simply ranked without the corpus prior.
+    /// </summary>
+    public void EnsureFresh()
+    {
+        if (DateTimeOffset.UtcNow - builtAt < Ttl)
+            return;
+        if (Interlocked.CompareExchange(ref building, 1, 0) != 0)
+            return;
+
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+        {
+            builtAt = DateTimeOffset.UtcNow; // nothing to scan here — don't retry every keystroke
+            Interlocked.Exchange(ref building, 0);
+            return;
+        }
+
+        // Accumulate the chunked query, settle after a quiet second, take one snapshot — the
+        // standard bounded read. Timeout + Catch make every failure mode "no prior".
+        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:Code limit:{MaxNodes}"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items.ToImmutableDictionary(n => n.Path);
+                foreach (var item in change.Items)
+                    map = change.ChangeType == QueryChangeType.Removed
+                        ? map.Remove(item.Path)
+                        : map.SetItem(item.Path, item);
+                return map;
+            })
+            .Throttle(TimeSpan.FromSeconds(1))
+            .Take(1)
+            .Timeout(QueryTimeout)
+            .Catch(Observable.Return(ImmutableDictionary<string, MeshNode>.Empty))
+            .Subscribe(
+                nodes =>
+                {
+                    try
+                    {
+                        frequencies = Tally(nodes.Values.Select(NodeCode));
+                        logger.LogDebug(
+                            "Completion usage index built from {NodeCount} Code node(s): {IdentifierCount} identifiers",
+                            nodes.Count, frequencies.Count);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogDebug(ex, "Completion usage index build failed — ranking without the corpus prior");
+                    }
+                    finally
+                    {
+                        builtAt = DateTimeOffset.UtcNow;
+                        Interlocked.Exchange(ref building, 0);
+                    }
+                },
+                ex =>
+                {
+                    logger.LogDebug(ex, "Completion usage corpus query failed — ranking without the corpus prior");
+                    builtAt = DateTimeOffset.UtcNow;
+                    Interlocked.Exchange(ref building, 0);
+                });
+    }
+
+    /// <summary>The node's script text, in whatever shape the content arrived in.</summary>
+    private string NodeCode(MeshNode node)
+    {
+        var code = node.ContentAs<CodeConfiguration>(hub.JsonSerializerOptions)?.Code;
+        return code ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Counts identifier occurrences across <paramref name="sources"/>, keeping the most frequent
+    /// <see cref="MaxIdentifiers"/>. Public for the tests — pure, no mesh, no Roslyn.
+    /// </summary>
+    public static ImmutableDictionary<string, int> Tally(IEnumerable<string> sources)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var source in sources)
+        {
+            if (string.IsNullOrEmpty(source))
+                continue;
+            foreach (Match match in IdentifierPattern.Matches(source))
+            {
+                var token = match.Value;
+                if (token.Length < 2 || Ignored.Contains(token))
+                    continue;
+                counts[token] = counts.TryGetValue(token, out var n) ? n + 1 : 1;
+            }
+        }
+        return counts.Count <= MaxIdentifiers
+            ? counts.ToImmutableDictionary(StringComparer.Ordinal)
+            : counts.OrderByDescending(kv => kv.Value)
+                .Take(MaxIdentifiers)
+                .ToImmutableDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -49,6 +49,7 @@ public static class GraphConfigurationExtensions
                 .AddApprovalType()
                 .AddNotificationType()
                 .AddNotificationSettingsType()
+                .AddCompletionMemoryType()
                 .AddNotificationRuleType()
                 .AddNotificationChannelType()
                 .AddInvitationType()

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -63,6 +63,10 @@ internal sealed class MeshNodeLanguageService(
     // CompletionUsageIndex; until it is ready, ranking simply proceeds without it.
     private readonly CompletionUsageIndex usageIndex = new(hub, logger);
 
+    // This user's acceptance history — the per-user half of "likely usage" (VS Code's suggest
+    // memory). Used ONLY to preselect; it never reorders what the matcher decided.
+    private readonly CompletionMemoryStore memoryStore = new(hub, logger);
+
     // Compile pool: Roslyn LSP work is CPU-bound, so it routes through the bounded
     // Compile pool which caps concurrency so it can't starve other schedulers.
     // A bare Observable.FromAsync deadlocks under a blocking subscriber (SubscribeOn
@@ -95,7 +99,7 @@ internal sealed class MeshNodeLanguageService(
             {
                 if (cached is null || !cached.DocumentsByPath.TryGetValue(sourcePath, out var docId))
                     return Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>());
-                return _ioPool.Run(ct => GetCompletionsAsync(cached, docId, position, maxResults, usageIndex, ct));
+                return _ioPool.Run(ct => GetCompletionsAsync(cached, docId, position, maxResults, usageIndex, CurrentMemory(), ct));
             });
 
     /// <inheritdoc />
@@ -108,7 +112,8 @@ internal sealed class MeshNodeLanguageService(
                 ? GetOrBuildWorkspace(nodeTypePath).SelectMany(cached => cached is null
                     ? Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>())
                     : _ioPool.Run(ct => GetOverlayCompletionsAsync(
-                        cached, sourcePath, proposedCode, position, maxResults, usageIndex, ct)))
+                        cached, sourcePath, proposedCode, position, maxResults, usageIndex,
+                        CurrentMemory(), ct)))
                 // Not a NodeType → a standalone SCRIPT Code node (e.g. a course lesson cell):
                 // complete in the kernel's script environment.
                 : _ioPool.Run(ct => GetScriptCompletionsAsync(proposedCode, position, maxResults, ct)));
@@ -138,6 +143,15 @@ internal sealed class MeshNodeLanguageService(
     private static bool IsNodeType(MeshNode? node)
         => node is not null
             && string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public void RecordCompletionAccepted(string prefix, string label, CompletionKind kind)
+    {
+        var viewer = memoryStore.Viewer();
+        if (viewer is null || string.IsNullOrEmpty(label))
+            return;
+        memoryStore.Record(viewer, prefix, label, (int)kind);
+    }
 
     /// <inheritdoc />
     public void Evict(string nodeTypePath)
@@ -296,11 +310,11 @@ internal sealed class MeshNodeLanguageService(
 
     private static async Task<IReadOnlyList<CompletionEntry>> GetCompletionsAsync(
         CachedWorkspace cached, DocumentId docId, SourcePosition position, int maxResults,
-        CompletionUsageIndex? usage, CancellationToken ct)
+        CompletionUsageIndex? usage, CompletionMemory? memory, CancellationToken ct)
     {
         var document = cached.Workspace.CurrentSolution.GetDocument(docId);
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, memory, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -312,7 +326,7 @@ internal sealed class MeshNodeLanguageService(
     /// </summary>
     private static async Task<IReadOnlyList<CompletionEntry>> GetOverlayCompletionsAsync(
         CachedWorkspace cached, string sourcePath, string proposedCode, SourcePosition position,
-        int maxResults, CompletionUsageIndex? usage, CancellationToken ct)
+        int maxResults, CompletionUsageIndex? usage, CompletionMemory? memory, CancellationToken ct)
     {
         var solution = cached.Workspace.CurrentSolution;
         Document? document;
@@ -330,7 +344,7 @@ internal sealed class MeshNodeLanguageService(
                 .GetDocument(newId);
         }
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, memory, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -343,12 +357,13 @@ internal sealed class MeshNodeLanguageService(
         string proposedCode, SourcePosition position, int maxResults, CancellationToken ct)
     {
         var usage = usageIndex;
+        var memory = CurrentMemory();
         var script = _scriptWorkspace.Value;
         var document = script.Workspace.CurrentSolution
             .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
             .GetDocument(script.DocumentId);
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, memory, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -385,7 +400,7 @@ internal sealed class MeshNodeLanguageService(
     /// </summary>
     private static async Task<IReadOnlyList<CompletionEntry>> CompleteAsync(
         Document document, SourcePosition position, int maxResults, CompletionUsageIndex? usage,
-        CancellationToken ct)
+        CompletionMemory? memory, CancellationToken ct)
     {
         var text = await document.GetTextAsync(ct).ConfigureAwait(false);
         var offset = TryGetOffset(text, position);
@@ -445,7 +460,31 @@ internal sealed class MeshNodeLanguageService(
                 Documentation: null,
                 SortText: item.SortText));
         }
+
+        // Finally, this user's own history: what they accepted last time in this situation is
+        // PRESELECTED — the order stays exactly as ranked above, only the highlighted row moves
+        // (VS Code's suggest memory works this way, and it is why the memory can be aggressive
+        // without ever hiding a better match).
+        var remembered = memory?.Select(
+            result.Select(r => (r.Label, (int)r.Kind)).ToList(), prefix);
+        if (remembered is not null)
+        {
+            for (var i = 0; i < result.Count; i++)
+            {
+                if (!string.Equals(result[i].Label, remembered, StringComparison.Ordinal))
+                    continue;
+                result[i] = result[i] with { Preselect = true };
+                break;
+            }
+        }
         return result;
+    }
+
+    /// <summary>This viewer's acceptance history, or null when nobody is signed in.</summary>
+    private CompletionMemory? CurrentMemory()
+    {
+        var viewer = memoryStore.Viewer();
+        return viewer is null ? null : memoryStore.For(viewer);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -46,6 +46,18 @@ internal sealed class MeshNodeLanguageService(
     private readonly ConcurrentDictionary<string, CachedWorkspace> _cache =
         new(StringComparer.Ordinal);
 
+    // The ONE script workspace — for Code nodes with no NodeType compilation behind them
+    // (course lesson cells). Its reference set is process-shared and fixed for the service's
+    // lifetime, so a single lazily-built project serves every request: each suggest forks the
+    // immutable solution with the in-flight text, nothing is applied back, and concurrent
+    // requests never contend. Bounded: one AdhocWorkspace total, not one per cell.
+    private readonly Lazy<ScriptWorkspace> _scriptWorkspace = new(
+        () => BuildScriptWorkspace(hub.ServiceProvider),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    // Path used as the script document's FilePath — never a real MeshNode path.
+    private const string ScriptDocumentPath = "__script__.csx";
+
     // Compile pool: Roslyn LSP work is CPU-bound, so it routes through the bounded
     // Compile pool which caps concurrency so it can't starve other schedulers.
     // A bare Observable.FromAsync deadlocks under a blocking subscriber (SubscribeOn
@@ -81,16 +93,44 @@ internal sealed class MeshNodeLanguageService(
                 return _ioPool.Run(ct => GetCompletionsAsync(cached, docId, position, maxResults, ct));
             });
 
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<CompletionEntry>> GetCompletions(
+        string nodeTypePath, string sourcePath, string proposedCode, SourcePosition position, int maxResults = 20)
+        => ResolveNode(nodeTypePath)
+            .SelectMany(node => IsNodeType(node)
+                ? GetOrBuildWorkspace(nodeTypePath).SelectMany(cached => cached is null
+                    ? Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>())
+                    : _ioPool.Run(ct => GetOverlayCompletionsAsync(
+                        cached, sourcePath, proposedCode, position, maxResults, ct)))
+                // Not a NodeType → a standalone SCRIPT Code node (e.g. a course lesson cell):
+                // complete in the kernel's script environment.
+                : _ioPool.Run(ct => GetScriptCompletionsAsync(proposedCode, position, maxResults, ct)));
+
     public IObservable<IReadOnlyList<DiagnosticInfo>> CheckSpeculative(
         string nodeTypePath, string sourcePath, string proposedCode)
         => ResolveNode(nodeTypePath)
-            .SelectMany(node => node is null
-                ? Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>())
-                : compilationService.GetCompilationInputsAsync(node)
+            .SelectMany(node => IsNodeType(node)
+                ? compilationService.GetCompilationInputsAsync(node!)
                     .SelectMany(inputs => inputs is null
                         ? Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>())
                         : _ioPool.Run(ct =>
-                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct))));
+                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct)))
+                // Not a NodeType → a standalone script Code node: diagnose in the script
+                // environment so lesson cells get live squiggles too (this used to fall
+                // through to a compilation that parses a cell as REGULAR C#, reporting the
+                // spurious "top-level statements must be in an executable" on every cell).
+                : _ioPool.Run(ct => GetScriptDiagnosticsAsync(proposedCode, ct)));
+
+    /// <summary>
+    /// Is the completion/diagnostics owner an actual NodeType definition (whose sources
+    /// compile as a library), as opposed to any other node — a Markdown lesson page, a bare
+    /// Code node — whose code the kernel runs as a SCRIPT? This is the ONE dispatch between
+    /// the two language environments, and it must key on what the node IS: a plain Code node
+    /// still produces compilation inputs, so "inputs resolved" never distinguished them.
+    /// </summary>
+    private static bool IsNodeType(MeshNode? node)
+        => node is not null
+            && string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal);
 
     /// <inheritdoc />
     public void Evict(string nodeTypePath)
@@ -210,7 +250,6 @@ internal sealed class MeshNodeLanguageService(
 
         var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
         if (compilation is null) return Array.Empty<DiagnosticInfo>();
-
         var diags = compilation.GetDiagnostics(ct);
         if (diags.IsDefaultOrEmpty) return Array.Empty<DiagnosticInfo>();
 
@@ -253,7 +292,91 @@ internal sealed class MeshNodeLanguageService(
     {
         var document = cached.Workspace.CurrentSolution.GetDocument(docId);
         if (document is null) return Array.Empty<CompletionEntry>();
+        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+    }
 
+    /// <summary>
+    /// Overlay completions inside a NodeType's compilation: the CURRENT solution with the one
+    /// document's text substituted by the editor's in-flight code (an unknown
+    /// <paramref name="sourcePath"/> is added as a new document — same tolerance as
+    /// <see cref="CheckSpeculative"/>). Forked solutions are immutable, so concurrent suggest
+    /// requests never contend and nothing needs applying back.
+    /// </summary>
+    private static async Task<IReadOnlyList<CompletionEntry>> GetOverlayCompletionsAsync(
+        CachedWorkspace cached, string sourcePath, string proposedCode, SourcePosition position,
+        int maxResults, CancellationToken ct)
+    {
+        var solution = cached.Workspace.CurrentSolution;
+        Document? document;
+        if (cached.DocumentsByPath.TryGetValue(sourcePath, out var docId))
+        {
+            document = solution
+                .WithDocumentText(docId, SourceText.From(proposedCode))
+                .GetDocument(docId);
+        }
+        else
+        {
+            var newId = DocumentId.CreateNewId(cached.ProjectId);
+            document = solution
+                .AddDocument(newId, sourcePath, SourceText.From(proposedCode), filePath: sourcePath)
+                .GetDocument(newId);
+        }
+        if (document is null) return Array.Empty<CompletionEntry>();
+        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Completions for a standalone SCRIPT Code node in the environment the kernel executes
+    /// it in — script-kind parsing, the kernel's default imports and process-shared reference
+    /// set, and the script globals type in scope (see <c>MeshScriptEnvironment</c>), so the
+    /// editor suggests exactly what a ▶ Run can use.
+    /// </summary>
+    private async Task<IReadOnlyList<CompletionEntry>> GetScriptCompletionsAsync(
+        string proposedCode, SourcePosition position, int maxResults, CancellationToken ct)
+    {
+        var script = _scriptWorkspace.Value;
+        var document = script.Workspace.CurrentSolution
+            .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
+            .GetDocument(script.DocumentId);
+        if (document is null) return Array.Empty<CompletionEntry>();
+        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Diagnostics for a standalone SCRIPT Code node — the script-environment sibling of
+    /// <see cref="SpeculativeCompilation"/>, so lesson cells get live squiggles.
+    /// </summary>
+    private async Task<IReadOnlyList<DiagnosticInfo>> GetScriptDiagnosticsAsync(
+        string proposedCode, CancellationToken ct)
+    {
+        var script = _scriptWorkspace.Value;
+        var document = script.Workspace.CurrentSolution
+            .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
+            .GetDocument(script.DocumentId);
+        var compilation = document is null
+            ? null
+            : await document.Project.GetCompilationAsync(ct).ConfigureAwait(false);
+        if (compilation is null) return Array.Empty<DiagnosticInfo>();
+
+
+        var diags = compilation.GetDiagnostics(ct);
+        if (diags.IsDefaultOrEmpty) return Array.Empty<DiagnosticInfo>();
+        var result = new List<DiagnosticInfo>();
+        foreach (var d in diags)
+        {
+            if (d.Severity == RoslynDiagnosticSeverity.Hidden) continue;
+            result.Add(ToDiagnosticInfo(d));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The shared core: Roslyn <see cref="CompletionService"/> over one document at one
+    /// position, flattened to <see cref="CompletionEntry"/>.
+    /// </summary>
+    private static async Task<IReadOnlyList<CompletionEntry>> CompleteAsync(
+        Document document, SourcePosition position, int maxResults, CancellationToken ct)
+    {
         var text = await document.GetTextAsync(ct).ConfigureAwait(false);
         var offset = TryGetOffset(text, position);
         if (offset is null) return Array.Empty<CompletionEntry>();
@@ -264,11 +387,29 @@ internal sealed class MeshNodeLanguageService(
         var list = await service.GetCompletionsAsync(document, offset.Value, cancellationToken: ct).ConfigureAwait(false);
         if (list is null || list.ItemsList.Count == 0) return Array.Empty<CompletionEntry>();
 
-        var take = Math.Min(maxResults, list.ItemsList.Count);
-        var result = new List<CompletionEntry>(take);
-        for (var i = 0; i < take; i++)
+        // 🚨 Filter by the word being typed BEFORE truncating. Roslyn returns every symbol in
+        // scope, alphabetically — a bare Take(maxResults) keeps the A's and drops everything
+        // after them, so typing "Mes" could never reach "Mesh" no matter how the client
+        // filters afterwards. The prefix comes from the completion list's own span (the token
+        // Roslyn would replace), so it is exactly what the user has typed at the caret.
+        var prefix = list.Span.Length > 0 && list.Span.End <= text.Length
+            ? text.ToString(list.Span)
+            : string.Empty;
+
+        var ranked = (prefix.Length == 0
+                ? (IEnumerable<CompletionItem>)list.ItemsList
+                : list.ItemsList
+                    .Where(i => Matches(i, prefix))
+                    // Prefix matches first (what the user is literally typing), then Roslyn's
+                    // own ranking within each group.
+                    .OrderByDescending(i => (i.FilterText ?? i.DisplayText)
+                        .StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    .ThenBy(i => i.SortText ?? i.DisplayText, StringComparer.OrdinalIgnoreCase))
+            .Take(maxResults);
+
+        var result = new List<CompletionEntry>();
+        foreach (var item in ranked)
         {
-            var item = list.ItemsList[i];
             result.Add(new CompletionEntry(
                 Label: item.DisplayText,
                 Kind: MapTagsToKind(item.Tags),
@@ -278,6 +419,35 @@ internal sealed class MeshNodeLanguageService(
                 SortText: item.SortText));
         }
         return result;
+    }
+
+    /// <summary>Does a completion item match the typed prefix — by prefix, else by substring
+    /// (so "grid" still finds "DataGrid", the way an editor's fuzzy match behaves)?</summary>
+    private static bool Matches(CompletionItem item, string prefix)
+    {
+        var filterText = item.FilterText ?? item.DisplayText;
+        return filterText.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            || filterText.Contains(prefix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Blanks kernel-only directive lines (<c>#r "nuget: …"</c> — restored out of band by the
+    /// kernel, unknown to a workspace compilation) while PRESERVING line numbers, so positions
+    /// and diagnostic locations still line up with the editor's text.
+    /// </summary>
+    internal static string StripKernelDirectives(string code)
+    {
+        if (string.IsNullOrEmpty(code) || !code.Contains("#r", StringComparison.Ordinal))
+            return code;
+        var lines = code.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (trimmed.StartsWith("#r", StringComparison.Ordinal)
+                && trimmed.Contains("nuget:", StringComparison.OrdinalIgnoreCase))
+                lines[i] = string.Empty;
+        }
+        return string.Join("\n", lines);
     }
 
     private static DiagnosticInfo ToDiagnosticInfo(Diagnostic d)
@@ -381,6 +551,52 @@ internal sealed class MeshNodeLanguageService(
         }
         return CompletionKind.Text;
     }
+
+    /// <summary>
+    /// Builds the script workspace mirroring the kernel's execution environment
+    /// (<c>MeshScriptEnvironment</c>): script-kind parsing, the default imports as the
+    /// compilation's usings, the process-shared reference set, the shared metadata resolver,
+    /// and the script globals as the submission's host object — so <c>Mesh</c>, <c>Log</c>,
+    /// <c>Ct</c> and <c>Inputs</c> complete as bare identifiers exactly as they run.
+    /// </summary>
+    private static ScriptWorkspace BuildScriptWorkspace(IServiceProvider serviceProvider)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var docId = DocumentId.CreateNewId(projectId);
+        var projectInfo = ProjectInfo
+            .Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "MeshScript",
+                assemblyName: "MeshScript",
+                language: LanguageNames.CSharp,
+                compilationOptions: new CSharpCompilationOptions(
+                        OutputKind.DynamicallyLinkedLibrary,
+                        metadataReferenceResolver: Kernel.Hub.MeshScriptEnvironment.MetadataResolver)
+                    .WithUsings(Kernel.Hub.MeshScriptEnvironment.Imports),
+                parseOptions: new CSharpParseOptions(kind: SourceCodeKind.Script),
+                metadataReferences: Kernel.Hub.MeshScriptEnvironment.References(serviceProvider),
+                isSubmission: true,
+                hostObjectType: Kernel.Hub.MeshScriptEnvironment.GlobalsType)
+            .WithDocuments(
+            [
+                DocumentInfo.Create(
+                    docId,
+                    name: ScriptDocumentPath,
+                    filePath: ScriptDocumentPath,
+                    sourceCodeKind: SourceCodeKind.Script,
+                    loader: TextLoader.From(TextAndVersion.Create(
+                        SourceText.From(string.Empty), VersionStamp.Create()))),
+            ]);
+        workspace.AddProject(projectInfo);
+        return new ScriptWorkspace(workspace, projectId, docId);
+    }
+
+    private sealed record ScriptWorkspace(
+        AdhocWorkspace Workspace,
+        ProjectId ProjectId,
+        DocumentId DocumentId);
 
     private sealed record CachedWorkspace(
         AdhocWorkspace Workspace,

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -58,6 +58,11 @@ internal sealed class MeshNodeLanguageService(
     // Path used as the script document's FilePath — never a real MeshNode path.
     private const string ScriptDocumentPath = "__script__.csx";
 
+    // The likely-usage prior (how often each identifier occurs in the Code nodes this mesh
+    // already runs). Built lazily in the BACKGROUND and never awaited on a request — see
+    // CompletionUsageIndex; until it is ready, ranking simply proceeds without it.
+    private readonly CompletionUsageIndex usageIndex = new(hub, logger);
+
     // Compile pool: Roslyn LSP work is CPU-bound, so it routes through the bounded
     // Compile pool which caps concurrency so it can't starve other schedulers.
     // A bare Observable.FromAsync deadlocks under a blocking subscriber (SubscribeOn
@@ -90,18 +95,20 @@ internal sealed class MeshNodeLanguageService(
             {
                 if (cached is null || !cached.DocumentsByPath.TryGetValue(sourcePath, out var docId))
                     return Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>());
-                return _ioPool.Run(ct => GetCompletionsAsync(cached, docId, position, maxResults, ct));
+                return _ioPool.Run(ct => GetCompletionsAsync(cached, docId, position, maxResults, usageIndex, ct));
             });
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<CompletionEntry>> GetCompletions(
         string nodeTypePath, string sourcePath, string proposedCode, SourcePosition position, int maxResults = 20)
-        => ResolveNode(nodeTypePath)
+        // Kick the likely-usage prior's background refresh (never awaited — a cold or wedged
+        // index just means this request ranks without the corpus signal).
+        => Observable.Defer(() => { usageIndex.EnsureFresh(); return ResolveNode(nodeTypePath); })
             .SelectMany(node => IsNodeType(node)
                 ? GetOrBuildWorkspace(nodeTypePath).SelectMany(cached => cached is null
                     ? Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>())
                     : _ioPool.Run(ct => GetOverlayCompletionsAsync(
-                        cached, sourcePath, proposedCode, position, maxResults, ct)))
+                        cached, sourcePath, proposedCode, position, maxResults, usageIndex, ct)))
                 // Not a NodeType → a standalone SCRIPT Code node (e.g. a course lesson cell):
                 // complete in the kernel's script environment.
                 : _ioPool.Run(ct => GetScriptCompletionsAsync(proposedCode, position, maxResults, ct)));
@@ -288,11 +295,12 @@ internal sealed class MeshNodeLanguageService(
     }
 
     private static async Task<IReadOnlyList<CompletionEntry>> GetCompletionsAsync(
-        CachedWorkspace cached, DocumentId docId, SourcePosition position, int maxResults, CancellationToken ct)
+        CachedWorkspace cached, DocumentId docId, SourcePosition position, int maxResults,
+        CompletionUsageIndex? usage, CancellationToken ct)
     {
         var document = cached.Workspace.CurrentSolution.GetDocument(docId);
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -304,7 +312,7 @@ internal sealed class MeshNodeLanguageService(
     /// </summary>
     private static async Task<IReadOnlyList<CompletionEntry>> GetOverlayCompletionsAsync(
         CachedWorkspace cached, string sourcePath, string proposedCode, SourcePosition position,
-        int maxResults, CancellationToken ct)
+        int maxResults, CompletionUsageIndex? usage, CancellationToken ct)
     {
         var solution = cached.Workspace.CurrentSolution;
         Document? document;
@@ -322,7 +330,7 @@ internal sealed class MeshNodeLanguageService(
                 .GetDocument(newId);
         }
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -334,12 +342,13 @@ internal sealed class MeshNodeLanguageService(
     private async Task<IReadOnlyList<CompletionEntry>> GetScriptCompletionsAsync(
         string proposedCode, SourcePosition position, int maxResults, CancellationToken ct)
     {
+        var usage = usageIndex;
         var script = _scriptWorkspace.Value;
         var document = script.Workspace.CurrentSolution
             .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
             .GetDocument(script.DocumentId);
         if (document is null) return Array.Empty<CompletionEntry>();
-        return await CompleteAsync(document, position, maxResults, ct).ConfigureAwait(false);
+        return await CompleteAsync(document, position, maxResults, usage, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -375,7 +384,8 @@ internal sealed class MeshNodeLanguageService(
     /// position, flattened to <see cref="CompletionEntry"/>.
     /// </summary>
     private static async Task<IReadOnlyList<CompletionEntry>> CompleteAsync(
-        Document document, SourcePosition position, int maxResults, CancellationToken ct)
+        Document document, SourcePosition position, int maxResults, CompletionUsageIndex? usage,
+        CancellationToken ct)
     {
         var text = await document.GetTextAsync(ct).ConfigureAwait(false);
         var offset = TryGetOffset(text, position);
@@ -387,25 +397,42 @@ internal sealed class MeshNodeLanguageService(
         var list = await service.GetCompletionsAsync(document, offset.Value, cancellationToken: ct).ConfigureAwait(false);
         if (list is null || list.ItemsList.Count == 0) return Array.Empty<CompletionEntry>();
 
-        // 🚨 Filter by the word being typed BEFORE truncating. Roslyn returns every symbol in
-        // scope, alphabetically — a bare Take(maxResults) keeps the A's and drops everything
-        // after them, so typing "Mes" could never reach "Mesh" no matter how the client
-        // filters afterwards. The prefix comes from the completion list's own span (the token
-        // Roslyn would replace), so it is exactly what the user has typed at the caret.
+        // 🚨 Rank BEFORE truncating. Roslyn returns every symbol in scope, alphabetically — a
+        // bare Take(maxResults) keeps the A's and drops everything after them, so typing "Mes"
+        // could never reach "Mesh" no matter how the client filters afterwards. The word being
+        // completed comes from the completion list's own span (the token Roslyn would replace),
+        // so it is exactly what the user has typed at the caret.
         var prefix = list.Span.Length > 0 && list.Span.End <= text.Length
             ? text.ToString(list.Span)
             : string.Empty;
 
-        var ranked = (prefix.Length == 0
-                ? (IEnumerable<CompletionItem>)list.ItemsList
-                : list.ItemsList
-                    .Where(i => Matches(i, prefix))
-                    // Prefix matches first (what the user is literally typing), then Roslyn's
-                    // own ranking within each group.
-                    .OrderByDescending(i => (i.FilterText ?? i.DisplayText)
-                        .StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                    .ThenBy(i => i.SortText ?? i.DisplayText, StringComparer.OrdinalIgnoreCase))
-            .Take(maxResults);
+        // Two regimes, the same split every editor makes (VS Code: client fuzzy-scorer for the
+        // typed word, server sortText/priority for ties, learned prior otherwise):
+        //
+        //   • The user has TYPED something → MATCH QUALITY decides, and Roslyn's own matcher is
+        //     the authority (exact > prefix > CamelCase hump > substring, honouring the
+        //     MatchPriority that target-typing sets). Popularity must NOT reorder across match
+        //     quality here, or typing "Bad" would surface the popular "Stack" above "Badge".
+        //   • The user has typed NOTHING (just pressed `.`) → there is no match quality to rank
+        //     by and alphabetical is worthless. This is where LIKELY USAGE decides: how often
+        //     each identifier occurs in the code this mesh already runs, plus a locality bonus
+        //     for identifiers already in this very cell (VS Code's locality bonus, and the
+        //     signal IntelliCode models over a public corpus — ours is better, it is the
+        //     MeshWeaver idiom itself).
+        IEnumerable<CompletionItem> ranked;
+        if (prefix.Length > 0)
+        {
+            ranked = service.FilterItems(document, list.ItemsList.ToImmutableArray(), prefix);
+        }
+        else
+        {
+            var local = LocalIdentifierCounts(text.ToString());
+            ranked = list.ItemsList
+                .OrderByDescending(i => UsageScore(i, usage, local))
+                .ThenByDescending(i => i.Rules.MatchPriority)
+                .ThenBy(i => i.SortText ?? i.DisplayText, StringComparer.OrdinalIgnoreCase);
+        }
+        ranked = ranked.Take(maxResults);
 
         var result = new List<CompletionEntry>();
         foreach (var item in ranked)
@@ -421,13 +448,36 @@ internal sealed class MeshNodeLanguageService(
         return result;
     }
 
-    /// <summary>Does a completion item match the typed prefix — by prefix, else by substring
-    /// (so "grid" still finds "DataGrid", the way an editor's fuzzy match behaves)?</summary>
-    private static bool Matches(CompletionItem item, string prefix)
+    /// <summary>
+    /// The likely-usage score for one candidate: how often the identifier appears in THIS cell
+    /// (weighted heavily — the strongest signal about what the author is doing right now, and it
+    /// works on a cold index) plus how often it appears across the mesh's existing Code nodes.
+    /// </summary>
+    private static int UsageScore(
+        CompletionItem item, CompletionUsageIndex? usage, IReadOnlyDictionary<string, int> local)
     {
-        var filterText = item.FilterText ?? item.DisplayText;
-        return filterText.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            || filterText.Contains(prefix, StringComparison.OrdinalIgnoreCase);
+        var name = item.FilterText is { Length: > 0 } f ? f : item.DisplayText;
+        var localCount = local.TryGetValue(name, out var n) ? n : 0;
+        return (LocalityWeight * localCount) + (usage?.Frequency(name) ?? 0);
+    }
+
+    /// <summary>How much an occurrence in the current cell outweighs one in the corpus.</summary>
+    private const int LocalityWeight = 5;
+
+    /// <summary>Identifier occurrences within the cell being edited (VS Code's locality bonus).</summary>
+    private static Dictionary<string, int> LocalIdentifierCounts(string code)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(code))
+            return counts;
+        foreach (System.Text.RegularExpressions.Match m in
+                 System.Text.RegularExpressions.Regex.Matches(code, @"[A-Za-z_][A-Za-z0-9_]*"))
+        {
+            var token = m.Value;
+            if (token.Length < 2) continue;
+            counts[token] = counts.TryGetValue(token, out var n) ? n + 1 : 1;
+        }
+        return counts;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -414,68 +414,22 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         scriptLogger = new ScriptLogger(defaultLogger);
         scriptGlobals = new MeshScriptGlobals { Mesh = publicHub, Log = scriptLogger };
 
-        // Curated anchors + DI-contributed module assemblies. The full reference
-        // set ("every loaded non-dynamic assembly with a usable Location, so
-        // scripts can reach types from packages the host already loaded") comes
-        // from KernelScriptReferences — a process-shared, materialized-ONCE
-        // PortableExecutableReference snapshot. 🚨 Never pass raw Assembly objects
-        // to WithReferences here: Roslyn then materializes a fresh AssemblyMetadata
-        // + native metadata block per reference PER SESSION (~350 refs ≈ 150-200 MiB
-        // of native memory per kernel session, never reclaimed — the CI
-        // memory-pressure leak; see KernelScriptReferences docs).
-        var sessionAssemblies = new HashSet<Assembly>
-        {
-            typeof(IMessageHub).Assembly,
-            typeof(Address).Assembly,
-            typeof(UiControl).Assembly,
-            typeof(DataExtensions).Assembly,
-            typeof(EntityStore).Assembly,
-            typeof(System.ComponentModel.DescriptionAttribute).Assembly,
-            typeof(System.ComponentModel.DataAnnotations.RequiredAttribute).Assembly,
-            typeof(System.Reactive.Linq.Observable).Assembly,
-            typeof(FluentIcons).Assembly,
-            typeof(ILogger).Assembly,
-            typeof(LoggerExtensions).Assembly,
-            typeof(MeshScriptGlobals).Assembly,
-        };
-
-        // Modules that ship script templates (export, import, …) register their
-        // own assembly via DI so it's guaranteed in the references set even if it
-        // hasn't been loaded yet when the shared snapshot was taken. Each module
-        // pushes one <see cref="KernelScriptAssembly"/> singleton (or singletons)
-        // and we enumerate them here.
-        foreach (var contrib in publicHub.ServiceProvider
-                     .GetServices<KernelScriptAssembly>())
-        {
-            sessionAssemblies.Add(contrib.Assembly);
-        }
-
+        // Curated anchors + DI-contributed module assemblies + default imports all come
+        // from MeshScriptEnvironment — the ONE description of the script environment,
+        // shared with the language service's completion workspace so the editor suggests
+        // exactly what the kernel can run. 🚨 Never pass raw Assembly objects to
+        // WithReferences: Roslyn then materializes a fresh AssemblyMetadata + native
+        // metadata block per reference PER SESSION (~350 refs ≈ 150-200 MiB of native
+        // memory per kernel session, never reclaimed — the CI memory-pressure leak; see
+        // KernelScriptReferences docs).
         scriptOptions = ScriptOptions.Default
-            .WithReferences(KernelScriptReferences.GetReferences(sessionAssemblies))
+            .WithReferences(MeshScriptEnvironment.References(publicHub.ServiceProvider))
             // 🚨 Required for the sharing to be complete: the compilation resolves
             // the globals type's transitive closure via ResolveMissingAssembly —
             // with the default resolver that re-materializes every assembly's
             // native metadata PER SESSION (the other half of the leak).
-            .WithMetadataResolver(SharedScriptMetadataResolver.Instance)
-            .WithImports(
-                "System",
-                "System.Linq",
-                "System.Collections.Generic",
-                "System.ComponentModel",
-                "System.ComponentModel.DataAnnotations",
-                "System.Reactive.Linq",
-                "System.Text.Json",
-                "Microsoft.Extensions.Logging",
-                "MeshWeaver.Application.Styles",
-                "MeshWeaver.Layout",
-                // LayoutAreaHost + RenderingContext live here — used by the WithView((host, ctx) => …)
-                // lambda in nearly every `--render` layout cell. Companion to MeshWeaver.Layout above,
-                // so authors don't have to add the extra using for the standard layout-area pattern.
-                "MeshWeaver.Layout.Composition",
-                "MeshWeaver.Layout.DataGrid",
-                "MeshWeaver.Messaging",
-                "MeshWeaver.Mesh"
-            )
+            .WithMetadataResolver(MeshScriptEnvironment.MetadataResolver)
+            .WithImports(MeshScriptEnvironment.Imports)
             .WithEmitDebugInformation(true);
     }
 

--- a/src/MeshWeaver.Kernel.Hub/MeshScriptEnvironment.cs
+++ b/src/MeshWeaver.Kernel.Hub/MeshScriptEnvironment.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Messaging;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Kernel.Hub;
+
+/// <summary>
+/// The ONE description of the C# environment kernel scripts compile in — the curated
+/// assembly anchors, the default imports, the globals type, and the shared metadata
+/// resolver. <see cref="KernelExecutor"/> builds its <c>ScriptOptions</c> from this, and
+/// the language service builds its script-flavored completion workspace from the SAME
+/// values — so what the editor suggests is exactly what the kernel can run. Two copies
+/// of this list drift; this type is why there is only one.
+/// </summary>
+public static class MeshScriptEnvironment
+{
+    /// <summary>
+    /// The namespaces every kernel script sees without a <c>using</c> — applied via
+    /// <c>ScriptOptions.WithImports</c> at run time and as the compilation's usings in the
+    /// language-service script workspace.
+    /// </summary>
+    public static readonly ImmutableArray<string> Imports =
+    [
+        "System",
+        "System.Linq",
+        "System.Collections.Generic",
+        "System.ComponentModel",
+        "System.ComponentModel.DataAnnotations",
+        "System.Reactive.Linq",
+        "System.Text.Json",
+        "Microsoft.Extensions.Logging",
+        "MeshWeaver.Application.Styles",
+        "MeshWeaver.Layout",
+        // LayoutAreaHost + RenderingContext live here — used by the WithView((host, ctx) => …)
+        // lambda in nearly every `--render` layout cell. Companion to MeshWeaver.Layout above,
+        // so authors don't have to add the extra using for the standard layout-area pattern.
+        "MeshWeaver.Layout.Composition",
+        "MeshWeaver.Layout.DataGrid",
+        "MeshWeaver.Messaging",
+        "MeshWeaver.Mesh",
+    ];
+
+    /// <summary>The globals type whose properties scripts address as bare identifiers
+    /// (<c>Mesh</c>, <c>Log</c>, <c>Ct</c>, <c>Inputs</c>).</summary>
+    public static Type GlobalsType => typeof(MeshScriptGlobals);
+
+    /// <summary>
+    /// The shared, process-memoized metadata resolver — REQUIRED wherever script code is
+    /// compiled (run time or language service): the default resolver re-materializes the
+    /// globals type's whole transitive closure of native metadata per compilation (the
+    /// ~200 MiB-per-session leak documented on <see cref="KernelScriptReferences"/>).
+    /// </summary>
+    public static MetadataReferenceResolver MetadataResolver => SharedScriptMetadataResolver.Instance;
+
+    /// <summary>
+    /// The curated assembly anchors plus the DI-contributed module assemblies
+    /// (<see cref="KernelScriptAssembly"/>) for one script session.
+    /// </summary>
+    public static IReadOnlyCollection<Assembly> SessionAssemblies(IServiceProvider serviceProvider)
+    {
+        var assemblies = new HashSet<Assembly>
+        {
+            typeof(IMessageHub).Assembly,
+            typeof(Address).Assembly,
+            typeof(UiControl).Assembly,
+            typeof(DataExtensions).Assembly,
+            typeof(EntityStore).Assembly,
+            typeof(System.ComponentModel.DescriptionAttribute).Assembly,
+            typeof(System.ComponentModel.DataAnnotations.RequiredAttribute).Assembly,
+            typeof(System.Reactive.Linq.Observable).Assembly,
+            typeof(FluentIcons).Assembly,
+            typeof(ILogger).Assembly,
+            typeof(LoggerExtensions).Assembly,
+            typeof(MeshScriptGlobals).Assembly,
+        };
+        foreach (var contrib in serviceProvider.GetServices<KernelScriptAssembly>())
+            assemblies.Add(contrib.Assembly);
+        return assemblies;
+    }
+
+    /// <summary>
+    /// The full, process-shared metadata reference set for a script session — the shared
+    /// snapshot of every referenceable loaded assembly plus the session anchors. Safe to
+    /// hand to a Roslyn workspace: every instance is the one shared materialization.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> References(IServiceProvider serviceProvider)
+        => KernelScriptReferences.GetReferences(SessionAssemblies(serviceProvider));
+}

--- a/src/MeshWeaver.Mesh.Contract/CompletionMemory.cs
+++ b/src/MeshWeaver.Mesh.Contract/CompletionMemory.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One remembered completion acceptance: what the user picked, and what they had typed when they
+/// picked it.
+/// </summary>
+/// <param name="Key">Identity of the chosen item — kind + label, so <c>Stack</c> the property and
+/// <c>Stack</c> the class are remembered separately (VS Code keys its LRU the same way).</param>
+/// <param name="Prefix">The word being completed at the moment of acceptance ("" when the user had
+/// typed nothing — e.g. accepted straight off a <c>.</c>).</param>
+/// <param name="Label">The item's label, which is what a later selection matches against.</param>
+/// <param name="Kind">The LSP completion kind, as its wire value.</param>
+/// <param name="Touch">Monotonic acceptance sequence — higher is more recent.</param>
+public sealed record CompletionMemoryEntry(string Key, string Prefix, string Label, int Kind, long Touch);
+
+/// <summary>
+/// A user's completion acceptance history — the mesh's equivalent of VS Code's suggest memory
+/// (<c>editor.suggestSelection</c>), stored per user at <c>{userId}/_Settings/Completions</c>.
+///
+/// <para><b>Why it exists.</b> Frequency over a corpus predicts what people generally write;
+/// it cannot know that <i>you</i> always pick <c>Markdown</c> off <c>Controls.</c>. VS Code's
+/// answer is to remember acceptances and use them to choose the SELECTED item — never to reorder
+/// the list, so the matcher's ranking is left intact and only the highlighted row changes. This
+/// type is that memory, and <see cref="Select"/> reproduces both of VS Code's modes:</para>
+/// <list type="bullet">
+///   <item><b>recentlyUsedByPrefix</b> — the strongest signal: what you accepted last time you had
+///   typed this word. VS Code stores prefixes in a trie and looks up the LONGEST stored prefix that
+///   is a prefix of the current word, so accepting <c>Stack</c> after typing <c>St</c> still
+///   selects it when you later type <c>Sta</c>. <see cref="Select"/> does the same.</item>
+///   <item><b>recentlyUsed</b> — the fallback when no prefix entry applies: among the candidates,
+///   the one accepted most recently.</item>
+/// </list>
+///
+/// <para>Bounded at <see cref="MaxEntries"/> (VS Code's own limit), dropping the least recently
+/// accepted — the memory is a ranking hint, so losing the tail is free.</para>
+/// </summary>
+public sealed record CompletionMemory
+{
+    /// <summary>The retained acceptances, newest-touch first is NOT guaranteed — read via <see cref="Select"/>.</summary>
+    public ImmutableList<CompletionMemoryEntry> Entries { get; init; } = ImmutableList<CompletionMemoryEntry>.Empty;
+
+    /// <summary>The monotonic acceptance counter backing <see cref="CompletionMemoryEntry.Touch"/>.</summary>
+    public long Sequence { get; init; }
+
+    /// <summary>How many acceptances are retained — VS Code's suggest-memory bound.</summary>
+    public const int MaxEntries = 300;
+
+    /// <summary>
+    /// Records an acceptance, replacing any previous entry for the same item+prefix and trimming
+    /// the least recently accepted once the bound is exceeded. Pure — returns the new memory.
+    /// </summary>
+    public CompletionMemory Record(string? prefix, string label, int kind)
+    {
+        if (string.IsNullOrEmpty(label))
+            return this;
+
+        var touch = Sequence + 1;
+        var key = KeyOf(kind, label);
+        var word = prefix ?? string.Empty;
+        var entries = Entries
+            .RemoveAll(e => string.Equals(e.Key, key, StringComparison.Ordinal)
+                && string.Equals(e.Prefix, word, StringComparison.OrdinalIgnoreCase))
+            .Add(new CompletionMemoryEntry(key, word, label, kind, touch));
+
+        if (entries.Count > MaxEntries)
+            entries = entries.OrderByDescending(e => e.Touch).Take(MaxEntries).ToImmutableList();
+
+        return this with { Entries = entries, Sequence = touch };
+    }
+
+    /// <summary>
+    /// The label to PRESELECT among <paramref name="candidates"/> for a user who has currently
+    /// typed <paramref name="prefix"/>, or null when this memory says nothing about them.
+    /// Prefix memory wins over plain recency (VS Code's by-prefix mode is the more specific
+    /// signal); within prefix memory the LONGEST stored prefix that still prefixes the typed word
+    /// wins, then the most recent. Pure and total.
+    /// </summary>
+    public string? Select(IReadOnlyCollection<(string Label, int Kind)> candidates, string? prefix)
+    {
+        if (Entries.IsEmpty || candidates.Count == 0)
+            return null;
+
+        var keys = candidates.Select(c => KeyOf(c.Kind, c.Label)).ToHashSet(StringComparer.Ordinal);
+        var word = prefix ?? string.Empty;
+
+        if (word.Length > 0)
+        {
+            var byPrefix = Entries
+                .Where(e => e.Prefix.Length > 0
+                    && word.StartsWith(e.Prefix, StringComparison.OrdinalIgnoreCase)
+                    && keys.Contains(e.Key))
+                .OrderByDescending(e => e.Prefix.Length)
+                .ThenByDescending(e => e.Touch)
+                .FirstOrDefault();
+            if (byPrefix is not null)
+                return byPrefix.Label;
+        }
+
+        return Entries
+            .Where(e => keys.Contains(e.Key))
+            .OrderByDescending(e => e.Touch)
+            .FirstOrDefault()
+            ?.Label;
+    }
+
+    /// <summary>Item identity: kind + label, so same-named symbols of different kinds stay distinct.</summary>
+    public static string KeyOf(int kind, string label) => $"{kind}:{label}";
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
@@ -49,6 +49,30 @@ public interface IMeshLanguageService
         int maxResults = 20);
 
     /// <summary>
+    /// OVERLAY completions: emits up to <paramref name="maxResults"/> completion entries at
+    /// <paramref name="position"/> WITHIN <paramref name="proposedCode"/> — the editor's
+    /// in-flight text, not the saved source. This is the method a live editor calls on every
+    /// suggest request; the position-only overload above completes against the last SAVED
+    /// text and is only right for read-side tooling.
+    /// <para>
+    /// When <paramref name="nodeTypePath"/> resolves to a NodeType, the completion runs in
+    /// that type's compilation with the one document substituted (the
+    /// <see cref="CheckSpeculative"/> shape). When it does NOT — a standalone script Code
+    /// node, e.g. a course lesson cell under a Markdown page — the completion runs in the
+    /// SCRIPT environment the kernel executes such cells in: script-kind parsing, the
+    /// kernel's default imports and reference set, and the script globals
+    /// (<c>Mesh</c>, <c>Log</c>, <c>Ct</c>, <c>Inputs</c>) in scope. So the editor suggests
+    /// exactly what a ▶ Run can use.
+    /// </para>
+    /// </summary>
+    IObservable<IReadOnlyList<CompletionEntry>> GetCompletions(
+        string nodeTypePath,
+        string sourcePath,
+        string proposedCode,
+        SourcePosition position,
+        int maxResults = 20);
+
+    /// <summary>
     /// Speculative pre-flight check: rebuild the NodeType's compilation with one source
     /// file replaced by <paramref name="proposedCode"/>, return all diagnostics. The
     /// substitute file is identified by <paramref name="sourcePath"/> — if no source at

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
@@ -90,6 +90,15 @@ public interface IMeshLanguageService
         string proposedCode);
 
     /// <summary>
+    /// Remembers that this user accepted <paramref name="label"/> while <paramref name="prefix"/>
+    /// was the word being completed — the acceptance history that preselects the same choice next
+    /// time (VS Code's <c>editor.suggestSelection: recentlyUsedByPrefix</c>, persisted per user).
+    /// Fire-and-forget: never blocks the editor, never throws, and does nothing for an anonymous
+    /// viewer. Writes are coalesced, so a burst of acceptances costs one save.
+    /// </summary>
+    void RecordCompletionAccepted(string prefix, string label, CompletionKind kind);
+
+    /// <summary>
     /// Drops and disposes the cached Roslyn workspace for <paramref name="nodeTypePath"/>, if any.
     /// Called when the NodeType's hub disposes (node deleted / grain deactivated) so its
     /// <c>AdhocWorkspace</c> — which strongly roots a full <c>CSharpCompilation</c>, every
@@ -137,13 +146,18 @@ public enum DiagnosticSeverity
 public sealed record HoverInfo(string ContentMarkdown, SourceRange? Range);
 
 /// <summary>One code-completion suggestion.</summary>
+/// <param name="Preselect">True on the ONE item the editor should highlight when the list opens —
+/// what this user accepted last time in this situation (see <c>CompletionMemory</c>). Mirrors LSP's
+/// <c>preselect</c> and VS Code's suggest memory: it moves the SELECTION only, never the order, so
+/// the matcher's ranking is left exactly as computed.</param>
 public sealed record CompletionEntry(
     string Label,
     CompletionKind Kind,
     string InsertText,
     string? Detail = null,
     string? Documentation = null,
-    string? SortText = null);
+    string? SortText = null,
+    bool Preselect = false);
 
 /// <summary>
 /// Completion-item kind. Values match the LSP wire protocol so they can be passed through to

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
@@ -623,4 +623,78 @@ var c = Controls.Bad";
             "a popular member that does not match the typed prefix must not appear. Got: {0}",
             string.Join(", ", completions.Select(c => c.Label)));
     }
+
+    [Fact]
+    public void CompletionMemory_ByPrefix_LongestStoredPrefixWins()
+    {
+        // VS Code's recentlyUsedByPrefix keeps prefixes in a trie and looks up the LONGEST stored
+        // prefix that still prefixes what you have typed — so accepting Stack after typing "St"
+        // keeps selecting it when you later type "Sta", and a more specific memory beats a
+        // shorter one.
+        var memory = new CompletionMemory()
+            .Record("St", "Stack", (int)CompletionKind.Property)
+            .Record("Sta", "StackPanel", (int)CompletionKind.Class);
+
+        var candidates = new[]
+        {
+            ("Stack", (int)CompletionKind.Property),
+            ("StackPanel", (int)CompletionKind.Class),
+            ("Standard", (int)CompletionKind.Class),
+        };
+
+        memory.Select(candidates, "Stac").Should().Be("StackPanel",
+            "the longer stored prefix 'Sta' is the more specific memory for 'Stac'");
+        memory.Select(candidates, "St").Should().Be("Stack",
+            "'Sta' does not prefix 'St', so the 'St' memory applies");
+    }
+
+    [Fact]
+    public void CompletionMemory_FallsBackToMostRecentlyAccepted()
+    {
+        // With nothing remembered for this word, VS Code's recentlyUsed mode picks the candidate
+        // accepted most recently — regardless of the prefix it was accepted under.
+        var memory = new CompletionMemory()
+            .Record("", "Markdown", (int)CompletionKind.Method)
+            .Record("", "Stack", (int)CompletionKind.Property);
+
+        var candidates = new[]
+        {
+            ("Badge", (int)CompletionKind.Method),
+            ("Markdown", (int)CompletionKind.Method),
+            ("Stack", (int)CompletionKind.Property),
+        };
+
+        memory.Select(candidates, "").Should().Be("Stack", "Stack was accepted last");
+        memory.Record("", "Markdown", (int)CompletionKind.Method)
+            .Select(candidates, "").Should().Be("Markdown", "re-accepting Markdown makes it the most recent");
+    }
+
+    [Fact]
+    public void CompletionMemory_IgnoresWhatIsNotOffered_AndKeysOnKind()
+    {
+        var memory = new CompletionMemory().Record("", "Stack", (int)CompletionKind.Property);
+
+        memory.Select([("Badge", (int)CompletionKind.Method)], "").Should().BeNull(
+            "a remembered item that is not among the candidates must not be selected");
+        memory.Select([("Stack", (int)CompletionKind.Class)], "").Should().BeNull(
+            "memory keys on kind+label, so the class Stack is not the property Stack");
+    }
+
+    [Fact]
+    public void CompletionMemory_IsBounded_DroppingLeastRecent()
+    {
+        var memory = new CompletionMemory();
+        for (var i = 0; i < CompletionMemory.MaxEntries + 25; i++)
+            memory = memory.Record("", $"Item{i}", (int)CompletionKind.Method);
+
+        memory.Entries.Count.Should().Be(CompletionMemory.MaxEntries, "the memory is bounded");
+        memory.Select([("Item0", (int)CompletionKind.Method)], "").Should().BeNull(
+            "the least recently accepted entries are the ones dropped");
+        memory.Select([($"Item{CompletionMemory.MaxEntries + 24}", (int)CompletionKind.Method)], "")
+            .Should().NotBeNull("the most recent acceptance is retained");
+    }
+
+    [Fact]
+    public void CompletionMemoryPath_IsThePerUserSettingsNode()
+        => CompletionMemoryStore.PathFor("alice").Should().Be("alice/_Settings/Completions");
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
@@ -542,4 +542,85 @@ public static class Consumer
         completions.Should().OnlyContain(c => c.Label.Contains("Mes", System.StringComparison.OrdinalIgnoreCase),
             "every returned item must match the typed prefix");
     }
+
+    [Fact]
+    public void UsageTally_CountsIdentifiers_IgnoringKeywordsAndNoise()
+    {
+        var tally = CompletionUsageIndex.Tally(
+        [
+            "var s = Controls.Stack.WithView(Controls.Markdown(\"x\"));",
+            "Controls.Stack.WithView(Controls.DataGrid(rows));",
+            "return Controls.Stack;",
+        ]);
+
+        tally["Stack"].Should().Be(3, "Stack occurs in all three sources");
+        tally["Controls"].Should().Be(5);
+        tally["Markdown"].Should().Be(1);
+        tally.ContainsKey("var").Should().BeFalse("C# keywords carry no ranking signal");
+        tally.ContainsKey("return").Should().BeFalse();
+        tally.ContainsKey("s").Should().BeFalse("single characters are noise");
+    }
+
+    [Fact]
+    public async Task ScriptCompletions_NoPrefix_RankByLikelyUsage_NotTheAlphabet()
+    {
+        // Just typed `Controls.` — there is no word to match on, so alphabetical ordering is
+        // worthless (it leads with Badge/Body/Button). Ranking must instead follow LIKELY USAGE:
+        // the locality bonus from this very cell (the strongest, always-available signal — VS
+        // Code does the same) ahead of the alphabet.
+        await MeshService.CreateNode(new MeshNode("Rank", "script")
+        {
+            NodeType = "Code",
+            Name = "Rank",
+            Content = new CodeConfiguration { Code = "// owner", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+
+        // The cell already builds a Stack twice; the caret sits at the trailing `Controls.`.
+        const string cell = @"var a = Controls.Stack;
+var b = Controls.Stack;
+var c = Controls.";
+
+        var completions = await LanguageService
+            .GetCompletions("script/Rank", "script/Rank/Source/Cell", cell,
+                new SourcePosition(2, 17), maxResults: 10)
+            .Should().Within(60.Seconds()).Emit();
+
+        completions.Should().NotBeEmpty();
+        completions[0].Label.Should().Be("Stack",
+            "the member this cell actually uses must lead, not the alphabetically-first one. Got: {0}",
+            string.Join(", ", completions.Select(c => c.Label)));
+    }
+
+    [Fact]
+    public async Task ScriptCompletions_TypedPrefix_MatchQualityWinsOverPopularity()
+    {
+        // The complement of the rule above: once the user types, MATCH QUALITY decides. A
+        // popular-but-non-matching member must never displace what was literally typed —
+        // otherwise "Bad" would surface "Stack" because the cell is full of Stacks.
+        await MeshService.CreateNode(new MeshNode("Quality", "script")
+        {
+            NodeType = "Code",
+            Name = "Quality",
+            Content = new CodeConfiguration { Code = "// owner", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+
+        const string cell = @"var a = Controls.Stack;
+var b = Controls.Stack;
+var c = Controls.Bad";
+
+        var completions = await LanguageService
+            .GetCompletions("script/Quality", "script/Quality/Source/Cell", cell,
+                new SourcePosition(2, 20), maxResults: 10)
+            .Should().Within(60.Seconds()).Emit();
+
+        completions.Should().NotBeEmpty();
+        completions.Should().Contain(c => c.Label == "Badge",
+            "the typed prefix must be matched. Got: {0}",
+            string.Join(", ", completions.Select(c => c.Label)));
+        completions.Should().NotContain(c => c.Label == "Stack",
+            "a popular member that does not match the typed prefix must not appear. Got: {0}",
+            string.Join(", ", completions.Select(c => c.Label)));
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
@@ -368,4 +368,178 @@ public class CompletionDemo
             "string.Empty is a static member that must appear in completions. Got: {0}",
             string.Join(", ", completions.Select(c => c.Label)));
     }
+
+    [Fact]
+    public async Task OverlayCompletions_CompleteAgainstProposedText()
+    {
+        // The saved source has no member access anywhere; the completions must run against
+        // the PROPOSED text (the editor's in-flight buffer), not the saved one.
+        await SeedNodeType(
+            "OverlayDemo",
+            new NodeTypeDefinition { Configuration = "config => config.WithContentType<Widget>()" },
+            ("Widget.cs", @"
+public record Widget
+{
+    public string Name { get; init; } = string.Empty;
+    public double Price { get; init; }
+}")).Should().Within(60.Seconds()).Emit();
+
+        // Proposed: the same record plus a consumer poised at `w.` — line 8 (0-based),
+        // char 26 = right after the dot in "    public string M(Widget w) => w.".
+        const string proposed = @"
+public record Widget
+{
+    public string Name { get; init; } = string.Empty;
+    public double Price { get; init; }
+}
+public static class Consumer
+{
+    public static string M(Widget w) => w.
+}";
+
+        var completions = await LanguageService
+            .GetCompletions(
+                "type/OverlayDemo",
+                "type/OverlayDemo/Source/Widget.cs",
+                proposed,
+                new SourcePosition(8, 42),
+                maxResults: 100)
+            .Should().Within(60.Seconds()).Emit();
+
+        completions.Should().NotBeEmpty("member access on the proposed text must complete");
+        completions.Should().Contain(c => c.Label == "Name",
+            "Widget.Name must complete on `w.` in the PROPOSED buffer. Got: {0}",
+            string.Join(", ", completions.Select(c => c.Label)));
+        completions.Should().Contain(c => c.Label == "Price");
+    }
+
+    [Fact]
+    public async Task ScriptCompletions_ForStandaloneCodeNode_GlobalsAndImportsInScope()
+    {
+        // A Code node whose OWNER exists but is not a NodeType — the course lesson-cell
+        // shape (the owner is the lesson page). The language service must fall back to the
+        // kernel's SCRIPT environment: script-kind parsing, the default imports, and the
+        // script globals in scope.
+        await MeshService.CreateNode(new MeshNode("Lesson", "script")
+        {
+            NodeType = "Code",
+            Name = "Lesson",
+            Content = new CodeConfiguration { Code = "// lesson", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(new MeshNode("Cell", "script/Lesson/Source")
+        {
+            NodeType = "Code",
+            Name = "Cell",
+            Content = new CodeConfiguration { Code = "var x = 1;", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+
+        // `Controls.` — the layout factory from the default imports; char 9 = after the dot.
+        var members = await LanguageService
+            .GetCompletions(
+                "script/Lesson",
+                "script/Lesson/Source/Cell",
+                "Controls.",
+                new SourcePosition(0, 9),
+                maxResults: 200)
+            .Should().Within(60.Seconds()).Emit();
+        members.Should().Contain(c => c.Label == "Stack",
+            "Controls.Stack must complete in the script environment. Got: {0}",
+            string.Join(", ", members.Take(30).Select(c => c.Label)));
+
+        // Bare identifier: the script GLOBALS complete as if they were locals — `Mesh`
+        // is a property of the kernel's globals type, in scope only for a submission
+        // with that host object.
+        var globals = await LanguageService
+            .GetCompletions(
+                "script/Lesson",
+                "script/Lesson/Source/Cell",
+                "Mes",
+                new SourcePosition(0, 3),
+                maxResults: 200)
+            .Should().Within(60.Seconds()).Emit();
+        globals.Should().Contain(c => c.Label == "Mesh",
+            "the script global `Mesh` must complete as a bare identifier. Got: {0}",
+            string.Join(", ", globals.Take(30).Select(c => c.Label)));
+    }
+
+    [Fact]
+    public async Task ScriptDiagnostics_ForStandaloneCodeNode_SurfaceErrors()
+    {
+        // Same non-NodeType owner shape: CheckSpeculative must diagnose in the script
+        // environment instead of silently returning nothing (lesson cells get squiggles).
+        await MeshService.CreateNode(new MeshNode("Diag", "script")
+        {
+            NodeType = "Code",
+            Name = "Diag",
+            Content = new CodeConfiguration { Code = "// owner", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(new MeshNode("Bad", "script/Diag/Source")
+        {
+            NodeType = "Code",
+            Name = "Bad",
+            Content = new CodeConfiguration { Code = "var ok = 1;", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+
+        var diagnostics = await LanguageService
+            .CheckSpeculative("script/Diag", "script/Diag/Source/Bad", "var x = notDefined;")
+            .Should().Within(60.Seconds()).Emit();
+        diagnostics.Should().Contain(d => d.Severity == LspDiagnosticSeverity.Error
+                && d.Message.Contains("notDefined", System.StringComparison.Ordinal),
+            "an undefined identifier must surface as an error in the script environment. Got: {0}",
+            string.Join("; ", diagnostics.Select(d => $"{d.Id} {d.Severity} {d.Message}")));
+
+        // And a clean script — including the trailing-expression return value and a kernel-only
+        // #r nuget directive (stripped with line numbers preserved) — has no errors.
+        var clean = await LanguageService
+            .CheckSpeculative("script/Diag", "script/Diag/Source/Bad",
+                "#r \"nuget: Some.Package\"\nvar y = 2;\ny + 1")
+            .Should().Within(60.Seconds()).Emit();
+        clean.Where(d => d.Severity == LspDiagnosticSeverity.Error).Should().BeEmpty(
+            "a clean script cell (trailing expression, #r nuget stripped) must not error. Got: {0}",
+            string.Join("; ", clean.Select(d => $"{d.Id} {d.Severity} {d.Message}")));
+    }
+
+    [Fact]
+    public void StripKernelDirectives_PreservesLineNumbers()
+    {
+        const string code = "#r \"nuget: A.B\"\nvar x = 1;\n  #r \"nuget: C\"\nx + 1";
+        var stripped = MeshNodeLanguageService.StripKernelDirectives(code);
+        stripped.Split('\n').Length.Should().Be(code.Split('\n').Length,
+            "blanking directive lines must never shift positions");
+        stripped.Should().NotContain("nuget");
+        stripped.Split('\n')[1].Should().Be("var x = 1;");
+    }
+
+    [Fact]
+    public async Task ScriptCompletions_FilterByTypedPrefix_NotJustTheAlphabet()
+    {
+        // Roslyn returns EVERY symbol in scope, alphabetically. Truncating that to maxResults
+        // before considering the typed word keeps the A's and drops the rest — "Mes" could
+        // never reach "Mesh" however the client filters afterwards. The service must filter by
+        // the completion span's text first; this pins that (a small cap + a late-alphabet word).
+        await MeshService.CreateNode(new MeshNode("Prefix", "script")
+        {
+            NodeType = "Code",
+            Name = "Prefix",
+            Content = new CodeConfiguration { Code = "// owner", Language = "csharp" },
+            State = MeshNodeState.Active,
+        }).Should().Within(60.Seconds()).Emit();
+
+        var completions = await LanguageService
+            .GetCompletions("script/Prefix", "script/Prefix/Source/Cell", "Mes",
+                new SourcePosition(0, 3), maxResults: 15)
+            .Should().Within(60.Seconds()).Emit();
+
+        completions.Should().NotBeEmpty();
+        completions.Count.Should().BeLessThanOrEqualTo(15, "maxResults still caps the result");
+        completions.Should().Contain(c => c.Label == "Mesh",
+            "a late-alphabet match must survive a small cap — filtering happens BEFORE truncation. Got: {0}",
+            string.Join(", ", completions.Select(c => c.Label)));
+        completions.Should().OnlyContain(c => c.Label.Contains("Mes", System.StringComparison.OrdinalIgnoreCase),
+            "every returned item must match the typed prefix");
+    }
 }


### PR DESCRIPTION
Code-node Monaco editors had **diagnostics but no completions**. Two things were missing: the completion plumbing was shaped for `@`-reference *trigger tokens* (it cannot express "complete C# at line/column"), and the language service could only complete against **saved** text — useless while typing.

## What's in here

**1. Overlay completions.** `IMeshLanguageService` gains a `GetCompletions` overload taking the editor's in-flight buffer: the NodeType's solution is forked with that one document substituted (the `CheckSpeculative` shape), so suggestions reflect what is on screen. Forked solutions are immutable, so concurrent suggest requests never contend and nothing is applied back.

**2. A script environment for cells that aren't part of a NodeType compile** — a course lesson's `{lesson}/Source/{cell}`, whose owner is a Markdown page. Those execute on the kernel, so they now *complete* on the kernel's terms: script-kind parsing, its imports and reference set, and the script globals (`Mesh`, `Log`, `Ct`, `Inputs`) in scope. `MeshScriptEnvironment` is that one description and `KernelExecutor` now builds its `ScriptOptions` from the same values — the editor cannot drift from what ▶ Run accepts.

  The dispatch keys on whether the owner **is** a NodeType. "Did compilation inputs resolve" does *not* distinguish them — a plain Code node resolves inputs too — which silently parsed every lesson cell as regular C# and reported a spurious *"top-level statements must be in an executable"* on all of them. `CheckSpeculative` takes the same fork, so lesson cells get honest live squiggles too.

**3. A position-based Monaco provider** (`registerCodeCompletionProvider` + `GetCodeCompletions`), independent of the trigger-token one, with the LSP→Monaco kind mapping at the boundary and a bounded, never-throwing call so a stalled service cannot hang the suggest widget.

## The bug the tests caught

Filtering now happens **before** truncation. Roslyn returns every symbol in scope, alphabetically — a bare `Take(maxResults)` kept the A's and dropped everything after, so typing `Mes` could never reach `Mesh` no matter how the client filtered afterwards. The prefix comes from the completion list's own span; pinned by a test using a small cap and a late-alphabet match.

## Scope change

With the script environment in place, the old opt-in (C# only under a NodeType's `Source/` subtree) has no reason to exclude standalone cells: **every C# Code node now gets language services**, each answered by the environment it actually compiles in.

## Tests

`MeshNodeLanguageServiceTest` +5: overlay completes against proposed text; script completions resolve both imported types (`Controls.Stack`) and the globals (`Mesh`) as bare identifiers; script diagnostics surface real errors and stay quiet on a clean cell (trailing expression, `#r nuget` stripped with line numbers preserved); prefix filtering survives a small cap. 13/13 green, full solution builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)