### PR TITLE
Revert #772 — GetMeshNodeStream doesn't wait for a node that doesn't exist yet

### DIFF
--- a/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
@@ -116,25 +116,20 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
             NodeType: "Markdown",
             Namespace: user));
 
-        // 🚨 Wait on the NODE STREAM of the hub that actually performs the write, not on a query.
-        // The query index is eventually consistent BY DESIGN, so polling it for a just-written node
-        // races the indexer — that is exactly how this test failed on CI (2026-08-03, shard 1): the
-        // 15s budget expired with the node written but not yet indexed. Widening the budget would
-        // only make the race rarer; reading the authoritative source removes it.
-        // The write originates on the dedicated tracking hub against the shared root cache (see the
-        // class docs), so its workspace is where the node is observable — NOT the calling connHub,
-        // and not ReadNode (a one-shot GetMeshNode that returns null on NotFound and completes,
-        // so it cannot wait for a node that has not been written yet).
-        var expectedPath = $"{user}/_UserActivity/{nodePath.Replace("/", "_")}";
-        var node = await Mesh.GetActivityTrackingHub().GetWorkspace().GetMeshNodeStream(expectedPath)
-            .Where(n => n is not null)
-            .Select(n => (MeshNode?)n)
-            .Should().Within(TimeSpan.FromSeconds(15)).Emit();
+        // 🚨 Wait on the QUERY, not on GetMeshNodeStream(path). This looks like the wrong
+        // primitive — the query index is eventually consistent — but it is the only one that
+        // WAITS for a node that does not exist yet. Both authoritative reads terminate instead:
+        // ReadNode is a one-shot GetMeshNode that returns null on NotFound and completes, and
+        // GetMeshNodeStream(path) on a not-yet-created node likewise COMPLETES rather than staying
+        // open until the write lands. #772 switched to the stream and turned an occasional 15s
+        // timeout into a deterministic 250ms "completed without a value" on CI (afe2fc6ea) — the
+        // whole wait collapsed. Reverted; the poll is correct here precisely because it retries.
+        var node = await PollForFirst($"namespace:{user}/_UserActivity nodeType:UserActivity");
 
         node.Should().NotBeNull(
             "a track posted to a connection-style hub must still land a UserActivity node — " +
             "the handler originates the write from the dedicated tracking hub, not the caller");
-        node!.Path.Should().Be(expectedPath);
+        node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
         node.NodeType.Should().Be("UserActivity");
 
         // 🚨 The write ran under the CALLER's identity, not system/empty. The handler builds


### PR DESCRIPTION
## #772 didn't fix this test — it made it worse

#772 moved `TrackActivity_InitiatedFromConnectionHub_LandsNode`'s wait off the eventually-consistent query index onto the tracking hub's node stream. The CI trx for `afe2fc6ea` (which **contains** #772) shows it failing again, and the timing is decisive:

```
ObservableAssertions.WaitForFirst  ←  ActivityTrackingHubTest.cs:129
INIT    11:48:03.142
DISPOSE 11:48:03.390          ← 250 ms, NOT the 15 s budget
```

It did not time out. The observable **completed without emitting**.

## What that teaches

`GetMeshNodeStream(path)` on a **not-yet-created** node *terminates* rather than staying open until the write lands — the same failure shape as `ReadNode` (a one-shot `GetMeshNode` returning null on NotFound and completing), which #772 had already rejected for exactly that reason. **Neither authoritative read is a "wait for creation" primitive.**

Net effect of #772: an occasional 15 s-timeout flake became a **deterministic fast failure** whenever the node wasn't already present.

Locally the node always *was* present (357/357, twice), which is why this didn't show before merge. A green local run was never evidence for a race that only reproduces on CI — I said so in #772 and shipped it as fixed anyway.

## The fix

Revert to `PollForFirst`. The query poll *looks* like the wrong primitive — the index really is eventually consistent — but it is the only one here that **retries**, which is what "wait for a write that hasn't happened yet" actually requires. The comment now records why, so the swap isn't repeated.

## Scope

⚠️ The underlying flake — the node occasionally not landing within 15 s — is **not fixed** and stays open. This only restores the previous, better behaviour.

## Verification

`Query.Test` **357/357** native, Release `-warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)