### PR TITLE
fix(test): both CI flakes at the root — a paged-out assertion and a halved compile budget (#834)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
@@ -927,18 +927,25 @@ public class DynamicGraphFileSystemPersistenceTest : MonolithMeshTestBase
     /// Tests the complete flow: node loading, type compilation, and HubConfiguration setting.
     /// This is the end-to-end test for the production scenario.
     /// </summary>
-    [Fact(Timeout = 20000)]
+    // 🚨 The waits below are EXPLICIT because this test performs a real on-demand Roslyn compile.
+    // The default stream-assertion budget is 10s (ObservableAssertions.DefaultTimeout), which a
+    // compile can exceed on a loaded CI runner — the test then fails with "did not emit within 10s"
+    // on PRs that changed nothing (#834). The declared Fact budget already anticipated a slow
+    // operation; the inner waits now match it instead of silently capping at half.
+    [Fact(Timeout = 60_000)]
     public async Task FileSystem_Organizations_GetsHubConfiguration_FromCompiledAssembly()
     {
+        var compileBudget = TimeSpan.FromSeconds(30);
+
         // Act - get the Organizations node (triggers on-demand compilation from disk files)
-        var node = await ReadNode("Organizations").Should().Emit();
+        var node = await ReadNode("Organizations").Should(compileBudget).Emit();
 
         // Assert
         node.Should().NotBeNull("Organizations node should exist on disk");
 
         // Resolve via INodeConfigurationResolver to trigger compilation and populate HubConfiguration.
         var resolver = Mesh.ServiceProvider.GetRequiredService<INodeConfigurationResolver>();
-        node = await resolver.ResolveConfiguration(node!).Should().Emit();
+        node = await resolver.ResolveConfiguration(node!).Should(compileBudget).Emit();
 
         node.HubConfiguration.Should().NotBeNull(
             "Organizations node should have HubConfiguration from the compiled assembly. " +

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionRealUserQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionRealUserQueryTests.cs
@@ -78,11 +78,25 @@ public class CrossPartitionRealUserQueryTests(PostgreSqlFixture fixture, ITestOu
         return (nsA, nsB);
     }
 
-    private IObservable<QueryResultChange<MeshNode>> RunUnpinned(string? userId) =>
+    /// <summary>
+    /// The unpinned (cross-partition) query the production surfaces issue.
+    /// <para>
+    /// 🚨 <paramref name="namespaceScope"/> is not decoration: without it this is a GLOBAL
+    /// <c>nodeType:Markdown</c> query capped at <c>Limit</c>, so any assertion about a SPECIFIC
+    /// seeded row only holds while fewer than <c>Limit</c> other Markdown nodes exist anywhere.
+    /// Against a shared database with sibling tests writing concurrently the seeded row is simply
+    /// paged out — an intermittent failure that lands on PRs which changed nothing (#834). Tests
+    /// that assert on a particular row MUST scope; tests that only assert the shape of the first
+    /// emission may stay global.
+    /// </para>
+    /// </summary>
+    private IObservable<QueryResultChange<MeshNode>> RunUnpinned(string? userId, string? namespaceScope = null) =>
         Mesh.ServiceProvider.GetRequiredService<IMeshService>()
             .Query<MeshNode>(new MeshQueryRequest
             {
-                Query = "nodeType:Markdown",
+                Query = namespaceScope is null
+                    ? "nodeType:Markdown"
+                    : $"namespace:{namespaceScope} nodeType:Markdown",
                 Limit = 10,
                 UserId = userId!,
             });
@@ -125,13 +139,14 @@ public class CrossPartitionRealUserQueryTests(PostgreSqlFixture fixture, ITestOu
     {
         var (nsA, _) = await SeedTwoPartitions();
 
-        var change = await RunUnpinned(WellKnownUsers.System)
+        var change = await RunUnpinned(WellKnownUsers.System, namespaceScope: nsA)
             .FirstAsync()
             .Timeout(TimeSpan.FromSeconds(20))
             .ToTask();
 
         change.ChangeType.Should().BeOneOf(QueryChangeType.Initial, QueryChangeType.Reset);
         change.Items.Should().Contain(n => n.Path == $"{nsA}/doc1",
-            "System sees every partition's rows");
+            "System reads a partition it was never granted — the query is scoped to that partition, "
+            + "so this cannot be crowded out by rows other tests happen to be writing");
     }
 }


### PR DESCRIPTION
Fixes both flakes from #834. **Neither was chance**, and both landed on PRs that changed nothing — #829 (skills/chart/docs) and #832 (one markdown file).

## 1. `CrossPartitionRealUserQueryTests` — the row was paged out

`RunUnpinned` issued a **global** `nodeType:Markdown` query capped at `Limit = 10`, and `UnpinnedStructuredQuery_AsSystem_EmitsInitial` then asserted its own seeded `{nsA}/doc1` was in the result. That only holds while **fewer than ten other Markdown nodes exist anywhere** — so against a shared PostgreSQL with sibling tests writing concurrently, the seeded row falls off the page. Hence intermittent, load-dependent, and unrelated to the diff.

The System case now scopes the query to the partition it seeded, so no unrelated writer can displace its row. The two sibling cases assert only the *shape* of the first emission, so they stay global deliberately. The helper carries a comment explaining which kind of test may skip the scope, since all three share it.

Also corrected the assertion's `because`: as written it claimed *"System sees every partition's rows"* while actually proving *"…within the first 10 global results"*.

**Not** a first-frame-completeness race — the `GetQuery` contract (gate the first emission until every sub-query has produced its `Initial`) is not implicated.

## 2. `DynamicGraphIntegrationTest` — the budget was halved

The compile test performs a **real on-demand Roslyn compile**, but its stream assertions were left on `ObservableAssertions.DefaultTimeout` (**10s**) inside a `[Fact(Timeout = 20000)]`. The inner wait silently capped at half the budget the author had declared, and a loaded runner exceeded it.

The waits are now **explicit** (30s) inside a 60s Fact, matching the sibling tests in the file. This is aligning a wait with the operation it wraps, not widening a timeout to hide a defect — the existing `Should(TimeSpan)` overload exists for exactly this.

## Tested

Both test projects build clean under CI flags (`-c Release -p:CIRun=true -warnaserror`). No product code changed; no gate weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB