### PR TITLE
Emit Open Graph metas as property=, and absolutize their URLs

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor
@@ -14,7 +14,18 @@
     <HeadContent>
         @foreach (var kvp in @MetaAttributes)
         {
-            <meta name="@kvp.Key" content="@kvp.Value" />
+            @* Open Graph is addressed by `property`, not `name` — a scraper (LinkedIn, Slack,
+               iMessage, Facebook) reading og:* looks for property= and ignores name=. Twitter's
+               own tags stay name=. Emitting the right attribute per key is the whole difference
+               between a link that unfurls into a card and one that renders as a bare URL. *@
+            @if (IsOpenGraph(kvp.Key))
+            {
+                <meta property="@kvp.Key" content="@AbsoluteMetaValue(kvp.Key, kvp.Value)" />
+            }
+            else
+            {
+                <meta name="@kvp.Key" content="@AbsoluteMetaValue(kvp.Key, kvp.Value)" />
+            }
         }
     </HeadContent>
 }

--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -37,6 +37,35 @@ public partial class NamedAreaView
     private string? PageTitle;
     private IDictionary<string, object>? MetaAttributes;
 
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+
+    /// <summary>Open Graph keys are emitted as <c>property=</c>; everything else as <c>name=</c>.</summary>
+    private static bool IsOpenGraph(string key) => key.StartsWith("og:", StringComparison.OrdinalIgnoreCase);
+
+    // URL-valued meta keys. A scraper fetches these from ITS OWN host, so a site-relative path is
+    // useless to it — they must be absolute.
+    private static readonly string[] UrlMetaKeys = ["og:image", "og:url", "og:video", "twitter:image"];
+
+    /// <summary>
+    /// Resolves a URL-valued meta tag against the REQUEST's own origin, so layout code can supply
+    /// a site-relative path (<c>/static/…</c>) and still emit the absolute URL a scraper needs.
+    /// This is the right seam for it: a plugin's layout area cannot know the public host it is
+    /// being served under (the same content runs on memex, systemorph, atioz and localhost), while
+    /// the component rendering the page knows exactly. Non-URL keys and already-absolute values
+    /// pass through untouched.
+    /// </summary>
+    private string? AbsoluteMetaValue(string key, object? value)
+    {
+        var text = value?.ToString();
+        if (string.IsNullOrEmpty(text)
+            || !UrlMetaKeys.Contains(key, StringComparer.OrdinalIgnoreCase)
+            || Uri.IsWellFormedUriString(text, UriKind.Absolute))
+            return text;
+        return Uri.TryCreate(new Uri(Navigation.BaseUri), text, out var absolute)
+            ? absolute.ToString()
+            : text;
+    }
+
     private string? AreaToBeRendered { get; set; }
 
     /// <summary>


### PR DESCRIPTION
The head-meta mechanism (`UiControl.Meta` → `<meta>`) emitted **everything as `name=`**. Open Graph is addressed by **`property=`** — a scraper reading `og:*` (LinkedIn, Slack, iMessage, Facebook) ignores `name=` — so og tags could never have unfurled a link. Twitter's own tags legitimately stay `name=`, so the attribute is now chosen per key.

URL-valued tags (`og:image`, `og:url`, `og:video`, `twitter:image`) are additionally resolved against the **request's own origin**, so layout code can supply a site-relative `/static/…` path and still emit the absolute URL a scraper requires. That seam belongs here: a plugin's layout area cannot know which public host it is being served under — the same content runs on memex, systemorph, atioz and localhost — while the component rendering the page knows exactly. Already-absolute values and non-URL keys pass through untouched.

First consumer: the store plugin cover ([MeshWeaver.Plugins#304](https://github.com/Systemorph/MeshWeaver.Plugins/pull/304)) + the course cards ([education#70](https://github.com/Systemorph/education/pull/70)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)