### PR TITLE
MCP read tools run as the calling user, not as system-security

### DIFF
--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -130,7 +130,44 @@ Legacy colon form `path/prefix:value` still works for backward compatibility.")]
   @Doc/Architecture/content/icon.svg            (file)
   @Cornerstone/schema/TypeName                  (schema)
   @Cornerstone/model/                           (full model)")] string path)
-        => ops.Get(path).FirstAsync().ToTask();
+        => AsCaller(() => ops.Get(path).FirstAsync().ToTask());
+
+    /// <summary>
+    /// 🚨 Runs an MCP tool under the CALLING USER's identity.
+    ///
+    /// <para><b>The paywall bug this closes.</b> <c>UserContextMiddleware</c> establishes the MCP
+    /// request's <c>AccessContext</c> on the PORTAL hub's <see cref="AccessService"/> (which is why
+    /// <c>git_hub_sync</c> can resolve the caller and refuses without one). <c>ops</c>, however, is
+    /// built on the SESSION hub, and <c>AccessContext</c> is an <c>AsyncLocal</c> that does not
+    /// survive the hops a read takes — so by the time
+    /// <c>MeshNodeStreamCache.GetStreamRaw</c> checks who is asking, it saw nobody. It then
+    /// deliberately passes through to its shared upstream, which was opened under the cache's own
+    /// SYSTEM read identity. Absent identity did not fail closed: it read as
+    /// <c>system-security</c>, which holds <c>Permission.All</c>.</para>
+    ///
+    /// <para>Measured on memex 2026-08-05, and confirmed in the silo trace:
+    /// <c>GrainCallFilter: grain=messagehub/AgenticPrimerDe/02-CodeWunsch, userId=system-security</c>
+    /// — an unentitled signed-in user read a full PAID course lesson (79,650 chars) by exact path,
+    /// while the gating rows were correct and the SQL query path hid the same node.</para>
+    ///
+    /// <para>Re-establishing the caller for the duration of the tool call makes the EXISTING gate
+    /// apply. It is the same pattern <c>git_hub_sync</c> already uses a few methods below
+    /// (<c>using (accessService.SwitchAccessContext(user))</c>) — this just applies it to the READ
+    /// tools, where its absence was a paywall bypass rather than a wrong audit stamp.</para>
+    ///
+    /// <para>A caller with no resolvable identity is left exactly as before (no switch), so
+    /// background / infrastructure flows are unaffected.</para>
+    /// </summary>
+    private Task<string> AsCaller(Func<Task<string>> tool)
+    {
+        var accessService = rootHub.ServiceProvider.GetService<AccessService>();
+        var user = accessService?.Context ?? accessService?.CircuitContext;
+        if (accessService is null || user is null)
+            return tool();
+
+        using (accessService.SwitchAccessContext(user))
+            return tool();
+    }
 
     /// <summary>
     /// Uploads raw file bytes into a node's content collection — the write-side
@@ -183,7 +220,7 @@ Full reference: read the 'tools-reference' MCP resource.")]
         [Description("Query string (e.g., 'nodeType:Agent', 'laptop', 'path:ACME scope:descendants', 'name:*sales*')")] string query,
         [Description("Base path to search from (e.g., @graph). Empty for all.")] string? basePath = null,
         [Description("Maximum number of results to return. Default 50, max 200.")] int limit = 50)
-        => ops.Search(query, basePath, limit).FirstAsync().ToTask();
+        => AsCaller(() => ops.Search(query, basePath, limit).FirstAsync().ToTask());
 
     /// <summary>
     /// Autocompletes a partial @-reference using the in-portal autocomplete engine,


### PR DESCRIPTION
## The cause, from the silo trace

An unentitled signed-in user could read gated **paid** content by exact path. The trace names it:

```
GrainCallFilter: grain=messagehub/AgenticPrimerDe/02-CodeWunsch,
                 method=DeliverMessage, userId=system-security
```

The read executed as **`system-security`**, which holds `Permission.All` — so the read gate passed *legitimately*. The identity wasn't lost late; **it was never established for the tool call.**

`UserContextMiddleware` sets the MCP request's `AccessContext` on the **portal** hub's `AccessService` — which is why `git_hub_sync`, a few methods below, resolves the caller and hard-fails without one. But `ops` is built on the **session** hub, and `AccessContext` is an `AsyncLocal` that doesn't survive the hops a read takes. So `MeshNodeStreamCache.GetStreamRaw` saw nobody and — by design, for background/hub-principal flows — passed through to its shared upstream, which is opened under the cache's own **system read identity**. Absent identity did not fail closed: it read everything.

## Fix

`AsCaller()` re-establishes the caller for the duration of the tool call — the same `SwitchAccessContext` pattern `git_hub_sync` already uses in this file, now applied to the **read** tools where its absence was a paywall bypass rather than a wrong audit stamp. Applied to `get` and `search`.

A caller with no resolvable identity is left exactly as before (no switch), so background / infrastructure flows are unaffected.

## Evidence the rest of the stack was already correct

- Gating rows present and right: `Public|AgenticPrimerDe/02-CodeWunsch|Read|is_allow=false`
- The SQL query path (`GenerateAccessControlClause`) already hid the same node
- `sst`/`agenticprimerde` projections verified per-partition — 46 rows in SST, denies intact

Only the exact-path read leaked it, which is exactly why it presented as *"children vanish from listings but direct get by path still works"* (filed 2026-07-29 as an operational quirk).

## Relationship to #819

#819 fixed a real identity-loss seam in `MeshOperations.FetchNode` and its tests (`GatedNodeExactPathReadTests`) are worth keeping, but it did **not** close the breach: the identity was absent one level higher. Verified by deploying #819 to prod (`3.0.0-ci.1829`) and re-running the repro — still leaked. This PR addresses that level.

**Verification plan:** after deploy, `get @AgenticPrimerDe/02-CodeWunsch` as an unentitled account must be denied, and `get @AgenticPrimerDe` (the cover) must still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)