### PR TITLE
docs: three gotchas that cost real time reading a CI core dump

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -66,6 +66,25 @@ docker run --rm --platform linux/amd64 -v "$HOME/segv-dump/shard/collected-logs:
   '
 ```
 
+Use the **`curl` single-file download above, not `dotnet tool install -g dotnet-dump`** — the tool
+installer fails under qemu emulation with `There was an error reflecting type '…DotNetCliTool'`,
+and the resulting `dotnet-dump: command not found` looks like a PATH problem rather than what it is.
+
+## Free triage before you start a container
+
+`strings` on the raw core answers two questions in seconds, with no DAC and no emulation:
+
+```bash
+strings -a dump.dmp | grep -oE "AccessViolation|FailFast|SIGSEGV" | sort | uniq -c
+strings -a dump.dmp | grep -oE "/usr/share/dotnet/shared/Microsoft.NETCore.App/[0-9.]+/lib[a-z]+\.so" | sort -u
+```
+
+- `AccessViolation` + `FailFast` ⇒ the runtime tripped over bad memory; this is not a managed
+  exception that someone forgot to catch.
+- The second line reveals **which runtime patch CI actually ran**. It is regularly *not* the one you
+  have locally (2026-08-03: CI on `10.0.10`, local on `10.0.9`) — on its own a candidate explanation
+  for "only fails on CI", and worth eliminating before blaming load or shard composition.
+
 ## The command sequence that actually answers the question
 
 Run these in order; each one kills off a class of hypothesis.
@@ -101,6 +120,12 @@ tempting to fix that and declare victory. Discipline:
   showed it crashing during hub *construction*.
 - A method's **name** is not evidence of the phase. `SubscribeToOwnDeletion` is a
   `.WithInitialization(...)` hook: it names what the subscription later watches for, not when it runs.
+- **A frame appearing TWICE in one stack is re-entrancy, and re-entrancy is the finding.** That is
+  what the 2026-08-03 crash turned out to be — `CreateHub → Build → … → CreateHub → Build` nested an
+  Autofac `ComponentRegistryBuilder.Build` inside the in-progress one, and that builder is not
+  re-entrant. Scan the stack for repeats before theorising about anything else (fixed in #774: the
+  own-node subscription moved from the synchronous `WithInitialization` overload, which runs *inside*
+  `Build`, to the observable one, which runs on `InitializeHubRequest` after `Build` returns).
 - If a hypothesis survives, write down what would disprove it, then go and check that.
 
 ## Why the dump may have no precursor in the logs


### PR DESCRIPTION
Complements `DebuggingNativeCrashes.md` — which landed earlier today and already covers the macOS refusal and the Colima `$HOME` mount — with the three things still missing, each of which cost real time during the 2026-08-03 `FutuRe.Test` SIGSEGV investigation.

## 1. `dotnet tool install -g dotnet-dump` fails under emulation

It dies with `There was an error reflecting type '…DotNetCliTool'`, and the resulting `dotnet-dump: command not found` reads like a PATH problem rather than what it is. The doc's `curl` single-file download is correct — this says *why*, so nobody "fixes" it back to the tool installer.

## 2. `strings` triage before any container

Two questions answered in seconds with no DAC and no emulation:

- `AccessViolation` + `FailFast` ⇒ a runtime memory fault, **not** an uncaught managed exception
- the loaded `libcoreclr.so` path ⇒ **which runtime patch CI actually ran**

On 2026-08-03 that was **`10.0.10` on CI against `10.0.9` locally** — on its own a candidate explanation for "only fails on CI", and worth eliminating before blaming load or shard composition.

## 3. A repeated frame is re-entrancy, and re-entrancy is the finding

Scanning the stack for repeats first would have short-circuited the whole investigation. Three theories — teardown, ALC unload, a scope registry — were each argued from circumstantial evidence and each wrong, before the dump showed:

```
CreateHub → Build → … → CreateHub → Build → Autofac ComponentRegistryBuilder.Build
```

Hub construction re-entering hub construction, nesting an Autofac container build inside the in-progress one. Fixed in #774.

## Verification

`DocumentationLinkIntegrityTest` passes.

## Release note

Skipped — internal documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)