### PR TITLE
fix(plugin-catalog): installs run as SYSTEM — the clicking user owns nothing mid-install

### DIFF
--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -234,12 +234,13 @@ public static class CatalogLayoutAreas
         // PluginUpdateWatcher wraps this very InstallOrUpdate in ImpersonateAsSystem, and the
         // Store plugin's SystemInstall/Provisioning sources do the same. Authorisation for the
         // TRIGGER stays where it belongs: on the catalog surface the click came from.
-        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        // REQUIRED, never optional: a missing AccessService would silently run the install under
+        // the ambient (user) identity — the exact regression this fix removes. Same treatment the
+        // PluginUpdateWatcher already gives it.
+        var accessService = host.Hub.ServiceProvider.GetRequiredService<AccessService>();
 
         var install = InstallOrUpdate(host.Hub, source, sourceRef, pkg, logger);
-        (accessService is null
-                ? install
-                : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => install))
+        Observable.Using(() => accessService.ImpersonateAsSystem(), _ => install)
             .Subscribe(
                 result => logger?.LogInformation("Installed {Id}: {Written} written, {Unchanged} unchanged.",
                     pkg.Id, result.Written, result.Unchanged),

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -221,17 +221,25 @@ public static class CatalogLayoutAreas
     {
         var logger = Logger(host);
 
-        // Capture the caller's identity NOW — the click delivery stamped AccessService.Context. The
-        // fetch runs off-hub (GitCli / Http IIoPool), so the install continuation lands on a pool
-        // thread where that AsyncLocal is wiped; re-establish it for the install's whole lifetime via
-        // Observable.Using so the CreateOrUpdate writes run as the user and don't fail closed.
+        // 🚨 The install runs under SYSTEM for its WHOLE lifetime — an install is PROVISIONING,
+        // not a user data write. Post core #804 every partition the installer creates lands under
+        // the System identity with no user grants, so the CLICKING user legitimately holds NOTHING
+        // on it mid-install — any step that authorises against the ambient identity then fails
+        // closed. The previous code re-established the clicking USER's context here instead, and
+        // #817's batch topology made exactly such a step deterministic: the self-typed root's
+        // reconciliation read (PackageInstaller.RootRetypeReconciled → the per-user gate in
+        // MeshNodeStreamCache) ran as the user and every Store install died with
+        // "User '…' lacks Read permission on 'Store'" (education CI, 2026-08-05, first image
+        // carrying #817). System is also what the OTHER install triggers already do — the
+        // PluginUpdateWatcher wraps this very InstallOrUpdate in ImpersonateAsSystem, and the
+        // Store plugin's SystemInstall/Provisioning sources do the same. Authorisation for the
+        // TRIGGER stays where it belongs: on the catalog surface the click came from.
         var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
-        var user = accessService?.Context;
 
         var install = InstallOrUpdate(host.Hub, source, sourceRef, pkg, logger);
         (accessService is null
                 ? install
-                : Observable.Using(() => accessService.SwitchAccessContext(user), _ => install))
+                : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => install))
             .Subscribe(
                 result => logger?.LogInformation("Installed {Id}: {Written} written, {Unchanged} unchanged.",
                     pkg.Id, result.Written, result.Unchanged),

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -706,9 +706,11 @@ public static class PackageInstaller
         IObservable<System.Reactive.Unit> RootRetypeReconciled() =>
             placeholderRoot is null || root is null || string.IsNullOrEmpty(root.NodeType)
                 ? Observable.Return(System.Reactive.Unit.Default)
+                // REQUIRED, never optional: falling back to the ambient identity on a missing
+                // AccessService would re-open the exact "lacks Read on '{root}'" hole this scope
+                // exists to close.
                 : Observable.Using(
-                        () => hub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem()
-                              ?? System.Reactive.Disposables.Disposable.Empty,
+                        () => hub.ServiceProvider.GetRequiredService<AccessService>().ImpersonateAsSystem(),
                         _ => hub.GetMeshNodeStream(root.Path))
                     .Where(n => n is not null
                         && string.Equals(n.NodeType, root.NodeType, StringComparison.Ordinal))

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -696,10 +696,20 @@ public static class PackageInstaller
         // before for every reader of that SAME handle. Reactive and bounded by the retype LANDING
         // (it is in flight and always settles); the Timeout is the graceful sink for a wedged owner,
         // never a fixed sleep that would cache the fallback.
+        // 🚨 Explicitly SYSTEM-scoped: the shared-handle read runs through MeshNodeStreamCache's
+        // per-user read gate, and the freshly-installed partition is System-owned with NO user
+        // grants — an ambient USER identity at this subscription (the catalog click's, before it
+        // ran installs as System; any future caller's) turns the reconciliation into
+        // "lacks Read permission on '{root}'" and fails the whole install (education CI,
+        // 2026-08-05, first image carrying #817). Provisioning reads its own outcome as System,
+        // never as whoever happened to trigger it.
         IObservable<System.Reactive.Unit> RootRetypeReconciled() =>
             placeholderRoot is null || root is null || string.IsNullOrEmpty(root.NodeType)
                 ? Observable.Return(System.Reactive.Unit.Default)
-                : hub.GetMeshNodeStream(root.Path)
+                : Observable.Using(
+                        () => hub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem()
+                              ?? System.Reactive.Disposables.Disposable.Empty,
+                        _ => hub.GetMeshNodeStream(root.Path))
                     .Where(n => n is not null
                         && string.Equals(n.NodeType, root.NodeType, StringComparison.Ordinal))
                     .Take(1)


### PR DESCRIPTION
## The regression (first image carrying #817)

Education CI, 2026-08-05 15:00 dispatch — every mesh job red with the same signature: **`Install of Store failed. System.UnauthorizedAccessException: User 'e2e-admin' lacks Read permission on 'Store'`**, `Store/Plugin` never reaching `compilationStatus Ok`, every course import aborted. Same content and same harness were green on the pre-#817 image at 13:58 and 14:21 (phase marks: `Store/Plugin compiled` at +159s).

## Root cause

An install is **provisioning**. Post-#804 every partition the installer creates lands under the System identity with **no user grants**, so the clicking user legitimately holds nothing on it mid-install — any step authorising against the ambient identity fails closed. `CatalogLayoutAreas.InstallPackage` nevertheless re-established the clicking USER's context for the install's whole lifetime. #817's batch topology made the latent failure deterministic: the self-typed root's reconciliation read (`PackageInstaller.RootRetypeReconciled` → `MeshNodeStreamCache`'s per-user read gate) now reliably subscribes under that user and throws; the pre-#817 N-request topology usually wiped the AsyncLocal before that read, which is the only reason it ever passed.

## Fix (aligned with every other install trigger)

- `InstallPackage` wraps the whole install in `ImpersonateAsSystem` — exactly what `PluginUpdateWatcher` already does around this very `InstallOrUpdate`, and what the Store plugin's `SystemInstall`/`Provisioning` sources do. Authorisation for the TRIGGER stays on the catalog surface the click came from.
- `RootRetypeReconciled`'s shared-handle read is explicitly System-scoped, so no install path ever depends on ambient identity for reading its own provisioning outcome.

## Verification

- 19/19 `MeshWeaver.PluginCatalog.Test` install tests green locally (Release, `-warnaserror` clean).
- After merge + CD: the education repo's dispatchable mesh suite is the end-to-end proof (its 15:00 run is the red baseline).

No What's New: fixes a same-day regression that never shipped in a working image; #817's entry remains accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB