### PR TITLE
Self-update: bind SelfUpdateOptions from configuration (PollInterval was unreachable)

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -152,6 +152,14 @@ config:
     # failures fall back to lazy compile instead of holding readiness.
     PreWarm__DynamicTypes: "true"
     PreWarm__GateReadiness: "false"
+    # ---- Platform self-update cadence --------------------------------------
+    # The poller's built-in default is 6h, which is why a freshly published image
+    # could sit unpicked for hours and look like "self-update is broken" (memex,
+    # 2026-08-03: running ci.1672 while ci.1674 had been in ACR since 07:34).
+    # Managed envs track main closely, so poll every 20 minutes. Binding only
+    # works from the image that added SelfUpdateOptions.SectionName — before that
+    # this key is inert, because AddSelfUpdate() constructed its options directly.
+    SelfUpdate__PollInterval: "00:20:00"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # ---- AI model providers (templated by the chart) ------------------------
     # These seed the system model catalog on deploy (BuiltInLanguageModelProvider

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using MeshWeaver.Mesh;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,10 +16,17 @@ public static class SelfUpdateConfiguration
         where TBuilder : MeshBuilder
     {
         builder.AddUpdatePolicyType();
-        var opts = options ?? new SelfUpdateOptions();
         builder.ConfigureServices(services =>
         {
-            services.AddSingleton(opts);
+            // Bind from configuration when the caller passes nothing. Without this the defaults were
+            // baked into the image: PollInterval sat at 6h with NO way for an environment to change
+            // it, and a SelfUpdate__PollInterval in the configmap silently did nothing — the failure
+            // mode where an operator sets a knob, sees no effect, and concludes self-update is dead.
+            services.AddSingleton(sp =>
+                options
+                ?? sp.GetService<IConfiguration>()?.GetSection(SelfUpdateOptions.SectionName)
+                       .Get<SelfUpdateOptions>()
+                ?? new SelfUpdateOptions());
             // The poller lists ACR tags (Azure.Identity) and patches k8s deployments (X.509/TLS) via
             // APIs that are [UnsupportedOSPlatform("browser")]. It is a server-side hosted service and
             // is never wanted in a Blazor WASM client, so skip registration on browser. The guard also

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateOptions.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateOptions.cs
@@ -7,6 +7,9 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// </summary>
 public record SelfUpdateOptions
 {
+    /// <summary>Configuration section this binds from (e.g. <c>SelfUpdate__PollInterval</c>).</summary>
+    public const string SectionName = "SelfUpdate";
+
     /// <summary>The container registry login server the running install pulls from and polls.</summary>
     public string Registry { get; init; } = "meshweaver.azurecr.io";
 


### PR DESCRIPTION
## Symptom

memex was running `ci.1672` while `ci.1674` had been in ACR since 07:34 — reported as "self-update not picking up updates".

## The mechanism was working

It had rolled `ci.1661` → `ci.1672` overnight on its own. The real problem is that its **6 h `PollInterval` is unreachable**:

```csharp
var opts = options ?? new SelfUpdateOptions();
services.AddSingleton(opts);
```

`AddSelfUpdate()` is called with no options (`MemexConfiguration.cs:897`) and **nothing ever binds configuration**. So every knob on `SelfUpdateOptions` is baked into the image, and setting `SelfUpdate__PollInterval` in a configmap **silently does nothing**.

That's the worst shape of bug for an operator: you set the documented-looking knob, observe no effect, and reasonably conclude the feature is dead. It also means the cadence could never be tuned per environment.

## Fix

Bind the options from the `SelfUpdate` section when the caller passes none, and add `SelfUpdateOptions.SectionName`. An explicit `AddSelfUpdate(opts)` still wins, so callers that pass options are unaffected.

Managed envs get `SelfUpdate__PollInterval: "00:20:00"` — they track `main` closely and 6 h is far longer than the gap between merges.

⚠️ **The key is inert until an env runs an image containing this commit**, since before it the options were constructed directly. First roll must still be manual (already done for memex → `ci.1674`).

## Verification

`dotnet build memex/Memex.Portal.Shared -c Release -warnaserror` → **0 warnings, 0 errors**; YAML validated.

## Release note

Skipped — deploy/infrastructure configuration, no user-visible feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)