### PR TITLE
Completions: an unreadable owner is UNKNOWN, not a script cell

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -108,41 +108,74 @@ internal sealed class MeshNodeLanguageService(
         // Kick the likely-usage prior's background refresh (never awaited — a cold or wedged
         // index just means this request ranks without the corpus signal).
         => Observable.Defer(() => { usageIndex.EnsureFresh(); return ResolveNode(nodeTypePath); })
-            .SelectMany(node => IsNodeType(node)
-                ? GetOrBuildWorkspace(nodeTypePath).SelectMany(cached => cached is null
-                    ? Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>())
-                    : _ioPool.Run(ct => GetOverlayCompletionsAsync(
-                        cached, sourcePath, proposedCode, position, maxResults, usageIndex,
-                        CurrentMemory(), ct)))
-                // Not a NodeType → a standalone SCRIPT Code node (e.g. a course lesson cell):
-                // complete in the kernel's script environment.
-                : _ioPool.Run(ct => GetScriptCompletionsAsync(proposedCode, position, maxResults, ct)));
+            .SelectMany(node => Environment(node, nodeTypePath) switch
+            {
+                CompletionEnvironment.NodeType => GetOrBuildWorkspace(nodeTypePath)
+                    .SelectMany(cached => cached is null
+                        ? Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>())
+                        : _ioPool.Run(ct => GetOverlayCompletionsAsync(
+                            cached, sourcePath, proposedCode, position, maxResults, usageIndex,
+                            CurrentMemory(), ct))),
+                // A non-NodeType owner that EXISTS → a standalone SCRIPT Code node (e.g. a course
+                // lesson cell): complete in the kernel's script environment.
+                CompletionEnvironment.Script =>
+                    _ioPool.Run(ct => GetScriptCompletionsAsync(proposedCode, position, maxResults, ct)),
+                // Owner unresolvable → we do not know which language environment applies, and
+                // guessing "script" would suggest globals (Mesh/Log/Ct) that do not exist in a
+                // NodeType source. No suggestions beats wrong ones.
+                _ => Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>()),
+            });
 
     public IObservable<IReadOnlyList<DiagnosticInfo>> CheckSpeculative(
         string nodeTypePath, string sourcePath, string proposedCode)
         => ResolveNode(nodeTypePath)
-            .SelectMany(node => IsNodeType(node)
-                ? compilationService.GetCompilationInputsAsync(node!)
+            .SelectMany(node => Environment(node, nodeTypePath) switch
+            {
+                CompletionEnvironment.NodeType => compilationService.GetCompilationInputsAsync(node!)
                     .SelectMany(inputs => inputs is null
                         ? Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>())
                         : _ioPool.Run(ct =>
-                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct)))
-                // Not a NodeType → a standalone script Code node: diagnose in the script
-                // environment so lesson cells get live squiggles too (this used to fall
-                // through to a compilation that parses a cell as REGULAR C#, reporting the
+                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct))),
+                // A non-NodeType owner that EXISTS → a standalone script Code node: diagnose in
+                // the script environment so lesson cells get live squiggles too (this used to
+                // fall through to a compilation that parses a cell as REGULAR C#, reporting the
                 // spurious "top-level statements must be in an executable" on every cell).
-                : _ioPool.Run(ct => GetScriptDiagnosticsAsync(proposedCode, ct)));
+                CompletionEnvironment.Script => _ioPool.Run(ct => GetScriptDiagnosticsAsync(proposedCode, ct)),
+                // Owner unresolvable → no honest environment to diagnose in; stay silent rather
+                // than paint squiggles computed under the wrong language rules.
+                _ => Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>()),
+            });
+
+    /// <summary>Which language environment a Code node's text belongs to.</summary>
+    private enum CompletionEnvironment
+    {
+        /// <summary>The owner could not be read — the environment is genuinely unknown.</summary>
+        Unknown,
+        /// <summary>The owner is a NodeType: its sources compile as a library.</summary>
+        NodeType,
+        /// <summary>The owner exists and is not a NodeType: the kernel runs this text as a script.</summary>
+        Script,
+    }
 
     /// <summary>
