### PR TITLE
An install that lands dark is not an install — warm the root you just wrote

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-installs-open-right-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-installs-open-right-away.md
@@ -1,0 +1,16 @@
+---
+Name: What you install opens right away
+Category: What's New
+Description: A freshly installed package is live the moment it lands, instead of staying invisible until an administrator intervened.
+Icon: Sparkle
+---
+
+# What you install opens right away
+
+Installing a package wrote all of its content correctly, but left it asleep. The permissions that
+make a package readable are set up the first time it is opened — and nobody could open it, because
+it was not yet readable. A course or plugin could therefore finish installing and still show nothing
+but access errors, and only an administrator could wake it up.
+
+Installing now wakes up what it just wrote. The package is usable the moment the install reports
+success, with no extra step and nothing for an administrator to do.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1,6 +1,9 @@
 using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
@@ -108,7 +111,9 @@ public static class PackageInstaller
                 logger?.LogInformation(
                     "Installed package {Id} v{Version}: {Written} written, {Unchanged} unchanged into {Partition} @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, partition, installedFromRef);
-                return WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length).Select(_ => result);
+                return WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length)
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
+                    .Select(_ => result);
             });
     }
 
@@ -149,6 +154,68 @@ public static class PackageInstaller
     // Internal for the BuildCompletionSubscriptionTest pin (InternalsVisibleTo).
     internal static bool SeedAutoUpdate(PackageManifest? existingRecord, PluginCatalogOptions? options) =>
         existingRecord?.AutoUpdate ?? options?.AutoUpdateByDefault ?? false;
+
+    /// <summary>How long one root gets to activate before the warm gives up on it.</summary>
+    private static readonly TimeSpan WarmTimeout = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// ACTIVATES each partition root this install just wrote, by opening its node stream once.
+    ///
+    /// <para>🚨 Without this a fresh install lands <b>DARK</b>. An install runs entirely as SYSTEM and
+    /// never touches the installed partition's root hub; a node type's gating (which seeds the cover
+    /// grants that make the partition readable) runs on HUB ACTIVATION; and a viewer cannot activate a
+    /// hub they hold no Read on yet. So nobody can open what was just installed — observed as a fully
+    /// installed Store with compiled types and 286 straight denials, and as the education install gate
+    /// painting an empty "your exercises" grid. The Store's own <c>PluginHubWarmer</c> covers
+    /// <c>Store/Plugin</c> roots once they appear, but nothing covers a partition core installs that
+    /// is not a plugin — a course, for instance. The installer is the one component that always knows
+    /// what it just wrote, so the first touch belongs here.</para>
+    ///
+    /// <para>SYSTEM, explicitly and inside the subscription: the install pipeline hops schedulers and
+    /// an ambient impersonation does not survive the hop (the same reason <c>Upsert</c> scopes its own).
+    /// Sequential (<c>Concat</c>), because each activation's gating pass writes its partition's access
+    /// table and concurrent passes deadlock (40P01) on the shared effective-permissions rebuild.</para>
+    ///
+    /// <para>Best-effort by design: the content has already landed and been recorded, so a root that
+    /// will not activate is logged and stepped over rather than failing an install that succeeded.</para>
+    /// </summary>
+    private static IObservable<Unit> WarmInstalledRoots(
+        IMessageHub hub, IEnumerable<string> paths, ILogger? logger)
+    {
+        var workspace = hub.GetWorkspace();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var roots = paths
+            .Select(path => path.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Select(root => root!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (roots.Length == 0)
+            return Observable.Return(Unit.Default);
+
+        return roots
+            .Select(root => Observable
+                .Using(
+                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => workspace.GetMeshNodeStream(root)
+                        .Where(node => node is not null)
+                        .Take(1)
+                        .Timeout(WarmTimeout))
+                .Select(_ => root)
+                .Catch<string, Exception>(exception =>
+                {
+                    logger?.LogWarning(exception,
+                        "[PackageInstaller] warming installed root {Root} failed — it stays dark until "
+                        + "something else activates it", root);
+                    return Observable.Empty<string>();
+                }))
+            .ToObservable()
+            .Concat()
+            .Do(root => logger?.LogInformation("[PackageInstaller] warmed installed root {Root}", root))
+            .DefaultIfEmpty(string.Empty)
+            .LastAsync()
+            .Select(_ => Unit.Default);
+    }
 
     private static IObservable<MeshNode> WriteInstalledRecord(
         IMessageHub hub, PackageManifest manifest, string installedFromRef, int count,
@@ -273,7 +340,9 @@ public static class PackageInstaller
                             onError: msg => logger?.LogWarning(
                                 "Release request for {Path} failed: {Msg}", nodeTypePath, msg));
                 }
-                return WriteInstalledRecord(hub, manifest, installedFromRef, all.Length).Select(_ => result);
+                return WriteInstalledRecord(hub, manifest, installedFromRef, all.Length)
+                    .SelectMany(_ => WarmInstalledRoots(hub, all.Select(n => n.Path), logger))
+                    .Select(_ => result);
             });
     }
 
@@ -864,6 +933,7 @@ public static class PackageInstaller
                                 onError: msg => logger?.LogWarning("Release request for {Path} failed: {Msg}", path, msg));
                 }
                 return WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length, moduleManifest)
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
                     .Select(_ => result);
             }));
             });
@@ -1008,6 +1078,7 @@ public static class PackageInstaller
                 }
                 return WriteInstalledRecord(hub, manifest, installedFromRef,
                         newManifest.Files.Count, newManifest)
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
                     .Select(_ => result);
             });
     }

--- a/test/MeshWeaver.PluginCatalog.Test/PackageInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PackageInstallTest.cs
@@ -87,6 +87,57 @@ public class PackageInstallTest(ITestOutputHelper output) : MonolithMeshTestBase
         }
     }
 
+    /// <summary>
+    /// 🚨 An install must leave its partition root ACTIVATED, not dark.
+    ///
+    /// <para>An install runs entirely as SYSTEM and used to never touch the root hub of what it wrote.
+    /// A node type's gating — which seeds the cover grants that make the partition readable — runs on
+    /// HUB ACTIVATION, and a viewer cannot activate a hub they hold no Read on yet. So nothing ever
+    /// started it: a fully installed package that nobody could open (observed as a compiled Store with
+    /// 286 straight denials, and as the education gate painting an empty "your exercises" grid, where
+    /// the harness only recovered by having an admin RECYCLE the roots — something no real learner can
+    /// do).</para>
+    ///
+    /// <para>Probed with <see cref="HostedHubCreation.Never"/>, which is a pure read: asking for the
+    /// stream instead would itself activate the hub and the assertion would pass vacuously.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Install_LeavesTheInstalledRootActivated_NotDark()
+    {
+        var repo = CreateTempDir();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+            WriteFile(repo, "warm-pack/package.json",
+                """{"id":"warm-pack","name":"Warm Pack","kind":"content","targetPartition":"WarmTest","version":"1.0.0"}""");
+            WriteFile(repo, "warm-pack/Page.md", "# Warm\n\nThe root must be live once this lands.");
+
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            var source = new GitPackageSource(git, repo);
+            var pkg = (await source.ListPackages("HEAD").FirstAsync().ToTask())[0];
+            var files = await source.FetchPackageFiles(pkg, "HEAD").FirstAsync().ToTask();
+
+            // Nothing has touched the partition yet — the hub must not exist before the install.
+            Mesh.GetHostedHub(new Address("WarmTest"), c => c, HostedHubCreation.Never)
+                .Should().BeNull("nothing has activated the partition before its install");
+
+            await PackageInstaller.Install(Mesh, pkg, files, "HEAD").FirstAsync().ToTask();
+
+            Mesh.GetHostedHub(new Address("WarmTest"), c => c, HostedHubCreation.Never)
+                .Should().NotBeNull(
+                    "the installer must warm the root it just wrote — otherwise its gating never runs "
+                    + "and nobody but an admin recycling it can ever open the partition");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
     [Fact(Timeout = 120000)]
     public async Task AgentPackage_InstallsAsAgentNode()
     {


### PR DESCRIPTION
## The defect

A package installs correctly and then **nobody can open it**.

Three facts compose into a deadlock:
1. An install runs entirely as **SYSTEM** (core #820) and never touches the root hub of what it wrote.
2. A node type's **gating** — which seeds the cover grants that make the partition readable — runs on **hub activation**.
3. A viewer **cannot activate a hub they hold no Read on** yet.

So nothing ever performs the first touch and the partition stays dark. Observed twice: a fully installed Store with compiled types and **286 straight denials**, and the education install gate painting an empty *"your exercises"* grid while the learner's copies provably existed as real nodes.

The Store's own `PluginHubWarmer` warms `Store/Plugin` roots as they appear — but nothing covers a partition core installs that is **not** a plugin. A course, for instance.

The e2e harness worked around it by having an admin **recycle** each course root after bootstrap. Its README says the quiet part out loud:

> *(Product follow-up: a real learner cannot recycle anything, so a mesh in that state is broken for everyone until an admin does.)*

That is a product defect, not a test step — and it is why that gate goes red whenever bootstrap is slow enough to widen the window.

## The change

The installer is the one component that always knows what it just wrote, so the first touch belongs here. `WarmInstalledRoots` opens each written partition root's node stream once, wired into **all four** completion paths (content, code, node-repo, node-repo delta).

Three details are load-bearing:

- **SYSTEM explicitly, inside the subscription.** The install pipeline hops schedulers and an ambient impersonation does not survive the hop — the same reason `Upsert` scopes its own rather than wrapping the pipeline.
- **Sequential (`Concat`).** Each activation's gating pass writes its partition's access table; concurrent passes deadlock (40P01) on the shared effective-permissions rebuild. Same rule `PluginHubWarmer` already follows.
- **Best-effort.** The content has landed and been recorded before this runs, so a root that will not activate is logged and stepped over rather than failing an install that actually succeeded.

## Tests

`Install_LeavesTheInstalledRootActivated_NotDark` probes with **`HostedHubCreation.Never`** — a pure read that never constructs. This matters: asking for the node stream would itself activate the hub and the assertion would pass vacuously.

Verified it is a real repro, not a tautology — with the warm disabled it fails:

```
Expected value not to be <null> because the installer must warm the root it just wrote —
otherwise its gating never runs and nobody but an admin recycling it can ever open the partition.
```

- `MeshWeaver.PluginCatalog.Test` **79 / 0**
- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` — **Build succeeded**

## Follow-up this enables

With core warming its own installs, the education bootstrap's post-install recycle of every course root and grid host becomes redundant. I have not touched the harness here — that belongs in the education repo once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXtvWpB51YDAT5a3u1A81m