### PR TITLE
On a fresh database, group licensing silently granted nothing

### DIFF
--- a/memex/aspire/Memex.Database.Migration/Migrations/SchemaInitialization.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/SchemaInitialization.cs
@@ -89,14 +89,19 @@ public static class SchemaInitialization
         await using (var ensureVUser = dataSource.CreateCommand("SELECT public.ensure_partition_schema('vuser')"))
             await ensureVUser.ExecuteNonQueryAsync();
 
-        // NOTE: the framework schemas `auth` (V27 access-object mirror) and `system_access`
-        // (global/root-scope grants) are NOT created here. The portal's
-        // PostgreSqlPartitionSubscriptionHostedService provisions them (and every other
-        // registered framework partition) at boot, BEFORE any user write — so the mirror
-        // trigger always has a destination. Creating them here would also make
-        // DetectFreshDbAsync see `auth.mesh_nodes`/`system_access.mesh_nodes` and wrongly
-        // classify a fresh DB as non-fresh, running the legacy `user`-schema repair chain
-        // (V05+, which references the long-gone `user` schema) instead of fast-forwarding.
+        // NOTE: `auth` (the V27 access-object mirror) IS created — but by
+        // PostgreSqlSchemaInitializer.InitializeAsync above (step 4.5), not here: the per-boot
+        // auth-mirror self-heal that runs at the end of that same init installs the global
+        // group-recompute triggers ON auth.mesh_nodes and no-ops when the schema is absent, so
+        // the destination has to exist inside that init or a fresh DB never gets them.
+        // DetectFreshDbAsync excludes 'auth', so this does not flip a fresh DB to "existing".
+        //
+        // `system_access` (global/root-scope grants) is NOT created here — nothing in the
+        // migration depends on it, DetectFreshDbAsync does NOT exclude it (creating it would
+        // wrongly classify a fresh DB as non-fresh and run the legacy `user`-schema repair chain,
+        // V05+, which references the long-gone `user` schema), and the portal's
+        // PostgreSqlPartitionSubscriptionHostedService provisions it (and every other registered
+        // framework partition) at boot, BEFORE any user write.
 
         // Detect fresh DB: no CONTENT partition schemas (i.e., no schemas with a mesh_nodes
         // table) existed before this run. Framework schemas don't count.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -251,13 +251,43 @@ public static class PostgreSqlSchemaInitializer
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
+        // Step 4.5: Provision the `auth` mirror schema ITSELF — the destination table every
+        // access-object mirror trigger writes to, and the relation the GLOBAL group-recompute
+        // triggers (zzz_group_recompute_ins/_del) hang off. It is a framework schema with no
+        // owner but this initializer, so this init must create it rather than assume someone
+        // else did.
+        //
+        // 🚨 Why this MUST precede step 5: the self-heal opens with
+        // `IF to_regclass('"auth".mesh_nodes') IS NULL THEN RETURN`. Nothing else in the product
+        // creates auth before the migration runs (SchemaInitialization deliberately doesn't; the
+        // portal's PostgreSqlPartitionSubscriptionHostedService provisions it only at boot, i.e.
+        // AFTER the migration container has already come and gone). So on a FRESH database the
+        // heal silently no-opped on its only run, and `public.trg_group_changed()` + the two
+        // zzz_group_recompute_* triggers were never installed — a Group/GroupMembership change
+        // recomputed NOTHING until some later migration run happened to find auth present.
+        // Adding a member to a licensed group granted them nothing; removing one revoked nothing.
+        // Creating auth here makes the heal's guard a genuine fail-safe instead of the normal path.
+        //
+        // Safe for fresh-DB detection: SchemaInitialization.DetectFreshDbAsync explicitly excludes
+        // 'auth' from the content-partition probe, so provisioning it does not flip a fresh DB to
+        // "existing" (which would run the legacy `user`-schema repair chain).
+        //
+        // PUBLIC-INIT ONLY, same as step 5 — per-schema data sources must not provision auth.
+        if (string.Equals(options.Schema, "public", StringComparison.OrdinalIgnoreCase))
+        {
+            await using var cmd = dataSource.CreateCommand("SELECT public.ensure_partition_schema('auth')");
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
         // Step 5: SELF-HEAL the auth mirror. Step 2.5 heals the trigger FUNCTION on every init;
         // this heals the TRIGGERS and the DATA, so the mirror converges on every boot instead of
         // depending on a one-time migration: (a) any partition schema missing the
         // mesh_node_mirror_access_objects trigger (provisioned during a bad window) gets it,
         // (b) mirrored rows that were missed or went stale while the function/trigger was wrong
-        // are reconciled into auth.mesh_nodes. One server-side pass, idempotent, fail-safe (skips
-        // when auth isn't provisioned yet — e.g. a bare test fixture). This is the durable answer
+        // are reconciled into auth.mesh_nodes, and (c) the global group-recompute triggers are
+        // (re)installed on auth.mesh_nodes. One server-side pass, idempotent, fail-safe (skips
+        // when auth isn't provisioned — which step 4.5 now guarantees it is, so the guard is a
+        // belt-and-braces fail-safe, not the fresh-DB path). This is the durable answer
         // to the 2026-07 "spaces invisible in the catalog" incident: even if the mirror breaks
         // again, the next restart repairs both trigger topology and data.
         //


### PR DESCRIPTION
Started as "why do 4 `GroupMembershipRecomputeTests` fail locally but pass in CI". It is a **product bug**, not a test bug.

## The defect

On any **fresh deployment**, adding a member to a licensed group gave them no access, and removing one revoked none — until a *second* migration run happened to come along.

`PostgreSqlSchemaInitializer.InitializeAsync` step 5 (the auth-mirror self-heal) is the **only** thing in the product that creates `public.trg_group_changed()` and the `zzz_group_recompute_ins/_del` triggers on `auth.mesh_nodes`. It opens with:

```sql
IF to_regclass('"auth".mesh_nodes') IS NULL THEN RETURN; END IF;
```

…and **nothing creates `auth` before that point**. `SchemaInitialization` deliberately did not (its NOTE said so), and the portal's `PostgreSqlPartitionSubscriptionHostedService` provisions it only at *portal boot* — after the migration container has already come and gone. So on a fresh database the self-heal silently no-opped on its only run, the triggers were never installed, and a `GroupMembership` write recomputed nothing.

## The fix

**Step 4.5** provisions `auth` via the `ensure_partition_schema` proc that step 4 just created, before the heal runs — turning the heal's guard into a genuine fail-safe instead of the normal fresh-DB path. Public-init only, same as step 5, so per-schema data sources don't provision `auth`.

Safe for fresh-DB detection: `DetectFreshDbAsync`'s probe is `NOT IN ('public','admin','auth','apitoken','vuser')` — `auth` is excluded, so creating it **cannot** flip a fresh DB to "existing" and run the legacy `user`-schema repair chain (V05+, which references the long-gone `user` schema). `system_access` is deliberately still not created here, because it is *not* in that exclusion list. The stale NOTE is rewritten to say which schema is created where and why the other is not.

This also restores a contract `DefaultPartitionProvider`'s own doc already claimed but that was false: *"The migration creates the `auth` schema so the trigger has a destination."*

## Why CI never caught it

Three test classes run the self-heal script themselves against the shared container, and two of them — `AccessTriggerSchemaResolutionTests`, `AuthMirrorTriggerTests` — sort **alphabetically before** `GroupMembershipRecomputeTests`. A full-project run therefore installs the triggers as a side effect and the tests pass. Filter to just that class and nothing installs them.

So the failure is **order-dependent, not machine-dependent** — two different machines saw 4/2 and 3/3 depending on which sibling ran first.

## Blast radius

**No backfill migration needed.** Every existing database (memex, atioz, memex-cloud, …) already has `auth`, so their migration runs were already installing the triggers. Only fresh deployments were affected — which is also why no What's New entry: no existing deployment changes behaviour.

## Verification

- `MeshWeaver.Hosting.PostgreSql`, `Memex.Database.Migration`, and the test project all build clean at `-c Release -warnaserror`.
- Deterministic repro — the failing test **alone in the process**, the shape that was 100% red — now passes.
- `GroupMembershipRecomputeTests` 6/6 (was 4 failed / 2 passed).
- Full project: 626 passed / 0 failed / 1 skipped (pre-existing, unrelated).

No timeout raised, no retry, no sleep, no assertion weakened, no test skipped.

## Side finding (not fixed here)

`PostgreSqlExtensions.InitializePostgreSqlSchemaAsync` has **zero callers** — the portal never runs the self-heal at boot, only the migration container does. That is why this fresh-DB gap persisted until a second migration run instead of closing on first portal start. Left alone as out of scope, but it means "per-boot self-heal" is really "per-migration-run self-heal".