### PR TITLE
GitSync updates recompile what they change — owner and sharers (Gap C-1)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-gitsync-updates-recompile.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-gitsync-updates-recompile.md
@@ -1,0 +1,21 @@
+---
+Name: GitSync updates recompile what they change
+Category: What's New
+Description: A synced Space's update now recompiles every affected NodeType by itself — including types in other spaces that share the changed sources — so an update means new behavior, not just new files.
+Icon: ArrowSync
+---
+
+Updating a GitHub-synced Space now finishes the job. When a sync lands code — a `Source/*.cs`
+file, a test, an edited NodeType definition — the sync itself requests a recompile of every
+NodeType that compiles the changed nodes: the owning type, and any type anywhere on the mesh that
+pulls those sources in via a `shared=@…` reference. Recompiles run dependencies-first, and the
+sync's activity log names exactly which types were rebuilt.
+
+Previously a sync updated the nodes and stopped there, so the mesh kept executing the previous
+assemblies until someone recompiled the affected types by hand — the deploy step that read
+"sync → recompile the changed NodeTypes → verify compiledSources", easy to forget and expensive
+to diagnose when forgotten, because the sources on screen looked current while the behavior was
+stale.
+
+Content-only syncs are unaffected: a sync that touches no code requests no recompiles, so routine
+document updates stay as cheap as they were.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -381,6 +381,22 @@ public sealed class GitHubSyncService
                 return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath,
                         SyncIgnore.For(config), progress, policy,
                         baseSha: force ? null : config.LastSyncCommitSha)
+                    // 🚨 RECOMPILE WHAT THE SYNC CHANGED — part of the sync transaction, not a
+                    // follow-up human step. Importing new Source/Code nodes and walking away leaves
+                    // every affected NodeType serving its STALE assembly (the "assembly is the
+                    // deliverable" failure the AGENTS.md deploy procedure hand-patched; paid again
+                    // 2026-08-03/04). The set derives from what actually LANDED (written + pruned
+                    // node paths — an unchanged/content-only sync releases nothing) and covers the
+                    // owning types AND every shared=@ sharer, mesh-wide; releases are requested
+                    // under SYSTEM, consistent with how the import's own writes land, and the set
+                    // is logged onto the sync's activity via `progress`.
+                    .SelectMany(x =>
+                    {
+                        var changed = x.Result.WrittenPaths.AddRange(x.Result.PrunedPaths);
+                        return changed.Count == 0
+                            ? Observable.Return(x)
+                            : hub.ReleaseAffectedNodeTypes(changed, progress).Select(_ => x);
+                    })
                     // 🚨 Only advance the last-sync baseline when the mesh is now IN SYNC with the repo.
                     // A two-way import that PRESERVED server-newer nodes leaves the mesh AHEAD of the repo
                     // (those edits aren't committed back yet); advancing LastSyncedAt would move the

--- a/src/MeshWeaver.Graph/Configuration/RecompileClosure.cs
+++ b/src/MeshWeaver.Graph/Configuration/RecompileClosure.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Which NodeTypes must RECOMPILE after a set of node paths changed — the affected-set half of the
+/// "assembly is the deliverable" rule. An update channel that lands new <c>Source/*.cs</c> nodes and
+/// walks away leaves every affected assembly stale: the mesh keeps serving the old behavior while
+/// the nodes read current (the repeatedly-paid GitSync deploy lesson, and the 2026-08-04
+/// <c>ParameterSegment</c> incident for cross-package sharers).
+///
+/// <para><b>The affected set is a DIRECT match, deliberately not transitive.</b> A type is affected
+/// exactly when (a) its OWN NodeType node is among the changed paths (its authored definition
+/// moved), or (b) a changed path falls inside its resolved Source/Test queries — the SAME
+/// <see cref="CodeQueryResolver"/> expansion + <see cref="CodeQueryResolver.Matches"/> the compiler
+/// and the release classification run, so "affected" can never disagree with "compiled". It is not
+/// transitive because a sharer compiles the shared files' TEXT into its own assembly
+/// (<see cref="NodeTypeDependencyGraph"/>): when <c>A/Source/X.cs</c> changes, every type whose
+/// queries reach <c>X.cs</c> holds stale text — but a type that merely shares the SHARER's own
+/// sources holds text that did not change, so its assembly is already correct.</para>
+///
+/// <para><b>Ordering</b> reuses <see cref="NodeTypeDependencyGraph.TopologicalOrder(IReadOnlyDictionary{string, ImmutableHashSet{string}}, out ImmutableList{string})"/>
+/// over the FULL type graph, filtered to the affected set — dependencies before dependents, the
+/// same deterministic order the pre-warmer compiles in. Filtering the full order (rather than
+/// ordering a subgraph) keeps edges THROUGH unaffected intermediates intact.</para>
+///
+/// <para>Pure data on purpose — no hub, no mesh, no I/O — so the rules are unit-testable without a
+/// fixture, exactly like <see cref="NodeTypeDependencyGraph"/>.</para>
+/// </summary>
+public static class RecompileClosure
+{
+    /// <summary>
+    /// The NodeTypes affected by <paramref name="changedNodePaths"/>: a type whose own node changed,
+    /// or whose expanded Source/Test queries match any changed path. Deterministic (sorted by path).
+    /// </summary>
+    /// <param name="types">Every known NodeType: path → definition (null = defaults apply).</param>
+    /// <param name="changedNodePaths">Node paths written or pruned by the update.</param>
+    public static ImmutableSortedSet<string> AffectedTypes(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> types,
+        IReadOnlyCollection<string> changedNodePaths)
+    {
+        if (types.Count == 0 || changedNodePaths.Count == 0)
+            return ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
+
+        var changed = changedNodePaths
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var affected = ImmutableSortedSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (typePath, definition) in types)
+        {
+            if (changed.Contains(typePath))
+            {
+                affected.Add(typePath);
+                continue;
+            }
+
+            // The SAME expansion the compiler runs (defaults, $self, @-shorthand, bare-namespace
+            // rebasing) and the SAME path matcher the release classification uses — a private
+            // re-implementation here is how "affected" and "compiled" would drift apart.
+            var expanded = CodeQueryResolver
+                .ExpandAll(definition?.Sources, CodeQueryResolver.DefaultSources, typePath)
+                .Concat(CodeQueryResolver.ExpandAll(definition?.Tests, CodeQueryResolver.DefaultTests, typePath))
+                .ToArray();
+            if (changed.Any(p => CodeQueryResolver.Matches(p, expanded)))
+                affected.Add(typePath);
+        }
+        return affected.ToImmutable();
+    }
+
+    /// <summary>
+    /// The affected set in COMPILE ORDER — dependencies before dependents — computed by filtering
+    /// the full <see cref="NodeTypeDependencyGraph.TopologicalOrder(IReadOnlyDictionary{string, ImmutableHashSet{string}}, out ImmutableList{string})"/>
+    /// down to <paramref name="affected"/>. <paramref name="cyclic"/> reports the affected members
+    /// that sit in a dependency cycle (they are still emitted, deterministically — a cycle must be
+    /// SEEN, never silently drop a recompile); callers surface them loudly.
+    /// </summary>
+    public static ImmutableList<string> OrderAffected(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> types,
+        IReadOnlyCollection<string> affected,
+        out ImmutableList<string> cyclic)
+    {
+        if (affected.Count == 0)
+        {
+            cyclic = ImmutableList<string>.Empty;
+            return ImmutableList<string>.Empty;
+        }
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(types), out var allCyclic);
+        var affectedSet = affected.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+        cyclic = allCyclic.Where(affectedSet.Contains).ToImmutableList();
+        return order.Where(affectedSet.Contains).ToImmutableList();
+    }
+}

