### PR TITLE
A node type can supply its own left-hand navigation

### DIFF
--- a/src/MeshWeaver.Graph/INodeNavigationProvider.cs
+++ b/src/MeshWeaver.Graph/INodeNavigationProvider.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Supplies the left-hand navigation for pages a module OWNS, in place of core's default
+/// "the node's own children" list.
+///
+/// <para><b>Why this is a seam and not a widening.</b> Core's default lists the current node's
+/// children, which is right for a doc or a space and wrong for a course: a reader standing in
+/// lesson 2 sees lesson 2's sub-nodes and nothing else, so they cannot tell how long the course is,
+/// what is coming, or that they are nearly done. But core must not learn what a lesson is to fix
+/// that. The course semantics — the <c>module*100 + difficulty</c> Order convention, what counts as
+/// a chapter, which satellites to hide — already live in the Edu module, and re-deriving them here
+/// would put a copy in the wrong repo.</para>
+///
+/// <para><b>The default stands.</b> A provider that does not claim a node returns null and core
+/// renders exactly what it renders today, so docs and spaces are untouched and a deployment without
+/// the module simply loses the richer menu rather than breaking.</para>
+/// </summary>
+public interface INodeNavigationProvider
+{
+    /// <summary>
+    /// The entries to show for <paramref name="node"/>, or <c>null</c> to decline — core then falls
+    /// back to its default child list. Declining is the normal answer for nodes this module does
+    /// not own; it must be cheap and must never throw.
+    /// </summary>
+    /// <param name="node">The page being rendered.</param>
+    /// <param name="children">The children core would have listed, so a provider that only wants to
+    /// re-order or re-label them need not query again.</param>
+    IReadOnlyList<NodeNavigationEntry>? GetNavigation(MeshNode? node, IReadOnlyList<MeshNode> children);
+}
+
+/// <summary>
+/// One line of a supplied navigation. <paramref name="IsCurrent"/> marks where the reader is —
+/// core renders that entry as text rather than a link, because a link to the page you are on is a
+/// dead control that teaches the reader their position marker is broken.
+/// </summary>
+public record NodeNavigationEntry(string Label, string Path, bool IsCurrent = false, string? Icon = null);

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Reactive.Linq;
 using MeshWeaver.Layout;
@@ -49,7 +50,13 @@ public static class MarkdownOverviewLayoutArea
                     .Where(c => !LastSegment(c.Path).StartsWith('_'))
                     .OrderBy(c => c.Name ?? c.Id, System.StringComparer.OrdinalIgnoreCase)
                     .ToList();
-                return (UiControl?)(subNodes.Count == 0 ? content : BuildWithSubNodeNav(node, subNodes, content));
+                // A module that OWNS this page may supply its own menu (a course lists the whole
+                // course, not the branch you are in). Nothing supplied → core's default child list,
+                // unchanged — which is why docs and spaces are untouched by this.
+                var supplied = SuppliedNavigation(host, node, subNodes);
+                return (UiControl?)(subNodes.Count == 0 && supplied is null
+                    ? content
+                    : BuildWithSubNodeNav(node, subNodes, content, supplied));
             });
     }
 
@@ -63,9 +70,56 @@ public static class MarkdownOverviewLayoutArea
     /// Wraps the page content with a collapsible left-hand NavMenu listing the node's sub-nodes,
     /// giving every markdown node with children a navigable side menu of them.
     /// </summary>
-    private static UiControl BuildWithSubNodeNav(MeshNode? node, IReadOnlyList<MeshNode> subNodes, UiControl content)
+        /// <summary>
+    /// Asks each registered <see cref="INodeNavigationProvider"/> for this node's navigation, first
+    /// non-null wins. A provider that declines (or throws — a broken module must not take the page
+    /// down with it) leaves core's default child list in place.
+    /// </summary>
+    private static IReadOnlyList<NodeNavigationEntry>? SuppliedNavigation(
+        LayoutAreaHost host, MeshNode? node, IReadOnlyList<MeshNode> children)
+    {
+        var providers = host.Hub.ServiceProvider
+            .GetServices<INodeNavigationProvider>();
+        foreach (var provider in providers)
+        {
+            try
+            {
+                if (provider.GetNavigation(node, children) is { Count: > 0 } entries)
+                    return entries;
+            }
+            catch
+            {
+                // A module's navigation is a nicety; the page is not. Fall through to the default.
+            }
+        }
+        return null;
+    }
+
+private static UiControl BuildWithSubNodeNav(
+        MeshNode? node, IReadOnlyList<MeshNode> subNodes, UiControl content,
+        IReadOnlyList<NodeNavigationEntry>? supplied = null)
     {
         var group = new NavGroupControl(node?.Name ?? "Contents").WithSkin(s => s.WithExpanded(true));
+        if (supplied is { Count: > 0 })
+        {
+            // A module OWNS these pages and knows more about them than core does — a course knows
+            // its whole chapter list and which one the reader is standing in. The current entry is
+            // rendered as TEXT, not a link: a link to the page you are on is a dead control that
+            // teaches the reader their position marker is broken.
+            foreach (var entry in supplied)
+                group = entry.IsCurrent
+                    ? group.WithView(Controls.Body($"▸ {entry.Label}")
+                        .WithStyle("display:block;padding:4px 12px;font-weight:600;"))
+                    : group.WithView(new NavLinkControl(entry.Label, entry.Icon, $"/{entry.Path}"));
+            var suppliedNav = Controls.NavMenu
+                .WithSkin(s => s.WithWidth(240).WithCollapsible(true)).WithNavGroup(group);
+            return Controls.Stack
+                .WithOrientation(Orientation.Horizontal).WithWidth("100%")
+                .WithStyle("gap: 24px; align-items: flex-start;")
+                .WithView(suppliedNav)
+                .WithView(Controls.Stack.WithStyle("flex: 1; min-width: 0;").WithView(content));
+        }
+
         foreach (var child in subNodes)
         {
             var href = $"/{child.Path}";


### PR DESCRIPTION
The left index lists the **current node's children**, so a reader standing in lesson 2 of a course sees lesson 2's sub-nodes and nothing else — no sense of how long the course is, what's coming, or that they're nearly done.

**The fix is not to widen core's list.** Core must not learn what a lesson is: the course semantics — the `module*100 + difficulty` Order convention, what counts as a chapter, which satellites to hide — already live in Edu, and re-deriving them here would put a copy in the wrong repo.

So this adds a seam. `INodeNavigationProvider` lets a module supply the menu for pages it **owns**:

- **first non-null wins**; a provider that declines returns null;
- **a provider that throws is ignored** — a module's navigation is a nicety, the page is not;
- **nothing supplied → core's default child list, unchanged**, so docs and spaces are untouched and a deployment without the module loses the richer menu rather than breaking;
- a supplied **current** entry renders as **text, not a link** — a link to the page you're on is a dead control that teaches the reader their position marker is broken.

Sequenced so main stays green throughout: this lands first with today's behaviour as the default (nothing to regress), then Edu registers a provider behind it.

Core half of #770. Edu already has the whole-course entry list it will hand over — MeshWeaver.Plugins#315 (`CourseIndexEntries`, pure and tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)