### PR TITLE
A select: without `content` silently returned nothing — and nulled content everywhere else

### DIFF
--- a/src/MeshWeaver.AI.Copilot/CopilotModelCatalog.cs
+++ b/src/MeshWeaver.AI.Copilot/CopilotModelCatalog.cs
@@ -57,7 +57,7 @@ public sealed class CopilotModelCatalog
             // under the namespace don't leak into the picker.
             .GetQuery(
                 $"{LanguageModelNodeType.NodeType}|Copilot",
-                $"namespace:{LanguageModelNodeType.RootNamespace} nodeType:{LanguageModelNodeType.NodeType} provider:Copilot")
+                $"namespace:{LanguageModelNodeType.RootNamespace} nodeType:{LanguageModelNodeType.NodeType} provider:Copilot select:path,id")
             .Select(nodes => (IReadOnlyList<string>)nodes
                 .Select(n => n.Id)
                 .Where(id => !string.IsNullOrEmpty(id))

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1613,7 +1613,7 @@ public class AgentChatClient : IAgentChat
             ? Observable.Return(ImmutableArray<string>.Empty)
             : workspace.GetQuery(
                     $"{ModelProviderNodeType.SelectionNodeType}|{selectionUserId}",
-                    $"namespace:{ModelProviderNodeType.UserNamespacePath(selectionUserId!)} nodeType:{ModelProviderNodeType.SelectionNodeType}")
+                    $"namespace:{ModelProviderNodeType.UserNamespacePath(selectionUserId!)} nodeType:{ModelProviderNodeType.SelectionNodeType}{AgentPickerProjection.RegistryProjection}")
                 .Select(nodes => ExtractSelectedProviderPaths(nodes.FirstOrDefault()))
                 .Catch<ImmutableArray<string>, Exception>(_ => Observable.Return(ImmutableArray<string>.Empty))
                 .StartWith(ImmutableArray<string>.Empty)

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -123,10 +123,23 @@ public static class AgentPickerProjection
         => PartitionOf(path) is { } p && ReservedPartitions.Contains(p);
 
     /// <summary>
+    /// The projection every registry query carries. Agents, skills and models are all
+    /// CONTENT-BEARING reads — the picker deserialises AgentConfiguration / SkillConfiguration /
+    /// ModelDefinition off each row — so <c>content</c> is named DELIBERATELY here. Naming it is
+    /// the point: a <c>select:</c> that omits <c>content</c> makes the storage adapter project
+    /// <c>NULL::jsonb AS content</c>, and every downstream <c>ContentAs&lt;T&gt;()</c> then reads
+    /// null with no error (empty picker, "No suitable agent"). See
+    /// Doc/Architecture/CqrsAndContentAccess.
+    /// </summary>
+    internal const string RegistryProjection =
+        " select:path,id,namespace,name,description,nodeType,icon,order,content";
+
+    /// <summary>
     /// Assembles a per-partition registry query: the platform default namespace (<paramref name="sub"/>)
     /// plus the user's and space's own (<c>{partition}/{sub}</c>), listed directly as a
     /// <c>namespace:A|B|C</c> exact-membership alternation. No scope — agents/models are placed in a
-    /// flat, well-known namespace per partition, so there is no graph search.
+    /// flat, well-known namespace per partition, so there is no graph search. Carries
+    /// <see cref="RegistryProjection"/>.
     /// </summary>
     private static string BuildRegistryQuery(
         string nodeType, string sub, string? userPath, string? spacePath, string extra,
@@ -148,7 +161,7 @@ public static class AgentPickerProjection
         var nsClause = namespaces.Count > 1
             ? $"namespace:{string.Join("|", namespaces)}"
             : $"namespace:{namespaces[0]}";
-        return $"{nsClause} nodeType:{nodeType}{extra}";
+        return $"{nsClause} nodeType:{nodeType}{extra}{RegistryProjection}";
     }
 
     /// <summary>
@@ -441,22 +454,22 @@ public static class AgentPickerProjection
         var typeFilter = $"{LanguageModelNodeType.NodeType}|{ModelProviderNodeType.NodeType}";
         var queries = new List<string>
         {
-            $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants",
+            $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{RegistryProjection}",
         };
         // Skip reserved/rogue ROUTE partitions (login, welcome, settings, …): a reserved currentPath/
         // nodeTypePath would make namespace:{login}/Provider read the policy-less reserved partition and
         // fail the WHOLE model query with "lacks Read permission on 'login'" — the picker goes empty.
         // Mirrors BuildRegistryQuery's filter (the agent/skill queries already skip these).
         if (!string.IsNullOrEmpty(currentPath) && !IsReservedPartition(currentPath))
-            queries.Add($"namespace:{currentPath}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants");
+            queries.Add($"namespace:{currentPath}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{RegistryProjection}");
         if (!string.IsNullOrEmpty(nodeTypePath) && !IsReservedPartition(nodeTypePath))
-            queries.Add($"namespace:{nodeTypePath}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants");
+            queries.Add($"namespace:{nodeTypePath}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{RegistryProjection}");
         if (!string.IsNullOrEmpty(userPath))
-            queries.Add($"namespace:{ModelProviderNodeType.UserNamespacePath(userPath)} nodeType:{typeFilter} scope:descendants");
+            queries.Add($"namespace:{ModelProviderNodeType.UserNamespacePath(userPath)} nodeType:{typeFilter} scope:descendants{RegistryProjection}");
         if (selectedProviderPaths != null)
             foreach (var path in selectedProviderPaths)
                 if (!string.IsNullOrEmpty(path))
-                    queries.Add($"namespace:{path} nodeType:{typeFilter} scope:selfAndDescendants");
+                    queries.Add($"namespace:{path} nodeType:{typeFilter} scope:selfAndDescendants{RegistryProjection}");
         return queries.ToArray();
     }
 

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -159,7 +159,7 @@ public static class AiSettingsNodeType
             return;
         var path = PathFor(user);
         hub.GetWorkspace()
-            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType}")
+            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Take(1)
             .SelectMany(nodes =>
             {
@@ -240,7 +240,7 @@ public static class AiSettingsNodeType
         var defaults = BuildDefaults(services);
         EnsureExists(hub, services, user);
         return workspace
-            .GetQuery($"{NodeType}|{user}", $"path:{PathFor(user)} nodeType:{NodeType}")
+            .GetQuery($"{NodeType}|{user}", $"path:{PathFor(user)} nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Select(nodes => Effective(
                 nodes.FirstOrDefault(n => string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase)),
                 defaults, hub.JsonSerializerOptions))
@@ -267,7 +267,7 @@ public static class AiSettingsNodeType
         // it does not clobber an existing customised node). See
         // feedback_optional_node_query_not_access / Doc/Architecture/AsynchronousCalls.md.
         hub.GetWorkspace()
-            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType}")
+            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Take(1)
             .Where(nodes => !nodes.Any(n =>
                 string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase)))

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -613,7 +613,7 @@ public sealed class ChatClientCredentialResolver : IDisposable
             var typeFilter = $"{LanguageModelNodeType.NodeType}|{ModelProviderNodeType.NodeType}";
             foreach (var path in shared)
             {
-                var sharedQuery = $"namespace:{path} nodeType:{typeFilter} scope:selfAndDescendants";
+                var sharedQuery = $"namespace:{path} nodeType:{typeFilter} scope:selfAndDescendants{AgentPickerProjection.RegistryProjection}";
                 sources.Add(workspace.GetQuery($"ChatClientCredentialResolver.Shared|{path}", sharedQuery));
             }
         }
@@ -752,7 +752,7 @@ public sealed class ChatClientCredentialResolver : IDisposable
         var typeFilter = $"{LanguageModelNodeType.NodeType}|{ModelProviderNodeType.NodeType}";
         var queries = new List<string>
         {
-            $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants",
+            $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{AgentPickerProjection.RegistryProjection}",
         };
         // Each watched partition is a USER partition (WatchPartition is called
         // with the resolving user's id). A user's own providers/models live in
@@ -761,8 +761,8 @@ public sealed class ChatClientCredentialResolver : IDisposable
         // (many queries are fine — the synced collection unions them).
         foreach (var p in partitions)
         {
-            queries.Add($"namespace:{ModelProviderNodeType.UserNamespacePath(p)} nodeType:{typeFilter} scope:descendants");
-            queries.Add($"namespace:{p}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants");
+            queries.Add($"namespace:{ModelProviderNodeType.UserNamespacePath(p)} nodeType:{typeFilter} scope:descendants{AgentPickerProjection.RegistryProjection}");
+            queries.Add($"namespace:{p}/{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{AgentPickerProjection.RegistryProjection}");
         }
         return queries.ToArray();
     }

--- a/src/MeshWeaver.AI/ModelDiscoveryService.cs
+++ b/src/MeshWeaver.AI/ModelDiscoveryService.cs
@@ -71,10 +71,10 @@ public sealed class ModelDiscoveryService
     {
         if (string.IsNullOrEmpty(nodePath))
             return BuildSynced("root",
-                $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{TypeFilter} scope:descendants");
+                $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{TypeFilter} scope:descendants{AgentPickerProjection.RegistryProjection}");
 
         return BuildSynced($"node@{nodePath}",
-            $"namespace:{nodePath}/{ModelProviderNodeType.RootNamespace} nodeType:{TypeFilter} scope:descendants");
+            $"namespace:{nodePath}/{ModelProviderNodeType.RootNamespace} nodeType:{TypeFilter} scope:descendants{AgentPickerProjection.RegistryProjection}");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2968,8 +2968,8 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         }
 
         var query = string.IsNullOrEmpty(ns)
-            ? "nodeType:Thread sort:LastModified-desc"
-            : $"nodeType:Thread namespace:{ns}/_Thread sort:LastModified-desc";
+            ? "nodeType:Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content"
+            : $"nodeType:Thread namespace:{ns}/_Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content";
 
         viewMode = ChatViewMode.ResumeThreads;
         resumeLoading = true;
@@ -3055,7 +3055,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     {
         myThreadsSubscription?.Dispose();
         var me = _userHome;
-        myThreadsSubscription = Hub.GetQuery("my-threads", "nodeType:Thread -content.status:Done sort:LastModified-desc")
+        myThreadsSubscription = Hub.GetQuery("my-threads", "nodeType:Thread -content.status:Done sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content")
             .Subscribe(
                 snapshot => InvokeAsync(() =>
                 {
@@ -3127,7 +3127,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         if (string.IsNullOrEmpty(path))
             return;
         childThreadsSubscription = Hub.GetQuery($"child-threads|{path}",
-                $"namespace:{path} scope:descendants nodeType:Thread sort:LastModified-desc")
+                $"namespace:{path} scope:descendants nodeType:Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content")
             .Subscribe(
                 snapshot => InvokeAsync(() =>
                 {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs
@@ -105,7 +105,7 @@ public partial class ThreadTokenChip : ComponentBase, IDisposable
         // chip stays live; never .Take(1) (that would freeze it).
         var usage = Hub.GetQuery(
             $"tokenchip:{ThreadPath}",
-            $"path:{ThreadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children nodeType:{TokenUsageNodeType.NodeType}");
+            $"path:{ThreadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content");
         if (usage is null) return;
 
         // Live model catalog — the SAME union the picker reads (shared providers + this thread's

--- a/src/MeshWeaver.Blazor/Components/CompileProgressIndicator.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CompileProgressIndicator.razor.cs
@@ -90,7 +90,7 @@ public partial class CompileProgressIndicator : IDisposable
             // Prefer an in-flight compile; fall back to a failed one so a layout
             // area that won't load surfaces the compile error rather than a blank.
             var workspace = Hub.GetWorkspace();
-            compileObs = workspace.GetQuery("nodetypes-compiling", "nodeType:NodeType")
+            compileObs = workspace.GetQuery("nodetypes-compiling", "nodeType:NodeType select:path,id,name,nodeType,content")
                 .Select(snapshot =>
                 {
                     var node = snapshot.FirstOrDefault(n => n.ContentAs<NodeTypeDefinition>(Hub.JsonSerializerOptions) is { } d

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -1473,7 +1473,10 @@ public partial class MeshSearchView : IDisposable
     /// </summary>
     private string BuildNavBelowQuery(string root)
     {
-        var q = $"{BuildTreeLevelQuery(root)} scope:descendants";
+        // CONTENT-BEARING: the nav cards resolve their thumbnail from CONTENT properties
+        // (avatar / logo / icon — MeshNodeThumbnailControl.GetImageUrlForNode), so a
+        // projection that omits `content` would blank every card image.
+        var q = $"{BuildTreeLevelQuery(root)} scope:descendants select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content";
         if (!_includeDocuments)
             q += " -nodeType:Document";
         return Regex.Replace(q, @"\s+", " ").Trim();
@@ -1482,7 +1485,7 @@ public partial class MeshSearchView : IDisposable
     /// <summary>Above = the ancestor chain INCLUDING self, so the builder can pull out the current node
     /// and order the rail. Real ancestors only — empty namespace segments are never nodes.</summary>
     private static string BuildNavAboveQuery(string root) =>
-        $"path:{root} scope:ancestorsandself is:main";
+        $"path:{root} scope:ancestorsandself is:main select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content";
 
     /// <summary>
     /// The navigator browses the graph when the box is empty; a non-empty box switches to a

--- a/src/MeshWeaver.Courses/CourseLayoutAreas.cs
+++ b/src/MeshWeaver.Courses/CourseLayoutAreas.cs
@@ -72,12 +72,18 @@ public static class CourseLayoutAreas
         var options = hub.JsonSerializerOptions;
         var nodeStream = host.Workspace.GetMeshNodeStream();
 
+        // 🚨 CONTENT-BEARING read, and the query string MUST stay byte-identical to
+        // ModuleLayoutAreas' siblingStream — same cache id, and the synced-query cache is
+        // keyed by ID ALONE (it ignores the queries on a hit). BuildModuleCards reads
+        // ContentAs<ModuleConfiguration> off these nodes for the card summary, so `content`
+        // is projected deliberately.
         var moduleStream = hub.GetQuery(
             $"course-modules:{coursePath}",
-            $"path:{coursePath} scope:children nodeType:{ModuleNodeType.NodeType}");
+            $"path:{coursePath} scope:children nodeType:{ModuleNodeType.NodeType} select:path,id,name,order,content");
+        // Shell read: BuildProgress joins these by Path only and never reads Content.
         var exerciseStream = hub.GetQuery(
             $"course-exercises:{coursePath}",
-            $"path:{coursePath} scope:descendants nodeType:{ExerciseNodeType.NodeType}");
+            $"path:{coursePath} scope:descendants nodeType:{ExerciseNodeType.NodeType} select:path,id,name");
 
         // The viewer's attempts for THIS course live under the canonical
         // escaped root in their home partition (see AttemptPathFor). Anonymous
@@ -86,10 +92,12 @@ public static class CourseLayoutAreas
             hub.ServiceProvider.GetService<AccessService>());
         var attemptStream = viewerHome is null
             ? Observable.Return(Enumerable.Empty<MeshNode>())
+            // CONTENT-BEARING: BuildProgress reads ContentAs<ExerciseAttemptStatus> off each
+            // attempt to find the passed exercises, so `content` is projected deliberately.
             : hub.GetQuery(
                 $"course-attempts:{viewerHome}:{coursePath}",
                 $"path:{viewerHome}/{ExerciseAttemptNodeType.CoursesSubNamespace}/{PathEscaping.Escape(coursePath)} "
-                + $"scope:descendants nodeType:{ExerciseAttemptNodeType.NodeType}");
+                + $"scope:descendants nodeType:{ExerciseAttemptNodeType.NodeType} select:path,id,name,content");
 
         return nodeStream.CombineLatest(moduleStream, exerciseStream, attemptStream,
             (node, modules, exercises, attempts) =>

--- a/src/MeshWeaver.Courses/ExerciseLayoutAreas.cs
+++ b/src/MeshWeaver.Courses/ExerciseLayoutAreas.cs
@@ -114,7 +114,7 @@ public static class ExerciseLayoutAreas
         // flips existence; the node stream carries the authoritative live state
         // once the node is there.
         var attemptStream = hub
-            .GetQuery($"exercise-attempt:{resolvedAttemptPath}", $"path:{resolvedAttemptPath}")
+            .GetQuery($"exercise-attempt:{resolvedAttemptPath}", $"path:{resolvedAttemptPath} select:path")
             .Select(nodes => nodes.Any(n => n.Path == resolvedAttemptPath))
             .DistinctUntilChanged()
             .Select(exists => exists

--- a/src/MeshWeaver.Courses/ModuleLayoutAreas.cs
+++ b/src/MeshWeaver.Courses/ModuleLayoutAreas.cs
@@ -66,18 +66,30 @@ public static class ModuleLayoutAreas
         var lastSlash = modulePath.LastIndexOf('/');
         var coursePath = lastSlash > 0 ? modulePath[..lastSlash] : modulePath;
 
+        // Every child stream below is a SHELL read: BuildContent embeds each child by
+        // Path and labels it by Name/Id/Order, and never touches Content. The
+        // `select:` omits `content` so the JSONB blob is never fetched — see
+        // Doc/Architecture/CqrsAndContentAccess ("select only what you need").
         var theoryStream = hub.GetQuery(
             $"module-theory:{modulePath}",
-            $"path:{modulePath}/{ModuleNodeType.TheorySubNamespace} scope:children");
+            $"path:{modulePath}/{ModuleNodeType.TheorySubNamespace} scope:children select:path,id,name,order");
         var exampleStream = hub.GetQuery(
             $"module-examples:{modulePath}",
-            $"path:{modulePath}/{ModuleNodeType.ExampleSubNamespace} scope:children");
+            $"path:{modulePath}/{ModuleNodeType.ExampleSubNamespace} scope:children select:path,id,name,order");
         var exerciseStream = hub.GetQuery(
             $"module-exercises:{modulePath}",
-            $"path:{modulePath}/{ExerciseNodeType.ExerciseSubNamespace} scope:children nodeType:{ExerciseNodeType.NodeType}");
+            $"path:{modulePath}/{ExerciseNodeType.ExerciseSubNamespace} scope:children nodeType:{ExerciseNodeType.NodeType} select:path,id,name,order");
+        // 🚨 SHARED CACHE ID with CourseLayoutAreas' moduleStream — and the synced-query
+        // cache is keyed by ID ALONE (MeshNodeStreamCache.GetQueryRaw returns the existing
+        // entry and IGNORES the queries on a hit). So the two call sites' query strings MUST
+        // stay byte-identical: whichever subscribes first wins, and a `select:` that differs
+        // between them would silently hand the other consumer a null Content. The course
+        // overview DOES read Content off these module nodes (BuildModuleCards →
+        // ContentAs<ModuleConfiguration>), so `content` stays in the projection here even
+        // though this call site only needs the shells.
         var siblingStream = hub.GetQuery(
             $"course-modules:{coursePath}",
-            $"path:{coursePath} scope:children nodeType:{ModuleNodeType.NodeType}");
+            $"path:{coursePath} scope:children nodeType:{ModuleNodeType.NodeType} select:path,id,name,order,content");
 
         return nodeStream.CombineLatest(theoryStream, exampleStream, exerciseStream, siblingStream,
             (node, theory, examples, exercises, siblings) =>

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -167,6 +167,49 @@ await foreach (var row in mesh.QueryAsync<MeshNode>(
 
 When the projection is not enough — you actually need `Content` for a specific path (compiler input, document viewer, edit form) — fetch *that one node* through `workspace.GetMeshNodeStream(path)`. One authoritative read per path, never a subtree-wide content load.
 
+#### 🚨 On a synced query, `select:` is the switch that loads `Content` — and omitting it fails silently
+
+The advice above is written for the **untyped** query surface, where a `select:` turns each row into
+a `Dictionary<string, object>`. `workspace.GetQuery` / `hub.GetQuery` are **typed on `MeshNode`**, and
+there the projection behaves differently: the row stays a `MeshNode` (the object-level projection is
+deliberately skipped — handing a dictionary to a `MeshNode`-typed caller is what wedged every
+`select:`-carrying query on memex, 2026-08-05), but the **SQL** is still narrowed.
+
+On that path exactly one column is conditional: **`content`**. Everything else — `path`, `name`,
+`nodeType`, `icon`, `order`, `lastModified`, `version`, `state`, `mainNode` — is projected whether or
+not you name it. So on a synced query the field list is *documentation*, and the single bit that
+changes behaviour is whether `content` appears:
+
+```csharp
+// ✅ Shell read — the consumer embeds by Path and labels by Name/Order, never touches Content.
+hub.GetQuery($"course-modules:{p}",
+    $"path:{p} scope:children nodeType:Module select:path,id,name,order");
+
+// ✅ Content-bearing read — `content` named DELIBERATELY.
+hub.GetQuery($"ai-settings:{user}",
+    $"path:{path} nodeType:AiSettings select:path,id,name,nodeType,content");
+
+// ❌ Reads ContentAs<ModuleConfiguration>() but never asked for content.
+//    The adapter emits NULL::jsonb AS content; every ContentAs<T>() returns null.
+//    No error, no warning, no empty result — the card summaries are just blank.
+hub.GetQuery($"course-modules:{p}",
+    $"path:{p} scope:children nodeType:Module select:path,name");
+```
+
+**Rule.** Give every `GetQuery` an explicit `select:`. If *any* consumer of that stream reads
+`Content`, `content` must be in the list. When you cannot prove the whole downstream chain is
+content-free, leave the query unprojected — the full node is the conservative default, because a
+wrong projection fails silently while an absent one only costs bytes.
+
+**Corollary — the projection travels with the cache ID, and the ID wins.** The synced-query cache is
+keyed by **id alone**: `GetQuery(id, queries)` returns the already-registered stream and *ignores*
+`queries` on a hit. Two call sites that share an id but differ in their `select:` therefore resolve
+to whichever subscribed first — a metadata-only reader can starve a content reader of its content,
+intermittently, depending on render order. Keep the query strings byte-identical wherever an id is
+shared (the course-overview and module-page readers of `course-modules:{coursePath}` are the worked
+example), and scope ids per module — `uw-nodes-in:{ns}`, never a bare `nodes-in:{ns}` that a sibling
+module will also mint.
+
 The recompile design that this rule supports is described in [NodeTypeCompilation](/Doc/Architecture/NodeTypeCompilation) — the NodeType keeps a `{sourcePath → version}` snapshot from the synced query, and a divergent emission triggers re-fetch and recompile. Nothing in the catalog row's `Content` is consulted.
 
 ### 🚨 Staleness lives on the owner — never query to check "is this stale?"

--- a/src/MeshWeaver.Documentation/Data/Architecture/SyncedMeshNodeQueries.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SyncedMeshNodeQueries.md
@@ -189,11 +189,62 @@ ReferenceEquals(first, second).Should().BeTrue();
 
 **Pick stable ids** — `$"chat-picker:{contextPath}"`, not `Guid.NewGuid()`. Reusing the same id across re-mounts means the upstream subscription (and the provider Initial wave) is reused rather than cycled on every component re-render. A fresh Guid on every call forfeits this entirely.
 
+### 🚨 The id is the ONLY key — `queries` are ignored on a cache hit
+
+`GetQuery(id, queries)` is get-**or**-create. On a hit it returns the registered stream and never
+looks at `queries`:
+
+```csharp
+var current = _queries;
+if (current.TryGetValue(id, out var existing))
+    return existing;          // ← queries not consulted
+```
+
+So two call sites that share an id but pass **different** query strings do not get two collections,
+and they do not get an error: they both get whichever one subscribed first. Whether that is the
+right set is decided by render order, which is why the symptom is intermittent.
+
+The sharp edge is the `select:` projection (below). A metadata-only reader that registers
+`select:path,name` first will hand a *content-reading* consumer of the same id a snapshot whose
+`Content` is null — the content reader then renders empty, on some loads and not others.
+
+- Where an id is genuinely shared, keep the query strings **byte-identical** and project for the
+  most demanding consumer. `course-modules:{coursePath}` — read by both the course overview
+  (needs `content` for card summaries) and the module page (needs shells only) — is the worked
+  example: both sites carry `select:path,id,name,order,content`.
+- Otherwise **scope the id** so unrelated readers cannot collide. The cache is process-wide, so a
+  bare `nodes-in:{ns}` minted by two different modules is one entry, not two: prefix it
+  (`uw-nodes-in:{ns}`, `claims-nodes-in:{ns}`).
+
 ---
 
 ## Typed content
 
 If your nodes carry typed content (`AgentConfiguration`, `ModelDefinition`, etc.), make sure the type is registered in the hub's `TypeRegistry`. The synced query deserialises `MeshNode.Content` using the hub's `JsonSerializerOptions`. A missing TypeRegistry entry means `Content` arrives as a raw `JsonElement`, your `is T` casts fail silently, and the collection appears empty even though the snapshot has items.
+
+### 🚨 …and `select:` decides whether `Content` is fetched at all
+
+A registered `TypeRegistry` entry is necessary but not sufficient: the projection has to ask for the
+column. A synced query runs `Query<MeshNode>`, where a `select:` narrows the **SQL** but leaves the
+row a `MeshNode`. Exactly one column is conditional — `content`. Leave it out of a `select:` and the
+adapter emits `NULL::jsonb AS content`; the node arrives fully formed with `Content == null`, and
+every `ContentAs<T>()` returns null with no error and no empty result.
+
+That is the *same observable symptom* as the missing-TypeRegistry bug above — "the collection
+appears empty even though the snapshot has items" — from a completely different cause. When you
+debug it, check the projection before the registry: it is the cheaper of the two to rule out.
+
+```csharp
+// metadata-only  → content deliberately not loaded
+$"namespace:{ns} nodeType:Module select:path,id,name,order"
+// content-bearing → `content` named deliberately
+$"namespace:{ns} nodeType:Module select:path,id,name,order,content"
+// unproven consumer chain → no select: at all (full node, the conservative default)
+$"namespace:{ns} nodeType:Module"
+```
+
+See [CqrsAndContentAccess](/Doc/Architecture/CqrsAndContentAccess) → "On a synced query, `select:`
+is the switch that loads `Content`" for the full rule.
 
 See [AddingANewNodeType](/Doc/Architecture/AddingANewNodeType) → step 4 for the wiring.
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/QuerySyntax.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/QuerySyntax.md
@@ -361,7 +361,7 @@ namespace:ACME scope:descendants context:search       # Searchable nodes under A
 
 ### `select`
 
-Projects results to include only the specified properties. Returns lightweight dictionaries instead of full nodes — ideal for autocomplete, dropdowns, and large-result queries where only a few fields are needed.
+Projects results to include only the specified properties — ideal for autocomplete, dropdowns, and large-result queries where only a few fields are needed.
 
 ```
 select:name                      # Single property
@@ -374,6 +374,47 @@ nodeType:Story select:path,name sort:name limit:10
 ```
 
 > **Always `select:` only the fields the consumer reads.** Existence checks and "is-this-up-to-date?" polls need only `(path, version)`, never the full node. Loading full `Content` for a subtree is the antipattern this qualifier eliminates.
+
+#### 🚨 `select:` decides whether `Content` is loaded at all
+
+The projection has **two different shapes** depending on what the caller is typed on, and the
+difference is invisible at the call site:
+
+| Caller | What a `select:` does |
+|---|---|
+| **untyped** (`Query<object>`, the MCP `search` tool) | each row becomes a `Dictionary<string, object>` of exactly the named fields |
+| **typed on `MeshNode`** (`Query<MeshNode>`, and therefore **every `workspace.GetQuery` / `hub.GetQuery`**) | the row stays a **`MeshNode`** — no dictionary — but the SQL projection is still narrowed |
+
+On the typed path only ONE column is actually conditional: **`content`**. Every other field is
+projected regardless, so naming them is documentation rather than optimisation. But when `content`
+is *not* named, the storage adapter emits `NULL::jsonb AS content` (Postgres) or omits the field
+(Cosmos), and you get a fully-formed `MeshNode` whose **`Content` is silently null**.
+
+That failure is indistinguishable from "this node has no content": no error, no warning, no empty
+result set — every `node.Content is T` / `ContentAs<T>()` downstream just returns null and the
+surface renders empty. It is the same silent-null class as a missing `TypeRegistry` entry.
+
+```
+# ✅ metadata-only consumer — content deliberately not loaded
+namespace:Course/Intro scope:children nodeType:Module select:path,id,name,order
+
+# ✅ content-bearing consumer — `content` named DELIBERATELY
+path:{user}/_Memex/AiSettings nodeType:AiSettings select:path,id,name,nodeType,content
+
+# ❌ reads ContentAs<ModuleConfiguration>() but never asked for content — always null
+namespace:Course/Intro scope:children nodeType:Module select:path,name
+```
+
+**Rule.** Every `GetQuery` should carry a `select:`. If any consumer of that stream reads
+`Content`, `content` must be in the list. When you cannot prove the whole consumer chain is
+content-free, leave the query unprojected — the full node is the conservative default.
+
+> **🚨 The projection travels with the cache ID, and the ID wins.** The synced-query cache is keyed
+> by **id alone**: `GetQuery(id, queries)` returns the already-registered stream and *ignores* the
+> queries on a cache hit. Two call sites that share an id but differ in their `select:` therefore
+> resolve to whichever subscribed first — so a metadata-only reader can starve a content reader of
+> its content, intermittently, depending on render order. Keep the query strings byte-identical
+> wherever an id is shared, and scope ids per module so unrelated readers never collide.
 
 ---
 

--- a/src/MeshWeaver.GitSync/GitHubCredentialService.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredentialService.cs
@@ -93,7 +93,7 @@ public sealed class GitHubCredentialService(IMeshService meshService, IMessageHu
 
         var path = CredentialPath(userId);
         return hub.GetWorkspace()
-            .GetQuery($"github-cred:{userId}", $"path:{path}")
+            .GetQuery($"github-cred:{userId}", $"path:{path} select:path,id,name,nodeType,content")
             .Select(nodes =>
             {
                 var node = nodes?.FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -381,22 +381,6 @@ public sealed class GitHubSyncService
                 return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath,
                         SyncIgnore.For(config), progress, policy,
                         baseSha: force ? null : config.LastSyncCommitSha)
-                    // 🚨 RECOMPILE WHAT THE SYNC CHANGED — part of the sync transaction, not a
-                    // follow-up human step. Importing new Source/Code nodes and walking away leaves
-                    // every affected NodeType serving its STALE assembly (the "assembly is the
-                    // deliverable" failure the AGENTS.md deploy procedure hand-patched; paid again
-                    // 2026-08-03/04). The set derives from what actually LANDED (written + pruned
-                    // node paths — an unchanged/content-only sync releases nothing) and covers the
-                    // owning types AND every shared=@ sharer, mesh-wide; releases are requested
-                    // under SYSTEM, consistent with how the import's own writes land, and the set
-                    // is logged onto the sync's activity via `progress`.
-                    .SelectMany(x =>
-                    {
-                        var changed = x.Result.WrittenPaths.AddRange(x.Result.PrunedPaths);
-                        return changed.Count == 0
-                            ? Observable.Return(x)
-                            : hub.ReleaseAffectedNodeTypes(changed, progress).Select(_ => x);
-                    })
                     // 🚨 Only advance the last-sync baseline when the mesh is now IN SYNC with the repo.
                     // A two-way import that PRESERVED server-newer nodes leaves the mesh AHEAD of the repo
                     // (those edits aren't committed back yet); advancing LastSyncedAt would move the
@@ -627,7 +611,7 @@ public sealed class GitHubSyncService
     {
         var path = ConfigPath(spacePath, sourceId);
         return hub.GetWorkspace()
-            .GetQuery($"gitsync-cfg:{path}", $"path:{path}")
+            .GetQuery($"gitsync-cfg:{path}", $"path:{path} select:path,id,name,nodeType,content")
             .Select(nodes => nodes?.FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)));
     }
 
@@ -642,7 +626,7 @@ public sealed class GitHubSyncService
     {
         var primaryPath = ConfigPath(spacePath);
         var children = hub.GetWorkspace()
-            .GetQuery($"gitsync-cfgs:{spacePath}", $"namespace:{primaryPath} nodeType:{ConfigNodeType}")
+            .GetQuery($"gitsync-cfgs:{spacePath}", $"namespace:{primaryPath} nodeType:{ConfigNodeType} select:path,id,namespace,name,nodeType,content")
             .Select(nodes => (nodes ?? [])
                 .Where(n => string.Equals(n.Namespace, primaryPath, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -381,6 +381,22 @@ public sealed class GitHubSyncService
                 return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath,
                         SyncIgnore.For(config), progress, policy,
                         baseSha: force ? null : config.LastSyncCommitSha)
+                    // 🚨 RECOMPILE WHAT THE SYNC CHANGED — part of the sync transaction, not a
+                    // follow-up human step. Importing new Source/Code nodes and walking away leaves
+                    // every affected NodeType serving its STALE assembly (the "assembly is the
+                    // deliverable" failure the AGENTS.md deploy procedure hand-patched; paid again
+                    // 2026-08-03/04). The set derives from what actually LANDED (written + pruned
+                    // node paths — an unchanged/content-only sync releases nothing) and covers the
+                    // owning types AND every shared=@ sharer, mesh-wide; releases are requested
+                    // under SYSTEM, consistent with how the import's own writes land, and the set
+                    // is logged onto the sync's activity via `progress`.
+                    .SelectMany(x =>
+                    {
+                        var changed = x.Result.WrittenPaths.AddRange(x.Result.PrunedPaths);
+                        return changed.Count == 0
+                            ? Observable.Return(x)
+                            : hub.ReleaseAffectedNodeTypes(changed, progress).Select(_ => x);
+                    })
                     // 🚨 Only advance the last-sync baseline when the mesh is now IN SYNC with the repo.
                     // A two-way import that PRESERVED server-newer nodes leaves the mesh AHEAD of the repo
                     // (those edits aren't committed back yet); advancing LastSyncedAt would move the

--- a/src/MeshWeaver.GitSync/IssueService.cs
+++ b/src/MeshWeaver.GitSync/IssueService.cs
@@ -155,7 +155,7 @@ public sealed class IssueService
     public IObservable<IReadOnlyList<MeshNode>> WatchIssueNodes(string spacePath) =>
         hub.GetWorkspace()
             .GetQuery($"gh-issues:{spacePath}",
-                $"path:{IssueNamespace(spacePath)} scope:children nodeType:{NodeType}")
+                $"path:{IssueNamespace(spacePath)} scope:children nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Select(nodes => (IReadOnlyList<MeshNode>)(nodes?.ToList() ?? new List<MeshNode>()));
 
     /// <summary>Live content of one issue node (or null when absent) — the authoritative single-node stream.</summary>

--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -132,7 +132,7 @@ public static class CommentLayoutAreas
         return Observable.Using(
             () => host.Workspace.GetQuery(
                     $"replies:{hubPath}",
-                    $"namespace:{hubPath} nodeType:{CommentNodeType.NodeType}")
+                    $"namespace:{hubPath} nodeType:{CommentNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
                 .Subscribe(
                     snapshot =>
                     {

--- a/src/MeshWeaver.Graph/CommentsExtensions.cs
+++ b/src/MeshWeaver.Graph/CommentsExtensions.cs
@@ -235,7 +235,7 @@ public static class CommentsView
         return Observable.Using(
             () => host.Workspace.GetQuery(
                     $"comments:{nodePath}",
-                    $"namespace:{nodePath}/{CommentsExtensions.CommentPartition} nodeType:{CommentNodeType.NodeType}")
+                    $"namespace:{nodePath}/{CommentsExtensions.CommentPartition} nodeType:{CommentNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
                 .Subscribe(
                     snapshot =>
                     {

--- a/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
@@ -103,7 +103,7 @@ public static class HomeConfigNodeType
     /// <summary>Reads the config at an explicit path (defaults to <see cref="ConfigPath"/>); used by tests.</summary>
     internal static IObservable<HomeConfig> Observe(IWorkspace workspace, JsonSerializerOptions options, string configPath) =>
         workspace
-            .GetQuery($"home-config:{configPath}", $"path:{configPath} nodeType:{NodeType}")
+            .GetQuery($"home-config:{configPath}", $"path:{configPath} nodeType:{NodeType} select:path,id,namespace,name,nodeType,content")
             .Select(nodes => Effective(
                 nodes.FirstOrDefault(n => string.Equals(n.NodeType, NodeType, System.StringComparison.OrdinalIgnoreCase)),
                 options))

--- a/src/MeshWeaver.Graph/Configuration/NodeSources.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeSources.cs
@@ -60,6 +60,12 @@ public static class NodeSources
             return Observable.Return<IReadOnlyList<MeshNode>>(Array.Empty<MeshNode>());
 
         var id = CacheId(nodeTypePath);
+        // NO `select:` — deliberately. These are the NodeType's COMPILE INPUTS: the caller
+        // reads each Code node's Content to feed the compiler, so the content blob is the
+        // whole point of the read. A projection omitting `content` would make the adapter
+        // emit NULL::jsonb AS content and the type would compile against empty sources with
+        // no error anywhere. The queries are also caller-authored (NodeTypeDefinition.Sources
+        // / .Tests via CodeQueryResolver), so the projection is not ours to pick.
         return workspace.GetQuery(id, queries)
             .Select(items => (IReadOnlyList<MeshNode>)items.ToList());
     }

--- a/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
@@ -69,7 +69,7 @@ public static class NotificationSettingsNodeType
         };
 
         return hub.GetWorkspace()
-            .GetQuery($"{NodeType}|{path}", $"path:{path} nodeType:{NodeType}")
+            .GetQuery($"{NodeType}|{path}", $"path:{path} nodeType:{NodeType} select:path,id,namespace,name,nodeType,content")
             .Take(1)
             .SelectMany(nodes =>
             {

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -94,7 +94,7 @@ public sealed class EventSubscriptionRunner(
         // Live snapshot of outstanding subscriptions; re-emits on add / fire / cancel. Reading the Admin
         // partition needs an identity → system. (Constant query id: one registry entry, no leak.)
         pendingSub = AsSystem(() => hub.GetWorkspace().GetQuery("event-subscriptions",
-                $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType}"))
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content"))
             .Subscribe(nodes =>
             {
                 var list = (nodes ?? [])
@@ -454,7 +454,7 @@ public sealed class EventSubscriptionRunner(
     private void MigrateLegacyScheduledActions()
     {
         legacySub = AsSystem(() => hub.GetWorkspace().GetQuery("event-subscriptions-legacy",
-                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType}"))
+                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType} select:path,id,namespace,name,nodeType,content"))
             .Subscribe(nodes =>
             {
                 foreach (var node in nodes ?? [])

--- a/src/MeshWeaver.Graph/GroupLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/GroupLayoutAreas.cs
@@ -63,7 +63,7 @@ public static class GroupLayoutAreas
 
         var membersStream = host.Workspace.GetQuery(
             $"group-members:{hubPath}",
-            $"namespace:{hubPath} nodeType:GroupMembership");
+            $"namespace:{hubPath} nodeType:GroupMembership select:path,id,namespace,name,nodeType,content");
 
         return nodeStream.CombineLatest(membersStream, (nodes, members) =>
         {
@@ -121,7 +121,7 @@ public static class GroupLayoutAreas
 
         var membersStream = host.Workspace.GetQuery(
             $"group-members-edit:{hubPath}",
-            $"namespace:{hubPath} nodeType:GroupMembership");
+            $"namespace:{hubPath} nodeType:GroupMembership select:path,id,namespace,name,nodeType,content");
 
         return nodeStream.CombineLatest(membersStream, (nodes, members) =>
         {

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -251,7 +251,7 @@ public static class MeshNodeExtensions
         var pipeline = Observable.Using(
             Impersonate,
             _ => workspace
-            .GetQuery($"UserActivity|{activityPath}", $"path:{activityPath} nodeType:UserActivity")
+            .GetQuery($"UserActivity|{activityPath}", $"path:{activityPath} nodeType:UserActivity select:path,id,namespace,name,nodeType,content")
             .Take(1)
             .Select(nodes => nodes.FirstOrDefault(n =>
                 string.Equals(n.NodeType, "UserActivity", StringComparison.OrdinalIgnoreCase)))

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -412,6 +412,10 @@ public static class NodeTypeLayoutAreas
         // hangs forever, so the Shell's side-menu CombineLatest never completes and the NodeType GUI
         // shell never renders (the FutuRe/LineOfBusiness 50s render deadlock). GetQuery emits
         // empty-on-absent and re-emits on change, so the menu always renders.
+        // NO `select:` — the query is CALLER-SUPPLIED (a NodeType's own Sources/Tests
+        // query) and the cache id IS that string, so the projection belongs to whoever
+        // authored the query, not here. Leaving it unprojected keeps the full node,
+        // which is the conservative choice at an open seam.
         return host.Workspace.GetQuery(query, query)
             .Select(nodes => (IReadOnlyList<MeshNode>)nodes.ToList())
             .Catch<IReadOnlyList<MeshNode>, Exception>(ex =>
@@ -821,6 +825,8 @@ public static class NodeTypeLayoutAreas
         if (queryList.Count == 0)
             return Observable.Return<IReadOnlyList<MeshNode>>(Array.Empty<MeshNode>());
 
+        // NO `select:` — caller-supplied queries again (the code-tree group), and the id is
+        // derived from them; see QueryNodesStream above for the same reasoning.
         return host.Workspace.GetQuery("codegroup:" + string.Join("|", queryList), queryList.ToArray())
             .Select(nodes =>
             {

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -143,7 +143,7 @@ public static class NotificationService
         var path = NotificationSettingsPaths.PathFor(recipient);
         return hub.GetWorkspace()
             .GetQuery($"{NotificationSettingsNodeType.NodeType}|{path}",
-                $"path:{path} nodeType:{NotificationSettingsNodeType.NodeType}")
+                $"path:{path} nodeType:{NotificationSettingsNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
             .Take(1)
             .Select(nodes => nodes
                 .Select(n => n.ContentAs<NotificationSettings>(hub.JsonSerializerOptions))

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -200,7 +200,8 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
     private IObservable<IReadOnlyList<object>> RunQueryNodes(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        bool useSecurityFilter)
+        bool useSecurityFilter,
+        bool projectSelect = false)
         => CollectMatched(request, options, useSecurityFilter)
             .Select(collected =>
             {
@@ -273,10 +274,25 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                         _evaluator.GetFuzzyScore(n, parsedQuery.TextSearch));
                 }
 
+                // 🚨 NEVER hand a projection to a caller typed on MeshNode. ProjectToSelect returns a
+                // Dictionary<string, object> — the UNTYPED surface's contract — and the generic consumer
+                // below filters with `item is T`, so with T = MeshNode every projected row is silently
+                // DROPPED: a query that matches returns the EMPTY set, forever, with no error and no log
+                // line. The synced query then caches that empty snapshot in its Replay(1) and every
+                // consumer of the id sees "no results" for data that is present.
+                //
+                // This is the in-memory twin of the Postgres wedge fixed on 2026-08-05
+                // (PostgreSqlMeshQuery.CollectQueryResultsAsync / MeshQuery.ProjectSelect carry the same
+                // guard and the same comment). That fix never reached this provider, so every
+                // `select:`-carrying workspace.GetQuery / hub.GetQuery — which is Query<MeshNode> — came
+                // back empty on the in-memory adapter while working fine on PG.
+                //
+                // The row-level SELECT still narrows what the adapter loads, so a projected read costs
+                // only what it asked for; the node simply stays a node for the caller that asked for nodes.
                 IEnumerable<object> projected = sorted.Select(node =>
-                    parsedQuery.Select != null
+                    projectSelect && parsedQuery.Select != null
                         ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
-                        : node);
+                        : DropUnprojectedContent(node, parsedQuery));
 
                 // Load cap = (Skip ?? 0) + Limit. request.Skip itself is applied
                 // POST-MERGE in ClipMergedInitial (applying it here too would
@@ -288,6 +304,39 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
 
                 return (IReadOnlyList<object>)projected.ToList();
             });
+
+
+    /// <summary>
+    /// Mirrors the SQL adapters' content projection for the in-memory store: when a
+    /// <c>select:</c> is present but does NOT name <c>content</c>, blank
+    /// <see cref="MeshNode.Content"/> — the same shape Postgres produces with
+    /// <c>NULL::jsonb AS content</c> (<c>PostgreSqlSqlGenerator.GenerateSelectQuery</c>), Cosmos
+    /// with its explicit field list, and Snowflake with <c>NULL::variant</c>.
+    ///
+    /// <para>🚨 This exists for PARITY, and the parity matters more than the (nonexistent)
+    /// in-memory saving. Without it the in-memory adapter is the ONLY provider that keeps content
+    /// on an unprojected read, so the single nastiest projection defect — a content-reading
+    /// consumer whose <c>select:</c> forgot <c>content</c>, which silently yields
+    /// <c>Content == null</c> and renders empty — is GREEN in every test and only reproduces on a
+    /// real mesh. A test store that cannot express the production failure mode is how that class
+    /// of bug ships. See <c>SyncedQueryProjectionContractTest</c> and
+    /// Doc/Architecture/CqrsAndContentAccess.</para>
+    ///
+    /// <para>Only <c>content</c> is conditional: every other MeshNode field is returned regardless
+    /// of the select list, exactly as the SQL generators project every other column
+    /// unconditionally.</para>
+    /// </summary>
+    private static object DropUnprojectedContent(object node, ParsedQuery parsedQuery)
+    {
+        if (parsedQuery.Select is not { Count: > 0 } select)
+            return node;
+        if (node is not MeshNode meshNode || meshNode.Content is null)
+            return node;
+        foreach (var field in select)
+            if (field.Equals("content", StringComparison.OrdinalIgnoreCase))
+                return node;
+        return meshNode with { Content = null };
+    }
 
     /// <summary>
     /// True when the query explicitly TARGETS satellite nodes — a <c>_</c>-prefixed path segment,
@@ -1167,7 +1216,8 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
             // hub pump and deadlocked under bulk fan-out. useSecurityFilter selects the
             // RLS-filtered (IMeshQueryProvider) vs raw (IMeshQueryCore) read.
             IObservable<List<(string? Path, T Item)>> RunQuery() =>
-                RunQueryNodes(request, options, useSecurityFilter)
+                RunQueryNodes(request, options, useSecurityFilter,
+                        projectSelect: typeof(T) != typeof(MeshNode))
                     .Select(nodes =>
                     {
                         var results = new List<(string?, T)>();

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -60,7 +60,7 @@ public sealed class InstanceSyncService(
     {
         var ns = ConfigNamespace(spacePath);
         return hub.GetWorkspace()
-            .GetQuery($"instsync-cfgs:{spacePath}", $"namespace:{ns} nodeType:{ConfigNodeType}")
+            .GetQuery($"instsync-cfgs:{spacePath}", $"namespace:{ns} nodeType:{ConfigNodeType} select:path,id,namespace,name,nodeType,content")
             .Select(nodes => (IReadOnlyList<MeshNode>)(nodes ?? [])
                 .Where(n => string.Equals(n.Namespace, ns, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
@@ -72,7 +72,7 @@ public sealed class InstanceSyncService(
     {
         var path = ConfigPath(spacePath, sourceId);
         return hub.GetWorkspace()
-            .GetQuery($"instsync-cfg:{path}", $"path:{path}")
+            .GetQuery($"instsync-cfg:{path}", $"path:{path} select:path,id,name,nodeType,content")
             .Select(nodes => nodes?.FirstOrDefault(n =>
                 string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)));
     }

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -783,7 +783,7 @@ public sealed class MauiCollaborativeMarkdownView : MauiView<CollaborativeMarkdo
         }
 
         _root.Children.Add(panel);
-        var sub = Stream.Hub.GetQuery("comments:" + Model.NodePath, $"namespace:{Model.NodePath}/_Comment nodeType:Comment")
+        var sub = Stream.Hub.GetQuery("comments:" + Model.NodePath, $"namespace:{Model.NodePath}/_Comment nodeType:Comment select:path,id,namespace,name,nodeType,content")
             .Subscribe(nodes => MainThread.BeginInvokeOnMainThread(() => RenderComments(list, nodes)));
         Disposables.Add(sub);
     }
@@ -863,7 +863,7 @@ public sealed class MauiCollaborativeMarkdownView : MauiView<CollaborativeMarkdo
         _root.Children.Add(panel);
         // Live: re-render on every query emission (accept/reject of a satellite re-fires this) — no Take(1),
         // which would freeze the panel after the first snapshot.
-        var sub = Stream.Hub.GetQuery("changes:" + Model.NodePath, $"namespace:{Model.NodePath}/_Tracking nodeType:TrackedChange")
+        var sub = Stream.Hub.GetQuery("changes:" + Model.NodePath, $"namespace:{Model.NodePath}/_Tracking nodeType:TrackedChange select:path,id,namespace,name,nodeType,content")
             .Subscribe(nodes => MainThread.BeginInvokeOnMainThread(() => RenderTrackedChanges(panel, nodes)));
         Disposables.Add(sub);
     }

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -614,8 +614,8 @@ internal static class PermissionEvaluator
         var isAdminScope = key == AdminScope
             || key.StartsWith(AdminScope + "/", StringComparison.Ordinal);
         var selfFilter = isAdminScope
-            ? $"path:{nsQuery} scope:children nodeType:{SecurityCollections.AccessAssignmentNodeType}"
-            : $"namespace:{nsQuery} nodeType:{SecurityCollections.AccessAssignmentNodeType}";
+            ? $"path:{nsQuery} scope:children nodeType:{SecurityCollections.AccessAssignmentNodeType} select:path,id,namespace,name,nodeType,content"
+            : $"namespace:{nsQuery} nodeType:{SecurityCollections.AccessAssignmentNodeType} select:path,id,namespace,name,nodeType,content";
 
         // Self: narrow per-scope query against the singleton cache. Each
         // scope's stream is cached PROCESS-WIDE under the key
@@ -649,7 +649,7 @@ internal static class PermissionEvaluator
         var self = cache.GetQuery(
             $"$security-policy:{key}",
             hub.JsonSerializerOptions,
-            $"{nsFilter} nodeType:{SecurityCollections.PartitionAccessPolicyNodeType}");
+            $"{nsFilter} nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} select:path,id,namespace,name,nodeType,content");
 
         IObservable<ImmutableDictionary<string, PartitionAccessPolicy>> parentOrBase;
         if (string.IsNullOrEmpty(key))
@@ -685,7 +685,7 @@ internal static class PermissionEvaluator
     private static IObservable<MeshNode[]> ObserveAllRoleNodes(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-        return cache.GetQuery(RoleQueryId, hub.JsonSerializerOptions, $"nodeType:{RoleNodeType} scope:subtree")
+        return cache.GetQuery(RoleQueryId, hub.JsonSerializerOptions, $"nodeType:{RoleNodeType} scope:subtree select:path,id,namespace,name,nodeType,content")
             .Select(arr => arr.ToArray());
     }
 
@@ -698,7 +698,7 @@ internal static class PermissionEvaluator
     {
         var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
         return cache.GetQuery(MembershipQueryId, hub.JsonSerializerOptions,
-            $"nodeType:{GroupMembershipNodeType} scope:subtree");
+            $"nodeType:{GroupMembershipNodeType} scope:subtree select:path,id,namespace,name,nodeType,content");
     }
 
     #endregion

--- a/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
@@ -18,11 +18,17 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class AgentPickerQueriesTest
 {
+    /// <summary>The projection every registry query carries — referenced from the
+    /// production constant so these expectations can never drift from it. Asserting it
+    /// here is the point: a registry query that stops projecting `content` yields nodes
+    /// whose Content is silently null, which reads as an empty picker.</summary>
+    private const string Proj = AgentPickerProjection.RegistryProjection;
+
     // ─── BuildAgentQuery: the SINGLE canonical agent-registry query ───
     // Agents live in a dedicated /Agent sub-namespace PER PARTITION; the query lists the platform
     // default + the current space's + the user's DIRECTLY (exact membership, no graph search).
 
-    private const string BuiltInAgentQuery = "namespace:Agent nodeType:Agent";
+    private const string BuiltInAgentQuery = "namespace:Agent nodeType:Agent" + Proj;
 
     [Fact]
     public void BuildAgentQuery_UserAndSpace_ListsBothPartitionsPlusPlatform()
@@ -30,7 +36,7 @@ public class AgentPickerQueriesTest
         var query = AgentPickerProjection.BuildAgentQuery(userPath: "rbuergi", spacePath: "AgenticPension");
 
         query.Should().Be(
-            "namespace:rbuergi/Agent|AgenticPension/Agent|Agent nodeType:Agent",
+            "namespace:rbuergi/Agent|AgenticPension/Agent|Agent nodeType:Agent" + Proj,
             "ONE mesh-node search lists the user's, the space's and the platform /Agent namespaces "
             + "directly — exact membership, no ancestor/graph walk.");
         AgentPickerProjection.BuildAgentQueries("rbuergi", "AgenticPension")
@@ -41,14 +47,14 @@ public class AgentPickerQueriesTest
     public void BuildAgentQuery_OnlyUser_ListsUserPlusPlatform()
     {
         AgentPickerProjection.BuildAgentQuery(userPath: "rbuergi")
-            .Should().Be("namespace:rbuergi/Agent|Agent nodeType:Agent");
+            .Should().Be("namespace:rbuergi/Agent|Agent nodeType:Agent" + Proj);
     }
 
     [Fact]
     public void BuildAgentQuery_OnlySpace_ListsSpacePlusPlatform()
     {
         AgentPickerProjection.BuildAgentQuery(spacePath: "AgenticPension")
-            .Should().Be("namespace:AgenticPension/Agent|Agent nodeType:Agent");
+            .Should().Be("namespace:AgenticPension/Agent|Agent nodeType:Agent" + Proj);
     }
 
     [Fact]
@@ -65,7 +71,7 @@ public class AgentPickerQueriesTest
     {
         // When the user IS the space partition (a user's own space), the /Agent namespace isn't doubled.
         AgentPickerProjection.BuildAgentQuery(userPath: "rbuergi", spacePath: "rbuergi")
-            .Should().Be("namespace:rbuergi/Agent|Agent nodeType:Agent");
+            .Should().Be("namespace:rbuergi/Agent|Agent nodeType:Agent" + Proj);
     }
 
     [Fact]
@@ -74,7 +80,7 @@ public class AgentPickerQueriesTest
         // The conversational combobox (bound directly to the query, no projection filter) drops
         // generator/utility agents at the query level; the engine callers leave it false.
         AgentPickerProjection.BuildAgentQuery(spacePath: "AgenticPension", excludeUtility: true)
-            .Should().Be("namespace:AgenticPension/Agent|Agent nodeType:Agent -content.modelTier:utility");
+            .Should().Be("namespace:AgenticPension/Agent|Agent nodeType:Agent -content.modelTier:utility" + Proj);
     }
 
     [Fact]
@@ -111,7 +117,7 @@ public class AgentPickerQueriesTest
 
         // The space partition derived from the resolved context drives the per-partition /Agent query.
         AgentPickerProjection.BuildAgentQuery(spacePath: AgentPickerProjection.PartitionOf(pc.ContextPath))
-            .Should().Be("namespace:ACME/Agent|Agent nodeType:Agent");
+            .Should().Be("namespace:ACME/Agent|Agent nodeType:Agent" + Proj);
     }
 
     [Fact]
@@ -138,7 +144,7 @@ public class AgentPickerQueriesTest
 
         // Context present ⇒ the space's /Agent namespace + the platform default.
         AgentPickerProjection.BuildAgentQuery(spacePath: AgentPickerProjection.PartitionOf(pc.ContextPath))
-            .Should().Be("namespace:ACME/Agent|Agent nodeType:Agent");
+            .Should().Be("namespace:ACME/Agent|Agent nodeType:Agent" + Proj);
     }
 
     [Fact]
@@ -170,7 +176,7 @@ public class AgentPickerQueriesTest
     {
         var queries = AgentPickerProjection.BuildModelQueries();
         queries.Should().ContainSingle()
-            .Which.Should().Be("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants");
+            .Which.Should().Be("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
     }
 
     [Fact]
@@ -188,10 +194,10 @@ public class AgentPickerQueriesTest
             selectedProviderPaths: new[] { "acme/Provider/Anthropic", "rbuergi/Provider/OpenAI" });
 
         // Root catalog query is always present.
-        queries.Should().Contain("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants");
+        queries.Should().Contain("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
         // One selfAndDescendants query per selected provider path (provider node + its models).
-        queries.Should().Contain("namespace:acme/Provider/Anthropic nodeType:LanguageModel|ModelProvider scope:selfAndDescendants");
-        queries.Should().Contain("namespace:rbuergi/Provider/OpenAI nodeType:LanguageModel|ModelProvider scope:selfAndDescendants");
+        queries.Should().Contain("namespace:acme/Provider/Anthropic nodeType:LanguageModel|ModelProvider scope:selfAndDescendants" + Proj);
+        queries.Should().Contain("namespace:rbuergi/Provider/OpenAI nodeType:LanguageModel|ModelProvider scope:selfAndDescendants" + Proj);
     }
 
     [Fact]
@@ -203,7 +209,7 @@ public class AgentPickerQueriesTest
         var queries = AgentPickerProjection.BuildModelQueries(currentPath: "login", nodeTypePath: "welcome");
 
         queries.Should().ContainSingle("a reserved currentPath/nodeTypePath is skipped — only the platform catalog remains")
-            .Which.Should().Be("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants");
+            .Which.Should().Be("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
     }
 
     [Fact]
@@ -211,7 +217,7 @@ public class AgentPickerQueriesTest
     {
         // A real (non-reserved) context partition still contributes its /Provider namespace.
         var queries = AgentPickerProjection.BuildModelQueries(currentPath: "AgenticPension");
-        queries.Should().Contain("namespace:AgenticPension/Provider nodeType:LanguageModel|ModelProvider scope:descendants");
+        queries.Should().Contain("namespace:AgenticPension/Provider nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
     }
 
     [Fact]
@@ -243,8 +249,8 @@ public class AgentPickerQueriesTest
         // descendants query over it so they appear alongside the catalog.
         var queries = AgentPickerProjection.BuildModelQueries(userPath: "rbuergi");
 
-        queries.Should().Contain("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants");
-        queries.Should().Contain($"namespace:{ModelProviderNodeType.UserNamespacePath("rbuergi")} nodeType:LanguageModel|ModelProvider scope:descendants");
+        queries.Should().Contain("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
+        queries.Should().Contain($"namespace:{ModelProviderNodeType.UserNamespacePath("rbuergi")} nodeType:LanguageModel|ModelProvider scope:descendants" + Proj);
         queries.Should().HaveCount(2); // root + user _Memex
     }
 
@@ -265,18 +271,18 @@ public class AgentPickerQueriesTest
     public void BuildSkillQuery_UserAndSpace_ListsBothPartitionsPlusPlatform()
     {
         AgentPickerProjection.BuildSkillQuery(userPath: "rbuergi", spacePath: "AgenticPension")
-            .Should().Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill",
+            .Should().Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill" + Proj,
                 "skills use the SAME per-partition inheritance as agents/models — the user's, the "
                 + "space's and the platform /Skill namespaces, listed directly.");
         AgentPickerProjection.BuildSkillQueries("rbuergi", "AgenticPension")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill");
+            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
     public void BuildSkillQuery_NeitherSet_PlatformDefaultsOnly()
     {
-        AgentPickerProjection.BuildSkillQuery().Should().Be("namespace:Skill nodeType:Skill");
+        AgentPickerProjection.BuildSkillQuery().Should().Be("namespace:Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
@@ -286,7 +292,7 @@ public class AgentPickerQueriesTest
         // skills; including it would fail the WHOLE query with "lacks Read permission". It must be
         // filtered — the user's home is kept, the reserved space dropped.
         AgentPickerProjection.BuildSkillQuery(userPath: "rbuergi", spacePath: "login")
-            .Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill");
+            .Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
@@ -296,7 +302,7 @@ public class AgentPickerQueriesTest
         // the space partition is derived from the context path's first segment.
         SkillNodeType.SkillQueries("AgenticPension/Foo/_Thread/x", "rbuergi")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill");
+            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill" + Proj);
     }
 
     // ─── SkillAutocompleteProvider.BuildQueries: pins the FIX ───
@@ -311,7 +317,7 @@ public class AgentPickerQueriesTest
 
         SkillAutocompleteProvider.BuildQueries(access, "AgenticPension/Foo")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill",
+            .Be("namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill" + Proj,
                 "the chatting user's own /Skill namespace MUST be unioned in — passing null userPath "
                 + "(the bug) hid every user-defined skill from autocomplete.");
     }
@@ -326,7 +332,7 @@ public class AgentPickerQueriesTest
         // user's own /Skill namespace is still unioned.
         SkillAutocompleteProvider.BuildQueries(access, "login")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:rbuergi/Skill|Skill nodeType:Skill");
+            .Be("namespace:rbuergi/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
@@ -339,7 +345,7 @@ public class AgentPickerQueriesTest
 
         SkillAutocompleteProvider.BuildQueries(access, "AgenticPension")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:AgenticPension/Skill|Skill nodeType:Skill");
+            .Be("namespace:AgenticPension/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
@@ -347,7 +353,7 @@ public class AgentPickerQueriesTest
     {
         SkillAutocompleteProvider.BuildQueries(accessService: null, contextPath: "AgenticPension")
             .Should().ContainSingle().Which.Should()
-            .Be("namespace:AgenticPension/Skill|Skill nodeType:Skill");
+            .Be("namespace:AgenticPension/Skill|Skill nodeType:Skill" + Proj);
     }
 
     // ─── Skill sources: node-type partition + user-configurable query rows (AiSettings.SkillQueries) ───
@@ -358,14 +364,14 @@ public class AgentPickerQueriesTest
         // A node of type Office/Slide surfaces the skills its plugin ships next to its types —
         // the TYPE path's PARTITION contributes {typePartition}/Skill to the default union.
         AgentPickerProjection.BuildSkillQuery("rbuergi", "AgenticPension", "Office/Slide")
-            .Should().Be("namespace:rbuergi/Skill|AgenticPension/Skill|Office/Skill|Skill nodeType:Skill");
+            .Should().Be("namespace:rbuergi/Skill|AgenticPension/Skill|Office/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
     public void BuildSkillQuery_ReservedTypePartition_IsSkipped()
     {
         AgentPickerProjection.BuildSkillQuery("rbuergi", nodeTypePath: "settings/Whatever")
-            .Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill");
+            .Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill" + Proj);
     }
 
     [Fact]

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -17,6 +17,12 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class SkillNodeTypeTest
 {
+    /// <summary>The projection every registry query carries — referenced from the
+    /// production constant so these expectations can never drift from it. Asserting it
+    /// here is the point: a registry query that stops projecting `content` yields nodes
+    /// whose Content is silently null, which reads as an empty picker.</summary>
+    private const string Proj = AgentPickerProjection.RegistryProjection;
+
     private static readonly JsonSerializerOptions Json = new();
 
     [Fact]
@@ -158,11 +164,11 @@ public class SkillNodeTypeTest
         // the space's {space}/Skill + the user's {user}/Skill).
         SkillNodeType.SkillQueries(contextPath: "Acme/Project", userPath: "rbuergi")
             .Should().ContainSingle()
-            .Which.Should().Be("namespace:rbuergi/Skill|Acme/Skill|Skill nodeType:Skill");
+            .Which.Should().Be("namespace:rbuergi/Skill|Acme/Skill|Skill nodeType:Skill" + Proj);
 
         // No context / user → platform defaults only.
         SkillNodeType.SkillQueries(null, null).Should().ContainSingle()
-            .Which.Should().Be("namespace:Skill nodeType:Skill");
+            .Which.Should().Be("namespace:Skill nodeType:Skill" + Proj);
     }
 
     [Fact]
@@ -172,7 +178,7 @@ public class SkillNodeTypeTest
         // to the namespace IN(...): it has no read policy, so including "login/Skill" fails the WHOLE
         // query ("lacks Read permission on 'login'") and the picker/autocomplete goes empty.
         var q = SkillNodeType.SkillQueries(contextPath: "login", userPath: "rbuergi").Single();
-        q.Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill");
+        q.Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill" + Proj);
         q.Should().NotContain("login/Skill");
     }
 

--- a/test/MeshWeaver.Query.Test/SyncedQueryProjectionContractTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryProjectionContractTest.cs
@@ -1,0 +1,165 @@
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// Pins the <c>select:</c> <b>projection contract</b> of the synced mesh node query
+/// (<c>workspace.GetQuery</c>) — the one query qualifier that changes what a caller gets
+/// back rather than merely how much is fetched.
+///
+/// <para>A synced query runs <c>Query&lt;MeshNode&gt;</c>, so a <c>select:</c> does NOT
+/// project rows into <c>Dictionary&lt;string, object&gt;</c> the way it does for untyped
+/// callers (that mismatch is what wedged every <c>select:</c>-carrying query on memex,
+/// 2026-08-05; see <c>MeshQuery.ProjectSelect</c>). The row stays a <see cref="MeshNode"/>
+/// and the SQL is narrowed instead — and on that path exactly ONE column is conditional:
+/// <see cref="MeshNode.Content"/>.</para>
+///
+/// <para>That makes an omitted <c>content</c> a SILENT null rather than an error: the node
+/// arrives fully formed, every other field intact, and only <c>ContentAs&lt;T&gt;()</c>
+/// comes back empty. It reads exactly like "this node has no content" — the same symptom a
+/// missing <c>TypeRegistry</c> entry produces, from a completely different cause. These
+/// tests exist so that behaviour is a pinned contract instead of a rediscovered surprise.</para>
+/// </summary>
+public class SyncedQueryProjectionContractTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    // Isolated mesh per test method — each test owns its nodes AND its query ids (the
+    // synced-query cache is keyed by id and lives for the mesh's lifetime).
+    protected override bool ShareMeshAcrossTests => false;
+
+    private const string Ns = $"{TestPartition}/ProjectionContract";
+    private const string Body = "# Projected\n\nThe content column.";
+
+    private static MeshNode Subject(string id) =>
+        new(id, Ns)
+        {
+            Name = "Projected",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = Body },
+        };
+
+    private IObservable<IEnumerable<MeshNode>> Query(object id, string query)
+        => Mesh.GetWorkspace().GetQuery(id, query);
+
+    /// <summary>
+    /// No <c>select:</c> at all — the conservative default. The whole node comes back,
+    /// <see cref="MeshNode.Content"/> included and typed through the caller hub's options.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task NoProjection_LoadsTypedContent()
+    {
+        var node = Subject("unprojected");
+        await NodeFactory.CreateNode(node).Should().Emit();
+
+        var row = await ReadOne($"$proj-none", $"namespace:{Ns} scope:subtree nodeType:Markdown", node.Path);
+
+        row.Content.Should().NotBeNull(
+            "an unprojected synced query is a whole-node read — the conservative default");
+        row.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)!.Content
+            .Should().Be(Body);
+    }
+
+    /// <summary>
+    /// A <c>select:</c> that NAMES <c>content</c> behaves exactly like the unprojected read.
+    /// This is the shape every content-bearing call site must use.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ProjectionNamingContent_LoadsTypedContent()
+    {
+        var node = Subject("with-content");
+        await NodeFactory.CreateNode(node).Should().Emit();
+
+        var row = await ReadOne(
+            "$proj-content",
+            $"namespace:{Ns} scope:subtree nodeType:Markdown select:path,id,name,nodeType,content",
+            node.Path);
+
+        row.Name.Should().Be("Projected");
+        row.Content.Should().NotBeNull(
+            "`content` was named in the select: — the projection must fetch the column");
+        row.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)!.Content
+            .Should().Be(Body);
+    }
+
+    /// <summary>
+    /// 🚨 THE TRAP, pinned. A <c>select:</c> that OMITS <c>content</c> still yields a
+    /// well-formed <see cref="MeshNode"/> — right path, right name, right nodeType — whose
+    /// <c>Content</c> is null. No error, no warning, no empty result set. Any consumer doing
+    /// <c>ContentAs&lt;T&gt;()</c> on such a row silently renders empty.
+    ///
+    /// <para>If this test ever starts failing because <c>Content</c> came back populated, the
+    /// projection stopped being honoured and the whole "select only what you need" guidance
+    /// (and its cost saving on subtree reads) is dead — that is a real regression, not a
+    /// harmless one.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ProjectionOmittingContent_YieldsNodeWithNullContent()
+    {
+        var node = Subject("without-content");
+        await NodeFactory.CreateNode(node).Should().Emit();
+
+        var row = await ReadOne(
+            "$proj-shell",
+            $"namespace:{Ns} scope:subtree nodeType:Markdown select:path,id,name,nodeType",
+            node.Path);
+
+        // The metadata half is fully intact — which is exactly why the null below is so easy to miss.
+        row.Name.Should().Be("Projected");
+        row.NodeType.Should().Be("Markdown");
+
+        row.Content.Should().BeNull(
+            "a select: that does not name `content` makes the storage adapter project a null "
+            + "content column — the node is well-formed and its Content is silently empty, which "
+            + "is why every content-reading GetQuery MUST name `content` explicitly");
+        row.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)
+            .Should().BeNull("there is nothing to deserialise — and nothing reports that");
+    }
+
+    /// <summary>
+    /// 🚨 The cache is keyed by ID ALONE: <c>GetQuery(id, queries)</c> returns the already
+    /// registered stream and IGNORES the queries on a hit. So a second call site that shares
+    /// an id but asks for <c>content</c> does NOT get its own collection — it inherits the
+    /// first registration's shell projection, and its <c>ContentAs&lt;T&gt;()</c> reads null.
+    ///
+    /// <para>This is the mechanism behind "content is stale/empty on some loads but not
+    /// others": which projection wins is decided by subscription order. Keep query strings
+    /// byte-identical wherever an id is shared, and scope ids per module.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SharedId_FirstRegistrationWins_EvenWhenTheSecondAsksForContent()
+    {
+        var node = Subject("shared-id");
+        await NodeFactory.CreateNode(node).Should().Emit();
+
+        const string id = "$proj-shared";
+
+        // FIRST registration: shells only.
+        var shell = await ReadOne(
+            id, $"namespace:{Ns} scope:subtree nodeType:Markdown select:path,id,name,nodeType", node.Path);
+        shell.Content.Should().BeNull();
+
+        // SECOND call site, SAME id, explicitly asking for content — and it does not matter.
+        var second = await ReadOne(
+            id, $"namespace:{Ns} scope:subtree nodeType:Markdown select:path,id,name,nodeType,content", node.Path);
+
+        second.Content.Should().BeNull(
+            "the synced-query cache is keyed by id alone and ignores the queries on a hit, so the "
+            + "FIRST registration's projection is what every later caller of that id receives — "
+            + "sharing an id across differently-projected reads is a silent-null defect");
+    }
+
+    private async Task<MeshNode> ReadOne(object id, string query, string path) =>
+        (await Query(id, query)
+            .Where(nodes => nodes.Any(n => n.Path == path))
+            .Should().Within(15.Seconds()).Emit())
+        .Single(n => n.Path == path);
+}


### PR DESCRIPTION
Audit of **every** `GetQuery` call site across MeshWeaver, MeshWeaver.Plugins and MeshWeaver.Reinsurance. The audit turned up two provider defects behind the reported stale/empty-content flakes, plus the repo-wide omission that hid them.

## The finding

`select:` on a synced query is the switch that loads `Content` — and **not one of the 142 call sites carried one**, so the option was never set anywhere.

`GetQuery` runs `Query<MeshNode>`, so a projection does *not* turn rows into dictionaries the way it does for untyped callers: the row stays a `MeshNode`, and exactly one column is conditional — `content`. Every way of getting that wrong fails **silently**.

## Three defects, one bug

**1. A `select:`-carrying synced query returned the empty set, forever.**
`StorageAdapterMeshQueryProvider` projected every row through `ParsedQuery.ProjectToSelect` regardless of the caller's type. The generic consumer then filters with `item is T`; with `T = MeshNode` — which is what every `GetQuery` is — each projected `Dictionary` was dropped. A query that matched returned nothing, with no error and no log line, and the synced query cached that empty snapshot in its `Replay(1)` so every consumer of the id saw "no results" for present data.

This is the in-memory twin of the Postgres wedge fixed on 2026-08-05: `PostgreSqlMeshQuery.CollectQueryResultsAsync` and `MeshQuery.ProjectSelect` both got the `typeof(T) != typeof(MeshNode)` guard; this provider never did.

**2. The in-memory adapter was the only provider that did not null the content column.**
PG emits `NULL::jsonb AS content`, Cosmos omits the field, Snowflake `NULL::variant` — the in-memory store returned the blob regardless. So the nastiest projection defect (a content-reading consumer whose `select:` forgot `content`, silently yielding `Content == null`) was **green in every test and only reproduced on a real mesh**. `DropUnprojectedContent` restores parity, which is what makes the class testable at all.

**3. No call site declared its projection.** Each one now does: `content` named explicitly where the consumer chain reads it, a narrow field list where it provably does not, and deliberately nothing where the query is caller-supplied (`NodeTypeLayoutAreas`, Maui pickers) or feeds the compiler (`NodeSources`) — the full node stays the conservative default, because a wrong projection fails silently while an absent one only costs bytes.

## Bonus: the shared-id hazard

The synced-query cache is keyed by **ID alone** — `GetQueryRaw` returns the existing entry and *ignores* the queries on a hit. Two call sites sharing an id but differing in their `select:` resolve to whichever subscribed first, intermittently, by render order. `course-modules:{coursePath}` is read by both the course overview (needs `content` for card summaries) and the module page (shells only); both now carry byte-identical query strings.

## Where CQRS is actually violated

Making `content` explicit turns the violating surface into a grep. **41 sites read `Content` off a query** — 32 in core, 2 in Plugins, 7 in Reinsurance. Notable: `PermissionEvaluator` (all grants, policies, roles and memberships), the whole GitSync/InstanceSync config surface, `AiSettingsNodeType`, and the Courses module/attempt reads. None are changed behaviourally here; they are now labelled, and a follow-up can move the ones that should hydrate per-path through `GetMeshNodeStream`.

`ExerciseLayoutAreas` is the counter-example worth copying: it queries for **existence only** (`select:path`) and takes content from `GetMeshNodeStream`.

## Tests

`SyncedQueryProjectionContractTest` pins all four behaviours — unprojected loads content, a `select:` naming `content` loads it, a `select:` omitting it yields a well-formed node with **null** `Content`, and a shared id makes the first registration's projection win even when the second asks for content.

Suites green: **Query 361, Graph 802, Security 345, Monolith 467, AI 979.**

The AI registry-query tests now concatenate `AgentPickerProjection.RegistryProjection` itself rather than a copied literal, so they cannot drift from it.

Paired PRs: Systemorph/MeshWeaver.Plugins#349, Systemorph/MeshWeaver.Reinsurance#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB