### PR TITLE
Model sizes are labels on the node, not config keys

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1924,11 +1924,21 @@ public class AgentChatClient : IAgentChat
         if (resolver.HasUsableCredential(currentModelName))
             return;
         // Either NO model is selected, or the selected one isn't usable (deleted/refactored out of the
-        // catalog, or its provider carries no key). Seed the DEFAULT available model (lowest-Order model
-        // with a usable key) so the round runs on a working model instead of dead-ending on the first
-        // factory (OpenAI) with "(none selected)". When nothing usable exists, `fallback` is empty →
-        // currentModelName stays as-is → the round surfaces the clear "No AI model available" message.
-        var fallback = resolver.ResolveDefaultModelId();
+        // catalog, or its provider carries no key). Seed a working model so the round runs instead of
+        // dead-ending on the first factory (OpenAI) with "(none selected)".
+        //
+        // 📏 Seed by the selected agent's declared SIZE, not the bare default. This is the ONE place a
+        // size label can take effect: the concrete factories consult ResolveTierModel only when no model
+        // is selected, and by then this method has already seeded one — so seeding the plain default
+        // here would make every sized agent run on the default and the label would be decorative.
+        // ResolveModelIdForSize(null) IS the default, so an agent declaring no size is unaffected, and
+        // an explicit USABLE selection never reaches this line (early return above) — a human pick still
+        // wins. When nothing usable exists, `fallback` is empty → currentModelName stays as-is → the
+        // round surfaces the clear "No AI model available" message.
+        var declaredSize = loadedAgents
+            .FirstOrDefault(a => string.Equals(a.Name, currentAgentName, StringComparison.OrdinalIgnoreCase))
+            ?.AgentConfiguration?.ModelTier;
+        var fallback = resolver.ResolveModelIdForSize(declaredSize);
         if (string.IsNullOrEmpty(fallback)
             || string.Equals(fallback, currentModelName, StringComparison.OrdinalIgnoreCase))
             return;

