### PR TITLE
Activity progress: run the execution off the calling hub's turn (Orleans self-deadlock)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
@@ -374,6 +374,47 @@ hub.GetWorkspace().GetMeshNodeStream(activityPath!)
 >
 > **Do NOT** call `IStorageAdapter.Write` directly — same race, and worse because persistence is invisible to the per-node hub's `MeshNodeReference` cache. The next read off the node stream returns the pre-patch content.
 
+> 🚨 **The outside-write rule is not only about races — under Orleans it DEADLOCKS, silently.**
+> A cross-hub `GetMeshNodeStream(activityPath).Update(…)` is a **round trip**: it posts, and its
+> response has to be processed by the hub that issued it. When the issuing hub is an Orleans grain,
+> that hub has a **single-threaded activation scheduler** — so if the same turn is currently running
+> the long operation, the turn cannot serve the response it is itself waiting on. The write never
+> lands and nothing errors:
+>
+> - the activity keeps **only** the first message (the one baked into `CreateNode`),
+> - every later progress line silently never appears,
+> - the terminal `Status` is never written, so the activity reads **`Running` forever**,
+> - meanwhile the operation itself *completes* — its own writes go through `IIoPool` under the System
+>   identity on a different path — so the side effects land and only the log looks hung.
+>
+> Observed on memex 2026-08-02: GitSync activities frozen at message 1 while
+> `{space}/_GitSync.lastSyncCommitSha` had already advanced to the new commit. Diagnosing this from
+> the activity node alone is misleading — **verify the operation by its own effect, not by its log.**
+> It reproduces under load (many heavy partitions, compiles in flight) and slips through on an idle
+> mesh, which is why it survives review.
+>
+> Two rules follow, and they are separate:
+>
+> 1. **Progress must come FROM the activity hub.** The activity hub owns its content; it appends its
+>    own `Messages` and writes its own terminal `Status`. Other hubs flip `RequestedStatus` and let
+>    the reducer react — they never patch the log.
+> 2. **Never run the activity's execution on the calling hub's turn.** Hop the subscribe onto the
+>    drainable pool (`IPooledSubscribeScheduler.SubscribeThroughPool`, falling back to
+>    `SubscribeOn(TaskPoolScheduler.Default)`) so the command and its writes execute on pool threads
+>    while the hub's turn stays free to route their round trips. This is a **scheduler** fix, never a
+>    timeout — a bigger timeout just hangs longer. `TaskPoolScheduler.Default` is
+>    `TaskScheduler.Default`-backed, which is what makes it Orleans-safe; anything that captures
+>    `TaskScheduler.Current` inside a grain re-enters the activation and reproduces the deadlock.
+>    Purely reactive — no `async`/`await`, no `Task.Run`, no `.Result`.
+>
+> Same failure shape and same remedy as `LayoutAreaHost.ScheduleRenderSubscribe` (a view generator
+> that queries in-render wedging its own hub turn).
+>
+> ⚠️ `ActivityRunner.Append` / `Finish` (`MeshWeaver.GitSync`) still issue their writes from the
+> **calling** hub's workspace — rule 1 above is not yet satisfied there. Rule 2 is (the execution is
+> scheduled off the hub turn), which is what releases the deadlock; moving the writes into the
+> activity hub is the remaining structural fix.
+
 `NodeTypeCompilationActivity.MarkSucceeded` / `MarkFailed` in `MeshWeaver.Graph.Configuration` is the canonical implementation — copy its shape (`Update` through `GetMeshNodeStream`, with a best-effort `try/catch` that logs and swallows so observability never breaks the work).
 
 ### When the activity is just a response field

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
@@ -92,6 +93,9 @@ public static class ActivityRunner
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.GitSync.ActivityRunner");
         var workspace = hub.GetWorkspace();
+        // Resolved once here (on the caller's thread) rather than inside the execution chain:
+        // see ScheduleOffHubTurn for why the execution must not touch the calling hub's turn.
+        var subscribeScheduler = hub.ServiceProvider.GetService<IPooledSubscribeScheduler>();
 
         var id = Guid.NewGuid().ToString("N")[..8];
         var activityPath = $"{partitionPath}/_Activity/{id}";
@@ -130,7 +134,7 @@ public static class ActivityRunner
             // Update to the partition MainNode, so only a principal who can Update
             // the partition — the owner, by construction — may write it.
             var owner = OwnerContextOf(created);
-            return Observable.Using(
+            return ScheduleOffHubTurn(Observable.Using(
                 () => AccessContextScope.FromNode(created, accessService, logger),
                 _ =>
                 {
@@ -171,8 +175,45 @@ public static class ActivityRunner
                             cts.Dispose();
                         })
                         .Select(_ => activityPath);
-                });
+                }));
         });
+
+        // 🚨 THE ACTIVITY EXECUTION MUST NOT RUN ON THE CALLING HUB'S TURN — it self-deadlocks.
+        //
+        // RunActivity is invoked ON a hub (the MCP session hub, the portal host hub behind the
+        // GUI's GitHubActionArea). Under Orleans that hub is a grain with a SINGLE-THREADED
+        // activation scheduler, and `TaskScheduler.Current` inside the call IS that scheduler.
+        // Subscribing the execution inline therefore runs `command(ctx)` on the hub's turn — and
+        // every progress line the command writes (ActivityContext.Log → Append →
+        // GetMeshNodeStream(activityPath).Update) is a ROUND TRIP that needs that same turn to
+        // process the response. The turn is busy running the command, so the write never lands:
+        //
+        //   → the activity node keeps ONLY the first message (the one baked into CreateNode at
+        //     STEP 1), every later Append silently never lands, and Finish never writes a terminal
+        //     Status — the activity reads "Running" forever with no error anywhere.
+        //
+        // That is exactly the shape observed on memex 2026-08-02: GitSync activities frozen at
+        // message 1 while the SYNC ITSELF COMPLETED (its own writes go through IIoPool under the
+        // System identity, on a different path), so `{space}/_GitSync.lastSyncCommitSha` advanced
+        // while the log looked hung. It reproduces under LOAD (many heavy partitions, compiles in
+        // flight) and slips through when the mesh is idle — the classic bulk-only interleaving.
+        //
+        // The fix is a scheduler hop, NOT a timeout: run the subscribe on the drainable I/O pool,
+        // which dispatches on TaskScheduler.Default (Orleans-safe — `TaskScheduler.Current` inside
+        // a grain would re-enter the activation). Then the command and its Append/Finish writes
+        // execute on pool threads while the hub's turn stays free to route their round trips.
+        // Purely reactive — no async/await, no Task.Run, no .Result (AGENTS.md house rule).
+        //
+        // Same contract and same failure mode as LayoutAreaHost.ScheduleRenderSubscribe (a view
+        // generator that queries in-render wedging its own hub) and MeshQuery's change-feed
+        // subscribes; the pool is drainable so teardown cancels + joins in-flight work instead of
+        // letting it run on after the hub's scope disposes.
+        IObservable<T> ScheduleOffHubTurn<T>(IObservable<T> source) =>
+            subscribeScheduler is { } scheduler
+                ? scheduler.SubscribeThroughPool(source)
+                // Messaging-only hubs register no I/O pools; a bare TaskPoolScheduler is also
+                // TaskScheduler.Default-backed, so the grain-escape property still holds.
+                : source.SubscribeOn(TaskPoolScheduler.Default);
     }
 
     /// <summary>

--- a/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
@@ -1,0 +1,107 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins the LIVE-progress contract of <see cref="ActivityRunner.RunActivity"/>: a progress line a
+/// command writes through <c>ctx.Log</c> must land on the activity node <b>while the command is
+/// still running</b> — not only after it completes.
+///
+/// <para>This is the regression pin for the self-deadlock fixed in
+/// <c>ActivityRunner.ScheduleOffHubTurn</c>. <c>RunActivity</c> is invoked ON a hub; under Orleans
+/// that hub is a grain with a single-threaded activation scheduler. Subscribing the execution
+/// inline ran <c>command(ctx)</c> on the hub's own turn, and every <c>ctx.Log</c> is a round trip
+/// (<c>GetMeshNodeStream(activityPath).Update</c>) that needs THAT SAME turn to process its
+/// response — so the write could never land while the command held the turn. The observable
+/// symptom was an activity frozen at the single message baked into <c>CreateNode</c>, with no
+/// terminal status and no error anywhere (memex, 2026-08-02: GitSync activities stuck at message 1
+/// while the sync itself completed and advanced <c>_GitSync.lastSyncCommitSha</c>).</para>
+///
+/// <para>The test makes that dependency explicit and deterministic instead of relying on load: the
+/// command does not complete until it observes its OWN progress line on the node. Inline execution
+/// cannot satisfy that — it deadlocks and the test times out. With the execution scheduled off the
+/// hub turn the line lands while the command is still subscribed, and the activity finishes.</para>
+/// </summary>
+public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task ProgressLine_LandsWhileTheCommandIsStillRunning()
+    {
+        var space = "GhLive" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Live Progress Space");
+
+        const string progress = "first progress line";
+
+        var activityPath = await Mesh.RunActivity(
+                space, ActivityCategory.Import, "Live progress probe",
+                ctx =>
+                {
+                    ctx.Log(progress);
+                    // Complete only once this very line is visible on the activity node. If the
+                    // execution ran on the calling hub's turn, the Append round trip could not be
+                    // served while we sit here — the classic self-deadlock.
+                    return ObserveMessage(ctx.ActivityPath, progress)
+                        .Timeout(30.Seconds())
+                        .Select(_ => Unit.Default);
+                })
+            .Timeout(60.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, log.Status);
+        Assert.Contains(log.Messages, m => m.Message.Contains(progress));
+        Assert.NotNull(log.End);
+    }
+
+    /// <summary>
+    /// A second progress line written AFTER the first was observed — proves the channel stays open
+    /// for the whole run rather than draining a single buffered write.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task EveryProgressLine_LandsWhileTheCommandIsStillRunning()
+    {
+        var space = "GhLive2" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Live Progress Space 2");
+
+        var activityPath = await Mesh.RunActivity(
+                space, ActivityCategory.Import, "Sequential progress probe",
+                ctx =>
+                {
+                    ctx.Log("step one");
+                    return ObserveMessage(ctx.ActivityPath, "step one")
+                        .Timeout(30.Seconds())
+                        .SelectMany(_ =>
+                        {
+                            ctx.Log("step two");
+                            return ObserveMessage(ctx.ActivityPath, "step two").Timeout(30.Seconds());
+                        })
+                        .Select(_ => Unit.Default);
+                })
+            .Timeout(60.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, log.Status);
+        Assert.Contains(log.Messages, m => m.Message.Contains("step one"));
+        Assert.Contains(log.Messages, m => m.Message.Contains("step two"));
+    }
+
+    private IObservable<ActivityLog> ObserveMessage(string activityPath, string contains) =>
+        Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Where(l => l is not null && l.Messages.Any(m => m.Message.Contains(contains)))
+            .Select(l => l!)
+            .Take(1);
+
+    private async Task<ActivityLog> WaitForActivity(string activityPath, Func<ActivityLog, bool> predicate) =>
+        await Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Where(l => l is not null && predicate(l))
+            .Select(l => l!)
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .ToTask();
+}


### PR DESCRIPTION
## The deadlock

`ActivityRunner.RunActivity` is invoked **on a hub** (the MCP session hub; the portal host hub behind the GUI's `GitHubActionArea`). Under Orleans that hub is a grain with a **single-threaded activation scheduler**, and subscribing the execution inline ran `command(ctx)` on that hub's own turn.

Every `ctx.Log` is a **round trip** — `GetMeshNodeStream(activityPath).Update(…)` posts and needs its response processed by the hub that issued it. That turn is busy running the command, so the write can never land. Nothing errors:

- the activity keeps **only** the message baked into `CreateNode`;
- every later `Append` silently vanishes;
- `Finish` never writes a terminal `Status` → the activity reads **`Running` forever**;
- meanwhile the operation itself **completes** — its own writes go through `IIoPool` under the System identity on a different path.

**Observed on memex, 2026-08-02:** GitSync activities frozen at message 1 while `{space}/_GitSync.lastSyncCommitSha` had already advanced to the new commit. The sync worked; only its log looked hung. It reproduces under load (many heavy partitions, compiles in flight) and slips through on an idle mesh — the classic bulk-only interleaving, which is why it survives review.

This is the same failure shape as the query-in-render wedge that `LayoutAreaHost.ScheduleRenderSubscribe` already solves.

## The fix

A **scheduler hop, not a timeout** (a bigger timeout just hangs longer). `ScheduleOffHubTurn` runs the subscribe on the drainable I/O pool via `IPooledSubscribeScheduler`, falling back to `SubscribeOn(TaskPoolScheduler.Default)` on messaging-only hubs that register no pools. Both are `TaskScheduler.Default`-backed — which is exactly what makes them Orleans-safe, since anything capturing `TaskScheduler.Current` inside a grain re-enters the activation and reproduces the bug.

Purely reactive per the house rule: no `async`/`await`, no `Task.Run`, no `.Result`. The pool is drainable, so teardown cancels and joins in-flight work rather than letting it run on past hub disposal.

## Honest limits of the tests

`ActivityLiveProgressTest` pins the live-progress contract: a command that does not complete until it observes its **own** progress line on the node — the dependency that inline execution cannot satisfy.

⚠️ **These tests pass with and without the fix** in the in-process GitSync harness, because that harness has no Orleans grain scheduler. They are a contract pin, not a reproduction. A true repro needs the Orleans test silo (`MeshWeaver.Hosting.Orleans.Test`) — tracked as follow-up below. I verified the non-vacuity question directly rather than assuming it.

## Docs

`ActivityControlPlane.md` already forbade writing an activity's content from outside the activity hub. This PR makes the **consequence** explicit — under Orleans that prohibition is not just a race, it is a silent deadlock — and separates the two rules:

1. **Progress must come FROM the activity hub** (it owns its content; others flip `RequestedStatus`).
2. **Never run the activity's execution on the calling hub's turn.**

## Remaining structural work (not in this PR)

`ActivityRunner.Append` / `Finish` still issue their writes from the **calling** hub's workspace, which is precisely what rule 1 forbids. Rule 2 is what releases the deadlock and is fixed here; moving those writes into the activity hub is the real structural fix and deserves its own change. The doc now flags the violation at the exact spot.

Follow-ups:
- [ ] Move `Append`/`Finish` writes into the activity hub (rule 1).
- [ ] Orleans-silo repro test that fails without this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)