### PR TITLE
Render collection properties read-only in the node Edit form (#777)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-list-fields-safe-edit.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-06-list-fields-safe-edit.md
@@ -1,0 +1,12 @@
+---
+Name: List fields can't be wiped by a stray keystroke
+Category: What's New
+Description: The node Edit form no longer lets a single character overwrite a whole list-valued field — collections now display read-only instead of as a destructive text box.
+Icon: ShieldCheckmark
+---
+
+# List fields can't be wiped by a stray keystroke
+
+Editing a node whose type has a list-valued field is now safe. Such a field used to render in the Edit form as a text box that looked empty; typing a single character into it replaced the entire list with that text, corrupting the node — and once corrupted, the node could no longer be repaired through the form.
+
+Those fields now display read-only in the Edit form, so an edit can no longer destroy the list. A proper in-form list editor is a separate future improvement; until then, the data stays intact.

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -1334,6 +1334,16 @@ public static class EditorExtensions
         {
             editCtrl = new CheckBoxControl(jsonPointer) { Required = isRequired };
         }
+        else if (propType != typeof(string)
+                 && typeof(System.Collections.IEnumerable).IsAssignableFrom(propType))
+        {
+            // #777: a collection has no scalar text form. The TextFieldControl fallthrough below binds
+            // it Immediate, so a single keystroke overwrites the whole list with a string and corrupts
+            // the node's content (the node then fails to deserialize and the form degrades to editing
+            // JsonElement internals). Render the value read-only — the same LabelControl the display
+            // path uses — until a real collection editor exists, so an edit can never destroy the list.
+            editCtrl = new LabelControl(jsonPointer);
+        }
         else
         {
             var textCtrl = new TextFieldControl(jsonPointer)

--- a/test/MeshWeaver.Graph.Test/OverviewLayoutAreaTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverviewLayoutAreaTest.cs
@@ -39,6 +39,7 @@ public class OverviewLayoutAreaTest(ITestOutputHelper output) : HubTestBase(outp
                 .WithView(OverviewView, BuildOverviewView)
                 .WithView(nameof(MarkdownOverviewView), MarkdownOverviewView)
                 .WithView(nameof(EditToggleView), EditToggleView)
+                .WithView(nameof(CollectionEditView), CollectionEditView)
                 .WithView(nameof(PreRenderedHtmlView), PreRenderedHtmlView)
                 .WithView(nameof(NoPreRenderedHtmlView), NoPreRenderedHtmlView));
     }
@@ -82,6 +83,21 @@ public class OverviewLayoutAreaTest(ITestOutputHelper output) : HubTestBase(outp
         // Use MapToToggleableControl directly for a single property
         var prop = typeof(TestTodo).GetProperty(nameof(TestTodo.Category))!;
         return host.Hub.ServiceProvider.MapToToggleableControl(prop, dataId, canEdit: true, host);
+    }
+
+    /// <summary>
+    /// A collection property in EDIT mode (isToggleable:false starts directly in edit) — the #777
+    /// regression seam: its edit control must NOT be a bound TextFieldControl.
+    /// </summary>
+    private static UiControl CollectionEditView(LayoutAreaHost host, RenderingContext ctx)
+    {
+        var entity = new TestWithTags { Id = "t1", Tags = ["a", "b", "c"] };
+        var dataId = "collectionEditData";
+        host.UpdateData(dataId, entity);
+
+        var prop = typeof(TestWithTags).GetProperty(nameof(TestWithTags.Tags))!;
+        // isToggleable:false → renders directly in edit mode, so the EDIT control is what shows.
+        return host.Hub.ServiceProvider.MapToToggleableControl(prop, dataId, canEdit: true, host, isToggleable: false);
     }
 
     [HubFact]
@@ -176,6 +192,32 @@ public class OverviewLayoutAreaTest(ITestOutputHelper output) : HubTestBase(outp
             .Should().Within(3.Seconds()).Match(c => c is TextFieldControl or NumberFieldControl or SelectControl);
 
         editControl.Should().NotBeNull("should switch to an edit control");
+    }
+
+    [HubFact]
+    public async Task CollectionProperty_EditControl_IsReadOnlyLabel_NotTextField()
+    {
+        var reference = new LayoutAreaReference(nameof(CollectionEditView));
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), reference);
+
+        var control = await stream
+            .GetControlStream(reference.Area!)
+            .Should().Within(5.Seconds()).Match(x => x != null);
+
+        var stack = control.Should().BeOfType<StackControl>().Subject;
+        var editAreaName = stack.Areas.Last().Area?.ToString();
+        editAreaName.Should().NotBeNullOrEmpty();
+
+        // isToggleable:false renders the EDIT control directly. #777: a collection must render
+        // read-only, never a bound TextFieldControl — a keystroke there overwrites the whole list.
+        var editControl = await stream
+            .GetControlStream(editAreaName!)
+            .Should().Within(5.Seconds()).Match(c => c is not null);
+
+        editControl.Should().BeOfType<LabelControl>(
+            "a collection edit must be read-only; a bound text field would let one keystroke destroy the list");
     }
 
     [HubFact]
@@ -339,4 +381,16 @@ public record TestDocument
 
     [UiControl<MarkdownEditorControl, MarkdownControl>(SeparateEditView = true)]
     public string Content { get; init; } = "";
+}
+
+/// <summary>
+/// Test entity with a collection property — the #777 regression seam: its Edit control must be
+/// read-only, never a bound text field.
+/// </summary>
+public record TestWithTags
+{
+    [Key]
+    public string Id { get; init; } = "";
+
+    public string[] Tags { get; init; } = [];
 }


### PR DESCRIPTION
Fixes #777.

The generated node Edit form fell any unhandled property type through to a `TextFieldControl` bound `Immediate = true`. For a **collection** property that box rendered empty, and typing one character wrote a scalar string over the whole list — corrupting the node's `content` (which then failed to deserialize, degrading the form to editing `JsonElement` internals, with no way to repair it through the product).

## Fix
`BuildEditControl` now renders a non-string `IEnumerable` property as a **read-only `LabelControl`** — the same control the read-only display path already uses — so an edit can never destroy the list. (Issue option 1, the cheapest.) A real in-form collection editor (chips/tags) is a separate follow-up.

## Test
`CollectionProperty_EditControl_IsReadOnlyLabel_NotTextField` — via `MapToToggleableControl(isToggleable:false)` (which renders the edit control directly), asserts a collection's edit control is a `LabelControl`, not a `TextFieldControl`.

## Scope / verification
- `src/` framework: `MeshWeaver.Layout`.
- Release `-warnaserror` build clean; `OverviewLayoutAreaTest` 10/10 pass.
- What's New entry added (`list-fields-safe-edit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
