### PR TITLE
test: ActivityLiveProgress waits via ContentAs, not a cast (Copilot review on #758)

### DIFF
--- a/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
@@ -23,8 +23,11 @@ namespace MeshWeaver.GitSync.Test;
 /// while the sync itself completed and advanced <c>_GitSync.lastSyncCommitSha</c>).</para>
 ///
 /// <para>The test makes that dependency explicit and deterministic instead of relying on load: the
-/// command does not complete until it observes its OWN progress line on the node. Inline execution
-/// cannot satisfy that — it deadlocks and the test times out. With the execution scheduled off the
+/// command does not complete until it observes its OWN progress line on the node. Under Orleans —
+/// where a grain turn is single-threaded and the activity hub is grain-hosted — inline execution
+/// cannot satisfy that: the turn is held by the command, so the write can never land, and the test
+/// times out. (A non-Orleans harness with a free-threaded scheduler would not deadlock here; the
+/// regression this pins is specifically the grain-turn one.) With the execution scheduled off the
 /// hub turn the line lands while the command is still subscribed, and the activity finishes.</para>
 /// </summary>
 public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
@@ -91,14 +94,22 @@ public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTest
 
     private IObservable<ActivityLog> ObserveMessage(string activityPath, string contains) =>
         Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
-            .Select(n => n?.Content as ActivityLog)
+            // ContentAs, not a cast: on a cross-hub stream the content arrives as a degraded
+            // JsonElement, and a plain `as` yields null forever — the wait would silently never
+            // match and the test would time out with no clue why. Same reason ActivityRunner.Append
+            // and every Blazor reader of this node use ContentAs.
+            .Select(n => n?.ContentAs<ActivityLog>(Mesh.JsonSerializerOptions))
             .Where(l => l is not null && l.Messages.Any(m => m.Message.Contains(contains)))
             .Select(l => l!)
             .Take(1);
 
     private async Task<ActivityLog> WaitForActivity(string activityPath, Func<ActivityLog, bool> predicate) =>
         await Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
-            .Select(n => n?.Content as ActivityLog)
+            // ContentAs, not a cast: on a cross-hub stream the content arrives as a degraded
+            // JsonElement, and a plain `as` yields null forever — the wait would silently never
+            // match and the test would time out with no clue why. Same reason ActivityRunner.Append
+            // and every Blazor reader of this node use ContentAs.
+            .Select(n => n?.ContentAs<ActivityLog>(Mesh.JsonSerializerOptions))
             .Where(l => l is not null && predicate(l))
             .Select(l => l!)
             .FirstAsync()


### PR DESCRIPTION
Addresses the two unresolved Copilot review threads on #758 (merged before they were handled).

## 1. `as` cast → `ContentAs` (substantive)

Both stream helpers did `node.Content as ActivityLog`. On a **cross-hub stream the content arrives as a degraded `JsonElement`**, so the cast yields `null` forever — the `Where` never matches and the test times out with nothing pointing at the actual cause.

Every production reader of this same node already uses `ContentAs` for exactly this reason (`ActivityRunner.Append`, `CompileProgressIndicator`, `SendDocumentDispatch`). The test now matches them, with a comment saying why so it doesn't regress back to a cast.

This was a latent flake, not a style nit.

## 2. Deadlock claim scoped to Orleans (wording)

The class summary asserted inline execution "deadlocks and the test times out" unconditionally. That's specific to Orleans' single-threaded grain scheduler — which is precisely the regression this test pins. Reworded to say so, and to note a free-threaded harness wouldn't deadlock there.

## Verification

- `dotnet build test/MeshWeaver.GitSync.Test -c Release -warnaserror` → 0 warnings, 0 errors
- `ActivityLiveProgressTest` → **2/2 passed** (843 ms)

## Release note

Skipped — test-only change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)