### PR TITLE
Chat code blocks are white on white in dark mode

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageItem.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageItem.razor.css
@@ -5,6 +5,8 @@
     max-width: calc(100% - 5rem);
     padding: 0.5rem 1.25rem;
     border-radius: 0.25rem;
+    /* Kept as a fixed PAIR: this bubble sets its own background, so it must set its own ink.
+       Theming only one half is how the rest of this file broke. */
     color: #1F2937;
     white-space: pre-wrap;
 }
@@ -132,11 +134,17 @@
 
 ::deep th,
 ::deep tr:nth-child(even) {
-    background-color: rgba(0, 0, 0, 0.05);
+    /* A black wash disappears on a dark surface; the divider token reads on both. */
+    background-color: var(--neutral-fill-stealth-hover, rgba(0, 0, 0, 0.05));
 }
 
 ::deep pre>code {
-    background-color: white;
+    /* 🚨 Themed, not white. A hardcoded white background with NO foreground inherits the theme's
+       text colour — near-white in dark mode — so every code block rendered white on white. That is
+       what a /code answer is mostly MADE of, which is why it read as "the chat is blank". Any
+       background here must state its own foreground; the two travel together or not at all. */
+    background-color: var(--neutral-fill-secondary-rest, #f6f8fa);
+    color: var(--neutral-foreground-rest, #24292e);
     display: block;
     padding: 0.5rem 1rem;
     margin: 1rem 0;
@@ -176,7 +184,8 @@
     align-items: center;
     justify-content: center;
     padding: 3rem 2rem;
-    background-color: #ffffff;
+    background-color: var(--neutral-fill-secondary-rest, #ffffff);
+    color: var(--neutral-foreground-rest, #24292e);
     border-radius: 0 0 6px 6px;
     min-height: 120px;
 }
@@ -301,12 +310,12 @@
 .code-content {
     padding: 0.75rem 1rem;
     margin: 0;
-    background-color: #ffffff;
+    background-color: var(--neutral-fill-secondary-rest, #ffffff);
     border-radius: 0 0 6px 6px;
     font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
     font-size: 0.875rem;
     line-height: 1.45;
-    color: #24292e;
+    color: var(--neutral-foreground-rest, #24292e);
     overflow-x: auto;
     white-space: pre-wrap;
 }

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.css
@@ -29,7 +29,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .markdown-body:not([data-theme="light"]) {
+    html:not([data-theme="light"]) .markdown-body:not([data-theme="light"]) {
         --annotation-comment-bg: rgba(187, 128, 9, 0.15);
         --annotation-comment-border: #d29922;
         --annotation-insert-bg: rgba(46, 160, 67, 0.15);
@@ -406,10 +406,10 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .markdown-body:not([data-theme="light"]) ::deep .svg-theme-container .svg-light {
+    html:not([data-theme="light"]) .markdown-body:not([data-theme="light"]) ::deep .svg-theme-container .svg-light {
         display: none;
     }
-    .markdown-body:not([data-theme="light"]) ::deep .svg-theme-container .svg-dark {
+    html:not([data-theme="light"]) .markdown-body:not([data-theme="light"]) ::deep .svg-theme-container .svg-dark {
         display: block;
     }
 }


### PR DESCRIPTION
A learner on an iPad reported the chat as **"white on white"**. It is — and it's worst exactly where it hurts most: **code blocks**, which is most of what a `/code` answer consists of. The reply reads as blank.

`ChatMessageItem.razor.css` hardcodes 20+ colours and has **no dark-theme handling at all**. The specific killer:

```css
::deep pre>code { background-color: white; }
```

A hardcoded white background with **no foreground** inherits the theme's text colour — near-white in dark mode. White text, white background. The same shape repeats in `.code-content` and the pending-code panel.

## Fix

Backgrounds and foregrounds now **travel together**, on theme tokens with the old values as fallbacks:

- `::deep pre>code`, `.code-content` and the pending-code panel each state **both halves**;
- the table zebra stripe moves off an `rgba(0,0,0,.05)` wash that is invisible on a dark surface.

The user bubble keeps its fixed blue and fixed dark ink **deliberately** — it sets its own background, so it must set its own ink. There's a comment saying so, because theming only one half is precisely how this file broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)