### PR TITLE
perf(plugin-catalog): bulk-save node-repo installs — one visibility barrier per install (fixes #815)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-save-node-repo-installs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-save-node-repo-installs.md
@@ -1,0 +1,18 @@
+---
+Name: Plugin installs are minutes faster — nodes now land in bulk
+Category: What's New
+Description: Installing a node-repo plugin (a course, a module) now writes its new nodes in a few transactional batches instead of one at a time.
+Icon: Sparkle
+---
+
+# Plugin installs are minutes faster
+
+Installing a plugin from a node repository — a course, a domain module — used to write every
+node one at a time, each write waiting on its own round-trip and a 100 ms visibility poll. A
+course-sized package of a few hundred nodes paid that tax on every install, on every mesh.
+
+New nodes now land in a handful of transactional bulk batches (compile sources, then types,
+then content), and each batch is visible the moment it commits — no polling. Everything that
+needs the careful one-at-a-time path keeps it: the package root, access grants and other
+satellites, and updates to nodes you already have. Re-installing an unchanged package still
+writes nothing.

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
@@ -85,6 +85,63 @@ public sealed class RoutingProxyAdapter : IStorageAdapter
                         : Observable.Return<MeshNode?>(d.Message.WrittenNodes.First())));
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The multi-node producer <see cref="WriteBatchRequest"/> was designed for: groups the
+    /// caller's nodes by owning partition-storage hub and posts ONE batch per group, so a
+    /// course-sized install is a handful of messages (and, on Postgres, a handful of
+    /// <c>NpgsqlBatch</c> round-trips) instead of one message per node. Before this override the
+    /// interface default degraded every batch back into per-node <see cref="Write"/> calls — the
+    /// single-node producer the WriteMany commit set out to retire.
+    ///
+    /// <para>Order: the caller's order is preserved by grouping CONSECUTIVE RUNS of the same
+    /// target address (never re-sorting across runs) and posting the runs sequentially —
+    /// <see cref="IStorageAdapter.WriteMany"/>'s contract pins the caller's order onto the
+    /// <see cref="IStorageAdapter.Changes"/> feed, and callers order parents before children on
+    /// purpose. Nodes no partition hub claims are absent from the result, mirroring
+    /// <see cref="Write"/>'s null. A batch error fails the whole observable, mirroring
+    /// <see cref="Write"/>'s throw.</para>
+    /// </remarks>
+    public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+        IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+    {
+        if (nodes.Count == 0)
+            return Observable.Return<IReadOnlyList<MeshNode>>(ImmutableList<MeshNode>.Empty);
+
+        // Resolve every node's owning hub IN CALLER ORDER (Concat, not Merge — order is contract).
+        return nodes
+            .Select(n => _router.AddressFor(n.Path).Take(1).Select(addr => (Node: n, Address: addr)))
+            .ToObservable().Concat().ToList()
+            .SelectMany(pairs =>
+            {
+                // Consecutive runs of the same address — one WriteBatchRequest per run.
+                var runs = new List<(Address? Address, List<MeshNode> Nodes)>();
+                foreach (var (node, address) in pairs)
+                {
+                    if (runs.Count == 0 || !Equals(runs[^1].Address, address))
+                        runs.Add((address, new List<MeshNode>()));
+                    runs[^1].Nodes.Add(node);
+                }
+
+                return runs
+                    .Select(run => run.Address is null
+                        // Unowned: absent from the result so the try-then-claim chain moves on.
+                        ? Observable.Return<IReadOnlyList<MeshNode>>(ImmutableList<MeshNode>.Empty)
+                        : _callerHub
+                            .Observe<WriteBatchResponse>(
+                                new WriteBatchRequest(run.Nodes.ToImmutableList(), options),
+                                o => o.WithTarget(run.Address))
+                            .Take(1)
+                            .SelectMany(d => d.Message.Error != null
+                                ? Observable.Throw<IReadOnlyList<MeshNode>>(
+                                    new InvalidOperationException(d.Message.Error))
+                                : Observable.Return<IReadOnlyList<MeshNode>>(d.Message.WrittenNodes)))
+                    .ToObservable().Concat().ToList()
+                    .Select(lists => (IReadOnlyList<MeshNode>)lists
+                        .SelectMany(l => l).ToImmutableList());
+            });
+    }
+
+    /// <inheritdoc/>
     public IObservable<string> Delete(string path)
         => _router.AddressFor(path).SelectMany(addr =>
             addr is null

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -280,22 +280,24 @@ public static class PackageInstaller
     // Bulk-reads the CURRENT persisted state of every path — ONE round-trip on Postgres
     // (IStorageAdapter.ReadMany batches `WHERE (namespace, id) IN (…)`), parallel single reads
     // elsewhere — replacing the per-node read that made a course-sized install pay N sequential
-    // probes before writing anything (#815). Missing paths are absent from the dictionary; a read
-    // failure degrades to "everything is new", the same write-on-failure bias UpsertIfChanged has.
-    private static IObservable<IReadOnlyDictionary<string, MeshNode>> ReadCurrent(
+    // probes before writing anything (#815). Missing paths are absent from the dictionary. A read
+    // FAILURE emits null — "existence unknown" — which the caller must treat as "no bulk routing":
+    // an empty snapshot would make every node look NEW and bulk-write nodes that may exist,
+    // bypassing the per-node handler path existing nodes require. Null instead keeps the old
+    // write-on-failure bias per node THROUGH the validating request path.
+    private static IObservable<IReadOnlyDictionary<string, MeshNode>?> ReadCurrent(
         IStorageAdapter? persistence, IReadOnlyCollection<string> paths, JsonSerializerOptions options)
         => persistence is null || paths.Count == 0
-            ? Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
+            ? Observable.Return<IReadOnlyDictionary<string, MeshNode>?>(
                 ImmutableDictionary<string, MeshNode>.Empty)
             : persistence.ReadMany(paths, options)
                 .Where(n => n is not null)
                 .ToList()
-                .Select(found => (IReadOnlyDictionary<string, MeshNode>)found
+                .Select(found => (IReadOnlyDictionary<string, MeshNode>?)found
                     .GroupBy(n => n.Path, StringComparer.Ordinal)
                     .ToImmutableDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal))
-                .Catch<IReadOnlyDictionary<string, MeshNode>, Exception>(_ =>
-                    Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
-                        ImmutableDictionary<string, MeshNode>.Empty));
+                .Catch<IReadOnlyDictionary<string, MeshNode>?, Exception>(_ =>
+                    Observable.Return<IReadOnlyDictionary<string, MeshNode>?>(null));
 
     // Upserts a node only if it is new or meaningfully changed; returns true if it wrote, false if it
     // skipped an unchanged node. Reads the CURRENT persisted node authoritatively via the storage
@@ -745,11 +747,16 @@ public static class PackageInstaller
 
         return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
             .SelectMany(_ => ReadCurrent(persistence, nodes.Select(n => n.Path).ToArray(), options))
-            .SelectMany(current =>
+            .SelectMany(maybeCurrent =>
             {
                 // Route: NEW non-satellite, non-root nodes take the bulk path per ordering
                 // bucket; the root, satellites and existing nodes keep the request path.
-                bool IsBulk(MeshNode n) => !current.ContainsKey(n.Path);
+                // A FAILED bulk read (maybeCurrent == null) means existence is UNKNOWN — bulk
+                // routing is disabled entirely and every node takes the request path, whose
+                // handler decides create-vs-update against its own authoritative read (the same
+                // per-node write-on-failure the pre-bulk installer had).
+                var current = maybeCurrent ?? ImmutableDictionary<string, MeshNode>.Empty;
+                bool IsBulk(MeshNode n) => maybeCurrent is not null && !current.ContainsKey(n.Path);
                 var bulkSources = stage1.Where(n => Order(n) == 0 && IsBulk(n)).ToArray();
                 var bulkTypes = stage1.Where(n => Order(n) == 1 && IsBulk(n)).ToArray();
                 var requestStage1 = stage1.Where(n => !IsBulk(n)).ToArray(); // keeps Order sort

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -277,6 +277,26 @@ public static class PackageInstaller
             });
     }
 
+    // Bulk-reads the CURRENT persisted state of every path — ONE round-trip on Postgres
+    // (IStorageAdapter.ReadMany batches `WHERE (namespace, id) IN (…)`), parallel single reads
+    // elsewhere — replacing the per-node read that made a course-sized install pay N sequential
+    // probes before writing anything (#815). Missing paths are absent from the dictionary; a read
+    // failure degrades to "everything is new", the same write-on-failure bias UpsertIfChanged has.
+    private static IObservable<IReadOnlyDictionary<string, MeshNode>> ReadCurrent(
+        IStorageAdapter? persistence, IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+        => persistence is null || paths.Count == 0
+            ? Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
+                ImmutableDictionary<string, MeshNode>.Empty)
+            : persistence.ReadMany(paths, options)
+                .Where(n => n is not null)
+                .ToList()
+                .Select(found => (IReadOnlyDictionary<string, MeshNode>)found
+                    .GroupBy(n => n.Path, StringComparer.Ordinal)
+                    .ToImmutableDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal))
+                .Catch<IReadOnlyDictionary<string, MeshNode>, Exception>(_ =>
+                    Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
+                        ImmutableDictionary<string, MeshNode>.Empty));
+
     // Upserts a node only if it is new or meaningfully changed; returns true if it wrote, false if it
     // skipped an unchanged node. Reads the CURRENT persisted node authoritatively via the storage
     // adapter (the SAME read the CreateOrUpdate handler uses) — no eventual-consistency lag and no
@@ -289,33 +309,39 @@ public static class PackageInstaller
             : Observable.Return<MeshNode?>(null);
         return existing
             .Take(1)
-            .SelectMany(current =>
-            {
-                // A CLAIMED node — the user set a non-Include SyncBehavior on it, typically after
-                // modifying it — is theirs, not the repo's. Skip it, exactly as the static-repo
-                // importer does. This is one of the fences that makes UNATTENDED updates (opted-in
-                // records; our deployments opt in wholesale) safe: a local edit under a claim can
-                // never be clobbered by a green build. An unclaimed local edit IS overwritten —
-                // claiming is the deliberate act that decouples a node from its package.
-                if (current is not null && current.SyncBehavior != SyncBehavior.Include)
-                    return Observable.Return(false);
-                if (current is not null && IsUnchanged(current, node, options))
-                    return Observable.Return(false);
-                if (current is not null && Environment.GetEnvironmentVariable("MW_INSTALL_DIFF") == "1")
-                {
-                    var cur = ContentSignature(current.Content, options);
-                    var inc = ContentSignature(node.Content ?? current.Content, options);
-                    var at = 0;
-                    while (at < cur.Length && at < inc.Length && cur[at] == inc[at]) at++;
-                    var lo = Math.Max(0, at - 120);
-                    Console.WriteLine($"[DIFF] {node.Path} scalars={ScalarsUnchanged(current, node)} " +
-                        $"lens={cur.Length}/{inc.Length} firstDiff@{at}");
-                    Console.WriteLine($"  cur({current.Content?.GetType().Name}): …{cur[lo..Math.Min(cur.Length, at + 160)]}");
-                    Console.WriteLine($"  inc({node.Content?.GetType().Name}): …{inc[lo..Math.Min(inc.Length, at + 160)]}");
-                }
-                return Upsert(hub, node).Select(_ => true);
-            })
+            .SelectMany(current => DecideAndWrite(hub, current, node, options))
             .Catch<bool, Exception>(_ => Upsert(hub, node).Select(_ => true));
+    }
+
+    // The write decision against a KNOWN current state — the body UpsertIfChanged wraps with its
+    // own authoritative read. The node-repo install path calls this directly with one BULK-read
+    // snapshot (ReadCurrent) instead of paying a per-node read round-trip (#815).
+    private static IObservable<bool> DecideAndWrite(
+        IMessageHub hub, MeshNode? current, MeshNode node, JsonSerializerOptions options)
+    {
+        // A CLAIMED node — the user set a non-Include SyncBehavior on it, typically after
+        // modifying it — is theirs, not the repo's. Skip it, exactly as the static-repo
+        // importer does. This is one of the fences that makes UNATTENDED updates (opted-in
+        // records; our deployments opt in wholesale) safe: a local edit under a claim can
+        // never be clobbered by a green build. An unclaimed local edit IS overwritten —
+        // claiming is the deliberate act that decouples a node from its package.
+        if (current is not null && current.SyncBehavior != SyncBehavior.Include)
+            return Observable.Return(false);
+        if (current is not null && IsUnchanged(current, node, options))
+            return Observable.Return(false);
+        if (current is not null && Environment.GetEnvironmentVariable("MW_INSTALL_DIFF") == "1")
+        {
+            var cur = ContentSignature(current.Content, options);
+            var inc = ContentSignature(node.Content ?? current.Content, options);
+            var at = 0;
+            while (at < cur.Length && at < inc.Length && cur[at] == inc[at]) at++;
+            var lo = Math.Max(0, at - 120);
+            Console.WriteLine($"[DIFF] {node.Path} scalars={ScalarsUnchanged(current, node)} " +
+                $"lens={cur.Length}/{inc.Length} firstDiff@{at}");
+            Console.WriteLine($"  cur({current.Content?.GetType().Name}): …{cur[lo..Math.Min(cur.Length, at + 160)]}");
+            Console.WriteLine($"  inc({node.Content?.GetType().Name}): …{inc[lo..Math.Min(inc.Length, at + 160)]}");
+        }
+        return Upsert(hub, node).Select(_ => true);
     }
 
     /// <summary>
@@ -452,7 +478,7 @@ public static class PackageInstaller
         IMessageHub hub, PackageManifest manifest, IReadOnlyList<PackageFile> files,
         string installedFromRef, ILogger? logger, int batchSize)
     {
-        _ = batchSize; // node-repo installs are ordered (Concat), not fanned out
+        _ = batchSize; // node-repo installs are ordered (bucketed bulk saves + Concat), not fanned out
         var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions);
         // The CI manifest sidecar (when the package ships one) becomes the install record's diff
         // baseline — the next update touches only what its manifest diff names.
@@ -508,7 +534,25 @@ public static class PackageInstaller
             return 3;                                            // plain content + typed instances
         }
 
-        // Three stages with VISIBILITY BARRIERS between them, solving two races at once:
+        // Three stages, same ordering guarantees as ever — but the writes are now ROUTED (#815):
+        //
+        // • A NEW non-root, non-satellite node takes the BULK path: one transactional
+        //   IStorageAdapter.WriteMany per ordering bucket (Postgres: one NpgsqlBatch per table
+        //   window; the partition-storage proxy: one WriteBatchRequest per owning hub). The
+        //   response IS the visibility barrier — a committed batch needs no 100 ms Exists poll,
+        //   which is what made a ~300-node course install pay minutes of serial round-trips.
+        //   Per-node validation is preserved: the claimed/unchanged skip runs per node against
+        //   the ONE bulk-read snapshot (ReadCurrent), and the create path's type-existence check
+        //   is applied per DISTINCT type up front (ValidateBulkTypes, identical rule:
+        //   static registry → in-package → persistence).
+        // • The ROOT, the underscore satellites, and every node that ALREADY EXISTS keep the
+        //   per-node CreateOrUpdateNodeRequest path unchanged — the root because its create runs
+        //   the standard partition path (provisioning + the placeholder dance below), satellites
+        //   because their guards live in the handler (AccessAssignment scoping, system-owned
+        //   grant rejection, MainNode normalisation), existing nodes because updates must flow
+        //   through the owning per-node hub's stream (version bump + reconciliation).
+        //
+        // The original two races the stage barriers solve, still solved:
         //
         // (1) THE ROOT lands first — as a Space PLACEHOLDER when its real type is dynamic and
         //     ships in this very package (the Store: the root is nodeType Store/Catalog, defined
@@ -517,11 +561,10 @@ public static class PackageInstaller
         //     partition bootstrap: without it, the first CHILD create triggers the heal, whose
         //     generic Space root races OUR typed root through the debounced per-node-hub
         //     persists — last persist wins (observed: the heal's Space replacing the typed root).
-        // (2) THE TYPES land before any instance referencing them: the create path's
-        //     type-existence check reads PERSISTENCE (MeshExtensions, step 3), and a
-        //     freshly-created type node persists through the DEBOUNCED pipeline — an instance
-        //     written right behind its in-package type races that debounce and is refused as
-        //     "not registered". The barrier polls until every type node is persistence-visible.
+        // (2) THE TYPES land before any instance referencing them. Bulk-written types are
+        //     COMMITTED when their batch responds, so only types updated through the per-node
+        //     path (already-existing ones — which are persistence-visible by definition) still
+        //     go through the Exists barrier; on a fresh mesh that set is empty and no poll runs.
         //
         // Then the FINAL root (retyping the placeholder), the plain content, and LAST the
         // underscore satellites (a satellite must anchor under an existing owner).
@@ -550,12 +593,92 @@ public static class PackageInstaller
                         .Timeout(TimeSpan.FromSeconds(30)))
                     .ToObservable().Concat().LastAsync().Select(_ => System.Reactive.Unit.Default);
 
-        IObservable<IList<(string Path, bool Wrote)>> WriteAll(IReadOnlyList<MeshNode> batch) =>
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+
+        // The per-node REQUEST path — decisions run against the bulk-read snapshot (one shared
+        // read instead of N sequential probes), the write itself is the full validating
+        // CreateOrUpdateNodeRequest, retry-on-error parity with UpsertIfChanged.
+        IObservable<IList<(string Path, bool Wrote)>> WriteAll(
+            IReadOnlyList<MeshNode> batch, IReadOnlyDictionary<string, MeshNode> current) =>
             batch.Count == 0
                 ? Observable.Return((IList<(string, bool)>)new List<(string, bool)>())
-                : batch.Select(n => UpsertIfChanged(hub, persistence, n, options)
+                : batch.Select(n => DecideAndWrite(hub, current.GetValueOrDefault(n.Path), n, options)
+                        .Catch<bool, Exception>(_ => Upsert(hub, n).Select(_ => true))
                         .Select(wrote => (n.Path, wrote)))
                     .ToObservable().Concat().ToList(); // sequential to respect the ordering
+
+        // The BULK path for NEW nodes: one transactional WriteMany per ordering bucket. The
+        // response means COMMITTED — storage acceptance is checked loudly (an install must never
+        // report success for a node persistence did not take), and the create path's stamps
+        // (CreatedDate/LastModified, Active state) are applied for parity. System-impersonated
+        // exactly as Upsert is — per call, because ambient impersonation does not survive the
+        // pipeline's scheduler hops.
+        IObservable<IList<(string Path, bool Wrote)>> BulkSave(IReadOnlyList<MeshNode> batch)
+        {
+            if (batch.Count == 0)
+                return Observable.Return((IList<(string, bool)>)new List<(string, bool)>());
+            if (persistence is null)
+                return WriteAll(batch, ImmutableDictionary<string, MeshNode>.Empty);
+            var now = DateTimeOffset.UtcNow;
+            var stamped = batch
+                .Select(n => n with
+                {
+                    State = MeshNodeState.Active,
+                    CreatedDate = n.CreatedDate == default ? now : n.CreatedDate,
+                    LastModified = now,
+                })
+                .ToArray();
+            return Observable.Using(
+                    () => accessService?.ImpersonateAsSystem()
+                          ?? System.Reactive.Disposables.Disposable.Empty,
+                    _ => persistence.WriteMany(stamped, options))
+                .Select(written =>
+                {
+                    if (written.Count != batch.Count)
+                    {
+                        var missing = batch.Select(n => n.Path)
+                            .Except(written.Select(w => w.Path), StringComparer.Ordinal)
+                            .ToArray();
+                        throw new InvalidOperationException(
+                            $"Bulk install of '{manifest.Id}' persisted {written.Count}/{batch.Count} "
+                            + $"node(s) — storage did not accept: {string.Join(", ", missing)}");
+                    }
+                    return (IList<(string, bool)>)batch.Select(n => (n.Path, true)).ToList();
+                });
+        }
+
+        // The same per-node type-existence rule the create path applies (MeshExtensions, step 3:
+        // static registry → persistence), evaluated once per DISTINCT type instead of once per
+        // node — with the types THIS package installs satisfied by construction (the bulk write
+        // of the types commits before any instance batch is sent).
+        IObservable<System.Reactive.Unit> ValidateBulkTypes(IReadOnlyList<MeshNode> bulk)
+        {
+            var inPackage = nodeTypePaths
+                .Concat(root?.Content is NodeTypeDefinition ? new[] { root.Path } : Array.Empty<string>())
+                .ToImmutableHashSet(StringComparer.Ordinal);
+            var unknown = bulk
+                .Select(n => n.NodeType)
+                .Where(t => !string.IsNullOrEmpty(t))
+                .Select(t => t!)
+                .Distinct(StringComparer.Ordinal)
+                .Where(t => !inPackage.Contains(t)
+                    && hub.ServiceProvider.FindStaticNode(t) is null)
+                .ToArray();
+            if (unknown.Length == 0 || persistence is null)
+                return Observable.Return(System.Reactive.Unit.Default);
+            return unknown
+                .Select(t => persistence.Exists(t).Take(1).Select(exists => (Type: t, Exists: exists)))
+                .ToObservable().Merge().ToList()
+                .SelectMany(results =>
+                {
+                    var missing = results.Where(r => !r.Exists).Select(r => r.Type).ToArray();
+                    return missing.Length == 0
+                        ? Observable.Return(System.Reactive.Unit.Default)
+                        : Observable.Throw<System.Reactive.Unit>(new InvalidOperationException(
+                            $"Install of '{manifest.Id}' failed: NodeType(s) not registered: "
+                            + string.Join(", ", missing)));
+                });
+        }
 
         // 🚨 CONFIRM THE SELF-TYPED ROOT'S RETYPE RECONCILED before the install reports success.
         // Stage 2 retypes the Space placeholder to the in-package type via
@@ -611,27 +734,56 @@ public static class PackageInstaller
         // CONSTRUCTION, so stage 0 rewrote it and stage 2 retyped it back — one guaranteed churn
         // write per package per sync (the idempotence pin's "wrote 1 node" on EVERY repo the day
         // the plugins gate was first executed, 2026-07-29), plus a window in which a LIVE plugin
-        // root is a contentless Space. Decide REACTIVELY off the same authoritative read
-        // UpsertIfChanged uses; a read failure means "not final", so a fresh mesh still gets its
-        // placeholder. When the root is already final, stage 0 writes NOTHING — the root's
-        // (idempotent) content upsert happens in stage 2 like any other node.
-        IObservable<bool> PlaceholderNeeded() =>
-            placeholderRoot is null || root is null || persistence is null
-                ? Observable.Return(placeholderRoot is not null)
-                : persistence.Read(root.Path, options)
-                    .Take(1)
-                    .Select(current => current is null
-                        || !string.Equals(current.NodeType, root.NodeType, StringComparison.Ordinal))
-                    .Catch<bool, Exception>(_ => Observable.Return(true));
+        // root is a contentless Space. Decide off the SAME authoritative bulk-read snapshot the
+        // routing uses (ReadCurrent — a read failure yields the empty snapshot, so a fresh mesh
+        // still gets its placeholder). When the root is already final, stage 0 writes NOTHING —
+        // the root's (idempotent) content upsert happens in stage 2 like any other node.
+        bool PlaceholderNeeded(IReadOnlyDictionary<string, MeshNode> current) =>
+            placeholderRoot is not null && root is not null
+                && (!current.TryGetValue(root.Path, out var curRoot)
+                    || !string.Equals(curRoot.NodeType, root.NodeType, StringComparison.Ordinal));
 
         return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
-            .SelectMany(_ => PlaceholderNeeded())
-            .SelectMany(needed => WriteAll(
-                needed || placeholderRoot is null ? stage0 : Array.Empty<MeshNode>()))
-            .SelectMany(rootWrites => Visible(root is null ? [] : [root.Path])
-                .SelectMany(_ => WriteAll(stage1))
-                .SelectMany(typeWrites => Visible(nodeTypePaths)
-                    .SelectMany(_ => WriteAll(stage2))
+            .SelectMany(_ => ReadCurrent(persistence, nodes.Select(n => n.Path).ToArray(), options))
+            .SelectMany(current =>
+            {
+                // Route: NEW non-satellite, non-root nodes take the bulk path per ordering
+                // bucket; the root, satellites and existing nodes keep the request path.
+                bool IsBulk(MeshNode n) => !current.ContainsKey(n.Path);
+                var bulkSources = stage1.Where(n => Order(n) == 0 && IsBulk(n)).ToArray();
+                var bulkTypes = stage1.Where(n => Order(n) == 1 && IsBulk(n)).ToArray();
+                var requestStage1 = stage1.Where(n => !IsBulk(n)).ToArray(); // keeps Order sort
+                var stage2Root = stage2.Where(n => Order(n) == 2).ToArray();
+                var bulkInstances = stage2.Where(n => Order(n) == 3 && IsBulk(n)).ToArray();
+                var requestInstances = stage2.Where(n => Order(n) == 3 && !IsBulk(n)).ToArray();
+                var satellites = stage2.Where(n => Order(n) == 4).ToArray();
+                // Only types updated through the debounced per-node path still need the Exists
+                // barrier; a bulk-written type is committed when its batch responds. (These paths
+                // already exist, so the barrier passes on its first probe — no 100 ms tail.)
+                var requestTypePaths = requestStage1
+                    .Where(n => n.Content is NodeTypeDefinition).Select(n => n.Path).ToArray();
+                var allBulk = bulkSources.Concat(bulkTypes).Concat(bulkInstances).ToArray();
+
+                return ValidateBulkTypes(allBulk)
+                    .SelectMany(_ => WriteAll(
+                        PlaceholderNeeded(current) || placeholderRoot is null
+                            ? stage0
+                            : Array.Empty<MeshNode>(),
+                        current))
+                    .SelectMany(rootWrites => Visible(root is null ? [] : [root.Path])
+                        .SelectMany(_ => BulkSave(bulkSources))
+                        .SelectMany(sourceWrites => BulkSave(bulkTypes)
+                            .SelectMany(typeBulkWrites => WriteAll(requestStage1, current)
+                                .Select(typeReqWrites => (IList<(string Path, bool Wrote)>)sourceWrites
+                                    .Concat(typeBulkWrites).Concat(typeReqWrites).ToList()))
+                            .SelectMany(typeWrites => Visible(requestTypePaths)
+                                .SelectMany(_ => WriteAll(stage2Root, current))
+                                .SelectMany(rootFinalWrites => BulkSave(bulkInstances)
+                                    .SelectMany(instBulkWrites => WriteAll(requestInstances, current)
+                                        .SelectMany(instReqWrites => WriteAll(satellites, current)
+                                            .Select(satWrites => (IList<(string Path, bool Wrote)>)rootFinalWrites
+                                                .Concat(instBulkWrites).Concat(instReqWrites)
+                                                .Concat(satWrites).ToList()))))
                     // The retype's optimistic emit is not the reconciled state — wait for the
                     // shared root handle to carry the in-package type AND for the debounced
                     // persist to land it in storage (a later install reads persistence).
@@ -674,7 +826,6 @@ public static class PackageInstaller
                 {
                     // System-impersonated: the release flips are stream writes posted from a
                     // continuation with no ambient context (see Upsert).
-                    var accessService = hub.ServiceProvider.GetService<AccessService>();
                     using (accessService?.ImpersonateAsSystem())
                         foreach (var path in nodeTypePaths)
                             hub.RequestNodeTypeRelease(path,
@@ -682,6 +833,7 @@ public static class PackageInstaller
                 }
                 return WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length, moduleManifest)
                     .Select(_ => result);
+            }));
             });
     }
 

--- a/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
@@ -1,0 +1,200 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the BULK-SAVE mechanics of a node-repo install (#815): a fresh multi-node install must
+/// write its NEW non-root, non-satellite nodes through <see cref="IStorageAdapter.WriteMany"/>
+/// batches — one per ordering bucket, whose response IS the visibility barrier — never through
+/// per-node writes, while a re-install of the unchanged snapshot writes NOTHING (the
+/// idempotence contract that guards every plugin-gate run). The assertions are
+/// timing-insensitive: they check WHICH path the nodes travelled and the final stored state,
+/// not how long anything took.
+/// </summary>
+public class BulkSaveInstallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly RecordingStorageAdapter _recorder = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog()
+            .ConfigureServices(s =>
+            {
+                // Wrap the in-memory adapter so the test can observe which write PATH each node
+                // took (WriteMany batch vs per-node Write). The wrapper forwards everything.
+                s.RemoveAll<IStorageAdapter>();
+                return s.AddSingleton<IStorageAdapter>(_recorder);
+            });
+
+    // A course-shaped node-repo plugin: a static-typed Space root, one NodeType with its Source,
+    // and several plain content instances — the population whose one-at-a-time writes made a
+    // ~300-node course install pay minutes of serial round-trips.
+    private static readonly IReadOnlyList<RepoFile> Repo = new List<RepoFile>
+    {
+        new("BulkPack/index.json",
+            """{"$type":"MeshNode","id":"BulkPack","namespace":"","path":"BulkPack","mainNode":"BulkPack","name":"Bulk Pack","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"bulk-save pin."}}"""),
+        new("BulkPack/Thing.json",
+            """{"$type":"MeshNode","id":"Thing","namespace":"BulkPack","path":"BulkPack/Thing","mainNode":"BulkPack/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"a thing.","configuration":"config => config.WithContentType<Thing>()","includeGlobalTypes":true}}"""),
+        new("BulkPack/Thing/Source/Thing.cs",
+            "public record Thing { public string Name { get; init; } = string.Empty; }"),
+        new("BulkPack/Lesson1.md", "# Lesson 1"),
+        new("BulkPack/Lesson2.md", "# Lesson 2"),
+        new("BulkPack/Lesson3.md", "# Lesson 3"),
+        new("BulkPack/Deep.json",
+            """{"$type":"MeshNode","id":"Deep","namespace":"BulkPack","path":"BulkPack/Deep","mainNode":"BulkPack/Deep","name":"Deep","nodeType":"BulkPack/Thing","state":"Active"}"""),
+    };
+
+    [Fact(Timeout = 120_000)]
+    public async Task FreshInstall_BulkSavesNewNodes_PerBucket_AndReinstallWritesNothing()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-bulk", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/bulk");
+        var manifest = new PackageManifest
+        {
+            Id = "BulkPack",
+            Name = "Bulk Pack",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "BulkPack",
+            SourceFolder = "BulkPack",
+            Version = "commit-bulk",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+        files.Count.Should().Be(7);
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "commit-bulk")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+
+        // Correctness: everything landed, and WrittenPaths names all seven nodes.
+        result.Total.Should().Be(7);
+        result.Written.Should().Be(7);
+        result.WrittenPaths.OrderBy(p => p, StringComparer.Ordinal).Should().Equal(
+            "BulkPack", "BulkPack/Deep", "BulkPack/Lesson1", "BulkPack/Lesson2",
+            "BulkPack/Lesson3", "BulkPack/Thing", "BulkPack/Thing/Source/Thing");
+        (await Read("BulkPack")).NodeType.Should().Be("Space");
+        (await Read("BulkPack/Thing")).NodeType.Should().Be("NodeType");
+        (await Read("BulkPack/Lesson2")).NodeType.Should().Be("Markdown");
+        (await Read("BulkPack/Deep")).NodeType.Should().Be("BulkPack/Thing",
+            "a typed instance must land AFTER its in-package type's bulk batch committed");
+
+        // Mechanism: the new non-root nodes travelled the BULK path — one WriteMany batch per
+        // ordering bucket (compile inputs → types → instances), never a per-node write. The
+        // batch RESPONSE is the visibility barrier, so bucket count is the whole story: no
+        // 100 ms per-node Exists polling is left to observe.
+        var batches = _recorder.WriteManyBatches;
+        batches.Should().HaveCount(3,
+            "a fresh install bulk-saves exactly its three ordering buckets: sources, types, instances");
+        // bucket 0: the types' compile inputs; bucket 1: the type nodes — committed before any
+        // instance batch is sent; bucket 2: plain content + typed instances, in ONE batch.
+        batches[0].Should().Equal("BulkPack/Thing/Source/Thing");
+        batches[1].Should().Equal("BulkPack/Thing");
+        batches[2].OrderBy(p => p, StringComparer.Ordinal).Should().Equal(
+            "BulkPack/Deep", "BulkPack/Lesson1", "BulkPack/Lesson2", "BulkPack/Lesson3");
+        // The root is the one node that must keep the per-node request path (its create runs the
+        // standard partition path), so it never appears in a bulk batch.
+        batches.SelectMany(b => b).Should().NotContain("BulkPack");
+
+        // Idempotence: the unchanged snapshot re-installs with ZERO writes — and with no new
+        // bulk batches (the decisions run against the single ReadMany snapshot).
+        var batchCountAfterInstall = _recorder.WriteManyBatches.Count;
+        var second = await PackageInstaller.Install(Mesh, manifest, files, "commit-bulk")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+        second.Written.Should().Be(0, "an unchanged node-repo re-install must not rewrite any node");
+        _recorder.WriteManyBatches.Count.Should().Be(batchCountAfterInstall,
+            "a re-install of the unchanged snapshot must not send any bulk batch");
+    }
+
+    private async Task<MeshNode> Read(string path) =>
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).Select(n => n!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+    /// <summary>
+    /// Pass-through <see cref="IStorageAdapter"/> that records every <see cref="WriteMany"/>
+    /// batch's paths so the test can pin WHICH path a node's write travelled. Everything
+    /// forwards to a real <see cref="InMemoryStorageAdapter"/> — including the change feed the
+    /// synced-query providers subscribe to.
+    /// </summary>
+    private sealed class RecordingStorageAdapter : IStorageAdapter
+    {
+        private readonly InMemoryStorageAdapter _inner = new();
+        private readonly ConcurrentQueue<IReadOnlyList<string>> _writeManyBatches = new();
+
+        public IReadOnlyList<IReadOnlyList<string>> WriteManyBatches => _writeManyBatches.ToArray();
+
+        public IObservable<DataChangeNotification> Changes => ((IStorageAdapter)_inner).Changes;
+
+        public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).Read(path, options);
+
+        public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).ReadMany(paths, options);
+
+        public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).Write(node, options);
+
+        public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+            IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+        {
+            _writeManyBatches.Enqueue(nodes.Select(n => n.Path).ToImmutableList());
+            return ((IStorageAdapter)_inner).WriteMany(nodes, options);
+        }
+
+        public IObservable<string> Delete(string path) => ((IStorageAdapter)_inner).Delete(path);
+
+        public IObservable<bool> DeleteIfExists(string path) => ((IStorageAdapter)_inner).DeleteIfExists(path);
+
+        public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
+            ListChildPaths(string? parentPath)
+            => ((IStorageAdapter)_inner).ListChildPaths(parentPath);
+
+        public IObservable<bool> Exists(string path) => ((IStorageAdapter)_inner).Exists(path);
+
+        public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
+            string fullPath, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).FindBestPrefixMatch(fullPath, options);
+
+        public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
+            string fullPath, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).ResolvePath(fullPath, options);
+
+        public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
+            => ((IStorageAdapter)_inner).ListPartitionSubPaths(nodePath);
+
+        public IObservable<object> GetPartitionObjects(
+            string nodePath, string? subPath, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).GetPartitionObjects(nodePath, subPath, options);
+
+        public IObservable<Unit> SavePartitionObjects(
+            string nodePath, string? subPath, IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+            => ((IStorageAdapter)_inner).SavePartitionObjects(nodePath, subPath, objects, options);
+
+        public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+            => ((IStorageAdapter)_inner).DeletePartitionObjects(nodePath, subPath);
+
+        public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+            => ((IStorageAdapter)_inner).GetPartitionMaxTimestamp(nodePath, subPath);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
@@ -126,6 +126,39 @@ public class BulkSaveInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
             "a re-install of the unchanged snapshot must not send any bulk batch");
     }
 
+    [Fact(Timeout = 120_000)]
+    public async Task WhenTheBulkReadFails_EveryNodeFallsBackToTheRequestPath()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-fallback", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/bulk");
+        var manifest = new PackageManifest
+        {
+            Id = "BulkPack",
+            Name = "Bulk Pack",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "BulkPack",
+            SourceFolder = "BulkPack",
+            Version = "commit-fallback",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+
+        // Existence is UNKNOWN when the bulk read fails — bulk routing must be disabled
+        // entirely (an empty-snapshot fallback would bulk-write nodes that may already exist,
+        // bypassing the per-node handler path existing nodes require). Every node then takes
+        // the validating request path, whose handler decides create-vs-update against its own
+        // authoritative read — the pre-bulk installer's exact write-on-failure behavior.
+        _recorder.FailReadMany = true;
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "commit-fallback")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+        _recorder.FailReadMany = false;
+
+        result.Written.Should().Be(7, "the degraded install still lands every node");
+        _recorder.WriteManyBatches.Should().BeEmpty(
+            "a failed bulk read must disable bulk routing, not route unknown-existence nodes to it");
+        (await Read("BulkPack/Deep")).NodeType.Should().Be("BulkPack/Thing");
+    }
+
     private async Task<MeshNode> Read(string path) =>
         await Mesh.GetWorkspace().GetMeshNodeStream(path)
             .Where(n => n is not null).Select(n => n!)
@@ -144,13 +177,18 @@ public class BulkSaveInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
 
         public IReadOnlyList<IReadOnlyList<string>> WriteManyBatches => _writeManyBatches.ToArray();
 
+        /// <summary>When set, <see cref="ReadMany"/> errors — simulating a transient bulk-read failure.</summary>
+        public bool FailReadMany { get; set; }
+
         public IObservable<DataChangeNotification> Changes => ((IStorageAdapter)_inner).Changes;
 
         public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
             => ((IStorageAdapter)_inner).Read(path, options);
 
         public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
-            => ((IStorageAdapter)_inner).ReadMany(paths, options);
+            => FailReadMany
+                ? Observable.Throw<MeshNode>(new InvalidOperationException("simulated bulk-read failure"))
+                : ((IStorageAdapter)_inner).ReadMany(paths, options);
 
         public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
             => ((IStorageAdapter)_inner).Write(node, options);


### PR DESCRIPTION
Fixes #815.

## The defect

`InstallNodeRepo` wrote every node one at a time: a per-node persistence read (`UpsertIfChanged`), a serial (`Concat`) `CreateOrUpdateNodeRequest` round-trip per node — each fanning out an inner create + per-node hub spin-up — and 100 ms `Exists` polls for the type visibility barrier. A ~300-node course paid that serial tax on EVERY install on EVERY mesh; on Systemorph/education's blocking e2e gate this is the dominant cost of the ~27–35 min install job.

## The change — writes are ROUTED, and the batch response IS the barrier

- **NEW non-root, non-satellite nodes take the BULK path.** One bulk-read snapshot up front (`IStorageAdapter.ReadMany` — one PG query), then one transactional `IStorageAdapter.WriteMany` per ordering bucket: compile sources → types → instances. A committed batch is persistence-visible by construction, so the fresh-install path has **no 100 ms polling loops left at all** — the only Exists barrier that can still poll is the root's (one path) and it passes on its first probe for an existing root.
- **Everything that needs the per-node validating request path keeps it**: the ROOT (placeholder dance runs the standard partition path), underscore satellites (`AccessAssignment` scoping, system-owned-grant rejection and MainNode normalisation live in the handler), and every node that ALREADY EXISTS (updates must flow through the owning per-node hub's stream — version bump + reconciliation; a direct storage write would regress `version = EXCLUDED.version`).
- **Per-node validation preserved**: the claimed/unchanged skip runs per node against the shared snapshot (`DecideAndWrite` — the exact body `UpsertIfChanged` wraps), and the create path's type-existence rule (static registry → in-package → persistence, same failure message) is applied per DISTINCT type up front.
- **`RoutingProxyAdapter.WriteMany`** — the override the WriteMany commit (d0f8e0689) left open ("its only producer sent one node"): consecutive same-hub runs group into ONE `WriteBatchRequest` per owning partition hub, caller order intact per the WriteMany ordering contract, so on partition-storage meshes a bucket is a handful of messages and, on Postgres, `NpgsqlBatch` round-trips.

Idempotence tightens: a re-install of the unchanged snapshot now costs ONE `ReadMany` round-trip and zero writes (previously N serial reads).

## Mechanism pin

`BulkSaveInstallTest` installs a 7-node repo through a recording adapter and asserts — timing-insensitively — the exact three bucket batches and their membership, that the root never appears in a bulk batch, correctness of the landed nodes (typed instance included), complete `WrittenPaths`, and that a re-install writes nothing and sends no bulk batch.

Local: PluginCatalog suite **75/75** green (ordering, self-typed-root, idempotence and signature pins included), `StorageAdapterWriteManyTests` 4/4, Release `-p:CIRun=true -warnaserror` clean on MeshWeaver.Hosting, MeshWeaver.PluginCatalog and both test projects.

## Out of scope / notes for review

- `InstallNodeRepoDelta` (manifest-diff updates — few nodes by construction) stays on the request path; follow-up if it ever shows in a profile.
- `RoutingProxyAdapter` had no test coverage at all before this PR and still has none directly; the override mirrors `Write`'s message shape and the interface default's pinned contract. Worth a partition-storage-hub harness test as a follow-up.
- Bulk-written nodes stamp `CreatedDate`/`LastModified`/`State` exactly like the create path; `CreatedBy` is left as parsed (null) rather than stamped with the system identity — flag if that matters for provenance.

What's New entry included (user-facing performance change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB