### PR TITLE
A module's version is its own, not the repo's commit sha

### DIFF
--- a/src/MeshWeaver.PluginCatalog/ModuleManifest.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleManifest.cs
@@ -29,6 +29,21 @@ public sealed record ModuleManifest
     /// Equal versions ⇒ identical file set ⇒ nothing to sync.</summary>
     public string ModuleVersion { get; init; } = "";
 
+    /// <summary>
+    /// The module's released SemVer (<c>MAJOR.MINOR.PATCH</c>), published by the plugins repo as the
+    /// git tag <c>&lt;Module&gt;/vMAJOR.MINOR.PATCH</c>.
+    ///
+    /// <para>🚨 Distinct from <see cref="ModuleVersion"/>, and not interchangeable with it.
+    /// <see cref="ModuleVersion"/> is a content HASH: it identifies a tree exactly but is UNORDERED,
+    /// so nothing can express "at least 1.2" against it — which is why a consumer had no choice but
+    /// to track a moving ref. This is the ordered number a dependency can actually be pinned to.</para>
+    ///
+    /// <para><c>null</c> for a module whose manifest predates versioning; callers fall back to
+    /// whatever they used before (for a node repo, the whole-repo commit sha) rather than treating a
+    /// missing version as an error.</para>
+    /// </summary>
+    public string? Version { get; init; }
+
     /// <summary>The git commit the manifest was generated at (traceability only — excluded from
     /// <see cref="ModuleVersion"/>).</summary>
     public string? SourceCommit { get; init; }
@@ -73,6 +88,11 @@ public sealed record ModuleManifest
                 Module = r.TryGetProperty("module", out var m) && m.ValueKind == JsonValueKind.String
                     ? m.GetString()! : "",
                 ModuleVersion = version.GetString()!,
+                // Optional by design: a manifest generated before versioning has no `version`, and
+                // that must degrade to the old behaviour rather than refuse to parse.
+                Version = r.TryGetProperty("version", out var semver)
+                          && semver.ValueKind == JsonValueKind.String
+                    ? semver.GetString() : null,
                 SourceCommit = r.TryGetProperty("sourceCommit", out var c) && c.ValueKind == JsonValueKind.String
                     ? c.GetString() : null,
                 Files = map.ToImmutable(),

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -120,8 +120,16 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         Kind = PackageKind.NodeRepo,
                         TargetPartition = id,
                         SourceFolder = id,
-                        Version = snapshot.CommitSha,
-                        ModuleVersion = moduleManifests.TryGetValue(id, out var mm) ? mm.ModuleVersion : null,
+                        // 🚨 The module's OWN released SemVer when it has one, and only then the
+                        // whole-repo commit sha. A sha is unorderable and repo-wide: every module in
+                        // the repo "changed version" whenever any one of them did, and no dependent
+                        // could express a constraint against it. The manifest's version is per module
+                        // and ordered, so it is what a pin resolves to; the sha stays as the fallback
+                        // for a module whose manifest predates versioning.
+                        Version = moduleManifests.TryGetValue(id, out var mm) && mm.Version is { } semver
+                            ? semver
+                            : snapshot.CommitSha,
+                        ModuleVersion = mm?.ModuleVersion,
                         // The candidate file set at this ref. Diffed against the install record's
                         // InstalledFiles to produce the added/modified/removed list; null when the
                         // module ships no manifest.lock (legacy commit-sha comparison applies).

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleManifestTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleManifestTest.cs
@@ -44,6 +44,43 @@ public class ModuleManifestTest
         m.Files["Widget/Thing.json"].Should().Be("hash-type");
     }
 
+    /// <summary>
+    /// The module's released SemVer is carried alongside the content hash. The two are NOT
+    /// interchangeable: the hash identifies a tree exactly but is unordered, so nothing can express
+    /// "at least 1.2" against it — which is why a consumer had to track a moving ref instead.
+    /// </summary>
+    [Fact]
+    public void ParsesTheReleasedSemVerAlongsideTheContentHash()
+    {
+        var m = ModuleManifest.TryParse(
+            """
+            {
+              "schema": "mw-manifest/1",
+              "module": "Widget",
+              "moduleVersion": "3fa1b2c4d5e6f708",
+              "version": "2.5.1",
+              "files": { "Widget/index.json": "hash-root" }
+            }
+            """);
+
+        m.Should().NotBeNull();
+        m!.Version.Should().Be("2.5.1");
+        m.ModuleVersion.Should().Be("3fa1b2c4d5e6f708", "the content hash stays what it was");
+    }
+
+    /// <summary>
+    /// A manifest generated before versioning has no <c>version</c>. That must parse and degrade to
+    /// the previous behaviour — a missing version is a legacy manifest, never a broken one.
+    /// </summary>
+    [Fact]
+    public void ManifestWithoutAVersion_StillParses_WithNoVersion()
+    {
+        var m = ModuleManifest.TryParse(Valid);
+
+        m.Should().NotBeNull();
+        m!.Version.Should().BeNull("callers fall back to what they used before versioning existed");
+    }
+
     [Theory]
     [InlineData("not json at all")]
     [InlineData("[]")]


### PR DESCRIPTION
## The defect

`NodeRepoPackageSource` stamped every module's `Version` with `snapshot.CommitSha`:

```csharp
Version = snapshot.CommitSha,
```

That value is **unorderable** and **repo-wide**. Every module in the repo "changed version" whenever any *one* of them did, and no dependent could express a constraint against it — there is no way to say "at least 1.2" to a sha. So consumers track a moving ref instead of pinning, which is why the same `education` commit can test different code on two different runs.

## The change

The plugins repo now derives a real SemVer per module and publishes it as the git tag `<Module>/vMAJOR.MINOR.PATCH` ([Plugins#347](https://github.com/Systemorph/MeshWeaver.Plugins/pull/347)). This PR carries it through core:

- `ModuleManifest.Version` — parses the manifest's `version`.
- A node-repo package takes its **own released version** when it has one; the commit sha stays only as the fallback for a module whose manifest predates versioning.

`Version` and `ModuleVersion` remain separate on purpose and are **not** interchangeable:

| field | what it is |
|---|---|
| `ModuleVersion` | a content **hash** — exact, but unordered. Cannot express a constraint. |
| `Version` | **SemVer** — the ordered number a dependency can be pinned to. |

## Backwards compatibility

A missing `version` parses to `null` rather than failing. A manifest generated before versioning is **legacy, not broken**, and degrades to exactly the previous behaviour — pinned by `ManifestWithoutAVersion_StillParses_WithNoVersion`.

## Tests

- `ParsesTheReleasedSemVerAlongsideTheContentHash` — both fields carried, neither clobbering the other
- `ManifestWithoutAVersion_StillParses_WithNoVersion` — the legacy path
- `MeshWeaver.PluginCatalog.Test` **80 / 0**
- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` — **Build succeeded**

## Next

With an ordered version on the install record, `requires` can carry caret constraints (`"Store@^1.4.0"`) and `DependencyCheck` can enforce them. That is the last piece of the pinning story and lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXtvWpB51YDAT5a3u1A81m