### PR TITLE
Instrument the cross-schema fan-out: it was slow and invisible

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -342,15 +342,24 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         // "300 schemas". Escalates to Warning past the threshold so it shows at default level.
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var rows = 0;
-        await using (var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        var firstRowMs = -1L;
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        // 🚨 try/FINALLY, not a call after the loop. A caller that stops enumerating early — a
+        // `.Take(n)`, a `break`, a cancellation, or a throw out of ReadMeshNode — disposes the
+        // iterator without ever reaching code placed after the `while`. The slow fan-out would then
+        // go UNLOGGED, which is the one case this instrumentation exists to catch. `finally` runs on
+        // that disposal path too, so an abandoned enumeration still reports what it cost.
+        try
         {
-            var firstRowMs = -1L;
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
             {
                 if (rows++ == 0)
                     firstRowMs = sw.ElapsedMilliseconds;
                 yield return ReadMeshNode(reader, options);
             }
+        }
+        finally
+        {
             LogFanOutTiming("search_across_schemas", sw.ElapsedMilliseconds, firstRowMs, rows, limit);
         }
     }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -18,6 +18,13 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     private readonly PostgreSqlSqlGenerator _sqlGenerator = new();
     private readonly ILogger? _logger;
 
+    /// <summary>
+    /// Fan-out width of the LAST schema list read — how many partitions a cross-schema UNION spans.
+    /// Only ever used to annotate the timing log, so a stale-by-one value is harmless; keeping it a
+    /// plain int avoids putting a lock on the query path to serve a diagnostic.
+    /// </summary>
+    internal int _cachedSchemaCount;
+
     // SyncSearchableSchemasAsync throttle. PostgreSqlPartitionedMeshQuery
     // calls this once per cross-schema fan-out, which under thread-render
     // load is N times per page-load. Without throttling, each call does a
@@ -221,6 +228,7 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
                     schemas.Add(reader2.GetString(0));
             }
 
+            _cachedSchemaCount = schemas.Count;
             return schemas;
         }
         catch (OperationCanceledException) { return []; }
@@ -324,11 +332,50 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         cmd.Parameters.Add(new NpgsqlParameter("@p_order", orderBy));
         cmd.Parameters.Add(new NpgsqlParameter("@p_limit", limit));
 
-        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        // ⏱️ TIMED, because this is the expensive shape and nothing used to measure it.
+        // search_across_schemas builds a UNION ALL over EVERY row of public.searchable_schemas,
+        // so an unanchored query (no path:/namespace: first segment) scans every partition —
+        // every plugin AND every user partition. Its cost therefore grows with the number of
+        // users on the mesh, which makes it get quietly slower over months with no code change.
+        // Log the fan-out width next to the elapsed time so a slow query says WHY it was slow;
+        // a WHERE-clause dump alone (the previous logging) cannot distinguish "bad filter" from
+        // "300 schemas". Escalates to Warning past the threshold so it shows at default level.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var rows = 0;
+        await using (var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false))
         {
-            yield return ReadMeshNode(reader, options);
+            var firstRowMs = -1L;
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                if (rows++ == 0)
+                    firstRowMs = sw.ElapsedMilliseconds;
+                yield return ReadMeshNode(reader, options);
+            }
+            LogFanOutTiming("search_across_schemas", sw.ElapsedMilliseconds, firstRowMs, rows, limit);
         }
+    }
+
+    /// <summary>Elapsed above which a cross-schema fan-out is logged as a Warning, not Debug.</summary>
+    internal const long SlowFanOutMs = 1000;
+
+    /// <summary>
+    /// One line per cross-schema fan-out: total elapsed, time to the FIRST row, rows returned, the
+    /// limit, and how many schemas the UNION spanned. Time-to-first-row separates a slow QUERY (the
+    /// scan) from slow STREAMING (the caller's own consumption) — without it a slow log line is
+    /// ambiguous and the usual next step is to blame the database.
+    /// </summary>
+    internal void LogFanOutTiming(string what, long totalMs, long firstRowMs, int rows, int limit)
+    {
+        var schemas = _cachedSchemaCount;
+        if (totalMs >= SlowFanOutMs)
+            _logger?.LogWarning(
+                "[CrossSchema] SLOW {What}: {TotalMs}ms (first row {FirstMs}ms) — {Rows}/{Limit} rows across {Schemas} schema(s). " +
+                "An unanchored query UNIONs every partition; add a path:/namespace: first segment to pin it to one schema.",
+                what, totalMs, firstRowMs, rows, limit, schemas);
+        else
+            _logger?.LogDebug(
+                "[CrossSchema] {What}: {TotalMs}ms (first row {FirstMs}ms) — {Rows}/{Limit} rows across {Schemas} schema(s).",
+                what, totalMs, firstRowMs, rows, limit, schemas);
     }
 
     /// <inheritdoc />

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
@@ -25,6 +25,9 @@ public class CrossSchemaFanOutTimingTests
     private sealed class CapturingLogger : ILogger<PostgreSqlCrossSchemaQueryProvider>
     {
         public readonly List<Entry> Entries = new();
+        // NB: no `where TState : notnull` here — CS0460 forbids restating a constraint on an
+        // EXPLICIT interface implementation; it is inherited from ILogger.BeginScope. (Copilot
+        // suggested adding it; the compiler rejects it.)
         IDisposable? ILogger.BeginScope<TState>(TState state) => null;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex,

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins the cross-schema fan-out's TIMING instrumentation.
+///
+/// <para>Why this exists: <c>search_across_schemas</c> builds a <c>UNION ALL</c> over every row of
+/// <c>public.searchable_schemas</c>, so a query with no <c>path:</c>/<c>namespace:</c> anchor scans
+/// EVERY partition — every plugin and every user partition. Its cost therefore grows with the number
+/// of users, and it degrades over months with no code change. Before this, the provider logged the
+/// WHERE clause but never a duration, so a slow query was indistinguishable from a bad filter and
+/// the fan-out width was invisible.</para>
+///
+/// <para>The assertions are about what an operator can ACT on: a slow fan-out must be visible at
+/// default log level (Warning, not Debug), must state how many schemas it spanned, and must name the
+/// fix. A fast one must stay quiet.</para>
+/// </summary>
+public class CrossSchemaFanOutTimingTests
+{
+    private sealed record Entry(LogLevel Level, string Message);
+
+    private sealed class CapturingLogger : ILogger<PostgreSqlCrossSchemaQueryProvider>
+    {
+        public readonly List<Entry> Entries = new();
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add(new Entry(level, formatter(state, ex)));
+    }
+
+    /// <summary>
+    /// The provider only needs a data source to be CONSTRUCTED; the timing helper touches neither it
+    /// nor the database, which is the point of extracting it — the log decision is unit-testable
+    /// without Postgres.
+    /// </summary>
+    private static (PostgreSqlCrossSchemaQueryProvider Provider, CapturingLogger Log) Subject(int schemas)
+    {
+        var logger = new CapturingLogger();
+        var dataSource = NpgsqlDataSource.Create("Host=localhost;Database=unused;Username=unused");
+        var provider = new PostgreSqlCrossSchemaQueryProvider(dataSource, logger)
+        {
+            _cachedSchemaCount = schemas,
+        };
+        return (provider, logger);
+    }
+
+    [Fact]
+    public void SlowFanOut_WarnsAtDefaultLevel()
+    {
+        var (provider, log) = Subject(schemas: 312);
+
+        provider.LogFanOutTiming("search_across_schemas",
+            totalMs: PostgreSqlCrossSchemaQueryProvider.SlowFanOutMs, firstRowMs: 900, rows: 15, limit: 15);
+
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("SLOW", entry.Message);
+    }
+
+    [Fact]
+    public void SlowFanOut_ReportsTheFanOutWidth()
+    {
+        // The width is the whole diagnosis: "1200ms" alone reads as a database problem, "1200ms
+        // across 312 schemas" tells the operator it is an unanchored query.
+        var (provider, log) = Subject(schemas: 312);
+
+        provider.LogFanOutTiming("search_across_schemas", totalMs: 4200, firstRowMs: 4100, rows: 3, limit: 50);
+
+        var message = Assert.Single(log.Entries).Message;
+        Assert.Contains("312", message);
+        Assert.Contains("4200", message);
+        Assert.Contains("3/50", message);
+    }
+
+    [Fact]
+    public void SlowFanOut_NamesTheFix()
+    {
+        // A warning that does not say what to do gets muted rather than fixed.
+        var (provider, log) = Subject(schemas: 200);
+
+        provider.LogFanOutTiming("search_across_schemas", totalMs: 9000, firstRowMs: 8000, rows: 1, limit: 10);
+
+        var message = Assert.Single(log.Entries).Message;
+        Assert.Contains("path:", message);
+        Assert.Contains("namespace:", message);
+    }
+
+    [Fact]
+    public void FastFanOut_StaysAtDebug()
+    {
+        // Every page render fans out; warning on the normal case would drown the slow one.
+        var (provider, log) = Subject(schemas: 12);
+
+        provider.LogFanOutTiming("search_across_schemas", totalMs: 40, firstRowMs: 30, rows: 8, limit: 50);
+
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.DoesNotContain("SLOW", entry.Message);
+    }
+
+    [Fact]
+    public void TheThresholdIsInclusive_SoTheBoundaryCannotFallThroughSilently()
+    {
+        var (slowProvider, slowLog) = Subject(schemas: 5);
+        slowProvider.LogFanOutTiming("q", PostgreSqlCrossSchemaQueryProvider.SlowFanOutMs, 1, 1, 1);
+        Assert.Equal(LogLevel.Warning, Assert.Single(slowLog.Entries).Level);
+
+        var (fastProvider, fastLog) = Subject(schemas: 5);
+        fastProvider.LogFanOutTiming("q", PostgreSqlCrossSchemaQueryProvider.SlowFanOutMs - 1, 1, 1, 1);
+        Assert.Equal(LogLevel.Debug, Assert.Single(fastLog.Entries).Level);
+    }
+
+    [Fact]
+    public void TimeToFirstRow_IsReported_SoScanTimeIsSeparableFromStreamingTime()
+    {
+        // Total alone cannot distinguish "the scan was slow" from "the caller consumed slowly".
+        var (provider, log) = Subject(schemas: 40);
+
+        provider.LogFanOutTiming("search_across_schemas", totalMs: 5000, firstRowMs: 120, rows: 200, limit: 200);
+
+        var message = Assert.Single(log.Entries).Message;
+        Assert.Contains("120", message);
+        Assert.Contains("5000", message);
+    }
+}


### PR DESCRIPTION
`search nodeType:Skill scope:subtree` takes seconds on memex. The cause is **structural, not a bad filter**: `search_across_schemas` builds a `UNION ALL` over every row of `public.searchable_schemas`

```sql
FOR schema_rec IN SELECT schema_name FROM public.searchable_schemas ORDER BY schema_name
LOOP  union_sql := union_sql || ' UNION ALL ' || format(...)
```

so a query with no `path:`/`namespace:` first segment scans **every partition — every plugin AND every user partition**. Its cost therefore grows with the number of *users* on the mesh: the same query degrades over months with no code change.

The provider logged the WHERE clause and nothing else — no duration, no fan-out width — so a slow query was indistinguishable from a bad filter, and the real variable was invisible.

## What this adds

Each fan-out now logs elapsed, **time to first row**, rows/limit and the schema count, escalating to **Warning past 1s** so it surfaces at default log level and *names the fix* (anchor the query).

Time-to-first-row is deliberate: total alone cannot separate a slow **scan** from slow **streaming** by the caller, and without that split the usual next step is to blame the database.

## Testing

**No database required** — the log decision is a pure function of the numbers, so it is unit-testable. 6 tests pin it:

- Warning above the threshold, Debug below, boundary **inclusive** so it cannot fall through silently
- the fan-out width and both timings appear in the message
- the message names `path:`/`namespace:` as the fix — a warning that doesn't say what to do gets muted rather than fixed
- the fast path stays at Debug, because every page render fans out and warning on the normal case would drown the slow one

## Scope

This is **diagnosis, not the cure**. It makes the cost measurable so the actual fix — narrowing callers, or indexing the fan-out — can be chosen on evidence rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)