### PR TITLE
docs: plugin roots are Store/Plugin + PluginContent, not a Space/PluginManifest root

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
@@ -17,8 +17,8 @@ changes back to git.
 A plugin is a **folder of mesh nodes** in a git repo — nothing else. The on-disk shape:
 
 ```text
-MyPlugin.json                       the plugin's Space node ("package node": name, description, manifest)
-MyPlugin/
+MyPlugin/                           the plugin folder — the unit of import
+  index.json                        the plugin ROOT — nodeType "Store/Plugin", content PluginContent
   Widget.json                       a NodeType node (Content = NodeTypeDefinition{ configuration })
   Widget/
     Source/
@@ -30,6 +30,12 @@ MyPlugin/
 ```
 
 - `*.json` files ARE MeshNodes, verbatim. `*.cs` files become `Code` nodes keyed by path.
+- The **root** `index.json` is `nodeType: "Store/Plugin"` with a `PluginContent` — the cover
+  (`Body`/`Video`/`Poster`), price, `EntryPoint`, `MarketingPath`, `SetupPath` and `InstallPaths`.
+  The `Store/Plugin` type gives the plugin its store card, its gated children and its cover page. (A
+  `Space` root is correct only when its content is a partition-level `NodeTypeDefinition` compiling a
+  shared `Source/` model, e.g. `UWDeepfield`; a `PluginManifest` root is the deprecated pre-"Store
+  retype" form. Canonical reference: `MeshWeaver.Plugins/AGENTS.md`.)
 - The **NodeType node** carries the type's configuration, e.g.
   `"configuration": "config => config.WithContentType<WidgetContent>().AddDefaultLayoutAreas().AddLayout(l => l.AddWidgetLayoutAreas())"`.
 - The mesh **compiles `Source/` live** on install (Roslyn) — no app rebuild, no NuGet. Version = the

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -45,7 +45,7 @@ Only when **no** tokens are configured — the local-dev / e2e-stub mode — doe
 anonymously; a production registry always configures tokens. What a registered instance can then
 read is **curated plugins** only:
 by default the node-native repos the [`MeshWeaver.Plugins`](/Doc/Architecture/Plugins) repo ships —
-`<Plugin>/index.json` **Space** roots carrying a `PluginManifest`, node-per-file — via a
+`<Plugin>/index.json` **Store/Plugin** roots carrying a `PluginContent`, node-per-file — via a
 `NodeRepoPackageSource` (`PluginCatalog:SourceFormat=node-repo`, the default). A `package.json`-manifest
 repo can be served instead with `SourceFormat=package-json`. Nothing outside a published plugin is
 exposed, and the registry's own credential never leaves.
@@ -76,8 +76,8 @@ via the `PluginCatalog:Sources` list:
 Each entry takes `RepoPath` (a URL → via GitSync's client, or a local path), optional `Subdir`,
 `Ref` (default `HEAD`) and `Format` (`node-repo` default / `package-json`). A source lists only
 folders matching its format — the Education repo's courses (DataModeling, AgenticEngineering, …)
-appear once each course folder gains a `<Course>/index.json` Space root carrying a
-`PluginManifest`, the same node-repo convention `MeshWeaver.Plugins` uses. `GET /api/plugins`
+appear once each course folder gains a `<Course>/index.json` Store/Plugin root carrying a
+`PluginContent`, the same node-repo convention `MeshWeaver.Plugins` uses. `GET /api/plugins`
 merges all sources' packages (on an id collision the first configured source wins); `/files`
 resolves an id in the same order. With several sources one failing repo degrades to an empty
 contribution (logged), never a broken catalog. The legacy single-source keys

--- a/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
@@ -22,7 +22,7 @@ A node repo is exactly the on-disk shape the sample partitions use — a `*.json
 `Source/` (and `Test/`) C# — e.g. the Slide type:
 
 ```text
-Slides/index.json                 the plugin's Space root (the "package node") — INSIDE the folder
+Slides/index.json                 the plugin ROOT — nodeType "Store/Plugin", content PluginContent (INSIDE the folder)
 Slides/Slide.json                 a NodeType node (Content = NodeTypeDefinition{ configuration })
 Slides/Slide/Source/*.cs          the content type + layout areas — compiled live
 Slides/Slide/Test/*.cs            the type's own tests — compiled together with Source
@@ -34,11 +34,27 @@ be part of the partition.
 
 | Concept | Where it lives (node-native) |
 |---|---|
-| The "manifest" | the plugin's **Space root** (`<Plugin>/index.json`) — its Content carries e.g. `minMeshVersion` |
+| The "manifest" | the plugin **root** (`<Plugin>/index.json`, `nodeType: "Store/Plugin"`) — its `PluginContent` carries the cover, price, entry point and install paths |
 | The "kind" (content vs code) | the child's **NodeType** — a NodeType-with-`Source/` vs plain content |
 | The "version" | the **node's version**, mesh-tracked, bumped on every change — nobody hand-bumps a field |
 | The "installer" | **GitSync** — `GitHubSyncService.ImportFromGitHub` / `StaticRepoImporter` |
 | "what to install" | the **StaticRepoSync partition list** |
+
+### The plugin root is a `Store/Plugin` node
+
+The root `<Plugin>/index.json` is **`nodeType: "Store/Plugin"`** — the Store's generic root type —
+carrying a **`PluginContent`** (the cover `Body`, `Description`, `Video`/`Poster`, the `OgImage`
+social preview, `EntryPoint`, `MarketingPath`, `SetupPath`, `InstallPaths`, price). Card-level
+identity (Name, the one-line Description tagline, Icon, Category) stays on the node itself. The
+`Store/Plugin` type owns the install funnel: the anonymous cover, the auto-gated children
+(`AddPluginGating`) and the store card. The canonical reference for the repo shape is
+**`MeshWeaver.Plugins/AGENTS.md`**.
+
+- **Exception — a `Space` root** is correct only when the root's own content IS a partition-level
+  `NodeTypeDefinition` compiling a shared `Source/` model (e.g. `UWDeepfield`, in
+  `MeshWeaver.Reinsurance`); retyping it to `Store/Plugin` would kill that compile.
+- **Deprecated — a `PluginManifest` root** is the pre-"Store retype" form. A bare manifest root has
+  no home page and reads as broken, so don't author new plugins this way.
 
 ## Install = GitSync
 
@@ -63,7 +79,7 @@ configured git source (the plugins repo):
 
 | Verb | Returns |
 |---|---|
-| `GET /api/plugins` | `{ packages:[PackageManifest…] }` — the curated modules from the configured source (node-native `<Plugin>/index.json` Space roots by default) |
+| `GET /api/plugins` | `{ packages:[PackageManifest…] }` — the curated modules from the configured source (node-native `<Plugin>/index.json` **Store/Plugin** roots by default) |
 | `POST /api/plugins/files` `{id}` | `{ files:[{relativePath, content}…] }` — the files that plugin (by id) ships |
 
 A consuming instance browses this from its **Plugin Catalog** admin tab (Settings ▸ Administration,


### PR DESCRIPTION
Fixes #632.

The framework architecture docs described a plugin's partition root as a "Space root / package node" carrying a `PluginManifest` — the pre-"Store retype" shape. The current model is a root with `nodeType: "Store/Plugin"` and content `PluginContent`; the `Store/Plugin` type owns the cover, the gated children and the store card.

## What changed

- **Plugins.md** — corrected the on-disk example, the "manifest" table row and the `/api/plugins` row to `Store/Plugin` roots; added a **"The plugin root is a `Store/Plugin` node"** subsection covering the `PluginContent` fields, the `Space`-root exception (`UWDeepfield`, in `MeshWeaver.Reinsurance`), and the deprecated `PluginManifest` form.
- **PluginRegistry.md** — the two "`Space` roots carrying a `PluginManifest`" lines → `Store/Plugin` roots carrying `PluginContent`.
- **PluginAuthoring.md** — fixed the plugin anatomy (the root is `index.json` **inside** the folder, typed `Store/Plugin` + `PluginContent`; removed the stale sibling `<Plugin>.json`) and added a root-type bullet.

All three cross-link `MeshWeaver.Plugins/AGENTS.md` as the canonical repo-shape reference.

## Scope / verification

- **Docs-only** — no framework `src/` code changed.
- `DocumentationLinkIntegrityTest` passes (no internal links broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