--- a/src/MeshWeaver.AI/ChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI/ChatClientAgentFactory.cs
@@ -73,19 +73,41 @@ public abstract class ChatClientAgentFactory : IChatClientFactory
             string.Equals(m, modelName, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// Resolves the agent's <see cref="AgentConfiguration.ModelTier"/> ("heavy" / "standard" /
-    /// "light" / "utility") to a concrete model via the <c>ModelTier:*</c> config section.
-    /// Returns null when the agent declares no tier, the tier isn't configured, or this
-    /// factory doesn't serve the resolved model (so the caller falls back to its provider
-    /// default instead of creating a client for a model another factory owns).
-    /// Precedence in concrete factories: composer selection (<see cref="CurrentModelName"/>)
-    /// → agent tier → provider default.
+    /// Resolves the agent's <see cref="AgentConfiguration.ModelTier"/> — a SIZE label ("S"/"M"/"L"/"XL",
+    /// or the legacy "utility"/"light"/"standard"/"heavy") — to a concrete model.
+    ///
+    /// <para>Two sources, in order: the <b>model nodes themselves</b> (a node carrying that
+    /// <see cref="ModelDefinition.Size"/>, lowest Order wins — the data-driven form, so a new
+    /// environment labels its models and needs no config keys at all), then the legacy
+    /// <c>ModelTier:*</c> config section for deployments still expressing tiers that way.</para>
+    ///
+    /// Returns null when the agent declares no tier, neither source names a model, or this factory
+    /// doesn't serve the resolved one (so the caller falls back to its provider default rather than
+    /// creating a client for a model another factory owns). Precedence in concrete factories:
+    /// composer selection (<see cref="CurrentModelName"/>) → agent tier → provider default.
     /// </summary>
     protected string? ResolveTierModel(AgentConfiguration agentConfig)
     {
         if (string.IsNullOrEmpty(agentConfig.ModelTier))
             return null;
 
+        // 1. The label as DATA on the model nodes. Deliberately does NOT fall through to the
+        //    deployment default here: that is the caller's own last resort, and swallowing it at
+        //    this level would hand this factory a model another factory owns.
+        if (ModelSizes.Parse(agentConfig.ModelTier) is { } size
+            && Hub.ServiceProvider.GetService<ChatClientCredentialResolver>() is { } resolver)
+        {
+            var labelled = ModelSizeCatalog.Resolve(
+                size, resolver.ReadSizeCandidates(), resolver.HasUsableCredential);
+            if (!string.IsNullOrEmpty(labelled) && Supports(labelled))
+            {
+                Logger.LogDebug("[AgentFactory] Agent {Agent} size '{Size}' resolved to labelled model {Model}",
+                    agentConfig.Id, agentConfig.ModelTier, labelled);
+                return labelled;
+            }
+        }
+
+        // 2. Legacy: the ModelTier:* config section.
         var configuration = Hub.ServiceProvider.GetService<Microsoft.Extensions.Configuration.IConfiguration>();
         if (configuration == null)
             return null;

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -279,7 +279,14 @@ public sealed class ChatClientCredentialResolver : IDisposable
     /// <summary>
     /// The DEFAULT model id to fall back to when a selected model no longer resolves — the
     /// LOWEST-<see cref="MeshNode.Order"/> <c>LanguageModel</c> in the live catalog whose credentials
-    /// actually resolve (so the fallback is never ANOTHER broken model). Mirrors
+    /// actually resolve (so the fallback is never ANOTHER broken model).
+    ///
+    /// <para><b>Routers are excluded</b> (<see cref="ModelDefinition.IsRouter"/>): the Auto entry
+    /// dispatches to a real model rather than serving a round, so it must never become the default —
+    /// not even when it deliberately sorts first in the picker at a very low Order. Auto is reachable
+    /// only by an explicit pick.</para>
+    ///
+    /// Mirrors
     /// <c>AgentPickerProjection.ObserveDefaultComposer</c>'s "lowest Order wins" rule, read from the
     /// same warm snapshot this resolver already maintains. Returns <c>null</c> when no model in the
     /// catalog resolves (e.g. a deployment whose models bypass the catalog entirely).

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -284,27 +284,47 @@ public sealed class ChatClientCredentialResolver : IDisposable
     /// same warm snapshot this resolver already maintains. Returns <c>null</c> when no model in the
     /// catalog resolves (e.g. a deployment whose models bypass the catalog entirely).
     /// </summary>
-    public string? ResolveDefaultModelId()
-    {
-        var snapshot = ReadSnapshot();
-        return snapshot
+    public string? ResolveDefaultModelId() =>
+        ModelSizeCatalog.Default(ReadSizeCandidates(), HasUsableCredential);
+
+    /// <summary>
+    /// The model an agent asking for a SIZE should run on — the lowest-Order model whose node carries
+    /// that <see cref="ModelDefinition.Size"/> label, else the deployment default. Accepts the legacy
+    /// tier vocabulary too (<c>utility</c>/<c>light</c>/<c>standard</c>/<c>heavy</c>).
+    ///
+    /// <para>A size nobody carries is a MISS, not a failure: it falls through to
+    /// <see cref="ResolveDefaultModelId"/>, which is what lets an environment label only the models
+    /// it cares about. Routers (the Auto entry) are excluded — resolving a size to Auto would hand
+    /// the round to something that dispatches rather than answers.</para>
+    /// </summary>
+    /// <param name="sizeOrTier">"S"/"M"/"L"/"XL", or a legacy tier name. Null/unknown → the default.</param>
+    /// <returns>The model id, or <c>null</c> when nothing in the catalog is usable.</returns>
+    public string? ResolveModelIdForSize(string? sizeOrTier) =>
+        ModelSizeCatalog.ResolveOrDefault(sizeOrTier, ReadSizeCandidates(), HasUsableCredential);
+
+    /// <summary>
+    /// Projects the warm snapshot's <c>LanguageModel</c> nodes into the flat shape the selection
+    /// rules work on. Rank comes from <see cref="MeshNode.Order"/>, falling back to the
+    /// <see cref="ModelDefinition.Order"/> when the node carries none — mirroring the picker
+    /// (<c>ToModelInfo</c> reads <c>def.Order</c>), so a per-model default (Order = -1) is honoured
+    /// whether the Order lives on the node or only in its content. Without that fallback a BYO model
+    /// that set only <see cref="ModelDefinition.Order"/> ranked 0 here while ranking correctly in
+    /// the picker.
+    /// </summary>
+    public IReadOnlyList<ModelSizeCandidate> ReadSizeCandidates() =>
+        ReadSnapshot()
             .Where(n => string.Equals(n.NodeType, LanguageModelNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
             .Select(n =>
             {
                 var def = ExtractContent<ModelDefinition>(n.Content);
-                // Rank by MeshNode.Order, falling back to the ModelDefinition's Order when the node
-                // carries none — mirrors the picker (ToModelInfo reads def.Order), so a per-model
-                // default (DeepSeek-V4-Flash → -1) is honoured whether the Order lives on the node
-                // or only on its content. Without the def fallback a BYO model that set only
-                // ModelDefinition.Order ranked 0 here while ranking correctly in the picker.
-                var order = n.Order ?? (def?.Order ?? 0);
-                return (Order: order, Id: def?.Id);
+                return new ModelSizeCandidate(
+                    def?.Id ?? string.Empty,
+                    n.Order ?? (def?.Order ?? 0),
+                    def?.Size,
+                    def?.IsRouter == true);
             })
-            .Where(x => !string.IsNullOrEmpty(x.Id))
-            .OrderBy(x => x.Order)
-            .Select(x => x.Id!)
-            .FirstOrDefault(HasUsableCredential);
-    }
+            .Where(c => !string.IsNullOrEmpty(c.Id))
+            .ToList();
 
     /// <summary>
     /// True when <paramref name="modelId"/> resolves to a credential the model factories can ACTUALLY

--- a/src/MeshWeaver.AI/ModelDefinition.cs
+++ b/src/MeshWeaver.AI/ModelDefinition.cs
@@ -127,6 +127,30 @@ public record ModelDefinition
     public bool? SupportsTools { get; init; }
 
     /// <summary>
+    /// Abstract SIZE label — which rung of the catalog this model is (see <see cref="ModelSize"/>).
+    /// An agent asks for a size (<see cref="AgentConfiguration.ModelTier"/>) and the resolver picks
+    /// the lowest-<see cref="Order"/> model carrying that label, so "which model is our large one"
+    /// is DATA on the node rather than a <c>ModelTier:*</c> config key a new environment must set.
+    ///
+    /// <para><c>null</c> = unlabelled, which is normal: a deployment does NOT have to populate every
+    /// size. A size nobody carries is a MISS and falls through to the deployment default, so
+    /// labelling one model is a valid setup.</para>
+    /// </summary>
+    [System.ComponentModel.Description("Size label: S, M, L, or XL")]
+    public ModelSize? Size { get; init; }
+
+    /// <summary>
+    /// <c>true</c> marks this entry a ROUTER (the "Auto" pseudo-model) rather than a model that can
+    /// serve a round itself: it inspects the ask and dispatches to a real model.
+    ///
+    /// <para>A router is excluded from every automatic selection — the default-model fallback and
+    /// the size lookup — because selecting it there would resolve Auto to Auto. It is only ever
+    /// chosen EXPLICITLY, by a user picking it in the composer.</para>
+    /// </summary>
+    [System.ComponentModel.Description("Router (Auto) — dispatches to a real model")]
+    public bool? IsRouter { get; init; }
+
+    /// <summary>
     /// Projects this definition into the lighter <see cref="ModelInfo"/>
     /// shape consumed by the chat picker.
     /// </summary>

--- a/src/MeshWeaver.AI/ModelSize.cs
+++ b/src/MeshWeaver.AI/ModelSize.cs
@@ -1,0 +1,54 @@
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Abstract SIZE of a language model — the label an agent asks for instead of naming a concrete
+/// model id. The label lives on the model NODE (<see cref="ModelDefinition.Size"/>), so a
+/// deployment expresses "which model is our large one" as data rather than as
+/// <c>ModelTier:*</c> configuration keys that every new environment has to get right.
+///
+/// <para>Sizes are a preference, never a requirement: <b>an environment does not have to populate
+/// all of them.</b> A label with no model behind it falls through to the deployment default
+/// (see <c>ChatClientCredentialResolver.ResolveDefaultModelId</c>), so labelling a single model is
+/// a valid — and common — setup.</para>
+/// </summary>
+public enum ModelSize
+{
+    /// <summary>Cheapest and fastest. Classification, titles, summaries, routing decisions —
+    /// latency and cost dominate, and the work does not involve code.</summary>
+    S = 0,
+
+    /// <summary>Fast general-purpose. Ordinary chat and agent rounds; must still be able to write
+    /// correct code, or it does not belong at this label.</summary>
+    M = 1,
+
+    /// <summary>The capable default. Complex reasoning, multi-step agent work, code that matters.</summary>
+    L = 2,
+
+    /// <summary>The strongest available. Reserved for the hardest asks — slowest and most expensive,
+    /// so it is chosen deliberately, never as a fallback.</summary>
+    XL = 3,
+}
+
+/// <summary>
+/// Parsing for <see cref="ModelSize"/>, including the legacy tier vocabulary
+/// (<c>utility</c> / <c>light</c> / <c>standard</c> / <c>heavy</c>) that
+/// <see cref="AgentConfiguration.ModelTier"/> and the <c>ModelTier:*</c> config section speak.
+/// Both spellings resolve to the same label so existing agents keep working unchanged.
+/// </summary>
+public static class ModelSizes
+{
+    /// <summary>
+    /// Parses a size label or a legacy tier name. Returns <c>null</c> for null/empty/unknown input —
+    /// an unrecognised label is a MISS, which falls through to the default, never an exception.
+    /// </summary>
+    /// <param name="value">"S"/"M"/"L"/"XL", or "utility"/"light"/"standard"/"heavy".</param>
+    /// <returns>The parsed <see cref="ModelSize"/>, or <c>null</c> when it does not name one.</returns>
+    public static ModelSize? Parse(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "s" or "small" or "utility" => ModelSize.S,
+        "m" or "medium" or "light" => ModelSize.M,
+        "l" or "large" or "standard" => ModelSize.L,
+        "xl" or "xlarge" or "heavy" => ModelSize.XL,
+        _ => null,
+    };
+}

--- a/src/MeshWeaver.AI/ModelSizeCatalog.cs
+++ b/src/MeshWeaver.AI/ModelSizeCatalog.cs
@@ -1,0 +1,86 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// One catalog entry as the size resolution sees it — deliberately a flat value so the selection
+/// rules are pure functions over data, testable with no hub, no snapshot and no credentials.
+/// </summary>
+/// <param name="Id">The model id the provider expects (<see cref="ModelDefinition.Id"/>).</param>
+/// <param name="Order">Rank; lower sorts first. This is what makes one model "the default".</param>
+/// <param name="Size">The size label carried by the node, or <c>null</c> when unlabelled.</param>
+/// <param name="IsRouter">True for the Auto pseudo-model, which is never selected automatically.</param>
+public readonly record struct ModelSizeCandidate(string Id, int Order, ModelSize? Size, bool IsRouter);
+
+/// <summary>
+/// Selection over the model catalog by SIZE label, and the default-model rule.
+///
+/// <para>Two rules, and they are the whole contract:</para>
+/// <list type="number">
+/// <item><b>A size resolves to the lowest-<see cref="ModelSizeCandidate.Order"/> model carrying that
+/// label.</b> Nothing carries it → <c>null</c>, a MISS, which the caller turns into the default.
+/// This is what lets an environment populate only the sizes it cares about.</item>
+/// <item><b>Routers are excluded from both.</b> The Auto entry dispatches to a real model, so
+/// resolving a size — or the default — to Auto would either loop or hand a round to something that
+/// cannot serve it. Auto is reachable ONLY by an explicit pick.</item>
+/// </list>
+/// </summary>
+public static class ModelSizeCatalog
+{
+    /// <summary>
+    /// The model to use for <paramref name="size"/>: the lowest-Order non-router candidate carrying
+    /// that label and passing <paramref name="usable"/>.
+    /// </summary>
+    /// <param name="size">The requested size label.</param>
+    /// <param name="candidates">The catalog.</param>
+    /// <param name="usable">Optional predicate — a model whose credential cannot serve a round is
+    /// skipped, exactly as the default-model rule skips it. Null accepts every candidate.</param>
+    /// <returns>The model id, or <c>null</c> when the size is unpopulated (a miss, not an error).</returns>
+    public static string? Resolve(
+        ModelSize size,
+        IEnumerable<ModelSizeCandidate> candidates,
+        Func<string, bool>? usable = null) =>
+        Eligible(candidates, usable)
+            .Where(c => c.Size == size)
+            .Select(c => c.Id)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// The deployment default: the lowest-Order non-router candidate that passes
+    /// <paramref name="usable"/>. Pin exactly one model at <c>Order = -1</c> to make it the default.
+    /// </summary>
+    /// <param name="candidates">The catalog.</param>
+    /// <param name="usable">Optional usability predicate; null accepts every candidate.</param>
+    /// <returns>The default model id, or <c>null</c> when nothing is usable.</returns>
+    public static string? Default(
+        IEnumerable<ModelSizeCandidate> candidates,
+        Func<string, bool>? usable = null) =>
+        Eligible(candidates, usable).Select(c => c.Id).FirstOrDefault();
+
+    /// <summary>
+    /// What an agent asking for <paramref name="sizeOrTier"/> should run on: the labelled model,
+    /// else the default. One call so every caller degrades the same way — a size nobody carries
+    /// must never fail, it must fall through.
+    /// </summary>
+    /// <param name="sizeOrTier">"S"/"M"/"L"/"XL" or a legacy tier name; null/unknown → the default.</param>
+    /// <param name="candidates">The catalog.</param>
+    /// <param name="usable">Optional usability predicate; null accepts every candidate.</param>
+    /// <returns>The model id to run, or <c>null</c> when the catalog offers nothing usable.</returns>
+    public static string? ResolveOrDefault(
+        string? sizeOrTier,
+        IEnumerable<ModelSizeCandidate> candidates,
+        Func<string, bool>? usable = null)
+    {
+        var list = candidates as IReadOnlyCollection<ModelSizeCandidate> ?? candidates.ToImmutableList();
+        var size = ModelSizes.Parse(sizeOrTier);
+        return (size is null ? null : Resolve(size.Value, list, usable)) ?? Default(list, usable);
+    }
+
+    private static IEnumerable<ModelSizeCandidate> Eligible(
+        IEnumerable<ModelSizeCandidate> candidates, Func<string, bool>? usable) =>
+        candidates
+            .Where(c => !c.IsRouter && !string.IsNullOrEmpty(c.Id))
+            .OrderBy(c => c.Order)
+            .ThenBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
+            .Where(c => usable is null || usable(c.Id));
+}

--- a/src/MeshWeaver.Documentation/Data/AI/ModelSizes.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ModelSizes.md
@@ -1,0 +1,80 @@
+---
+nodeType: Markdown
+name: Model Sizes (S / M / L / XL)
+category: AI
+description: Label your models by size on the node, pin one default at order -1, and agents pick a rung instead of a model id — the whole model-selection setup for a new environment.
+icon: /static/NodeTypeIcons/document.svg
+---
+
+# Model Sizes (S / M / L / XL)
+
+An agent should say **how much model it needs**, not which model it needs. A model id is a deployment detail — it changes when a provider ships a new version, when prices move, when you switch clouds — and an agent that names one hard-codes that detail into its definition.
+
+So agents ask for a **size**, and each model NODE carries the size label it satisfies. Setting up a new environment is then one job: **label your models**. No `ModelTier:*` environment variables, no per-deployment config drift — the labels are data on the mesh, visible and editable like any other content.
+
+## The four rungs
+
+| Label | What belongs here | Chosen for |
+|---|---|---|
+| **S** | Cheapest and fastest, no code involved | Classification, thread titles, summaries, the Auto router's own decision |
+| **M** | Fast general-purpose that can still write correct code | Ordinary chat and agent rounds |
+| **L** | The capable default | Complex reasoning, multi-step agent work, code that matters |
+| **XL** | The strongest available — slowest, most expensive | The hardest asks, chosen deliberately |
+
+The legacy tier vocabulary still works everywhere a label is accepted: `utility` → **S**, `light` → **M**, `standard` → **L**, `heavy` → **XL**. Existing agents carrying `modelTier: utility` need no change.
+
+> A model whose name contains "coder" is not automatically an M. Benchmark before you label: in one head-to-head, the second-cheapest "coder" model failed four of five checks on a routine C# task while a cheaper general model passed all five. **Label from measurements, not from model names.**
+
+## Setting up a new environment
+
+Two steps. Neither is required to be complete.
+
+**1. Pin the default.** Exactly one model gets `order: -1`. The default is simply the lowest-`order` model whose credentials actually work, so `-1` means "this one, unless somebody picks otherwise".
+
+```json
+{ "nodeType": "LanguageModel",
+  "content": { "$type": "ModelDefinition", "id": "z-ai/glm-5.2",
+               "providerRef": "Provider/OpenRouter", "order": -1, "size": "L" } }
+```
+
+**2. Label whatever else you have.**
+
+```json
+{ "content": { "$type": "ModelDefinition", "id": "moonshotai/kimi-k3", "order": 7, "size": "XL" } }
+```
+
+> ⚠️ Without a deliberate `-1`, the default is whatever happens to sort first. On one deployment that silently made a slow, expensive reasoning model the default for every round where nobody picked a model — for weeks, invisibly, because nothing is wrong with such a round except the bill and the latency.
+
+### You do NOT have to populate every size
+
+**A size nobody carries is a miss, and a miss falls through to the default.** An environment with a single labelled model is valid and works: agents asking for S, M or XL all land on the default rather than failing. Populate the rungs you actually have, and add more as you add models.
+
+That is the difference from the old `ModelTier:*` config: a missing tier there meant a missing environment variable, discovered when a background agent quietly ran on the wrong model. Here the fallback is one rule, in one place, and it is the same rule everywhere.
+
+## How resolution actually runs
+
+For one round, in order — the first hit wins:
+
+1. **The user's explicit pick** in the composer. Always wins; a size label never overrides a human choice.
+2. **The agent's declared size** (`AgentConfiguration.ModelTier`) → the lowest-`order` model carrying that label.
+3. **Legacy `ModelTier:*` config**, for deployments still expressing tiers that way.
+4. **The deployment default** — lowest `order`, credentials verified.
+
+Two exclusions apply to every automatic step (2–4):
+
+- **Models whose credentials don't resolve are skipped**, so a fallback never lands on another broken model.
+- **Routers are skipped** — see below.
+
+The rules are pure functions over the catalog (`ModelSizeCatalog`), so "which model does an agent asking for L get" is answerable from data alone, without a running mesh. They are unit-tested that way.
+
+## Auto, and why routers are excluded
+
+The **Auto** entry is not a model — it is a *router*: it looks at the ask, estimates how much model it needs, and dispatches to a real one. It is marked on its node:
+
+```json
+{ "content": { "$type": "ModelDefinition", "id": "openrouter/auto", "isRouter": true, "order": -10 } }
+```
+
+`isRouter: true` keeps it out of every automatic selection — the size lookup and the default. That exclusion is not cosmetic: a default that could resolve to Auto would resolve Auto to Auto, and a size that could resolve to Auto would hand the round to something that dispatches rather than answers. **Auto is reachable only by an explicit pick** (which is why it can still sort first in the picker at a low `order`).
+
+Its cost is worth stating plainly: routing adds a classification call before the real one, and it will sometimes route wrong. Anything touching code should land on L or XL; the router's own decision runs on S, where a wrong guess costs a fraction of a cent.

--- a/src/MeshWeaver.Documentation/Data/AI/ModelSizes.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ModelSizes.md
@@ -67,6 +67,24 @@ Two exclusions apply to every automatic step (2–4):
 
 The rules are pure functions over the catalog (`ModelSizeCatalog`), so "which model does an agent asking for L get" is answerable from data alone, without a running mesh. They are unit-tested that way.
 
+### Where the label actually takes effect
+
+Worth knowing, because it is not where you would guess. When a round starts with **no usable model selected**, `AgentChatClient.ApplyStaleModelFallback` **seeds** one before any factory is chosen — and that seed is where the size is honoured (`ResolveModelIdForSize(agent.ModelTier)`, which is the plain default when the agent declares nothing).
+
+It has to happen there. The concrete factories also consult the tier (`ResolveTierModel`), but only when no model is selected — and by that point the seed has already set one. Seeding the bare default instead would make **every** sized agent run on the default, with the label sitting on the node looking meaningful and changing nothing. A size label that silently does nothing is worse than no label at all, because you stop looking.
+
+An explicit, usable composer selection never reaches the seed at all — the fallback returns early when the current model resolves — so **a human pick always wins over a label**.
+
+### "My agent declares L but ran on the default"
+
+That is the designed fallback, not a bug, and there are exactly three causes:
+
+1. **No model carries the `L` label** — the miss falls through. Check `size` on your model nodes.
+2. **The labelled model's credentials don't resolve** — it is skipped like any unusable model. Check its `providerRef` and that the provider node has a key.
+3. **Someone picked a model in the composer** — an explicit selection wins, by design.
+
+The operator log line names the swap; the round itself is silent, deliberately (an unusable pinned model is a config problem a user cannot act on mid-thread).
+
 ## Auto, and why routers are excluded
 
 The **Auto** entry is not a model — it is a *router*: it looks at the ask, estimates how much model it needs, and dispatches to a real one. It is marked on its node:

--- a/test/MeshWeaver.AI.Test/ModelSizeCatalogTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSizeCatalogTest.cs
@@ -1,0 +1,133 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Collections.Immutable;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The size-label selection rules. Pure functions over the catalog — no hub, no snapshot, no
+/// credentials — which is the point: "which model does an agent asking for L actually get" is
+/// decidable from data alone, and stays decidable when an environment labels only some of its
+/// models.
+/// </summary>
+public class ModelSizeCatalogTest
+{
+    // A catalog shaped like a real deployment: GLM pinned default at -1, a labelled S and M, an
+    // XL, and the Auto router. Ordered deliberately out of Order so nothing passes by luck.
+    private static ImmutableList<ModelSizeCandidate> Catalog =>
+    [
+        new("moonshotai/kimi-k3", 7, ModelSize.XL, false),
+        new("openrouter/auto", -10, null, true),
+        new("z-ai/glm-5.2", -1, ModelSize.L, false),
+        new("amazon/nova-micro-v1", 3, ModelSize.S, false),
+        new("qwen/qwen3-next-80b-a3b-instruct", 2, ModelSize.M, false),
+    ];
+
+    [Fact]
+    public void ResolvesEachPopulatedLabel()
+    {
+        Assert.Equal("amazon/nova-micro-v1", ModelSizeCatalog.Resolve(ModelSize.S, Catalog));
+        Assert.Equal("qwen/qwen3-next-80b-a3b-instruct", ModelSizeCatalog.Resolve(ModelSize.M, Catalog));
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.Resolve(ModelSize.L, Catalog));
+        Assert.Equal("moonshotai/kimi-k3", ModelSizeCatalog.Resolve(ModelSize.XL, Catalog));
+    }
+
+    [Fact]
+    public void LowestOrderWinsWithinALabel()
+    {
+        var twoLarges = Catalog.Add(new("second-large", 5, ModelSize.L, false));
+
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.Resolve(ModelSize.L, twoLarges));
+    }
+
+    [Fact]
+    public void UnpopulatedLabelIsAMiss_NotAnError()
+    {
+        var noExtraLarge = Catalog.RemoveAll(c => c.Size == ModelSize.XL);
+
+        Assert.Null(ModelSizeCatalog.Resolve(ModelSize.XL, noExtraLarge));
+    }
+
+    [Fact]
+    public void UnpopulatedLabelFallsThroughToTheDefault()
+    {
+        // The whole point of not having to populate every size: asking for one nobody carries
+        // still runs a round, on the default.
+        var onlyLarge = Catalog.RemoveAll(c => c.Size is ModelSize.S or ModelSize.M or ModelSize.XL);
+
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.ResolveOrDefault("XL", onlyLarge));
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.ResolveOrDefault("S", onlyLarge));
+    }
+
+    [Fact]
+    public void DefaultIsTheLowestOrder_RouterExcluded()
+    {
+        // openrouter/auto sorts first at -10 and must STILL not be the default: it dispatches
+        // rather than answers, so defaulting to it would resolve Auto to Auto.
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.Default(Catalog));
+    }
+
+    [Fact]
+    public void RouterIsNeverSelectedByLabelEither()
+    {
+        var labelledRouter = Catalog
+            .RemoveAll(c => c.IsRouter)
+            .Add(new("openrouter/auto", -10, ModelSize.L, true));
+
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.Resolve(ModelSize.L, labelledRouter));
+    }
+
+    [Fact]
+    public void UnusableModelsAreSkipped()
+    {
+        // A labelled model whose credential can't serve a round must not shadow a usable one —
+        // the same rule the default already applied, extended to labels.
+        bool Usable(string id) => id != "z-ai/glm-5.2";
+
+        Assert.Null(ModelSizeCatalog.Resolve(ModelSize.L, Catalog, Usable));
+        Assert.Equal("qwen/qwen3-next-80b-a3b-instruct", ModelSizeCatalog.Default(Catalog, Usable));
+        Assert.Equal("qwen/qwen3-next-80b-a3b-instruct", ModelSizeCatalog.ResolveOrDefault("L", Catalog, Usable));
+    }
+
+    [Fact]
+    public void EmptyCatalogResolvesToNothing_NeverThrows()
+    {
+        Assert.Null(ModelSizeCatalog.Default([]));
+        Assert.Null(ModelSizeCatalog.Resolve(ModelSize.L, []));
+        Assert.Null(ModelSizeCatalog.ResolveOrDefault("L", []));
+    }
+
+    [Fact]
+    public void OnlyARouterAvailableStillYieldsNoDefault()
+    {
+        var routerOnly = Catalog.RemoveAll(c => !c.IsRouter);
+
+        Assert.Null(ModelSizeCatalog.Default(routerOnly));
+        Assert.Null(ModelSizeCatalog.ResolveOrDefault("M", routerOnly));
+    }
+
+    [Theory]
+    [InlineData("S", ModelSize.S)]
+    [InlineData("utility", ModelSize.S)]
+    [InlineData("m", ModelSize.M)]
+    [InlineData("light", ModelSize.M)]
+    [InlineData("L", ModelSize.L)]
+    [InlineData("standard", ModelSize.L)]
+    [InlineData("XL", ModelSize.XL)]
+    [InlineData("Heavy", ModelSize.XL)]
+    [InlineData("  xl  ", ModelSize.XL)]
+    public void LegacyTierNamesParseToTheSameLabels(string input, ModelSize expected) =>
+        Assert.Equal(expected, ModelSizes.Parse(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("gigantic")]
+    public void UnknownLabelIsAMiss_NotAThrow(string? input)
+    {
+        Assert.Null(ModelSizes.Parse(input));
+        // …and an agent declaring nonsense still runs, on the default.
+        Assert.Equal("z-ai/glm-5.2", ModelSizeCatalog.ResolveOrDefault(input, Catalog));
+    }
+}


### PR DESCRIPTION
## Why

An agent should declare **how much model it needs**, not which model. A model id is a deployment detail — it moves when a provider ships a new version, when prices change, when you switch clouds — and an agent naming one bakes that detail into its definition. Today the mapping lives in `ModelTier:*` **environment config**, which every new environment has to get right, invisibly, or a background agent quietly runs on the wrong model.

## What

- `ModelDefinition.Size` — **S / M / L / XL**, a label on the model NODE. Setting up a new environment becomes "label your models"; the labels are content, editable and visible like anything else on the mesh.
- `AgentConfiguration.ModelTier` now resolves against **the nodes first** (lowest `Order` carrying that label), then the legacy `ModelTier:*` config, then the deployment default. The legacy vocabulary is kept as aliases — `utility`/`light`/`standard`/`heavy` → S/M/L/XL — so existing agents and existing config work unchanged.
- **A size nobody carries is a MISS, not a failure** — it falls through to the default. That is deliberate: an environment does not have to populate every rung, and one labelled model is a valid setup.
- `ModelDefinition.IsRouter` — marks the **Auto** pseudo-model, which dispatches to a real model rather than serving a round. Routers are excluded from *every* automatic selection, the size lookup **and** the default: a default that can resolve to Auto resolves Auto to Auto, and a size that can resolve to Auto hands the round to something that cannot answer it. Auto is reachable only by an explicit pick.
- `ChatClientCredentialResolver.ResolveDefaultModelId` now runs on the same shared rule, so the picker default and the execution-time fallback cannot drift apart.

## Tests

21 tests over `ModelSizeCatalog` — pure functions, no hub, no snapshot, no credentials: label-hit, lowest-Order-within-label, miss → default, router excluded from both paths, unusable-credential skipping, empty and router-only catalogs, legacy aliases, unknown label. **Verified non-vacuous**: removing the router exclusion fails 8 of the 21.

## Docs

`Doc/AI/ModelSizes` — the setup for a new environment, including the deliberate `order: -1` default. Without one the default is whatever sorts first; on a live deployment that silently made a slow reasoning model serve every unpicked round for weeks, since nothing about such a round looks wrong except the bill and the latency.

## Not in this PR

The Auto **router agent** itself (classify the ask → dispatch by size, code-touching work floored at L) and the picker's fresh-thread default. This PR is the resolution half it stands on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)