### PR TITLE
Bake gate: a timeout is not a regression

### DIFF
--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -36,6 +36,7 @@ public enum BakePhase
 public sealed class NodeTypeBakeGateState
 {
     private readonly ConcurrentDictionary<string, string> regressions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> unevaluated = new(StringComparer.OrdinalIgnoreCase);
     private int phase = (int)BakePhase.NotStarted;
     private volatile string detail = "pre-warm not started";
 
@@ -47,6 +48,13 @@ public sealed class NodeTypeBakeGateState
 
     /// <summary>Types that regressed on this image, with their compile error.</summary>
     public IReadOnlyDictionary<string, string> Regressions => regressions;
+
+    /// <summary>
+    /// Types the sweep could NOT evaluate on this image — a timed-out warm or an upstream that
+    /// never built. Visible for diagnosis, but deliberately NOT readiness-blocking: "I don't know"
+    /// is not "it broke". See <see cref="MarkOutcome"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Unevaluated => unevaluated;
 
     /// <summary>The sweep has begun.</summary>
     public void MarkRunning(string message)
@@ -65,6 +73,27 @@ public sealed class NodeTypeBakeGateState
     {
         if (outcome.ReachedUsableBuild || !outcome.WasHealthyBeforeBake)
             return;
+
+        // 🚨 A TIMEOUT IS NOT A VERDICT. The per-type budget elapsing means the sweep never got an
+        // answer — it says nothing about whether the type builds. During a roll the baking pod and
+        // the serving pod are two silos, and the sweep's shared-source resolution can time out
+        // across that boundary (core #694), so a healthy type times out for reasons that have
+        // nothing to do with it.
+        //
+        // Enabling the gate while timeouts counted as regressions stalled memex-cloud's rollout on
+        // 2026-08-02: "7 NodeType(s) regressed on this image", with not a single CS#### diagnostic
+        // in the pod log — every one was a SubscribeRequest timeout. The old image kept serving (no
+        // outage), but self-update silently stopped advancing, which for an auto-updating fleet is
+        // the worse failure.
+        //
+        // Deliberately narrow: only TimedOut is reclassified. A CompileError is Roslyn's verdict
+        // that the type is broken on this image, and an UpstreamFailed still gates — see
+        // UpstreamFailedOnAPreviouslyHealthyType_AlsoGates for why that one is intentional.
+        if (outcome.Status is PreWarmStatus.TimedOut)
+        {
+            unevaluated[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
+            return;
+        }
 
         regressions[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
         Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
@@ -85,7 +114,13 @@ public sealed class NodeTypeBakeGateState
         }
 
         Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
-        detail = message;
+        // Ready, but say so honestly: a type we could not evaluate is not a type we verified.
+        // Surfacing it in the health payload is what keeps "non-blocking" from becoming "invisible"
+        // — a silently-swallowed timeout is how a real regression would hide behind this change.
+        detail = unevaluated.IsEmpty
+            ? message
+            : $"{message} ({unevaluated.Count} not evaluated — "
+                + string.Join(", ", unevaluated.Keys.OrderBy(k => k, StringComparer.Ordinal)) + ")";
     }
 }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -122,6 +122,65 @@ public class NodeTypeBakeGateStateTest
         state.Phase.Should().Be(BakePhase.Regressed);
         state.Regressions.Keys.Should().Contain("Dependent");
     }
+    /// <summary>
+    /// 🚨 A TIMEOUT IS NOT A VERDICT. The per-type budget elapsing means the sweep never got an
+    /// answer — not that the type is broken. During a roll the baking pod and the serving pod are
+    /// two silos and the sweep's source resolution can time out across that boundary (core #694),
+    /// so a perfectly healthy type times out for reasons that have nothing to do with it.
+    ///
+    /// <para>Counting that as a regression stalled memex-cloud's rollout on 2026-08-02 — "7
+    /// NodeType(s) regressed on this image" with not one CS#### diagnostic in the log; every one
+    /// was a SubscribeRequest timeout. The old image kept serving, but self-update stopped
+    /// advancing, which for an auto-updating fleet is the worse failure.</para>
+    /// </summary>
+    [Fact]
+    public void TimedOutOnAPreviouslyHealthyType_DoesNotGate()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Slow/Type", PreWarmStatus.TimedOut, "budget elapsed")
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+        state.Unevaluated.Keys.Should().Contain("Slow/Type");
+    }
+
+    /// <summary>
+    /// Non-blocking must not mean invisible: a swallowed timeout is exactly how a real regression
+    /// would hide behind that leniency, so the health payload names what it could not evaluate.
+    /// </summary>
+    [Fact]
+    public void UnevaluatedTypes_AreNamedInTheHealthDetail()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Slow/Type", PreWarmStatus.TimedOut) { WasHealthyBeforeBake = true });
+        state.MarkComplete("all good");
+
+        state.Detail.Should().Contain("Slow/Type").And.Contain("not evaluated");
+    }
+
+    /// <summary>
+    /// The leniency is scoped to timeouts ONLY. Roslyn rejecting the type is a verdict, and it must
+    /// still stall the rollout — otherwise the gate stops being a gate.
+    /// </summary>
+    [Fact]
+    public void CompileErrorStillGates_EvenAlongsideATimeout()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Slow/Type", PreWarmStatus.TimedOut) { WasHealthyBeforeBake = true });
+        state.MarkOutcome(Failed("Broken/Type", wasHealthy: true));
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Broken/Type");
+    }
+
 
     /// <summary>Outcomes default to "was healthy" so a caller that never sets the flag fails safe.</summary>
     [Fact]


### PR DESCRIPTION
## What went wrong

Enabling `PreWarm__GateReadiness` (#760) stalled memex-cloud's rollout the same day:

```
NodeType bake regressed on this image — refusing readiness so the rollout
stalls with the previous image still serving. 7 NodeType(s) regressed
```

**Not one `CS####` diagnostic in the pod log.** Every one of the seven was a `SubscribeRequest` timeout:

```
No response received in hub cache/… within 00:01:00 → target Claims /
Reinsurance / SocialMedia / ClaimsDeepfield / RiskTransfer
```

During a roll the baking pod and the serving pod are two silos, and the sweep's shared-source resolution times out across that boundary (core #694). **The types compiled fine — the sweep could not reach them.**

## The defect

`MarkOutcome` treated every non-usable outcome as a regression, so *"I could not get an answer"* was reported as *"this type is broken on this image"*. The gate then withheld readiness and the rollout stalled. The old image kept serving — no outage — but **self-update silently stopped advancing**, which for an auto-updating fleet is the worse failure.

## The fix

`PreWarmStatus.TimedOut` now goes into a separate **`Unevaluated`** bucket that does not gate.

**Deliberately narrow.** `CompileError` is Roslyn's verdict and still gates. `UpstreamFailed` still gates too — that is an existing, tested, deliberate decision (`UpstreamFailedOnAPreviouslyHealthyType_AlsoGates`), and nothing in the observed failure justifies overturning it. I initially reclassified it as well and backed that out: my evidence was entirely about timeouts.

**Non-blocking must not become invisible** — a swallowed timeout is exactly how a real regression would hide behind this leniency — so `MarkComplete` names the unevaluated types in the health detail.

## Scope

This makes the gate **safe to re-enable**; it does **not** fix #694. The cross-silo subscribe failure is still live and still needs its own fix. Re-enabling the flag should be a separate, deliberate change once someone is watching a roll.

## Verification

- `NodeTypeBakeGateStateTest` **12/12** — 9 pre-existing (unchanged) + 3 new covering: a timeout doesn't gate, unevaluated types are named in the health detail, and a compile error still gates alongside a timeout
- `MeshWeaver.Hosting` builds Release `-warnaserror`, 0 warnings

## Release note

Skipped — deploy-gate behaviour, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)