### PR TITLE
The type registry must not outlive the assemblies it points at

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-recompiles-no-longer-crash-the-process.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-recompiles-no-longer-crash-the-process.md
@@ -1,0 +1,17 @@
+---
+Name: Recompiling a node no longer risks crashing the process
+Category: What's New
+Description: Repeated node recompiles could leave the portal open to a hard crash; the type registry now cleans up after each one.
+Icon: Sparkle
+---
+
+# Recompiling a node no longer risks crashing the process
+
+Every time you recompile a code node, the platform loads a fresh copy of it and throws the old one
+away. Until now the type registry kept pointing at the discarded copy. That had two costs: the old
+copy could never be released, so memory crept up on a mesh where people edit and recompile a lot;
+and once enough of them had piled up, an unrelated background operation could stumble over one and
+take the whole process down — a hard crash with nothing in the logs to explain it.
+
+The registry now drops a node's types the moment its old copy is discarded. Recompile as often as
+you like; nothing accumulates, and there is no stale entry left for anything to trip over.

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 using MeshWeaver.Domain;
 
 namespace MeshWeaver.Messaging.Serialization;
@@ -72,9 +74,73 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
         typeByName[typeName] = typeDefinition;
         nameByType[type] = typeName;
         IndexFullNameAlias(type, typeDefinition, typeName);
+        TrackCollectible(type);
 
         return this;
     }
+
+    // Collectible load contexts this registry currently holds types from, so it subscribes to each
+    // one's Unloading exactly once. ConditionalWeakTable and NOT a dictionary: an ALC used as a
+    // dictionary KEY is a strong root, which is the very leak this eviction exists to close.
+    private readonly ConditionalWeakTable<AssemblyLoadContext, object> trackedContexts = new();
+
+    /// <summary>
+    /// A registry entry for a type from a COLLECTIBLE assembly (a dynamically compiled node — every
+    /// recompile mints a new assembly with a new CLR identity) strongly roots that assembly's
+    /// <see cref="AssemblyLoadContext"/>. Two consequences, exactly as for Autofac's shared
+    /// reflection cache (<c>ReflectionCacheEviction</c>, which mirrors this for its own store):
+    /// <list type="number">
+    /// <item>the context can never be collected — an unbounded leak; and</item>
+    /// <item>after the context IS unloaded, anything walking this registry dereferences <b>freed
+    /// metadata</b> → <see cref="AccessViolationException"/> / SIGSEGV. That is not hypothetical:
+    /// <c>PolymorphicTypeInfoResolver.ComputeDerivedTypes</c> enumerates <see cref="Types"/> and
+    /// calls <c>IsAssignableFrom</c> on every entry, and a CI core dump caught it faulting there
+    /// while FutuRe's node types sat at recompile v5/v8/v15 (exit=139, no failing test).</item>
+    /// </list>
+    /// So the registry cleans up after itself: it subscribes to the context's <c>Unloading</c> the
+    /// first time it takes a type from it. The event holds a delegate to THIS registry, never the
+    /// reverse — the only reference to the context is the weak key below, so nothing here defeats
+    /// the collection it enables.
+    /// </summary>
+    private void TrackCollectible(Type type)
+    {
+        if (!type.Assembly.IsCollectible)
+            return;
+        var context = AssemblyLoadContext.GetLoadContext(type.Assembly);
+        if (context is null || !context.IsCollectible)
+            return;
+        // AddOrUpdate would re-subscribe on every registration; Add throws on a duplicate key, so
+        // TryAdd-shaped semantics via TryGetValue keeps it to one handler per context.
+        if (trackedContexts.TryGetValue(context, out _))
+            return;
+        trackedContexts.Add(context, Sentinel);
+        context.Unloading += EvictLoadContext;
+    }
+
+    private static readonly object Sentinel = new();
+
+    /// <summary>
+    /// Drops every entry whose type came from <paramref name="context"/>. Runs from the context's
+    /// <c>Unloading</c> event — i.e. BEFORE the metadata is freed, while <c>type.Assembly</c> is
+    /// still safe to read.
+    /// </summary>
+    public void EvictLoadContext(AssemblyLoadContext context)
+    {
+        foreach (var (name, definition) in typeByName)
+            if (BelongsTo(definition.Type, context))
+                typeByName.TryRemove(name, out _);
+        foreach (var (name, definition) in aliasByName)
+            if (BelongsTo(definition.Type, context))
+                aliasByName.TryRemove(name, out _);
+        foreach (var (type, _) in nameByType)
+            if (BelongsTo(type, context))
+                nameByType.TryRemove(type, out _);
+        trackedContexts.Remove(context);
+        context.Unloading -= EvictLoadContext;
+    }
+
+    private static bool BelongsTo(Type type, AssemblyLoadContext context) =>
+        type.Assembly.IsCollectible && AssemblyLoadContext.GetLoadContext(type.Assembly) == context;
 
     // Resolution alias: index the full (namespace-qualified) name alongside the canonical name, so a
     // full-name $type discriminator — persisted data, OR a payload written before the short-name $type

--- a/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Domain;
@@ -221,6 +222,48 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         property.SetGetMethod(getter);
         property.SetSetMethod(setter);
         return typeBuilder.CreateType()!;
+    }
+
+    /// <summary>
+    /// 🚨 A registry entry from a COLLECTIBLE assembly must not survive that assembly's load context.
+    ///
+    /// <para>Dynamically compiled nodes live in collectible <c>AssemblyLoadContext</c>s and every
+    /// recompile unloads the previous one. A registry that keeps the old <see cref="Type"/> both roots
+    /// the context (it can never be collected) and leaves a landmine: anything that walks the registry
+    /// afterwards dereferences freed metadata. <c>PolymorphicTypeInfoResolver.ComputeDerivedTypes</c>
+    /// does exactly that — it enumerates <c>Types</c> and calls <c>IsAssignableFrom</c> on each entry —
+    /// and a CI core dump caught it faulting there with FutuRe's node types at recompile v5/v8/v15
+    /// (<c>exit=139</c>, AccessViolation, no failing test to point at).</para>
+    ///
+    /// <para>Asserted as the INVARIANT rather than by provoking the crash: an access violation takes
+    /// the whole test host down, so "no stale entry survives unload" is what a test can pin
+    /// deterministically — and it is the property the fix has to hold.</para>
+    /// </summary>
+    [Fact]
+    public void CollectibleType_IsEvictedWhenItsLoadContextUnloads()
+    {
+        var typeRegistry = GetHost().ServiceProvider.GetRequiredService<ITypeRegistry>();
+
+        // A real collectible context holding a real assembly: load THIS assembly again into its own
+        // context, so the type has a genuinely distinct CLR identity — the recompile shape exactly.
+        var context = new AssemblyLoadContext("evict-test", isCollectible: true);
+        var reloaded = context.LoadFromAssemblyPath(typeof(HelloEvent).Assembly.Location);
+        var collectibleType = reloaded.GetType(typeof(HelloEvent).FullName!)!;
+        collectibleType.Assembly.IsCollectible.Should().BeTrue("the fixture must reproduce the recompile shape");
+        collectibleType.Should().NotBeSameAs(typeof(HelloEvent), "a reload is a new CLR identity");
+
+        typeRegistry.WithType(collectibleType, "EvictMe");
+        typeRegistry.TryGetType("EvictMe", out var registered).Should().BeTrue();
+        registered!.Type.Should().BeSameAs(collectibleType);
+
+        context.Unload();
+
+        // The registry must have dropped it — by name, by type, and (the one the crash walked) from
+        // the enumeration the polymorphic resolver iterates.
+        typeRegistry.TryGetType("EvictMe", out _).Should()
+            .BeFalse("an entry from an unloaded context is freed metadata, not a resolvable type");
+        typeRegistry.Types.Should().NotContain(t => t.Key == "EvictMe",
+            "ComputeDerivedTypes walks this enumeration and calls IsAssignableFrom on every entry");
     }
 
     private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger


### PR DESCRIPTION
## The crash

CI run [31079747899](https://github.com/Systemorph/MeshWeaver/actions/runs/31079747899) — `[CI] MeshWeaver.FutuRe.Test exit=139`, **zero failing tests**. A host that dies on a signal fails the shard, not a test, so there is no assertion to read. I pulled the core dump per [DebuggingNativeCrashes.md](../blob/main/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md).

**Free triage:** `AccessViolation` + `FailFast` present ⇒ the runtime tripped over bad memory, not an escaped managed exception. (CI ran runtime `10.0.10`, local `10.0.9`.)

**Faulting thread** (DBG 19, `(GC)` threadpool worker), read bottom-up for the phase:

```
MeshNodeStreamHandle.Subscribe                  ← permission check (SelectMany over Permission)
MeshNodeStreamCache.SharedView → GetEntry → CreateEntry
  Workspace.GetRemoteStreamUnchecked → JsonSynchronizationStream.CreateExternalClient
    MessageHub.Observe → MessageHub.Post → MessageService.Post
      JsonSerializer.WriteString → MessageDeliveryConverter.Write
        PolymorphicTypeInfoResolver.GetTypeInfo
          PolymorphicTypeInfoResolver.ComputeDerivedTypes(Type)     ← FAULT (+1992)
```

**`clrmodules`:** correct process (`MeshWeaver.FutuRe.Test/bin/Release/net10.0/`), **no duplicate MeshWeaver assemblies** (so not the duplicate-statics-across-ALC case), and the smoking gun — node assemblies at *recompiled* versions:

```
/tmp/MeshWeaver-AssemblyStore-pid2969/FutuRe_LocalAnalysis/v15-…dll
/tmp/MeshWeaver-AssemblyStore-pid2969/FutuRe_GroupAnalysis/v8-…dll
/tmp/MeshWeaver-AssemblyStore-pid2969/FutuRe_BusinessUnit/v5-…dll
```

`v15`/`v8`/`v5` ⇒ recompiles happened ⇒ collectible contexts were unloaded.

## The defect

`ComputeDerivedTypes` walks `typeRegistry.Types` — the whole registry, **parent chain included** — and calls `IsAssignableFrom` on every entry. `TypeRegistry` holds strong `Type` handles in `typeByName` / `aliasByName` / `nameByType` and had **no eviction at all**. After a recompile unloads the old context, that walk dereferences freed metadata.

This is a known failure mode in this codebase — for a *different* cache. `ReflectionCacheEviction`'s doc comment spells it out, and `NodeAssemblyLoadContext` already hooks it (`Unloading += ReflectionCacheEviction.EvictFor`):

> a later, unrelated concurrent `GetOrAdd` … compares against the stale key and dereferences **freed metadata** → `AccessViolationException` / SIGSEGV

The TypeRegistry is the same class of cache and was simply never given the same treatment.

## The fix

The registry cleans up after itself: taking a type from a collectible context subscribes to that context's `Unloading` once, and the handler drops every entry belonging to it.

Two details that are load-bearing:
- **Direction** — the context holds a delegate to the registry, never the reverse. Nothing here roots the context.
- **`ConditionalWeakTable`, not a dictionary**, for the once-only dedupe. An ALC used as a dictionary *key* is a strong root — precisely the leak this eviction removes.

**Not** "skip collectible types in the walk": the resolver's own comments explain that dropping them loses the `$type` discriminator, which is the silent-skin-drop bug class it already warns about. The types are legitimately registered; what was wrong is that the registry outlived them.

## Tests

`CollectibleType_IsEvictedWhenItsLoadContextUnloads` pins the **invariant** rather than provoking the crash — an access violation takes the whole host down and cannot be asserted on. It loads a real assembly into a real collectible context (a genuinely distinct CLR identity — the recompile shape), registers it, unloads, and asserts the entry is gone from both `TryGetType` and the enumeration `ComputeDerivedTypes` walks.

Verified it is a real repro, not a tautology: with the fix disabled it fails —
`Expected value to be false because an entry from an unloaded context is freed metadata, not a resolvable type, but found True` — and passes with it.

- `MeshWeaver.Messaging.Hub.Test` **153 / 0**
- `MeshWeaver.Serialization.Test` **14 / 0**
- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` — **Build succeeded**

## Known remainder

`verifyheap` could not run — `dotnet-dump` itself threw a `NullReferenceException` at 2% of the scan — so culprit-vs-victim is not formally confirmed by the doc's step 5. The mechanism stands on its own (`IsAssignableFrom` over an unloaded ALC is a defined AV) and the repro pins it.

Separately: STJ caches `JsonTypeInfo` per options, so a `JsonDerivedType` built *before* an unload can still hold a stale `Type`. The observed fault is the registry walk building a **new** entry; that cache is a different path and deserves its own change rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXtvWpB51YDAT5a3u1A81m