-    /// Is the completion/diagnostics owner an actual NodeType definition (whose sources
-    /// compile as a library), as opposed to any other node — a Markdown lesson page, a bare
-    /// Code node — whose code the kernel runs as a SCRIPT? This is the ONE dispatch between
-    /// the two language environments, and it must key on what the node IS: a plain Code node
-    /// still produces compilation inputs, so "inputs resolved" never distinguished them.
+    /// Classifies the owner, and it must key on what the node IS: a plain Code node still
+    /// produces compilation inputs, so "inputs resolved" never distinguished the two
+    /// environments. An owner that cannot be READ is <see cref="CompletionEnvironment.Unknown"/>
+    /// rather than script — inferring an environment from a failed read would offer script
+    /// globals inside a NodeType source. The one exception is an owner we have already compiled:
+    /// a cached workspace proves it is a NodeType, so a transient read failure does not
+    /// interrupt completions in the file the user is actually editing.
     /// </summary>
-    private static bool IsNodeType(MeshNode? node)
-        => node is not null
-            && string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal);
+    private CompletionEnvironment Environment(MeshNode? node, string nodeTypePath)
+    {
+        if (node is not null)
+            return string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal)
+                ? CompletionEnvironment.NodeType
+                : CompletionEnvironment.Script;
+        return _cache.ContainsKey(nodeTypePath)
+            ? CompletionEnvironment.NodeType
+            : CompletionEnvironment.Unknown;
+    }
 
     /// <inheritdoc />
     public void RecordCompletionAccepted(string prefix, string label, CompletionKind kind)

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
@@ -384,8 +384,9 @@ public record Widget
     public double Price { get; init; }
 }")).Should().Within(60.Seconds()).Emit();
 
-        // Proposed: the same record plus a consumer poised at `w.` — line 8 (0-based),
-        // char 26 = right after the dot in "    public string M(Widget w) => w.".
+        // Proposed: the same record plus a consumer poised at `w.` — line 8 (0-based) is
+        // "    public static string M(Widget w) => w.", whose 42 characters put the caret at
+        // char 42, right after the dot.
         const string proposed = @"
 public record Widget
 {
@@ -697,4 +698,23 @@ var c = Controls.Bad";
     [Fact]
     public void CompletionMemoryPath_IsThePerUserSettingsNode()
         => CompletionMemoryStore.PathFor("alice").Should().Be("alice/_Settings/Completions");
+
+    [Fact]
+    public async Task Completions_UnresolvableOwner_ReturnNothing_NotScriptGuesses()
+    {
+        // An owner that cannot be read leaves the language environment UNKNOWN. Guessing
+        // "script" there would offer the kernel globals (Mesh/Log/Ct) inside what might be a
+        // NodeType source — wrong suggestions, confidently presented. No suggestions is the
+        // honest answer, and the same for diagnostics.
+        var completions = await LanguageService
+            .GetCompletions("does/not/exist", "does/not/exist/Source/Cell", "Mes",
+                new SourcePosition(0, 3), maxResults: 20)
+            .Should().Within(60.Seconds()).Emit();
+        completions.Should().BeEmpty("an unresolvable owner has no known completion environment");
+
+        var diagnostics = await LanguageService
+            .CheckSpeculative("does/not/exist", "does/not/exist/Source/Cell", "var x = notDefined;")
+            .Should().Within(60.Seconds()).Emit();
+        diagnostics.Should().BeEmpty("nor any environment to diagnose in");
+    }
 }


### PR DESCRIPTION
Follow-up addressing the Copilot review on #757 (both comments).

**1. Unresolvable owner was inferred as 'script'.** The environment dispatch treated a null owner node the same as a non-NodeType one, so a missing or slow-to-read owner silently got script completions — inside a NodeType source that means offering kernel globals (`Mesh`, `Log`, `Ct`) which do not exist there. Wrong suggestions presented confidently are worse than none, so the classification is now three-way (`NodeType` / `Script` / `Unknown`) and an unresolvable owner yields an empty list, and no diagnostics, rather than a guess.

One deliberate exception keeps the editor responsive: an owner we have **already compiled** is known to be a NodeType from its cached workspace, so a transient read failure does not interrupt completions in the file the user is actually editing.

**2. Stale test comment** — it described the caret as "char 26" while the assertion uses 42.

New test pins the unknown-owner behaviour for both completions and diagnostics. 22/22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)