### PR TITLE
verifyheap can die inside its own scan — that is the tool failing, not a verdict

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -104,6 +104,20 @@ Run these in order; each one kills off a class of hypothesis.
 5. **`verifyheap`** — clean output means **no GC heap corruption**, which distinguishes "this code is
    the culprit" from "this code is an innocent victim of corruption elsewhere". Requires
    `DbgMiniDumpType: 2` (already set).
+
+   ⚠️ **It may not run at all.** On a large dump `dotnet-dump` can die inside its own scan:
+
+   ```
+   Scanning heap: 6 MB / 266 MB (2%)...
+   Unhandled exception: System.NullReferenceException
+      at Microsoft.Diagnostics.DebugServices.Implementation.Utilities.Invoke(…)
+   ```
+
+   That is the TOOL failing, not a verdict — it says nothing about the heap either way. Do not read
+   it as "clean" and do not retry it hoping for a different answer (2026-08-06, a 1.2 GB FutuRe
+   dump). When it happens, step 5 is simply unavailable: say so rather than implying culprit-vs-victim
+   was established, and get the confidence elsewhere — a **deterministic repro** is worth more than
+   `verifyheap` anyway, because it pins the cause instead of describing the wreckage.
 6. **`eeheap -gc`** — heap size, to rule in/out memory pressure. Cross-check against
    `_meshweaver-memory-delta.log` in the same artifact for the deltas around the crash.
 


### PR DESCRIPTION
Step 5 of the core-dump sequence in `DebuggingNativeCrashes.md` reads as though `verifyheap` always answers. It does not.

On a large dump `dotnet-dump` can throw inside its own scan:

```
Scanning heap: 6 MB / 266 MB (2%)...
Unhandled exception: System.NullReferenceException
   at Microsoft.Diagnostics.DebugServices.Implementation.Utilities.Invoke(…)
```

Hit today on the 1.2 GB FutuRe dump while diagnosing the `exit=139` SIGSEGV (#837).

**The failure mode that matters is misreading it.** A crashed `verifyheap` is *not* "clean output" — it says nothing about the heap in either direction, so culprit-vs-victim stays **unestablished**. The honest move is to state that plainly rather than let the sequence imply a step ran that did not, which is the same discipline the *"Reading the result honestly"* section immediately below already asks for. Retrying is pointless; the dump is what it is.

The note also records what to do instead: get the confidence from a **deterministic repro**, which is worth more than `verifyheap` regardless — it pins the cause rather than describing the wreckage. That is exactly how #837 was settled in the end.

`DocumentationLinkIntegrityTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)