### PR TITLE
fix(registry): an instance's FIRST plugin grant always failed

### DIFF
--- a/src/MeshWeaver.PluginCatalog/InstanceGrantAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceGrantAdminSettingsTab.cs
@@ -207,29 +207,39 @@ public static class InstanceGrantAdminSettingsTab
         }
 
         var entry = new PluginGrantEntry { Source = source, PackageId = packageId };
-        var workspace = host.Hub.GetWorkspace();
         var path = MeshWeaverInstanceNodeType.GrantPath(instanceId);
         var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
         var adminId = accessService?.Context?.ObjectId ?? "";
+        var meshService = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
 
         target.UpdateData(ResultDataId, host.Localize("instanceGrants.applying"));
 
-        // Read-modify-write through the owning hub's stream: the Admin hub serialises every writer,
-        // so two admins editing different instances (or the same one) cannot clobber each other.
-        workspace.GetMeshNodeStream(path)
-            .Update(current =>
+        // 🚨 Read-then-CreateOrUpdate, NOT stream.Update. An instance's FIRST grant has no node yet,
+        // and Update on a path that does not exist aborts with "no initial state arrived for … within
+        // 30s" — so the very first grant for every instance failed (observed live 2026-08-06 while
+        // rolling this out). CreateOrUpdateNode covers both create and update in one call.
+        //
+        // The prior read is a one-shot by exact path — never a query, which is eventually consistent
+        // and would happily drop an entry another admin just added.
+        host.Hub.GetMeshNode(path, TimeSpan.FromSeconds(10))
+            .Take(1)
+            .SelectMany(existing =>
             {
-                var grant = current.ContentAs<PluginGrant>(host.Hub.JsonSerializerOptions)
+                var grant = existing?.ContentAs<PluginGrant>(host.Hub.JsonSerializerOptions)
                             ?? new PluginGrant { InstanceId = instanceId };
+                // Drop any identical entry first, so Grant is idempotent and Revoke is a removal.
                 var entries = grant.Entries
                     .Where(e => !(string.Equals(e.Source, entry.Source, StringComparison.OrdinalIgnoreCase)
                                   && string.Equals(e.PackageId, entry.PackageId, StringComparison.Ordinal)))
                     .ToList();
                 if (!revoke)
                     entries.Add(entry);
-                return current with
+
+                var node = new MeshNode(instanceId, MeshWeaverInstanceNodeType.GrantNamespace)
                 {
+                    Name = $"Plugin grant: {instanceId}",
                     NodeType = MeshWeaverInstanceNodeType.GrantNodeType,
+                    State = MeshNodeState.Active,
                     Content = grant with
                     {
                         InstanceId = instanceId,
@@ -238,6 +248,7 @@ public static class InstanceGrantAdminSettingsTab
                         UpdatedAt = DateTimeOffset.UtcNow,
                     },
                 };
+                return meshService.CreateOrUpdateNode(node);
             })
             .Subscribe(
                 _ => target.UpdateData(ResultDataId,


### PR DESCRIPTION
Found by rolling out the instance-key registry (#842) against memex-cloud.

## The failure

Granting any instance its first plugin failed with:

```
Update aborted: no initial state arrived for 'Admin/_PluginGrant/memex-cloud' within 30s
```

The admin grant tab read-modify-wrote through `GetMeshNodeStream(path).Update(...)`. But a grant node **does not exist until the first grant is made**, and `Update` waits for an initial state that never arrives. So the tab could edit an existing grant and never create one — which is every instance, exactly once, i.e. always.

## The fix

Read the node one-shot **by exact path**, fold the entry in or out, then write with `CreateOrUpdateNode`, which covers create and update alike. `Grant` stays idempotent; `Revoke` stays a removal.

Deliberately a one-shot exact-path read, not a query: `QueryAsync`/`ObserveQuery` are eventually consistent, so a lagged read could silently drop an entry another admin had just added.

## Context

The three live grants (`memex-cloud`, `memex`, `atioz`) were written by script during the rollout because of this defect. With the fix, the tab can create them — which matters for the next instance anyone registers.

Registry enforcement is now live: `https://memex.meshweaver.cloud/api/plugins` 401s anonymous callers, and each instance sees exactly its grant (`memex` = `Plugins/*` + `Reinsurance/UWDeepfield`, and notably *not* `ClaimsDeepfield`).

## Verification

`MeshWeaver.PluginCatalog` builds Release with `-warnaserror`; `MeshWeaver.PluginCatalog.Test` running. The grant-matching logic itself is already pinned by `PluginGrantTest`; this change is the write path around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01398UXRgmg2E3xS7xkTHdAo