### PR TITLE
fix(blazor): stale-cell chip persists after the re-run that clears it

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -538,6 +538,10 @@ public partial class CollaborativeMarkdownView
             return;
         _runTracker.Record(submission);
         Hub.Post(submission, o => o.WithTarget(KernelAddress));
+        // The toolbar's OnRun is a plain Action, not an EventCallback, so nothing re-renders THIS
+        // view after the click — and RunState is a parameter computed at the parent's last render,
+        // so without this the "stale cell" chip survives the very re-run that cleared it.
+        StateHasChanged();
     }
 
     private string RenderMarkdown(string content)

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
@@ -310,5 +310,9 @@ public partial class MarkdownView
             return;
         _runTracker.Record(submission);
         Hub.Post(submission, o => o.WithTarget(KernelAddress));
+        // The toolbar's OnRun is a plain Action, not an EventCallback, so nothing re-renders THIS
+        // view after the click — and RunState is a parameter computed at the parent's last render,
+        // so without this the "stale cell" chip survives the very re-run that cleared it.
+        StateHasChanged();
     }
 }


### PR DESCRIPTION
## What changed

`StateHasChanged()` added in both `ResubmitBlock` sites (`CollaborativeMarkdownView`, `MarkdownView`) after `_runTracker.Record(submission)` + the kernel post.

## Why

The cell toolbar's `OnRun` is a plain `Action<string>`, not an `EventCallback` — so clicking Run re-renders only the toolbar child. Its `RunState` is a `[Parameter]` computed at the **parent's** last render, and the parent never re-rendered after recording the fresh fingerprint. Result: the "stale cell" chip, the tinted toolbar and the re-run arrow all survive the very re-run that cleared them, until an unrelated event re-renders the page. (Reported live: "the re-run works now on code change, but the marker does not vanish.")

The tracker itself is correct — `StateOf` answers `UpToDate` immediately after `Record`; only the re-render was missing. The direct `StateHasChanged()` is safe: the click handler runs on the renderer's sync context (same pattern as `OnViewModeChanged`).

## How tested

`dotnet build src/MeshWeaver.Blazor` clean (0 warnings, 0 errors). The behavior is a Blazor render-cascade property — verify in the portal: edit a `--render` cell so the chip appears, press Run, the chip and tint must clear immediately while the output streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ppgo4xDrX9UcJ6exvsNzju