### PR TITLE
A thread is created where the user can WRITE — not where they were reading

### DIFF
--- a/src/MeshWeaver.AI/ThreadComposerView.cs
+++ b/src/MeshWeaver.AI/ThreadComposerView.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.DataBinding;
 using MeshWeaver.Layout.Domain;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using MeshWeaver.Utils;
@@ -256,6 +257,58 @@ public static class ThreadComposerView
             return;
         }
 
+        // 🚨 A thread is the USER'S conversation; the node it is about is only CONTEXT — and
+        // StartThread already takes that separately. So the owning namespace must be somewhere the
+        // user can actually WRITE. Where they cannot, this used to create the thread there anyway:
+        // the create was denied, the failure logged, and the conversation lived only in the browser
+        // until the next navigation — the reader watched a chat that was never being saved, then
+        // lost it (a gated course: enrolment grants Viewer, which is Read-only BY DESIGN; the same
+        // holds for every GitSynced doc/plugin space). Fall back to the user's own home, keep the
+        // context, and say so in the log.
+        OwningNamespace(host, ns!, user, logger)
+            .Take(1)
+            .Subscribe(
+                owner => StartThreadIn(host, owner, edited, user, contextPath),
+                ex => logger?.LogWarning(ex, "[ThreadComposer] Send: owner resolution failed"));
+    }
+
+    /// <summary>
+    /// Where the new thread's node belongs: <paramref name="ns"/> when the signed-in user may
+    /// CREATE there, otherwise their own home. Threads in a space the whole team can write stay
+    /// team-visible on the node — that is deliberate; only a namespace the user cannot write falls
+    /// back, because the alternative is silently losing the conversation. A permission read that
+    /// fails is treated as "cannot write": the user's home always works.
+    /// </summary>
+    private static IObservable<string> OwningNamespace(
+        LayoutAreaHost host, string ns, string? user, ILogger? logger)
+    {
+        if (string.IsNullOrEmpty(user) || string.Equals(ns, user, StringComparison.OrdinalIgnoreCase))
+            return Observable.Return(ns);
+        return host.Hub.GetEffectivePermissions(ns)
+            .Take(1)
+            .Select(permissions => permissions.HasFlag(Permission.Create) ? ns : user!)
+            .Catch<string, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[ThreadComposer] permission read for '{Namespace}' failed — owning the thread in '{User}'",
+                    ns, user);
+                return Observable.Return(user!);
+            })
+            .Do(owner =>
+            {
+                if (!string.Equals(owner, ns, StringComparison.Ordinal))
+                    logger?.LogInformation(
+                        "[ThreadComposer] '{User}' cannot create in '{Namespace}' — owning the thread in their "
+                        + "home instead; the context stays '{Context}'", user, ns, ns);
+            });
+    }
+
+    /// <summary>Creates the thread under <paramref name="owner"/>, keeping the page as context.</summary>
+    private static void StartThreadIn(
+        LayoutAreaHost host, string owner, ThreadComposer edited, string? user, string? contextPath)
+    {
+        var logger = Logger(host);
+        var ns = owner;
         host.Hub.StartThread(
             namespacePath: ns!,
             userText: edited.MessageContent!,


### PR DESCRIPTION
A ten-year-old opened the chat **on a course lesson**, had a conversation, navigated away, and it was gone. Nothing was deleted — **it was never saved.** Another learner doing the same got `Access denied: Create permission required`.

## Cause

```csharp
var ns = contextPath is null ? user : ThreadNodeType.MainNodeOf(contextPath);
```

The user's home is used **only when there is no page context**. Open the chat from a page and that page's space wins — with **no check that the user can write there**. On a gated course the learner holds `Viewer` (Read-only *by design* — that is what enrolment grants); on a GitSynced doc or plugin space only `system-security` writes.

So the create was denied, the failure was logged as a **warning**, and the chat carried on in the browser looking perfectly alive while nothing was being persisted.

## Fix

The node a chat is *about* is **context, not ownership** — and `StartThread` already takes `contextPath` as a separate argument. The thread is now owned where the user can actually create:

- they may write in the context space → unchanged (team-visible threads on a shared node are deliberate);
- they may not → **their own home**, with the context preserved and an Information log saying so;
- the permission read itself fails → treated as "cannot write", because the home always works.

## Evidence

On memex, `AgenticPrimerDe` holds **17 nodes and not one `_Thread`** — every learner conversation on that course had been silently dropped.

## Still open (not in this PR)

- **The failure is invisible.** A denied thread/composer create logs a warning and the UI navigates on. A write the user cannot perform should not be offered, and when it fails anyway they must see it.
- **Onboarding seeds are missing for most users**: only 7 of 56 users on memex have the `{user}/_Thread/ThreadComposer` that `ThreadComposerSeedHandler` is supposed to create — the read-before-create NotFound storm that seed exists to prevent is live for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)