### PR TITLE
fix(plugin-catalog): Plugins partition gets a PublicRead policy — readable by real users on a fresh mesh

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-plugins-partition-readable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-plugins-partition-readable.md
@@ -1,7 +1,7 @@
 ---
 Name: Installed plugins visible on a fresh mesh
 Category: What's New
-Description: The plugin catalog's install records are now readable by every signed-in user, so the Plugin Catalog settings tab shows what is installed on a freshly bootstrapped mesh.
+Description: The plugin catalog's install records now ship with a read-only public access policy, so catalog views can show what is installed on a freshly bootstrapped mesh.
 Icon: Sparkle
 ---
 
@@ -9,6 +9,6 @@ Icon: Sparkle
 
 The plugin catalog's install records (the `Plugins` partition) now ship with a read-only public
 access policy, the same shape as the agent, skill and model catalogs. On a freshly bootstrapped
-mesh, a platform admin opening the Plugin Catalog settings tab now sees the installed plugins
-instead of an access denial. The partition stays read-only — install records are still written
+mesh, the catalog's installed-state queries now return the installed plugins for real users
+instead of being denied. The partition stays read-only — install records are still written
 exclusively by the platform itself during installs.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-plugins-partition-readable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-plugins-partition-readable.md
@@ -1,0 +1,14 @@
+---
+Name: Installed plugins visible on a fresh mesh
+Category: What's New
+Description: The plugin catalog's install records are now readable by every signed-in user, so the Plugin Catalog settings tab shows what is installed on a freshly bootstrapped mesh.
+Icon: Sparkle
+---
+
+# Installed plugins visible on a fresh mesh
+
+The plugin catalog's install records (the `Plugins` partition) now ship with a read-only public
+access policy, the same shape as the agent, skill and model catalogs. On a freshly bootstrapped
+mesh, a platform admin opening the Plugin Catalog settings tab now sees the installed plugins
+instead of an access denial. The partition stays read-only — install records are still written
+exclusively by the platform itself during installs.

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -89,8 +89,9 @@ public static class PluginCatalogConfigurationExtensions
     // catalog). The records are written exclusively under ImpersonateAsSystem (PackageInstaller),
     // so no creator grant is ever minted, and a platform admin's Admin/_Access grant is scoped to
     // the Admin partition — without this policy NO real signed-in principal holds Read on
-    // "Plugins", and the settings tab's installed-state query (CatalogLayoutAreas.ObserveInstalled,
-    // `path:Plugins scope:children`) is denied for the very admin the tab is gated on (#811).
+    // "Plugins", and the installed-state query every catalog surface issues
+    // (CatalogLayoutAreas.ObserveInstalled, `path:Plugins scope:children`) is denied for every
+    // real principal, platform admins included (#811).
     // PublicRead is safe: PackageManifest carries no secrets. The write caps keep the partition
     // non-writable for every non-System identity (System bypasses the evaluator, so the
     // installer's own record writes are unaffected).

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MeshWeaver.Graph;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -29,6 +30,7 @@ public static class PluginCatalogConfigurationExtensions
         => (TBuilder)builder
             .AddMeshNodes(CreatePackageNodeType())
             .AddMeshNodes(CreateCatalogNodeType())
+            .AddMeshNodes(CreateInstalledPartitionPolicy())
             // The build-completion subscriber. A mesh-scoped SINGLETON, so its subscriptions live
             // and die with the mesh rather than surviving disposal into the next test
             // (Doc/Architecture/NoStaticState). The IHostedService registration is what STARTS it —
@@ -81,4 +83,30 @@ public static class PluginCatalogConfigurationExtensions
         Icon = "/static/NodeTypeIcons/box.svg",
         HubConfiguration = config => config.AddPluginCatalogViews(),
     };
+
+    // Read-only, world-readable policy for the install-records partition — the same shape every
+    // other built-in catalog ships (BuiltInAgentProvider / BuiltInSkillProvider / the model
+    // catalog). The records are written exclusively under ImpersonateAsSystem (PackageInstaller),
+    // so no creator grant is ever minted, and a platform admin's Admin/_Access grant is scoped to
+    // the Admin partition — without this policy NO real signed-in principal holds Read on
+    // "Plugins", and the settings tab's installed-state query (CatalogLayoutAreas.ObserveInstalled,
+    // `path:Plugins scope:children`) is denied for the very admin the tab is gated on (#811).
+    // PublicRead is safe: PackageManifest carries no secrets. The write caps keep the partition
+    // non-writable for every non-System identity (System bypasses the evaluator, so the
+    // installer's own record writes are unaffected).
+    private static MeshNode CreateInstalledPartitionPolicy() =>
+        new("_Policy", PackageInstaller.InstalledPartition)
+        {
+            NodeType = "PartitionAccessPolicy",
+            Name = "Access Policy",
+            Content = new PartitionAccessPolicy
+            {
+                PublicRead = true,
+                Create = false,
+                Update = false,
+                Delete = false,
+                Comment = false,
+                Thread = false
+            }
+        };
 }

--- a/test/MeshWeaver.PluginCatalog.Test/PluginsPartitionReadableTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginsPartitionReadableTest.cs
@@ -1,0 +1,94 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins #811(A): the <c>Plugins</c> install-records partition must be readable by a REAL signed-in
+/// principal on a freshly bootstrapped mesh — via the read-only <c>PublicRead</c>
+/// <c>PartitionAccessPolicy</c> that <see cref="PluginCatalogConfigurationExtensions.AddPluginCatalog"/>
+/// registers, the same shape every other built-in catalog ships.
+///
+/// <para>The principal deliberately has the PRODUCTION shape (post-#804), which no other catalog
+/// test exercises: a platform admin holding ONLY the correctly-scoped Admin-partition grant
+/// (<c>Admin/_Access</c>, <c>MainNode="Admin"</c> — the exact node
+/// <c>UserOnboardingService.GrantPlatformAdmin</c> writes), no root-scope grant and no
+/// <c>Roles=["Admin"]</c> claim. Such a grant is never on the <c>Plugins</c> scope walk, and the
+/// install records are written under <c>ImpersonateAsSystem</c> so no creator grant is ever minted
+/// — without the policy, the settings tab's installed-state query
+/// (<c>CatalogLayoutAreas.ObserveInstalled</c>, <c>path:Plugins scope:children</c>) is denied for
+/// the very admin the tab is gated on. The default <c>MonolithMeshTestBase</c> setup would mask
+/// all of this: it seeds a root-scope <c>Public → Admin</c> grant AND a circuit identity carrying
+/// <c>Roles=["Admin"]</c> — the very claim mechanism #804 removed — so this test builds on
+/// <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> instead.</para>
+/// </summary>
+public class PluginsPartitionReadableTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The production-shaped platform admin: Admin on the Admin partition, nothing else.</summary>
+    private const string PlatformAdmin = "e2e-admin";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            // The exact grant shape GrantPlatformAdmin writes: an AccessAssignment at
+            // Admin/_Access with MainNode="Admin" (Admin role scoped to the Admin partition).
+            .AddMeshNodes(AssignmentNodeFactory.UserRole(PlatformAdmin, "Admin", "Admin"));
+
+    [Fact(Timeout = 120000)]
+    public async Task PlatformAdmin_WithOnlyAdminScopedGrant_ReadsInstallRecords_OnFreshMesh()
+    {
+        // The seeded grant really is the production platform-admin shape …
+        await Mesh.IsGlobalAdmin(PlatformAdmin).Should().Match(isAdmin => isAdmin);
+
+        // … and NOT a data superuser: outside the catalog the principal holds nothing, so the
+        // read below can only come from the partition policy (a root-scope grant sneaking back
+        // into this fixture would fail here and void the pin).
+        await Mesh.GetEffectivePermissions(TestPartition, PlatformAdmin)
+            .Should().Match(p => p == Permission.None);
+
+        // Install a package on the fresh mesh — the records land in "Plugins" under the System
+        // identity (PackageInstaller.Upsert), exactly as in production, so no creator grant exists.
+        var manifest = new PackageManifest
+        {
+            Id = "readable-pack",
+            Name = "Readable Pack",
+            Kind = PackageKind.Content,
+            TargetPartition = "ReadableTarget",
+            SourceFolder = "readable-pack",
+            Version = "1.0.0",
+        };
+        var files = new[] { new PackageFile("readable-pack/Doc.md", "# Doc\n\nInstalled for the readability pin.") };
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "HEAD").FirstAsync().ToTask();
+        result.Written.Should().Be(1);
+
+        // The EXACT installed-state query the settings tab issues (CatalogLayoutAreas.
+        // ObserveInstalled), evaluated under the admin's identity — RLS filters unreadable nodes
+        // out of the result set, so without the PublicRead policy this set stays empty forever.
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{PackageInstaller.InstalledPartition} scope:children nodeType:{PackageInstaller.PackageNodeType}",
+                PlatformAdmin))
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(
+                change => change.Items.Any(n =>
+                    n.Path == $"{PackageInstaller.InstalledPartition}/readable-pack"),
+                "a signed-in platform admin must see the install records the plugin-catalog settings tab queries");
+
+        // Read-only: the policy grants exactly Read — its write caps deny Create/Update/Delete
+        // (and Comment/Thread) for every non-System identity.
+        await Mesh.GetEffectivePermissions(PackageInstaller.InstalledPartition, PlatformAdmin)
+            .Should().Match(p => p == Permission.Read);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/PluginsPartitionReadableTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginsPartitionReadableTest.cs
@@ -26,9 +26,9 @@ namespace MeshWeaver.PluginCatalog.Test;
 /// <c>UserOnboardingService.GrantPlatformAdmin</c> writes), no root-scope grant and no
 /// <c>Roles=["Admin"]</c> claim. Such a grant is never on the <c>Plugins</c> scope walk, and the
 /// install records are written under <c>ImpersonateAsSystem</c> so no creator grant is ever minted
-/// — without the policy, the settings tab's installed-state query
+/// — without the policy, the installed-state query every catalog surface issues
 /// (<c>CatalogLayoutAreas.ObserveInstalled</c>, <c>path:Plugins scope:children</c>) is denied for
-/// the very admin the tab is gated on. The default <c>MonolithMeshTestBase</c> setup would mask
+/// every real principal, platform admins included. The default <c>MonolithMeshTestBase</c> setup would mask
 /// all of this: it seeds a root-scope <c>Public → Admin</c> grant AND a circuit identity carrying
 /// <c>Roles=["Admin"]</c> — the very claim mechanism #804 removed — so this test builds on
 /// <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> instead.</para>
@@ -72,7 +72,7 @@ public class PluginsPartitionReadableTest(ITestOutputHelper output) : MonolithMe
         var result = await PackageInstaller.Install(Mesh, manifest, files, "HEAD").FirstAsync().ToTask();
         result.Written.Should().Be(1);
 
-        // The EXACT installed-state query the settings tab issues (CatalogLayoutAreas.
+        // The EXACT installed-state query the catalog UI issues (CatalogLayoutAreas.
         // ObserveInstalled), evaluated under the admin's identity — RLS filters unreadable nodes
         // out of the result set, so without the PublicRead policy this set stays empty forever.
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
@@ -84,7 +84,7 @@ public class PluginsPartitionReadableTest(ITestOutputHelper output) : MonolithMe
             .Match(
                 change => change.Items.Any(n =>
                     n.Path == $"{PackageInstaller.InstalledPartition}/readable-pack"),
-                "a signed-in platform admin must see the install records the plugin-catalog settings tab queries");
+                "a signed-in platform admin must see the install records the catalog's installed-state query returns");
 
         // Read-only: the policy grants exactly Read — its write caps deny Create/Update/Delete
         // (and Comment/Thread) for every non-System identity.


### PR DESCRIPTION
## What

`AddPluginCatalog` now registers a read-only **PublicRead `PartitionAccessPolicy`** for the `Plugins` install-records partition — the same `_Policy` node shape every other built-in catalog ships (`BuiltInAgentProvider`, `BuiltInSkillProvider`, the model catalog), seeded via `AddMeshNodes` (the `DocumentationExtensions` precedent: it flows through `StaticMeshNodeListProvider`, so the policy is present from the first permission evaluation, no synced-query cold start).

Fixes #811 part A.

## Why

After #804 removed the dev-login claim-Admin, **no real signed-in principal held Read on `Plugins`**:

- a platform admin is Admin at scope `Admin` only (no data superuser),
- the records are written under `ImpersonateAsSystem` (`PackageInstaller`), so no creator grant is ever minted,
- and unlike every other catalog, `AddPluginCatalog` registered no partition policy.

So the settings tab's installed-state query (`CatalogLayoutAreas.ObserveInstalled`, `path:Plugins scope:children`) was denied for the very admin the tab is gated on — `Access denied: user 'e2e-admin' lacks Read permission on 'Plugins'`. Same class as the Store partition bug (MeshWeaver.Plugins#203).

Safe: `PackageManifest` carries no secrets; the policy's write caps (`Create/Update/Delete/Comment/Thread = false`) keep the partition non-writable for every non-System identity (System bypasses the evaluator, so the installer's own record writes are unaffected). A policy is not an `AccessAssignment`, so #805's `AccessAssignmentGuard` never sees it.

## How tested

New regression test `PluginsPartitionReadableTest` closes the coverage gap #811(C) names — the **production principal shape** no other catalog test exercises: a signed-in user holding ONLY the correctly-scoped `Admin/_Access` grant (the exact node `UserOnboardingService.GrantPlatformAdmin` writes; no root-scope grant, no `Roles=["Admin"]` claim — built on `ConfigureMeshBase`, not the test-default superuser setup) runs `ObserveInstalled`'s query on a freshly bootstrapped mesh after an install and sees the record; effective permissions on `Plugins` for that principal are exactly `Read`, and the principal is pinned as a non-superuser (`Permission.None` elsewhere).

- Verified **red without the policy** (record RLS-filtered, query stays empty) and green with it.
- Full `MeshWeaver.PluginCatalog.Test` suite: 74/74 green.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean for `MeshWeaver.PluginCatalog`, `MeshWeaver.PluginCatalog.Test`, `Memex.Portal.Shared`, `MeshWeaver.Documentation`.

Ships a What's New entry (user-facing: the Plugin Catalog settings tab now shows installed plugins on a fresh mesh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB