### PR TITLE
An agent-facing read never runs as System when nobody is asking

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -780,7 +780,22 @@ public class MeshOperations
         // access model, and it cannot lock out the background/hub-principal paths the gate
         // deliberately passes through (a null capture stays null).
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var callerIdentity = accessService?.Context ?? accessService?.CircuitContext;
+        // 🚨 An AGENT-FACING read never proceeds with NO identity. The framework's global fallback
+        // deliberately treats an absent AccessContext as System — correct for background tasks
+        // (timers, seed jobs) that legitimately have none, and pinned by
+        // SubscribeRequestIdentityRoutingTest.SubscribeRequest_WithNullContext_FallsBackToSystem.
+        // But System holds Permission.All, so applying that default to a REQUEST-shaped read means
+        // "nobody is asking" is served everything — including gated, PAID content. Measured on
+        // memex 2026-08-05: an unentitled user read a full paid course lesson by exact path
+        // (`get @AgenticPrimerDe/02-CodeWunsch`), and the silo trace showed it reaching the grain
+        // as `userId=system-security`.
+        //
+        // This surface is only ever reached by a caller (MCP tool, agent round), so absence of a
+        // user here means UNAUTHENTICATED, not infrastructure: fall back to Anonymous. That sees
+        // public content and is denied gated content, exactly like a logged-out visitor — and it
+        // leaves the global background-task fallback untouched.
+        var callerIdentity = accessService?.Context ?? accessService?.CircuitContext
+            ?? new AccessContext { ObjectId = WellKnownUsers.Anonymous, Name = "Anonymous", IsVirtual = true };
 
         return Observable.Create<MeshNode?>(observer =>
         {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PaywallIdentityMatrixTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PaywallIdentityMatrixTests.cs
@@ -1,0 +1,138 @@
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The paywall, across EVERY identity shape a read can arrive with. One gated node, four callers:
+/// no identity at all, Anonymous, signed-in-but-unentitled, and the buyer.
+///
+/// <para>The fourth column is the one that catches an over-strict gate; the FIRST is the one that
+/// catches the bypass — a read with no ambient identity must NOT be served from the cache's shared
+/// system-identity upstream.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class PaywallIdentityMatrixTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string Buyer = "pw_buyer";
+    private const string Visitor = "pw_visitor";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    private async Task<(string Plugin, string Gated)> Seed(string suffix)
+    {
+        var plugin = $"PwCourse{suffix}";
+        var gated = $"{plugin}/PaidLesson";
+        var ct = TestContext.Current.CancellationToken;
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(plugin) with
+        { Name = plugin, NodeType = SpaceNodeType.NodeType, Content = new Space() })
+            .Should().Within(90.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(gated) with
+        { Name = "Paid Lesson", NodeType = "Markdown" })
+            .Should().Within(90.Seconds()).Emit();
+
+        var ac = fixture.AccessControl;
+        await ac.Grant(plugin, WellKnownUsers.Public, "Read", isAllow: true, ct).Should().Within(30.Seconds()).Emit();
+        await ac.Grant(gated, WellKnownUsers.Public, "Read", isAllow: false, ct).Should().Within(30.Seconds()).Emit();
+        await ac.Grant(gated, WellKnownUsers.Anonymous, "Read", isAllow: false, ct).Should().Within(30.Seconds()).Emit();
+        await ac.Grant(plugin, Buyer, "Read", isAllow: true, ct).Should().Within(30.Seconds()).Emit();
+        return (plugin, gated);
+    }
+
+    /// <summary>Reads through the same entry point the MCP `get` tool uses.</summary>
+    private async Task<string> Read(AccessContext? identity, string path)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetCircuitContext(identity);
+        try
+        {
+            return await new MeshOperations(Mesh).Get(path).Should().Within(60.Seconds()).Emit();
+        }
+        finally
+        {
+            access.SetCircuitContext(null);
+        }
+    }
+
+    /// <summary>🚨 NO AMBIENT IDENTITY — the production shape. Must not serve gated content.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task NoIdentity_IsDeniedGatedContent()
+    {
+        var (_, gated) = await Seed("None");
+        var result = await Read(null, gated);
+        Output.WriteLine(result);
+        result.Should().NotContain($"\"path\":\"{gated}\"",
+            "a read with NO ambient identity must fail closed, not fall through to the cache's " +
+            "shared system-identity upstream");
+    }
+
+    /// <summary>Anonymous — explicitly denied on the child.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task Anonymous_IsDeniedGatedContent()
+    {
+        var (_, gated) = await Seed("Anon");
+        var result = await Read(
+            new AccessContext { ObjectId = WellKnownUsers.Anonymous, Name = "Guest", IsVirtual = true }, gated);
+        Output.WriteLine(result);
+        result.Should().NotContain($"\"path\":\"{gated}\"", "anonymous must never see gated content");
+    }
+
+    /// <summary>Signed in, bought nothing — inherits Public's deny.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task AuthenticatedButNotPurchased_IsDenied()
+    {
+        var (_, gated) = await Seed("Visitor");
+        var result = await Read(new AccessContext { ObjectId = Visitor, Name = Visitor }, gated);
+        Output.WriteLine(result);
+        result.Should().NotContain($"\"path\":\"{gated}\"",
+            "a signed-in user who bought nothing must hit the paywall");
+    }
+
+    /// <summary>Purchased — must still get in.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task Purchased_CanRead()
+    {
+        var (_, gated) = await Seed("Buyer");
+        var result = await Read(new AccessContext { ObjectId = Buyer, Name = Buyer }, gated);
+        Output.WriteLine(result);
+        result.Should().Contain(gated, "the buyer's entitlement must open the gated child");
+    }
+
+    /// <summary>The cover stays public for a visitor — the funnel's one open page.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task Cover_StaysPublicForVisitor()
+    {
+        var (plugin, _) = await Seed("Cover");
+        var result = await Read(new AccessContext { ObjectId = Visitor, Name = Visitor }, plugin);
+        Output.WriteLine(result);
+        result.Should().Contain(plugin, "the cover must stay readable to a not-yet-subscribed visitor");
+    }
+}


### PR DESCRIPTION
Closes #822.

## The bug

An unentitled user could read gated **paid** content by exact path — `get @AgenticPrimerDe/02-CodeWunsch` returned 79,650 chars of the lesson — and the silo trace showed the read reaching the grain as `userId=system-security`.

## Why it happened, and why the obvious fix is wrong

The framework **deliberately** treats an absent `AccessContext` as System. That's correct for background tasks (timers, seed jobs) that legitimately have no identity, and it's pinned:

> `SubscribeRequestIdentityRoutingTest.SubscribeRequest_WithNullContext_FallsBackToSystem` — *"Background tasks … often have no AccessContext at all; the SubscribeRequest still has to open under SOME principal so the owner can decide. System is the right fallback for 'no identity'."*

But System holds `Permission.All`. Applying that default to a **request-shaped** read means *"nobody is asking"* is served everything.

I first made the cache gate itself fail closed on a null context. It closed the hole and **fought the architecture** — breaking that pinned contract and the static-repo import's verification reads. Reverted in favour of the narrow fix.

## The fix

At the **agent-facing surface** only. `MeshOperations.FetchNode` is reached solely by a caller (MCP tool, agent round), so absence of a user there means *unauthenticated*, not *infrastructure*. It now falls back to **Anonymous** — which sees public content and is denied gated content, exactly like a logged-out visitor. The global background-task fallback is untouched.

## Tests — `PaywallIdentityMatrixTests`

One gated node, read by every identity shape:

| Caller | Expected |
|---|---|
| **no ambient identity** (the production case) | denied ← **failed before this change** |
| Anonymous | denied |
| signed in, bought nothing | denied |
| **buyer** | allowed ← catches an over-strict gate |
| **public cover**, as visitor | allowed ← the funnel's one open page |

- `Hosting.PostgreSql`: **619 passed / 0 failed**
- `Hosting.Monolith`: **467 passed / 0 failed** — including the two tests the broad version regressed

## Relationship to #819 / #821

Both hardened real seams (reads run as the caller) and are worth keeping, but neither closed the breach: the identity was **absent**, not merely lost, so a no-op fallback left it running as System.

**Prod verification after deploy:** `get @AgenticPrimerDe/02-CodeWunsch` as an unentitled account must be denied, and `get @AgenticPrimerDe` must still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)