### PR TITLE
fix(gitsync): sync triggers run as SYSTEM — the click authorizes, the system executes (closes #811 part D)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-sync-triggers-run-as-system.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-sync-triggers-run-as-system.md
@@ -1,0 +1,22 @@
+---
+Name: GitHub sync triggers work again on system-owned Spaces
+Category: What's New
+Description: Check, update and commit on a GitSynced Space no longer demand write permissions nobody holds — your click authorizes the operation, and the platform executes it.
+Icon: ArrowSync
+---
+
+Triggering a Space's GitHub sync — Check branch, Update to latest, or Sync now — works again for
+everyone it should work for. A GitSynced Space is owned by its repository: the platform recently
+started enforcing that by removing per-space write grants, and the sync triggers were still trying
+to run under your identity, so even a read-only branch check failed with a permissions error.
+
+Now your click authorizes the operation and the platform executes it. Checking the branch or
+updating to the latest commit needs only read access to the Space — the repository is the source
+of truth, and an update simply brings the Space in line with it. Committing the Space back to its
+repository needs edit rights on the Space or a platform administrator, and platform administrators
+can trigger any sync operation on any Space. Your GitHub account is still what pushes: commits are
+authored with your connected credential, exactly as before.
+
+This applies everywhere syncs are triggered — the Space's GitHub menu and settings tab, and the
+`git_hub_sync` MCP tool. If an operation is denied, the page now tells you why instead of showing
+a spinner that never resolves.

--- a/src/MeshWeaver.GitSync/GitHubActionArea.cs
+++ b/src/MeshWeaver.GitSync/GitHubActionArea.cs
@@ -92,14 +92,25 @@ public static class GitHubActionArea
             return Observable.Return<UiControl?>(Message(
                 "Unknown operation", $"Unrecognized GitHub operation <code>{System.Net.WebUtility.HtmlEncode(op)}</code>.", backHref));
 
-        // Fire the work. The activity node it creates streams its own live progress.
-        action.Subscribe(_ => { }, ex => logger?.LogWarning(ex, "GitHub action {Op} failed for {Space}", op, spacePath));
+        // Fire the work. The activity node it creates streams its own live progress. A failure
+        // BEFORE the activity node exists (authorization denied, sign-in required, a wedged
+        // probe) is pushed through the subject so the render below surfaces it — otherwise the
+        // page would sit on "Starting…" forever with the denial visible only in the server log.
+        action.Subscribe(_ => { }, ex =>
+        {
+            logger?.LogWarning(ex, "GitHub action {Op} failed for {Space}", op, spacePath);
+            pathSubject.OnError(ex);
+        });
 
         // Render the live activity Overview as soon as the activity path arrives;
-        // until then show a "Starting…" placeholder.
+        // until then show a "Starting…" placeholder; on a pre-activity failure, the message.
         return pathSubject
             .Select(path => (UiControl?)BuildLiveView(title!, path, backHref))
-            .StartWith((UiControl?)BuildStarting(title!, backHref));
+            .StartWith((UiControl?)BuildStarting(title!, backHref))
+            .Catch((Exception ex) => Observable.Return<UiControl?>(Message(
+                "GitHub operation failed",
+                System.Net.WebUtility.HtmlEncode(ex.Message),
+                backHref)));
     }
 
     /// <summary>Back button + title + a "Starting…" indeterminate progress, shown until the activity path is known.</summary>

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -2,6 +2,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,52 +28,146 @@ namespace MeshWeaver.GitSync;
 /// </summary>
 public static class GitHubActivityExtensions
 {
+    /// <summary>
+    /// 🚨 THE CLICK AUTHORIZES, THE SYSTEM EXECUTES — #820's install pattern, applied to the sync
+    /// trigger (issue #811 part D, realized against this surface).
+    ///
+    /// <para>Every GitSynced Space is SYSTEM-OWNED by definition: the moment
+    /// <c>{space}/_GitSync</c> exists, <see cref="SystemOwnedAccessRetractionHandler"/> retracts
+    /// every write-conferring grant on the partition, so NO real principal holds Create there.
+    /// An activity created under the caller's ambient identity therefore dies at
+    /// <see cref="ActivityRunner.RunActivity"/>'s STEP 1 with <i>"Access denied: Create permission
+    /// required for node '{space}/_Activity/…'"</i> — which is how every legitimate sync trigger,
+    /// even the read-only <c>check</c>, failed for every real user once #805 shipped.</para>
+    ///
+    /// <para>So authorization is decided HERE, against what a user CAN legitimately hold on a
+    /// system-owned space — read/entitlement for repo → space convergence, Update on the Space for
+    /// space → repo commits, and for every op a PLATFORM ADMIN (an Admin-partition capability,
+    /// never a per-space grant the retraction handler removes) — and the activity plus the sync
+    /// itself then run under the System identity.
+    /// <c>Observable.Using</c> opens the scope at Subscribe, so
+    /// <c>RunActivity</c>'s EAGER identity capture (<c>MeshService.CreateNode</c> captures at the
+    /// call site) lands inside it: the activity node's <c>CreatedBy</c> IS System, and every
+    /// Append/Finish re-stamp of that owner runs as System too. An ambient System caller (the
+    /// webhook's push-triggered update, provisioning flows) short-circuits — it already carries
+    /// the executing identity.</para>
+    /// </summary>
+    private static IObservable<string> TriggerAuthorizedAsSystem(
+        IMessageHub hub,
+        string spacePath,
+        string operation,
+        bool requiresCommitAuthority,
+        Func<IObservable<string>> runActivity)
+    {
+        // REQUIRED, never optional: a missing AccessService would silently run the trigger under
+        // the ambient (user) identity — the exact regression this authorization replaces (the same
+        // treatment #820 gives the install trigger).
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+
+        // Capture the caller SYNCHRONOUSLY at the trigger — the permission probe below hops
+        // schedulers where the AsyncLocal is gone.
+        var caller = accessService.Context ?? accessService.CircuitContext;
+        var userId = caller?.ObjectId;
+        if (string.IsNullOrEmpty(userId) || caller?.IsVirtual == true)
+            userId = WellKnownUsers.Anonymous;
+
+        IObservable<string> AsSystem() =>
+            Observable.Using(() => accessService.ImpersonateAsSystem(), _ => runActivity());
+
+        if (string.Equals(userId, WellKnownUsers.System, StringComparison.Ordinal))
+            return AsSystem();
+
+        if (string.Equals(userId, WellKnownUsers.Anonymous, StringComparison.Ordinal))
+            return Observable.Throw<string>(new UnauthorizedAccessException(
+                $"Sign-in required: GitHub {operation} on '{spacePath}' needs an authenticated user."));
+
+        // check / update (repo → space): Read on the Space. The repo is the source of truth and
+        // the operation only converges the Space to it — a deploy is not an ownership claim — so
+        // any signed-in reader (an entitlement holder, a PublicRead viewer) may trigger it.
+        // commit (space → repo): the strongest authority a real principal can still hold — Update
+        // on the Space (a user's own self-scoped partition; nobody on a system-owned space).
+        // EVERY op additionally accepts a platform admin (hub.IsGlobalAdmin): triggering a sync is
+        // a platform action, and a global admin is deliberately NOT a data superuser (#811's pin),
+        // so they may hold no Read on the Space at all — without the OR, the very persona who runs
+        // deploys could not even `check`. IsGlobalAdmin is an Admin-partition capability, never a
+        // per-space grant, so the retraction handler cannot remove it.
+        var required = requiresCommitAuthority ? Permission.Update : Permission.Read;
+        var authorized = Observable.Zip(
+            hub.CheckPermission(spacePath, userId, required),
+            hub.IsGlobalAdmin(userId),
+            (onSpace, isAdmin) => onSpace || isAdmin);
+
+        return authorized
+            .Take(1)
+            // Fail CLOSED, loudly, on a wedged probe — never fall through to the ambient identity.
+            .Timeout(TimeSpan.FromSeconds(15))
+            .Catch<bool, TimeoutException>(ex => Observable.Throw<bool>(new TimeoutException(
+                $"GitHub {operation} on '{spacePath}': the authorization probe for '{userId}' did not answer.",
+                ex)))
+            .SelectMany(ok => ok
+                ? AsSystem()
+                : Observable.Throw<string>(new UnauthorizedAccessException(requiresCommitAuthority
+                    ? $"Access denied: committing '{spacePath}' to GitHub needs Update permission on " +
+                      "the Space or a platform admin. The Space is system-owned (GitSynced), so " +
+                      "per-space write grants do not exist — ask a platform admin, or change the " +
+                      "repo and sync."
+                    : $"Access denied: GitHub {operation} on '{spacePath}' needs Read permission on " +
+                      "the Space (or a platform admin), which the caller does not hold.")));
+    }
+
     /// <summary>Commit ("Sync now") — mirror the Space into the repo as one commit on the branch HEAD.
-    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary). The caller's click
+    /// authorizes (Update on the Space, or platform admin); the activity and the sync execute as
+    /// System. <paramref name="userId"/> stays the GitHub identity — whose credential pushes and
+    /// who the commit is attributed to.</summary>
     public static IObservable<string> CommitToGitHub(
         this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
         string? sourceId = null)
     {
         var sync = hub.ServiceProvider.GetRequiredService<GitHubSyncService>();
-        return hub.RunActivity(spacePath, ActivityCategory.DataUpdate, $"Commit {spacePath} to GitHub",
-            ctx =>
-            {
-                ctx.Log("Serializing Space content and committing on the branch HEAD…");
-                // ctx.Log as the progress sink: per-node export problems (skipped nodes) land on
-                // the activity log, and ActivityRunner.Finish rolls their level into the terminal
-                // status — instead of surfacing only in the server log.
-                return sync.SyncToGitHub(spacePath, userId, sourceId, ctx.Log).Select(r =>
+        return TriggerAuthorizedAsSystem(hub, spacePath, "commit", requiresCommitAuthority: true,
+            () => hub.RunActivity(spacePath, ActivityCategory.DataUpdate, $"Commit {spacePath} to GitHub",
+                ctx =>
                 {
-                    ctx.Log($"Committed {r.CommitSha[..Math.Min(8, r.CommitSha.Length)]} " +
-                            $"({r.FilesWritten} written, {r.FilesDeleted} removed)" +
-                            (r.RepoCreated ? ", repository created" : "") + ".");
-                    return Unit.Default;
-                });
-            }, onActivityCreated);
+                    ctx.Log("Serializing Space content and committing on the branch HEAD…");
+                    // ctx.Log as the progress sink: per-node export problems (skipped nodes) land on
+                    // the activity log, and ActivityRunner.Finish rolls their level into the terminal
+                    // status — instead of surfacing only in the server log.
+                    return sync.SyncToGitHub(spacePath, userId, sourceId, ctx.Log).Select(r =>
+                    {
+                        ctx.Log($"Committed {r.CommitSha[..Math.Min(8, r.CommitSha.Length)]} " +
+                                $"({r.FilesWritten} written, {r.FilesDeleted} removed)" +
+                                (r.RepoCreated ? ", repository created" : "") + ".");
+                        return Unit.Default;
+                    });
+                }, onActivityCreated));
     }
 
     /// <summary>Checkout / update to latest — re-import the Space at the configured branch HEAD.
-    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary). The caller's click
+    /// authorizes (Read on the Space — the repo is authoritative, an update only converges to it);
+    /// the activity and the import execute as System.</summary>
     public static IObservable<string> UpdateToLatestFromGitHub(
         this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
         string? sourceId = null, bool force = false)
     {
         var pr = hub.ServiceProvider.GetRequiredService<PullRequestService>();
-        return hub.RunActivity(spacePath, ActivityCategory.Import,
-            force ? $"Force-update {spacePath} to latest" : $"Update {spacePath} to latest",
-            ctx =>
-            {
-                ctx.Log(force
-                    ? "Fetching the branch HEAD from GitHub and overwriting local changes (force)…"
-                    : "Fetching the branch HEAD from GitHub and importing the deltas…");
-                // ctx.Log as the progress sink: files dropped from the import (parse failures)
-                // append an Error line here and flip the terminal status to Failed.
-                return pr.UpdateToLatest(spacePath, userId, sourceId, ctx.Log, force).Select(r =>
+        return TriggerAuthorizedAsSystem(hub, spacePath, "update", requiresCommitAuthority: false,
+            () => hub.RunActivity(spacePath, ActivityCategory.Import,
+                force ? $"Force-update {spacePath} to latest" : $"Update {spacePath} to latest",
+                ctx =>
                 {
-                    ctx.Log($"Imported {r.Outcome} ({r.Count} node(s)).");
-                    return Unit.Default;
-                });
-            }, onActivityCreated);
+                    ctx.Log(force
+                        ? "Fetching the branch HEAD from GitHub and overwriting local changes (force)…"
+                        : "Fetching the branch HEAD from GitHub and importing the deltas…");
+                    // ctx.Log as the progress sink: files dropped from the import (parse failures)
+                    // append an Error line here and flip the terminal status to Failed.
+                    return pr.UpdateToLatest(spacePath, userId, sourceId, ctx.Log, force).Select(r =>
+                    {
+                        ctx.Log($"Imported {r.Outcome} ({r.Count} node(s)).");
+                        return Unit.Default;
+                    });
+                }, onActivityCreated));
     }
 
     /// <summary>Re-import the Space at a chosen commit / branch (mirror to that state).
@@ -133,23 +228,25 @@ public static class GitHubActivityExtensions
     }
 
     /// <summary>Ask GitHub (live) for the configured branch's HEAD + whether the Space is up to date.
-    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary). Informational: any
+    /// signed-in caller who can Read the Space may check; the activity executes as System.</summary>
     public static IObservable<string> CheckBranchStateOnGitHub(
         this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
         string? sourceId = null)
     {
         var sync = hub.ServiceProvider.GetRequiredService<GitHubSyncService>();
-        return hub.RunActivity(spacePath, ActivityCategory.Unknown, $"Check branch of {spacePath}",
-            ctx =>
-            {
-                ctx.Log("Asking GitHub for the branch state…");
-                return sync.AskBranchState(spacePath, userId, sourceId).Select(st =>
+        return TriggerAuthorizedAsSystem(hub, spacePath, "check", requiresCommitAuthority: false,
+            () => hub.RunActivity(spacePath, ActivityCategory.Unknown, $"Check branch of {spacePath}",
+                ctx =>
                 {
-                    ctx.Log($"Branch '{st.Branch}' is at {st.HeadCommitSha[..Math.Min(8, st.HeadCommitSha.Length)]} — " +
-                            (st.UpToDate ? "your Space is up to date." : "your Space is behind (use Update to latest)."));
-                    return Unit.Default;
-                });
-            }, onActivityCreated);
+                    ctx.Log("Asking GitHub for the branch state…");
+                    return sync.AskBranchState(spacePath, userId, sourceId).Select(st =>
+                    {
+                        ctx.Log($"Branch '{st.Branch}' is at {st.HeadCommitSha[..Math.Min(8, st.HeadCommitSha.Length)]} — " +
+                                (st.UpToDate ? "your Space is up to date." : "your Space is behind (use Update to latest)."));
+                        return Unit.Default;
+                    });
+                }, onActivityCreated));
     }
 
     /// <summary>Sync the configured repo's issues into <c>{space}/_Issue/{number}</c> nodes.

--- a/src/MeshWeaver.GitSync/GitHubSyncMenuProvider.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncMenuProvider.cs
@@ -12,11 +12,13 @@ namespace MeshWeaver.GitSync;
 /// <summary>
 /// DI-registered <see cref="INodeMenuProvider"/> that contributes the Space's one-click GITHUB
 /// actions to their OWN "GitHub" dropdown — shown only when the containing Space has a configured
-/// <c>_GitSync</c> source (a repository URL) and the viewer may Update it. One submenu per source
-/// (its name) with Sync now / Update to latest / Check branch, gated by the source's
-/// <see cref="SyncDirection"/>; each navigates to <see cref="GitHubActionArea"/>. Setup (repo /
-/// branch / direction / account connect) and the input-driven flows (re-import at a commit, the PR
-/// workflow) stay in the settings tab.
+/// <c>_GitSync</c> source (a repository URL) and the viewer may TRIGGER a sync: Read on the Space
+/// (or platform admin) shows Check branch / Update to latest, Update (or platform admin) adds
+/// Sync now — the same predicate the trigger itself enforces
+/// (<c>GitHubActivityExtensions.TriggerAuthorizedAsSystem</c>). One submenu per source (its name),
+/// gated by the source's <see cref="SyncDirection"/>; each navigates to
+/// <see cref="GitHubActionArea"/>. Setup (repo / branch / direction / account connect) and the
+/// input-driven flows (re-import at a commit, the PR workflow) stay in the settings tab.
 /// </summary>
 public sealed class GitHubSyncMenuProvider : INodeMenuProvider
 {
@@ -39,10 +41,19 @@ public sealed class GitHubSyncMenuProvider : INodeMenuProvider
         return sync.WatchConfigNodes(spacePath).StartWith([])
             .CombineLatest(
                 host.Hub.GetEffectivePermissions(spacePath),
-                (nodes, perms) =>
+                host.Hub.IsGlobalAdmin(),
+                (nodes, perms, isAdmin) =>
                 {
-                    if (!perms.HasFlag(Permission.Update))
+                    // Visibility mirrors the TRIGGER authorization (GitHubActivityExtensions.
+                    // TriggerAuthorizedAsSystem): a GitSynced Space is SYSTEM-OWNED, so no real
+                    // principal holds Update there — gating the menu on Update hid it from
+                    // everyone the trigger now legitimately serves. Check/Update need Read on
+                    // the Space; Sync now (commit) needs Update; a platform admin may do any op
+                    // (an Admin-partition capability, never a per-space grant).
+                    var mayTrigger = isAdmin || perms.HasFlag(Permission.Read);
+                    if (!mayTrigger)
                         return (IReadOnlyCollection<NodeMenuItemDefinition>)[];
+                    var mayCommit = isAdmin || perms.HasFlag(Permission.Update);
 
                     var items = new List<NodeMenuItemDefinition>();
                     var order = 0;
@@ -61,7 +72,7 @@ public sealed class GitHubSyncMenuProvider : INodeMenuProvider
                         var childOrder = 0;
                         // Icons are emoji (NodeMenuItemDefinition.Icon = emoji or SVG URL) — a Fluent
                         // icon NAME would render as a broken <img src="Name"> in both clients.
-                        if (canExport)
+                        if (canExport && mayCommit)
                             children.Add(new NodeMenuItemDefinition("Sync now", GitHubActionArea.AreaName,
                                 Icon: "⬆️", Order: childOrder++,
                                 Href: GitHubActionArea.Href(hubPath, sourceId, GitHubActionArea.Commit))

--- a/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
@@ -58,9 +58,10 @@ public static class GitHubSyncSettingsTab
             Icon: FluentIcons.Document(),
             GroupIcon: FluentIcons.Document(),
             Order: 250,
-            // Visibility AND the Update check are gated on the CONTAINING SPACE below — not on the
-            // current node. The feature rewrites/exports the whole Space, so the right permission to
-            // require is Update on the Space, regardless of which node's Settings page we're on.
+            // Visibility AND the permission check are gated on the CONTAINING SPACE below — not on
+            // the current node. The feature rewrites/exports the whole Space, so the right gate is
+            // Update on the Space (or platform admin), regardless of which node's Settings page
+            // we're on.
             RequiredPermission: Permission.None);
 
         // GitHub Sync acts on the whole Space, so the tab appears on the Settings page of EVERY node
@@ -75,7 +76,14 @@ public static class GitHubSyncSettingsTab
             .Select(node => string.Equals(node?.NodeType, GitHubSyncService.SpaceNodeType, StringComparison.Ordinal))
             .CombineLatest(
                 host.Hub.GetEffectivePermissions(spaceRoot),
-                (isSpace, perms) => isSpace && perms.HasFlag(Permission.Update))
+                // Update on the Space OR platform admin. A GitSynced Space is system-owned — no
+                // real principal holds Update there — and the deploy persona is a platform admin,
+                // who is deliberately NOT a data superuser and may hold no per-space permission at
+                // all (the same OR the sync trigger's authorization applies). Entitlement-only
+                // readers keep the node menu's Check/Update; the setup surface stays hidden from
+                // them — its config writes require what they don't hold.
+                host.Hub.IsGlobalAdmin(),
+                (isSpace, perms, isAdmin) => isSpace && (perms.HasFlag(Permission.Update) || isAdmin))
             .DistinctUntilChanged()
             .Select(show => show ? (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab } : none)
             .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))

--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -457,10 +457,11 @@ Recommended: 'icon' as an inline SVG starting with <svg, using currentColor. 'co
     /// Triggers a Space's GitHub sync headlessly — the same one-click Commit / Update / Check the
     /// browser's <c>GitHubAction</c> layout area runs, reachable now from MCP. Each op runs as a mesh
     /// <b>Activity</b> (progress / cancel / persisted log) via <see cref="GitHubActivityExtensions"/>;
-    /// the tool FIRES the activity under the caller's identity and returns its handle IMMEDIATELY —
-    /// it never blocks the MCP handler on the long-running GitHub I/O. The caller observes progress
-    /// reactively with <c>get @{activityPath}</c> (its live <c>ActivityLog</c> carries the commit sha
-    /// + files-written line and the terminal Status).
+    /// the caller's identity AUTHORIZES the trigger and the activity then EXECUTES as System (a
+    /// GitSynced Space is system-owned — no user holds partition write there), and the tool returns
+    /// the handle IMMEDIATELY — it never blocks the MCP handler on the long-running GitHub I/O. The
+    /// caller observes progress reactively with <c>get @{activityPath}</c> (its live
+    /// <c>ActivityLog</c> carries the commit sha + files-written line and the terminal Status).
     /// </summary>
     // NOT Idempotent: 'commit' mints a new commit on each call. OpenWorld: it pushes to / reads from
     // GitHub, an external service (same classification as the instance Sync tool).
@@ -472,7 +473,7 @@ Operations (`op`):
   • update           — pull the branch HEAD from GitHub and import the deltas back into the Space.
   • check            — ask GitHub (live) for the branch HEAD and whether the Space is up to date.
 
-Runs under YOUR identity (needs Editor/Update on the Space for commit) and requires the Space's GitHub sync config (`{space}/_GitSync`) to already exist — configure it once in the Space's GitHub settings tab. Each op runs as an Activity: this returns the activity path immediately (it does NOT wait for the push to finish). Observe progress + result with `get` on that path — the activity log carries the commit sha and files written, and its Status goes Succeeded/Failed. `sourceId` selects a specific sync source (blank = the primary).
+Your call AUTHORIZES the operation — `check` and `update` need Read on the Space (any signed-in reader; the repo is the source of truth and an update only converges the Space to it), `commit` needs Update on the Space, and a platform admin may trigger any op — and the sync itself then EXECUTES under the System identity (a GitSynced Space is system-owned, so no per-space write grant exists or is needed). Your GitHub credential is still what pushes and what commits are attributed to. Requires the Space's GitHub sync config (`{space}/_GitSync`) to already exist — configure it once in the Space's GitHub settings tab. Each op runs as an Activity: this returns the activity path immediately (it does NOT wait for the push to finish). Observe progress + result with `get` on that path — the activity log carries the commit sha and files written, and its Status goes Succeeded/Failed. `sourceId` selects a specific sync source (blank = the primary).
 
 When the sync source has two-way enabled, `update` never overwrites a node changed on the server since the last sync (it is kept and carried back on the next `commit`); pass `force: true` to overwrite local changes from the repo regardless. `force` only affects `update`.")]
     public Task<string> GitHubSync(
@@ -514,8 +515,9 @@ When the sync source has two-way enabled, `update` never overwrites a node chang
         // pattern as StartThread) and complete as soon as the handle exists. The activity keeps running
         // via the retained subscription after this Task completes.
         // 🚨 AccessContext is an AsyncLocal wiped across the .Subscribe hop: re-establish the caller's
-        // identity AT the trigger so CreateNode stamps them as the activity owner (ActivityRunner then
-        // re-stamps that owner on every subsequent cross-hub write).
+        // identity AT the trigger so the op's authorization check evaluates THEM (the click
+        // authorizes; the activity itself then executes as System — see
+        // GitHubActivityExtensions.TriggerAuthorizedAsSystem).
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         cts.Token.Register(() => tcs.TrySetResult(JsonSerializer.Serialize(new

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
@@ -28,7 +28,16 @@ public abstract class GitHubSyncTestBase(ITestOutputHelper output) : MonolithMes
     protected readonly StubPullRequestDraftService DraftStub = new();
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
-        => base.ConfigureMesh(builder)
+        => ConfigureGitHubSync(base.ConfigureMesh(builder));
+
+    /// <summary>
+    /// The GitHub-sync wiring alone (types, services, fake repo client, draft stub, key protector) —
+    /// WITHOUT the default public-admin access <c>ConfigureMesh</c> layers on. Security-shaped tests
+    /// (e.g. <c>SyncTriggerAuthorizationTest</c>) chain this onto <c>ConfigureMeshBase</c> so their
+    /// principals hold exactly the grants they seed, the production shape after #804/#805.
+    /// </summary>
+    protected MeshBuilder ConfigureGitHubSync(MeshBuilder builder)
+        => builder
             .AddGitHubSyncTypes()
             .ConfigureDefaultNodeHub(c => c.AddGitHubSyncSettingsTab().AddGitHubIssuesTab())
             .ConfigureServices(s =>

--- a/test/MeshWeaver.GitSync.Test/SyncTriggerAuthorizationTest.cs
+++ b/test/MeshWeaver.GitSync.Test/SyncTriggerAuthorizationTest.cs
@@ -1,0 +1,187 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins #811 part D realized against the sync trigger: on a GitSynced (system-owned) Space the
+/// <see cref="SystemOwnedAccessRetractionHandler"/> retracts every write-conferring grant, so NO
+/// real principal holds Create on the partition — and the sync triggers
+/// (<see cref="GitHubActivityExtensions.CheckBranchStateOnGitHub"/> /
+/// <see cref="GitHubActivityExtensions.UpdateToLatestFromGitHub"/> /
+/// <see cref="GitHubActivityExtensions.CommitToGitHub"/>) used to create their Activity node under
+/// the CALLER's identity, dying with <i>"Access denied: Create permission required for node
+/// '{space}/_Activity/…'"</i> for every legitimate user, even on the read-only <c>check</c>
+/// (observed on memex 2026-08-06, the first morning after #805).
+///
+/// <para>The contract pinned here is #820's: <b>the click authorizes, the System executes.</b>
+/// A signed-in principal whose ONLY holding on the Space is a read entitlement — the exact grant
+/// shape the retraction handler deliberately leaves — may trigger <c>check</c> and <c>update</c>
+/// (repo → space convergence; the repo is the source of truth), and the activity runs under the
+/// System identity (its <c>CreatedBy</c> IS System). <c>commit</c> (space → repo) needs the
+/// strongest authority a real principal can still hold — Update on the Space. A PLATFORM ADMIN
+/// (the <c>Admin/_Access</c>-scoped grant — a platform capability, never on the Space's scope
+/// walk) may trigger EVERY op, holding no per-space permission at all. An anonymous caller is
+/// denied outright.</para>
+///
+/// <para>The principals deliberately have the PRODUCTION shape (post-#804/#805): the fixture
+/// builds on <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> (no root-scope
+/// <c>Public → Admin</c> grant), and the triggering identities carry no <c>Roles=["Admin"]</c>
+/// claim — the masking that hid this class of bug from every other GitSync test (#811 part C).</para>
+/// </summary>
+public class SyncTriggerAuthorizationTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    /// <summary>The GitSynced Space under test. Fixed name — grants are seeded statically on it.</summary>
+    private const string Space = "SyncedSpace";
+
+    /// <summary>Signed-in principal whose ONLY holding on the Space is a Viewer entitlement —
+    /// the one grant shape <c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c> lets survive.</summary>
+    private const string Reader = "sync-reader";
+
+    /// <summary>The production-shaped platform admin: Admin on the Admin partition, nothing else
+    /// (the exact node <c>UserOnboardingService.GrantPlatformAdmin</c> writes).</summary>
+    private const string PlatformAdmin = "sync-admin";
+
+    private const string RepoUrl = "https://github.com/test/synced-space";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureGitHubSync(ConfigureMeshBase(builder))
+            .AddMeshNodes(
+                AssignmentNodeFactory.UserRole(Reader, "Viewer", Space),
+                AssignmentNodeFactory.UserRole(PlatformAdmin, "Admin", "Admin"));
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private static AccessContext Principal(string id) => new() { ObjectId = id, Name = id };
+
+    /// <summary>Creates the Space, wires its GitHub sync (making it SYSTEM-OWNED — the retraction
+    /// handler fires on the <c>_GitSync</c> create), and seeds one commit in the fake repo. Runs
+    /// under the fixture's DevLogin claim identity, standing in for the provisioning flow.</summary>
+    private async Task ProvisionSyncedSpace()
+    {
+        await Connect();
+        await CreateSpace(Space, "Synced Space");
+        await CreateMarkdown($"{Space}/Page", "Page", "# page");
+        await Sync.SaveConfig(Space, RepoUrl, "main", null, true, true)
+            .Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(Space, UserId).Timeout(60.Seconds()).ToTask();
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Reader_WithOnlyAnEntitlement_TriggersCheckAndUpdate_ActivityRunsAsSystem()
+    {
+        await ProvisionSyncedSpace();
+        // The reader's own GitHub credential — whose token talks to the (fake) GitHub API.
+        await Credentials.Save(Reader, new GitHubToken("ghp_reader", null, "bearer", "repo", null), "reader")
+            .Timeout(30.Seconds()).ToTask();
+
+        // The seeded shape really is production's: Read via the entitlement, and NOT partition
+        // write — the retraction regime means no user can hold Create/Update here, which is
+        // exactly why the trigger must not require it.
+        var effective = await Mesh.GetEffectivePermissions(Space, Reader)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        Assert.True(effective.HasFlag(Permission.Read), $"reader should Read the Space, got {effective}");
+        Assert.False(effective.HasFlag(Permission.Create), $"reader must NOT hold Create, got {effective}");
+        Assert.False(effective.HasFlag(Permission.Update), $"reader must NOT hold Update, got {effective}");
+
+        // check — informational, any signed-in reader. Before the fix this died at the Activity
+        // create ("Create permission required for '{Space}/_Activity/…'").
+        Task<string> check;
+        using (Access.SwitchAccessContext(Principal(Reader)))
+            check = Mesh.CheckBranchStateOnGitHub(Space, Reader).Timeout(90.Seconds()).ToTask();
+        var checkPath = await check;
+        var checkLog = await WaitForActivity(checkPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, checkLog.Status);
+        Assert.Contains(checkLog.Messages, m => m.Message.Contains("up to date"));
+
+        // The System executes: the activity node is OWNED by the System identity, not the clicking
+        // reader — that ownership is what lets every Append/Finish land on the system-owned space.
+        var checkNode = await WaitForNode(checkPath);
+        Assert.Equal(WellKnownUsers.System, checkNode.CreatedBy);
+
+        // update — repo → space convergence, same Read-based authorization.
+        Task<string> update;
+        using (Access.SwitchAccessContext(Principal(Reader)))
+            update = Mesh.UpdateToLatestFromGitHub(Space, Reader).Timeout(90.Seconds()).ToTask();
+        var updatePath = await update;
+        var updateLog = await WaitForActivity(updatePath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, updateLog.Status);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Commit_IsDeniedForReaderAndAnonymous_NeverForMissingPartitionWrite()
+    {
+        await ProvisionSyncedSpace();
+
+        // The reader may check/update but NOT commit — space → repo needs commit authority.
+        Task<string> readerCommit;
+        using (Access.SwitchAccessContext(Principal(Reader)))
+            readerCommit = Mesh.CommitToGitHub(Space, Reader).Timeout(60.Seconds()).ToTask();
+        var deniedCommit = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => readerCommit);
+        Assert.Contains("platform admin", deniedCommit.Message);
+
+        // An anonymous caller is denied even the informational check — triggering still writes an
+        // activity into the mesh and must have an authenticated principal behind it.
+        Task<string> anonymousCheck;
+        using (Access.SwitchAccessContext(Principal(WellKnownUsers.Anonymous)))
+            anonymousCheck = Mesh.CheckBranchStateOnGitHub(Space, WellKnownUsers.Anonymous)
+                .Timeout(60.Seconds()).ToTask();
+        var deniedCheck = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => anonymousCheck);
+        Assert.Contains("Sign-in required", deniedCheck.Message);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task PlatformAdmin_WithOnlyAdminScopedGrant_TriggersEveryOp_AsSystem()
+    {
+        await ProvisionSyncedSpace();
+        await Credentials.Save(PlatformAdmin, new GitHubToken("ghp_admin", null, "bearer", "repo", null), "admin")
+            .Timeout(30.Seconds()).ToTask();
+
+        // A platform admin is NOT a data superuser (#811's pin): the Admin-partition grant confers
+        // nothing on the Space itself — no Read, no Update. Every trigger authorization below must
+        // therefore come from IsGlobalAdmin, never from a per-space permission (which the
+        // retraction handler would have removed anyway).
+        var onSpace = await Mesh.GetEffectivePermissions(Space, PlatformAdmin)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        Assert.False(onSpace.HasFlag(Permission.Update), $"platform admin must NOT hold Update on the Space, got {onSpace}");
+
+        // check — the deploy persona must be able to ask branch state even with NO Read on the
+        // Space (the exact shape of a platform admin running `git_hub_sync check` on a mesh).
+        Task<string> check;
+        using (Access.SwitchAccessContext(Principal(PlatformAdmin)))
+            check = Mesh.CheckBranchStateOnGitHub(Space, PlatformAdmin).Timeout(90.Seconds()).ToTask();
+        var checkLog = await WaitForActivity(await check, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, checkLog.Status);
+
+        await CreateMarkdown($"{Space}/Extra", "Extra", "# extra");
+
+        Task<string> commit;
+        using (Access.SwitchAccessContext(Principal(PlatformAdmin)))
+            commit = Mesh.CommitToGitHub(Space, PlatformAdmin).Timeout(90.Seconds()).ToTask();
+        var commitPath = await commit;
+        var commitLog = await WaitForActivity(commitPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Succeeded, commitLog.Status);
+        Assert.Contains(commitLog.Messages, m => m.Message.Contains("Committed"));
+        Assert.Contains(Fake.Tree(RepoUrl), f => f.Path == "Extra.md");
+
+        var commitNode = await WaitForNode(commitPath);
+        Assert.Equal(WellKnownUsers.System, commitNode.CreatedBy);
+    }
+
+    private async Task<ActivityLog> WaitForActivity(string activityPath, Func<ActivityLog, bool> predicate) =>
+        await Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Where(l => l is not null && predicate(l))
+            .Select(l => l!)
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .ToTask();
+}


### PR DESCRIPTION
## The regression

Triggering a GitHub sync (`check` / `update` / `commit`) on a GitSynced space fails for every legitimate user with

```
Access denied: Create permission required for node '{Space}/_Activity/...'
```

— even `op=check`, which is informational. Reproduced on memex 2026-08-06 via the `git_hub_sync` MCP tool against the `Reinsurance` / `Underwriting` / `ReinsuranceDemo` spaces, the first morning after #805 deployed.

## Root cause

The sync trigger surface (`GitHubActivityExtensions`) started its Activity node under the **caller's** identity: `ActivityRunner.RunActivity` STEP 1 creates `{space}/_Activity/{id}` with the ambient `AccessContext`, and the RLS create gate demands `Create` on the partition. #805's `SystemOwnedAccessRetractionHandler` makes every GitSynced space system-owned and retracts every write-conferring grant on it — so **no real principal holds Create there anymore**. Users who could trigger syncs yesterday cannot today. This is #811 **part D**'s latent hazard, realized against the sync trigger instead of `GrantPlatformAdmin`.

## The fix — #820's pattern, applied to the sync trigger

**The click authorizes, the System executes** (`TriggerAuthorizedAsSystem` in `GitHubActivityExtensions`):

| op | authorization (what a real principal CAN hold on a system-owned space) |
|---|---|
| `check` / `update` (repo → space) | **Read** on the Space — the repo is the source of truth; the op only converges the Space to it |
| `commit` (space → repo) | **Update** on the Space (a user's own self-scoped partition keeps this) |
| **every op** | **OR platform admin** (`hub.IsGlobalAdmin`) — a global admin is deliberately not a data superuser and may hold no Read on the Space at all; without the OR, the deploy persona could not even `check`. An Admin-partition capability — the retraction handler cannot remove it |

Anonymous is denied outright; an ambient System caller (the webhook's push-triggered update) short-circuits; the probe **fails closed** on timeout. Execution then runs under `ImpersonateAsSystem` for the activity's whole life — the scope opens at Subscribe, so `RunActivity`'s eager identity capture lands inside it: the activity's `CreatedBy` **is** System and every Append/Finish owner re-stamp runs as System. The user's GitHub credential still pushes; commit attribution is unchanged.

Also: `GitHubActionArea` now renders a pre-activity failure (denial / sign-in required) instead of a "Starting…" spinner that never resolves; the MCP tool description states the real contract; What's New entry included.

## Regression test — production shape (post-#804/#805)

`SyncTriggerAuthorizationTest` (harness pattern: `PluginsPartitionReadableTest` from #813; built on `ConfigureMeshBase` with the GitSync wiring split out of `GitHubSyncTestBase`, so no public-admin masking):

- a principal whose **only** holding is a Viewer entitlement (the grant shape `IsForbiddenOnSystemOwned` deliberately leaves) triggers `check` and `update` → both **Succeed**, and the activity's `CreatedBy` is System;
- the same principal cannot `commit`; an anonymous caller cannot even `check`;
- a production-shaped platform admin (`Admin/_Access`-scoped grant only, **no** per-space permission) triggers `check` and `commit` → **Succeed**, commit lands in the fake repo.

**Red-without / green-with verified:** on unmodified main all three tests fail with the exact production symptom (`Access denied: Create permission required for node 'SyncedSpace/_Activity/…'`); with the fix 3/3 green. Full GitSync suite **151/151**; full solution Release `-warnaserror` clean.

Closes #811 (part D). Pattern: #820.

> Merged under the standing directive of 2026-08-06 ("this must work → please fix"): merge on full green with a clean review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB