### PR TITLE
feat(mesh): CreateNodesRequest — the bulk create verb (one round-trip per plan, not per node)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-create-mesh-verb.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-create-mesh-verb.md
@@ -1,0 +1,19 @@
+---
+Name: One round-trip to create many nodes — the bulk create verb
+Category: What's New
+Description: Plugins and services can now create a whole plan of nodes in a single validated, permission-checked request instead of one round-trip per node.
+Icon: Sparkle
+---
+
+# One round-trip to create many nodes
+
+Anything that lands a plan of nodes — installing a course's exercises into your own space,
+importing a module, seeding a workspace — used to issue one create request per node, each
+paying its own round-trip through the mesh. Copying a course of a few dozen subtrees took
+minutes for that reason alone.
+
+The mesh now has a bulk create verb: one request carries the whole plan, every node is
+validated and permission-checked up front (a refusal writes nothing at all), and the batch
+lands in one ordered storage write with every downstream reader notified node by node, in
+order. Nodes you already have are skipped and reported, never overwritten — and everything
+that deliberately stays per-node (access grants, satellites, updates) keeps its careful path.

--- a/src/MeshWeaver.Hosting/MeshService.cs
+++ b/src/MeshWeaver.Hosting/MeshService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Hosting.Persistence.Query;
 using MeshWeaver.Mesh;
@@ -121,6 +122,33 @@ internal sealed class MeshService(
                         NodeCreationRejectionReason.NodeAlreadyExists =>
                             new InvalidOperationException($"Node already exists: {node.Path}"),
                         _ => new InvalidOperationException(r.Error ?? "Node creation failed")
+                    });
+                });
+        }).CarryAccessContext(hub.ServiceProvider);
+    }
+
+    public IObservable<CreateNodesResponse> CreateNodes(IReadOnlyCollection<MeshNode> nodes)
+    {
+        // Same eager identity capture as CreateNode — see the 🚨 note there: the request FIELD
+        // survives the cross-hub post and an emission-thread Subscribe; the ambient context does not.
+        var captured = CaptureContext();
+        return Observable.Defer(() =>
+        {
+            var request = new CreateNodesRequest(nodes as ImmutableList<MeshNode> ?? nodes.ToImmutableList());
+            if (string.IsNullOrEmpty(request.CreatedBy)
+                && captured?.ObjectId is { Length: > 0 } callerId)
+                request = request with { CreatedBy = callerId };
+            return hub.Observe(request, o => ConfigurePost(o, captured))
+                .SelectMany(d =>
+                {
+                    var r = d.Message;
+                    if (r.Success)
+                        return Observable.Return(r);
+                    return Observable.Throw<CreateNodesResponse>(r.RejectionReason switch
+                    {
+                        NodeCreationRejectionReason.ValidationFailed =>
+                            new UnauthorizedAccessException(r.Error ?? "Access denied"),
+                        _ => new InvalidOperationException(r.Error ?? "Bulk node creation failed"),
                     });
                 });
         }).CarryAccessContext(hub.ServiceProvider);

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -190,15 +190,22 @@ public class CreateNodesPermissionAttribute() : RequiresPermissionAttribute(Perm
     public override IEnumerable<(string Path, Permission Permission)> GetPermissionChecks(
         IMessageDelivery delivery, string hubPath)
     {
-        if (delivery.Message is not CreateNodesRequest req)
+        // Null request shape / null Nodes / null entries must not throw HERE — the pipeline
+        // permission evaluation runs before the handler can return a structured failure. Fall back
+        // to the Create floor; the handler then refuses the malformed batch cleanly.
+        if (delivery.Message is not CreateNodesRequest { Nodes: not null } req)
         {
             yield return (hubPath, Permission.Create);
             yield break;
         }
 
         var permissions = req.Nodes
+            .Where(n => n is not null)
             .Select(n => CreateNodePermissionAttribute.GetPermissionForNodeType(n.NodeType))
-            .Distinct();
+            .Distinct()
+            .ToList();
+        if (permissions.Count == 0)
+            permissions.Add(Permission.Create);
         foreach (var permission in permissions)
             yield return (hubPath, permission);
     }

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -102,6 +103,105 @@ public enum NodeCreationRejectionReason
     /// Node content validation failed.
     /// </summary>
     ValidationFailed
+}
+
+/// <summary>
+/// Request to create MANY new MeshNodes in one round-trip — the BULK sibling of
+/// <see cref="CreateNodeRequest"/>, and the sanctioned batched path for callers that today fan
+/// out one create request per node (a course install copies 50-250 nodes; each singular request
+/// is its own mesh-hub round-trip plus a full per-node pipeline pass).
+///
+/// <para>Semantics, relative to N singular creates:</para>
+/// <list type="bullet">
+///   <item><b>Plain nodes only.</b> Satellites (any <c>_</c>-prefixed path segment) and
+///     <c>AccessAssignment</c> nodes are REFUSED — their creation runs guards and side effects
+///     that are deliberately per-node; send them through <see cref="CreateNodeRequest"/>.</item>
+///   <item><b>Creates only.</b> A node whose path already exists is skipped and reported in
+///     <see cref="CreateNodesResponse.Existing"/> — never overwritten, never confirmed
+///     (no Transient→Active dance). Updates flow through the owning per-node hub's stream.</item>
+///   <item><b>Validate-all, then write.</b> Every guard, validator (including RLS) and
+///     type-existence probe runs for every node BEFORE anything is written; any failure fails
+///     the whole request with <see cref="CreateNodesResponse.FailedPath"/> naming the offender
+///     and NOTHING written.</item>
+///   <item><b>Caller order is contract.</b> Nodes are written in request order (parents before
+///     children is the caller's responsibility, exactly as with sequential singular creates)
+///     and the change feed publishes <c>Created</c> per node in that same order, post-commit.</item>
+/// </list>
+/// </summary>
+/// <param name="Nodes">The MeshNodes to create, in the order they must land.</param>
+[CreateNodesPermission]
+public record CreateNodesRequest(ImmutableList<MeshNode> Nodes) : IRequest<CreateNodesResponse>
+{
+    /// <summary>
+    /// The user or system requesting the creation — resolution identical to
+    /// <see cref="CreateNodeRequest.CreatedBy"/>.
+    /// </summary>
+    public string? CreatedBy { get; init; }
+}
+
+/// <summary>
+/// Response for <see cref="CreateNodesRequest"/>.
+/// </summary>
+/// <param name="Created">The nodes actually created (as stored), in request order.</param>
+/// <param name="Existing">Paths that already existed and were skipped (never overwritten).</param>
+public record CreateNodesResponse(ImmutableList<MeshNode> Created, ImmutableList<string> Existing)
+{
+    /// <summary>Error message if the request failed. A failure BEFORE the write means nothing
+    /// was written; a storage failure mid-batch reports what landed in <see cref="Created"/>.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>The path of the node the failure was detected on, when attributable.</summary>
+    public string? FailedPath { get; init; }
+
+    /// <summary>The rejection reason when the request failed.</summary>
+    public NodeCreationRejectionReason? RejectionReason { get; init; }
+
+    /// <summary>Indicates the whole request succeeded.</summary>
+    public bool Success => Error == null;
+
+    /// <summary>Creates a successful response.</summary>
+    public static CreateNodesResponse Ok(ImmutableList<MeshNode> created, ImmutableList<string> existing)
+        => new(created, existing);
+
+    /// <summary>Creates a failed response.</summary>
+    public static CreateNodesResponse Fail(
+        string error,
+        NodeCreationRejectionReason reason = NodeCreationRejectionReason.Unknown,
+        string? failedPath = null,
+        ImmutableList<MeshNode>? created = null)
+        => new(created ?? ImmutableList<MeshNode>.Empty, ImmutableList<string>.Empty)
+        {
+            Error = error,
+            RejectionReason = reason,
+            FailedPath = failedPath,
+        };
+}
+
+/// <summary>
+/// Permission attribute for <see cref="CreateNodesRequest"/>: the pipeline-level bound is the
+/// union of the per-node-type mapped permissions (via
+/// <see cref="CreateNodePermissionAttribute.GetPermissionForNodeType"/>) at the hub path — the
+/// same coarse gate the singular create gets. The authoritative per-node, per-path check is the
+/// RLS validator inside the handler, which runs for EVERY node before anything is written.
+/// </summary>
+public class CreateNodesPermissionAttribute() : RequiresPermissionAttribute(Permission.Create)
+{
+    /// <inheritdoc />
+    public override IEnumerable<(string Path, Permission Permission)> GetPermissionChecks(
+        IMessageDelivery delivery, string hubPath)
+    {
+        if (delivery.Message is not CreateNodesRequest req)
+        {
+            yield return (hubPath, Permission.Create);
+            yield break;
+        }
+
+        var permissions = req.Nodes
+            .Select(n => CreateNodePermissionAttribute.GetPermissionForNodeType(n.NodeType))
+            .Distinct();
+        foreach (var permission in permissions)
+            yield return (hubPath, permission);
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -142,6 +142,7 @@ public static class MeshExtensions
             .Set(new NodeOperationHandlersMarker())
             .AddMeshTypes()
             .WithHandler<CreateNodeRequest>(HandleCreateNodeRequest)
+            .WithHandler<CreateNodesRequest>(HandleCreateNodesRequest)
             .WithHandler<CreateOrUpdateNodeRequest>(HandleCreateOrUpdateNodeRequest)
             .WithHandler<DeleteNodeRequest>(HandleDeleteNodeRequest)
             .WithHandler<ValidateDeleteRequest>(HandleValidateDeleteRequest)
@@ -663,6 +664,301 @@ public static class MeshExtensions
                             CreateNodeResponse.Fail($"Unexpected error: {ex.Message}",
                                 NodeCreationRejectionReason.Unknown),
                             o => o.ResponseFor(request));
+                    }
+                });
+
+        return request.Processed();
+    }
+
+    /// <summary>
+    /// Handles <see cref="CreateNodesRequest"/> — the BULK sibling of
+    /// <see cref="HandleCreateNodeRequest"/>. One request creates N plain nodes with ONE batched
+    /// existence read, ONE partition bootstrap per distinct partition, the full validator/RLS +
+    /// type-existence pass for EVERY node BEFORE anything is written, then ONE
+    /// <see cref="IStorageAdapter.WriteMany"/> in caller order with the change-feed
+    /// <c>Created</c> publishes following post-commit in that same order, and the post-creation
+    /// handlers per created node. Satellites and <c>AccessAssignment</c> nodes are refused (their
+    /// guards and side effects are deliberately per-node); existing paths are skipped and
+    /// reported, never overwritten. Validate-all-then-write: a pre-write failure writes NOTHING.
+    ///
+    /// Fully synchronous handler — returns <see cref="IMessageDelivery"/>, never Task; the
+    /// terminal response is posted from inside the reactive chain (see
+    /// <see cref="HandleCreateNodeRequest"/>'s note).
+    /// </summary>
+    private static IMessageDelivery HandleCreateNodesRequest(
+        IMessageHub hub,
+        IMessageDelivery<CreateNodesRequest> request)
+    {
+        var logger = hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MeshWeaver.Mesh.CreateNodes");
+        var meshConfig = hub.ServiceProvider.GetService<MeshConfiguration>();
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
+
+        void PostFail(string error, NodeCreationRejectionReason reason, string? failedPath = null,
+            ImmutableList<MeshNode>? created = null)
+            => hub.Post(CreateNodesResponse.Fail(error, reason, failedPath, created),
+                o => o.ResponseFor(request));
+
+        if (meshConfig == null)
+        {
+            PostFail("MeshConfiguration not available", NodeCreationRejectionReason.Unknown);
+            return request.Processed();
+        }
+        // FAIL CLOSED on missing storage — same contract as the singular create (a create that
+        // cannot persist must error, never ack).
+        if (persistence == null)
+        {
+            logger.LogError(
+                "[CreateNodes] REFUSED batch of {Count}: no IStorageAdapter on hub {Hub} — the creates would be acked but never persisted.",
+                request.Message.Nodes?.Count ?? 0, hub.Address);
+            PostFail(
+                $"No storage adapter on hub '{hub.Address}' — refusing the batch because it could not be persisted.",
+                NodeCreationRejectionReason.Unknown);
+            return request.Processed();
+        }
+
+        var createdBy = request.Message.CreatedBy;
+        if (string.IsNullOrEmpty(createdBy) && request.AccessContext?.ObjectId is { Length: > 0 } senderId)
+            createdBy = senderId;
+
+        var nodes = request.Message.Nodes ?? ImmutableList<MeshNode>.Empty;
+        if (nodes.Count == 0)
+        {
+            hub.Post(CreateNodesResponse.Ok(ImmutableList<MeshNode>.Empty, ImmutableList<string>.Empty),
+                o => o.ResponseFor(request));
+            return request.Processed();
+        }
+
+        // ——— Phase 0: synchronous structural guards — the whole batch fails on the first offender,
+        // so a caller can never land half a plan behind a refusal it didn't see. ———
+        var seenPaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var candidate in nodes)
+        {
+            if (string.IsNullOrWhiteSpace(candidate.Id) || string.IsNullOrWhiteSpace(candidate.Path))
+            {
+                PostFail("Node path and Id must not be empty",
+                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
+                return request.Processed();
+            }
+            if (string.IsNullOrWhiteSpace(candidate.NodeType) && candidate.Content == null)
+            {
+                PostFail($"Node '{candidate.Path}' must have a NodeType or Content set; bare nodes are not allowed.",
+                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
+                return request.Processed();
+            }
+            // Satellites (_Access, _Activity, _Thread, …) carry per-node guards (ownerless-activity,
+            // assignment scope/system-owned) and satellite-MainNode normalization that are
+            // deliberately per-node lifecycle — refuse them here rather than half-support them.
+            if (candidate.Segments.Any(segment => segment.StartsWith('_')))
+            {
+                PostFail(
+                    $"'{candidate.Path}' is a satellite path — satellites are per-node lifecycle; use CreateNodeRequest/CreateOrUpdateNodeRequest.",
+                    NodeCreationRejectionReason.InvalidPath, candidate.Path);
+                return request.Processed();
+            }
+            if (string.Equals(candidate.NodeType, AccessAssignmentNodeTypeName, StringComparison.OrdinalIgnoreCase))
+            {
+                PostFail(
+                    $"'{candidate.Path}' is an AccessAssignment — grants are per-node lifecycle; use CreateNodeRequest.",
+                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
+                return request.Processed();
+            }
+            if (!seenPaths.Add(candidate.Path))
+            {
+                PostFail($"Duplicate path in batch: '{candidate.Path}'",
+                    NodeCreationRejectionReason.InvalidPath, candidate.Path);
+                return request.Processed();
+            }
+        }
+
+        var options = hub.JsonSerializerOptions;
+        var capturedBy = createdBy;
+        // What WriteMany reported as committed — read by the terminal error path so a storage
+        // failure mid-batch reports what actually landed instead of guessing.
+        var written = ImmutableList<MeshNode>.Empty;
+
+        // ——— Phase 1: existence — ONE batched authoritative read plus the static/config fallback
+        // the singular create consults (a definition-only catalog type-def is NOT a real node). ———
+        persistence.ReadMany(nodes.Select(n => n.Path).ToArray(), options)
+            .Select(existingNode => existingNode.Path)
+            .ToList()
+            .SelectMany(persistedPaths =>
+            {
+                var existing = new HashSet<string>(persistedPaths, StringComparer.Ordinal);
+                foreach (var candidate in nodes)
+                {
+                    if (existing.Contains(candidate.Path))
+                        continue;
+                    var configNode = hub.ServiceProvider.FindStaticNode(candidate.Path);
+                    if (configNode is not null && configNode is not { IsDefinitionOnly: true })
+                        existing.Add(candidate.Path);
+                }
+
+                var existingPaths = nodes.Where(n => existing.Contains(n.Path))
+                    .Select(n => n.Path).ToImmutableList();
+                var toCreate = nodes
+                    .Where(n => !existing.Contains(n.Path))
+                    // The 1b' stale-bare-Id MainNode repair from the singular path (satellites are
+                    // refused above, so the satellite normalization does not apply here).
+                    .Select(n => !string.IsNullOrEmpty(n.NodeType)
+                                 && !string.IsNullOrEmpty(n.Namespace)
+                                 && !meshConfig.IsSatelliteNodeType(n.NodeType)
+                                 && n.MainNode == n.Id
+                        ? n with { MainNode = n.Path }
+                        : n)
+                    .ToImmutableList();
+
+                if (toCreate.Count == 0)
+                {
+                    hub.Post(CreateNodesResponse.Ok(ImmutableList<MeshNode>.Empty, existingPaths),
+                        o => o.ResponseFor(request));
+                    return Observable.Empty<(ImmutableList<MeshNode> Created, ImmutableList<string> Existing)>();
+                }
+
+                // ——— Phase 2: partition bootstrap ONCE per distinct partition (the bootstrap
+                // itself is idempotent and re-healing; batching it is pure round-trip economy). ———
+                var bootstrap = toCreate
+                    .Where(n => !string.IsNullOrEmpty(n.Namespace))
+                    .GroupBy(n => n.Segments[0], StringComparer.Ordinal)
+                    .Select(group => EnsurePartitionBootstrap(
+                        hub, group.First(),
+                        new CreateNodeRequest(group.First()) { CreatedBy = capturedBy }, logger))
+                    .Concat()
+                    .ToList()
+                    .Select(_ => System.Reactive.Unit.Default);
+
+                // ——— Phase 3: validators (RLS included) for EVERY node, sequential, before any
+                // write. First failure fails the whole request — nothing has been written yet. ———
+                var validate = toCreate
+                    .Select(n => RunCreationValidatorsObs(
+                            hub, n, new CreateNodeRequest(n) { CreatedBy = capturedBy })
+                        .Select(error => (Node: n, Error: error)))
+                    .Concat()
+                    .Where(t => t.Error != null)
+                    .Take(1)
+                    .Select(t => ((MeshNode Node, (string? ErrorMessage, NodeCreationRejectionReason Reason)? Error)?)t)
+                    .DefaultIfEmpty(null);
+
+                // ——— Phase 4: type existence per DISTINCT NodeType (static provider, else
+                // persistence — same recognition order as the singular create). ———
+                var typesToProbe = toCreate
+                    .Select(n => n.NodeType)
+                    .Where(t => !string.IsNullOrEmpty(t))
+                    .Select(t => t!)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                var probeTypes = typesToProbe
+                    .Select(type => hub.ServiceProvider.FindStaticNode(type) is not null
+                        ? Observable.Return((Type: type, Exists: true))
+                        : persistence.Exists(type).Select(exists => (Type: type, Exists: exists)))
+                    .Concat()
+                    .Where(t => !t.Exists)
+                    .Take(1)
+                    .Select(t => ((string Type, bool Exists)?)t)
+                    .DefaultIfEmpty(null);
+
+                return bootstrap
+                    .SelectMany(_ => validate)
+                    .SelectMany(validationFailure =>
+                    {
+                        if (validationFailure is { } failure)
+                        {
+                            logger.LogWarning(
+                                "[CreateNodes] validator rejected {Path}: {Error} — batch of {Count} refused, nothing written",
+                                failure.Node.Path, failure.Error!.Value.ErrorMessage, toCreate.Count);
+                            PostFail(failure.Error.Value.ErrorMessage ?? "Validation failed",
+                                failure.Error.Value.Reason, failure.Node.Path);
+                            return Observable.Empty<(ImmutableList<MeshNode>, ImmutableList<string>)>();
+                        }
+
+                        return probeTypes.SelectMany(missingType =>
+                        {
+                            if (missingType is { } missing)
+                            {
+                                var offender = toCreate.First(n => string.Equals(
+                                    n.NodeType, missing.Type, StringComparison.Ordinal));
+                                PostFail($"NodeType '{missing.Type}' is not registered",
+                                    NodeCreationRejectionReason.InvalidNodeType, offender.Path);
+                                return Observable.Empty<(ImmutableList<MeshNode>, ImmutableList<string>)>();
+                            }
+
+                            // ——— Phase 5: stamps — identical to the singular create. ———
+                            var now = DateTimeOffset.UtcNow;
+                            var stamped = toCreate.Select(n => n with
+                            {
+                                State = MeshNodeState.Active,
+                                CreatedDate = n.CreatedDate == default ? now : n.CreatedDate,
+                                CreatedBy = string.IsNullOrEmpty(n.CreatedBy) ? capturedBy : n.CreatedBy,
+                                LastModified = n.LastModified == default ? now : n.LastModified,
+                                LastModifiedBy = string.IsNullOrEmpty(n.LastModifiedBy) ? capturedBy : n.LastModifiedBy,
+                                Version = n.Version > 0 ? n.Version : 1,
+                            }).ToImmutableList();
+
+                            // ——— Phase 6: ONE ordered WriteMany; the Created publishes ride the
+                            // post-commit emission in caller order (commit-then-publish, exactly
+                            // like WriteAndPublishCreated) — so stream caches and live queries
+                            // invalidate for every node, which the installer's System-side bulk
+                            // path never did. ———
+                            return persistence.WriteMany(stamped, options)
+                                .Select(list => list.ToImmutableList())
+                                .Do(list =>
+                                {
+                                    written = list;
+                                    foreach (var saved in list)
+                                        changeFeed?.Publish(MeshChangeEvent.Created(saved));
+                                })
+                                .SelectMany(list =>
+                                {
+                                    if (list.Count != stamped.Count)
+                                    {
+                                        PostFail(
+                                            $"Storage accepted {list.Count} of {stamped.Count} nodes — the batch did not land completely.",
+                                            NodeCreationRejectionReason.Unknown, created: list);
+                                        return Observable.Empty<(ImmutableList<MeshNode>, ImmutableList<string>)>();
+                                    }
+
+                                    // ——— Phase 7: post-creation handlers per created node,
+                                    // sequential — same semantics as the singular create
+                                    // (FailsCreateOnError propagates; best-effort handlers
+                                    // log-and-continue inside the runner). ———
+                                    return list
+                                        .Select(saved => RunPostCreationHandlersObs(hub, saved, capturedBy, logger))
+                                        .Concat()
+                                        .ToList()
+                                        .Select(_ => (list, existingPaths));
+                                });
+                        });
+                    });
+            })
+            .Subscribe(
+                result =>
+                {
+                    logger.LogInformation(
+                        "[CreateNodes] created {Created} node(s), {Existing} already existed, by {CreatedBy}",
+                        result.Item1.Count, result.Item2.Count, capturedBy ?? "system");
+                    hub.Post(CreateNodesResponse.Ok(result.Item1, result.Item2),
+                        o => o.ResponseFor(request));
+                },
+                ex =>
+                {
+                    if (written.Count > 0)
+                    {
+                        logger.LogError(ex,
+                            "[CreateNodes] failed AFTER {Written} node(s) were persisted — reporting the partial landing",
+                            written.Count);
+                        PostFail($"Nodes persisted but a later step failed: {ex.Message}",
+                            NodeCreationRejectionReason.Unknown, created: written);
+                    }
+                    else if (ex is InvalidOperationException)
+                    {
+                        logger.LogWarning(ex, "[CreateNodes] batch refused");
+                        PostFail(ex.Message, NodeCreationRejectionReason.ValidationFailed);
+                    }
+                    else
+                    {
+                        logger.LogError(ex, "[CreateNodes] unexpected error");
+                        PostFail($"Unexpected error: {ex.Message}", NodeCreationRejectionReason.Unknown);
                     }
                 });
 

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -735,6 +735,14 @@ public static class MeshExtensions
         var seenPaths = new HashSet<string>(StringComparer.Ordinal);
         foreach (var candidate in nodes)
         {
+            // A null entry (deserialization artifact / caller bug) must refuse the batch as a
+            // structured response, never surface as a NullReferenceException.
+            if (candidate is null)
+            {
+                PostFail("Batch contains a null node entry",
+                    NodeCreationRejectionReason.ValidationFailed);
+                return request.Processed();
+            }
             if (string.IsNullOrWhiteSpace(candidate.Id) || string.IsNullOrWhiteSpace(candidate.Path))
             {
                 PostFail("Node path and Id must not be empty",
@@ -777,6 +785,11 @@ public static class MeshExtensions
         // What WriteMany reported as committed — read by the terminal error path so a storage
         // failure mid-batch reports what actually landed instead of guessing.
         var written = ImmutableList<MeshNode>.Empty;
+        // The paths the write phase ATTEMPTED (set right before WriteMany subscribes). WriteMany
+        // can throw after partially committing (Postgres windows commit per table, then a later
+        // window rethrows) WITHOUT emitting — `written` then stays empty although nodes exist.
+        // The error path probes these to keep the failure report honest.
+        string[]? attemptedPaths = null;
 
         // ——— Phase 1: existence — ONE batched authoritative read plus the static/config fallback
         // the singular create consults (a definition-only catalog type-def is NOT a real node). ———
@@ -900,6 +913,7 @@ public static class MeshExtensions
                             // like WriteAndPublishCreated) — so stream caches and live queries
                             // invalidate for every node, which the installer's System-side bulk
                             // path never did. ———
+                            attemptedPaths = stamped.Select(n => n.Path).ToArray();
                             return persistence.WriteMany(stamped, options)
                                 .Select(list => list.ToImmutableList())
                                 .Do(list =>
@@ -942,24 +956,50 @@ public static class MeshExtensions
                 },
                 ex =>
                 {
-                    if (written.Count > 0)
+                    void ReportError()
                     {
-                        logger.LogError(ex,
-                            "[CreateNodes] failed AFTER {Written} node(s) were persisted — reporting the partial landing",
-                            written.Count);
-                        PostFail($"Nodes persisted but a later step failed: {ex.Message}",
-                            NodeCreationRejectionReason.Unknown, created: written);
+                        if (written.Count > 0)
+                        {
+                            logger.LogError(ex,
+                                "[CreateNodes] failed AFTER {Written} node(s) were persisted — reporting the partial landing",
+                                written.Count);
+                            PostFail($"Nodes persisted but a later step failed: {ex.Message}",
+                                NodeCreationRejectionReason.Unknown, created: written);
+                        }
+                        else if (ex is InvalidOperationException)
+                        {
+                            logger.LogWarning(ex, "[CreateNodes] batch refused");
+                            PostFail(ex.Message, NodeCreationRejectionReason.ValidationFailed);
+                        }
+                        else
+                        {
+                            logger.LogError(ex, "[CreateNodes] unexpected error");
+                            PostFail($"Unexpected error: {ex.Message}", NodeCreationRejectionReason.Unknown);
+                        }
                     }
-                    else if (ex is InvalidOperationException)
-                    {
-                        logger.LogWarning(ex, "[CreateNodes] batch refused");
-                        PostFail(ex.Message, NodeCreationRejectionReason.ValidationFailed);
-                    }
+
+                    // WriteMany can partially COMMIT and then throw without emitting (Postgres
+                    // windows are each their own transaction) — `written` is then empty although
+                    // nodes exist. The attempted paths were all absent before the write (existence-
+                    // filtered), so anything present NOW landed in this batch: probe and report it,
+                    // never claim a clean refusal for a half-landed batch. Best-effort probe: a
+                    // failing read falls back to the plain report rather than masking the error.
+                    if (attemptedPaths is { Length: > 0 } probe && written.Count == 0)
+                        persistence.ReadMany(probe, options)
+                            .ToList()
+                            .Catch<IList<MeshNode>, Exception>(probeEx =>
+                            {
+                                logger.LogWarning(probeEx,
+                                    "[CreateNodes] partial-landing probe failed — reporting without it");
+                                return Observable.Return((IList<MeshNode>)new List<MeshNode>());
+                            })
+                            .Subscribe(found =>
+                            {
+                                written = found.ToImmutableList();
+                                ReportError();
+                            });
                     else
-                    {
-                        logger.LogError(ex, "[CreateNodes] unexpected error");
-                        PostFail($"Unexpected error: {ex.Message}", NodeCreationRejectionReason.Unknown);
-                    }
+                        ReportError();
                 });
 
         return request.Processed();

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshService.cs
@@ -24,6 +24,25 @@ public interface IMeshService
     IObservable<MeshNode> CreateNode(MeshNode node);
 
     /// <summary>
+    /// Creates MANY plain nodes in ONE round-trip — the batched sibling of
+    /// <see cref="CreateNode"/>, routed through <see cref="CreateNodesRequest"/> so the full
+    /// validation surface (structural guards, validators/RLS per node, type existence) runs for
+    /// EVERY node before anything is written, then the storage adapter lands the batch with one
+    /// ordered <c>WriteMany</c> and the change feed publishes per node post-commit.
+    /// <para>Semantics: creates only — existing paths are skipped and reported in
+    /// <see cref="CreateNodesResponse.Existing"/>, never overwritten. Satellites
+    /// (<c>_</c>-segment paths) and <c>AccessAssignment</c> nodes are refused; caller order is
+    /// preserved (order parents before children). A pre-write failure means nothing was written;
+    /// the observable then errors (<see cref="UnauthorizedAccessException"/> for a
+    /// validation/RLS refusal, <see cref="InvalidOperationException"/> otherwise). Identity is
+    /// captured eagerly at call time, exactly like <see cref="CreateNode"/>.</para>
+    /// <para>Use it for install/copy/import plans that land dozens-to-hundreds of nodes — the
+    /// per-node request fan-out (one mesh round-trip per node) is the measured dominant cost of
+    /// a course install.</para>
+    /// </summary>
+    IObservable<CreateNodesResponse> CreateNodes(IReadOnlyCollection<MeshNode> nodes);
+
+    /// <summary>
     /// Updates an existing node with validation.
     /// Routes through the canonical <c>GetMeshNodeStream(path).Update</c> write path;
     /// the owning per-node hub re-validates RLS on the merge patch and stamps auditing.

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Tests for the BULK create verb: <see cref="CreateNodesRequest"/> /
+/// <see cref="IMeshService.CreateNodes"/>. The contract under test: one round-trip creates N
+/// plain nodes with the FULL validation surface run for every node BEFORE anything is written
+/// (validate-all-then-write), caller order preserved onto the change feed post-commit, existing
+/// paths skipped and reported (never overwritten), and satellites refused. This is the
+/// sanctioned batched path for install/copy plans that used to fan out one
+/// <see cref="CreateNodeRequest"/> round-trip per node.
+/// </summary>
+public class CreateNodesRequestTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private static MeshNode Node(string path, string body) =>
+        new(path.Split('/').Last(), string.Join('/', path.Split('/')[..^1]))
+        {
+            Name = path.Split('/').Last(),
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = body },
+            State = MeshNodeState.Active,
+        };
+
+    /// <summary>
+    /// The happy path: N nodes land in one round-trip, in caller order — asserted on the change
+    /// feed, whose per-node <c>Created</c> publishes are the contract that keeps parents ahead of
+    /// children for every subscriber (stream caches, live queries).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_CreatesAll_InCallerOrder_AndReadsBack()
+    {
+        var stem = $"{TestPartition}/bulk-{Guid.NewGuid():N}";
+        var paths = Enumerable.Range(0, 5).Select(i => $"{stem}-{i}").ToArray();
+
+        // Collect the change feed's Created events for OUR paths, subscribed before the post.
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var seen = new List<string>();
+        using var sub = feed.Subscribe(change =>
+        {
+            if (paths.Contains(change.Path))
+                lock (seen) seen.Add(change.Path);
+        }, MeshChangeKind.Created);
+
+        var response = await NodeFactory
+            .CreateNodes(paths.Select(p => Node(p, $"# body of {p}")).ToImmutableList())
+            .Should().Emit();
+
+        response.Success.Should().BeTrue(response.Error ?? "");
+        response.Existing.Should().BeEmpty();
+        response.Created.Should().HaveCount(paths.Length);
+        response.Created.Select(n => n.Path).Should().ContainInOrder(paths,
+            "caller order is contract — parents land before children");
+        response.Created.Should().OnlyContain(n => n.State == MeshNodeState.Active && n.Version >= 1,
+            "bulk-created nodes get the same stamps as singular creates");
+
+        lock (seen)
+            seen.Should().ContainInOrder(paths,
+                "the change feed publishes Created per node post-commit, in caller order");
+
+        // The nodes are REAL: a per-node read resolves content.
+        var live = await Mesh.GetMeshNode(paths[^1], 10.Seconds()).Should().Emit();
+        live.Should().NotBeNull();
+        live!.Content.Should().BeOfType<MarkdownContent>()
+            .Which.Content.Should().Be($"# body of {paths[^1]}");
+    }
+
+    /// <summary>
+    /// Creates only: a path that already exists is skipped and reported — its content is never
+    /// overwritten (updates flow through the owning per-node hub, not through a bulk create).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_SkipsExisting_NeverOverwrites()
+    {
+        var stem = $"{TestPartition}/bulk-skip-{Guid.NewGuid():N}";
+        var existingPath = $"{stem}-existing";
+        var freshPath = $"{stem}-fresh";
+
+        await NodeFactory.CreateNode(Node(existingPath, "# original")).Should().Emit();
+
+        var response = await NodeFactory
+            .CreateNodes(new[] { Node(existingPath, "# CLOBBER"), Node(freshPath, "# fresh") })
+            .Should().Emit();
+
+        response.Success.Should().BeTrue(response.Error ?? "");
+        response.Existing.Should().ContainSingle().Which.Should().Be(existingPath);
+        response.Created.Should().ContainSingle().Which.Path.Should().Be(freshPath);
+
+        var untouched = await Mesh.GetMeshNode(existingPath, 10.Seconds()).Should().Emit();
+        untouched!.Content.Should().BeOfType<MarkdownContent>()
+            .Which.Content.Should().Be("# original", "an existing node must never be overwritten by a bulk create");
+    }
+
+    /// <summary>
+    /// Satellites are per-node lifecycle: a <c>_</c>-segment path refuses the WHOLE batch before
+    /// anything is written — the valid sibling in the same batch must not land.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_RefusesSatellitePaths_NothingWritten()
+    {
+        var stem = $"{TestPartition}/bulk-sat-{Guid.NewGuid():N}";
+        var satellitePath = $"{stem}/_Activity/act-1";
+        var plainPath = $"{stem}-plain";
+
+        var response = await Mesh
+            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+                Node(plainPath, "# plain"),
+                Node(satellitePath, "# satellite"))))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        response.Success.Should().BeFalse("a satellite path must refuse the batch");
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.InvalidPath);
+        response.FailedPath.Should().Be(satellitePath);
+        response.Created.Should().BeEmpty("validate-all-then-write: nothing may land on a refusal");
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var plain = await storage.Read(plainPath, Mesh.JsonSerializerOptions).FirstAsync().ToTask();
+        plain.Should().BeNull("the valid sibling of a refused batch must not have been written");
+    }
+
+    /// <summary>
+    /// An unregistered NodeType anywhere in the batch fails the whole request pre-write — the
+    /// valid sibling must not land (same recognition order as the singular create: static
+    /// provider, then persistence).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_UnregisteredType_FailsWholeBatch_NothingWritten()
+    {
+        var stem = $"{TestPartition}/bulk-type-{Guid.NewGuid():N}";
+        var validPath = $"{stem}-valid";
+        var bogus = Node($"{stem}-bogus", "# bogus") with { NodeType = $"NoSuchType{Guid.NewGuid():N}" };
+
+        var response = await Mesh
+            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+                Node(validPath, "# valid"), bogus)))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        response.Success.Should().BeFalse();
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.InvalidNodeType);
+        response.FailedPath.Should().Be(bogus.Path);
+        response.Created.Should().BeEmpty();
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var valid = await storage.Read(validPath, Mesh.JsonSerializerOptions).FirstAsync().ToTask();
+        valid.Should().BeNull("validate-all-then-write: the valid sibling must not have been written");
+    }
+
+    /// <summary>
+    /// Duplicate paths inside one batch are a caller bug and refuse the batch — last-write-wins
+    /// inside a single WriteMany would be silent data loss.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_DuplicatePathInBatch_Refused()
+    {
+        var path = $"{TestPartition}/bulk-dup-{Guid.NewGuid():N}";
+
+        var response = await Mesh
+            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+                Node(path, "# first"), Node(path, "# second"))))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        response.Success.Should().BeFalse();
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.InvalidPath);
+        response.FailedPath.Should().Be(path);
+    }
+
+    /// <summary>
+    /// The empty batch is a trivial success — no round-trip side effects, empty result lists.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_EmptyBatch_TrivialOk()
+    {
+        var response = await NodeFactory.CreateNodes(Array.Empty<MeshNode>()).Should().Emit();
+        response.Success.Should().BeTrue(response.Error ?? "");
+        response.Created.Should().BeEmpty();
+        response.Existing.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
@@ -183,6 +183,31 @@ public class CreateNodesRequestTest(ITestOutputHelper output)
     }
 
     /// <summary>
+    /// A null entry in the batch (deserialization artifact / caller bug) refuses the batch as a
+    /// STRUCTURED response — never a NullReferenceException swallowed by the handler, and never a
+    /// throw inside the pipeline's permission evaluation.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task BulkCreate_NullEntry_RefusedStructurally()
+    {
+        var path = $"{TestPartition}/bulk-null-{Guid.NewGuid():N}";
+
+        var response = await Mesh
+            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+                Node(path, "# fine"), null!)))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        response.Success.Should().BeFalse();
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.ValidationFailed);
+        response.Created.Should().BeEmpty();
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var sibling = await storage.Read(path, Mesh.JsonSerializerOptions).FirstAsync().ToTask();
+        sibling.Should().BeNull("nothing may land from a refused batch");
+    }
+
+    /// <summary>
     /// The empty batch is a trivial success — no round-trip side effects, empty result lists.
     /// </summary>
     [Fact(Timeout = 30_000)]


### PR DESCRIPTION
## The gap

Every batched caller fans out **one `CreateNodeRequest` round-trip per node** — the measured dominant cost of a course install's learner copy (Store `Localizer`: ~50 nodes ≈ **2.2 min**, while the same course's #817-bulk import takes 40 s; education CI phase marks, 2026-08-05). A batched primitive exists at storage (`IStorageAdapter.WriteMany`, #817/d0f8e0689) and at transport (`WriteBatchRequest`), but nothing bridges it to the **validated, permission-checked mesh verb surface** — the only sanctioned surface plugin Source has. (A plugin CAN reach `IStorageAdapter.WriteMany` today via the TPA reference set, and would get the installer's bypass semantics with none of its compensations — no validators, no RLS, no change-feed publish. This verb closes that hole with a sanctioned path.)

## The verb

`CreateNodesRequest` / `IMeshService.CreateNodes` — the bulk sibling of `CreateNodeRequest`, same lifecycle-verb family:

- **Validate-all-then-write.** Structural guards, per-node validators (RLS included) and type-existence probes all run BEFORE anything is written; any refusal fails the batch with `FailedPath` and writes nothing.
- **One** batched existence read (`ReadMany`), **one** partition bootstrap per distinct partition, **one** ordered `WriteMany`.
- **Change feed per node, post-commit, in caller order** — stream caches and live queries invalidate, which the installer's System-side bulk path never did.
- **Creates only**: existing paths skipped and reported (`Existing`), never overwritten; updates stay on the owning per-node hub's stream. **Satellites and AccessAssignments refused** — their guards and side effects are deliberately per-node.
- Post-creation handlers per created node with the singular path's exact semantics (`FailsCreateOnError` propagates).
- Pipeline permission bound = union of per-node-type mapped permissions (`CreateNodesPermissionAttribute`); the authoritative per-node, per-path check remains the RLS validator inside the handler.

## Tests

Six `MonolithMeshTestBase` tests pin the contract: caller-ordered landing asserted on the change feed; skip-existing without overwrite; satellite refusal with nothing written; unregistered-type refusal with nothing written; in-batch duplicate refusal; trivial empty batch. All green locally (Release, `-warnaserror` build clean).

## Follow-up (separate PR, MeshWeaver.Plugins)

`Store/Plugin/Source/Localizer.cs` switches its one-at-a-time `CopyRoot` writes to this verb — expected learner install 2.2 min → seconds per course, and it removes the cold-per-node-hub pathology behind the quarantined re-install stall.

What's New entry included (`2026-08-05-bulk-create-mesh-verb.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB