### PR TITLE
Revert PreWarm__GateReadiness to off — #694 residue makes the sweep flag FALSE regressions

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -200,7 +200,7 @@ reverts them):
 | Knob | What it does |
 |---|---|
 | `config.memex_portal.PreWarm__DynamicTypes: "true"` | every new pod sweeps + compiles ALL dynamic NodeTypes at start (resumes from the shared `/data` cache — warm restarts are cheap) |
-| `config.memex_portal.PreWarm__GateReadiness: "true"` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **ON since 2026-08-02** (was held off for core #694, fixed by #718 + #719 on 2026-07-29). This is what makes a roll — including a self-update — *wait for the compile* before cutting traffic over. ⚠️ If a roll stalls with types flagged `Regressed` that compile clean on a single silo, that is #694 residue: set back to `"false"` and reopen — do NOT widen the probe budget to hide it |
+| `config.memex_portal.PreWarm__GateReadiness` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **⛔ OFF** — tried 2026-08-02 and reverted the same day: the first gated roll stalled on 7 FALSE regressions that were cross-silo `SubscribeRequest` timeouts, not compile errors (#694 residue, see SELF-UPDATE.md). Do NOT re-enable by widening the probe budget — the sweep is erroring, not slow |
 | `probes.startup: {periodSeconds: 10, failureThreshold: 1080}` | ⚠️ REQUIRED with the gate: a cold bake is ~90 s/type, sequential — the default 5 min budget kills the pod mid-bake forever |
 
 ⛔ **The bake Job (`bake.enabled`) stays OFF on AKS until core asserts fingerprint-match.** On its
@@ -228,7 +228,7 @@ Live-env equivalent without a helm apply (what enabled memex-cloud on 2026-07-30
 
 ```bash
 kubectl -n <env> patch configmap memex-portal-config --type merge \
-  -p '{"data":{"PreWarm__DynamicTypes":"true","PreWarm__GateReadiness":"true"}}'
+  -p '{"data":{"PreWarm__DynamicTypes":"true","PreWarm__GateReadiness":"false"}}'
 kubectl -n <env> patch deployment memex-portal-deployment --type json -p \
   '[{"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/periodSeconds","value":10},
     {"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/failureThreshold","value":1080}]'

--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -32,19 +32,25 @@ NodeTypes at start, so an un-visited type can no longer sit "no definition" unti
 Managed envs run the sweep ON — an env with it off has no deploy-time compile at all on this
 channel.
 
-**The self-update waits for that compile.** The companion readiness gate (`PreWarm__GateReadiness`,
-ON in managed envs since 2026-08-02) holds the new pod's `/health` red until every NodeType is built
-against ITS image; the deployment's `startupProbe` is on `/health` and `maxUnavailable: 0` keeps the
-old pod serving, so traffic only moves once the compile is done. A type that regressed on the new
-image therefore STALLS the roll with the previous image still serving, instead of surfacing as
-user-facing errors after the cutover. Database migration is gated the same way and comes first: the
-unconditional `db_version` health check keeps the pod un-Ready until the schema is migrated, so the
-order on every roll is **migrate → compile → serve**.
+**⛔ The self-update does NOT currently wait for the compile.** The companion readiness gate
+(`PreWarm__GateReadiness`) is designed to do exactly that — hold the new pod's `/health` red until
+every NodeType is built against ITS image, with the `startupProbe` on `/health` and
+`maxUnavailable: 0` keeping the old pod serving — so a regressed type STALLS the roll instead of
+surfacing as user-facing errors. It is **off**.
 
-The gate was held OFF pending core #694 (cross-silo reply routing), fixed by #718 + #719 on
-2026-07-29. ⚠️ Its failure mode is a stalled rollout — no outage, but self-update silently stops
-advancing — so if a roll stalls on types flagged `Regressed` that compile clean on a single silo,
-that is #694 residue: set the flag back to `"false"` and reopen.
+It was enabled on 2026-08-02 and reverted the same day. The first gated roll on memex-cloud stalled
+with `7 NodeType(s) regressed on this image`, and those were **false** regressions: the pod log
+contained no `CS####` compile error at all, only the sweep timing out across the roll window —
+`No response received in hub cache/… within 00:01:00 for request SubscribeRequest → target
+Claims / Reinsurance / SocialMedia / ClaimsDeepfield / RiskTransfer`. During a roll the baking pod
+and the serving pod are two silos and the sweep cannot resolve shared sources across that boundary.
+This is core #694 residue: #718 + #719 (2026-07-29) did NOT close it, so the earlier 2026-07-30
+observation stands unexplained by them.
+
+Until the sweep's cross-silo source resolution is fixed, database migration is the only part of the
+roll that is gated (the unconditional `db_version` health check), and NodeType compiles fall back to
+the pod-side sweep with lazy compile on failure. ⚠️ Do not re-enable the gate by widening the probe
+budget — the sweep is not slow, it is erroring.
 
 ## Update policy (Admin → Platform updates)
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -130,26 +130,28 @@ config:
     # image keeps serving) instead of surfacing as user-facing errors.
     # ⚠️ Enabling the gate REQUIRES the raised probes.startup budget below —
     # paired settings, never change one without the other.
-    # Gate ON since 2026-08-02. It was held OFF pending core #694 (cross-silo
-    # reply routing): during a roll the baking pod + the serving pod are TWO
-    # silos, the sweep's shared-source resolution flaked across that boundary,
-    # and the gate accumulated FALSE regressions that stalled every rollout
-    # (memex-cloud 2026-07-30: three sweeps in a row, a different regression set
-    # each time, while every flagged type compiled clean on one silo). #694 is
-    # fixed in TWO layers — #718 (stamp the caller's AccessContext on the
-    # cross-hub post) and #719 (stream-route 'mesh', register the reply stream),
-    # both merged 2026-07-29.
-    # ⚠️ RESIDUAL RISK, verify on the first roll: the 07-30 observation may or
-    # may not postdate those merges (the image it ran, ci.1565, has aged out of
-    # ACR, and the same-day ci.1575 DOES contain both). If the sweep still flakes
-    # across the roll window, the gate's failure mode is a STALLED rollout with
-    # the old image serving — no outage, but self-update silently stops
-    # advancing. Watch the first gated roll (DEPLOY-RUNBOOK.md §7 "Verify after
-    # every roll"); if a type is flagged Regressed here but compiles clean on a
-    # single silo, that is the #694 residue — set this back to "false" and
-    # reopen, do NOT paper over it by widening the probe budget.
+    # ⛔ Gate OFF — core #694 (cross-silo reply routing) is NOT fully fixed.
+    # Enabled 2026-08-02 on the reasoning that #718 + #719 (both 2026-07-29)
+    # closed #694; reverted the SAME DAY after the first gated roll on
+    # memex-cloud stalled with "7 NodeType(s) regressed on this image".
+    # Those were FALSE regressions: the pod log contains no CS#### compile
+    # error at all, only cross-silo subscribe timeouts from the sweep —
+    #   No response received in hub cache/… within 00:01:00 for request
+    #   SubscribeRequest → target Claims / Reinsurance / SocialMedia /
+    #   ClaimsDeepfield / RiskTransfer
+    # i.e. during a roll the baking pod and the serving pod are two silos and
+    # the sweep cannot resolve shared sources across that boundary, exactly as
+    # this comment warned before. The types compile fine; the sweep cannot
+    # reach them. So the 2026-07-30 observation was NOT explained by #718/#719.
+    # The gate's failure mode is a STALLED rollout (old image keeps serving —
+    # no outage, but self-update silently stops advancing), which is why this
+    # must stay off until the sweep's cross-silo source resolution is fixed.
+    # ⚠️ Do NOT re-enable by widening the probe budget — the sweep is not slow,
+    # it is erroring. Fix the cross-silo SubscribeRequest first.
+    # The sweep itself stays ON: deploys still compile every type at pod start;
+    # failures fall back to lazy compile instead of holding readiness.
     PreWarm__DynamicTypes: "true"
-    PreWarm__GateReadiness: "true"
+    PreWarm__GateReadiness: "false"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # ---- AI model providers (templated by the chart) ------------------------
     # These seed the system model catalog on deploy (BuiltInLanguageModelProvider


### PR DESCRIPTION
Reverts the flag enabled in #760. **The residual risk #760 flagged as unverified turned out to be real, and the very first gated roll proved it.**

## What happened

Enabling the gate stalled the first gated roll on memex-cloud:

```
NodeType bake regressed on this image — refusing readiness so the rollout
stalls with the previous image still serving. 7 NodeType(s) regressed
```

Old pod kept serving (no outage, as designed) but the rollout could not advance.

## The 7 regressions are FALSE

There is **not one `CS####` compile error** in the pod log. Every failure is the sweep timing out across the roll window:

```
No response received in hub cache/G7be3zQpjECQkZoPg8VFSg within 00:01:00
for request SubscribeRequest → target Claims / Reinsurance / SocialMedia
/ ClaimsDeepfield / RiskTransfer
```

During a roll the baking pod and the serving pod are two silos, and the sweep cannot resolve shared sources across that boundary. **The types compile fine — the sweep cannot reach them.**

This is precisely the failure mode the `values.aks.yaml` comment described before #760.

## Consequence for #694

#760 reasoned that #718 + #719 (both 2026-07-29) closed core #694, and recorded that it could not confirm the 2026-07-30 flake predated them (`ci.1565` had aged out of ACR). **That is now settled: they did not close it.** The cross-silo subscribe failure is still live, so the 07-30 observation stands unexplained by those merges and #694 should be reopened for the sweep's source resolution.

## Action taken

- `values.aks.yaml` → `"false"`, with the evidence and reasoning recorded inline
- **Live envs already reverted** — memex-cloud's configmap patched back and restarted, so it can roll forward again
- Docs corrected: `SELF-UPDATE.md` no longer claims the self-update waits for the compile; `DEPLOY-RUNBOOK.md` marks the gate OFF with the reason

⚠️ Both docs and the values comment now carry: **do not re-enable by widening the probe budget — the sweep is erroring, not running slow.** That would be treating a symptom.

The sweep itself stays **ON**: deploys still compile every type at pod start, with lazy compile as the fallback. Migration remains gated by the unconditional `db_version` health check.

## Release note

Skipped — deploy configuration, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)