### PR TITLE
deploy: enable PreWarm__GateReadiness on managed envs — rolls wait for the compile

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -200,7 +200,7 @@ reverts them):
 | Knob | What it does |
 |---|---|
 | `config.memex_portal.PreWarm__DynamicTypes: "true"` | every new pod sweeps + compiles ALL dynamic NodeTypes at start (resumes from the shared `/data` cache — warm restarts are cheap) |
-| `config.memex_portal.PreWarm__GateReadiness` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **⛔ OFF until core #694 is fixed** — the two-silo roll window makes the sweep flake (see below) and the gate then stalls every rollout on FALSE regressions |
+| `config.memex_portal.PreWarm__GateReadiness: "true"` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **ON since 2026-08-02** (was held off for core #694, fixed by #718 + #719 on 2026-07-29). This is what makes a roll — including a self-update — *wait for the compile* before cutting traffic over. ⚠️ If a roll stalls with types flagged `Regressed` that compile clean on a single silo, that is #694 residue: set back to `"false"` and reopen — do NOT widen the probe budget to hide it |
 | `probes.startup: {periodSeconds: 10, failureThreshold: 1080}` | ⚠️ REQUIRED with the gate: a cold bake is ~90 s/type, sequential — the default 5 min budget kills the pod mid-bake forever |
 
 ⛔ **The bake Job (`bake.enabled`) stays OFF on AKS until core asserts fingerprint-match.** On its
@@ -228,7 +228,7 @@ Live-env equivalent without a helm apply (what enabled memex-cloud on 2026-07-30
 
 ```bash
 kubectl -n <env> patch configmap memex-portal-config --type merge \
-  -p '{"data":{"PreWarm__DynamicTypes":"true","PreWarm__GateReadiness":"false"}}'
+  -p '{"data":{"PreWarm__DynamicTypes":"true","PreWarm__GateReadiness":"true"}}'
 kubectl -n <env> patch deployment memex-portal-deployment --type json -p \
   '[{"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/periodSeconds","value":10},
     {"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/failureThreshold","value":1080}]'

--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -30,11 +30,21 @@ The self-updater itself only patches the image; the compiling happens on the NEW
 `PreWarm__DynamicTypes` (see `DEPLOY-RUNBOOK.md` §7): every new pod sweeps and compiles all dynamic
 NodeTypes at start, so an un-visited type can no longer sit "no definition" until its pages hang.
 Managed envs run the sweep ON — an env with it off has no deploy-time compile at all on this
-channel. The companion readiness gate (`PreWarm__GateReadiness`) additionally stalls a rollout on a
-type that regressed on the new image (`maxSurge 1 / maxUnavailable 0` keeps the old pod serving) —
-⛔ it stays OFF until core #694 (cross-silo reply routing) is fixed, because the two-silo roll
-window makes the sweep's shared-source resolution flake and the gate then stalls every rollout on
-false regressions.
+channel.
+
+**The self-update waits for that compile.** The companion readiness gate (`PreWarm__GateReadiness`,
+ON in managed envs since 2026-08-02) holds the new pod's `/health` red until every NodeType is built
+against ITS image; the deployment's `startupProbe` is on `/health` and `maxUnavailable: 0` keeps the
+old pod serving, so traffic only moves once the compile is done. A type that regressed on the new
+image therefore STALLS the roll with the previous image still serving, instead of surfacing as
+user-facing errors after the cutover. Database migration is gated the same way and comes first: the
+unconditional `db_version` health check keeps the pod un-Ready until the schema is migrated, so the
+order on every roll is **migrate → compile → serve**.
+
+The gate was held OFF pending core #694 (cross-silo reply routing), fixed by #718 + #719 on
+2026-07-29. ⚠️ Its failure mode is a stalled rollout — no outage, but self-update silently stops
+advancing — so if a roll stalls on types flagged `Regressed` that compile clean on a single silo,
+that is #694 residue: set the flag back to `"false"` and reopen.
 
 ## Update policy (Admin → Platform updates)
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -130,17 +130,26 @@ config:
     # image keeps serving) instead of surfacing as user-facing errors.
     # ⚠️ Enabling the gate REQUIRES the raised probes.startup budget below —
     # paired settings, never change one without the other.
-    # ⛔ Gate OFF until core #694 (cross-silo reply routing) is fixed: during a
-    # roll the baking pod + the serving pod are TWO silos, the sweep's
-    # shared-source resolution flakes across that boundary, and the gate then
-    # accumulates FALSE regressions and stalls every rollout (memex-cloud
-    # 2026-07-30: three sweeps in a row, a different regression set each time,
-    # while every flagged type compiled clean when triggered on one silo).
-    # The sweep itself stays ON — deploys still compile every type at pod
-    # start; failures fall back to lazy compile instead of holding readiness.
-    # Flip to "true" together with the #694 fix.
+    # Gate ON since 2026-08-02. It was held OFF pending core #694 (cross-silo
+    # reply routing): during a roll the baking pod + the serving pod are TWO
+    # silos, the sweep's shared-source resolution flaked across that boundary,
+    # and the gate accumulated FALSE regressions that stalled every rollout
+    # (memex-cloud 2026-07-30: three sweeps in a row, a different regression set
+    # each time, while every flagged type compiled clean on one silo). #694 is
+    # fixed in TWO layers — #718 (stamp the caller's AccessContext on the
+    # cross-hub post) and #719 (stream-route 'mesh', register the reply stream),
+    # both merged 2026-07-29.
+    # ⚠️ RESIDUAL RISK, verify on the first roll: the 07-30 observation may or
+    # may not postdate those merges (the image it ran, ci.1565, has aged out of
+    # ACR, and the same-day ci.1575 DOES contain both). If the sweep still flakes
+    # across the roll window, the gate's failure mode is a STALLED rollout with
+    # the old image serving — no outage, but self-update silently stops
+    # advancing. Watch the first gated roll (DEPLOY-RUNBOOK.md §7 "Verify after
+    # every roll"); if a type is flagged Regressed here but compiles clean on a
+    # single silo, that is the #694 residue — set this back to "false" and
+    # reopen, do NOT paper over it by widening the probe budget.
     PreWarm__DynamicTypes: "true"
-    PreWarm__GateReadiness: "false"
+    PreWarm__GateReadiness: "true"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # ---- AI model providers (templated by the chart) ------------------------
     # These seed the system model catalog on deploy (BuiltInLanguageModelProvider


### PR DESCRIPTION
## What

Flips `PreWarm__GateReadiness` to `"true"` in `deploy/aks/values.aks.yaml`, and updates the two docs that documented it as deliberately off.

## Why

A roll — **including a self-update** — cut traffic over to the new pod *while it was still compiling*. `PreWarm__DynamicTypes` was ON, so the sweep ran, but readiness was not gated on it: the pod went Ready mid-bake and served a mesh whose NodeTypes were not built against its own image.

With the gate on, `/health` stays red until this pod's NodeTypes are built against **its** image. Combined with the `startupProbe` on `/health` and `maxUnavailable: 0`, the old pod keeps serving until the compile finishes. So every roll is now:

**migrate → compile → serve**

(`db_version` is an *unconditional* health check, so the migration gate already came first — that half was never broken.)

## No new machinery

The gate, the sweep, and the 3 h startup budget (`10s × 1080`, sized deliberately and commented "PAIRED with `PreWarm__GateReadiness`") were all already implemented. Only the flag was off.

## Why it was off, and why it can go on now

Held off pending core **#694** (cross-silo reply routing): during a roll the baking pod and the serving pod are two silos, the sweep's shared-source resolution flaked across that boundary, and the gate accumulated **false** regressions that stalled every rollout.

#694 is fixed in two layers — **#718** (stamp the caller's `AccessContext` on the cross-hub post) and **#719** (stream-route `mesh`, register the reply stream) — both merged 2026-07-29.

## ⚠️ Residual risk — watch the first gated roll

The 2026-07-30 memex-cloud flake ran on `ci.1565`, which has **aged out of ACR**, so I could not confirm it predates those merges (the same-day `ci.1575` *does* contain both). This is stated inline in `values.aks.yaml` rather than assumed away.

The gate's failure mode is a **stalled rollout with the old image still serving** — no outage, but self-update silently stops advancing. If a roll stalls on types flagged `Regressed` that compile clean on a single silo, that is #694 residue: set the flag back to `"false"` and reopen. **Do not widen the probe budget to hide it.**

Verification commands are in `DEPLOY-RUNBOOK.md` §7 ("Verify after every roll").

## Note

`deploy/helm/values.yaml` default stays `"false"` — a gate that can withhold readiness should be an intentional deployment choice, and a self-host without the raised probe budget would be killed mid-bake forever. This change targets managed envs only.

## Release note

Skipped — infrastructure/deploy configuration with no user-visible feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)