### PR TITLE
Ignore the 547 MB whisper model; track the Aspire CLI app-host config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,3 +414,14 @@ memex/aspire/Memex.Portal.Distributed/wwwroot/app/
 # macOS's case-insensitive filesystem it also matches `Plugins/` — which silently dropped every NEW
 # file under src/MeshWeaver.AI/Plugins/ and .claude/skills/plugins/. Keep the slash.
 /plugins/
+
+# The Whisper voice model is a 547 MB DOWNLOAD, never a tracked file — GitHub rejects any blob
+# over 100 MB, so committing it makes the push fail for everyone (it did: a `git add -A` swept it
+# in and the pre-receive hook declined the whole branch). The Dockerfile bakes no model; it is
+# mounted at /models/model.bin (see deploy/whisper/docker-compose.yml).
+#
+# 🗄️ BACKUP OF RECORD — a GitHub RELEASE ASSET on this repo, which is exempt from the 100 MB blob
+# limit (2 GB/asset): tag `voice-model-swiss-german`, asset `ggml-swiss-german-turbo-q5_0.bin`
+# (574,041,195 bytes). Re-fetch it exactly as deploy/whisper/README.md documents:
+#   curl -fSL https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin -o deploy/whisper/models/model.bin
+deploy/whisper/models/

--- a/memex/aspire/Memex.AppHost/aspire.config.json
+++ b/memex/aspire/Memex.AppHost/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "Memex.AppHost.csproj"
+  }
+}


### PR DESCRIPTION
Two untracked files were sitting in the working tree. Neither should be committed as-is, but one needed an ignore rule and the other genuinely belongs in the repo.

## `deploy/whisper/models/model.bin` — ignore, don't commit

The Swiss-German Whisper weights are a **download**, not a tracked file:

- the Dockerfile says so explicitly — *"no model baked — the model is mounted at `/models/model.bin`"*
- `deploy/whisper/README.md` tells you to `curl` it

But nothing ignored that directory, so a `git add -A` swept the 547 MB blob into a commit and GitHub's pre-receive hook declined the **entire push**. The error names the file and the 100 MB limit but not what to do about it, and the whole branch is stuck until you rewrite the commit.

**Nothing is lost by ignoring it.** The backup of record is a **GitHub release asset on this repo** — exempt from the 100 MB blob limit (2 GB per asset):

| | |
|---|---|
| tag | `voice-model-swiss-german` |
| asset | `ggml-swiss-german-turbo-q5_0.bin` |
| size | 574,041,195 bytes — byte-for-byte the size of the local copy |

The ignore rule carries the re-fetch `curl` command inline, so the next person doesn't have to go looking for where the model lives.

## `memex/aspire/Memex.AppHost/aspire.config.json` — track it

57 bytes, project-relative path, no secrets:

```json
{ "appHost": { "path": "Memex.AppHost.csproj" } }
```

It's the newer Aspire CLI's app-host pointer. The repo already tracks the older-format equivalent (`.aspire/settings.json`, `{"appHostPath": "../Memex.AppHost.csproj"}`) and even force-includes `launchSettings.json`, so tracking this is consistent with the existing convention and keeps `aspire run` working out of the box instead of leaving each machine to regenerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVb5f4N6KuJnvLaNrvjDB