### PR TITLE
Remove the duplicate InternalsVisibleTo Copilot flagged on #804

### DIFF
--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -4,10 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
-  </ItemGroup>
-
-  <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 


### PR DESCRIPTION
`Memex.Portal.Shared` already grants the test project friend access via an assembly-level `[InternalsVisibleTo("Memex.Portal.Shared.Test")]` in `ApiTokenService.cs:17`.

I added a second one in the csproj while making `DevAuthController.IsDevAdmin` testable. Copilot caught it on #804 and I fixed it locally — but merged before pushing that commit, so the duplicate landed on main. Fixing forward.

The 8 `DevLoginIsNotAdmin` tests still pass with only the assembly-level attribute, which is the proof the csproj entry was never needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)