### PR TITLE
Honor MeshNode.Order in the markdown side menu and the installer (#727)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-side-menu-order.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-side-menu-order.md
@@ -1,0 +1,12 @@
+---
+Name: Side menus follow the order you set
+Category: What's New
+Description: A page's left-hand menu of sub-pages now follows the order you set on each node, and re-installing a course whose only change was the ordering now takes effect.
+Icon: ArrowSort
+---
+
+# Side menus follow the order you set
+
+The collapsible left-hand menu on a page that has sub-pages now lists them in the order you set on each node — pages with no order sort last, then alphabetically — the same sequence the space navigator already used. Previously that menu sorted by name only, so setting an order changed nothing there.
+
+A second fix had to land with it, because reordering also has to reach the page. Re-installing a course or plugin whose only change was the sequence of its pages now writes that change; before, an order-only change was judged "unchanged" and silently skipped, so an author saw no effect from reordering and no error either.

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -46,10 +46,8 @@ public static class MarkdownOverviewLayoutArea
                 // @@ embeds and when there are none; internal satellites (_Access, _Thread, …) excluded.
                 if (hideHeader)
                     return (UiControl?)content;
-                var subNodes = children
-                    .Where(c => !LastSegment(c.Path).StartsWith('_'))
-                    .OrderBy(c => c.Name ?? c.Id, System.StringComparer.OrdinalIgnoreCase)
-                    .ToList();
+                var subNodes = OrderSubNodes(
+                    children.Where(c => !LastSegment(c.Path).StartsWith('_')));
                 // A module that OWNS this page may supply its own menu (a course lists the whole
                 // course, not the branch you are in). Nothing supplied → core's default child list,
                 // unchanged — which is why docs and spaces are untouched by this.
@@ -65,6 +63,15 @@ public static class MarkdownOverviewLayoutArea
         var i = path.LastIndexOf('/');
         return i < 0 ? path : path[(i + 1)..];
     }
+
+    // Sub-nodes for the side menu, ordered by the node's declared Order (nulls last, per the
+    // MeshNode.Order contract) then by name — mirroring the graph navigator and every other child
+    // list in the codebase. internal for unit testing (InternalsVisibleTo MeshWeaver.Graph.Test).
+    internal static List<MeshNode> OrderSubNodes(IEnumerable<MeshNode> children) =>
+        children
+            .OrderBy(c => c.Order ?? int.MaxValue)
+            .ThenBy(c => c.Name ?? c.Id, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
     /// <summary>
     /// Wraps the page content with a collapsible left-hand NavMenu listing the node's sub-nodes,

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -511,7 +511,8 @@ public static class PackageInstaller
         && (incoming.Icon ?? current.Icon) == current.Icon
         && (incoming.Category ?? current.Category) == current.Category
         && (incoming.State == default ? current.State : incoming.State) == current.State
-        && (incoming.PreRenderedHtml ?? current.PreRenderedHtml) == current.PreRenderedHtml;
+        && (incoming.PreRenderedHtml ?? current.PreRenderedHtml) == current.PreRenderedHtml
+        && (incoming.Order ?? current.Order) == current.Order;
 
     // Content serialized with the hub options ($type discriminators), then CANONICALIZED — object
     // keys sorted recursively — so the comparison is order-insensitive. It must be: on a

--- a/test/MeshWeaver.Graph.Test/MarkdownSideMenuOrderTest.cs
+++ b/test/MeshWeaver.Graph.Test/MarkdownSideMenuOrderTest.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #727 defect 1: the markdown node's side menu must honour <see cref="MeshNode.Order"/> (nulls
+/// last, per the field's contract) then name — not sort by name only, which disagreed with the
+/// graph navigator and every other child list in the codebase.
+/// </summary>
+public class MarkdownSideMenuOrderTest
+{
+    [Fact]
+    public void OrderSubNodes_SortsByOrderThenName_WithNullsLast()
+    {
+        // Names deliberately sort OPPOSITE to Order, so a name-only sort produces a different result.
+        var children = new[]
+        {
+            new MeshNode("c", "ns") { Name = "Zulu", Order = 10 },
+            new MeshNode("b", "ns") { Name = "Yankee", Order = 20 },
+            new MeshNode("a", "ns") { Name = "Xray", Order = 30 },
+            new MeshNode("m", "ns") { Name = "Bravo" },   // no Order -> last
+            new MeshNode("n", "ns") { Name = "Alpha" },   // no Order -> last, alphabetical among nulls
+        };
+
+        var ordered = MarkdownOverviewLayoutArea.OrderSubNodes(children);
+
+        ordered.Select(n => n.Name).Should()
+            .Equal("Zulu", "Yankee", "Xray", "Alpha", "Bravo");
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
@@ -94,4 +94,28 @@ public class InstallSignatureAlignmentTest(ITestOutputHelper output) : MonolithM
                 "an unknown incoming member means the file carries something the persisted shape " +
                 "does not — alignment must fall back to the raw compare, never silently drop it");
     }
+
+    /// <summary>#727 defect 2: a change to <c>Order</c> ALONE must read as a change — the installer
+    /// skipped order-only updates because <c>ScalarsUnchanged</c> did not compare Order.</summary>
+    [Fact(Timeout = 30000)]
+    public void OrderOnlyChange_IsDetected()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" }) with { Order = 10 };
+        var incoming = current with { Order = 20 };
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse("an order-only change must be written, not skipped as unchanged");
+    }
+
+    /// <summary>Control: identical nodes (same Order) still read as unchanged — the fix must not
+    /// over-trigger a rewrite.</summary>
+    [Fact(Timeout = 30000)]
+    public void SameOrder_IsStillUnchanged()
+    {
+        var current = Node(new PluginCatalogContent { SourceRepoPath = "/repo" }) with { Order = 10 };
+        var incoming = current with { };
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeTrue("nodes identical in every applied field (Order included) stay unchanged");
+    }
 }


### PR DESCRIPTION
Fixes #727.

`MeshNode.Order` was silently ignored for a markdown node's side menu — two independent defects that compounded, so fixing either alone left the symptom.

## Fixes

- **`MarkdownOverviewLayoutArea`** sorted side-menu children by **name only**, disagreeing with the graph navigator and every other child list. Now orders by `Order ?? int.MaxValue` (nulls last, per the field's documented contract) then name. The sort is extracted to a small `internal OrderSubNodes` helper for unit testing.
- **`PackageInstaller.ScalarsUnchanged`** did not compare `Order`, so an order-only package change was judged "unchanged" and never written. Now compares `Order`.

## Tests
- `MarkdownSideMenuOrderTest` — orders by Order then name, nulls last.
- `InstallSignatureAlignmentTest` — two new cases: an order-only change is detected; an identical node stays unchanged (control, so the fix doesn't over-trigger).
- `IncrementalUpdateTest` re-run — confirms the `ScalarsUnchanged` change doesn't regress the incremental-update behavior.

## Scope / verification
- `src/` framework: `MeshWeaver.Graph`, `MeshWeaver.PluginCatalog`.
- Release `-warnaserror` build clean; affected tests 8/8 pass.
- What's New entry added (`side-menu-order`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
