### PR TITLE
A system-owned space grants nobody write access

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -898,9 +898,11 @@ public static class MemexConfiguration
                         .AddGitHubSyncSettingsTab()
                         // GitHub Issues & PRs tab — browse/act on the repo's issues + pull requests.
                         .AddGitHubIssuesTab()
-                        // Plugin Catalog tab (platform admins only) — browse the registry's modules
-                        // and Install / Update them onto this instance. Replaces the old Plugins Space.
-                        .AddPluginCatalogSettingsTab()
+                        // NO Plugin Catalog tab. Browsing and provisioning packages is the STORE's
+                        // job (/Store → the package card → Provision), and it is the only surface
+                        // that runs the install under the System identity via SystemInstall. A
+                        // second admin-only page onto the same registry duplicated that flow while
+                        // bypassing the funnel it exists to enforce.
                         // Coupons tab (platform admins only) — the Store's typed coupon codes at
                         // Admin/Coupons: live list, redemption tallies, create/open.
                         .AddCouponAdminSettingsTab()

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -1,6 +1,7 @@
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
@@ -59,6 +60,15 @@ public static class GitHubSyncConfiguration
         services.AddSingleton<IPartitionSyncSourceProvider>(sp => new GitHubPartitionSyncSourceProvider(
             sp.GetRequiredService<GitHubSyncService>(),
             sp.GetRequiredService<IMessageHub>()));
+        // Wiring a _GitSync makes the partition SYSTEM-OWNED — retract any privileged account
+        // grant that predates it. See SystemOwnedAccessRetractionHandler for the seven-second
+        // window this closes (create the Space, get Admin, wire the sync).
+        services.AddSingleton<INodePostCreationHandler>(sp => new SystemOwnedAccessRetractionHandler(
+            sp.GetRequiredService<IMessageHub>(),
+            sp.GetRequiredService<IMeshService>(),
+            sp.GetRequiredService<IStorageAdapter>(),
+            sp.GetService<AccessService>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger<SystemOwnedAccessRetractionHandler>()));
         // On-disk per-user git working trees (clone/edit/commit/push) — the working-tree
         // counterpart to content sync, shared by the AI harness + the in-portal editor.
         // Root binds from GitWorkspace:Root (env GitWorkspace__Root=/workspace in the portal,

--- a/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
+++ b/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
@@ -1,0 +1,124 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// 🚨 THE MOMENT A PARTITION GAINS A <c>_GitSync</c> IT BECOMES SYSTEM-OWNED — so every privileged
+/// account grant on it is retracted, right there.
+///
+/// <para><b>The window this closes.</b> <c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c> makes
+/// it impossible to WRITE such a grant onto a space that is already system-owned, and
+/// <c>EnsurePartitionBootstrap</c> stopped re-minting one on every deploy. Neither helps when the
+/// order is reversed: a Space hand-created by a person is an ORDINARY space for as long as it takes
+/// to wire the sync, its creator gets Admin the ordinary way, and that grant then sits on a space
+/// the repo owns — legal when written, wrong one second later.</para>
+///
+/// <para>Measured on memex 2026-08-04: <c>SST/_Access/rbuergi_Access</c> (Admin) at 14:48:07,
+/// <c>SST/_GitSync</c> at 14:48:14. Seven seconds. Seventeen Admin grants across three meshes
+/// entered through that window, and nothing anywhere reported them — the space looked correct,
+/// the content synced, the pages rendered.</para>
+///
+/// <para><b>Why retract rather than refuse the sync.</b> Refusing to wire <c>_GitSync</c> while a
+/// grant exists turns a deploy into a permissions error at the worst moment and teaches people to
+/// hand-clean access lists. Retracting states the invariant instead: the repo owns this space now,
+/// so nobody else does. It is also SELF-HEALING — a mesh that already drifted converges the next
+/// time its sync is (re)wired.</para>
+///
+/// <para><b>What survives, deliberately:</b> <c>Viewer</c>/<c>Commenter</c> entitlements (a
+/// purchase, a redeemed coupon, an admin-issued grant — the only door into a gated plugin), every
+/// <c>Denied</c> assignment (that IS the gating), and <c>system-security</c> itself (the identity
+/// the importer writes under — retracting it would make the space unwritable by anything).</para>
+///
+/// <para>Best-effort by design (<c>FailsCreateOnError</c> stays false): a partition that cannot be
+/// swept must not block its own sync from being configured. Every retraction is logged at Warning
+/// naming the subject and the space, because access silently disappearing is its own bug class.</para>
+/// </summary>
+public sealed class SystemOwnedAccessRetractionHandler(
+    IMessageHub hub,
+    IMeshService meshService,
+    IStorageAdapter persistence,
+    AccessService? accessService,
+    ILogger<SystemOwnedAccessRetractionHandler>? logger) : INodePostCreationHandler
+{
+    /// <summary>Fires for the sync-config node — the thing whose existence MAKES a space system-owned.</summary>
+    public string NodeType => GitHubSyncService.ConfigNodeType;
+
+    public IObservable<Unit> Handle(MeshNode createdNode, string? createdBy)
+    {
+        // The config lives at {partition}/_GitSync, so the owning partition is its namespace's
+        // first segment. A root-level config owns nothing and is not this handler's business.
+        var partition = AccessAssignmentGuard.PartitionOf(createdNode.Namespace ?? "");
+        if (string.IsNullOrEmpty(partition))
+            return Observable.Return(Unit.Default);
+
+        var accessFolder = $"{partition}/_Access";
+
+        return persistence.ListChildPaths(accessFolder)
+            .Take(1)
+            .Catch<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths), Exception>(ex =>
+            {
+                logger?.LogDebug(ex,
+                    "[SystemOwned] could not list '{Folder}'; nothing to retract", accessFolder);
+                return Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(([], []));
+            })
+            .SelectMany(children =>
+            {
+                var paths = children.NodePaths?.ToArray() ?? [];
+                return paths.Length == 0
+                    ? Observable.Return<IList<MeshNode>>([])
+                    : persistence.ReadMany(paths, hub.JsonSerializerOptions).ToList();
+            })
+            .SelectMany(RetractAll);
+    }
+
+    private IObservable<Unit> RetractAll(IList<MeshNode> grants)
+    {
+        // The SAME predicate the write boundary uses — one rule, two enforcement points, so a
+        // grant that could not be created here can never survive here either.
+        var doomed = grants
+            .Where(n => AccessAssignmentGuard.IsForbiddenOnSystemOwned(
+                n, n.ContentAs<AccessAssignment>(hub.JsonSerializerOptions), systemOwned: true, out _))
+            .Select(n => n.Path)
+            .ToArray();
+
+        if (doomed.Length == 0)
+            return Observable.Return(Unit.Default);
+
+        logger?.LogWarning(
+            "[SystemOwned] retracting {Count} privileged grant(s) — the partition is now system-owned "
+            + "and only {System} may write it: {Paths}",
+            doomed.Length, WellKnownUsers.System, string.Join(", ", doomed));
+
+        // Sequential (Concat, never Merge): these are node deletes into a partition that may have
+        // been created seconds ago, and a fan-out of cold per-node hub activations is what crashes
+        // writes into a fresh partition. Under System — the retraction is the platform's decision,
+        // not the caller's, and the caller may hold no rights on the space at all.
+        return AsSystem(() => doomed
+            .Select(path => meshService.DeleteNode(path)
+                .Take(1)
+                .Select(_ => Unit.Default)
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogError(ex,
+                        "[SystemOwned] FAILED to retract '{Path}' — it still grants write access to a "
+                        + "system-owned space", path);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .TakeLast(1));
+    }
+
+    /// <summary>Establishes the System identity on the write's own subscribe thread — mirrors
+    /// <c>MeshExtensions.AsSystem</c>, so the deletes are attributed to the platform.</summary>
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> write)
+        => accessService is null
+            ? Observable.Defer(write)
+            : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => write());
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -454,7 +454,15 @@ public static class MeshExtensions
                 //     See EnsurePartitionBootstrap.
                 // 2. Validators → 3. NodeType existence → 4-7. Enrich + save + change feed + version
                 return EnsurePartitionBootstrap(hub, node, capturedRequest, logger)
-                    .SelectMany(_ => RunCreationValidatorsObs(hub, node, capturedRequest))
+                    // 1d. A SYSTEM-OWNED space grants nobody write access. Sequenced AFTER the
+                    //     bootstrap (which may have just created the partition) and ahead of the
+                    //     validators, and folded into the same rejection tuple so the failure is
+                    //     posted by the one code path that already knows how.
+                    .SelectMany(_ => SystemOwnedGrantRejection(hub, node))
+                    .SelectMany(grantRejection => grantRejection is not null
+                        ? Observable.Return<(string? ErrorMessage, NodeCreationRejectionReason Reason)?>(
+                            (grantRejection, NodeCreationRejectionReason.ValidationFailed))
+                        : RunCreationValidatorsObs(hub, node, capturedRequest))
                     .SelectMany(validationError =>
                     {
                         if (validationError != null)
@@ -1626,6 +1634,48 @@ public static class MeshExtensions
     }
 
     /// <summary>
+    /// Emits the rejection reason when the node is a privileged grant on a SYSTEM-OWNED (GitSynced)
+    /// partition, else <c>null</c>. See <see cref="AccessAssignmentGuard.IsForbiddenOnSystemOwned"/>
+    /// for why that shape is refused.
+    ///
+    /// <para><b>The storage read is paid for only by the shape that can fail.</b> The pure checks
+    /// run first — node type, grant path, and whether the assignment confers write at all — so the
+    /// hot path (an entitlement's <c>Viewer</c> grant, written on every enrollment) never touches
+    /// persistence. Only an Admin/Editor grant costs the one <c>{partition}/_GitSync</c> read, which
+    /// is the same probe <c>EnsurePartitionBootstrap</c> already performs on this path.</para>
+    ///
+    /// <para>Content is materialised through the TYPED accessor, never a raw <c>JsonElement</c>
+    /// test: a grant arrives typed on the hub that owns it, as <c>JsonObject</c> from the node
+    /// builders, and as <c>JsonElement</c> over the wire — and a shape test that misses would read
+    /// "no roles", i.e. silently allow exactly what this guard exists to refuse.</para>
+    /// </summary>
+    private static IObservable<string?> SystemOwnedGrantRejection(IMessageHub hub, MeshNode node)
+    {
+        if (!string.Equals(node.NodeType, AccessAssignmentGuard.AccessAssignmentNodeType,
+                StringComparison.OrdinalIgnoreCase))
+            return Observable.Return<string?>(null);
+
+        var scope = AccessAssignmentGuard.ScopeFromPath(node.Path);
+        if (string.IsNullOrEmpty(scope))
+            return Observable.Return<string?>(null);
+
+        var assignment = node.ContentAs<AccessAssignment>(hub.JsonSerializerOptions);
+        if (!AccessAssignmentGuard.ConfersWriteAccess(assignment))
+            return Observable.Return<string?>(null);
+
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (persistence is null)
+            return Observable.Return<string?>(null);
+
+        var partition = AccessAssignmentGuard.PartitionOf(scope);
+        return ReadNodeAuthoritative(hub, persistence, $"{partition}/_GitSync")
+            .Select(sync => AccessAssignmentGuard.IsForbiddenOnSystemOwned(
+                node, assignment, systemOwned: sync is not null, out var reason)
+                ? reason
+                : null);
+    }
+
+    /// <summary>
     /// Sync-friendly observable variant of the creation-validator runner. Iterates
     /// validators sequentially via <c>Concat</c> (preserves short-circuit semantics —
     /// stops at the first failure), emits the first failure as a tuple or <c>null</c>
@@ -2014,7 +2064,22 @@ public static class MeshExtensions
 
         var inboundCtx = request.AccessContext;
 
-        existingObs.Subscribe(
+        // Same rule as the create path: a SYSTEM-OWNED space grants nobody write access. Guarding
+        // only the create would leave the hole open through the UPDATE branch below — an existing
+        // Viewer grant could simply be upserted up to Admin, which is the identical ownership claim
+        // with a version bump instead of a create. Both write paths, or neither.
+        var gatedExisting = SystemOwnedGrantRejection(hub, node)
+            .SelectMany(grantRejection =>
+            {
+                if (grantRejection is null)
+                    return existingObs;
+                logger.LogError("[UpsertNode] REFUSED privileged grant on system-owned partition {Path}: {Reason}",
+                    node.Path, grantRejection);
+                PostFail(grantRejection, NodeUpsertRejectionReason.ValidationFailed);
+                return Observable.Empty<MeshNode?>();
+            });
+
+        gatedExisting.Subscribe(
             existing =>
             {
                 if (existing is null)

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 
 namespace MeshWeaver.Mesh.Services;
 
@@ -129,5 +130,96 @@ public static class AccessAssignmentGuard
     {
         if (IsScopeInvalid(node, out var reason))
             throw new InvalidOperationException(reason);
+    }
+
+    /// <summary>
+    /// The roles an ENTITLEMENT legitimately confers on a system-owned space. Everything else —
+    /// including any custom role — counts as write access, because this list is an ALLOWLIST: a
+    /// role nobody here recognises must not be waved through on a space the repo owns.
+    /// </summary>
+    private static readonly HashSet<string> ReadOnlyRoles =
+        new(StringComparer.OrdinalIgnoreCase) { "Viewer", "Commenter" };
+
+    /// <summary>
+    /// The assignment confers WRITE access — any non-denied role outside <see cref="ReadOnlyRoles"/>.
+    /// A <c>Denied</c> role never counts: a deny only ever removes access, and the plugin gating
+    /// writes exactly those on every non-public child.
+    /// </summary>
+    public static bool ConfersWriteAccess(AccessAssignment? assignment)
+    {
+        if (assignment?.Roles is null)
+            return false;
+
+        foreach (var role in assignment.Roles)
+        {
+            if (role.Denied || string.IsNullOrWhiteSpace(role.Role))
+                continue;
+            if (!ReadOnlyRoles.Contains(role.Role))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 🚨 A SYSTEM-OWNED space grants nobody write access. A partition with a <c>_GitSync</c> is
+    /// rewritten from its repo on every sync, so the ONLY identity that may write it is the one the
+    /// importer runs as (<see cref="WellKnownUsers.System"/>). Any other Admin/Editor grant is an
+    /// ownership claim over content the repo owns — and the change it enables is silently reverted
+    /// by the next sync, which is the worst of both worlds.
+    ///
+    /// <para><b>The hole this closes.</b> Core already refuses to MINT a creator grant when a
+    /// deploy writes into a GitSynced partition (<c>EnsurePartitionBootstrap</c>). But a Space
+    /// hand-created BEFORE its <c>_GitSync</c> exists is not system-owned yet, so its creator gets
+    /// Admin the ordinary way and keeps it once the sync is wired. Measured on memex 2026-08-04:
+    /// <c>SST/_Access/rbuergi_Access</c> (Admin) was written at 14:48:07 and <c>SST/_GitSync</c> at
+    /// 14:48:14 — seven seconds later. Seventeen such grants across three meshes came from that
+    /// window and from the pre-fix re-mint.</para>
+    ///
+    /// <para><b>What stays legal</b>, because it is how the funnel works: <c>Viewer</c>/
+    /// <c>Commenter</c> (an entitlement — a purchase, a redeemed coupon, an admin-issued grant),
+    /// every <c>Denied</c> assignment (the gating), and anything the System identity writes for
+    /// itself.</para>
+    /// </summary>
+    /// <param name="node">The grant node, already normalised.</param>
+    /// <param name="assignment">Its content, materialised by the caller through the typed accessor
+    /// — never re-read here as raw JSON, which is how a typed content silently reads as empty.</param>
+    /// <param name="systemOwned">Whether the partition has a <c>_GitSync</c>. The caller reads it;
+    /// keeping it a parameter is what makes this predicate pure and unit-testable with no hub.</param>
+    public static bool IsForbiddenOnSystemOwned(
+        MeshNode? node, AccessAssignment? assignment, bool systemOwned, out string reason)
+    {
+        reason = "";
+        if (!systemOwned || node is null)
+            return false;
+        if (!string.Equals(node.NodeType, AccessAssignmentNodeType, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var scope = ScopeFromPath(node.Path);
+        if (string.IsNullOrEmpty(scope))
+            return false;                       // not a grant path, or the root shape IsScopeInvalid owns
+
+        var subject = assignment?.AccessObject ?? "";
+        if (string.Equals(subject, WellKnownUsers.System, StringComparison.OrdinalIgnoreCase))
+            return false;                       // the importer's own identity — this is the one Admin
+
+        if (!ConfersWriteAccess(assignment))
+            return false;                       // an entitlement, not an ownership claim
+
+        var partition = PartitionOf(scope);
+        reason = $"AccessAssignment '{node.Path}' would give '{subject}' write access to "
+               + $"'{partition}', which is SYSTEM-OWNED (it has {partition}/_GitSync and is rewritten "
+               + "from its repo on every sync). Only '" + WellKnownUsers.System + "' may write it; a "
+               + "live edit by anyone else is reverted by the next sync. Grant Viewer as an "
+               + "entitlement instead, or change the repo and sync it.";
+        return true;
+    }
+
+    /// <summary>The partition a scope belongs to — its first segment. <c>Store/Plugin</c> → <c>Store</c>,
+    /// because <c>_GitSync</c> is wired on the partition root, not on nested scopes.</summary>
+    public static string PartitionOf(string scope)
+    {
+        var slash = scope.IndexOf('/');
+        return slash < 0 ? scope : scope[..slash];
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 
@@ -137,8 +138,8 @@ public static class AccessAssignmentGuard
     /// including any custom role — counts as write access, because this list is an ALLOWLIST: a
     /// role nobody here recognises must not be waved through on a space the repo owns.
     /// </summary>
-    private static readonly HashSet<string> ReadOnlyRoles =
-        new(StringComparer.OrdinalIgnoreCase) { "Viewer", "Commenter" };
+    private static readonly FrozenSet<string> ReadOnlyRoles =
+        new[] { "Viewer", "Commenter" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The assignment confers WRITE access — any non-denied role outside <see cref="ReadOnlyRoles"/>.

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using Xunit;
 
@@ -231,5 +232,107 @@ public class AccessAssignmentGuardTest
         var act = () => AccessAssignmentGuard.EnsureScopeValid(node);
 
         act.Should().NotThrow();
+    }
+
+    // ── A system-owned space grants nobody write access ──────────────────────────────────
+    //
+    // memex 2026-08-04: SST/_Access/rbuergi_Access (Admin) was written at 14:48:07 and
+    // SST/_GitSync at 14:48:14 — the Space was hand-created seven seconds before it became
+    // system-owned, so the creator-Admin grant was minted the ordinary way and simply stayed.
+    // Seventeen Admin grants across three meshes came from that window.
+
+    private static MeshNode GrantOf(string path, string subject, params string[] roles) =>
+        Grant(path, mainNode: AccessAssignmentGuard.ScopeFromPath(path)) with
+        {
+            Content = new AccessAssignment
+            {
+                AccessObject = subject,
+                Roles = roles.Select(r => new RoleAssignment { Role = r }).ToArray()
+            }
+        };
+
+    private static AccessAssignment Content(MeshNode node) => (AccessAssignment)node.Content!;
+
+    [Theory]
+    [InlineData("Admin")]
+    [InlineData("Editor")]
+    [InlineData("PlatformAdmin")]
+    [InlineData("SomeCustomRole")]      // allowlist, not denylist: an unknown role is NOT waved through
+    public void PrivilegedGrantOnASystemOwnedSpace_IsRefused(string role)
+    {
+        var node = GrantOf("SST/_Access/rbuergi_Access", "rbuergi", role);
+
+        AccessAssignmentGuard.IsForbiddenOnSystemOwned(node, Content(node), systemOwned: true, out var reason)
+            .Should().BeTrue("a GitSynced space is rewritten from its repo — only the system identity may write it");
+        reason.Should().Contain("rbuergi");
+        reason.Should().Contain("SST", "the message must name the space it is protecting");
+    }
+
+    /// <summary>The entitlement shape — what a purchase, a coupon or an admin grant writes.</summary>
+    [Theory]
+    [InlineData("Viewer")]
+    [InlineData("Commenter")]
+    public void AnEntitlementIsStillAllowed(string role)
+    {
+        var node = GrantOf("SST/_Access/learner_Access", "learner", role);
+
+        AccessAssignmentGuard.IsForbiddenOnSystemOwned(node, Content(node), systemOwned: true, out _)
+            .Should().BeFalse("read-only access IS the funnel — buying a plugin must keep working");
+    }
+
+    /// <summary>The importer's own identity is the one Admin a system-owned space has.</summary>
+    [Fact]
+    public void TheSystemIdentityMayHoldAdmin()
+    {
+        var node = GrantOf("SST/_Access/system-security_Access", WellKnownUsers.System, "Admin");
+
+        AccessAssignmentGuard.IsForbiddenOnSystemOwned(node, Content(node), systemOwned: true, out _)
+            .Should().BeFalse("system-security is the identity the GitSync import writes under");
+    }
+
+    /// <summary>A deny only ever REMOVES access — it is how plugin gating darkens every child.</summary>
+    [Fact]
+    public void ADeniedRoleIsNotAWriteGrant()
+    {
+        var node = Grant("SST/StandReModel/_Access/Anonymous_Access", mainNode: "SST/StandReModel") with
+        {
+            Content = new AccessAssignment
+            {
+                AccessObject = WellKnownUsers.Anonymous,
+                Roles = [new RoleAssignment { Role = "Editor", Denied = true }]
+            }
+        };
+
+        AccessAssignmentGuard.IsForbiddenOnSystemOwned(node, Content(node), systemOwned: true, out _)
+            .Should().BeFalse("a Denied assignment cannot confer anything");
+    }
+
+    /// <summary>A user's own home, a hand-seeded tenant Space — not system-owned, not this rule's business.</summary>
+    [Fact]
+    public void AnOrdinarySpaceIsUntouched()
+    {
+        var node = GrantOf("rbuergi/_Access/rbuergi_Access", "rbuergi", "Admin");
+
+        AccessAssignmentGuard.IsForbiddenOnSystemOwned(node, Content(node), systemOwned: false, out _)
+            .Should().BeFalse("without a _GitSync the partition is owned by its creator, as before");
+    }
+
+    /// <summary>Nested scopes resolve to the PARTITION, because _GitSync is wired on the root.</summary>
+    [Theory]
+    [InlineData("Store/Plugin", "Store")]
+    [InlineData("SST", "SST")]
+    public void PartitionOf_TakesTheFirstSegment(string scope, string expected) =>
+        AccessAssignmentGuard.PartitionOf(scope).Should().Be(expected);
+
+    [Fact]
+    public void ConfersWriteAccess_IgnoresEmptyAndDeniedRoles()
+    {
+        AccessAssignmentGuard.ConfersWriteAccess(new AccessAssignment { Roles = [] })
+            .Should().BeFalse();
+        AccessAssignmentGuard.ConfersWriteAccess(null).Should().BeFalse();
+        AccessAssignmentGuard.ConfersWriteAccess(new AccessAssignment
+        {
+            Roles = [new RoleAssignment { Role = "" }, new RoleAssignment { Role = "Admin", Denied = true }]
+        }).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Why

A partition with a `_GitSync` is rewritten from its repo on every sync, so the only identity that may write it is the one the importer runs as (`system-security`). Any other Admin/Editor grant is an ownership claim over content the repo owns — and the change it enables is silently reverted by the next sync, which is the worst of both worlds.

Core already refused to *re-mint* a creator grant when a deploy writes into a GitSynced partition (`EnsurePartitionBootstrap`). Two holes remained:

1. **The seven-second window.** A Space hand-created *before* its `_GitSync` exists is an ordinary space until the sync is wired, so its creator gets Admin the ordinary way and keeps it. Measured on memex 2026-08-04: `SST/_Access/rbuergi_Access` (Admin) at `14:48:07`, `SST/_GitSync` at `14:48:14`.
2. **Nothing refused a grant written onto an already system-owned space** — by hand, or by an agent over MCP.

An audit of the three live meshes found **42 privileged grants** on synced spaces (17 Admin + 17 Editor on memex, 7 Admin on systemorph, 1 on atioz). They have been retracted live; this PR is what stops them coming back.

## What changed

- **`AccessAssignmentGuard.IsForbiddenOnSystemOwned`** — pure, hub-free, unit-tested. Wired at **both** write boundaries in `MeshExtensions`: guarding only `create` would let an `upsert` raise an existing Viewer to Admin, which is the identical ownership claim with a version bump.
  - The storage probe is paid for only by the shape that can fail: the pure checks (node type, grant path, confers-write) run first, so an entitlement's `Viewer` grant — written on every enrollment — never touches persistence.
  - Content is read through the **typed accessor**, never a raw `JsonElement` test. A shape test that missed would read "no roles" and silently allow exactly what the guard exists to refuse.
- **`SystemOwnedAccessRetractionHandler`** (`INodePostCreationHandler` on `GitHubSyncConfig`) — the moment a partition gains a `_GitSync` it becomes system-owned, so privileged account grants on it are retracted right there: under System, sequentially (`Concat`, never `Merge` — these are writes into a partition that may be seconds old), each one logged at Warning. Self-healing for any mesh that already drifted.
- **Plugin Catalog settings tab removed.** Browsing and provisioning packages is the Store's job (`/Store` → the card → **Provision**), the only surface that runs the install under System via `SystemInstall`. The admin page duplicated that flow while bypassing the funnel. `AddPluginCatalog()` — the registry API serving plugins to every other instance — is untouched.

## What deliberately still works

Read-only roles are an **allowlist**, not a denylist, so an unrecognised custom role is refused rather than waved through. Untouched: `Viewer`/`Commenter` entitlements (a purchase, a redeemed coupon, an admin grant — the only door into a gated plugin), every `Denied` assignment (that *is* the plugin gating), `system-security` itself, and user-home/tenant spaces with no `_GitSync`.

## Tests

`AccessAssignmentGuardTest` +15 cases: each privileged role refused (incl. an unknown custom one), each entitlement role allowed, the System identity allowed, a `Denied` Editor allowed, a non-system-owned space untouched, and `PartitionOf` on nested scopes. The allow/refuse assertions run in both directions, so a constant return fails one set or the other.

- `MeshWeaver.Graph.Test` — **802 passed**
- `MeshWeaver.Hosting.Monolith.Test` (bootstrap/access/space filter) — **55 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)