### PR TITLE
fix(chat): AI-menu "New thread" opens the composer in MAIN, closing the side panel

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -518,15 +518,19 @@ public static class MemexConfiguration
     }
 
     /// <summary>
-    /// The AI (✨) menu seed — Threads / Models / Agents / Skills / Providers, each opening mesh search
-    /// grouped by namespace, plus the imperative "New thread" entry. This is the SINGLE SOURCE OF TRUTH,
-    /// shared by the hub registration below and the unit tests, so a regression can't quietly drop an
-    /// entry (there was no coverage at all pinning "New thread" into this menu).
+    /// The AI (✨) menu seed. In render order (by <c>Order</c>): the imperative "New thread" entry, then
+    /// Threads / Models / Providers / Agents / Skills, each opening mesh search grouped by namespace.
+    /// This is the SINGLE SOURCE OF TRUTH, shared by the hub registration below and the unit tests, so a
+    /// regression can't quietly drop an entry (there was no coverage at all pinning "New thread" here).
     /// <para>
-    /// 🚨 "New thread" deliberately carries NO <c>Href</c>: its <c>Area</c> is the
-    /// <see cref="PortalLayoutBase.AiNewThreadAction"/> sentinel, handled imperatively in
-    /// <c>HandleMenuItemClick</c> (open the composer in the MAIN pane + close the side panel). Giving it
-    /// an Href would send the generic branch navigating to that "area" on whatever node is on screen.
+    /// 🚨 "New thread" carries NO <c>Href</c> because it CANNOT: the composer lives at
+    /// <c>/User/{me}/Chat</c>, and the signed-in user is not known here — this seed is static and
+    /// registered per node hub, with no viewer identity. So the destination has to be resolved at CLICK
+    /// time from the circuit's <c>AccessService</c>. That is what the
+    /// <see cref="PortalLayoutBase.AiNewThreadAction"/> sentinel is for: <c>HandleMenuItemClick</c>
+    /// matches it FIRST and returns (open the composer in the MAIN pane + close the side panel), so an
+    /// <c>Href</c> added here would be silently dead code rather than a redirect. Keep it null so the
+    /// declaration matches the behaviour.
     /// </para>
     /// </summary>
     internal static IReadOnlyList<NodeMenuItemDefinition> AiMenuItems { get; } =

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -531,8 +531,13 @@ public static class MemexConfiguration
     /// </summary>
     internal static IReadOnlyList<NodeMenuItemDefinition> AiMenuItems { get; } =
     [
+        // ➕ is deliberately a LANGUAGE-NEUTRAL glyph, not the chat.svg the "Threads" entry uses:
+        // "new" is the whole meaning here, and a plus carries it in every locale without translation
+        // (and without colliding visually with "Threads", which is also a chat bubble). Emoji icons
+        // are the established convention in these menus — the Node menu is ✏️ 🔖 ➡️ 📋 🗑️ — and
+        // MeshNodeImageHelper.IsEmoji routes it to a <span>, never an <img>.
         new NodeMenuItemDefinition("New thread", PortalLayoutBase.AiNewThreadAction,
-            Icon: "/static/NodeTypeIcons/chat.svg", Order: 0,
+            Icon: "➕", Order: 0,
             Tooltip: "Start a new conversation"),
         new NodeMenuItemDefinition("Threads", "AiThreads", Icon: "/static/NodeTypeIcons/chat.svg", Order: 10,
             Href: "/search?q=nodeType%3AThread&groupBy=Namespace",

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -517,6 +517,42 @@ public static class MemexConfiguration
             + "misconfiguration surfaces now rather than after users have uploaded and lost files.");
     }
 
+    /// <summary>
+    /// The AI (✨) menu seed — Threads / Models / Agents / Skills / Providers, each opening mesh search
+    /// grouped by namespace, plus the imperative "New thread" entry. This is the SINGLE SOURCE OF TRUTH,
+    /// shared by the hub registration below and the unit tests, so a regression can't quietly drop an
+    /// entry (there was no coverage at all pinning "New thread" into this menu).
+    /// <para>
+    /// 🚨 "New thread" deliberately carries NO <c>Href</c>: its <c>Area</c> is the
+    /// <see cref="PortalLayoutBase.AiNewThreadAction"/> sentinel, handled imperatively in
+    /// <c>HandleMenuItemClick</c> (open the composer in the MAIN pane + close the side panel). Giving it
+    /// an Href would send the generic branch navigating to that "area" on whatever node is on screen.
+    /// </para>
+    /// </summary>
+    internal static IReadOnlyList<NodeMenuItemDefinition> AiMenuItems { get; } =
+    [
+        new NodeMenuItemDefinition("New thread", PortalLayoutBase.AiNewThreadAction,
+            Icon: "/static/NodeTypeIcons/chat.svg", Order: 0,
+            Tooltip: "Start a new conversation"),
+        new NodeMenuItemDefinition("Threads", "AiThreads", Icon: "/static/NodeTypeIcons/chat.svg", Order: 10,
+            Href: "/search?q=nodeType%3AThread&groupBy=Namespace",
+            Tooltip: "Conversation threads across every namespace"),
+        // Scope-tabbed catalogs (This space · User · Global) with per-tab "+" create,
+        // anchored on the type roots so the catalog area resolves (AddAiCatalogLayoutAreas).
+        new NodeMenuItemDefinition("Models", "AiModels", Icon: "/static/NodeTypeIcons/sparkle.svg", Order: 20,
+            Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ModelsArea}",
+            Tooltip: "Language models — global, space, and user"),
+        new NodeMenuItemDefinition("Providers", "AiProviders", Icon: "/static/NodeTypeIcons/key.svg", Order: 25,
+            Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ProvidersArea}",
+            Tooltip: "AI providers — endpoints + keys"),
+        new NodeMenuItemDefinition("Agents", "AiAgents", Icon: "/static/NodeTypeIcons/bot.svg", Order: 30,
+            Href: $"/Agent/{AiCatalogLayoutAreas.AgentsArea}",
+            Tooltip: "AI agents — global, space, and user"),
+        new NodeMenuItemDefinition("Skills", "AiSkills", Icon: "/static/NodeTypeIcons/rocket.svg", Order: 40,
+            Href: $"/{SkillNodeType.RootNamespace}/{AiCatalogLayoutAreas.SkillsArea}",
+            Tooltip: "Reusable skills — global, space, and user"),
+    ];
+
     extension<TBuilder>(TBuilder builder) where TBuilder : MeshBuilder
     {
         /// <summary>
@@ -824,30 +860,7 @@ public static class MemexConfiguration
                         // opens mesh search grouped by namespace, so every tier (global / space / user)
                         // where the concern is defined shows as its own section. Per-item configurable
                         // (label / icon / order / tooltip / href); register more under the same AI context.
-                        .AddNodeMenuItems(NodeMenuItemsExtensions.AiMenuContext,
-                            // "New thread" — opens the chat side panel ready for a brand-new conversation.
-                            // The Area is a sentinel handled imperatively in PortalLayoutBase.HandleMenuItemClick
-                            // (no Href → no navigation): it opens the panel + signals new-thread mode.
-                            new NodeMenuItemDefinition("New thread", PortalLayoutBase.AiNewThreadAction,
-                                Icon: "/static/NodeTypeIcons/chat.svg", Order: 0,
-                                Tooltip: "Start a new conversation in the chat panel"),
-                            new NodeMenuItemDefinition("Threads", "AiThreads", Icon: "/static/NodeTypeIcons/chat.svg", Order: 10,
-                                Href: "/search?q=nodeType%3AThread&groupBy=Namespace",
-                                Tooltip: "Conversation threads across every namespace"),
-                            // Scope-tabbed catalogs (This space · User · Global) with per-tab "+" create,
-                            // anchored on the type roots so the catalog area resolves (AddAiCatalogLayoutAreas).
-                            new NodeMenuItemDefinition("Models", "AiModels", Icon: "/static/NodeTypeIcons/sparkle.svg", Order: 20,
-                                Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ModelsArea}",
-                                Tooltip: "Language models — global, space, and user"),
-                            new NodeMenuItemDefinition("Agents", "AiAgents", Icon: "/static/NodeTypeIcons/bot.svg", Order: 30,
-                                Href: $"/Agent/{AiCatalogLayoutAreas.AgentsArea}",
-                                Tooltip: "AI agents — global, space, and user"),
-                            new NodeMenuItemDefinition("Skills", "AiSkills", Icon: "/static/NodeTypeIcons/rocket.svg", Order: 40,
-                                Href: $"/{SkillNodeType.RootNamespace}/{AiCatalogLayoutAreas.SkillsArea}",
-                                Tooltip: "Reusable skills — global, space, and user"),
-                            new NodeMenuItemDefinition("Providers", "AiProviders", Icon: "/static/NodeTypeIcons/key.svg", Order: 25,
-                                Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ProvidersArea}",
-                                Tooltip: "AI providers — endpoints + keys"))
+                        .AddNodeMenuItems(NodeMenuItemsExtensions.AiMenuContext, [.. AiMenuItems])
                         // Dedicated Admin menu (platform-wide GlobalSettings area), gated on root
                         // Permission.All: Invitations + Inbox.
                         .AddInvitationsSettingsTab()

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -396,8 +396,10 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
 
     /// <summary>
     /// Sentinel <see cref="NodeMenuItemDefinition.Area"/> for the AI menu's "New thread" item. It carries
-    /// NO Href, so it is handled imperatively in <see cref="HandleMenuItemClick"/> (open the chat panel in
-    /// new-thread mode) instead of navigating. Lives here so the menu seed and the handler agree.
+    /// NO Href, so it is handled imperatively in <see cref="HandleMenuItemClick"/> (open the composer in
+    /// the MAIN pane) instead of navigating to an area on the CURRENT node — the composer is a per-user
+    /// surface at <c>/User/{me}/Chat</c>, never <c>/{whatever-I-am-looking-at}/…</c>. Lives here so the
+    /// menu seed and the handler agree.
     /// </summary>
     public const string AiNewThreadAction = "ai-new-thread";
 
@@ -411,10 +413,10 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         isMeshMenuOpen = false;
         isAiMenuOpen = false;
         isGitHubMenuOpen = false;
-        // Imperative actions (no Href): the AI menu's "New thread" opens the chat panel fresh.
+        // Imperative actions (no Href): the AI menu's "New thread" opens the composer in the MAIN pane.
         if (string.Equals(item.Area, AiNewThreadAction, StringComparison.Ordinal))
         {
-            _ = OpenNewThreadInSidePanel();
+            OpenNewThreadInMain();
             return;
         }
         if (!string.IsNullOrEmpty(item.Href))
@@ -424,20 +426,44 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     }
 
     /// <summary>
-    /// Opens the chat side panel ready for a brand-new thread: clears any shown content (so the new-chat
-    /// composer renders), signals a mounted composer to reset to chat mode, and shows the panel (applying
-    /// the persisted size). Same end state as the side panel's existing New-thread button.
+    /// The user-scoped chat URL for <paramref name="userId"/> — <c>/User/{id}/Chat</c>. That area is
+    /// <see cref="UserActivityLayoutAreas.ChatArea"/>, which renders <c>ComposerAreaView</c>: the SAME
+    /// <c>ThreadChatControl</c> the side panel mounts for a new chat. Static + internal so the routing
+    /// contract is unit-testable without standing up a circuit.
     /// </summary>
-    private async Task OpenNewThreadInSidePanel()
+    internal static string NewThreadHref(string userId) =>
+        $"/User/{userId}/{UserActivityLayoutAreas.ChatArea}";
+
+    /// <summary>
+    /// Opens a brand-new conversation in the MAIN pane: navigates to <see cref="NewThreadHref"/> and
+    /// CLOSES the side panel.
+    /// <para>
+    /// 🚨 It closes the panel rather than leaving it be: a conversation lives in EITHER the main view
+    /// OR the side panel, never both (the same invariant <c>OnLocationChanged</c> enforces when the main
+    /// view navigates to a thread). Leaving the panel open would put a second, independent composer on
+    /// screen beside the one we just navigated to — two "new thread" surfaces, only one of which the
+    /// user is looking at, each able to start its own thread.
+    /// </para>
+    /// <para>
+    /// This replaces the previous side-panel implementation, which also had a live defect:
+    /// <c>RequestAction("New")</c> is a bare event (<c>OnActionRequested?.Invoke</c>), and it fired
+    /// BEFORE <c>SetVisible(true)</c> — so with the panel closed no composer was mounted, nothing was
+    /// subscribed, and the reset signal was dropped on the floor.
+    /// </para>
+    /// </summary>
+    private void OpenNewThreadInMain()
     {
+        var userId = AccessService?.Context?.ObjectId;
+        if (string.IsNullOrEmpty(userId))
+            return;
+
+        // Drop any side-panel conversation first, so the composer exists exactly once, in main.
         SidePanelState.SetContentPath(null);
         SidePanelState.SetTitle(null);
-        SidePanelState.RequestAction("New");
-        if (!SidePanelState.IsVisible)
-        {
-            SidePanelState.SetVisible(true);
-            await ApplyPersistedSizeAsync();
-        }
+        if (SidePanelState.IsVisible)
+            SidePanelState.SetVisible(false);
+
+        NavigationManager.NavigateTo(NewThreadHref(userId));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -395,11 +395,11 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     }
 
     /// <summary>
-    /// Sentinel <see cref="NodeMenuItemDefinition.Area"/> for the AI menu's "New thread" item. It carries
-    /// NO Href, so it is handled imperatively in <see cref="HandleMenuItemClick"/> (open the composer in
-    /// the MAIN pane) instead of navigating to an area on the CURRENT node — the composer is a per-user
-    /// surface at <c>/User/{me}/Chat</c>, never <c>/{whatever-I-am-looking-at}/…</c>. Lives here so the
-    /// menu seed and the handler agree.
+    /// Sentinel <see cref="NodeMenuItemDefinition.Area"/> for the AI menu's "New thread" item.
+    /// <see cref="HandleMenuItemClick"/> matches it BEFORE the Href/Area navigation branches and returns,
+    /// opening the composer in the MAIN pane instead. It has to be imperative because the destination is
+    /// per-user (<c>/User/{me}/Chat</c>) and only resolvable from the circuit at click time — a static
+    /// menu seed cannot name it. Lives here so the seed and the handler agree on the sentinel.
     /// </summary>
     public const string AiNewThreadAction = "ai-new-thread";
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-04-new-thread-opens-in-main.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-04-new-thread-opens-in-main.md
@@ -1,0 +1,21 @@
+---
+Name: New thread opens in the main view
+Category: What's New
+Description: Starting a conversation from the ✨ menu now opens the composer in the main view instead of the side panel, and the entry is marked with a language-neutral ➕.
+Icon: Sparkle
+---
+
+# New thread opens in the main view
+
+Picking **New thread** from the ✨ menu used to open the chat side panel. It now opens the composer
+in the **main view** — the full-width surface — and closes the side panel on the way, so you are
+never looking at two separate places to start a conversation.
+
+This also fixes a case where the menu entry appeared to do nothing at all: when the side panel was
+closed, the signal telling the composer to start fresh was sent before there was anything listening
+for it, and it was simply lost. That path is gone.
+
+The entry is now marked with a plain **➕** rather than a chat bubble. A plus reads as "new" in every
+language and no longer looks identical to the **Threads** entry right below it.
+
+On your home page, **My items** now sits above **Open threads**.

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -270,9 +270,9 @@ public static class UserActivityLayoutAreas
 
         @@("area/Composer")
 
-        @@("area/Threads")
-
         @@("area/Catalog")
+
+        @@("area/Threads")
 
         @@("area/Pinned")
 

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -34,6 +34,20 @@ public class AiMenuNewThreadTest
     }
 
     [Fact]
+    public void NewThread_Icon_Is_LanguageNeutral()
+    {
+        var newThread = MemexConfiguration.AiMenuItems
+            .Single(i => i.Area == PortalLayoutBase.AiNewThreadAction);
+
+        // A plus reads as "new" in every locale. Pin BOTH halves of that contract: the glyph itself,
+        // and that IsEmoji routes it to a <span> — an icon that fell through to the IsImageUrl branch
+        // would render as <img src="➕"> (a broken-image box), which is how icon regressions show up.
+        Assert.Equal("➕", newThread.Icon);
+        Assert.True(MeshNodeImageHelper.IsEmoji(newThread.Icon));
+        Assert.False(MeshNodeImageHelper.IsImageUrl(newThread.Icon));
+    }
+
+    [Fact]
     public void NewThread_Carries_No_Href_So_It_Stays_Imperative()
     {
         var newThread = MemexConfiguration.AiMenuItems

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -53,10 +53,10 @@ public class AiMenuNewThreadTest
         var newThread = MemexConfiguration.AiMenuItems
             .Single(i => i.Area == PortalLayoutBase.AiNewThreadAction);
 
-        // 🚨 The regression this guards: HandleMenuItemClick checks the sentinel FIRST, but if someone
-        // gives this entry an Href the generic branch would navigate to it instead — and because Area
-        // is not a real layout area, NavigateToArea would build "/{current-node}/ai-new-thread" and
-        // 404 on whatever page the user happened to be on.
+        // The destination (/User/{me}/Chat) depends on the signed-in user, which the static seed cannot
+        // know — it is resolved at click time from the circuit. HandleMenuItemClick matches the sentinel
+        // FIRST and returns, so an Href here would never be followed: it would be dead code that reads
+        // like a working destination. This pins the declaration to the behaviour.
         Assert.Null(newThread.Href);
     }
 

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -1,0 +1,77 @@
+using MeshWeaver.Blazor.Portal.Layout;
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the AI (✨) menu's "New thread" entry end to end: that it is seeded at all, that it stays
+/// imperative (no Href), and that it routes to the user's OWN composer in the MAIN pane.
+/// <para>
+/// Why this exists: "New thread" was reported missing from the sparkle menu and there was no test
+/// anywhere asserting the AI menu's contents — a dropped seed entry, or an Href accidentally added to
+/// it, would both have shipped silently. The live server payload turned out to carry the item, which
+/// is exactly why the interesting contract is the SHAPE of the entry, not merely its presence.
+/// </para>
+/// </summary>
+public class AiMenuNewThreadTest
+{
+    [Fact]
+    public void AiMenu_Seeds_NewThread_First()
+    {
+        var items = MemexConfiguration.AiMenuItems;
+
+        var newThread = Assert.Single(items, i => i.Area == PortalLayoutBase.AiNewThreadAction);
+        Assert.Equal("New thread", newThread.Label);
+
+        // Order 0 → it sorts ahead of every other AI entry (Threads 10, Models 20, …). The menu
+        // aggregator inserts into an ImmutableSortedSet keyed on Order, so this IS the positioning
+        // contract — there is no post-hoc OrderBy to fall back on.
+        Assert.Equal(0, newThread.Order);
+        Assert.All(
+            items.Where(i => i.Area != PortalLayoutBase.AiNewThreadAction),
+            i => Assert.True(i.Order > 0, $"'{i.Label}' must sort after New thread"));
+    }
+
+    [Fact]
+    public void NewThread_Carries_No_Href_So_It_Stays_Imperative()
+    {
+        var newThread = MemexConfiguration.AiMenuItems
+            .Single(i => i.Area == PortalLayoutBase.AiNewThreadAction);
+
+        // 🚨 The regression this guards: HandleMenuItemClick checks the sentinel FIRST, but if someone
+        // gives this entry an Href the generic branch would navigate to it instead — and because Area
+        // is not a real layout area, NavigateToArea would build "/{current-node}/ai-new-thread" and
+        // 404 on whatever page the user happened to be on.
+        Assert.Null(newThread.Href);
+    }
+
+    [Fact]
+    public void NewThread_Routes_To_The_Users_Own_Composer_In_Main()
+    {
+        var href = PortalLayoutBase.NewThreadHref("alice");
+
+        // /User/{me}/Chat — ChatArea renders ComposerAreaView, i.e. the SAME ThreadChatControl the
+        // side panel mounts for a new chat. User-scoped, never scoped to the node being viewed.
+        Assert.Equal($"/User/alice/{UserActivityLayoutAreas.ChatArea}", href);
+    }
+
+    [Fact]
+    public void Every_Other_AiMenu_Entry_Navigates_By_Href()
+    {
+        // The inverse of the sentinel contract: everything that is NOT the imperative entry must be a
+        // plain navigation, so it works identically from any page and needs no client state.
+        Assert.All(
+            MemexConfiguration.AiMenuItems.Where(i => i.Area != PortalLayoutBase.AiNewThreadAction),
+            i => Assert.False(string.IsNullOrEmpty(i.Href), $"'{i.Label}' must navigate by Href"));
+    }
+
+    [Fact]
+    public void AiMenu_Entries_Are_Uniquely_Keyed()
+    {
+        // The aggregator dedupes on (Order, Label, Area) via ImmutableSortedSet — two entries
+        // colliding on all three would silently drop one from the rendered menu.
+        var keys = MemexConfiguration.AiMenuItems.Select(i => (i.Order, i.Label, i.Area)).ToList();
+        Assert.Equal(keys.Count, keys.Distinct().Count());
+    }
+}

--- a/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
@@ -56,10 +56,11 @@ public class UserActivityHomeOverrideTest
         // The welcome heading is back at the very top — above the chat composer.
         welcome.Should().BeLessThan(composer, "the welcome heading must be at the top of the home page");
         // Chat composer above the regions.
-        composer.Should().BeLessThan(threads, "the chat composer sits above the regions");
-        // Pinned is moved to the END of the regions — after Threads and Catalog.
-        threads.Should().BeLessThan(catalog);
-        catalog.Should().BeLessThan(pinned, "pinned items sit at the end of the regions");
+        composer.Should().BeLessThan(catalog, "the chat composer sits above the regions");
+        // My items (Catalog) sits ABOVE Open threads.
+        catalog.Should().BeLessThan(threads, "my items come before open threads");
+        // Pinned is at the END of the regions — after Catalog and Threads.
+        threads.Should().BeLessThan(pinned, "pinned items sit at the end of the regions");
         // The configurable note sits at the BOTTOM — after the regions (the only "configurable" text).
         configurable.Should().BeGreaterThan(pinned, "the configurable text must be at the bottom of the page");
     }


### PR DESCRIPTION
Reported as "the new thread menu is not working".

## What was actually wrong

Reading the live `$Menu:AI` payload showed the entry **was** being served correctly — so this was never a missing menu item. The defect was in the handler:

```csharp
SidePanelState.RequestAction("New");     // ← bare event, fired FIRST
if (!SidePanelState.IsVisible)
{
    SidePanelState.SetVisible(true);     // ← composer mounts only now
```

`RequestAction` is `OnActionRequested?.Invoke(action)`. With the panel closed, **no composer was mounted, nothing was subscribed, and the reset signal was dropped on the floor.**

## What it does now

Clicking **New thread** navigates the **main** pane to `/User/{me}/Chat` — `UserActivityLayoutAreas.ChatArea`, which renders `ComposerAreaView`: by its own doc comment *"the SAME `ThreadChatControl` the side panel mounts for a new chat"*. The side panel is closed on the way, so the composer exists exactly once on screen — the same "a conversation lives in EITHER main OR the panel, never both" invariant `OnLocationChanged` already enforces when main navigates to a thread.

Two small UX changes ride along:

- The entry's icon becomes **➕** instead of `chat.svg`. A plus reads as "new" in every locale and no longer looks identical to the **Threads** entry directly below it. Emoji icons are already the convention here (the Node menu is ✏️ 🔖 ➡️ 📋 🗑️), and `IsEmoji` routes it to a `<span>`, never an `<img>`.
- On the default user home, **My items** now sits above **Open threads**.

## Testability

The AI menu seed moves out of the per-node-hub config lambda into `MemexConfiguration.AiMenuItems` — one source of truth shared by the registration and the tests, mirroring how `UserWelcomeMarkdown` is structured. There was **no coverage anywhere** of the AI menu's contents, so a dropped entry or an `Href` added to the imperative entry would both have shipped silently.

## Tests

- `AiMenuNewThreadTest` — 6/6 (new). Pins: the entry is seeded and sorts first; it carries **no** `Href` (an `Href` would send the generic branch to `/{current-node}/ai-new-thread`); every *other* entry does navigate by `Href`; entries are uniquely keyed for the `ImmutableSortedSet` dedup; the icon is ➕ **and** takes the emoji branch; the route resolves to the user's own Chat area.
- `UserActivityHomeOverrideTest` — 11/11, updated for the new region order.
- `Memex.Portal.Shared.Test` — 227/227.
- Pre-flight: `MeshWeaver.Graph`, `MeshWeaver.Blazor.Portal`, `Memex.Portal.Shared` all build `-c Release -warnaserror -p:CIRun=true` with 0 warnings, 0 errors.

What's New entry included (`2026-08-04-new-thread-opens-in-main.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)