### PR TITLE
Register Icon — it rides in control state and the reflection sweep can't see it

### DIFF
--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -206,7 +206,14 @@ public static class LayoutExtensions
                 typeof(MeshWeaver.Layout.Catalog.GridConfig),
                 typeof(MeshWeaver.Layout.Catalog.CatalogGroup),
                 typeof(MeshWeaver.Layout.Catalog.SearchResultGroup),
-                typeof(MeshWeaver.Layout.Catalog.GroupedSearchResult)
+                typeof(MeshWeaver.Layout.Catalog.GroupedSearchResult),
+                // Icon lives in MeshWeaver.Domain, so the IUiControl/Skin reflection sweep above
+                // cannot see it — yet it rides inside control state on almost every control
+                // (IconStart/IconEnd, NavItem, MenuItem, ProgressMessage). Unregistered, it
+                // serialises with an auto short-name and the receiving hub adopts the type as a
+                // SIDE EFFECT of the read (ObjectPolymorphicConverter.GetTypeName -> unguarded
+                // GetOrAddType). Measured: 37 fallbacks in one bulk plugin run.
+                typeof(MeshWeaver.Domain.Icon)
             )
             .WithHandler<GetLayoutAreasRequest>(HandleGetLayoutAreasRequest);
 


### PR DESCRIPTION
`LayoutExtensions` registers control/skin types by reflecting over the `UiControl` assembly, plus an explicit list for *"non-IUiControl content/config records serialised **INSIDE** control state (so the reflection sweep above misses them)"*.

`Icon` is exactly that case, and it was missing. It lives in `MeshWeaver.Domain`, so the sweep can't see it — yet it rides inside almost every control: `IconStart` / `IconEnd`, `NavItem`, `MenuItem`, `ProgressMessage`.

Unregistered, it serialises with an auto short-name and the receiving hub **adopts the type as a side effect of the read** (`ObjectPolymorphicConverter.GetTypeName` → unguarded `GetOrAddType`) — the hazard AGENTS.md calls out under *"Read `node.Content` in whatever shape it arrives"*.

## This omission has already cost us once

The sibling registration in `ActivityNodeType` carries the scar:

> `ObjectPolymorphicConverter` falls back to `JsonElement` for `$type=CodeConfiguration` payloads, and the `n.Content is CodeConfiguration cf` filter in `MeshNodeCompilationService.CompileCore` **silently drops every source**. Symptom in prod: *"⚠ Compilation failed"* with no specific error.

Same shape, different type.

## Measured

`mw-plugin-test` over the 19-package plugins repo with `MW_LOG_LEVEL=Trace` (see #798):

| | `Unregistered type MeshWeaver.Domain.Icon` |
|---|---|
| before | **37** |
| after | **0** |

Run green both ways — exit 0, ~1.0M `MESSAGE_FLOW` events, **zero** failed deliveries.

## Not included

`MeshWeaver.Graph.Configuration.NodeTypeCompileState` also shows 37 fallbacks, but it is **benign** and deliberately left alone: it is written with `SerializeToElement(state, options)` into `ActivityLog.ReturnValue` and read back with `Deserialize<NodeTypeCompileState>(options)` — a concrete round-trip on both ends, never a polymorphic `$type` dispatch. Registering it would only silence a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)