### PR TITLE
CI: split the two heaviest test projects across shards

### DIFF
--- a/.github/scripts/shard-assign.sh
+++ b/.github/scripts/shard-assign.sh
@@ -37,6 +37,19 @@
 #
 # Unlisted projects get DEFAULT_WEIGHT — a deliberate over-estimate, since an
 # unlisted project is a NEW one whose cost nobody has measured yet.
+#
+# ── Splitting a heavyweight across shards ────────────────────────────────────
+# An optional THIRD column splits one project into N parts, each weighted 1/N and
+# scheduled independently — so the halves land on DIFFERENT shards, i.e. different
+# runners. That matters twice over: it lowers the floor (no amount of sharding can
+# beat the heaviest single project), and it introduces no shared-resource contention,
+# because two runners share nothing. `maxParallelThreads: 1` is per-process and stays
+# intact.
+#
+# A split entry prints as `<csproj>#<part>/<parts>`; the test job turns that into an
+# `-class` filter list by enumerating the assembly's classes and taking every Nth.
+# The BUILD job strips the suffix, so a split project's bin is packed into every shard
+# that runs one of its parts.
 set -euo pipefail
 
 : "${SHARD_INDEX:?SHARD_INDEX must be set}"
@@ -46,8 +59,8 @@ DEFAULT_WEIGHT=10
 
 # "<seconds> <project-name>", heaviest first.
 WEIGHTS=$(cat <<'EOF'
-345 MeshWeaver.Hosting.Monolith.Test
-263 MeshWeaver.AI.Test
+345 MeshWeaver.Hosting.Monolith.Test 2
+263 MeshWeaver.AI.Test 2
 239 MeshWeaver.Hosting.Orleans.Test
 130 MeshWeaver.Hosting.PostgreSql.Test
 104 MeshWeaver.Threading.Test
@@ -125,10 +138,15 @@ printf '%s\n' "$WEIGHTS" > "$weights_file"
 # the runner while failing for anyone verifying a change locally.
 find test -name '*.csproj' ! -path '*Cosmos*' ! -path '*/bin/*' \
   | awk -v dflt="$DEFAULT_WEIGHT" '
-      FNR == NR { if (NF == 2) weight[$2] = $1; next }
+      FNR == NR { if (NF >= 2) { weight[$2] = $1; if (NF >= 3) parts[$2] = $3 } next }
       {
         name = $0; sub(/.*\//, "", name); sub(/\.csproj$/, "", name)
-        printf "%06d %s %s\n", (name in weight ? weight[name] : dflt), name, $0
+        w = (name in weight ? weight[name] : dflt)
+        n = (name in parts ? parts[name] : 1)
+        if (n <= 1) { printf "%06d %s %s\n", w, name, $0; next }
+        # Each part is its own schedulable unit at 1/N the weight.
+        for (i = 1; i <= n; i++)
+          printf "%06d %s#%d/%d %s#%d/%d\n", int(w / n), name, i, n, $0, i, n
       }' "$weights_file" - \
   | sort -k1,1nr -k2,2 \
   | awk -v idx="$SHARD_INDEX" -v total="$SHARD_TOTAL" '

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -262,12 +262,15 @@ jobs:
         # downloaded.
         for ((i=0; i<SHARD_TOTAL; i++)); do
           SHARD_INDEX=$i .github/scripts/shard-assign.sh \
-            | while read -r csproj; do
+            | while read -r entry; do
+                # A split project arrives as `<csproj>#<part>/<parts>`. Strip the suffix: the
+                # SAME bin has to travel to every shard running one of its parts.
+                csproj="${entry%%#*}"
                 d="$(dirname "$csproj")/bin"
                 # A project that produced no output (helper with nothing to
                 # build) simply contributes nothing to its shard's tarball.
                 [ -d "$d" ] && echo "$d"
-              done > ".build-paths-$i.txt"
+              done | sort -u > ".build-paths-$i.txt"
           # zstd -T0 = all cores. --long=27 (128 MiB match window) dedupes ACROSS
           # files: the self-contained test bins each carry near-identical copies
           # of the same framework + MeshWeaver DLLs, which the default 8 MiB
@@ -408,8 +411,19 @@ jobs:
         echo "Shard $SHARD_INDEX/$SHARD_TOTAL runs ${#selected[@]} projects"
 
         # ── Run each assigned project's native xUnit v3 host ─────────────────
-        for csproj in "${selected[@]}"; do
+        for entry in "${selected[@]}"; do
+          # A heavyweight may be SPLIT across shards, arriving as `<csproj>#<part>/<parts>`.
+          # Each part runs in its own process on its own runner, so the halves share
+          # nothing — no ports, no containers, no state. maxParallelThreads:1 is
+          # per-process and is unaffected.
+          csproj="${entry%%#*}"
+          partspec="${entry#*#}"
+          if [ "$partspec" = "$entry" ]; then part=1; parts=1; else
+            part="${partspec%%/*}"; parts="${partspec##*/}"
+          fi
           name=$(basename "$csproj" .csproj)
+          label="$name"
+          [ "$parts" -gt 1 ] && label="$name (part $part/$parts)"
           dir=$(dirname "$csproj")/bin/Release/net10.0
           # Helper projects (TestDomain, Hub.Fixture, AI.Test.FakeCli) ship no
           # xunit.v3 host — nothing to run. Recorded so the log shows they were
@@ -440,11 +454,30 @@ jobs:
           # CWD = the project's bin dir, exactly like `dotnet test` ran the
           # host: appsettings.json + xunit.runner.json + TestData resolve there.
           mkdir -p "$dir/TestResults"
+          # For a split project, enumerate the assembly's classes and take every Nth from
+          # the SORTED list. Deterministic, and self-maintaining: a newly added test class
+          # is distributed automatically without anyone editing the weight table.
+          classargs=()
+          trxname="$name"
+          if [ "$parts" -gt 1 ]; then
+            mapfile -t allclasses < <( cd "$dir" && dotnet "$name.dll" -list classes 2>/dev/null \
+              | grep -E "^[A-Za-z_][A-Za-z0-9_.]*$" | sort )
+            if [ "${#allclasses[@]}" -eq 0 ]; then
+              echo "::error::$label: could not enumerate test classes — refusing to run a partial shard silently."
+              echo "[CI] $name exit=96 NO_CLASSES (class enumeration failed for a split project)" >> test/test-results.log
+              continue
+            fi
+            for ((ci=part-1; ci<${#allclasses[@]}; ci+=parts)); do
+              classargs+=(-class "${allclasses[$ci]}")
+            done
+            trxname="$name.part$part"
+            echo "$label: ${#classargs[@]} of ${#allclasses[@]} classes"
+          fi
           ( cd "$dir" && timeout --signal=TERM --kill-after=30s 8m \
-              dotnet "$name.dll" -trx "TestResults/$name.trx" )
+              dotnet "$name.dll" -trx "TestResults/$trxname.trx" "${classargs[@]}" )
           rc=$?
           if [ "$rc" = "124" ] || [ "$rc" = "137" ]; then
-            marker="[CI] $name exit=$rc TIMEOUT (6m wall-clock cap hit — likely fixture/init hang)"
+            marker="[CI] $label exit=$rc TIMEOUT (6m wall-clock cap hit — likely fixture/init hang)"
           else
             marker="[CI] $name exit=$rc"
           fi


### PR DESCRIPTION
Stacked on #784 — merge that first.

## ⚠️ Corrected scope: this buys ~5 s at 6 shards, not minutes

An earlier version of this description claimed the sharding floor drops "345 s → ~175 s", implying a large win. **That was wrong and I'm correcting it.** With `SHARD_TOTAL: 6`, LPT already balances to 345/340/340/339/339/339 against a total test weight of 2030 s (ideal 338 s). Splitting takes the maximum from **345 → 340**. We were already within 2% of optimal.

## What it's actually for: making more shards worthwhile

The floor only binds when you *add* shards — and there it's the thing that unlocks the gain, because `Hosting.Monolith.Test` at 345 s otherwise caps any shard count:

| shards | worst shard tests | est. run wall |
|---|---:|---:|
| 6 (today) | ~340 s | ~18 min |
| 8 | ~254 s | ~15.3 min |
| 12 | ~170 s | ~13.9 min |

So this is the **enabler** for raising `SHARD_TOTAL`, not a standalone win. Merge it if you intend to scale shards; there's no urgency otherwise.

Note the diminishing returns in that table: the build job (545 s) doesn't shard at all and is now over half the critical path.

## How it works

The weight table gains an optional third column, a part count. A split project becomes N independently schedulable units at 1/N weight, so LPT places the halves on **different shards** — i.e. different runners, sharing no ports, no containers, no state. `maxParallelThreads: 1` is per-process and untouched.

The parts are derived, not hand-listed: the runner enumerates the assembly's classes (`dotnet X.dll -list classes`), sorts, and takes every Nth — so a newly added class distributes itself.

Both primitives were verified against a real binary before designing around them, and partitioning was checked end to end: **32 classes → 16 + 16, union 32, overlap 0.**

## Guards

- class enumeration returning nothing is **`exit=96 NO_CLASSES`**, never a quiet skip;
- the build job strips the `#part` suffix and `sort -u`s the path list, so a split project's bin reaches every shard running one of its parts, exactly once.

## Not yet proven

The workflow path has **not run in CI** — partitioning is verified locally only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)