### PR TITLE
A bulk-written node must be ANNOUNCED, or it is invisible to the mesh that wrote it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-installed-nodes-are-announced.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-05-bulk-installed-nodes-are-announced.md
@@ -1,0 +1,23 @@
+---
+Name: A freshly installed plugin is fully there — no restart needed
+Category: What's New
+Description: Fixes an install landing a node that the running mesh could not see — the page reported "No node found" and the type never compiled until the portal restarted.
+Icon: Sparkle
+---
+
+# A freshly installed plugin is fully there
+
+Installing a plugin could leave one of its nodes written to storage but invisible to the mesh
+that just installed it. The page for that node answered *"No node found"*, and if the node was
+a type, nothing ever compiled it — so every plugin or course built on that type showed the
+missing-type error instead of its content. Restarting the portal fixed it, which is a poor thing
+to have to know.
+
+The cause was an announcement that never went out. When a node is written one at a time, the
+mesh publishes a change event and every cache that tracks where nodes live updates itself. The
+faster bulk install path wrote its batches straight to storage and skipped that event, so any
+path already remembered as "nothing here" stayed that way for the life of the process.
+
+Bulk writes now announce every node they land, exactly as single writes do. A fresh install is
+usable immediately, and the rule is enforced in one place, so no future bulk path can quietly
+skip it.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -908,20 +908,18 @@ public static class MeshExtensions
                                 Version = n.Version > 0 ? n.Version : 1,
                             }).ToImmutableList();
 
-                            // ——— Phase 6: ONE ordered WriteMany; the Created publishes ride the
-                            // post-commit emission in caller order (commit-then-publish, exactly
-                            // like WriteAndPublishCreated) — so stream caches and live queries
-                            // invalidate for every node, which the installer's System-side bulk
-                            // path never did. ———
+                            // ——— Phase 6: ONE ordered WriteManyAndPublishCreated; the Created
+                            // publishes ride the post-commit emission in caller order
+                            // (commit-then-publish, exactly like WriteAndPublishCreated) — so
+                            // stream caches, live queries AND the resolution caches invalidate
+                            // for every node. The helper is the single publish site every bulk
+                            // write goes through; the installer's System-side bulk path skipped
+                            // it and left nodes in storage that the running mesh could not
+                            // resolve. ———
                             attemptedPaths = stamped.Select(n => n.Path).ToArray();
-                            return persistence.WriteMany(stamped, options)
+                            return persistence.WriteManyAndPublishCreated(stamped, options, changeFeed)
                                 .Select(list => list.ToImmutableList())
-                                .Do(list =>
-                                {
-                                    written = list;
-                                    foreach (var saved in list)
-                                        changeFeed?.Publish(MeshChangeEvent.Created(saved));
-                                })
+                                .Do(list => written = list)
                                 .SelectMany(list =>
                                 {
                                     if (list.Count != stamped.Count)

--- a/src/MeshWeaver.Mesh.Contract/Services/StorageAdapterChangeFeedExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/StorageAdapterChangeFeedExtensions.cs
@@ -76,6 +76,41 @@ public static class StorageAdapterChangeFeedExtensions
             });
 
     /// <summary>
+    /// Writes <paramref name="nodes"/> in ONE <see cref="IStorageAdapter.WriteMany"/> and
+    /// publishes a <see cref="MeshChangeEvent.Created"/> per node the adapter reports as
+    /// written — the bulk twin of <see cref="WriteAndPublishCreated"/>, with the same
+    /// commit-then-publish ordering (the <c>Do</c> fires on the post-commit emission).
+    ///
+    /// <para><b>Why this exists.</b> A bulk write is a mutation like any other, and the
+    /// mesh-change feed is what invalidates the caches that decide whether a node is
+    /// REACHABLE: <c>PathResolutionService</c>'s resolution cache, <c>MeshNodeStreamCache</c>,
+    /// the Orleans path-cache invalidator. Writing rows without publishing leaves a node that
+    /// EXISTS in storage and does not exist to the running mesh — a path whose resolution was
+    /// cached as a miss (prefix + non-empty remainder is a perfectly cacheable value) stays a
+    /// miss, so routing answers <c>No node found at '…'</c> until the process restarts. That is
+    /// exactly what the installer's System-side bulk path did to <c>Store/Plugin</c> on a fresh
+    /// mesh (2026-08-05): the row was in Postgres, every plugin root typed on it wore the
+    /// missing-type overlay, and no compile ever started because no hub was ever woken.
+    /// The adapter's own in-process <c>Changes</c> subject is NOT a substitute — it feeds
+    /// synced queries, not the resolution caches.</para>
+    ///
+    /// <para>Nodes absent from the adapter's result were not claimed/written (see
+    /// <see cref="IStorageAdapter.WriteMany"/>), so they are not announced — same rule as the
+    /// singular helper's null sentinel.</para>
+    /// </summary>
+    public static IObservable<IReadOnlyList<MeshNode>> WriteManyAndPublishCreated(
+        this IStorageAdapter adapter,
+        IReadOnlyCollection<MeshNode> nodes,
+        JsonSerializerOptions options,
+        IMeshChangeFeed? changeFeed)
+        => adapter.WriteMany(nodes, options)
+            .Do(written =>
+            {
+                foreach (var saved in written)
+                    changeFeed?.Publish(MeshChangeEvent.Created(saved));
+            });
+
+    /// <summary>
     /// Deletes <paramref name="path"/> via <paramref name="adapter"/> and publishes a
     /// <see cref="MeshChangeEvent.Deleted"/> on <paramref name="changeFeed"/> after the
     /// delete emits (post-commit). The deleted path flows through unchanged for further

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -596,6 +596,7 @@ public static class PackageInstaller
                     .ToObservable().Concat().LastAsync().Select(_ => System.Reactive.Unit.Default);
 
         var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
 
         // The per-node REQUEST path — decisions run against the bulk-read snapshot (one shared
         // read instead of N sequential probes), the write itself is the full validating
@@ -615,6 +616,18 @@ public static class PackageInstaller
         // (CreatedDate/LastModified, Active state) are applied for parity. System-impersonated
         // exactly as Upsert is — per call, because ambient impersonation does not survive the
         // pipeline's scheduler hops.
+        //
+        // 🚨 ANNOUNCED on the mesh-change feed, per node, post-commit — via
+        // WriteManyAndPublishCreated, never a bare WriteMany. Bypassing the per-node request
+        // path also bypasses its MeshChangeEvent, and that event is what invalidates the
+        // caches deciding whether a node is REACHABLE (PathResolutionService's resolution
+        // cache, MeshNodeStreamCache, the Orleans path-cache invalidator). Without it a node
+        // lands in storage and stays invisible to the running mesh: on a fresh mesh the Store
+        // package's `Store/Plugin` row was written and then answered `No node found` forever
+        // (2026-08-05) — probed by the already-installed Edu/Publish roots during the window
+        // between the Store ROOT landing and its TYPES landing, that probe cached the miss,
+        // and nothing ever invalidated it. Every plugin root typed on Store/Plugin wore the
+        // missing-type overlay, no compile ever started, and only a portal restart healed it.
         IObservable<IList<(string Path, bool Wrote)>> BulkSave(IReadOnlyList<MeshNode> batch)
         {
             if (batch.Count == 0)
@@ -633,7 +646,7 @@ public static class PackageInstaller
             return Observable.Using(
                     () => accessService?.ImpersonateAsSystem()
                           ?? System.Reactive.Disposables.Disposable.Empty,
-                    _ => persistence.WriteMany(stamped, options))
+                    _ => persistence.WriteManyAndPublishCreated(stamped, options, changeFeed))
                 .Select(written =>
                 {
                     if (written.Count != batch.Count)

--- a/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/BulkSaveInstallTest.cs
@@ -159,6 +159,125 @@ public class BulkSaveInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
         (await Read("BulkPack/Deep")).NodeType.Should().Be("BulkPack/Thing");
     }
 
+    /// <summary>
+    /// A bulk-written node must be ANNOUNCED on the mesh-change feed, exactly like one written
+    /// through the per-node request path. The feed is what invalidates the caches that decide
+    /// whether a node is REACHABLE — <c>PathResolutionService</c>'s resolution cache,
+    /// <c>MeshNodeStreamCache</c>, the Orleans path-cache invalidator — so a silent bulk write
+    /// leaves a node that is in storage and does not exist to the running mesh.
+    ///
+    /// <para>That is not hypothetical: it took down every fresh-mesh install (2026-08-05).
+    /// The Store package's <c>Store/Plugin</c> row landed and then answered
+    /// <c>No node found at 'Store/Plugin'</c> forever — the already-installed Edu/Publish roots,
+    /// which are TYPED on it, probed the path during the window between the Store root landing
+    /// and its types landing; that probe cached the miss (prefix + non-empty remainder is a
+    /// perfectly cacheable resolution), the bulk write never invalidated it, no hub was ever
+    /// woken, no compile ever started, and only a process restart healed it.</para>
+    ///
+    /// <para>The adapter's in-process <c>Changes</c> subject is NOT a substitute — it feeds
+    /// synced queries, not the resolution caches. Hence: every path the install reports as
+    /// written carries a <see cref="MeshChangeEvent"/>, whichever path it travelled.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task BulkWrittenNodes_AreAnnouncedOnTheMeshChangeFeed()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-announce", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/bulk");
+        var manifest = new PackageManifest
+        {
+            Id = "BulkPack",
+            Name = "Bulk Pack",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "BulkPack",
+            SourceFolder = "BulkPack",
+            Version = "commit-announce",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var announced = new ConcurrentBag<string>();
+        using var subscription = changeFeed.Subscribe(c => announced.Add(c.Path));
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "commit-announce")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+
+        result.Written.Should().Be(7);
+        // The bulk buckets are the whole point — pin them explicitly so a regression that
+        // routes them to the silent WriteMany again fails HERE and not three layers away.
+        _recorder.WriteManyBatches.SelectMany(b => b).Should().NotBeEmpty(
+            "this test is only meaningful while the install actually uses the bulk path");
+        announced.Should().Contain(_recorder.WriteManyBatches.SelectMany(b => b),
+            "every bulk-written node must be announced — an unannounced node is in storage but "
+            + "unreachable to the running mesh until the process restarts");
+        announced.Should().Contain(result.WrittenPaths,
+            "the announcement rule is per WRITTEN node, not per write path");
+    }
+
+    /// <summary>
+    /// The production symptom, end to end: a path PROBED while it is still absent — and so
+    /// resolved to its existing ancestor with a remainder, a perfectly cacheable value — must
+    /// become reachable the moment a bulk install lands it. No restart, no recycle.
+    ///
+    /// <para>This is the 2026-08-05 fresh-mesh outage in miniature. Edu and Publish install
+    /// before Store and their roots are TYPED on <c>Store/Plugin</c>, so their overlay watchers
+    /// probed that path in the window between the Store root landing and its types landing. The
+    /// probe cached the miss; the bulk write landed the row without announcing it; nothing ever
+    /// invalidated the cache. <c>Store/Plugin</c> answered <c>No node found</c> for the life of
+    /// the process, no hub was woken, no compile started, and every course install failed on a
+    /// type that was sitting in Postgres the whole time.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ANodeProbedBeforeItExisted_IsReachableRightAfterItsBulkInstall()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-reach", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/bulk");
+        var manifest = new PackageManifest
+        {
+            Id = "BulkPack",
+            Name = "Bulk Pack",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "BulkPack",
+            SourceFolder = "BulkPack",
+            Version = "commit-reach",
+        };
+
+        // The ROOT first, alone — this is the window's opening. The partition now exists, so a
+        // probe of a not-yet-installed child resolves to prefix=BulkPack + remainder, which is
+        // exactly the shape that gets cached.
+        var rootOnly = await new NodeRepoPackageSource(
+                (_, _, _, _) => Observable.Return(
+                    new RepoSnapshot("commit-root", Repo.Take(1).ToList())),
+                "https://github.com/acme/bulk")
+            .FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+        await PackageInstaller.Install(Mesh, manifest, rootOnly, "commit-root")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+
+        // PROBE the absent child — the poisoning step. It must not find anything (that is the
+        // point), and whatever the resolver caches here is what the install has to invalidate.
+        var beforeInstall = await Mesh.GetWorkspace().GetMeshNodeStream("BulkPack/Thing")
+            .Take(1).Timeout(TimeSpan.FromSeconds(5))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .FirstAsync().ToTask();
+        beforeInstall.Should().BeNull("the child is genuinely absent at this point");
+
+        // Now the full package — BulkPack/Thing travels the BULK path.
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+        await PackageInstaller.Install(Mesh, manifest, files, "commit-reach")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+        _recorder.WriteManyBatches.SelectMany(b => b).Should().Contain("BulkPack/Thing",
+            "this test is only meaningful while that node travels the bulk path");
+
+        // …and it must be REACHABLE, without restarting anything.
+        var afterInstall = await Mesh.GetWorkspace().GetMeshNodeStream("BulkPack/Thing")
+            .Where(n => n is not null).Select(n => n!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask();
+        afterInstall.NodeType.Should().Be("NodeType",
+            "a bulk-installed node that was probed while absent must not stay unreachable — "
+            + "that is the fresh-mesh install outage this pins");
+    }
+
     private async Task<MeshNode> Read(string path) =>
         await Mesh.GetWorkspace().GetMeshNodeStream(path)
             .Where(n => n is not null).Select(n => n!)


### PR DESCRIPTION
## The outage

Since #815/#817 a node-repo install writes its new nodes straight to storage via `IStorageAdapter.WriteMany`. That path skips the `MeshChangeEvent` the per-node request path publishes — and that event is what invalidates the caches deciding whether a node is **reachable**: `PathResolutionService`'s resolution cache, `MeshNodeStreamCache`, the Orleans path-cache invalidator.

So the install lands a node that exists in Postgres and does not exist to the running mesh. A path probed while it was still absent resolves to its ancestor with a remainder — a perfectly cacheable value — and nothing ever evicts it. Routing answers `No node found at '…'` for the life of the process.

On a fresh mesh this took down **every plugin install** from portal image `3.0.0-ci.1819` (pushed 14:59:04 UTC, = the #817 merge) onward:

- Edu and Publish install before Store, and their roots are typed on `Store/Plugin`. Their overlay watchers probe that path in the window between the Store **root** landing and its **types** landing → the miss gets cached.
- The bulk write then lands `Store/Plugin` unannounced → still unresolvable → no hub activation → the first-build compile never kicks off → `compilationStatus` never appears.
- Every plugin root typed on it wears the missing-type overlay, and education's install gates fail on a type that is sitting in the database the whole time.

Measured on a fresh mesh: all 8 `Store/*` NodeType rows created at 18:11:00.388; 7 updated again within 300 ms (compile kicked off), `Store/Plugin` never touched again — `last_modified == created_date`, no `_Activity/compile-*`, no `Release`. `docker compose restart portal` and it compiles within seconds. Storage was never the problem.

## The fix

Fixed where the invariant lives. `StorageAdapterChangeFeedExtensions` already exists so that *"there is no longer a way to call `Publish(Created/Updated/Deleted)` without first chaining off the adapter's write"* — but it only covered the single-node writes. `WriteManyAndPublishCreated` joins it, so a bulk write can no more skip the announcement than a single write can.

Both bulk sites now go through it: the installer (which never announced at all) and `CreateNodesRequest`'s phase 6 (which hand-rolled the same loop — and whose own comment already named the installer's gap: *"which the installer's System-side bulk path never did"*).

## Pins — both red without the fix, verified by reverting the call site

- `BulkWrittenNodes_AreAnnouncedOnTheMeshChangeFeed` — the invariant: every written path carries a `MeshChangeEvent`, whichever path it travelled.
- `ANodeProbedBeforeItExisted_IsReachableRightAfterItsBulkInstall` — the outage in miniature, deterministic and in-process: install the root, probe the absent child (poisoning the resolution cache), bulk-install it, require it reachable with no restart.

## Verification

- 78/78 `MeshWeaver.PluginCatalog.Test`, 7/7 `CreateNodesRequestTest`.
- Full solution clean: `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → 0 warnings, 0 errors.
- Portal image built from this branch and driven through the education repo's real fresh-learner install journey on a disposable mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174YXHK2sMD6NVFszfq2Wcr