### PR TITLE
Dev login must not mint admins — it was a paywall bypass

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
@@ -20,6 +20,7 @@ public class DevAuthController : ControllerBase
     private readonly UserOnboardingService _onboarding;
     private readonly IMessageHub _hub;
     private readonly AccessService _accessService;
+    private readonly IConfiguration _configuration;
     private readonly bool _devLoginEnabled;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
@@ -35,6 +36,7 @@ public class DevAuthController : ControllerBase
         // (PascalCase), so the string comparison silently disabled self-provisioning for every
         // appsettings that used the natural boolean form.
         _devLoginEnabled = bool.TryParse(configuration["Authentication:EnableDevLogin"], out var enabled) && enabled;
+        _configuration = configuration;
     }
 
     /// <summary>
@@ -172,15 +174,50 @@ public class DevAuthController : ControllerBase
         // id-derivations for the same person, and the circuit's email-local-part heuristic
         // (CircuitAccessHandler.UsernameFromEmail) is aligned with the lowercase convention.
         var username = personId.Trim().ToLowerInvariant();
+        // 🚨 A dev-login user is an ORDINARY USER. This used to pass `Role: Role.Admin.Id`, which
+        // made EVERY throwaway dev identity a claim-Admin — and a claim role is added in
+        // PermissionEvaluator.ComputeRoleState AFTER the per-scope deny subtraction, so no gating
+        // deny could ever remove it. The visible effect was a paywall BYPASS that looked like a
+        // gating bug: a signed-in user saw the CHF 900 checkout (entitlement is a record, and they
+        // had none) yet still read the gated lessons (read came from the Admin claim). Anonymous
+        // was correctly blocked, which is exactly why it survived — the two are denied by
+        // different mechanisms. See AGENTS.md, "the access rule for a system-synced space".
         var request = new UserOnboardingRequest(
             Username: username,
             Email: $"{username}@dev.local",
-            FullName: personId,
-            Role: Role.Admin.Id);
+            FullName: personId);
         var userNode = await _onboarding.CreateUser(request).FirstAsync();
+        // Self-Admin on the user's OWN partition only — they must be able to write their own home
+        // (installed course copies, skills, agents). This is scoped to `{user}/_Access` with
+        // MainNode = {user}; it confers nothing anywhere else.
         await _onboarding.GrantSelfAdmin(username).FirstAsync();
+        // PLATFORM admin is opt-in and explicit, never a side effect of signing in. A harness that
+        // needs one (the e2e bootstrap installs courses through the Plugin Catalog) names it in
+        // `Authentication:DevAdminUsers`; everyone else stays an ordinary user, which is what makes
+        // the suite able to prove the purchase funnel at all.
+        if (IsConfiguredDevAdmin(username))
+            await _onboarding.GrantPlatformAdmin(username).FirstAsync();
         return userNode;
     }
+
+    /// <summary>
+    /// Whether this dev-login username is declared a PLATFORM admin in configuration
+    /// (<c>Authentication:DevAdminUsers</c>, a comma-separated list). Empty/unset → nobody, which
+    /// is the safe default: a dev portal that hands out admin by default cannot be used to test any
+    /// access rule, because every identity passes every gate.
+    /// </summary>
+    private bool IsConfiguredDevAdmin(string username) =>
+        IsDevAdmin(_configuration["Authentication:DevAdminUsers"], username);
+
+    /// <summary>
+    /// Pure form of the rule, so it is unit-testable without a controller, a mesh or a request.
+    /// Empty/unset list → FALSE for everyone; that default is the security property worth pinning.
+    /// </summary>
+    internal static bool IsDevAdmin(string? configuredList, string username) =>
+        !string.IsNullOrWhiteSpace(username)
+        && (configuredList ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(u => string.Equals(u, username, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Signs out the current user.

--- a/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
@@ -109,6 +109,20 @@ public class DevAuthController : ControllerBase
             return BadRequest("Person not found");
         }
 
+        // PLATFORM admin is opt-in and explicit, never a side effect of signing in: only the
+        // usernames named in `Authentication:DevAdminUsers` get it, and everyone else stays an
+        // ordinary user — which is what lets the e2e suite prove the purchase funnel at all.
+        //
+        // 🚨 Applied on EVERY signin, not inside ProvisionDevUser. That branch runs only when the
+        // User node is MISSING, so on any mesh whose database already holds the user — a re-boot
+        // reusing the volume, a seeded user, the second run of a suite — the grant would never be
+        // written and the configured admin would silently come back as an ordinary user. That is
+        // exactly how it failed the first time: a fresh identity got the grant, `e2e-admin` did
+        // not, and the bootstrap hung on an admin-gated Plugin Catalog it could no longer read.
+        // GrantPlatformAdmin is an idempotent create-or-update, so re-running it is free.
+        if (_devLoginEnabled && IsConfiguredDevAdmin(node.Id))
+            await _onboarding.GrantPlatformAdmin(node.Id).FirstAsync();
+
         var person = ExtractPersonInfo(node.Id, node.Content);
         if (person == null)
         {
@@ -191,12 +205,6 @@ public class DevAuthController : ControllerBase
         // (installed course copies, skills, agents). This is scoped to `{user}/_Access` with
         // MainNode = {user}; it confers nothing anywhere else.
         await _onboarding.GrantSelfAdmin(username).FirstAsync();
-        // PLATFORM admin is opt-in and explicit, never a side effect of signing in. A harness that
-        // needs one (the e2e bootstrap installs courses through the Plugin Catalog) names it in
-        // `Authentication:DevAdminUsers`; everyone else stays an ordinary user, which is what makes
-        // the suite able to prove the purchase funnel at all.
-        if (IsConfiguredDevAdmin(username))
-            await _onboarding.GrantPlatformAdmin(username).FirstAsync();
         return userNode;
     }
 

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -4,6 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 

--- a/test/Memex.Portal.Shared.Test/DevLoginIsNotAdminTest.cs
+++ b/test/Memex.Portal.Shared.Test/DevLoginIsNotAdminTest.cs
@@ -1,0 +1,71 @@
+using Memex.Portal.Shared.Authentication;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the rule that a dev-login identity is an ORDINARY USER unless configuration says otherwise.
+///
+/// <para>🚨 Why this is security-relevant and not a dev-only nicety: <c>ProvisionDevUser</c> used to
+/// onboard every dev identity with <c>Role: Admin</c>. That role becomes a CLAIM, and
+/// <c>PermissionEvaluator.ComputeRoleState</c> adds claim roles AFTER the per-scope deny
+/// subtraction — so a claim-Admin cannot be removed by any gating deny. The visible effect was a
+/// paywall BYPASS that read as a gating bug: a signed-in user saw the CHF 900 checkout (entitlement
+/// is a record, and they had none) yet still read the gated lessons. Anonymous stayed blocked,
+/// because it carries no claim role — which is precisely why it went unnoticed.</para>
+///
+/// <para>It also made the e2e suite unable to prove the purchase funnel at all: every identity it
+/// minted passed every gate, so the gating specs asserted nothing.</para>
+/// </summary>
+public class DevLoginIsNotAdminTest
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoConfiguredList_MeansNobodyIsAdmin(string? configured)
+    {
+        // The DEFAULT is the property that matters: a dev portal that hands out admin by default
+        // cannot test any access rule, because every identity passes every gate.
+        Assert.False(DevAuthController.IsDevAdmin(configured, "e2e-admin"));
+        Assert.False(DevAuthController.IsDevAdmin(configured, "roland"));
+    }
+
+    [Fact]
+    public void OnlyTheNamedUsersAreAdmin()
+    {
+        const string list = "e2e-admin,ops";
+
+        Assert.True(DevAuthController.IsDevAdmin(list, "e2e-admin"));
+        Assert.True(DevAuthController.IsDevAdmin(list, "ops"));
+        // The locked-out fixtures the gating specs rely on MUST stay ordinary users.
+        Assert.False(DevAuthController.IsDevAdmin(list, "e2e-locked"));
+        Assert.False(DevAuthController.IsDevAdmin(list, "e2e-user"));
+    }
+
+    [Fact]
+    public void MatchingIsCaseInsensitiveAndTolerantOfSpacing()
+    {
+        // The list is hand-written in compose/env files; whitespace must not silently drop an admin
+        // (which would break a harness bootstrap in a way that looks like a permissions bug).
+        Assert.True(DevAuthController.IsDevAdmin(" e2e-admin , ops ", "E2E-Admin"));
+        Assert.True(DevAuthController.IsDevAdmin("E2E-ADMIN", "e2e-admin"));
+    }
+
+    [Fact]
+    public void APrefixOrSubstringIsNotAMatch()
+    {
+        // "e2e-admin" must not make "e2e-admin2" — or a bare "e2e" — an admin.
+        Assert.False(DevAuthController.IsDevAdmin("e2e-admin", "e2e-admin2"));
+        Assert.False(DevAuthController.IsDevAdmin("e2e-admin", "e2e"));
+        Assert.False(DevAuthController.IsDevAdmin("e2e", "e2e-admin"));
+    }
+
+    [Fact]
+    public void AnEmptyUsernameIsNeverAdmin()
+    {
+        // Guards the degenerate case where a blank id would otherwise match a stray empty entry.
+        Assert.False(DevAuthController.IsDevAdmin("e2e-admin,,", ""));
+        Assert.False(DevAuthController.IsDevAdmin(",", ""));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/DevLoginIsNotAdminTest.cs
+++ b/test/Memex.Portal.Shared.Test/DevLoginIsNotAdminTest.cs
@@ -62,6 +62,23 @@ public class DevLoginIsNotAdminTest
     }
 
     [Fact]
+    public void TheRuleIsPositionIndependent_SoItCanRunOnEverySignin()
+    {
+        // Regression: the grant first lived inside ProvisionDevUser, which runs ONLY when the User
+        // node is missing. On any mesh whose database already held the user — a re-boot reusing the
+        // volume, a seeded user, the second run of a suite — the configured admin silently came back
+        // as an ordinary user and the e2e bootstrap hung on an admin-gated Plugin Catalog it could
+        // no longer read. The rule must therefore be a pure function of (list, username) with no
+        // dependence on whether this is the user's first signin, so it is safe to evaluate every
+        // time; the caller now does exactly that.
+        const string list = "e2e-admin";
+        Assert.True(DevAuthController.IsDevAdmin(list, "e2e-admin"));
+        Assert.True(DevAuthController.IsDevAdmin(list, "e2e-admin"));   // second signin: unchanged
+        Assert.False(DevAuthController.IsDevAdmin(list, "e2e-locked"));
+        Assert.False(DevAuthController.IsDevAdmin(list, "e2e-locked")); // and still not an admin
+    }
+
+    [Fact]
     public void AnEmptyUsernameIsNeverAdmin()
     {
         // Guards the degenerate case where a blank id would otherwise match a stray empty entry.


### PR DESCRIPTION
`ProvisionDevUser` onboarded **every** dev-login identity with `Role: Admin`. That role becomes a **claim**, and `PermissionEvaluator.ComputeRoleState` adds claim roles **after** the per-scope deny subtraction — so a claim-Admin cannot be removed by any gating deny.

## Why it looked like a gating bug, and why it survived

A signed-in user saw the **CHF 900 checkout** (entitlement is a *record*, and they had none) yet still **read the gated lessons** (read came from the claim). **Anonymous was correctly blocked the whole time**, because it carries no claim role.

The two are denied by different mechanisms, so the case that regressed was the one nobody checks. education CI has been failing on it across three separate surfaces:

- `40-gating` — DataModeling: *a fresh signed-in NON-admin user gets the CHF 900 checkout, not the lesson*
- `80-primer` — both AgenticPrimer and AgenticPrimerDe: *a regular user … hits the paywall on a gated one*
- `16-store-lifecycle` — **AgenticOffice and DataModeling**: *an un-purchased course is gated* (and, being `describe.serial`, it cascaded the whole buy/install/uninstall block to skipped for both)

It also made the suite unable to prove the funnel at all: every identity it minted passed every gate, so the gating specs asserted nothing.

## The change

- a dev-login user is an **ordinary user** — no `Role` on the User node, no claim;
- `GrantSelfAdmin` stays, scoped to the user's **own** partition (`{user}/_Access`, `MainNode = {user}`) so they can write their own home (installed course copies, skills, agents) and nothing else;
- **platform admin is opt-in and explicit**: `Authentication:DevAdminUsers`. A harness that needs one names it; everyone else stays ordinary.

## Testing

The rule is extracted as a pure static, so it is unit-testable without a controller, a mesh or a request. 7 tests — and the ones that matter are the defaults:

- an **unset or empty** list means **nobody** is admin (a dev portal that hands out admin by default cannot test any access rule, because every identity passes every gate)
- a prefix is not a match — `e2e-admin` must not admit `e2e-admin2`
- a blank username never matches a stray empty entry
- matching is case-insensitive and tolerant of spacing, since the list is hand-written in compose/env files

Paired with Systemorph/education's harness change, which declares `e2e-admin` as its single admin so bootstrap keeps its rights while `e2e-locked` / `e2e-user` become genuine outsiders.

## Deliberately not changed here

That `ComputeRoleState` applies claim roles **after** the deny subtraction is arguably wrong on its own merits — any identity provider supplying a role claim bypasses every scope deny. That is a broader access change with its own blast radius; this PR removes the thing that was actually handing out the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)