### PR TITLE
ActivityTrackingHubTest: wait on the node stream, not the query index

### DIFF
--- a/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
@@ -116,12 +116,25 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
             NodeType: "Markdown",
             Namespace: user));
 
-        var node = await PollForFirst($"namespace:{user}/_UserActivity nodeType:UserActivity");
+        // 🚨 Wait on the NODE STREAM of the hub that actually performs the write, not on a query.
+        // The query index is eventually consistent BY DESIGN, so polling it for a just-written node
+        // races the indexer — that is exactly how this test failed on CI (2026-08-03, shard 1): the
+        // 15s budget expired with the node written but not yet indexed. Widening the budget would
+        // only make the race rarer; reading the authoritative source removes it.
+        // The write originates on the dedicated tracking hub against the shared root cache (see the
+        // class docs), so its workspace is where the node is observable — NOT the calling connHub,
+        // and not ReadNode (a one-shot GetMeshNode that returns null on NotFound and completes,
+        // so it cannot wait for a node that has not been written yet).
+        var expectedPath = $"{user}/_UserActivity/{nodePath.Replace("/", "_")}";
+        var node = await Mesh.GetActivityTrackingHub().GetWorkspace().GetMeshNodeStream(expectedPath)
+            .Where(n => n is not null)
+            .Select(n => (MeshNode?)n)
+            .Should().Within(TimeSpan.FromSeconds(15)).Emit();
 
         node.Should().NotBeNull(
             "a track posted to a connection-style hub must still land a UserActivity node — " +
             "the handler originates the write from the dedicated tracking hub, not the caller");
-        node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
+        node!.Path.Should().Be(expectedPath);
         node.NodeType.Should().Be("UserActivity");
 
         // 🚨 The write ran under the CALLER's identity, not system/empty. The handler builds


### PR DESCRIPTION
## The flake

`TrackActivity_InitiatedFromConnectionHub_LandsNode` is one of the tests turning `main` red intermittently (CI 2026-08-03, shard 1). It waited via `PollForFirst`, which polls **`MeshQuery` — the eventually-consistent index** — with a 15 s budget:

```csharp
MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(query))
    .Should().Within(TimeSpan.FromSeconds(15)).Emit();
```

The failing CI run took **15.2 s** (class INIT 08:35:14.890 → DISPOSE 08:35:30.120). The node was written but **not yet indexed** — the test raced the indexer.

## Why not just widen the budget

That would make the race rarer, not absent — and the project rules are explicit that a query is the wrong primitive for reading a single node. The activity node's path is **deterministic** (the test asserts it two lines later), so the fix is to read the authoritative source: the live `MeshNode` stream, which emits when the write lands and cannot go stale.

## Which hub — two obvious choices are wrong

Both of these were tried and **fail**:

- **`ReadNode(path)`** is a *one-shot* `GetMeshNode` that returns `null` on NotFound and completes, so it cannot wait for a node that hasn't been written yet → `"completed without one"`
- **the calling `connHub`'s workspace** never emits it either

The write originates on the dedicated **`ActivityTrackingHub`** against the shared root cache (`cache/{meshRootId}`) — exactly what this test class's own docs describe — so that hub's workspace is where the node is observable.

## Verification

Full project, native xUnit host, Release `-warnaserror`:

| | result |
|---|---|
| before | 357 total, 0 failed |
| after | **357 total, 0 failed** |

⚠️ Honest limitation: the race **does not reproduce on macOS/arm64**, so a green local run does not by itself prove the flake is gone. The argument is structural — the test no longer depends on the indexer at all, which is what made it load-sensitive on CI. The real confirmation is this test no longer appearing in shard-1 reds.

`PollForFirst` is retained: other tests in the class legitimately assert queryability, where the lagged index *is* the thing under test.

## Release note

Skipped — test-only change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)