### PR TITLE
Make router traffic loud: ERROR when mesh/ is sender or target

### DIFF
--- a/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
+++ b/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
@@ -1,0 +1,39 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Whether a delivery involves the ROOT MESH HUB — the router — as an end, and in which role.
+///
+/// <para>A pure predicate, decidable from three values with no hub, no logger and no delivery
+/// pipeline. The detector's whole value is that it fires on exactly the right traffic: a false
+/// ERROR trains people to mute the channel, and a missed one is how a router-starvation wedge stays
+/// invisible. That is worth pinning directly rather than through a running hub.</para>
+/// </summary>
+public static class RouterTrafficRule
+{
+    /// <summary>
+    /// The role the mesh hub plays in this delivery, or <c>null</c> when it is not an end of it (or
+    /// when the message is routing liveness rather than work).
+    /// </summary>
+    /// <param name="targetAddressType">Address type of the hub receiving the delivery.</param>
+    /// <param name="senderAddressType">Address type of the sender, if any.</param>
+    /// <param name="message">The message being delivered.</param>
+    /// <returns><c>"target"</c>, <c>"sender"</c>, <c>"sender AND target"</c>, or <c>null</c>.</returns>
+    public static string? RoleOf(string? targetAddressType, string? senderAddressType, object? message)
+    {
+        // Heartbeats ARE the router's own job — routing liveness, not work. Type check, not a name
+        // match: a rename must not silently turn this exclusion off.
+        if (message is HeartBeatEvent)
+            return null;
+
+        var targetIsRouter = string.Equals(targetAddressType, AddressExtensions.MeshType, StringComparison.Ordinal);
+        var senderIsRouter = string.Equals(senderAddressType, AddressExtensions.MeshType, StringComparison.Ordinal);
+
+        return (targetIsRouter, senderIsRouter) switch
+        {
+            (true, true) => "sender AND target",
+            (true, false) => "target",
+            (false, true) => "sender",
+            _ => null,
+        };
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1248,20 +1248,12 @@ public sealed class MessageHub : IMessageHub
     /// </summary>
     private void ReportRouterTraffic(IMessageDelivery delivery)
     {
-        var targetIsRouter = string.Equals(Address.Type, AddressExtensions.MeshType, StringComparison.Ordinal);
-        var senderIsRouter = string.Equals(delivery.Sender?.Type, AddressExtensions.MeshType, StringComparison.Ordinal);
-        if (!targetIsRouter && !senderIsRouter)
-            return;
-
-        // Heartbeats ARE the router's own job — routing liveness, not work. Type check, not a name
-        // match: a rename must not silently turn this exclusion off.
-        if (delivery.Message is HeartBeatEvent)
+        // The rule itself is a pure predicate — see RouterTrafficRule, where it is unit-tested.
+        var role = RouterTrafficRule.RoleOf(Address.Type, delivery.Sender?.Type, delivery.Message);
+        if (role is null)
             return;
 
         var messageType = delivery.Message?.GetType().Name ?? "(null)";
-
-        var role = targetIsRouter && senderIsRouter ? "sender AND target"
-            : targetIsRouter ? "target" : "sender";
         if (!routerTrafficReported.TryAdd($"{role}:{messageType}", 0))
             return;
 

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1253,21 +1253,26 @@ public sealed class MessageHub : IMessageHub
         if (!targetIsRouter && !senderIsRouter)
             return;
 
-        var messageType = delivery.Message?.GetType().Name ?? "(null)";
-        // Heartbeats ARE the router's own job — routing liveness, not work.
-        if (messageType is "HeartBeatEvent")
+        // Heartbeats ARE the router's own job — routing liveness, not work. Type check, not a name
+        // match: a rename must not silently turn this exclusion off.
+        if (delivery.Message is HeartBeatEvent)
             return;
+
+        var messageType = delivery.Message?.GetType().Name ?? "(null)";
 
         var role = targetIsRouter && senderIsRouter ? "sender AND target"
             : targetIsRouter ? "target" : "sender";
         if (!routerTrafficReported.TryAdd($"{role}:{messageType}", 0))
             return;
 
+        // Log BOTH ends explicitly. {Address} is this hub — the delivery TARGET — so when the router
+        // is the SENDER it would name the innocent hub and send the reader hunting the wrong one.
         logger.LogError(
-            "ROUTER_TRAFFIC: {MessageType} has the mesh hub as {Role} ({Address}). The mesh hub is the "
-            + "ROUTER and must not execute work — it belongs on a hub of its own (session portal hub "
-            + "for REST/Blazor/MCP, import hub for bulk imports). Reported once per role+type for this hub.",
-            messageType, role, Address);
+            "ROUTER_TRAFFIC: {MessageType} has the mesh hub as {Role} (sender: {Sender}, target: {Target}). "
+            + "The mesh hub is the ROUTER and must not execute work — it belongs on a hub of its own "
+            + "(session portal hub for REST/Blazor/MCP, import hub for bulk imports). Reported once per "
+            + "role+type for this hub.",
+            messageType, role, delivery.Sender?.ToString() ?? "(none)", Address);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1212,6 +1212,8 @@ public sealed class MessageHub : IMessageHub
                 messageTypeName, Address, delivery.Id);
         MessageTrace.Write($"hub={Address} msg={delivery.Message?.GetType().Name} id={delivery.Id} HUB.DeliverMessage ENTER state={delivery.State}");
 
+        ReportRouterTraffic(delivery);
+
         var ret = delivery.ChangeState(MessageDeliveryState.Submitted);
         var result = messageService.RouteMessageAsync(ret, default);
 
@@ -1220,6 +1222,52 @@ public sealed class MessageHub : IMessageHub
                 messageTypeName, Address, delivery.Id, result.State);
         MessageTrace.Write($"hub={Address} msg={delivery.Message?.GetType().Name} id={delivery.Id} HUB.DeliverMessage EXIT state={result.State}");
         return result;
+    }
+
+
+    // One report per (role, message type) for this hub's lifetime. Node CRUD targets the router on
+    // EVERY write today, so an un-deduped line would be a storm — and a storm gets muted, which is
+    // how this stayed invisible in the first place.
+    private readonly ConcurrentDictionary<string, byte> routerTrafficReported = new();
+
+    /// <summary>
+    /// 🚨 Logs an ERROR when the ROOT MESH HUB is the sender or the target of a delivery.
+    ///
+    /// <para>The mesh hub is the mesh's ROUTER and nothing else. Work executed on its action block —
+    /// node CRUD above all — competes with routing itself: a burst of creates starves real
+    /// <c>SubscribeRequest</c> traffic and every node op then times out, which is a portal-wide wedge
+    /// (atioz 2026-06-11: "11× CreateOrUpdateNodeRequest + 3× CreateNodeRequest@mesh/&lt;self&gt; stale
+    /// &gt;60s while real user SubscribeRequests starved"). Work belongs on a hub of its own — the
+    /// session portal hub for REST / Blazor / MCP, the dedicated <c>import/{id}</c> hub for bulk
+    /// imports.</para>
+    ///
+    /// <para>This is a DETECTOR, not a guard: it never blocks a delivery. Every violating path must
+    /// stay working while it is migrated — and must stay VISIBLE, because the failure is silent until
+    /// it is catastrophic. The leaked-callback CI failure that surfaced it read as a flaky test, not
+    /// as the router doing someone else's job.</para>
+    /// </summary>
+    private void ReportRouterTraffic(IMessageDelivery delivery)
+    {
+        var targetIsRouter = string.Equals(Address.Type, AddressExtensions.MeshType, StringComparison.Ordinal);
+        var senderIsRouter = string.Equals(delivery.Sender?.Type, AddressExtensions.MeshType, StringComparison.Ordinal);
+        if (!targetIsRouter && !senderIsRouter)
+            return;
+
+        var messageType = delivery.Message?.GetType().Name ?? "(null)";
+        // Heartbeats ARE the router's own job — routing liveness, not work.
+        if (messageType is "HeartBeatEvent")
+            return;
+
+        var role = targetIsRouter && senderIsRouter ? "sender AND target"
+            : targetIsRouter ? "target" : "sender";
+        if (!routerTrafficReported.TryAdd($"{role}:{messageType}", 0))
+            return;
+
+        logger.LogError(
+            "ROUTER_TRAFFIC: {MessageType} has the mesh hub as {Role} ({Address}). The mesh hub is the "
+            + "ROUTER and must not execute work — it belongs on a hub of its own (session portal hub "
+            + "for REST/Blazor/MCP, import hub for bulk imports). Reported once per role+type for this hub.",
+            messageType, role, Address);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficRuleTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficRuleTest.cs
@@ -1,0 +1,44 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The detector must fire on exactly the traffic that means "the router is doing work" — no more
+/// (a false ERROR trains people to mute it) and no less (a missed one is how the wedge stayed
+/// invisible).
+/// </summary>
+public class RouterTrafficRuleTest
+{
+    private const string Mesh = "mesh";
+
+    [Theory]
+    [InlineData(Mesh, "portal", "target")]
+    [InlineData("portal", Mesh, "sender")]
+    [InlineData(Mesh, Mesh, "sender AND target")]
+    public void RouterAsAnEnd_IsReported(string target, string sender, string expected) =>
+        Assert.Equal(expected, RouterTrafficRule.RoleOf(target, sender, new object()));
+
+    [Theory]
+    [InlineData("portal", "client")]
+    [InlineData("import", "mesh-ish")]   // near-miss must NOT match
+    [InlineData("client", null)]
+    public void TrafficBetweenOtherHubs_IsSilent(string target, string? sender) =>
+        Assert.Null(RouterTrafficRule.RoleOf(target, sender, new object()));
+
+    [Fact]
+    public void HeartbeatsAreTheRoutersOwnJob_AndNeverReported()
+    {
+        Assert.Null(RouterTrafficRule.RoleOf(Mesh, "portal", new HeartBeatEvent()));
+        Assert.Null(RouterTrafficRule.RoleOf(Mesh, Mesh, new HeartBeatEvent()));
+    }
+
+    [Fact]
+    public void MatchIsExact_NotCaseInsensitiveOrPrefixed()
+    {
+        Assert.Null(RouterTrafficRule.RoleOf("Mesh", "portal", new object()));
+        Assert.Null(RouterTrafficRule.RoleOf("meshx", "portal", new object()));
+    }
+}


### PR DESCRIPTION
## What

An **ERROR** log whenever the root mesh hub is the **sender or target** of a delivery — naming the message type, the role, and the hub. Deduped per role+type per hub lifetime. Heartbeats excluded (routing liveness is genuinely the router's job).

That is all this PR does. It never blocks a delivery.

## Why only the detector

The mesh hub is the **router**. Work on its action block competes with routing itself: a burst of creates starves `SubscribeRequest` traffic and every node op times out — the atioz 2026-06-11 portal-wide wedge, whose signature `StaticRepoImporter` still records:

> "11× CreateOrUpdateNodeRequest + 3× `CreateNodeRequest@mesh/<self>` stale >60s while real user SubscribeRequests starved"

It resurfaced in CI as a leaked `Observe` callback (`1 pending callback(s) after 2.00s: CreateNodeRequest@mesh/<id>(3009ms)`) failing `ContentCollectionReferenceTest` — a test that never calls `CreateNode`. That reads as a flaky test, not as a structural defect, which is exactly the problem.

**The write-path fix is held back on purpose** ([#794](https://github.com/Systemorph/MeshWeaver/pull/794), staying open). Retargeting CRUD to the nearest handling hub relocates two invariants `mesh/` was silently providing:

1. the **action-block hop** — the handler otherwise runs on the caller's turn (`ActivityLiveProgressTest` pins this; under Orleans that turn is the grain activation);
2. the **identity the write runs under** — it broke `EducationStartExerciseTest` with *"lacks Create permission"*, i.e. **silent privilege reduction** on the learner course-install path.

Neither is a reason to abandon the fix; both are reasons not to ship it before the detector has told us, from production, which paths hit the router and how loudly. Measurement first.

## Cost

One dictionary probe per inbound delivery on hubs that aren't the router, and at most one log line per role+type per hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)