### PR TITLE
Migrate GitHub.Copilot.SDK 1.0.0-beta.3 → 1.0.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -218,7 +218,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.runner.console" Version="3.2.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.3" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.8" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Octokit.Reactive" Version="14.0.0" />
   </ItemGroup>

--- a/src/MeshWeaver.AI.Copilot/CopilotChatClient.cs
+++ b/src/MeshWeaver.AI.Copilot/CopilotChatClient.cs
@@ -2,7 +2,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using MeshWeaver.AI.Connect;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Reactive;
@@ -203,25 +203,8 @@ public class CopilotChatClient : IChatClient, IAsyncDisposable
     {
         try
         {
-            var clientOptions = new CopilotClientOptions
-            {
-                AutoStart = true
-            };
-
-            if (!string.IsNullOrEmpty(configuration.CliPath))
-            {
-                clientOptions.CliPath = configuration.CliPath;
-            }
-
-            if (!string.IsNullOrEmpty(configuration.CliUrl))
-            {
-                clientOptions.CliUrl = configuration.CliUrl;
-            }
-
-            if (configuration.Port.HasValue)
-            {
-                clientOptions.Port = configuration.Port.Value;
-            }
+            var clientOptions = CopilotClientOptionsFactory.Create(
+                configuration.CliPath, configuration.CliUrl, configuration.Port);
 
             // Auth: a per-user GitHub token wins (co-hosted multi-user); otherwise
             // fall back to the machine's logged-in user (dev / ambient auth).
@@ -290,7 +273,10 @@ public class CopilotChatClient : IChatClient, IAsyncDisposable
         await using var session = await client.CreateSessionAsync(sessionConfig, cancellationToken);
 
         // Set up event handling using pattern matching
-        subscription = session.On(evt =>
+        // 1.0.8: On is generic (On<T>(Action<T>)) — the type argument is explicit because the
+        // lambda switches over event subtypes, so inference has nothing to bind to. SessionEvent
+        // is the base, i.e. subscribe to EVERY event and pattern-match, as before.
+        subscription = session.On<SessionEvent>(evt =>
         {
             switch (evt)
             {
@@ -436,7 +422,9 @@ public class CopilotChatClient : IChatClient, IAsyncDisposable
         // Add tools if provided - the SDK accepts AIFunction from Microsoft.Extensions.AI.Abstractions
         if (options?.Tools != null && options.Tools.Count > 0)
         {
-            config.Tools = options.Tools.OfType<AIFunction>().ToList();
+            // 1.0.8: Tools is ICollection<AIFunctionDeclaration> (AIFunction derives from it),
+            // so the executable AIFunctions still go in — only the static type widened.
+            config.Tools = options.Tools.OfType<AIFunction>().Cast<AIFunctionDeclaration>().ToList();
         }
 
         // The mesh: per-user `meshweaver` HTTP MCP server (Bearer-authenticated as the calling user).

--- a/src/MeshWeaver.AI.Copilot/CopilotClientOptionsFactory.cs
+++ b/src/MeshWeaver.AI.Copilot/CopilotClientOptionsFactory.cs
@@ -1,0 +1,48 @@
+using GitHub.Copilot;
+
+namespace MeshWeaver.AI.Copilot;
+
+/// <summary>
+/// Builds <see cref="CopilotClientOptions"/> from our configuration shape.
+/// </summary>
+/// <remarks>
+/// SDK 1.0.8 replaced the flat <c>AutoStart</c> / <c>CliPath</c> / <c>CliUrl</c> / <c>Port</c>
+/// switches with a single <c>Connection</c> of type <c>RuntimeConnection</c>, and renamed
+/// <c>CopilotHome</c> to <c>BaseDirectory</c>. The three transports are mutually exclusive, which the
+/// old flat shape could not express — setting both <c>CliUrl</c> and <c>Port</c> was silently
+/// ambiguous. Centralised here so the connect strategy and the chat client cannot drift apart on
+/// which one wins.
+/// </remarks>
+internal static class CopilotClientOptionsFactory
+{
+    /// <summary>
+    /// Precedence: an explicit URL, else an explicit port, else the configured CLI executable.
+    /// <para>Returns <c>null</c> when none is configured — and null is MEANINGFUL: the SDK then
+    /// spawns its bundled runtime over stdio, which is exactly what the old
+    /// <c>AutoStart = true</c> with no <c>CliPath</c> did. Do not "fix" this by substituting a
+    /// hard-coded executable name.</para>
+    /// </summary>
+    public static RuntimeConnection? CreateConnection(string? cliPath, string? cliUrl, int? port) =>
+        !string.IsNullOrEmpty(cliUrl) ? RuntimeConnection.ForUri(cliUrl)
+        : port.HasValue ? RuntimeConnection.ForTcp(port.Value)
+        : !string.IsNullOrEmpty(cliPath) ? RuntimeConnection.ForStdio(cliPath)
+        : null;
+
+    /// <summary>
+    /// <paramref name="copilotHome"/> maps to <c>BaseDirectory</c>, which the SDK turns into
+    /// <c>COPILOT_HOME</c> on the spawned runtime. It is IGNORED when connecting to an already
+    /// running runtime (URL / TCP) — per-user config dirs only mean something for a CLI we spawn.
+    /// </summary>
+    public static CopilotClientOptions Create(
+        string? cliPath, string? cliUrl, int? port, string? copilotHome = null)
+    {
+        var options = new CopilotClientOptions();
+        // Leave Connection unset when nothing is configured — null means "bundled runtime over
+        // stdio", the SDK's own default.
+        if (CreateConnection(cliPath, cliUrl, port) is { } connection)
+            options.Connection = connection;
+        if (!string.IsNullOrEmpty(copilotHome))
+            options.BaseDirectory = copilotHome;
+        return options;
+    }
+}

--- a/src/MeshWeaver.AI.Copilot/CopilotConnectStrategy.cs
+++ b/src/MeshWeaver.AI.Copilot/CopilotConnectStrategy.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using MeshWeaver.AI.Connect;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.DependencyInjection;
@@ -122,11 +122,8 @@ public sealed class CopilotConnectStrategy : IConnectStrategy
     private CopilotClient BuildClient(string? userConfigDir)
     {
         var cfg = CopilotConfig;
-        var options = new CopilotClientOptions { AutoStart = true, UseLoggedInUser = true };
-        if (!string.IsNullOrEmpty(cfg.CliPath)) options.CliPath = cfg.CliPath;
-        if (!string.IsNullOrEmpty(cfg.CliUrl)) options.CliUrl = cfg.CliUrl;
-        if (cfg.Port.HasValue) options.Port = cfg.Port.Value;
-        if (!string.IsNullOrEmpty(userConfigDir)) options.CopilotHome = userConfigDir;
+        var options = CopilotClientOptionsFactory.Create(cfg.CliPath, cfg.CliUrl, cfg.Port, userConfigDir);
+        options.UseLoggedInUser = true;
         return new CopilotClient(options);
     }
 


### PR DESCRIPTION
Finishes the long-deferred Copilot SDK bump. Five breaking changes, all resolved against the SDK's shipped XML docs rather than guesswork.

| change | resolution |
|---|---|
| `GitHub.Copilot.SDK` namespace removed | flattened to **`GitHub.Copilot`** |
| `AutoStart` / `CliPath` / `CliUrl` / `Port` gone | collapsed into one `Connection` of type `RuntimeConnection`, built via `ForUri` / `ForTcp` / `ForStdio` |
| `CopilotHome` gone | renamed **`BaseDirectory`** (still sets `COPILOT_HOME`; ignored when attaching to an already-running runtime) |
| `CopilotSession.On(...)` | now generic — explicit `On<SessionEvent>(...)`, since inference can't bind a lambda that switches over event subtypes |
| `SessionConfig.Tools` | widened to `ICollection<AIFunctionDeclaration>`; `AIFunction` derives from it, so the executable functions still go in |

## 🚨 `Connection = null` is meaningful

Not "unconfigured" — the SDK then **spawns its bundled runtime over stdio**, which is exactly what `AutoStart = true` with no `CliPath` did. Substituting a hard-coded executable name there would silently change behaviour, so the null is deliberate and commented in-place.

## One factory instead of two call sites

`CopilotConnectStrategy.BuildClient` and `CopilotChatClient.StartClientAsync` built the options identically, so construction moved into `CopilotClientOptionsFactory`. The three transports are now **mutually exclusive** — a distinction the old flat shape could not express, where setting both `CliUrl` and `Port` was silently ambiguous — so centralising also pins which one wins (URL → port → CLI path → bundled).

## Verification

`dotnet build -c Release -warnaserror` across the **full solution** → **0 warnings, 0 errors**.

⚠️ Compile-verified only. There is no test coverage that spawns a real Copilot runtime, so the connection-selection behaviour (particularly the null/bundled path and `BaseDirectory`) is verified against the SDK's documented semantics, not exercised end-to-end.

## Release note

Skipped — dependency migration with no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)