### PR TITLE
One disposed subscriber silently starved every other one — including the security fold

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/IsolatedChangeFeed.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/IsolatedChangeFeed.cs
@@ -24,9 +24,11 @@ namespace MeshWeaver.Hosting.PostgreSql;
 /// out on its fold barrier; in a live portal it is a silently stale security cache.</para>
 ///
 /// <para>So: deliver to a SNAPSHOT of the observers, isolate each one, and never let a throw from
-/// one reach another. A faulted observer is dropped from the feed (it can never recover — an
-/// observer that threw has violated the Rx contract) and LOGGED, because a swallowed fault on the
-/// security-fold path is precisely what made this take three CI runs to see.</para>
+/// one reach another. A DISPOSED observer is dropped (provably dead — every later notification
+/// would throw again); any OTHER throw is isolated but the observer stays subscribed, because
+/// permanently disabling a live subscriber over a transient fault would just relocate this very
+/// bug. Either way it is LOGGED: a swallowed fault on the security-fold path is precisely what
+/// made this take three CI runs to see.</para>
 /// </summary>
 internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, IObserver<DataChangeNotification>, IDisposable
 {
@@ -68,16 +70,28 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
             {
                 observer.OnNext(value);
             }
-            catch (Exception ex)
+            catch (ObjectDisposedException ex)
             {
-                // ISOLATED: the next observer still gets the notification. Drop the faulted one —
-                // an observer that throws out of OnNext has broken the Rx contract and will keep
-                // throwing — and say so, loudly enough to find. Warning, not Debug: a dropped
-                // change notification means some subscriber's view of the mesh is now stale.
+                // PROVABLY DEAD, so drop it: the subscriber's sink is disposed and every later
+                // notification would throw again. This is the shape the disposal-order race
+                // produced (a CompositeDisposable killing changeBuffer while its feed was live).
                 Remove(observer);
                 _logger?.LogWarning(ex,
-                    "Change-feed observer {Observer} threw on {Path} ({adapter}); it has been dropped from the feed. "
-                    + "Delivery to the remaining {Remaining} observer(s) was NOT affected.",
+                    "Change-feed observer {Observer} was disposed while still subscribed ({Adapter}); dropped from the feed "
+                    + "at {Path}. Delivery to the other {Remaining} observer(s) was NOT affected.",
+                    observer.GetType().Name, _adapter, value.Path, observers.Count - 1);
+            }
+            catch (Exception ex)
+            {
+                // ISOLATED but KEPT. A transient throw must not permanently disable a live
+                // subscriber — dropping it here would starve it of every future change, which is
+                // the very failure this class exists to prevent, just moved. Only a disposed sink
+                // (above) is provably unrecoverable. Warning, not Debug: a subscriber that missed
+                // a change has a stale view of the mesh, and on the security-fold path that means
+                // stale permissions.
+                _logger?.LogWarning(ex,
+                    "Change-feed observer {Observer} threw on {Path} ({Adapter}) and MISSED that notification; it remains "
+                    + "subscribed. Delivery to the other {Remaining} observer(s) was NOT affected.",
                     observer.GetType().Name, value.Path, _adapter, observers.Count - 1);
             }
         }

--- a/src/MeshWeaver.Hosting.PostgreSql/IsolatedChangeFeed.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/IsolatedChangeFeed.cs
@@ -1,0 +1,138 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Hosting.PostgreSql;
+
+/// <summary>
+/// The storage adapter's in-process change feed: a hot broadcast where ONE faulty subscriber
+/// cannot starve the others.
+///
+/// <para>This replaces a plain <see cref="System.Reactive.Subjects.Subject{T}"/>, which is
+/// fan-out-hostile in exactly the way that matters here. <c>Subject&lt;T&gt;.OnNext</c> delivers to
+/// its observers SYNCHRONOUSLY, IN SUBSCRIPTION ORDER, on the caller's thread — so the first
+/// observer that throws aborts delivery to every observer after it. The adapter then wrapped the
+/// publish in <c>catch { /* best-effort */ }</c>, which turned that into silence.</para>
+///
+/// <para>The concrete failure (CI 31083356138 and again on main at 0744169c): a synced query being
+/// torn down disposes its buffer before the subscription feeding it, so a write landing in that
+/// window throws <see cref="ObjectDisposedException"/> into the fan-out. Every OTHER live
+/// subscriber — including the <c>$security-access</c> query the permission evaluator folds — never
+/// saw that notification. Its <c>Replay(1)</c> cache stayed frozen at the pre-write snapshot, the
+/// access fold never completed, and reads were evaluated against stale permissions until something
+/// else happened to re-trigger a query. In tests that surfaced as PaywallRealGateShapeTests timing
+/// out on its fold barrier; in a live portal it is a silently stale security cache.</para>
+///
+/// <para>So: deliver to a SNAPSHOT of the observers, isolate each one, and never let a throw from
+/// one reach another. A faulted observer is dropped from the feed (it can never recover — an
+/// observer that threw has violated the Rx contract) and LOGGED, because a swallowed fault on the
+/// security-fold path is precisely what made this take three CI runs to see.</para>
+/// </summary>
+internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, IObserver<DataChangeNotification>, IDisposable
+{
+    private readonly ILogger? _logger;
+    private readonly string _adapter;
+    private readonly object _gate = new();
+    // Immutable so OnNext iterates a stable snapshot with no lock held — a subscriber that
+    // subscribes or disposes DURING a publish can never mutate the list being walked.
+    private ImmutableList<IObserver<DataChangeNotification>> _observers =
+        ImmutableList<IObserver<DataChangeNotification>>.Empty;
+    private bool _disposed;
+
+    public IsolatedChangeFeed(ILogger? logger, string adapter)
+    {
+        _logger = logger;
+        _adapter = adapter;
+    }
+
+    public IDisposable Subscribe(IObserver<DataChangeNotification> observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+        lock (_gate)
+        {
+            if (_disposed)
+                return Disposable.Empty;
+            _observers = _observers.Add(observer);
+        }
+        return new Subscription(this, observer);
+    }
+
+    public void OnNext(DataChangeNotification value)
+    {
+        // Snapshot OUTSIDE the delivery loop: an observer is free to subscribe or dispose while we
+        // are publishing, and neither may disturb this fan-out.
+        var observers = Volatile.Read(ref _observers);
+        foreach (var observer in observers)
+        {
+            try
+            {
+                observer.OnNext(value);
+            }
+            catch (Exception ex)
+            {
+                // ISOLATED: the next observer still gets the notification. Drop the faulted one —
+                // an observer that throws out of OnNext has broken the Rx contract and will keep
+                // throwing — and say so, loudly enough to find. Warning, not Debug: a dropped
+                // change notification means some subscriber's view of the mesh is now stale.
+                Remove(observer);
+                _logger?.LogWarning(ex,
+                    "Change-feed observer {Observer} threw on {Path} ({adapter}); it has been dropped from the feed. "
+                    + "Delivery to the remaining {Remaining} observer(s) was NOT affected.",
+                    observer.GetType().Name, value.Path, _adapter, observers.Count - 1);
+            }
+        }
+    }
+
+    public void OnError(Exception error)
+    {
+        foreach (var observer in Volatile.Read(ref _observers))
+        {
+            try { observer.OnError(error); }
+            catch (Exception ex) { _logger?.LogWarning(ex, "Change-feed observer threw on OnError ({adapter}).", _adapter); }
+        }
+    }
+
+    public void OnCompleted()
+    {
+        foreach (var observer in Volatile.Read(ref _observers))
+        {
+            try { observer.OnCompleted(); }
+            catch (Exception ex) { _logger?.LogWarning(ex, "Change-feed observer threw on OnCompleted ({adapter}).", _adapter); }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _observers = ImmutableList<IObserver<DataChangeNotification>>.Empty;
+        }
+    }
+
+    private void Remove(IObserver<DataChangeNotification> observer)
+    {
+        lock (_gate)
+        {
+            _observers = _observers.Remove(observer);
+        }
+    }
+
+    private sealed class Subscription(IsolatedChangeFeed feed, IObserver<DataChangeNotification> observer) : IDisposable
+    {
+        private IObserver<DataChangeNotification>? _observer = observer;
+
+        public void Dispose()
+        {
+            var o = Interlocked.Exchange(ref _observer, null);
+            if (o is not null)
+                feed.Remove(o);
+        }
+    }
+
+    private sealed class Disposable : IDisposable
+    {
+        public static readonly IDisposable Empty = new Disposable();
+        public void Dispose() { }
+    }
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -689,12 +689,19 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                     DataChangeNotification[] backlog;
                     // 1) Set up live subscription first — starts buffering immediately.
                     var changeBuffer = new Subject<DataChangeNotification>();
-                    disposables.Add(changeBuffer);
+                    // 🚨 ORDER MATTERS. CompositeDisposable disposes in INSERTION order, so the
+                    // feeding subscription must be registered BEFORE the buffer it writes into.
+                    // The other way round, teardown disposes changeBuffer first while the
+                    // subscription is still live, and a write landing in that window calls OnNext
+                    // on a disposed Subject → ObjectDisposedException thrown back into the
+                    // adapter's fan-out. That is what starved the $security-access query of its
+                    // notification and froze the permission fold (see IsolatedChangeFeed).
                     disposables.Add(
                         _adapter.Changes
                             .Where(n => parsedFilters.Any(f =>
                                 PathMatcher.ShouldNotifyForQuery(n.Path, f.BasePath, f.Scope, f.Namespaces)))
                             .Subscribe(changeBuffer));
+                    disposables.Add(changeBuffer);
                     // 🚨 Strict unit-of-work + zero debounce: every change
                     // triggers its own RunQuery, serialised via Concat so the
                     // shared currentItems dictionary is never raced. Buffer

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -39,7 +39,11 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     // The pg:{adapter} write I/O pool — every WRITE / provisioning DB round-trip runs inside it
     // (Invoke), never a bare Observable.FromAsync. Unbounded fallback when no registry is wired.
     private readonly IIoPool _ioPool;
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // NOT a Subject<T>. Subject fan-out is synchronous and ordered, so the first observer that
+    // throws aborts delivery to every observer after it — and the publish sites used to wrap that
+    // in `catch { /* best-effort */ }`, turning a starved subscriber into silence. See
+    // IsolatedChangeFeed for the failure this caused (a permanently stale security fold).
+    private readonly IsolatedChangeFeed _changes;
 
     // Per-adapter cache of "does {schema}.content_chunks exist?" — drives whether the vector search
     // UNIONs the indexed-content branch (DocumentPaths-resolved Document rows). INSTANCE field (never
@@ -67,7 +71,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// for every row committed to <c>mesh_nodes</c> (and satellite tables),
     /// so synced-query subscribers see writes from any process in the cluster.
     /// </remarks>
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// Internal hook for <see cref="PostgreSqlChangeListener"/> to push
@@ -97,6 +101,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         _partitionDefinition = partitionDefinition;
         _schemaName = partitionDefinition?.Schema;
         _logger = logger;
+        _changes = new IsolatedChangeFeed(logger, partitionDefinition?.Schema ?? "public");
         _readPool = readPool ?? IoPool.Unbounded;
         _ioPool = ioPool ?? IoPool.Unbounded;
     }
@@ -436,12 +441,11 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             // PostgreSqlChangeListener still publishes for cross-process; the
             // listener's pg_notify dedup (PostgreSqlExtensions LISTEN/NOTIFY
             // dedup) makes the double-fire idempotent.
-            try
-            {
-                _changes.OnNext(DataChangeNotification.Updated(
-                    string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
-            }
-            catch { /* never throw — change feed is best-effort */ }
+            // No try/catch: IsolatedChangeFeed already isolates and LOGS a faulty observer, so a
+            // throw escaping here would be a bug in the feed itself, not a subscriber's fault to
+            // swallow.
+            _changes.OnNext(DataChangeNotification.Updated(
+                string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
             return node;
         });
 
@@ -531,12 +535,8 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         {
             if (!committed.Contains(node.Path))
                 continue;
-            try
-            {
-                _changes.OnNext(DataChangeNotification.Updated(
-                    string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
-            }
-            catch { /* never throw — change feed is best-effort */ }
+            _changes.OnNext(DataChangeNotification.Updated(
+                string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
         }
     }
 
@@ -648,8 +648,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         => _ioPool.Invoke(async ct =>
         {
             await DeleteAsyncCore(path, ct).ConfigureAwait(false);
-            try { _changes.OnNext(DataChangeNotification.Deleted(path)); }
-            catch { /* never throw — change feed is best-effort */ }
+            _changes.OnNext(DataChangeNotification.Deleted(path));
             return path;
         });
 
@@ -666,8 +665,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             var removed = await DeleteAsyncCore(path, ct).ConfigureAwait(false) > 0;
             if (removed)
             {
-                try { _changes.OnNext(DataChangeNotification.Deleted(path)); }
-                catch { /* never throw — change feed is best-effort */ }
+                _changes.OnNext(DataChangeNotification.Deleted(path));
             }
             return removed;
         });

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/IsolatedChangeFeedTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/IsolatedChangeFeedTests.cs
@@ -62,10 +62,10 @@ public class IsolatedChangeFeedTests
     }
 
     [Fact]
-    public void A_throwing_observer_is_dropped_and_the_rest_keep_receiving()
+    public void A_DISPOSED_observer_is_dropped_and_the_rest_keep_receiving()
     {
         var feed = new IsolatedChangeFeed(null, "test");
-        var thrower = new Thrower();
+        var thrower = new Thrower();   // throws ObjectDisposedException — provably dead
         var downstream = new Recorder();
         feed.Subscribe(thrower);
         feed.Subscribe(downstream);
@@ -73,10 +73,40 @@ public class IsolatedChangeFeedTests
         feed.OnNext(Change("one"));
         feed.OnNext(Change("two"));
 
-        // An observer that throws out of OnNext has broken the Rx contract — it is removed rather
-        // than re-invoked on every subsequent write.
+        // Its sink is disposed, so every later notification would throw again: drop it rather than
+        // re-invoke it on every write for the life of the process.
         thrower.Calls.Should().Be(1);
         downstream.Paths.Should().Equal("one", "two");
+    }
+
+    /// <summary>
+    /// A TRANSIENT fault must NOT unsubscribe a live observer. Dropping it would starve that
+    /// subscriber of every future change — which is the exact failure this class exists to
+    /// prevent, merely relocated. Only a disposed sink is treated as unrecoverable.
+    /// </summary>
+    [Fact]
+    public void A_transiently_throwing_observer_stays_subscribed()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        var seen = new List<string>();
+        var throwOnce = true;
+        feed.Subscribe(new AnonymousObserver(n =>
+        {
+            if (throwOnce)
+            {
+                throwOnce = false;
+                throw new InvalidOperationException("transient");
+            }
+            seen.Add(n.Path);
+        }));
+        var downstream = new Recorder();
+        feed.Subscribe(downstream);
+
+        feed.OnNext(Change("missed"));   // observer throws; it misses THIS one
+        feed.OnNext(Change("recovered")); // …but is still subscribed for the next
+
+        seen.Should().Equal("recovered");
+        downstream.Paths.Should().Equal("missed", "recovered");
     }
 
     [Fact]

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/IsolatedChangeFeedTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/IsolatedChangeFeedTests.cs
@@ -1,0 +1,178 @@
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins the storage adapter's change-feed fan-out contract.
+///
+/// <para>The defect these cover cost three CI runs to see. The feed used to be a plain
+/// <see cref="Subject{T}"/>, whose <c>OnNext</c> delivers synchronously in subscription order — so
+/// the FIRST observer that throws aborts delivery to every observer after it — and the publish
+/// sites wrapped that in <c>catch { }</c>, so it was silent. A synced query being torn down threw
+/// <see cref="ObjectDisposedException"/> into the fan-out, and the <c>$security-access</c> query
+/// behind it never received the notification: its <c>Replay(1)</c> froze at the pre-write snapshot
+/// and the permission fold never completed.</para>
+/// </summary>
+public class IsolatedChangeFeedTests
+{
+    private static DataChangeNotification Change(string path) =>
+        DataChangeNotification.Updated(path, MeshNode.FromPath(path));
+
+    /// <summary>An observer that throws on every notification — the disposed-buffer shape.</summary>
+    private sealed class Thrower : IObserver<DataChangeNotification>
+    {
+        public int Calls { get; private set; }
+        public void OnNext(DataChangeNotification value)
+        {
+            Calls++;
+            throw new ObjectDisposedException(nameof(Subject<DataChangeNotification>));
+        }
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    private sealed class Recorder : IObserver<DataChangeNotification>
+    {
+        public List<string> Paths { get; } = [];
+        public void OnNext(DataChangeNotification value) => Paths.Add(value.Path);
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    [Fact]
+    public void A_throwing_observer_does_not_starve_the_ones_after_it()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        var thrower = new Thrower();
+        var downstream = new Recorder();
+
+        // Subscription ORDER is the whole point: the thrower is first, so a Subject would have
+        // aborted before ever reaching `downstream`.
+        feed.Subscribe(thrower);
+        feed.Subscribe(downstream);
+
+        feed.OnNext(Change("acme/Gated"));
+
+        thrower.Calls.Should().Be(1);
+        downstream.Paths.Should().Equal("acme/Gated");
+    }
+
+    [Fact]
+    public void A_throwing_observer_is_dropped_and_the_rest_keep_receiving()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        var thrower = new Thrower();
+        var downstream = new Recorder();
+        feed.Subscribe(thrower);
+        feed.Subscribe(downstream);
+
+        feed.OnNext(Change("one"));
+        feed.OnNext(Change("two"));
+
+        // An observer that throws out of OnNext has broken the Rx contract — it is removed rather
+        // than re-invoked on every subsequent write.
+        thrower.Calls.Should().Be(1);
+        downstream.Paths.Should().Equal("one", "two");
+    }
+
+    [Fact]
+    public void The_publish_never_throws_at_the_caller()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        feed.Subscribe(new Thrower());
+
+        // A write must never be turned into a failure by a subscriber — but that guarantee now
+        // comes from per-observer isolation, not from a catch-all that also hid the starvation.
+        var publish = () => feed.OnNext(Change("acme/X"));
+        publish.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Disposing_a_subscription_stops_delivery_to_it_only()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        var stays = new Recorder();
+        var goes = new Recorder();
+        feed.Subscribe(stays);
+        var sub = feed.Subscribe(goes);
+
+        feed.OnNext(Change("before"));
+        sub.Dispose();
+        feed.OnNext(Change("after"));
+
+        stays.Paths.Should().Equal("before", "after");
+        goes.Paths.Should().Equal("before");
+    }
+
+    [Fact]
+    public void Subscribing_during_a_publish_does_not_disturb_the_fan_out()
+    {
+        var feed = new IsolatedChangeFeed(null, "test");
+        var late = new Recorder();
+        var tail = new Recorder();
+        // Mutates the observer list WHILE OnNext is walking it — the snapshot is what makes this
+        // safe (a List<T> would throw "collection was modified" mid-fan-out).
+        feed.Subscribe(new AnonymousObserver(_ => feed.Subscribe(late)));
+        feed.Subscribe(tail);
+
+        var publish = () => feed.OnNext(Change("during"));
+
+        publish.Should().NotThrow();
+        tail.Paths.Should().Equal("during");   // the observer after the mutator still got it
+        late.Paths.Should().BeEmpty();          // the late subscriber only sees LATER notifications
+    }
+
+    private sealed class AnonymousObserver(Action<DataChangeNotification> onNext) : IObserver<DataChangeNotification>
+    {
+        public void OnNext(DataChangeNotification value) => onNext(value);
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    /// <summary>
+    /// GUARD THE GUARD. Pins the <see cref="Subject{T}"/> behaviour the feed exists to avoid, so
+    /// the tests above cannot quietly become vacuous: if a future Rx made Subject isolate its
+    /// observers, this fails and the whole IsolatedChangeFeed rationale needs revisiting.
+    ///
+    /// <para>This is also the proof that those tests are meaningful — swap IsolatedChangeFeed for
+    /// a Subject and "does not starve the ones after it" fails exactly here.</para>
+    /// </summary>
+    [Fact]
+    public void Subject_aborts_the_fan_out_at_the_first_thrower_which_is_why_we_do_not_use_one()
+    {
+        var subject = new Subject<DataChangeNotification>();
+        var downstream = new Recorder();
+        subject.Subscribe(new Thrower());
+        subject.Subscribe(downstream);
+
+        // The throw escapes the publish AND the later observer never ran — the two halves of the
+        // defect. The old publish sites then wrapped this in `catch { }`, hiding both.
+        var publish = () => subject.OnNext(Change("acme/Gated"));
+        publish.Should().Throw<ObjectDisposedException>();
+        downstream.Paths.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The disposal-order half of the fix, at the shape level: a CompositeDisposable disposes in
+    /// INSERTION order, so a buffer registered before the subscription that feeds it is dead while
+    /// that subscription is still live — which is exactly how the thrower above came to exist.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_disposes_in_insertion_order()
+    {
+        var order = new List<string>();
+        var composite = new CompositeDisposable
+        {
+            Disposable.Create(() => order.Add("first")),
+            Disposable.Create(() => order.Add("second")),
+        };
+
+        composite.Dispose();
+
+        order.Should().Equal("first", "second");
+    }
+}


### PR DESCRIPTION
`PaywallRealGateShapeTests` kept timing out on its fold barrier (CI 31083356138, and **again on main at `0744169c`** after #849 stopped the cascade). #849 fixed the test's own defects. This is the **product defect underneath** — and it is not a test problem.

## The fan-out

The storage adapter's change feed was a `Subject<T>`. `Subject.OnNext` delivers to its observers **synchronously, in subscription order, on the caller's thread** — so the *first* observer that throws aborts delivery to every observer after it. Every publish site then wrapped that in:

```csharp
catch { /* never throw — change feed is best-effort */ }
```

…which turned a starved subscriber into silence.

## The thrower, manufactured a few files away

`CompositeDisposable` disposes in **insertion order**, and `PostgreSqlMeshQuery` registered the buffer *before* the subscription feeding it:

```csharp
var changeBuffer = new Subject<DataChangeNotification>();
disposables.Add(changeBuffer);                                          // disposed FIRST
disposables.Add(_adapter.Changes.Where(...).Subscribe(changeBuffer));   // still live
```

Tearing a query down killed the buffer while its feed was still running, so a write landing in that window called `OnNext` on a disposed Subject → `ObjectDisposedException`, thrown straight into the adapter's fan-out.

## Why this is a security bug, not a flake

Any query being disposed could drop that write's notification for **every other subscriber in the process** — including the `$security-access` query the permission evaluator folds. Its `Replay(1)` cache then stays frozen at the pre-write snapshot, so reads are evaluated against **stale permissions**.

And there is no reconciliation path: the initial query never re-runs (`Replay(1).AutoConnect(1)`), and the pg_notify LISTEN fallback is commented out for partitioned PG — whose own comment names this symptom. In tests it surfaced as a 120 s fold-barrier timeout; in a portal it is a silently stale access cache.

## The fix — both halves

- **`IsolatedChangeFeed`** replaces the Subject. It delivers to an **immutable snapshot** of the observers, isolates each one, and never lets a throw from one reach another. A faulted observer is dropped (one that throws out of `OnNext` has broken the Rx contract and will keep throwing) and **logged at Warning** — a swallowed fault on the security-fold path is exactly what made this take three CI runs to see. The `catch { }` blocks at the publish sites are gone: the feed is isolated now, so a throw escaping there would be a bug in the feed, not a subscriber's fault to swallow.
- **The disposal order is corrected**, removing the known thrower at its source.

## Tests

Seven, including a deliberate **guard-the-guard**: one asserts that a plain `Subject` *does* throw out and *does* starve the observer behind it — so the isolation tests cannot quietly become vacuous, which is the same trap #849 was about. The rest cover isolation, faulted-observer removal, per-subscription disposal, mutation during fan-out, and `CompositeDisposable`'s insertion-order contract.

## Verification

- `MeshWeaver.Hosting.PostgreSql` builds clean at `-c Release -warnaserror`.
- Full project: **629 passed / 4 failed**. Those 4 (`GroupMembershipRecomputeTests`) fail **identically on clean main `b6599ff91`** — pre-existing locally and unrelated to this change (they pass in CI, so they look environment-dependent; flagging rather than touching them here).

Internal correctness fix, no user-visible behaviour change — no What's New entry.