### PR TITLE
Pin the off-turn hop at the seam, not at a thread id (main is red)

### DIFF
--- a/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
@@ -36,7 +36,7 @@ namespace MeshWeaver.GitSync.Test;
 ///
 /// <para>⚠️ Consequence of that parenthesis, measured rather than assumed: on THIS harness the two
 /// live-progress tests below pass with <c>ScheduleOffHubTurn</c> deleted. They document the contract;
-/// they do not enforce it. <see cref="TheCommandDoesNotRunOnTheThreadThatDeliveredTheCreate"/> is the
+/// they do not enforce it. <see cref="ActivityExecutionGoesThroughThePooledSubscribeScheduler"/> is the
 /// one that fails — it asserts the scheduler hop itself rather than an outcome the hop happens to
 /// enable.</para>
 /// </summary>
@@ -177,7 +177,7 @@ public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTest
     /// and for the right reason — with no timing dependence whatsoever.</para>
     /// </summary>
     [Fact(Timeout = 120000)]
-    public async Task TheCommandDoesNotRunOnTheThreadThatDeliveredTheCreate()
+    public async Task ActivityExecutionGoesThroughThePooledSubscribeScheduler()
     {
         var recorder = Mesh.ServiceProvider.GetService<IPooledSubscribeScheduler>() as RecordingSubscribeScheduler;
         Assert.NotNull(recorder); // the harness must have installed the recorder — see ConfigureMesh

--- a/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ActivityLiveProgressTest.cs
@@ -1,8 +1,12 @@
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.GitSync.Test;
@@ -38,6 +42,50 @@ namespace MeshWeaver.GitSync.Test;
 /// </summary>
 public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
 {
+    /// <summary>
+    /// Installs the recording scheduler as a DECORATOR over whatever the mesh already registered,
+    /// so the activity path behaves exactly as in production and the test can still assert the hop
+    /// happened. Scoped to this mesh — it dies with it.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                var existing = services.LastOrDefault(d => d.ServiceType == typeof(IPooledSubscribeScheduler));
+                services.AddSingleton<IPooledSubscribeScheduler>(sp =>
+                {
+                    var inner = existing?.ImplementationFactory?.Invoke(sp) as IPooledSubscribeScheduler
+                                ?? (existing?.ImplementationType is { } t
+                                    ? ActivatorUtilities.CreateInstance(sp, t) as IPooledSubscribeScheduler
+                                    : existing?.ImplementationInstance as IPooledSubscribeScheduler);
+                    return new RecordingSubscribeScheduler(inner);
+                });
+                return services;
+            });
+
+    /// <summary>
+    /// Counts how many times an observable was routed through the drainable pool. Wraps the real
+    /// scheduler rather than replacing it, so the activity still executes exactly as it does in
+    /// production — the recorder only observes.
+    ///
+    /// <para>An INSTANCE registered per mesh, never a static counter: static state would survive
+    /// mesh disposal and bleed across tests (Doc/Architecture/NoStaticState).</para>
+    /// </summary>
+    private sealed class RecordingSubscribeScheduler(IPooledSubscribeScheduler? inner) : IPooledSubscribeScheduler
+    {
+        private int pooledSubscribes;
+
+        /// <summary>How many observables have been routed through the pool on this mesh.</summary>
+        public int PooledSubscribes => Volatile.Read(ref pooledSubscribes);
+
+        /// <inheritdoc />
+        public IObservable<T> SubscribeThroughPool<T>(IObservable<T> source)
+        {
+            Interlocked.Increment(ref pooledSubscribes);
+            return inner is null ? source : inner.SubscribeThroughPool(source);
+        }
+    }
+
     [Fact(Timeout = 120000)]
     public async Task ProgressLine_LandsWhileTheCommandIsStillRunning()
     {
@@ -106,36 +154,48 @@ public class ActivityLiveProgressTest(ITestOutputHelper output) : GitHubSyncTest
     /// scheduler hop: both still passed, in under a second. A regression pin that cannot fail is
     /// worse than no pin, because the next person to touch this reads green and ships the deadlock.</para>
     ///
-    /// <para>So pin the MECHANISM instead of the symptom, which needs no Orleans silo: the command
-    /// body must not run on the thread that delivered the create — under Orleans that thread IS the
-    /// grain's activation turn, and holding it is what makes every <c>ctx.Log</c> round trip
-    /// unserviceable. <c>onActivityCreated</c> fires on exactly that continuation, immediately
-    /// before the execution is scheduled, so the two thread ids are the before / after of the hop.</para>
+    /// <para><b>Why this pins the SEAM and not a thread id.</b> Two earlier probes were tried and
+    /// both are unsound on this harness:</para>
+    /// <list type="number">
+    ///   <item><description><c>createdThread != commandThread</c> — the runtime makes no such
+    ///   promise. The hop ENQUEUES the work (<c>SubscribeThroughPool</c> /
+    ///   <c>SubscribeOn(TaskPoolScheduler.Default)</c>) and the pool is free to run it on the thread
+    ///   that just went idle — the very thread that delivered the create. The hop happens correctly
+    ///   and the ids still match. Measured: 3 failures in 25 local runs (12%), and it reddened main
+    ///   within 20 minutes of merging.</description></item>
+    ///   <item><description>Blocking the delivering thread and waiting for the command to signal —
+    ///   the command does not run CONCURRENTLY with the create callback at all. The callback
+    ///   returns first, and only then is the execution scheduled. Measured: fails ~60% of runs even
+    ///   though the command demonstrably ran on another thread.</description></item>
+    /// </list>
+    ///
+    /// <para>On a free-threaded monolith harness there is no observable behavioural difference
+    /// between hopped and inline — the deadlock this guards is an ORLEANS property (the grain's
+    /// activation turn). So pin the mechanism where it is deterministic: the execution must go
+    /// through the injected <see cref="IPooledSubscribeScheduler"/>. Delete
+    /// <c>ScheduleOffHubTurn</c> and the recorder below is never called, so this fails immediately
+    /// and for the right reason — with no timing dependence whatsoever.</para>
     /// </summary>
     [Fact(Timeout = 120000)]
     public async Task TheCommandDoesNotRunOnTheThreadThatDeliveredTheCreate()
     {
+        var recorder = Mesh.ServiceProvider.GetService<IPooledSubscribeScheduler>() as RecordingSubscribeScheduler;
+        Assert.NotNull(recorder); // the harness must have installed the recorder — see ConfigureMesh
+        var before = recorder!.PooledSubscribes;
+
         var space = "GhTurn" + Guid.NewGuid().ToString("N")[..8];
         await CreateSpace(space, "Off-turn execution space");
 
-        int createdThread = -1;
-        int commandThread = -2;
-
         var activityPath = await Mesh.RunActivity(
                 space, ActivityCategory.Import, "Off-turn probe",
-                ctx =>
-                {
-                    commandThread = Environment.CurrentManagedThreadId;
-                    return Observable.Return(Unit.Default);
-                },
-                onActivityCreated: _ => createdThread = Environment.CurrentManagedThreadId)
+                ctx => Observable.Return(Unit.Default))
             .Timeout(60.Seconds()).ToTask();
 
-        Assert.NotEqual(-1, createdThread);
-        Assert.NotEqual(-2, commandThread);
-        Assert.True(createdThread != commandThread,
-            $"the command ran INLINE on the create's thread ({createdThread}) — under Orleans that is "
-            + "the grain turn, so every ctx.Log write would deadlock against the command holding it");
+        Assert.True(recorder.PooledSubscribes > before,
+            "the activity execution did not go through IPooledSubscribeScheduler — ScheduleOffHubTurn "
+            + "was bypassed, so the command runs on the thread that delivered the create. Under "
+            + "Orleans that thread is the grain's activation turn, and every ctx.Log write would "
+            + "deadlock against the command holding it.");
 
         var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
         Assert.Equal(ActivityStatus.Succeeded, log.Status);


### PR DESCRIPTION
**main is currently red on this test**, which blocks the self-update from rolling forward and is also failing #784.

`ActivityLiveProgressTest.TheCommandDoesNotRunOnTheThreadThatDeliveredTheCreate` (added by #787) was green on its own PR and reddened main within 20 minutes. Locally it fails **3 runs in 25 (12%)**.

## Why it fails

It asserted `createdThread != commandThread`. That's not an invariant the runtime offers — the hop *enqueues* the work (`SubscribeThroughPool` / `SubscribeOn(TaskPoolScheduler.Default)`), and the thread pool is free to run it on the thread that just went idle, which is precisely the thread that delivered the create. **The hop happens correctly and the ids still match.**

Neither #787 nor #790 touched `src/`, so nothing about production behaviour changed between them — the test was simply unsound from the start and got unlucky on main.

## What I tried that also doesn't work

Blocking the delivering thread and waiting for the command to signal — a "concurrency proof". It fails **~60%** of runs, and the output says why: the command reports a *different* thread but never runs concurrently with the callback. The callback returns first; only then is execution scheduled. There is no overlap to observe.

That forced the real conclusion: **on a free-threaded monolith harness there is no behavioural difference between hopped and inline.** The deadlock being guarded is an Orleans property — a command holding the grain's activation turn makes every `ctx.Log` round trip unserviceable — and it isn't reproducible without a silo. Thread identity was the only proxy available, and it's one the runtime never promised. The original author's reasoning was sound; only the probe was.

## The fix

`ActivityRunner` resolves `IPooledSubscribeScheduler` from DI (`ActivityRunner.cs:98`), so the test installs a recording **decorator** over whatever the mesh registered and asserts the execution went through the pool. Production behaviour is untouched — the recorder counts and delegates — and the counter is a per-mesh instance, never a static (`NoStaticState`).

## Verified both directions

The author's argument was that a pin which cannot fail is worse than no pin, so I checked both:

| | result |
|---|---|
| with the hop | **10/10 green**, zero timing dependence |
| hop deleted | **fails in 0.65 s**: *"the activity execution did not go through IPooledSubscribeScheduler"* |

Deleting only the *call site* doesn't even compile (`CS8321`, unused local function under `TreatWarningsAsErrors`), so the regression this guards has to be a deliberate removal of the whole hop — which the pin now catches.

Diff is one test file; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)