--- a/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
@@ -1,0 +1,137 @@
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The ONE recompile step every node-update channel runs after landing content: derive the
+/// NodeTypes whose resolved sources the update touched (<see cref="RecompileClosure"/> — the
+/// type's own node, its own <c>Source/</c>/<c>Test/</c> subtree, AND every type reaching a changed
+/// node via a <c>shared=@…</c> source reference) and request their release under the SYSTEM
+/// identity, dependencies before dependents.
+///
+/// <para>Without this step an update is only half-applied: the nodes read current while the mesh
+/// keeps executing the previous assembly — the "assembly is the deliverable" failure the GitSync
+/// deploy procedure existed to hand-patch (sync → recompile by hand → verify
+/// <c>compiledSources</c>), paid again on 2026-08-03/04. The GitSync re-import channel calls this
+/// as part of the sync transaction; the release requests are ISSUED within the transaction (the
+/// compiles themselves run on the per-type hubs' compile watchers, serialized on the Compile
+/// IoPool — an update must not block on Roslyn).</para>
+/// </summary>
+public static class NodeTypeRecompileExtensions
+{
+    private static readonly TimeSpan TypeEnumerationBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Requests a release for every NodeType affected by <paramref name="changedNodePaths"/>
+    /// (written or pruned node paths). Emits the release-requested type paths, in dependency
+    /// order, exactly once; an empty change set emits an empty list without querying anything.
+    ///
+    /// <para>Runs as SYSTEM end-to-end — the type enumeration spans every partition
+    /// (infrastructure, not a user-attributable read; mirrors <c>DynamicTypePreWarmer</c>), and the
+    /// release trigger is a node write on types the syncing user may not own, consistent with how
+    /// the update's own writes land. A derivation failure is surfaced LOUDLY on
+    /// <paramref name="progress"/> (an <see cref="LogLevel.Error"/> line — on an activity sink this
+    /// flips the terminal status) and emits empty rather than failing the caller: the content is
+    /// applied either way, and the operator must learn the assemblies were left stale.</para>
+    ///
+    /// <para>Types are enumerated from the query index (<c>nodeType:NodeType</c>) — eventually
+    /// consistent, which is correct for an UPDATE channel: the affected types existed before the
+    /// update by definition. A type CREATED by the very same update needs no release — its first
+    /// activation compiles it fresh.</para>
+    /// </summary>
+    /// <param name="hub">The hub the update runs on.</param>
+    /// <param name="changedNodePaths">The node paths the update wrote or pruned.</param>
+    /// <param name="progress">Optional progress sink (an activity's <c>ctx.Log</c>): receives the
+    /// recompile set, per-type release failures, and derivation failures.</param>
+    public static IObservable<IReadOnlyList<string>> ReleaseAffectedNodeTypes(
+        this IMessageHub hub,
+        IReadOnlyCollection<string> changedNodePaths,
+        Action<string, LogLevel>? progress = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (changedNodePaths.Count == 0)
+            return Observable.Return<IReadOnlyList<string>>([]);
+
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.NodeTypeRecompileExtensions");
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+
+        return Observable.Using(
+                () => AccessContextScope.AsSystem(accessService),
+                _ => meshService
+                    .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                    .Take(1)
+                    .Timeout(TypeEnumerationBudget))
+            .Select(change =>
+            {
+                // Shape-tolerant definition read (ContentAs): a degraded JsonElement content must
+                // still contribute its declared Sources — silently dropping it would silently skip
+                // its recompile, the exact failure class this step closes.
+                var types = change.Items
+                    .Where(n => !string.IsNullOrEmpty(n.Path) && n.State == MeshNodeState.Active)
+                    .GroupBy(n => n.Path!, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.First().ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions, logger),
+                        StringComparer.OrdinalIgnoreCase);
+
+                var affected = RecompileClosure.AffectedTypes(types, changedNodePaths);
+                var ordered = RecompileClosure.OrderAffected(types, affected, out var cyclic);
+                if (cyclic.Count > 0)
+                {
+                    var cycleList = string.Join(", ", cyclic);
+                    logger?.LogWarning(
+                        "[Recompile] Dependency cycle among affected NodeTypes: {Cyclic} — released in deterministic flush order.",
+                        cycleList);
+                    progress?.Invoke(
+                        $"⚠ Dependency cycle among NodeTypes: {cycleList} — recompiled in flush order, not dependency order.",
+                        LogLevel.Warning);
+                }
+                return ordered;
+            })
+            .Do(ordered =>
+            {
+                if (ordered.Count == 0)
+                    return;
+                logger?.LogInformation(
+                    "[Recompile] {Count} NodeType(s) affected by {Changed} changed node(s): {Types}",
+                    ordered.Count, changedNodePaths.Count, string.Join(", ", ordered));
+                progress?.Invoke(
+                    $"Recompiling {ordered.Count} NodeType(s): {string.Join(", ", ordered)}",
+                    LogLevel.Information);
+                // The release trigger is a node write; SYSTEM-impersonated per the channel's own
+                // write identity (RequestNodeTypeRelease captures the caller synchronously, so the
+                // scope around the loop covers every request).
+                using (accessService?.ImpersonateAsSystem())
+                    foreach (var path in ordered)
+                        hub.RequestNodeTypeRelease(path, onError: msg =>
+                        {
+                            logger?.LogError(
+                                "[Recompile] Release request for {Path} failed: {Message}", path, msg);
+                            progress?.Invoke(
+                                $"Recompile of {path} could not be requested: {msg} — its assembly is STALE until compiled manually.",
+                                LogLevel.Error);
+                        });
+            })
+            .Select(ordered => (IReadOnlyList<string>)ordered)
+            .Catch<IReadOnlyList<string>, Exception>(ex =>
+            {
+                // LOUD, not fatal: the content landed; what failed is deriving/issuing the
+                // recompiles. The Error line flips an owning activity's terminal status, so the
+                // stale-assembly state is impossible to miss — while the update itself stands.
+                logger?.LogError(ex, "[Recompile] Deriving the recompile set failed.");
+                progress?.Invoke(
+                    $"Recompile derivation failed: {ex.Message} — affected NodeType assemblies are STALE until compiled manually.",
+                    LogLevel.Error);
+                return Observable.Return<IReadOnlyList<string>>([]);
+            });
+    }
+}

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -21,7 +21,25 @@ namespace MeshWeaver.Graph;
 /// kept-not-pruned (the repo has no copy at all — a server-side addition). Non-zero means the mesh is
 /// now AHEAD of the repo, so the caller must NOT advance its last-sync baseline until those changes are
 /// committed back.</summary>
