### PR TITLE
Exact-path reads run under the caller's identity, so gating applies

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -756,8 +756,33 @@ public class MeshOperations
     /// Returns <c>null</c> on timeout or routing failure (node does not exist /
     /// hub couldn't be activated). See <c>Doc/Architecture/CqrsAndContentAccess.md</c>.
     /// </summary>
-    private IObservable<MeshNode?> FetchNode(string resolvedPath, int timeoutSeconds = 10) =>
-        Observable.Create<MeshNode?>(observer =>
+    private IObservable<MeshNode?> FetchNode(string resolvedPath, int timeoutSeconds = 10)
+    {
+        // 🚨 SECURITY: capture the caller's identity HERE, synchronously, while we are still on the
+        // caller's execution context — and re-establish it around the subscribe below.
+        //
+        // `AccessContext` is an AsyncLocal and is CLEARED across `.Subscribe` hops (the same reason
+        // ReadNodeOrUnified captures it for the PII projection). `MeshNodeStreamCache.GetStreamRaw`
+        // reads `accessService.Context ?? CircuitContext` AT SUBSCRIBE TIME to decide whether to
+        // apply its per-user read gate — and when that comes back null it deliberately FALLS
+        // THROUGH to the shared upstream, which was opened under the cache's own system-read
+        // identity. So a lost identity did not fail closed: it read EVERYTHING.
+        //
+        // Measured on memex 2026-08-05: `get @AgenticPrimerDe/02-CodeWunsch` returned 79,650 chars
+        // of a PAID course lesson to a signed-in user with no entitlement and no grant, while the
+        // gating data was entirely correct — `Public|AgenticPrimerDe/02-CodeWunsch|Read|is_allow=f`
+        // is present, and the SQL query path (GenerateAccessControlClause) hides the same node. Only
+        // the exact-path read leaked it, which is why it looked like "children vanish from listings
+        // but direct get by path still works" (noted 2026-07-29 as an operational quirk — it was
+        // this hole).
+        //
+        // Re-establishing the identity makes the EXISTING gate apply; it does not add a second
+        // access model, and it cannot lock out the background/hub-principal paths the gate
+        // deliberately passes through (a null capture stays null).
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var callerIdentity = accessService?.Context ?? accessService?.CircuitContext;
+
+        return Observable.Create<MeshNode?>(observer =>
         {
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             var emitted = 0;
@@ -792,6 +817,13 @@ public class MeshOperations
                 // read immediately after a write sees the fresh value. GetMeshNodeStream also
                 // activates a cold hub on subscribe. See Doc/Architecture/CqrsAndContentAccess.md.
                 // The CTS timeout above maps a never-emitting (non-existent) node to null.
+                // The identity must be ambient WHEN THE STREAM IS BUILT — the cache's read gate
+                // reads it at subscribe time, not on emission (so CarryAccessContext, which
+                // restores around each callback, would be too late). Scoped and disposed here;
+                // a null capture switches to null, which is exactly the pass-through the gate
+                // already documents for background / hub-principal flows.
+                using var identityScope = accessService?.SwitchAccessContext(callerIdentity);
+
                 innerSubscription = hub.GetWorkspace().GetMeshNodeStream(resolvedPath)
                     // Routing-fallback safety: a path with no per-node hub can route to the
                     // closest ancestor, which returns ITS node. Filter by exact path so
@@ -803,8 +835,17 @@ public class MeshOperations
                         node => EmitOnce(node),
                         ex =>
                         {
-                            // DeliveryFailure or other error — node not found / unreachable.
-                            logger.LogDebug(ex, "FetchNode read failed for {Path}", resolvedPath);
+                            // Read DENIED by the cache's per-user gate, or DeliveryFailure /
+                            // node not found. Both collapse to null → the caller reports
+                            // "Not found", which is the safe denial: it does not disclose that a
+                            // gated node exists. Logged distinctly so an operator can tell a
+                            // paywall denial from a routing failure.
+                            if (ex is UnauthorizedAccessException)
+                                logger.LogInformation(
+                                    "FetchNode DENIED for {Path} — caller lacks Read (gated content)",
+                                    resolvedPath);
+                            else
+                                logger.LogDebug(ex, "FetchNode read failed for {Path}", resolvedPath);
                             EmitOnce(null);
                         });
             }
@@ -820,6 +861,7 @@ public class MeshOperations
                 cts.Dispose();
             });
         });
+    }
 
     /// <summary>
     /// Read-your-writes barrier: waits (bounded) for the live mesh-node mirror at

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/GatedNodeExactPathReadTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/GatedNodeExactPathReadTests.cs
@@ -1,0 +1,166 @@
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 PINS THE PAYWALL ON THE EXACT-PATH READ.
+///
+/// <para>Gated content must be denied to a signed-in user who has no entitlement — on the
+/// <b>single-node read by path</b>, not merely on queries. The query fold already enforced this
+/// (<see cref="PerSubjectAccessFoldTests"/>); the exact-path read did not.</para>
+///
+/// <para><b>The hole.</b> <c>MeshNodeStreamCache.GetStreamRaw</c> reads
+/// <c>AccessService.Context</c> AT SUBSCRIBE TIME to decide whether to apply its per-user read
+/// gate, and deliberately passes through to the shared system-identity upstream when that comes
+/// back null (background / hub-principal flows). <c>AccessContext</c> is an <c>AsyncLocal</c> and
+/// is cleared across <c>.Subscribe</c> hops — so the identity was routinely gone by then, and a
+/// lost identity did not fail closed: it read EVERYTHING.</para>
+///
+/// <para>Measured on memex 2026-08-05: <c>get @AgenticPrimerDe/02-CodeWunsch</c> returned 79,650
+/// characters of a PAID course lesson to a signed-in user with no entitlement and no grant, while
+/// the gating data was entirely correct (<c>Public|…/02-CodeWunsch|Read|is_allow=false</c> present,
+/// and the SQL query path hid the same node). Only the exact-path read leaked it — the symptom
+/// filed on 2026-07-29 as "children vanish from listings but direct get by path still works".</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class GatedNodeExactPathReadTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string Buyer = "gated_buyer";      // entitled
+    private const string Visitor = "gated_visitor";  // signed in, bought nothing
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    /// <summary>
+    /// Seeds a FRESH plugin per test. The nodes and grants must be unique per case: xUnit runs the
+    /// methods in a class sequentially against the SAME mesh, so a shared path makes the second
+    /// CreateNode complete without emitting ("already exists") — which fails the seed and, worse,
+    /// would let a deny-assertion pass VACUOUSLY because the node was never created at all.
+    /// </summary>
+    private async Task<(string Plugin, string GatedChild)> Seed(string suffix)
+    {
+        var Plugin = $"GatedCourse{suffix}";
+        var GatedChild = $"{Plugin}/PaidLesson";
+        var ct = TestContext.Current.CancellationToken;
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(Plugin) with
+        {
+            Name = Plugin,
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space()
+        }).Should().Within(90.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(GatedChild) with
+        {
+            Name = "Paid Lesson",
+            NodeType = "Markdown"
+        }).Should().Within(90.Seconds()).Emit();
+
+        var ac = fixture.AccessControl;
+        // The store's gating shape: the cover is readable by everyone signed in; the paid child
+        // is DENIED to Public. An entitlement is a per-user allow at the ROOT.
+        await ac.Grant(Plugin, WellKnownUsers.Public, "Read", isAllow: true, ct)
+            .Should().Within(30.Seconds()).Emit();
+        await ac.Grant(GatedChild, WellKnownUsers.Public, "Read", isAllow: false, ct)
+            .Should().Within(30.Seconds()).Emit();
+        await ac.Grant(Plugin, Buyer, "Read", isAllow: true, ct)
+            .Should().Within(30.Seconds()).Emit();
+
+        return (Plugin, GatedChild);
+    }
+
+    private async Task<string> GetAs(string userId, string path)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetCircuitContext(new AccessContext { ObjectId = userId, Name = userId });
+        try
+        {
+            return await new MeshOperations(Mesh).Get(path)
+                .Should().Within(60.Seconds()).Emit();
+        }
+        finally
+        {
+            access.SetCircuitContext(null);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE PAYWALL. A signed-in visitor who bought nothing must NOT receive the gated node's
+    /// content from an exact-path read. Denial surfaces as "Not found" — deliberately, so the
+    /// response does not disclose that a paid node exists at that path.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task ExactPathRead_OfGatedNode_IsDeniedForAnUnentitledUser()
+    {
+        var (_, GatedChild) = await Seed("Deny");
+
+        // The evaluator agrees the visitor has no Read — proving any leak is the READ PATH,
+        // not the permission logic (same structure as AnonymousSpaceReadSecurityTests).
+        await Mesh.GetEffectivePermissions(GatedChild, Visitor)
+            .Should().Within(60.Seconds()).Match(p => !p.HasFlag(Permission.Read));
+
+        var result = await GetAs(Visitor, GatedChild);
+        Output.WriteLine(result);
+
+        result.Should().NotContain($"\"path\":\"{GatedChild}\"",
+            "an unentitled signed-in user must not receive gated content from an exact-path read — " +
+            "this is the paywall, and the read must fail closed when the identity is lost");
+    }
+
+    /// <summary>
+    /// The other half: an ENTITLED buyer still reads it. A paywall that denies everyone is not a
+    /// fix — this is what would break if the gate were made unconditionally strict.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task ExactPathRead_OfGatedNode_StillWorksForAnEntitledUser()
+    {
+        var (_, GatedChild) = await Seed("Buyer");
+
+        var result = await GetAs(Buyer, GatedChild);
+        Output.WriteLine(result);
+
+        result.Should().Contain(GatedChild,
+            "the buyer's root allow entitles them to the gated child (per-subject fold: the Public " +
+            "deny binds only Public)");
+    }
+
+    /// <summary>The public cover stays readable to a visitor — the funnel's one open page.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task ExactPathRead_OfTheCover_StaysPublic()
+    {
+        var (Plugin, _) = await Seed("Cover");
+
+        var result = await GetAs(Visitor, Plugin);
+        Output.WriteLine(result);
+
+        result.Should().Contain(Plugin,
+            "the cover is the one page a not-yet-subscribed visitor must always see");
+    }
+}


### PR DESCRIPTION
## The hole

**A signed-in user with no entitlement could read gated PAID content by exact path.**

Measured on memex 2026-08-05: `get @AgenticPrimerDe/02-CodeWunsch` returned **79,650 characters** of a paid course lesson to a user with no grant and no entitlement — while the gating data was entirely correct:

```
Public|AgenticPrimerDe                |Read|t   ← cover allow
Public|AgenticPrimerDe/02-CodeWunsch  |Read|f   ← DENY, present and correct
```

The SQL query path (`GenerateAccessControlClause`) hid the same node. **Only the single-node read leaked it** — which is why this had been filed on 2026-07-29 as an operational quirk: *"children vanish from listings but direct get by path still works"*. That clause was the hole.

## Cause

`MeshNodeStreamCache.GetStreamRaw` reads `AccessService.Context` **at subscribe time** to decide whether to apply its per-user read gate, and deliberately passes through to the shared *system-identity* upstream when that is null (background / hub-principal flows).

`AccessContext` is an `AsyncLocal` and is **cleared across `.Subscribe` hops** — the same reason `ReadNodeOrUnified` already captures it for the PII projection. So a lost identity did not fail closed: **it read everything.**

## Fix

`FetchNode` captures the caller synchronously and re-establishes it (`SwitchAccessContext`) around the subscribe, so the **existing** gate applies. No second access model; it cannot lock out the flows the gate intentionally passes through, because a null capture switches to null — exactly today's behaviour. A denial is logged distinctly and collapses to `"Not found"`, which does not disclose that a paid node exists at the path.

## Tests

`GatedNodeExactPathReadTests` — the visitor is **denied**, the entitled buyer **still reads** the same node, and the cover **stays public**. (A paywall that denies everyone is not a fix; the middle case is what catches an over-strict gate — and it did, on my first attempt.)

Each case seeds its **own** plugin: the methods share a mesh, so a shared path makes the second `CreateNode` complete without emitting, and a deny-assertion would pass **vacuously** against a node that was never created.

## ⚠️ Honest limit — please read before merging

**These tests pass with AND without the fix.** The monolith harness sets the identity on the calling thread and no Rx hop clears it, so it does **not** reproduce the loss that happens in the deployed MCP pipeline. They pin the paywall's *required behaviour*, not this specific regression.

So the fix is **unproven by CI**. It is verified against production after deploy by re-running the repro: as an account with no entitlement, `get @AgenticPrimerDe/02-CodeWunsch` must be denied. I'll run exactly that once the image rolls and report the result.

The change is low-risk in the meantime: it only supplies an identity where one was absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)