### PR TITLE
Serve /static content with an AccessContext, and accept HEAD (#666)

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -22,21 +22,27 @@ namespace MeshWeaver.Blazor.Infrastructure;
 /// <param name="logger">Logger for user resolution warnings and errors.</param>
 public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMiddleware> logger)
 {
-    // Blazor framework files, static assets, and favicon — no user context needed.
+    // Blazor framework files and favicon — no user context needed. NOTE: /static/ is intentionally
+    // NOT excluded (issue #666): the address-based /static/{address}/… content route posts a
+    // GetDataRequest into the mesh, which the never-null PostPipeline guard fail-closes to 500
+    // without an AccessContext. Unauthenticated requests resolve to AnonymousContext below, so public
+    // assets still serve; RLS filters the rest.
     private static readonly string[] ExcludedPrefixes =
-        ["/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico"];
+        ["/_framework", "/_content", "/_blazor", "/favicon.ico"];
 
     /// <summary>
     /// Resolves the user identity from OAuth claims or a Bearer token and sets the
     /// <c>AccessService</c> context for the current request before passing to the next middleware.
-    /// Static-asset paths are bypassed without any identity work.
+    /// Blazor framework paths are bypassed without any identity work; /static/ content assets are
+    /// resolved (issue #666).
     /// </summary>
     /// <param name="context">The current HTTP context.</param>
     public async Task InvokeAsync(HttpContext context)
     {
-        // Skip user resolution for static assets and Blazor framework resources.
+        // Skip user resolution for Blazor framework resources and the favicon.
         // These requests never need an AccessContext and resolving it adds unnecessary
         // overhead (hub lookup, mesh query) on every JS/CSS/SignalR resource download.
+        // (/static/ content assets ARE resolved now — see ExcludedPrefixes, issue #666.)
         var path = context.Request.Path.Value ?? "";
         if (ExcludedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
         {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-static-assets-reliable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-static-assets-reliable.md
@@ -1,0 +1,12 @@
+---
+Name: Static assets load reliably
+Category: What's New
+Description: Media and images served from a space no longer intermittently fail to load, and HEAD requests for them now succeed.
+Icon: CheckmarkCircle
+---
+
+# Static assets load reliably
+
+An image or video served from a space's files could intermittently fail to load on a busy portal — a cover or poster showing up on one page load and blank on the next. That intermittency is gone: these requests now resolve under the visitor's identity (anonymous for public content, so public assets still serve), which is what they needed to succeed consistently.
+
+A `HEAD` request for such a file — the lightweight request a browser or link checker makes to read a file's size and type without downloading it — now returns success instead of being rejected.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -179,7 +179,7 @@ public static class BlazorHostingExtensions
         // Lazy resolution of IMessageHub to avoid circular dependency during startup
         IMessageHub? mainHub = null;
 
-        app.MapGet("/static/{**path}",
+        app.MapMethods("/static/{**path}", ["GET", "HEAD"],
             (HttpContext context, string path) =>
         {
             // Resolve hub on first request

--- a/test/MeshWeaver.Hosting.Blazor.Test/UserContextMiddlewareExclusionTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/UserContextMiddlewareExclusionTest.cs
@@ -13,7 +13,6 @@ public class UserContextMiddlewareExclusionTest
     [InlineData("/_framework/blazor.web.js")]
     [InlineData("/_content/MeshWeaver.Blazor/css/app.css")]
     [InlineData("/_blazor/negotiate")]
-    [InlineData("/static/images/logo.png")]
     [InlineData("/favicon.ico")]
     public async Task ExcludedPrefixes_SkipUserResolution(string path)
     {
@@ -41,6 +40,9 @@ public class UserContextMiddlewareExclusionTest
     [InlineData("/ACME/Overview")]
     [InlineData("/User/Alice")]
     [InlineData("/")]
+    // #666: /static/ is deliberately NOT excluded — the address-based content route posts a
+    // GetDataRequest into the mesh and needs an AccessContext (else the never-null guard 500s).
+    [InlineData("/static/AgenticEngineering/content/videos/module1-intro.mp4")]
     public async Task NonExcludedPaths_AttemptUserResolution(string path)
     {
         RequestDelegate next = _ => Task.CompletedTask;
@@ -61,7 +63,6 @@ public class UserContextMiddlewareExclusionTest
     [Theory]
     [InlineData("/_FRAMEWORK/blazor.web.js")]
     [InlineData("/_Content/something")]
-    [InlineData("/Static/image.png")]
     [InlineData("/FAVICON.ICO")]
     public async Task ExcludedPrefixes_AreCaseInsensitive(string path)
     {


### PR DESCRIPTION
Fixes #666.

The MIME types, inline `Content-Disposition` and byte-range support were fixed by #692 (`fix/static-media-inline`). This closes the **residual** two defects.

## Fixes

- **HEAD → 405.** The `/static/{**path}` route was `MapGet` only. Now `MapMethods(["GET","HEAD"])`, so a `HEAD` request succeeds.
- **Intermittent 500.** `UserContextMiddleware.ExcludedPrefixes` still contained `/static/`, so the address-based `/static/{address}/…` content route posted a `GetDataRequest` with **no `AccessContext`** and the never-null `PostPipeline` guard fail-closed it (per-replica, depending on cache warmth). Removed `/static/` from the exclusion — the middleware already resolves an unauthenticated request to `AnonymousContext` (never null), so public assets still serve and RLS filters the rest.

## Tests
- `UserContextMiddlewareExclusionTest` updated: `/static/` moved from the "skipped" theories to the "attempts resolution" theory (the #666 regression guard).
- `StaticMediaServingTest` unchanged and green.
- **Not unit-tested:** the HEAD **route** registration (routing needs a full host; the response-level tests sit below routing). It's a trivial, safe registration change.

## Scope / verification
- `src/` framework: `MeshWeaver.Hosting.Blazor`, `MeshWeaver.Blazor`.
- Release `-warnaserror` build clean; affected tests 33/33 pass.
- What's New entry added (`static-assets-reliable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