-public sealed record StaticRepoImportResult(string Partition, string Fingerprint, string Outcome, int Count = 0, int Preserved = 0);
+public sealed record StaticRepoImportResult(string Partition, string Fingerprint, string Outcome, int Count = 0, int Preserved = 0)
+{
+    /// <summary>
+    /// The node paths this import actually WROTE (created or updated) — skipped-unchanged, claimed,
+    /// preserved and failed nodes are absent. What a caller derives its recompile set from: only a
+    /// node that really landed can leave a NodeType's assembly stale (an unchanged re-import writes
+    /// nothing and must recompile nothing). The partition ROOT's write is not tracked — it lands
+    /// through its own ensure path and is never a compile input. Empty on the Skipped/Failed
+    /// outcomes, mirroring <c>InstallResult.WrittenPaths</c>.
+    /// </summary>
+    public ImmutableList<string> WrittenPaths { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// The node paths this import PRUNED (deleted because the repo no longer carries them). A pruned
+    /// <c>Source/Test</c> node affects its owning NodeType exactly like a written one — stale code
+    /// must LEAVE the assembly — so recompile derivation takes the union of both lists.
+    /// </summary>
+    public ImmutableList<string> PrunedPaths { get; init; } = ImmutableList<string>.Empty;
+}
 
 /// <summary>
 /// Conflict policy for an import that reconciles against a LIVE partition — the GitHub
@@ -713,7 +731,14 @@ public static class StaticRepoImporter
                     // and silently NOT prune a genuinely-removed source file. Same freshness guard as
                     // ReadClaimedRoots; absent (first import) resolves promptly to an empty set (#435).
                     ReadContentManifest(hub, source.Partition),
-                    (claimedRoots, previousContentPaths) => (existingItems, claimedRoots, previousContentPaths)))
+                    // The per-node import manifest gets the SAME authoritative read: parsed from the
+                    // lagged query snapshot it can miss the map a just-completed import wrote, which
+                    // silently degraded the NEXT import to "everything changed" — a full re-write of
+                    // every node (churn versions, and a release request for every type in the
+                    // partition now that updates recompile what they change).
+                    ReadNodeManifest(hub, source.Partition),
+                    (claimedRoots, previousContentPaths, nodeManifest) =>
+                        (existingItems, claimedRoots, previousContentPaths, nodeManifest)))
             .SelectMany(snapshot =>
             {
                 var existing = snapshot.existingItems
@@ -723,12 +748,11 @@ public static class StaticRepoImporter
 
                 // Per-node incremental diff. The previous import stored each source node's token in the
                 // manifest ({partition}/_Activity/import-manifest — an ActivityLog whose ReturnValue holds
-                // the {path→token} map). It's a descendant of the subtree we already read, so parse it from
-                // `existing` — no extra query. A node whose token still matches AND is present is upserted-
-                // skipped below; a missing/empty manifest (first import, or a wipe) hashes everything as
-                // changed → full import (safe). This is what makes a one-node edit re-import one node.
-                var manifest = ParseManifest(
-                    existing.GetValueOrDefault(ManifestPath(source.Partition)), hub.JsonSerializerOptions);
+                // the {path→token} map), read AUTHORITATIVELY above (ReadNodeManifest). A node whose token
+                // still matches AND is present is upserted-skipped below; a missing/empty manifest (first
+                // import, or a wipe) hashes everything as changed → full import (safe). This is what makes
+                // a one-node edit re-import one node.
+                var manifest = snapshot.nodeManifest;
 
                 // The content-collection file paths the source owned at the LAST import (read
                 // authoritatively above from {partition}/_Activity/content-manifest). The inline content
@@ -763,7 +787,7 @@ public static class StaticRepoImporter
                         {
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: skip claimed {Path}", source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0));
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
                         }
 
                         // 🅶 Git-diff scope: when the caller supplied the changed-path set (a webhook /
@@ -781,7 +805,7 @@ public static class StaticRepoImporter
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: outside git-diff scope, skipping {Path}",
                                 source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0));
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
                         }
 
                         // Incremental skip: unchanged since the last import (same source token) AND the
@@ -795,7 +819,7 @@ public static class StaticRepoImporter
                         {
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: unchanged, skipping {Path}", source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0));
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
                         }
 
                         // Two-way conflict resolution: a node changed on the SERVER since the last sync
@@ -810,7 +834,7 @@ public static class StaticRepoImporter
                                 source.Partition, path);
                             NodeTypeCompilationActivity.AppendLog(hub, activityPath,
                                 $"↩ Kept local change to {path} (newer on the server — commit to sync it back).", logger!);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 1));
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null));
                         }
 
                         var materialized = Materialize(sourceNode);
@@ -837,8 +861,8 @@ public static class StaticRepoImporter
                         // Failed and continue. The Failed tally drives the terminal Warning status
                         // below — the activity never reports a green Succeeded while hiding failures.
                         return Upsert(hub, materialized)
-                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0))
-                            .Catch<(int Imported, int Failed, int Preserved), Exception>(ex =>
+                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0, Written: (string?)path))
+                            .Catch<(int Imported, int Failed, int Preserved, string? Written), Exception>(ex =>
                             {
                                 logger?.LogWarning(ex,
                                     "[StaticRepoImport] {Partition}: upsert of {Path} failed (continuing).",
@@ -846,13 +870,17 @@ public static class StaticRepoImporter
                                 NodeTypeCompilationActivity.AppendLog(hub, activityPath,
                                     $"⚠ Failed to import {path}: {ex.Message}", logger!,
                                     Microsoft.Extensions.Logging.LogLevel.Warning);
-                                return Observable.Return((Imported: 0, Failed: 1, Preserved: 0));
+                                return Observable.Return((Imported: 0, Failed: 1, Preserved: 0, Written: (string?)null));
                             });
                     })
                     .ToObservable()
                     .Merge(BatchSize)
-                    .Aggregate((Imported: 0, Failed: 0, Preserved: 0),
-                        (acc, x) => (acc.Imported + x.Imported, acc.Failed + x.Failed, acc.Preserved + x.Preserved));
+                    // WrittenPaths ride along with the counts: only a node that really landed can
+                    // leave a NodeType's assembly stale, so the recompile derivation downstream
+                    // (GitHubSyncService → ReleaseAffectedNodeTypes) keys off exactly this list.
+                    .Aggregate((Imported: 0, Failed: 0, Preserved: 0, Written: ImmutableList<string>.Empty),
+                        (acc, x) => (acc.Imported + x.Imported, acc.Failed + x.Failed, acc.Preserved + x.Preserved,
+                            x.Written is null ? acc.Written : acc.Written.Add(x.Written)));
 
                 return upserted.SelectMany(count =>
                 {
@@ -890,23 +918,29 @@ public static class StaticRepoImporter
                         }
                     }
 
+                    // Collect the actually-pruned PATHS (not just a count): a pruned Source/Test
+                    // node affects its owning NodeType exactly like a written one, so the recompile
+                    // derivation downstream needs to see it. A failed prune contributes nothing.
                     var pruned = toPrune.Count == 0
-                        ? Observable.Return(0)
+                        ? Observable.Return(ImmutableList<string>.Empty)
                         : toPrune
                             .Select(t => AsSystem(hub, () => meshService.DeleteNode(t.Path))
-                                .Select(_ => 1)
-                                .Catch<int, Exception>(ex =>
+                                .Select(_ => (string?)t.Path)
+                                .Catch<string?, Exception>(ex =>
                                 {
                                     logger?.LogWarning(ex,
                                         "[StaticRepoImport] {Partition}: prune of {Path} failed (continuing).",
                                         source.Partition, t.Path);
-                                    return Observable.Return(0);
+                                    return Observable.Return<string?>(null);
                                 }))
                             .ToObservable()
                             .Merge(BatchSize)
-                            .Sum();
+                            .Where(p => p is not null)
+                            .Select(p => p!)
+                            .ToList()
+                            .Select(list => list.ToImmutableList());
 
-                    return pruned.SelectMany(prunedCount =>
+                    return pruned.SelectMany(prunedPaths =>
                         // Sync content-collection files (the assets behind @@content/<file> embeds)
                         // collection→collection into each owning node — AFTER the node upsert.
                         SyncContentImports(hub, source, logger).SelectMany(embedCount =>
@@ -934,8 +968,8 @@ public static class StaticRepoImporter
                             var preserved = count.Preserved + keptFromPrune.Length;
                             var preservedNote = preserved > 0 ? $", kept {preserved} local change(s)" : "";
                             var summary = failed > 0
-                                ? $"Imported {count.Imported} node(s), {failed} FAILED (see ⚠ above){preservedNote}, pruned {prunedCount}, synced {contentCount} content file(s)."
-                                : $"Imported {count.Imported} node(s){preservedNote}, pruned {prunedCount}, synced {contentCount} content file(s).";
+                                ? $"Imported {count.Imported} node(s), {failed} FAILED (see ⚠ above){preservedNote}, pruned {prunedPaths.Count}, synced {contentCount} content file(s)."
+                                : $"Imported {count.Imported} node(s){preservedNote}, pruned {prunedPaths.Count}, synced {contentCount} content file(s).";
                             NodeTypeCompilationActivity.Complete(hub, activityPath, status,
                                 new[]
                                 {
@@ -947,9 +981,13 @@ public static class StaticRepoImporter
                                 logger!);
                             logger?.LogInformation(
                                 "[StaticRepoImport] {Partition}: imported {Count}, failed {Failed}, pruned {Pruned}, content {Content} at {Fingerprint}.",
-                                source.Partition, count.Imported, failed, prunedCount, contentCount, fingerprint);
+                                source.Partition, count.Imported, failed, prunedPaths.Count, contentCount, fingerprint);
                             return new StaticRepoImportResult(source.Partition, fingerprint,
-                                failed > 0 ? "ImportedWithErrors" : "Imported", count.Imported, preserved);
+                                failed > 0 ? "ImportedWithErrors" : "Imported", count.Imported, preserved)
+                            {
+                                WrittenPaths = count.Written,
+                                PrunedPaths = prunedPaths,
+                            };
                         });
                         })));
                 });
@@ -1341,6 +1379,23 @@ public static class StaticRepoImporter
             .Catch((Exception _) => Observable.Return<MeshNode?>(null))
             .Take(1)
             .Select(node => ParseContentManifest(node, hub.JsonSerializerOptions));
+
+    /// <summary>
+    /// Reads the partition's PER-NODE import manifest ({path → source-token} map) AUTHORITATIVELY —
+    /// the owner round-trip via <see cref="MeshNodeStreamExtensions.GetMeshNode"/>, NOT the
+    /// eventually-consistent query snapshot (same freshness guard as <see cref="ReadClaimedRoots"/> /
+    /// <see cref="ReadContentManifest"/>). Parsed from the lagged snapshot, the manifest a
+    /// just-completed import wrote could be invisible to the next import, silently degrading it to
+    /// "everything changed": every node re-written (version churn) and — now that update channels
+    /// recompile what an import lands — every type in the partition needlessly release-requested.
+    /// Absent (first import) or any read failure resolves promptly to an empty map → full import,
+    /// never a wrong one.
+    /// </summary>
+    private static IObservable<ImmutableDictionary<string, string>> ReadNodeManifest(IMessageHub hub, string partition)
+        => hub.GetMeshNode(ManifestPath(partition), TimeSpan.FromSeconds(10))
+            .Catch((Exception _) => Observable.Return<MeshNode?>(null))
+            .Take(1)
+            .Select(node => ParseManifest(node, hub.JsonSerializerOptions));
 
     /// <summary>
     /// Parses the list of source-owned content-collection paths a prior import stored in the content

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -878,9 +878,17 @@ public static class StaticRepoImporter
                     // WrittenPaths ride along with the counts: only a node that really landed can
                     // leave a NodeType's assembly stale, so the recompile derivation downstream
                     // (GitHubSyncService → ReleaseAffectedNodeTypes) keys off exactly this list.
-                    .Aggregate((Imported: 0, Failed: 0, Preserved: 0, Written: ImmutableList<string>.Empty),
-                        (acc, x) => (acc.Imported + x.Imported, acc.Failed + x.Failed, acc.Preserved + x.Preserved,
-                            x.Written is null ? acc.Written : acc.Written.Add(x.Written)));
+                    // Collected in ONE materialization pass (not per-element immutable Adds), so a
+                    // large first import stays linear.
+                    .ToList()
+                    .Select(results => (
+                        Imported: results.Sum(x => x.Imported),
+                        Failed: results.Sum(x => x.Failed),
+                        Preserved: results.Sum(x => x.Preserved),
+                        Written: results
+                            .Where(x => x.Written is not null)
+                            .Select(x => x.Written!)
+                            .ToImmutableList()));
 
                 return upserted.SelectMany(count =>
                 {

--- a/test/MeshWeaver.GitSync.Test/GitSyncRecompileTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitSyncRecompileTest.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Gap C-1: a GitSync UPDATE must RECOMPILE what it changed — the sync transaction itself requests
+/// the NodeType releases, no human "sync → recompile → verify compiledSources" ritual.
+///
+/// <para>Pins both halves of the recompile derivation through the FULL sync loop (export → edit in
+/// the repo → re-import):</para>
+/// <list type="bullet">
+///   <item>a changed <b>shared Source node</b> release-requests the OWNING type and every
+///     <c>shared=@</c> SHARER (the generalized 2026-08-04 ParameterSegment incident);</item>
+///   <item>a <b>content-only</b> change (no Code/NodeType nodes) requests ZERO releases — releasing
+///     types on every sync is the compile-storm failure mode.</item>
+/// </list>
+/// </summary>
+public class GitSyncRecompileTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    /// <summary>
+    /// A synced Space with the shared-source shape: type <c>Widget</c> owning
+    /// <c>Widget/Source/Helper</c>, type <c>Consumer</c> compiling that same source via
+    /// <c>shared=@{space}/Widget/Source</c>, and a plain markdown node as the content-only control.
+    /// Exported, then RE-imported once so the per-node import manifest exists — the follow-up
+    /// import in each test therefore writes ONLY what the test actually changed.
+    /// </summary>
+    private async Task<(string Space, string Repo)> SetUpSyncedSpace()
+    {
+        await Connect();
+        var space = "GhR" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Recompile");
+
+        await NodeFactory.CreateNode(new MeshNode("Widget", space)
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Name = "Widget",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Configuration = "config => config" },
+        }).Timeout(60.Seconds()).ToTask();
+        await NodeFactory.CreateNode(new MeshNode("Helper", $"{space}/Widget/Source")
+        {
+            NodeType = CodeNodeType.NodeType,
+            Name = "Helper",
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = "public static class WidgetHelper { }", Language = "csharp" },
+        }).Timeout(60.Seconds()).ToTask();
+        await NodeFactory.CreateNode(new MeshNode("Consumer", space)
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Name = "Consumer",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                Sources = ["namespace:Source scope:subtree", $"shared=@{space}/Widget/Source"],
+            },
+        }).Timeout(60.Seconds()).ToTask();
+        await CreateMarkdown($"{space}/Notes", "Notes", "hello");
+
+        var repo = "https://github.com/test/space-recompile";
+        await Sync.SaveConfig(space, repo, "main", subdirectory: null,
+                createBranchIfMissing: true, createRepoIfMissing: true,
+                direction: SyncDirection.Bidirectional, sourceId: null, twoWay: false)
+            .Timeout(30.Seconds()).ToTask();
+        var commit = await Sync.SyncToGitHub(space, UserId).Timeout(60.Seconds()).ToTask();
+        await WaitForConfig(space, c => c.LastSyncCommitSha == commit.CommitSha);
+
+        // Baseline import: the FIRST re-import has no per-node manifest, so it writes every node —
+        // including both type nodes, which therefore get release-requested here. Wait for those
+        // baseline triggers to LAND so each test's before-snapshot is stable.
+        await Sync.ReimportAtCommit(space, "main", UserId).Timeout(90.Seconds()).ToTask();
+        await WaitForRelease($"{space}/Widget", after: null);
+        await WaitForRelease($"{space}/Consumer", after: null);
+        return (space, repo);
+    }
+
+    private async Task<DateTimeOffset?> ReleaseRequestedAt(string typePath) =>
+        (await ReadNode(typePath).Timeout(30.Seconds()).ToTask())
+            ?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)?.RequestedReleaseAt;
+
+    /// <summary>Waits until the type's release trigger has ADVANCED past <paramref name="after"/>
+    /// (null = any trigger at all) and returns the new timestamp.</summary>
+    private async Task<DateTimeOffset> WaitForRelease(string typePath, DateTimeOffset? after) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode(typePath))
+            .Select(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)?.RequestedReleaseAt)
+            .Where(at => at is not null && (after is null || at > after))
+            .Select(at => at!.Value)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+    /// <summary>Replaces one file's content in the fake repo and pushes the tree as the new HEAD.</summary>
+    private async Task PushEdit(string repo, string pathSuffix, Func<string, string> edit)
+    {
+        var tree = Fake.Tree(repo);
+        var file = tree.Single(f => f.Path.EndsWith(pathSuffix, StringComparison.Ordinal));
+        var seeded = tree
+            .Select(f => f.Path == file.Path ? f with { Content = edit(f.Content) } : f)
+            .ToImmutableList();
+        await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Files = seeded,
+            CommitMessage = $"edit {pathSuffix}",
+            AuthorName = "test",
+            AuthorEmail = "test@test",
+            AccessToken = "x",
+        }).Timeout(30.Seconds()).ToTask();
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task SharedSourceChange_ReleasesOwnerAndSharer()
+    {
+        var (space, repo) = await SetUpSyncedSpace();
+        var ownerBefore = await ReleaseRequestedAt($"{space}/Widget");
+        var sharerBefore = await ReleaseRequestedAt($"{space}/Consumer");
+
+        // Change ONLY the shared source file in the repo, then sync.
+        await PushEdit(repo, "Helper.cs", content => content + "\n// touched by the update");
+        var result = await Sync.ReimportAtCommit(space, "main", UserId).Timeout(90.Seconds()).ToTask();
+
+        // The import wrote exactly the changed source node…
+        result.WrittenPaths.Should().Equal([$"{space}/Widget/Source/Helper"],
+            "the per-node manifest skip must confine the write to what the commit changed");
+        // …and the sync transaction release-requested BOTH affected types: the owner (its own
+        // Source subtree) and the sharer (shared=@…/Widget/Source) — the ParameterSegment fix.
+        await WaitForRelease($"{space}/Widget", after: ownerBefore);
+        await WaitForRelease($"{space}/Consumer", after: sharerBefore);
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task ContentOnlyChange_ReleasesNothing()
+    {
+        var (space, repo) = await SetUpSyncedSpace();
+        var ownerBefore = await ReleaseRequestedAt($"{space}/Widget");
+        var sharerBefore = await ReleaseRequestedAt($"{space}/Consumer");
+
+        // Change ONLY the markdown node, then sync.
+        await PushEdit(repo, "Notes.md", content => content.Replace("hello", "hello again"));
+        var result = await Sync.ReimportAtCommit(space, "main", UserId).Timeout(90.Seconds()).ToTask();
+
+        result.WrittenPaths.Should().Equal([$"{space}/Notes"]);
+        // Negative: give a (wrong) release request time to land, then confirm neither type moved.
+        // Sanctioned Task.Delay — a "wait to confirm nothing happened" test has no positive signal
+        // to filter for.
+        await Task.Delay(2000);
+        (await ReleaseRequestedAt($"{space}/Widget")).Should().Be(ownerBefore,
+            "a content-only sync must trigger zero recompiles");
+        (await ReleaseRequestedAt($"{space}/Consumer")).Should().Be(sharerBefore,
+            "a content-only sync must trigger zero recompiles");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/RecompileClosureTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecompileClosureTest.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the RECOMPILE derivation — which NodeTypes an update must release after it landed a set of
+/// node changes, and in what order.
+///
+/// <para><b>The incident class.</b> A GitSync update imports new <c>Source/*.cs</c> nodes and used
+/// to walk away: every affected NodeType kept serving its STALE assembly until a human recompiled
+/// (the documented "sync → recompile the changed NodeTypes → verify compiledSources" ritual; the
+/// 2026-08-04 <c>ParameterSegment</c> incident is the cross-type variant — the fix was merged and
+/// synced, and the page still failed because a SHARER of the edited file was never recompiled).
+/// These are pure functions over paths and declared queries, so the rules are pinned without a hub
+/// or a compile.</para>
+/// </summary>
+public class RecompileClosureTest
+{
+    /// <summary>The generalized ParameterSegment shape: one owner, one sharer, one bystander.</summary>
+    private static Dictionary<string, NodeTypeDefinition?> SharedShape() => new()
+    {
+        ["SST/ParameterSegment"] = new NodeTypeDefinition(),
+        ["SST/StandReModel"] = new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree", "shared=@SST/ParameterSegment/Source"],
+        },
+        ["SST/Unrelated"] = new NodeTypeDefinition(),
+    };
+
+    [Fact]
+    public void OwnSourceChange_AffectsOwnerAndEverySharer()
+    {
+        var affected = RecompileClosure.AffectedTypes(
+            SharedShape(), ["SST/ParameterSegment/Source/Segment"]);
+
+        affected.Should().Equal(["SST/ParameterSegment", "SST/StandReModel"],
+            "the owner compiles its own Source subtree and the sharer compiles the same file "
+            + "into ITS assembly — recompiling only the owner is exactly the ParameterSegment "
+            + "incident");
+    }
+
+    [Fact]
+    public void ContentOnlyChange_AffectsNothing()
+    {
+        var affected = RecompileClosure.AffectedTypes(
+            SharedShape(), ["SST/Docs/Welcome", "SST/Filing/2026"]);
+
+        affected.Should().BeEmpty(
+            "a content-only update must trigger ZERO recompiles — releasing types on every sync "
+            + "is the compile-storm failure mode");
+    }
+
+    [Fact]
+    public void TypeNodeItselfChanged_AffectsThatType()
+    {
+        var affected = RecompileClosure.AffectedTypes(
+            SharedShape(), ["SST/ParameterSegment"]);
+
+        affected.Should().Equal(["SST/ParameterSegment"],
+            "an edited authored definition (Configuration / Sources) must recompile — but it is "
+            + "not a change to any shared FILE, so sharers keep their correct assemblies");
+    }
+
+    [Fact]
+    public void TestSubtreeChange_AffectsTheOwner()
+    {
+        var affected = RecompileClosure.AffectedTypes(
+            SharedShape(), ["SST/ParameterSegment/Test/SegmentTests"]);
+
+        affected.Should().Contain("SST/ParameterSegment",
+            "tests are compiled into the same assembly as sources");
+    }
+
+    /// <summary>
+    /// NOT transitive, by design: a sharer compiles the shared file's TEXT into its own assembly,
+    /// so a type sharing the SHARER's own sources holds text that did not change.
+    /// </summary>
+    [Fact]
+    public void AffectedSet_IsNotTransitiveThroughSharers()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition(),
+            ["B"] = new NodeTypeDefinition { Sources = ["namespace:Source scope:subtree", "shared=@A/Source"] },
+            ["C"] = new NodeTypeDefinition { Sources = ["namespace:Source scope:subtree", "shared=@B/Source"] },
+        };
+
+        var affected = RecompileClosure.AffectedTypes(types, ["A/Source/X"]);
+
+        affected.Should().Equal(["A", "B"],
+            "C compiles B's OWN sources, which did not change — its assembly is already correct, "
+            + "and a transitive closure would recompile half the mesh on every edit");
+    }
+
+    [Fact]
+    public void EmptyChangeSet_IsEmpty()
+    {
+        RecompileClosure.AffectedTypes(SharedShape(), []).Should().BeEmpty();
+        RecompileClosure.AffectedTypes(
+                new Dictionary<string, NodeTypeDefinition?>(), ["A/Source/X"])
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OrderAffected_DependenciesFirst()
+    {
+        var types = SharedShape();
+        var affected = RecompileClosure.AffectedTypes(types, ["SST/ParameterSegment/Source/Segment"]);
+
+        var ordered = RecompileClosure.OrderAffected(types, affected, out var cyclic);
+
+        cyclic.Should().BeEmpty();
+        ordered.Should().Equal(["SST/ParameterSegment", "SST/StandReModel"],
+            "the sharer's compile pulls the owner's sources, so the owner settles first — the "
+            + "same order the pre-warmer compiles in");
+    }
+
+    /// <summary>
+    /// The order must respect edges THROUGH types that are not themselves affected — filtering the
+    /// full topological order (rather than ordering an affected-only subgraph) is what guarantees
+    /// this.
+    /// </summary>
+    [Fact]
+    public void OrderAffected_RespectsEdgesThroughUnaffectedIntermediates()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition(),
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@A/Source"] },
+            ["C"] = new NodeTypeDefinition { Sources = ["shared=@B/Source"] },
+        };
+
+        var ordered = RecompileClosure.OrderAffected(types, ["C", "A"], out var cyclic);
+
+        cyclic.Should().BeEmpty();
+        ordered.Should().Equal(["A", "C"],
+            "A precedes C via the unaffected intermediate B — an affected-only subgraph would "
+            + "have no edge between them and could emit them in either order");
+    }
+
+    [Fact]
+    public void OrderAffected_CycleIsReportedAndStillReleased()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["X"] = new NodeTypeDefinition { Sources = ["namespace:Source scope:subtree", "shared=@Y/Source"] },
+            ["Y"] = new NodeTypeDefinition { Sources = ["namespace:Source scope:subtree", "shared=@X/Source"] },
+        };
+
+        var ordered = RecompileClosure.OrderAffected(types, ["X", "Y"], out var cyclic);
+
+        cyclic.Should().Equal(["X", "Y"], "the cycle must be SEEN — callers log it loudly");
+        ordered.OrderBy(p => p).Should().Equal(new[] { "X", "Y" },
+            "a cycle must never silently DROP a recompile — both types are still released, in "
+            + "deterministic flush order");
+    }
+
+    [Fact]
+    public void AffectedTypes_NullDefinitionUsesDefaultOwnSubtree()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?> { ["A"] = null };
+
+        RecompileClosure.AffectedTypes(types, ["A/Source/X"]).Should().Equal(["A"]);
+        RecompileClosure.AffectedTypes(types, ["A/Elsewhere/X"]).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## What

A `git_hub_sync` update imported node deltas and stopped — no `RequestNodeTypeRelease` existed anywhere under `MeshWeaver.GitSync` — so every code-bearing sync left the affected assemblies **stale** until a human ran the documented "sync → recompile the changed NodeTypes → verify compiledSources" ritual (paid four times in the week of 2026-08-03, including the `ParameterSegment` shape where the missed recompile was a shared-source **sharer**). This is **Gap C-1** of the release-pipeline spec (PR-1 of its plan).

Now the sync transaction finishes the job:

- **`StaticRepoImportResult.WrittenPaths` / `PrunedPaths`** — the importer reports what actually LANDED, so an unchanged or content-only sync derives an empty set and releases nothing (no compile storms on routine syncs). Mirrors `InstallResult.WrittenPaths`.
- **`RecompileClosure`** (`MeshWeaver.Graph`, pure): `AffectedTypes` = types whose OWN node changed plus every type whose expanded Source/Test queries match a changed path — the SAME `CodeQueryResolver` expansion + matcher the compiler runs, so "affected" can never disagree with "compiled". Deliberately **not transitive**: a sharer compiles the shared file's TEXT into its own assembly, so dependents of the sharer hold text that did not change. `OrderAffected` filters the full `NodeTypeDependencyGraph.TopologicalOrder` to the affected set — dependencies first, edges through unaffected intermediates intact.
- **`hub.ReleaseAffectedNodeTypes`**: enumerates NodeType nodes as SYSTEM (the identity the sync's own writes use), requests releases in dependency order, logs the recompile set into the sync's **Activity**, and surfaces derivation failures as Error lines (flips the activity terminal status) instead of silently leaving assemblies stale.
- **`GitHubSyncService.ReimportAtCommit`** chains the release step between the import and the baseline advance — every Update-to-latest, webhook push, and manual re-import goes through it. Fresh-space imports (`ImportFromGitHub`) deliberately do not release: a new type compiles on first activation.

## Root cause fixed along the way

The per-node import manifest was parsed from the **lagged query snapshot**, so a sync arriving inside the index-lag window silently degraded to "everything changed" — rewriting every node (and, with this PR, releasing every type). It now gets the same authoritative `GetMeshNode` read the content manifest and claimed roots already use (the #435 pattern) — `ReadNodeManifest`.

## Tests

- `RecompileClosureTest` (pure): sharer inclusion, non-transitivity, content-only ⇒ empty, type-node-change ⇒ that type only, ordering through unaffected intermediates, cycle reported-not-dropped.
- `GitSyncRecompileTest` (full export → edit in repo → re-import loop): a changed shared Source node release-requests the **owning type AND the sharer**; a content-only sync requests **zero** releases — both acceptance criteria of the spec.

Locally green: `MeshWeaver.Graph.Test` (812), `MeshWeaver.GitSync.Test` (150), `MeshWeaver.Hosting.Monolith.Test` (467), all `-c Release -warnaserror`.

Follow-up (separate PR, in flight): Gap C-3 — the same closure with module `requires` edges, wired into the installed-package update channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrzDB