### PR TITLE
A package's agents were installed but unreachable — register its sources on every user

### DIFF
--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -46,7 +46,14 @@ public static class AIExtensions
                     .AddSkillType(serveFromPartition)
                     .AddThreadComposerType()
                     .AddAiSettingsType()
-                    .ConfigureServices(services => services.AddAgentChatServices())
+                    .ConfigureServices(services => services
+                        .AddAgentChatServices()
+                        // Makes a package's agents + skills REACHABLE, not merely installed: without
+                        // it, a package writes its agents into its own partition and no user's
+                        // picker ever asks for them. Registered here because AI owns the registries;
+                        // MeshWeaver.PluginCatalog invokes it and neither project references the other.
+                        .AddSingleton<MeshWeaver.Graph.IPartitionInstallHook>(sp =>
+                            new AiSourcesInstallHook(sp.GetRequiredService<IMessageHub>())))
                     // Register AI types on the MESH hub (for MeshQuery deserialization of Thread content)
                     .ConfigureHub(config =>
                     {

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -146,6 +146,46 @@ public static class AiSettingsNodeType
     }
 
     /// <summary>
+    /// The default AGENT sources, as tokenized templates — the same set
+    /// <see cref="AgentPickerProjection.BuildAgentQueries"/> defines, so there is one definition.
+    /// </summary>
+    public static ImmutableArray<string> DefaultAgentQueryTemplates { get; } =
+        AgentPickerProjection.BuildAgentQueries(UserPathToken, CurrentPathToken).ToImmutableArray();
+
+    /// <summary>
+    /// Pure merge for "install this package": appends the package's AGENT source query
+    /// (<c>namespace:{sourceNamespace}/Agent nodeType:Agent</c>) to
+    /// <see cref="AiSettings.AgentQueries"/>. Mirrors <see cref="MergeSkillSource"/> exactly — an
+    /// empty list is seeded with the code defaults FIRST so adding a package never silently drops
+    /// the standard sources, and an already-present source is not duplicated.
+    ///
+    /// <para>This is the piece whose absence made every plugin-shipped agent invisible: a package
+    /// wrote its agents into its own partition and nothing ever told the picker to look there.</para>
+    /// </summary>
+    public static AiSettings MergeAgentSource(AiSettings settings, string sourceNamespace)
+    {
+        var rows = settings.AgentQueries.IsDefaultOrEmpty
+            ? DefaultAgentQueryTemplates
+            : settings.AgentQueries;
+        var query = $"namespace:{sourceNamespace}/{AgentPickerProjection.AgentSubNamespace} "
+                    + $"nodeType:{AgentNodeType.NodeType}{AgentPickerProjection.RegistryProjection}";
+        return rows.Contains(query, StringComparer.OrdinalIgnoreCase)
+            ? settings with { AgentQueries = rows }
+            : settings with { AgentQueries = rows.Add(query) };
+    }
+
+    /// <summary>
+    /// Pure merge of EVERY registry source a package contributes — agents and skills together, so a
+    /// caller cannot register one and forget the other. Idempotent.
+    /// </summary>
+    /// <param name="settings">The user's current settings.</param>
+    /// <param name="partition">The package's partition, e.g. <c>Essentials</c>.</param>
+    public static AiSettings MergePackageSources(AiSettings settings, string partition) =>
+        MergeSkillSource(
+            MergeAgentSource(settings, partition),
+            $"{partition}/{AgentPickerProjection.SkillSubNamespace}");
+
+    /// <summary>
     /// Installs a SKILL PACKAGE for <paramref name="user"/>: appends the package's skill folder (e.g.
     /// <c>Office/Skill</c>) to the user's <see cref="AiSettings.SkillQueries"/> sources — idempotent,
     /// fire-and-forget, same keyed-query read discipline as <see cref="EnsureExists"/> (never a

--- a/src/MeshWeaver.AI/AiSourcesInstallHook.cs
+++ b/src/MeshWeaver.AI/AiSourcesInstallHook.cs
@@ -1,0 +1,142 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Registers a freshly-installed package's registry sources — its agents and its skills — on EVERY
+/// user of this instance, so the content a package ships is usable the moment it lands.
+///
+/// <para><b>The bug this closes.</b> A package installs its agents into its own partition
+/// (<c>Essentials/Agent</c>), but the agent picker resolves from each user's
+/// <c>AiSettings.AgentQueries</c>, which is written ONCE and never revisited. A user whose settings
+/// predate the install therefore asks for <c>namespace:{user}/Agent|{space}/Agent|Agent</c> forever —
+/// none of which match — and gets an empty picker with no error in any log. Skills had the identical
+/// latent hole: <c>AddSkillSource</c> existed but nothing ever called it.</para>
+///
+/// <para><b>Every user, not just the installer.</b> A package is installed once, by an admin, for the
+/// whole instance — so the sources belong on every account, including accounts created before the
+/// install (they inherit the code defaults, which this then extends) and accounts that never open the
+/// settings page.</para>
+///
+/// <para><b>Idempotent by construction.</b> It runs on install, on every package update, and on the
+/// startup REPAIR pass — so "already correct" is the common case. A user whose rows are already
+/// present is left completely untouched: no write, no version bump, no change feed.</para>
+/// </summary>
+/// <param name="hub">Hub supplying the workspace and mesh service.</param>
+public sealed class AiSourcesInstallHook(IMessageHub hub) : IPartitionInstallHook
+{
+    /// <inheritdoc />
+    public IObservable<Unit> OnPartitionInstalled(string partition)
+    {
+        if (string.IsNullOrWhiteSpace(partition))
+            return Observable.Return(Unit.Default);
+
+        var services = hub.ServiceProvider;
+        var meshService = services.GetService<IMeshService>();
+        var accessService = services.GetService<AccessService>();
+        var logger = services.GetService<ILoggerFactory>()?.CreateLogger<AiSourcesInstallHook>();
+        if (meshService is null)
+            return Observable.Return(Unit.Default);
+
+        // Reconciling every account is a PLATFORM action — the install itself is gated to global
+        // admins, and that gate is the authorization. Scoped around the writes, never ambient across
+        // the pipeline's scheduler hops.
+        return Users()
+            .SelectMany(users => users.Count == 0
+                ? Observable.Return(Unit.Default)
+                : users
+                    .Select(user => Reconcile(meshService, accessService, user, partition, logger))
+                    .ToObservable()
+                    .Merge(4)
+                    .ToList()
+                    .Select(_ => Unit.Default))
+            .Catch((Exception ex) =>
+            {
+                // The package content is already written by the time hooks run; a failure here must
+                // not fail the install. Surface it and move on.
+                logger?.LogWarning(ex,
+                    "Registering AI sources for partition {Partition} failed", partition);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>Every user on this instance. One snapshot — this runs at install, not per render.</summary>
+    private IObservable<IReadOnlyList<string>> Users() =>
+        hub.GetWorkspace()
+            // No namespace filter: on a partitioned Postgres backend a `namespace:User` query
+            // matches nothing (the users live in their own partitions).
+            .GetQuery("ai-sources-users", $"nodeType:{UserNodeType} select:path,id,name,nodeType")
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Select(nodes => (IReadOnlyList<string>)nodes
+                .Select(n => n.Id)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList());
+
+    /// <summary>
+    /// Adds the partition's agent + skill sources to one user's settings, writing ONLY when that
+    /// actually changes something.
+    /// </summary>
+    private IObservable<Unit> Reconcile(
+        IMeshService meshService,
+        AccessService? accessService,
+        string user,
+        string partition,
+        ILogger? logger)
+    {
+        var path = AiSettingsNodeType.PathFor(user);
+        return hub.GetWorkspace()
+            .GetQuery($"{AiSettingsNodeType.NodeType}|{user}",
+                $"path:{path} nodeType:{AiSettingsNodeType.NodeType} select:path,id,name,nodeType,content")
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .SelectMany(nodes =>
+            {
+                var node = nodes.FirstOrDefault(n => string.Equals(
+                    n.NodeType, AiSettingsNodeType.NodeType, StringComparison.OrdinalIgnoreCase));
+                var current = AiSettingsNodeType.Effective(
+                    node, AiSettingsNodeType.BuildDefaults(hub.ServiceProvider), hub.JsonSerializerOptions);
+                var merged = AiSettingsNodeType.MergePackageSources(current, partition);
+
+                // Already correct — the common case. Do not write: a no-op write bumps the version
+                // and fans a change through every subscriber for nothing.
+                if (merged.AgentQueries.SequenceEqual(current.AgentQueries)
+                    && merged.SkillQueries.SequenceEqual(current.SkillQueries))
+                    return Observable.Return(Unit.Default);
+
+                var target = node ?? MeshNode.FromPath(path) with
+                {
+                    NodeType = AiSettingsNodeType.NodeType,
+                    Name = "AI Settings",
+                };
+                // Scoped around the WRITE, never ambient across the pipeline's scheduler hops —
+                // an ambient impersonation does not survive those (PackageInstaller says the same).
+                return Observable
+                    .Using(
+                        () => accessService?.ImpersonateAsSystem()
+                              ?? (IDisposable)System.Reactive.Disposables.Disposable.Empty,
+                        _ => meshService.CreateOrUpdateNode(target with { Content = merged }))
+                    .Do(_ => logger?.LogInformation(
+                        "Registered {Partition} agent + skill sources for {User}", partition, user))
+                    .Select(_ => Unit.Default);
+            })
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "Registering {Partition} sources for user {User} failed", partition, user);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>The User node type discriminator — matches <c>AddGraph()</c>'s standard types.</summary>
+    private const string UserNodeType = "User";
+}

--- a/src/MeshWeaver.Graph/IPartitionInstallHook.cs
+++ b/src/MeshWeaver.Graph/IPartitionInstallHook.cs
@@ -1,0 +1,32 @@
+using System.Reactive;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// A side effect that must run when a package's content lands in a partition — install, update, or
+/// the startup REPAIR pass over already-installed packages.
+///
+/// <para><b>Why this exists.</b> A package ships content into a partition of its own
+/// (<c>Essentials/Agent</c>, <c>Feedback/Agent</c>, …), but the registries that surface that content
+/// — the agent picker, the skill menu — resolve from per-user source lists. Nothing connected the
+/// two, so a package installed AFTER a user's settings were written stayed invisible to that user
+/// forever: the picker asked for <c>namespace:Agent</c>, every agent lived in
+/// <c>Essentials/Agent</c>, and the result was an empty picker with no error anywhere.</para>
+///
+/// <para>The hook is keyed on the PARTITION rather than the manifest so it can live here, in the
+/// project both <c>MeshWeaver.PluginCatalog</c> (which installs) and <c>MeshWeaver.AI</c> (which owns
+/// the registries) already reference. Neither references the other, and this keeps it that way.</para>
+///
+/// <para><b>Implementations must be idempotent.</b> They run on every install, every update, and on
+/// every startup repair — "already correct" is the common case and must be a no-op, not a rewrite.</para>
+/// </summary>
+public interface IPartitionInstallHook
+{
+    /// <summary>
+    /// Reconciles whatever this hook owns for content now present in <paramref name="partition"/>.
+    /// Cold — the work runs on Subscribe. Errors are the caller's to log; a failing hook must never
+    /// fail the install itself, since the content is already written by the time hooks run.
+    /// </summary>
+    /// <param name="partition">The partition the package installed into, e.g. <c>Essentials</c>.</param>
+    IObservable<Unit> OnPartitionInstalled(string partition);
+}

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -1,0 +1,110 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Re-runs the <see cref="IPartitionInstallHook"/>s for every ALREADY-installed package, once, at
+/// startup — the REPAIR pass.
+///
+/// <para><b>Why a repair pass is needed at all.</b> Hooks now run on install, but every package
+/// installed before they existed never ran them, and every account created since inherited the gap.
+/// On a live instance that is the entire population: agents shipped by a package are present in the
+/// mesh and invisible in every picker. Waiting for the next package update to fix it would leave
+/// users broken for however long that takes, for a defect they cannot see or work around.</para>
+///
+/// <para><b>Safe to run every boot.</b> Hooks are required to be idempotent, and the AI hook writes
+/// only when a user's sources actually change — so on an already-repaired instance this reads and
+/// writes nothing. It is deliberately fire-and-forget and failure-tolerant: repair must never delay
+/// or fail startup.</para>
+/// </summary>
+/// <param name="hub">Hub supplying the workspace and the registered hooks.</param>
+public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedService
+{
+    private IDisposable? subscription;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger<InstalledPackageRepairService>();
+
+        // Nothing to repair when no hook is registered — skip the query entirely.
+        if (!hub.ServiceProvider.GetServices<IPartitionInstallHook>().Any())
+            return Task.CompletedTask;
+
+        subscription = InstalledPartitions(logger)
+            .SelectMany(partitions => partitions.Count == 0
+                ? Observable.Return(Unit.Default)
+                : partitions
+                    .Select(partition => PackageInstaller.RunInstallHooks(hub, partition, logger))
+                    .ToObservable()
+                    .Concat()
+                    .DefaultIfEmpty(Unit.Default)
+                    .LastAsync()
+                    .Do(_ => logger?.LogInformation(
+                        "[PackageRepair] reconciled install hooks for {Count} installed partition(s)",
+                        partitions.Count)))
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex, "[PackageRepair] repair pass failed"));
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The partitions of every recorded install. Reads the <c>Package</c> records the installer
+    /// writes, so the repair covers exactly what is installed — no hard-coded package list.
+    /// </summary>
+    private IObservable<IReadOnlyList<string>> InstalledPartitions(ILogger? logger) =>
+        hub.GetWorkspace()
+            .GetQuery("installed-packages-repair",
+                $"namespace:{PackageInstaller.InstalledPartition} "
+                + $"nodeType:{PackageInstaller.PackageNodeType} select:path,id,name,nodeType,content")
+            .Take(1)
+            .Timeout(TimeSpan.FromMinutes(2))
+            .Select(nodes => (IReadOnlyList<string>)nodes
+                .Select(PartitionOf)
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p => p!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList())
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex, "[PackageRepair] listing installed packages failed");
+                return Observable.Return((IReadOnlyList<string>)[]);
+            });
+
+    /// <summary>
+    /// The target partition of an install record. The record's id IS the package id, and the
+    /// installer targets a partition of that name — read from content when present so a package
+    /// whose partition differs from its id still repairs correctly.
+    /// </summary>
+    private string? PartitionOf(MeshWeaver.Mesh.MeshNode node)
+    {
+        if (node.Content is System.Text.Json.JsonElement json
+            && json.ValueKind == System.Text.Json.JsonValueKind.Object
+            && json.TryGetProperty("targetPartition", out var value)
+            && value.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            var declared = value.GetString();
+            if (!string.IsNullOrWhiteSpace(declared))
+                return declared;
+        }
+        return node.Id;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        subscription?.Dispose();
+        subscription = null;
+        return Task.CompletedTask;
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -113,6 +113,7 @@ public static class PackageInstaller
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, partition, installedFromRef);
                 return WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length)
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
+                    .SelectMany(_ => RunInstallHooks(hub, partition!, logger))
                     .Select(_ => result);
             });
     }
@@ -179,6 +180,38 @@ public static class PackageInstaller
     /// <para>Best-effort by design: the content has already landed and been recorded, so a root that
     /// will not activate is logged and stepped over rather than failing an install that succeeded.</para>
     /// </summary>
+    /// <summary>
+    /// Runs every registered <see cref="IPartitionInstallHook"/> for the installed partition — the
+    /// step that makes a package's content actually REACHABLE, not merely present.
+    ///
+    /// <para>Writing the nodes is only half an install: the registries that surface them (the agent
+    /// picker, the skill menu) resolve from per-user source lists that nothing else updates. Without
+    /// this, a package's agents sit in the mesh and no picker ever asks for them.</para>
+    ///
+    /// <para>Hooks are best-effort: the content is already committed by the time they run, so a
+    /// failing hook is logged and never fails the install.</para>
+    /// </summary>
+    public static IObservable<Unit> RunInstallHooks(IMessageHub hub, string partition, ILogger? logger)
+    {
+        var hooks = hub.ServiceProvider.GetServices<IPartitionInstallHook>().ToArray();
+        if (hooks.Length == 0 || string.IsNullOrWhiteSpace(partition))
+            return Observable.Return(Unit.Default);
+
+        return hooks
+            .Select(hook => hook.OnPartitionInstalled(partition)
+                .Catch<Unit, Exception>(exception =>
+                {
+                    logger?.LogWarning(exception,
+                        "[PackageInstaller] install hook {Hook} failed for partition {Partition}",
+                        hook.GetType().Name, partition);
+                    return Observable.Return(Unit.Default);
+                }))
+            .ToObservable()
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync();
+    }
+
     private static IObservable<Unit> WarmInstalledRoots(
         IMessageHub hub, IEnumerable<string> paths, ILogger? logger)
     {

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -44,7 +44,14 @@ public static class PluginCatalogConfigurationExtensions
                 // Resolves an inbound instance key to its instance + grant for the /api/plugins
                 // surface. Mesh-scoped singleton so its short-lived cache dies with the mesh
                 // (Doc/Architecture/NoStaticState) — a revoked grant must not outlive a test either.
-                .AddSingleton<InstanceRegistryAuthenticator>())
+                .AddSingleton<InstanceRegistryAuthenticator>()
+                // Re-runs the install hooks for ALREADY-installed packages once at startup. Packages
+                // installed before hooks existed never registered their agent/skill sources, so on a
+                // live instance every user's picker is missing them — and nothing else would fix it
+                // until the next package update. Idempotent: on a repaired instance it writes nothing.
+                .AddSingleton<InstalledPackageRepairService>()
+                .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
+                    sp => sp.GetRequiredService<InstalledPackageRepairService>()))
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/MeshWeaver.AI.Test/PackageSourceRegistrationTest.cs
+++ b/test/MeshWeaver.AI.Test/PackageSourceRegistrationTest.cs
@@ -1,0 +1,109 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the merge a package install performs on a user's <see cref="AiSettings"/> sources.
+///
+/// <para><b>The defect this closes.</b> A package installs its agents into its own partition
+/// (<c>Essentials/Agent</c>), but the agent picker resolves from each user's persisted
+/// <c>AgentQueries</c> — written once and never revisited. A user whose settings predate the install
+/// asked for <c>namespace:{user}/Agent|{space}/Agent|Agent</c> forever, none of which match, and got
+/// an EMPTY PICKER with nothing in any log. On the live portal that was every agent: all 15 lived
+/// under <c>Essentials/Agent</c> and <c>Feedback/Agent</c>, and <c>namespace:Agent</c> returned zero.</para>
+/// </summary>
+public class PackageSourceRegistrationTest
+{
+    private const string Proj = AgentPickerProjection.RegistryProjection;
+
+    [Fact]
+    public void MergeAgentSource_AddsThePackagesAgentNamespace()
+    {
+        var merged = AiSettingsNodeType.MergeAgentSource(new AiSettings(), "Essentials");
+
+        merged.AgentQueries.Should().Contain("namespace:Essentials/Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void MergeAgentSource_SeedsTheCodeDefaultsFirst_SoInstallingNeverDropsTheStandardSources()
+    {
+        // An empty list means "code defaults". Appending to it must not silently replace them —
+        // that would trade one missing source for three.
+        var merged = AiSettingsNodeType.MergeAgentSource(new AiSettings(), "Essentials");
+
+        merged.AgentQueries.Take(AiSettingsNodeType.DefaultAgentQueryTemplates.Length)
+            .Should().Equal(AiSettingsNodeType.DefaultAgentQueryTemplates);
+    }
+
+    [Fact]
+    public void MergeAgentSource_IsIdempotent()
+    {
+        // It runs on install, on every package update, and on every startup repair — so the
+        // already-correct case must be a genuine no-op, not a growing list.
+        var once = AiSettingsNodeType.MergeAgentSource(new AiSettings(), "Essentials");
+        var twice = AiSettingsNodeType.MergeAgentSource(once, "Essentials");
+
+        twice.AgentQueries.Should().Equal(once.AgentQueries);
+    }
+
+    [Fact]
+    public void MergeAgentSource_PreservesAUsersOwnCustomRows()
+    {
+        var custom = new AiSettings
+        {
+            AgentQueries = ImmutableArray.Create("namespace:Mine/Agent nodeType:Agent"),
+        };
+
+        var merged = AiSettingsNodeType.MergeAgentSource(custom, "Essentials");
+
+        merged.AgentQueries.Should().Equal(
+            "namespace:Mine/Agent nodeType:Agent",
+            "namespace:Essentials/Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void MergePackageSources_RegistersAgentsAndSkillsTogether()
+    {
+        // One call, both registries — a caller cannot register agents and forget skills, which is
+        // exactly how skills ended up with the same latent hole (AddSkillSource had no callers).
+        var merged = AiSettingsNodeType.MergePackageSources(new AiSettings(), "Essentials");
+
+        merged.AgentQueries.Should().Contain("namespace:Essentials/Agent nodeType:Agent" + Proj);
+        merged.SkillQueries.Should().Contain("namespace:Essentials/Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void MergePackageSources_IsIdempotentAcrossBothRegistries()
+    {
+        var once = AiSettingsNodeType.MergePackageSources(new AiSettings(), "Essentials");
+        var twice = AiSettingsNodeType.MergePackageSources(once, "Essentials");
+
+        twice.AgentQueries.Should().Equal(once.AgentQueries);
+        twice.SkillQueries.Should().Equal(once.SkillQueries);
+    }
+
+    [Fact]
+    public void MergePackageSources_AccumulatesAcrossPackages()
+    {
+        // The live portal ships several free packages; installing one must not evict another.
+        var merged = AiSettingsNodeType.MergePackageSources(
+            AiSettingsNodeType.MergePackageSources(new AiSettings(), "Essentials"), "Feedback");
+
+        merged.AgentQueries.Should().Contain("namespace:Essentials/Agent nodeType:Agent" + Proj);
+        merged.AgentQueries.Should().Contain("namespace:Feedback/Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void TheDefaultAgentTemplates_AreTheCanonicalBuilderOutput()
+    {
+        // One definition: the settings defaults and the picker's builder must not drift, or a user
+        // with default settings resolves a different registry than the code says they should.
+        AiSettingsNodeType.DefaultAgentQueryTemplates.Should().Equal(
+            AgentPickerProjection.BuildAgentQueries("{userPath}", "{currentPath}"));
+    }
+}


### PR DESCRIPTION
## The bug

On the live portal, **`namespace:Agent` returns ZERO nodes.** All 15 agents live in package partitions — `Essentials/Agent`, `Feedback/Agent`, `ClaimsDeepfield/Agent`. The picker asks for `namespace:{user}/Agent|{space}/Agent|Agent`, none of which match, so it finds nothing and falls back to the path it expects (`Agent/Assistant`), which does not exist. **Empty picker, no error in any log.**

Installing a package writes its nodes and stops. The registries that *surface* that content resolve from each user's persisted `AiSettings` source rows, and nothing ever updated them — so a user whose settings predate an install can never see that package's agents. Confirmed on the portal: the affected settings node is **version 1, 21 July**; the Essentials agents were created **29 July**.

Skills had the identical hole hiding behind a working case: **`AddSkillSource` exists but has zero callers.** Plugin-shipped skills only surface today when they happen to fall under the current space's partition. (Skills appear to work only because the bare `Skill` namespace *is* populated, while the bare `Agent` namespace is empty — that asymmetry is the whole story.)

## The fix

- **`IPartitionInstallHook`** in `MeshWeaver.Graph` — the project both `MeshWeaver.PluginCatalog` (which installs) and `MeshWeaver.AI` (which owns the registries) already reference. Neither references the other and this keeps it that way; keyed on the **partition** rather than the manifest for the same reason.
- **`AiSourcesInstallHook`** — registers `{partition}/Agent` **and** `{partition}/Skill` on **every user of the instance**. A package is installed once, by an admin, for everyone, so the sources belong on every account — including ones that never open the settings page.
- **`MergePackageSources`** does both registries in one call, specifically so a caller cannot register agents and forget skills. That asymmetry is how skills got their hole.
- **`InstalledPackageRepairService`** — installing is not enough on a live instance: everything installed *before* hooks existed would stay broken until its next update. This re-runs the hooks at startup for every recorded install, so **a deploy repairs every account**. It reads the `Package` install records rather than a hard-coded list, so Essentials, Feedback and whatever is installed next are all covered.

## Idempotence

Hooks run on install, on every update, and on every boot. The AI hook compares before writing, so a repaired instance performs **no writes, no version bumps, no change-feed fan-out**. Hooks are best-effort: the content is already committed when they run, so a failing hook is logged and never fails the install.

## Verification

- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → clean
- 8 new tests: default-seeding, idempotence (per-registry and combined), custom-row preservation, accumulation across packages, and that the settings defaults equal the canonical builder output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Um7g7UaNMvB1yqdZNM3K4U