### PR TITLE
Fix re-entrant hub construction (FutuRe.Test SIGSEGV / exit=139)

### DIFF
--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 ﻿using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Reflection;
@@ -178,7 +179,18 @@ public static class MeshDataSourceExtensions
             // InitializeHubRequest, HeartBeatEvent, ShutdownRequest, DisposeRequest,
             // and DeliveryFailure are bypassed by the framework — see MessageService.cs.
             .WithInitializationGate(MeshNodeExtensions.MeshNodeInitGateName, d => d.Message is CreateNodeRequest)
-            .WithInitialization(SubscribeToOwnDeletion)
+            // 🚨 REACTIVE init, NOT the synchronous overload. SyncBuildupActions run INSIDE
+            // MessageHubConfiguration.Build, and SubscribeToOwnDeletion resolves the own-node
+            // stream — which can create another hub. That made hub construction RE-ENTER hub
+            // construction and nest an Autofac ComponentRegistryBuilder.Build inside the
+            // in-progress one; the registry builder is not re-entrant, so the process died with
+            // an access violation (SIGSEGV / exit=139) with no test named. Seen on CI as an
+            // intermittent MeshWeaver.FutuRe.Test crash; the core dump's faulting thread was
+            //   CreateHub → Build → SubscribeToOwnDeletion → GetStream → GetHub → CreateHub
+            //   → Build → Autofac ResolvePipelineBuilder.BuildPipeline
+            // Running it as a BuildupAction defers it to InitializeHubRequest — after Build has
+            // finished — so resolving a stream can never nest a container build.
+            .WithInitialization(SubscribeToOwnDeletionInit)
             .WithNodeOperationHandlers()
             // Per-node-hub contract for resolving (assembly + HubConfiguration) of the
             // NodeType this hub is responsible for. Kept as a fallback for hubs / callers
@@ -810,6 +822,19 @@ public static class MeshDataSourceExtensions
         {
             // Intentionally empty — see TryLogWarning.
         }
+    }
+
+    /// <summary>
+    /// Reactive wrapper so the own-node subscription runs as a BuildupAction (on
+    /// <c>InitializeHubRequest</c>) rather than a SyncBuildupAction (inside
+    /// <c>MessageHubConfiguration.Build</c>). A named static method, not a lambda: the observable
+    /// <c>WithInitialization</c> overload de-duplicates on DELEGATE IDENTITY, and a fresh lambda
+    /// per configurator call would stack N subscriptions instead of collapsing to one.
+    /// </summary>
+    private static IObservable<Unit> SubscribeToOwnDeletionInit(IMessageHub hub)
+    {
+        SubscribeToOwnDeletion(hub);
+        return Observable.Return(Unit.Default);
     }
 
     private static void SubscribeToOwnDeletion(IMessageHub hub)


### PR DESCRIPTION
## The crash

`MeshWeaver.FutuRe.Test` crashes intermittently on CI with **`exit=139`** — a SIGSEGV that names no test, so the shard only reports *"a test host exited non-zero"*. It has been one of the recurring reds gating the image channel.

## Root cause — from the core dump, not inference

CI already collects mini dumps (`DOTNET_DbgEnableMiniDump`, copied into the shard artifact). The faulting thread shows the problem literally:

```
ThreadPool worker ← Rx: MeshQuery result arrives
  MonolithRoutingService.CreateHub
    HostedHubsCollection.GetHub → Lazy → CreateHub
      MessageHubConfiguration.Build                      ← construction #1
        MeshDataSourceExtensions.SubscribeToOwnDeletion
          MeshNodeStreamHandle.Subscribe → GetStream
            Workspace.GetStream → ReduceManager → CreateReducedStream
              HostedHubsCollection.GetHub → Lazy → CreateHub
                MessageHubConfiguration.Build            ← construction #2, NESTED
                  Autofac ComponentRegistryBuilder.Build
                    Autofac ResolvePipelineBuilder.BuildPipeline   ← access violation
```

`SubscribeToOwnDeletion` was registered through the **synchronous** `WithInitialization(Action<IMessageHub>)` overload, whose actions run **inside** `MessageHubConfiguration.Build` (*"BEFORE message processing starts"*). But it resolves the own-node stream, and resolving a stream can create another hub — so **hub construction re-entered hub construction**, nesting an Autofac container build inside the in-progress one. `ComponentRegistryBuilder` is not re-entrant; the nested build corrupts state and the process dies with an access violation (the dump carries `AccessViolation` + `FailFast` markers).

It only fires when a query result lands mid-construction on a threadpool thread — which is why it is load-dependent and has never reproduced locally.

## The fix

Register it through the **observable** `WithInitialization` overload so it runs as a `BuildupAction` on `InitializeHubRequest` — after `Build` has returned — where resolving a stream can no longer nest a container build. Otherwise identical: same subscription, same cache, same disposal registration.

The wrapper is a **named static method, not a lambda**, deliberately: that overload de-duplicates on *delegate identity* (`RegisteredObservableInits`), so a fresh lambda per configurator call would stack N subscriptions instead of collapsing to one — the exact *"running on N stacked subscriptions"* bug the neighbouring docs warn about.

## Verification

- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror` → 0 warnings, 0 errors
- **`MeshWeaver.Graph.Test` 779/779**
- **`MeshWeaver.FutuRe.Test` 59/59**

The ordering change means the own-node cache populates on init rather than during `Build`; Graph.Test covers the consumers of that cache and is green.

⚠️ **A green local run does not prove the crash is gone** — it never reproduced on macOS/arm64. The claim is narrower: the re-entrant path is removed. Confirmation is `FutuRe.Test exit=139` no longer appearing in CI shards.

## Release note

Skipped — internal correctness fix, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)