### PR TITLE
A projected query must answer: never hand a dictionary to Query<MeshNode>

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -214,10 +214,19 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     /// <see cref="CollectQueryResultsAsync{T}"/>), never handed to a caller
     /// whose <c>await foreach</c> would pump it on a hub/grain scheduler.
     /// </summary>
+    /// <param name="projectSelect">
+    /// Whether a <c>select:</c> clause also projects each row to a
+    /// <c>Dictionary&lt;string,object&gt;</c>. TRUE for the untyped surface, whose callers expect
+    /// exactly that (pinned by <c>QuerySyntaxTests.Select_SingleProperty</c>). FALSE for a typed
+    /// <c>Query&lt;MeshNode&gt;</c>: a dictionary is not a MeshNode, so projecting there produced
+    /// rows the typed layer could not accept — and it dropped or mis-cast every one of them.
+    /// The SELECT is narrowed in SQL either way, so nothing extra is fetched.
+    /// </param>
     private async IAsyncEnumerable<object> QueryAsync(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default,
+        bool projectSelect = true)
     {
         // Self-filter — MeshQuery's aggregator deliberately doesn't pre-filter
         // by Matches() ("let each provider own the 'is this mine?' decision in
@@ -234,7 +243,7 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
         // PostgreSqlStorageAdapter.QueryNodesAsync(IReadOnlyList&lt;ParsedQuery&gt;,...).
         if (request.Queries is { Count: > 1 })
         {
-            await foreach (var item in QueryNodesUnionAsync(request, options, ct).ConfigureAwait(false))
+            await foreach (var item in QueryNodesUnionAsync(request, options, ct, projectSelect).ConfigureAwait(false))
                 yield return item;
             yield break;
         }
@@ -327,7 +336,7 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
             foreach (var (node, _) in buffered.OrderByDescending(b => b.Score))
             {
                 if (skip > 0) { skip--; continue; }
-                yield return parsedQuery.Select != null
+                yield return projectSelect && parsedQuery.Select != null
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
                     : node;
                 count++;
@@ -353,7 +362,7 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 continue;
             }
 
-            yield return parsedQuery.Select != null
+            yield return projectSelect && parsedQuery.Select != null
                 ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
                 : node;
 
@@ -372,7 +381,8 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private async IAsyncEnumerable<object> QueryNodesUnionAsync(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        [EnumeratorCancellation] CancellationToken ct)
+        [EnumeratorCancellation] CancellationToken ct,
+        bool projectSelect = true)
     {
         var queries = request.Queries!;
         var parsedList = new List<ParsedQuery>(queries.Count);
@@ -426,8 +436,8 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 continue;
             if (skip > 0) { skip--; continue; }
 
-            yield return firstParsed.Select != null
-                ? ParsedQuery.ProjectToSelect(node, firstParsed.Select)
+            yield return projectSelect && firstParsed!.Select is { } unionSelect
+                ? ParsedQuery.ProjectToSelect(node, unionSelect)
                 : node;
             count++;
             if (effectiveLimit.HasValue && count >= effectiveLimit.Value)
@@ -951,8 +961,26 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private async Task<List<(string? Path, T Item)>> CollectQueryResultsAsync<T>(
         MeshQueryRequest request, JsonSerializerOptions options, CancellationToken ct)
     {
+        // 🚨 A TYPED query must never be handed a projection. `select:` makes QueryAsync yield
+        // Dictionary<string,object> (the untyped surface's contract, pinned by
+        // QuerySyntaxTests.Select_SingleProperty) — and a dictionary is not a MeshNode, so the
+        // `is T` below silently DROPPED every row: a query that matched returned EMPTY. Upstream in
+        // MeshQuery's merge the same mismatch is a hard `(T)(object)` cast, which throws inside the
+        // merge where the fault reaches no subscriber — the provider then emits neither an Initial
+        // nor an error, the all-providers Initial gate starves, and the caller HANGS IN SILENCE.
+        //
+        // Measured on memex 2026-08-05: every query carrying a `select:` hung past 120 s —
+        // including `nodeType:NodeType select:path limit:5`, which certainly matches — while the
+        // same queries without one answered instantly and Postgres served the underlying
+        // 136-schema union in 57 ms. The MCP `search` tool is Query<MeshNode>, so every agent
+        // search with a select: wedged, and Doc/Architecture/CqrsAndContentAccess tells callers to
+        // add exactly that clause.
+        //
+        // The SELECT still narrows the SQL, so a projected read costs only what it asked for; the
+        // node simply stays a node for the caller that asked for nodes.
+        var projectSelect = typeof(T) != typeof(MeshNode);
         var results = new List<(string?, T)>();
-        await foreach (var item in QueryAsync(request, options, ct).ConfigureAwait(false))
+        await foreach (var item in QueryAsync(request, options, ct, projectSelect).ConfigureAwait(false))
             if (item is T typed)
                 results.Add(((item as MeshNode)?.Path, typed));
         return results;

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -820,7 +820,23 @@ public class MeshQuery : IMeshQueryCore
         var scores = new List<double>(finalList.Count);
         foreach (var (item, score) in finalList)
         {
-            if (parsed.Select is { } select && item is MeshNode node)
+            // 🚨 Never hand a projection to a caller typed on MeshNode. ProjectToSelect returns a
+            // Dictionary<string,object> — the untyped surface's contract — and `(T)(object)dict`
+            // with T = MeshNode throws InvalidCastException for EVERY item, right here inside the
+            // merge, where the fault reaches no subscriber: the provider emits neither an Initial
+            // nor an error, the all-providers Initial gate starves, and the caller HANGS IN TOTAL
+            // SILENCE (no error, no empty result, no log line).
+            //
+            // Measured on memex 2026-08-05: every query carrying a `select:` hung past 120 s —
+            // including `nodeType:NodeType select:path limit:5`, which certainly matches — while
+            // the same queries without one answered instantly and Postgres served the underlying
+            // 136-schema union in 57 ms. MeshOperations.Search (the MCP `search` tool) is
+            // Query<MeshNode>, so every agent search carrying a select: wedged — and
+            // Doc/Architecture/CqrsAndContentAccess tells callers to add exactly that clause.
+            //
+            // The SELECT already narrowed the columns in SQL, so skipping the object-level
+            // projection costs nothing; untyped callers still get their dictionary.
+            if (parsed.Select is { } select && item is MeshNode node && typeof(T) != typeof(MeshNode))
             {
                 items.Add((T)(object)ParsedQuery.ProjectToSelect(node, select));
             }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ProjectedSelectQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ProjectedSelectQueryTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 PINS "A PROJECTED Query&lt;MeshNode&gt; ANSWERS INSTEAD OF HANGING."
+///
+/// <para><c>select:</c> makes the query layer project each row to a
+/// <c>Dictionary&lt;string,object&gt;</c> — the untyped surface's contract, pinned by
+/// <c>QuerySyntaxTests.Select_SingleProperty</c>. A dictionary is not a MeshNode, so the typed
+/// surface either DROPPED every row (returning empty for a query that matched) or, in the
+/// aggregator's hard <c>(T)(object)</c> cast, threw inside the merge where the fault reached no
+/// subscriber — leaving the provider with no Initial and no error, starving the all-providers
+/// Initial gate, and hanging the caller in total silence.</para>
+///
+/// <para>Measured on memex 2026-08-05: every query carrying a <c>select:</c> hung past 120 s —
+/// including <c>nodeType:NodeType select:path limit:5</c>, which certainly matches — while the same
+/// queries without one answered instantly and Postgres served the underlying 136-schema union in
+/// 57 ms.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class ProjectedSelectQueryTests
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly JsonSerializerOptions _options = new();
+
+    public ProjectedSelectQueryTests(PostgreSqlFixture fixture) => _fixture = fixture;
+
+    private async Task Seed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = _fixture.StorageAdapter;
+        await adapter.Write(new MeshNode("Orchestrator", "Agent")
+        { Name = "Orchestrator", NodeType = "Agent", Description = "runs things" }, _options)
+            .Should().Within(30.Seconds()).Emit();
+        await adapter.Write(new MeshNode("Coder", "Agent")
+        { Name = "Coder", NodeType = "Agent" }, _options)
+            .Should().Within(30.Seconds()).Emit();
+        await _fixture.AccessControl.Grant("Agent", "Anonymous", "Read", isAllow: true, ct)
+            .Should().Within(30.Seconds()).Emit();
+    }
+
+    private async Task<IReadOnlyList<MeshNode>> QueryNodes(string query)
+    {
+        var meshQuery = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
+        var change = await meshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(query), _options)
+            .Take(1).Should().Within(30.Seconds()).Emit();
+        return change.Items.ToList();
+    }
+
+    /// <summary>The "does it exist?" projection from the CQRS cheat-sheet.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task SelectPath_AnswersInsteadOfHanging()
+    {
+        await Seed();
+        var results = await QueryNodes("nodeType:Agent select:path");
+        results.Select(n => n.Path).Should().BeEquivalentTo(
+            new[] { "Agent/Orchestrator", "Agent/Coder" }, JsonSerializerOptions.Default);
+    }
+
+    /// <summary>The "is anything stale?" projection.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task SelectPathAndVersion_Answers()
+    {
+        await Seed();
+        var results = await QueryNodes("nodeType:Agent select:path,version");
+        results.Should().HaveCount(2);
+    }
+
+    /// <summary>A projection including name still carries it.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task SelectWithName_CarriesTheRequestedColumn()
+    {
+        await Seed();
+        var results = await QueryNodes("nodeType:Agent select:path,name");
+        results.Select(n => n.Name).Should().BeEquivalentTo(
+            new[] { "Orchestrator", "Coder" }, JsonSerializerOptions.Default);
+    }
+
+    /// <summary>An unprojected typed query is unaffected.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task WithoutSelect_TheWholeNodeStillMaterializes()
+    {
+        await Seed();
+        var results = await QueryNodes("nodeType:Agent");
+        var orchestrator = results.Single(n => n.Path == "Agent/Orchestrator");
+        orchestrator.Name.Should().Be("Orchestrator");
+        orchestrator.Description.Should().Be("runs things");
+    }
+
+    /// <summary>
+    /// The UNTYPED surface keeps its dictionary contract — the fix must not have been achieved by
+    /// abolishing projections.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task UntypedSurface_StillProjectsToADictionary()
+    {
+        await Seed();
+        var meshQuery = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
+        var results = await meshQuery
+            .QueryList(MeshQueryRequest.FromQuery("nodeType:Agent select:name"), _options,
+                TestContext.Current.CancellationToken)
+            .Should().Within(30.Seconds()).Emit();
+        results[0].Should().BeAssignableTo<IDictionary<string, object?>>();
+    }
+}


### PR DESCRIPTION
## The bug

**Every mesh query carrying a `select:` clause hung.** Measured on memex 2026-08-05:

| Query | Result |
|---|---|
| `nodeType:AccessAssignment scope:subtree limit:20` | instant, 20 rows |
| `nodeType:AccessAssignment scope:subtree select:path limit:50` | hang > 120 s |
| `nodeType:NodeType select:path limit:5` (certainly matches) | hang > 120 s |

**The database was never involved.** Measured in-cluster: the 136-schema fan-out is **78 ms**, a 136-branch `UNION ALL` with `ORDER BY … LIMIT 50` is **57 ms**, and every one of the 136 schemas has the `node_type` index.

`select:` makes the query layer project each row to a `Dictionary<string,object>`. That **is** the contract for the untyped surface — `QuerySyntaxTests.Select_SingleProperty` pins it — but a dictionary is not a `MeshNode`, and both typed paths break on it:

- **`MeshQuery`** (the aggregator, the path `mesh.Query<MeshNode>` takes) does `(T)(object)ProjectToSelect(...)` → `InvalidCastException` for **every** item, thrown *inside the merge* where the fault reaches no subscriber. The provider then emits neither an `Initial` nor an error, the all-providers Initial gate starves, and the caller **hangs in total silence** — no error, no empty result, no log line.
- **`PostgreSqlMeshQuery.CollectQueryResultsAsync`** does `if (item is T typed)` → every projected row **silently dropped**: a query that matched returned empty.

So the MCP `search` tool — which is `Query<MeshNode>` — wedged on any projected query. And the documented best practice was a deadlock: `Doc/Architecture/CqrsAndContentAccess` tells callers to add a `select:` clause to avoid whole-node loads.

## The fix

Skip the **object-level** projection when the caller is typed on `MeshNode`, at both boundaries. Nothing is lost — `select:` still narrows the SELECT in SQL, so a projected read costs only what it asked for; the row simply stays a node for the caller that asked for nodes. Untyped callers still get their dictionary.

## Tests

`ProjectedSelectQueryTests` (new): `select:path`, `select:path,version` and `select:path,name` all **answer** — each threw `InvalidCastException` or returned empty before this change; an unprojected query is unchanged; and the untyped surface still projects to a dictionary, so the fix cannot have been achieved by abolishing projections.

- **PostgreSql suite: 611 passed / 0 failed** (1 skipped).

## Note on scope

The deeper issue Roland flagged — `async`/`IAsyncEnumerable` in the query pipeline, where a fault goes silent instead of erroring — is **not** addressed here; that's a dedicated refactor (measured surface: 148 `IAsyncEnumerable` occurrences across 50 files). This change makes projected queries work; it does not make the pipeline reactive. The `IIoPool.Invoke` boundary these paths use is the one sanctioned by `.claude/skills/async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)