### PR TITLE
A data change reports through an observable, not a hub-per-write Activity

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1256,8 +1256,7 @@ public static class DataExtensions
                     // Route via the hub's DataChangeRequest pipeline — the workspace
                     // writes through the data-source stream (which owns the typed
                     // InstanceCollection + persistence + reduction fan-out).
-                    hub.GetWorkspace().RequestChange(
-                        DataChangeRequest.Update([merged]), null);
+                    hub.GetWorkspace().RequestChange(DataChangeRequest.Update([merged]));
                 }
                 catch (Exception ex)
                 {
@@ -1654,7 +1653,7 @@ public static class DataExtensions
                 // Every hub now reports its REAL log, including the activity hub, which used to be
                 // handed a synthetic "Succeeded" because an Activity there would have recursed.
                 var changeSubscription = hub.GetWorkspace()
-                    .RequestChange(changeRequest with { ChangedBy = changeRequest.ChangedBy }, request)
+                    .RequestChange(changeRequest with { ChangedBy = changeRequest.ChangedBy })
                     .Select(log => isSatellite || string.IsNullOrEmpty(hubPath)
                         ? log
                         : log with { AffectedPaths = log.AffectedPaths.Add(hubPath) })
@@ -2393,7 +2392,7 @@ public static class DataExtensions
             ChangedBy = changedBy
         };
 
-        return workspace.RequestChange(changeRequest, null)
+        return workspace.RequestChange(changeRequest)
             .Select(log =>
             {
                 hub.ServiceProvider.GetService<ActivityLogBundler>()
@@ -2547,7 +2546,7 @@ public static class DataExtensions
                     ChangedBy = changedBy
                 };
 
-                return workspace.RequestChange(changeRequest, null)
+                return workspace.RequestChange(changeRequest)
                     .Select(log =>
                     {
                         hub.ServiceProvider.GetService<ActivityLogBundler>()

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1257,7 +1257,7 @@ public static class DataExtensions
                     // writes through the data-source stream (which owns the typed
                     // InstanceCollection + persistence + reduction fan-out).
                     hub.GetWorkspace().RequestChange(
-                        DataChangeRequest.Update([merged]), null, null);
+                        DataChangeRequest.Update([merged]), null);
                 }
                 catch (Exception ex)
                 {
@@ -1639,35 +1639,38 @@ public static class DataExtensions
                     return;
                 }
 
-                var isActivityHub = hub.Address.Type == AddressExtensions.ActivityType;
-                if (!isActivityHub && !IsSatelliteContentChange(changeRequest))
+                var isSatellite = IsSatelliteContentChange(changeRequest);
+                if (hub.Address.Type != AddressExtensions.ActivityType && !isSatellite)
                 {
                     hub.ServiceProvider.GetService<ActivityLogBundler>()
                         ?.RecordChange(changeRequest, ActivityCategory.DataUpdate);
                 }
 
-                var activity = isActivityHub ? null : new Activity(ActivityCategory.DataUpdate, hub);
+                var hubPath = hub.Address.ToString();
 
-                if (activity != null && !IsSatelliteContentChange(changeRequest))
-                {
-                    var hubPath = hub.Address.ToString();
-                    if (!string.IsNullOrEmpty(hubPath))
-                        activity.RecordAffectedPaths([hubPath]);
-                }
-
-                hub.GetWorkspace().RequestChange(changeRequest with { ChangedBy = changeRequest.ChangedBy }, activity, request);
-                if (activity is null)
-                    hub.Post(new DataChangeResponse(hub.Version, new(ActivityCategory.DataUpdate) { Status = ActivityStatus.Succeeded }),
-                        o => o.ResponseFor(request));
-                else activity.Complete(log =>
-                {
-                    var logger2 = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.ActivityCompletion");
-                    logger2?.LogDebug("DataChangeRequest activity completed: Status={Status}, Messages={MsgCount}, SubActivities={SubCount}, SubStatuses=[{SubStatuses}]",
-                        log.Status, log.Messages.Count, log.SubActivities.Count,
-                        string.Join(", ", log.SubActivities.Select(s => $"{s.Category}:{s.Status}")));
-                    hub.Post(new DataChangeResponse(hub.Version, log),
-                        o => o.ResponseFor(request));
-                });
+                // The write is issued here (RequestChange is eager); the observable reports the
+                // outcome once every affected stream applied its part. This replaces the
+                // Activity-per-change — a hosted hub whose only job was to latch that completion.
+                // Every hub now reports its REAL log, including the activity hub, which used to be
+                // handed a synthetic "Succeeded" because an Activity there would have recursed.
+                var changeSubscription = hub.GetWorkspace()
+                    .RequestChange(changeRequest with { ChangedBy = changeRequest.ChangedBy }, request)
+                    .Select(log => isSatellite || string.IsNullOrEmpty(hubPath)
+                        ? log
+                        : log with { AffectedPaths = log.AffectedPaths.Add(hubPath) })
+                    .Subscribe(
+                        log =>
+                        {
+                            var logger2 = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.ActivityCompletion");
+                            logger2?.LogDebug("DataChangeRequest completed: Status={Status}, Messages={MsgCount}",
+                                log.Status, log.Messages.Count);
+                            hub.Post(new DataChangeResponse(hub.Version, log), o => o.ResponseFor(request));
+                        },
+                        ex => hub.Post(
+                            new DataChangeResponse(hub.Version,
+                                new ActivityLog(ActivityCategory.DataUpdate).Fail(ex.Message)),
+                            o => o.ResponseFor(request)));
+                hub.RegisterForDisposal(changeSubscription);
             });
 
         hub.RegisterForDisposal(subscription);
@@ -2390,30 +2393,18 @@ public static class DataExtensions
             ChangedBy = changedBy
         };
 
-        var activity = hub.Address.Type == AddressExtensions.ActivityType
-            ? null
-            : new Activity(ActivityCategory.DataUpdate, hub);
-        workspace.RequestChange(changeRequest, activity, null);
-
-        if (activity == null)
-            return Observable.Return(UpdateUnifiedReferenceResponse.Ok(hub.Version));
-
-        return Observable.Create<UpdateUnifiedReferenceResponse>(observer =>
-        {
-            activity.Complete(log =>
+        return workspace.RequestChange(changeRequest, null)
+            .Select(log =>
             {
                 hub.ServiceProvider.GetService<ActivityLogBundler>()
                     ?.RecordChange(changeRequest, ActivityCategory.DataUpdate);
 
                 var response = new DataChangeResponse(hub.Version, log);
-                observer.OnNext(response.Status == DataChangeStatus.Committed
+                return response.Status == DataChangeStatus.Committed
                     ? UpdateUnifiedReferenceResponse.Ok(response.Version)
                     : UpdateUnifiedReferenceResponse.Fail(
-                        response.Log.Messages.LastOrDefault()?.Message ?? "Update failed"));
-                observer.OnCompleted();
+                        response.Log.Messages.LastOrDefault()?.Message ?? "Update failed");
             });
-            return System.Reactive.Disposables.Disposable.Empty;
-        });
     }
 
     /// <summary>
@@ -2556,30 +2547,18 @@ public static class DataExtensions
                     ChangedBy = changedBy
                 };
 
-                var activity = hub.Address.Type == AddressExtensions.ActivityType
-                    ? null
-                    : new Activity(ActivityCategory.DataUpdate, hub);
-                workspace.RequestChange(changeRequest, activity, null);
-
-                if (activity == null)
-                    return Observable.Return(DeleteUnifiedReferenceResponse.Ok());
-
-                return Observable.Create<DeleteUnifiedReferenceResponse>(observer =>
-                {
-                    activity.Complete(log =>
+                return workspace.RequestChange(changeRequest, null)
+                    .Select(log =>
                     {
                         hub.ServiceProvider.GetService<ActivityLogBundler>()
                             ?.RecordChange(changeRequest, ActivityCategory.DataUpdate);
 
                         var response = new DataChangeResponse(hub.Version, log);
-                        observer.OnNext(response.Status == DataChangeStatus.Committed
+                        return response.Status == DataChangeStatus.Committed
                             ? DeleteUnifiedReferenceResponse.Ok()
                             : DeleteUnifiedReferenceResponse.Fail(
-                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
-                        observer.OnCompleted();
+                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed");
                     });
-                    return System.Reactive.Disposables.Disposable.Empty;
-                });
             });
     }
 

--- a/src/MeshWeaver.Data/ISynchronizationStream.cs
+++ b/src/MeshWeaver.Data/ISynchronizationStream.cs
@@ -121,6 +121,16 @@ public interface ISynchronizationStream<TStream>
     /// Side effects only: log, push to a status subject, etc.</para>
     /// </summary>
     void Update(Func<TStream?, ChangeItem<TStream>?> update, Action<Exception> exceptionCallback);
+    /// <summary>
+    /// Change-based write that also reports COMPLETION: <paramref name="applied"/> runs in the same
+    /// turn, right after the change was applied (and for a no-op transform too). This is how a writer
+    /// says "committed" without scheduling another turn — and without the risk of reporting while the
+    /// store still holds the pre-change state.
+    /// </summary>
+    /// <param name="update">Builds the change item from the current value, or returns null for a no-op.</param>
+    /// <param name="exceptionCallback">Invoked synchronously if the write fails.</param>
+    /// <param name="applied">Invoked in the same turn, after the change was applied.</param>
+    void Update(Func<TStream?, ChangeItem<TStream>?> update, Action<Exception> exceptionCallback, Action? applied);
     /// <summary>Change-based write whose failures are ignored; see the overload taking an exception callback.</summary>
     /// <param name="update">Builds the change item from the current value, or returns null for a no-op.</param>
     void Update(Func<TStream?, ChangeItem<TStream>?> update) => Update(update, _ => { });

--- a/src/MeshWeaver.Data/IWorkspace.cs
+++ b/src/MeshWeaver.Data/IWorkspace.cs
@@ -18,37 +18,42 @@ public interface IWorkspace : IAsyncDisposable
     IReadOnlyCollection<Type> MappedTypes { get; }
     /// <summary>Creates or updates the given instances using default update options.</summary>
     /// <param name="instances">The entities to upsert.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">The originating message delivery, used for response correlation.</param>
-    void Update(IReadOnlyCollection<object> instances, Activity? activity, IMessageDelivery request) => Update(instances, new(), activity, request);
+    /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
+    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, IMessageDelivery request) => Update(instances, new(), request);
     /// <summary>Creates or updates the given instances using the supplied update options.</summary>
     /// <param name="instances">The entities to upsert.</param>
     /// <param name="updateOptions">Options controlling merge vs. snapshot semantics.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">The originating message delivery, used for response correlation.</param>
-    void Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, Activity? activity, IMessageDelivery request);
+    /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
+    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, IMessageDelivery request);
     /// <summary>Creates or updates a single instance using default update options.</summary>
     /// <param name="instance">The entity to upsert.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">The originating message delivery, used for response correlation.</param>
-    void Update(object instance, Activity? activity, IMessageDelivery request) => Update([instance], activity, request);
+    /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
+    IObservable<ActivityLog> Update(object instance, IMessageDelivery request) => Update([instance], request);
 
     /// <summary>Deletes the given instances from their mapped collections.</summary>
     /// <param name="instances">The entities to delete.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">The originating message delivery, used for response correlation.</param>
-    void Delete(IReadOnlyCollection<object> instances, Activity? activity, IMessageDelivery request);
+    /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
+    IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances, IMessageDelivery request);
     /// <summary>Deletes a single instance from its mapped collection.</summary>
     /// <param name="instance">The entity to delete.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">The originating message delivery, used for response correlation.</param>
-    void Delete(object instance, Activity? activity, IMessageDelivery request) => Delete([instance], activity, request);
+    /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
+    IObservable<ActivityLog> Delete(object instance, IMessageDelivery request) => Delete([instance], request);
 
-    /// <summary>Validates and applies a data change request (creations, updates and deletions) to the workspace streams.</summary>
+    /// <summary>
+    /// Validates and applies a data change request (creations, updates and deletions) to the workspace streams.
+    /// <para>The write is issued EAGERLY (on call); the returned observable emits ONE
+    /// <see cref="ActivityLog"/> — carrying validation failures and per-stream errors — once every
+    /// affected stream has applied its part, then completes. Ignore it for a fire-and-run write.</para>
+    /// </summary>
     /// <param name="change">The change request describing the creations, updates and deletions.</param>
-    /// <param name="activity">Optional activity to log the change against; may be null.</param>
     /// <param name="request">Optional originating message delivery, used for response correlation.</param>
-    public void RequestChange(DataChangeRequest change, Activity? activity, IMessageDelivery? request);
+    /// <returns>A single-emission observable carrying the finished <see cref="ActivityLog"/>.</returns>
+    public IObservable<ActivityLog> RequestChange(DataChangeRequest change, IMessageDelivery? request);
     /// <summary>Gets a synchronization stream over the collections backing the given CLR types.</summary>
     /// <param name="types">The CLR types whose collections should be combined into the stream.</param>
     /// <returns>A synchronization stream of the combined entity store.</returns>

--- a/src/MeshWeaver.Data/IWorkspace.cs
+++ b/src/MeshWeaver.Data/IWorkspace.cs
@@ -18,31 +18,26 @@ public interface IWorkspace : IAsyncDisposable
     IReadOnlyCollection<Type> MappedTypes { get; }
     /// <summary>Creates or updates the given instances using default update options.</summary>
     /// <param name="instances">The entities to upsert.</param>
-    /// <param name="request">The originating message delivery, used for response correlation.</param>
     /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
-    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, IMessageDelivery request) => Update(instances, new(), request);
+    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances) => Update(instances, new());
     /// <summary>Creates or updates the given instances using the supplied update options.</summary>
     /// <param name="instances">The entities to upsert.</param>
     /// <param name="updateOptions">Options controlling merge vs. snapshot semantics.</param>
-    /// <param name="request">The originating message delivery, used for response correlation.</param>
     /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
-    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, IMessageDelivery request);
+    IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions);
     /// <summary>Creates or updates a single instance using default update options.</summary>
     /// <param name="instance">The entity to upsert.</param>
-    /// <param name="request">The originating message delivery, used for response correlation.</param>
     /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
-    IObservable<ActivityLog> Update(object instance, IMessageDelivery request) => Update([instance], request);
+    IObservable<ActivityLog> Update(object instance) => Update([instance]);
 
     /// <summary>Deletes the given instances from their mapped collections.</summary>
     /// <param name="instances">The entities to delete.</param>
-    /// <param name="request">The originating message delivery, used for response correlation.</param>
     /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
-    IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances, IMessageDelivery request);
+    IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances);
     /// <summary>Deletes a single instance from its mapped collection.</summary>
     /// <param name="instance">The entity to delete.</param>
-    /// <param name="request">The originating message delivery, used for response correlation.</param>
     /// <returns>The change's <see cref="ActivityLog"/>; see <see cref="RequestChange"/> for its semantics.</returns>
-    IObservable<ActivityLog> Delete(object instance, IMessageDelivery request) => Delete([instance], request);
+    IObservable<ActivityLog> Delete(object instance) => Delete([instance]);
 
     /// <summary>
     /// Validates and applies a data change request (creations, updates and deletions) to the workspace streams.
@@ -51,9 +46,8 @@ public interface IWorkspace : IAsyncDisposable
     /// affected stream has applied its part, then completes. Ignore it for a fire-and-run write.</para>
     /// </summary>
     /// <param name="change">The change request describing the creations, updates and deletions.</param>
-    /// <param name="request">Optional originating message delivery, used for response correlation.</param>
     /// <returns>A single-emission observable carrying the finished <see cref="ActivityLog"/>.</returns>
-    public IObservable<ActivityLog> RequestChange(DataChangeRequest change, IMessageDelivery? request);
+    public IObservable<ActivityLog> RequestChange(DataChangeRequest change);
     /// <summary>Gets a synchronization stream over the collections backing the given CLR types.</summary>
     /// <param name="types">The CLR types whose collections should be combined into the stream.</param>
     /// <returns>A synchronization stream of the combined entity store.</returns>

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -753,7 +753,7 @@ public static class JsonSynchronizationStream
         //         .Subscribe(e =>
         //         {
         //             logger.LogDebug("Issuing change request from stream {subscriber} to owner {owner}", reduced.StreamId, reduced.Owner);
-        //             reduced.Host.GetWorkspace().RequestChange(e, null, null);
+        //             reduced.Host.GetWorkspace().RequestChange(e);
         //         })
         // );
 

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -983,7 +983,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 }
             ).WithHandler<DataChangeRequest>((hub, delivery) =>
                 {
-                    hub.GetWorkspace().RequestChange(delivery.Message, null, delivery);
+                    hub.GetWorkspace().RequestChange(delivery.Message, delivery);
                     return delivery.Processed();
                 }
             ).WithHandler<GetDataResponse>((_, delivery) =>

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -343,6 +343,10 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// <param name="update">Maps the current state to the change to apply, or <c>null</c> for a no-op.</param>
     /// <param name="exceptionCallback">Invoked synchronously if the write fails.</param>
     public void Update(Func<TStream?, ChangeItem<TStream>?> update, Action<Exception> exceptionCallback)
+        => Update(update, exceptionCallback, null);
+
+    /// <inheritdoc cref="ISynchronizationStream{TStream}.Update(System.Func{TStream,ChangeItem{TStream}},System.Action{System.Exception},System.Action)"/>
+    public void Update(Func<TStream?, ChangeItem<TStream>?> update, Action<Exception> exceptionCallback, Action? applied)
     {
         if (!TryGetActiveHub(out var hub))
         {
@@ -400,7 +404,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
         if (capturedContext is null && Configuration.RunsAsInfrastructure)
             capturedContext = InfrastructureContext;
         hub.Post(
-            new UpdateStreamRequest(update, exceptionCallback),
+            new UpdateStreamRequest(update, exceptionCallback, applied),
             opt => capturedContext is null ? opt : opt.WithAccessContext(capturedContext));
     }
 
@@ -983,7 +987,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 }
             ).WithHandler<DataChangeRequest>((hub, delivery) =>
                 {
-                    hub.GetWorkspace().RequestChange(delivery.Message, delivery);
+                    _ = hub.GetWorkspace().RequestChange(delivery.Message);
                     return delivery.Processed();
                 }
             ).WithHandler<GetDataResponse>((_, delivery) =>
@@ -1043,6 +1047,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 // AsynchronousCalls.md exists to kill.
                 var update = request.Message.Update;
                 var exceptionCallback = request.Message.ExceptionCallback;
+                var applied = request.Message.Applied;
                 try
                 {
                     // Read the current state right before invoking the update function
@@ -1055,6 +1060,19 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                     // The Message Hub serializes these messages, so only one UpdateStreamRequest
                     // is processed at a time per stream, preventing race conditions
                     SetCurrent(hub, newChangeItem);
+
+                    // Post-apply, SAME turn: the writer's "committed" signal cannot observe the
+                    // pre-change state, and costs no extra hub message. Guarded like the exception
+                    // callback — a writer that throws from its own signal must not kill the turn.
+                    if (applied is not null)
+                    {
+                        try { applied.Invoke(); }
+                        catch (Exception cbEx)
+                        {
+                            logger.LogError(cbEx,
+                                "[SYNC_STREAM] applied callback threw on {StreamId}", StreamId);
+                        }
+                    }
                 }
                 catch (Exception e)
                 {
@@ -1476,8 +1494,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// </summary>
     /// <param name="Update">The transform mapping the current state to the change to apply.</param>
     /// <param name="ExceptionCallback">Invoked synchronously if applying the update throws.</param>
+    /// <param name="Applied">Optional: invoked in the SAME turn, right after the change was applied
+    /// (also for a no-op transform). This is the stream's completion seam — a writer that must report
+    /// "committed" uses it instead of scheduling a second turn, so reporting costs no extra message
+    /// and can never observe the pre-change state.</param>
     [PreventLogging]
-    public record UpdateStreamRequest([property: JsonIgnore] Func<TStream?, ChangeItem<TStream>?> Update, [property: JsonIgnore] Action<Exception> ExceptionCallback);
+    public record UpdateStreamRequest([property: JsonIgnore] Func<TStream?, ChangeItem<TStream>?> Update, [property: JsonIgnore] Action<Exception> ExceptionCallback, [property: JsonIgnore] Action? Applied = null);
 
     /// <summary>
     /// Synchronisation-protocol message that propagates a state change to the

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -421,22 +421,22 @@ public class Workspace : IWorkspace
 
 
     /// <inheritdoc />
-    public void Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, Activity? activity, IMessageDelivery request) =>
+    public IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, IMessageDelivery request) =>
         RequestChange(
             new DataChangeRequest()
             {
                 Updates = instances.ToImmutableList(),
                 Options = updateOptions,
                 ChangedBy = null
-            }, activity, request
+            }, request
         );
 
 
 
     /// <inheritdoc />
-    public void Delete(IReadOnlyCollection<object> instances, Activity? activity, IMessageDelivery request) =>
+    public IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances, IMessageDelivery request) =>
         RequestChange(
-            new DataChangeRequest { Deletions = instances.ToImmutableList(), ChangedBy = null }, activity, request
+            new DataChangeRequest { Deletions = instances.ToImmutableList(), ChangedBy = null }, request
         );
 
     /// <inheritdoc />
@@ -478,10 +478,8 @@ public class Workspace : IWorkspace
     public DataContext DataContext { get; }
 
     /// <inheritdoc />
-    public void RequestChange(DataChangeRequest change, Activity? activity, IMessageDelivery? request)
-    {
-        this.Change(change, activity, request);
-    }
+    public IObservable<ActivityLog> RequestChange(DataChangeRequest change, IMessageDelivery? request)
+        => this.Change(change, request);
 
     private bool isDisposing;
 

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -421,22 +421,22 @@ public class Workspace : IWorkspace
 
 
     /// <inheritdoc />
-    public IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions, IMessageDelivery request) =>
+    public IObservable<ActivityLog> Update(IReadOnlyCollection<object> instances, UpdateOptions updateOptions) =>
         RequestChange(
             new DataChangeRequest()
             {
                 Updates = instances.ToImmutableList(),
                 Options = updateOptions,
                 ChangedBy = null
-            }, request
+            }
         );
 
 
 
     /// <inheritdoc />
-    public IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances, IMessageDelivery request) =>
+    public IObservable<ActivityLog> Delete(IReadOnlyCollection<object> instances) =>
         RequestChange(
-            new DataChangeRequest { Deletions = instances.ToImmutableList(), ChangedBy = null }, request
+            new DataChangeRequest { Deletions = instances.ToImmutableList(), ChangedBy = null }
         );
 
     /// <inheritdoc />
@@ -478,8 +478,8 @@ public class Workspace : IWorkspace
     public DataContext DataContext { get; }
 
     /// <inheritdoc />
-    public IObservable<ActivityLog> RequestChange(DataChangeRequest change, IMessageDelivery? request)
-        => this.Change(change, request);
+    public IObservable<ActivityLog> RequestChange(DataChangeRequest change)
+        => this.Change(change);
 
     private bool isDisposing;
 

--- a/src/MeshWeaver.Data/WorkspaceOperations.cs
+++ b/src/MeshWeaver.Data/WorkspaceOperations.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Json.Patch;
 using MeshWeaver.Data.Serialization;
 using MeshWeaver.Messaging;
@@ -18,90 +20,78 @@ public static class WorkspaceOperations
 {
     /// <summary>
     /// Validates the creations, updates and deletions in a change request and, if all are valid,
-    /// applies them to the matching data-source streams. Validation failures are logged on the
-    /// activity and the change is not applied.
+    /// applies them to the matching data-source streams. Validation failures are reported on the
+    /// returned <see cref="ActivityLog"/> and the change is not applied.
+    ///
+    /// <para>🚨 The write is issued EAGERLY — on call, exactly as before — so a caller that ignores
+    /// the result still writes. The returned observable REPORTS the outcome: it emits ONE
+    /// <see cref="ActivityLog"/> once every affected data-source stream has applied its part, then
+    /// completes (replayed to late subscribers). Subscribe when you need the log — which validations
+    /// failed, which stream errored; ignore it for fire-and-run writes.</para>
+    ///
+    /// <para>This replaces the former <c>Activity</c> parameter. An <c>Activity</c> is a hosted HUB;
+    /// creating one per data change spun a hub (plus one per data source) purely to latch completion
+    /// and accumulate messages — which is what this observable expresses natively. <c>Activity</c>
+    /// stays for INTENT-level work (import, GitSync, compile) where the activity is a persisted node
+    /// with live progress.</para>
     /// </summary>
     /// <param name="workspace">The workspace to apply the change to.</param>
     /// <param name="change">The change request to validate and apply.</param>
-    /// <param name="activity">Optional activity for logging validation and update progress; may be null.</param>
     /// <param name="request">Optional originating message delivery for failure propagation.</param>
-    public static void Change(this IWorkspace workspace, DataChangeRequest change, Activity? activity, IMessageDelivery? request)
+    /// <returns>A single-emission observable carrying the finished <see cref="ActivityLog"/>.</returns>
+    public static IObservable<ActivityLog> Change(this IWorkspace workspace, DataChangeRequest change, IMessageDelivery? request)
     {
-        var allValid = true;
         var logger = workspace.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger(typeof(WorkspaceOperations));
         logger.LogDebug("Updating workstream for workspace {Address} with {Creations} creations, {Updates} updates, {Deletions} deletions", workspace.Hub.Address, change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
 
-        if (change.Creations.Any())
+        var (isValid, messages) = workspace.Validate(change, logger);
+        if (!isValid)
+            return Observable.Return(Finish(workspace.Hub, messages));
+
+        logger.LogDebug("Update called: Creations={Creations}, Updates={Updates}, Deletions={Deletions}",
+            change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
+        return workspace.UpdateStreams(change, request, messages, logger);
+    }
+
+    /// <summary>
+    /// Runs the creation / update / deletion validators and folds every failure into log messages.
+    /// Validation is pure and synchronous — it never touches a stream.
+    /// </summary>
+    private static (bool IsValid, ImmutableList<LogMessage> Messages) Validate(
+        this IWorkspace workspace, DataChangeRequest change, ILogger logger)
+    {
+        var messages = ImmutableList<LogMessage>.Empty;
+        var isValid = true;
+
+        void Collect((bool IsValid, List<ValidationResult> Results) outcome)
         {
-            var (isValid, results) = workspace.ValidateCreation(change.Creations);
-            if (!isValid)
+            if (outcome.IsValid)
+                return;
+            isValid = false;
+            foreach (var validationResult in outcome.Results.Where(r => r != ValidationResult.Success))
             {
-                allValid = false;
-                foreach (var validationResult in results.Where(r => r != ValidationResult.Success))
+                var message = $"{string.Join(", ", validationResult.MemberNames)} invalid: {validationResult.ErrorMessage}";
+                messages = messages.Add(new LogMessage(message, LogLevel.Error)
                 {
-                    var scopes = new List<KeyValuePair<string, object>>
-                    {
+                    Scopes =
+                    [
                         new("members", validationResult.MemberNames.ToArray()),
                         new("error", validationResult.ErrorMessage!)
-                    };
-                    activity?.LogError($"{validationResult.ErrorMessage}", scopes);
-                    var message =
-                        $"{string.Join(", ", validationResult.MemberNames)} invalid: {validationResult.ErrorMessage!}";
-
-                    // Log validation errors (activityId: {activityId})
-                    workspace.Hub.ServiceProvider.GetService<ILogger>()?.LogWarning("Validation error in activityId {ActivityId}: {Message}", activity?.Id, message);
-                }
+                    ]
+                });
+                logger.LogWarning("Validation error on {Address}: {Message}", workspace.Hub.Address, message);
             }
-
         }
 
+        if (change.Creations.Any())
+            Collect(workspace.ValidateCreation(change.Creations));
         if (change.Updates.Any())
-        {
-            var (isValid, results) = workspace.ValidateUpdate(change.Updates);
-            if (!isValid)
-            {
-                allValid = false;
-                foreach (var validationResult in results.Where(r => r != ValidationResult.Success))
-                {
-                    var scopes = new List<KeyValuePair<string, object>>
-                    {
-                        new("members", validationResult.MemberNames.ToArray())
-                    };
-                    var message =
-                        $"{string.Join(", ", validationResult.MemberNames)} invalid: {validationResult.ErrorMessage!}";
-
-                    // Log validation errors (activityId: {activityId})
-                    activity?.LogError($"Validation error in {message}", scopes);
-                }
-            }
-
-        }
-
+            Collect(workspace.ValidateUpdate(change.Updates));
         if (change.Deletions.Any())
-        {
-            var (isValid, results) = workspace.ValidateDeletion(change.Deletions);
-            if (!isValid)
-            {
-                allValid = false;
-                foreach (var validationResult in results.Where(r => r != ValidationResult.Success))
-                {
-                    var scopes = new List<KeyValuePair<string, object>>
-                    {
-                        new("members", validationResult.MemberNames.ToArray())
-                    };
-                    var message = string.Format("{0} invalid: {1}", string.Join(", ", validationResult.MemberNames), validationResult.ErrorMessage!);
+            Collect(workspace.ValidateDeletion(change.Deletions));
 
-                    // Log validation errors (activityId: {activityId})
-                    activity?.LogError($"Validation error in activityId {message}", scopes);
-                }
-            }
-        }
-
-        if (allValid)
-        {
-            Update(activity, workspace, change, request);
-        }
+        return (isValid, messages);
     }
 
     private static void UpdateFailed(IMessageDelivery? delivery, Exception? exception)
@@ -110,59 +100,112 @@ public static class WorkspaceOperations
             throw new DataException($"Data update failed: {exception.Message}", exception);
     }
 
-    private static void Update(Activity? activity, IWorkspace workspace, DataChangeRequest change, IMessageDelivery? request)
+    private static IObservable<ActivityLog> UpdateStreams(this IWorkspace workspace, DataChangeRequest change,
+        IMessageDelivery? request, ImmutableList<LogMessage> messages, ILogger logger)
     {
-        activity?.LogInformation("Starting Update");
-        var logger = workspace.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
-            .CreateLogger(typeof(WorkspaceOperations));
-        logger.LogDebug("Update called: Creations={Creations}, Updates={Updates}, Deletions={Deletions}",
-            change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
-        workspace.UpdateStreams(change, activity, request);
-    }
-
-    private static void UpdateStreams(this IWorkspace workspace, DataChangeRequest change, Activity? activity, IMessageDelivery? request)
-    {
-        var logger = workspace.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
-            .CreateLogger(typeof(WorkspaceOperations));
         logger.LogDebug("Updating streams for workspace {Address} with {Creations} creations, {Updates} updates, {Deletions} deletions", workspace.Hub.Address, change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
-        foreach (var group in
-                 change.Creations.Select(i => ClassifyForRouting(workspace, i, OperationType.Add))
-                     .Concat(change.Updates.Select(i => ClassifyForRouting(workspace, i, OperationType.Replace)))
-                     .Concat(change.Deletions.Select(i => ClassifyForRouting(workspace, i, OperationType.Remove)))
-                     .GroupBy(x => (x.DataSource, x.Partition)))
-        {
-            if (group.Key.DataSource is null)
-            {
-                activity?.LogWarning("Types {types} could not be mapped to data source", string.Join(", ", group.Select(i => i.Instance.GetType().Name).Distinct()));
-                continue;
-            }
 
-            var stream = group.Key.DataSource.GetStreamForPartition(group.Key.Partition);
-            if (stream is null)
-                throw new DataException($"Data source {group.Key.DataSource.Reference} does not have a stream for partition {group.Key.Partition}");
-            if (!stream.Hub.Started.IsCompleted)
-                throw new DataException($"Data source {group.Key.DataSource.Reference} for partition {group.Key.Partition} is not initialized.");
+        var groups = change.Creations.Select(i => ClassifyForRouting(workspace, i, OperationType.Add))
+            .Concat(change.Updates.Select(i => ClassifyForRouting(workspace, i, OperationType.Replace)))
+            .Concat(change.Deletions.Select(i => ClassifyForRouting(workspace, i, OperationType.Remove)))
+            .GroupBy(x => (x.DataSource, x.Partition))
+            .ToArray();
 
-            // Start sub-activity for data update
-            var subActivity = activity?.StartSubActivity(ActivityCategory.DataUpdate);
+        messages = groups.Where(g => g.Key.DataSource is null)
+            .Aggregate(messages, (acc, g) => acc.Add(new LogMessage(
+                $"Types {string.Join(", ", g.Select(i => i.Instance.GetType().Name).Distinct())} could not be mapped to data source",
+                LogLevel.Warning)));
 
+        // ToArray() forces the writes NOW — Change is eager by contract; the observables only
+        // report when each stream has applied its part.
+        var applied = groups.Where(g => g.Key.DataSource is not null)
+            .Select(group => UpdateStream(change, group, request, logger))
+            .ToArray();
 
-            // Synchronous update — the transform is pure in-memory; the stream's
-            // handler serializes UpdateStreamRequests, so no retry logic is needed.
-            stream!.Update(store =>
-                {
-                    var result = UpdateDataChangeRequest(store, change, logger, stream, subActivity, group);
-                    subActivity?.Complete();
-                    return result;
-                },
-                ex =>
-                {
-                    subActivity?.Complete();
-                    UpdateFailed(request, ex);
-                }
-            );
-        }
+        if (applied.Length == 0)
+            return Observable.Return(Finish(workspace.Hub, messages));
+
+        return applied.Merge()
+            .Aggregate(messages, (acc, streamMessages) => acc.AddRange(streamMessages))
+            .Select(all => Finish(workspace.Hub, all));
     }
+
+    /// <summary>
+    /// Issues one data-source stream's part of the change and reports the messages it produced.
+    /// The <see cref="AsyncSubject{T}"/> replays, so a subscriber that arrives after the write
+    /// already committed still gets the log.
+    ///
+    /// <para>🚨 Completion is scheduled on the stream hub's action block, NOT signalled inline from
+    /// the transform: the transform's result is applied by the SAME turn that runs it, so completing
+    /// inline would report "committed" to a subscriber (and post the DataChangeResponse) while the
+    /// store still holds the pre-change state — ack-on-accept, the shape that raced read-after-write.
+    /// The next turn runs after the apply.</para>
+    /// </summary>
+    private static IObservable<ImmutableList<LogMessage>> UpdateStream(
+        DataChangeRequest change,
+        IGrouping<(IDataSource? DataSource, object? Partition), (object Instance, OperationType Op, ITypeSource?
+            TypeSource, IDataSource? DataSource, object? Partition)> group,
+        IMessageDelivery? request,
+        ILogger logger)
+    {
+        var stream = group.Key.DataSource!.GetStreamForPartition(group.Key.Partition);
+        if (stream is null)
+            throw new DataException($"Data source {group.Key.DataSource.Reference} does not have a stream for partition {group.Key.Partition}");
+        if (!stream.Hub.Started.IsCompleted)
+            throw new DataException($"Data source {group.Key.DataSource.Reference} for partition {group.Key.Partition} is not initialized.");
+
+        var applied = new AsyncSubject<ImmutableList<LogMessage>>();
+
+        // Synchronous update — the transform is pure in-memory; the stream's
+        // handler serializes UpdateStreamRequests, so no retry logic is needed.
+        stream.Update(store =>
+            {
+                var (result, messages) = UpdateDataChangeRequest(store, change, logger, stream, group);
+                Report(stream.Hub, applied, messages);
+                return result;
+            },
+            ex =>
+            {
+                // A DISPOSED stream is the benign teardown marker the rest of the stream classifies
+                // as Debug-only ("stop the source"), so it stays a WARNING — which still commits
+                // (DataChangeResponse maps Warning → Committed) and keeps shutdown quiet. Any other
+                // failure is a real one and must surface as Failed rather than the silent
+                // "Succeeded" the sub-activity used to report.
+                applied.OnNext([new LogMessage(
+                    $"Update of {stream.StreamIdentity} failed: {ex.Message}",
+                    ex is ObjectDisposedException ? LogLevel.Warning : LogLevel.Error)]);
+                applied.OnCompleted();
+                UpdateFailed(request, ex);
+            }
+        );
+        return applied;
+    }
+
+    /// <summary>
+    /// Reports one stream's messages on the stream hub's NEXT turn, so the change this turn
+    /// returned is already applied when a subscriber sees the log. Falls back to reporting inline
+    /// once the hub is tearing down — there is no later turn then, and an unreported change would
+    /// leave the caller's response pending until its request timeout.
+    /// </summary>
+    private static void Report(IMessageHub streamHub, AsyncSubject<ImmutableList<LogMessage>> applied,
+        ImmutableList<LogMessage> messages)
+    {
+        void Emit()
+        {
+            applied.OnNext(messages);
+            applied.OnCompleted();
+        }
+
+        if (streamHub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
+            Emit();
+        else
+            streamHub.InvokeAsync(Emit);
+    }
+
+    /// <summary>Finishes a data-update log: status is rolled up from the message levels.</summary>
+    private static ActivityLog Finish(IMessageHub hub, ImmutableList<LogMessage> messages) =>
+        new ActivityLog(ActivityCategory.DataUpdate) { Messages = messages }
+            .Finish((int)hub.Version, null);
 
     // Maps an instance to its routing tuple. An EntityDeltaUpdate (a minimal-bytes
     // string-delta carrying no CLR entity) is routed by its declared Collection +
@@ -202,13 +245,15 @@ public static class WorkspaceOperations
         return EntityDelta.Apply(current, d, stream.Host.JsonSerializerOptions);
     }
 
-    private static ChangeItem<EntityStore>? UpdateDataChangeRequest(EntityStore? store, DataChangeRequest change, ILogger logger, ISynchronizationStream<EntityStore> stream, Activity? subActivity,
+    private static (ChangeItem<EntityStore>? Result, ImmutableList<LogMessage> Messages) UpdateDataChangeRequest(
+        EntityStore? store, DataChangeRequest change, ILogger logger, ISynchronizationStream<EntityStore> stream,
         IGrouping<(IDataSource? DataSource, object? Partition), (object Instance, OperationType Op, ITypeSource?
             TypeSource, IDataSource? DataSource, object? Partition)> group)
     {
+        // Only what a CALLER needs to act on lands in the log — the play-by-play is Debug on the
+        // logger. An empty message list rolls up to Succeeded.
+        var messages = ImmutableList<LogMessage>.Empty;
         logger.LogDebug("Starting update of {Stream} with {StreamId}", stream.StreamIdentity, stream.StreamId);
-        // For sub-activity logging, we use the main activity as we don't have direct access to sub-activity
-        subActivity?.LogInformation("Updating Data Stream {Stream}", stream!.StreamIdentity);
         try
         {
             // Get the current store state (might be different from initial 'store' parameter if updates occurred)
@@ -230,8 +275,9 @@ public static class WorkspaceOperations
                             {
                                 logger.LogError("Skipping {Count} instances with null key in collection {Collection}",
                                     invalidInstances.Count, g.Key.TypeSource!.CollectionName);
-                                subActivity?.LogError("Skipping {Count} instances with null key in collection {Collection}",
-                                    invalidInstances.Count, g.Key.TypeSource!.CollectionName);
+                                messages = messages.Add(new LogMessage(
+                                    $"Skipping {invalidInstances.Count} instances with null key in collection {g.Key.TypeSource!.CollectionName}",
+                                    LogLevel.Error));
                             }
                             var instances =
                                 new InstanceCollection(allInstances
@@ -269,22 +315,15 @@ public static class WorkspaceOperations
 
                         throw new NotSupportedException($"Operation {g.Key.Op} not supported");
                     });
-            subActivity?.LogInformation("Applying changes to Data Stream {Stream}", stream.StreamIdentity);
             logger.LogDebug("Applying changes to Data Stream {Stream}", stream.StreamIdentity);
-            // Complete sub-activity - this would need proper sub-activity tracking to work correctly
-            return stream.ApplyChanges(updates);
+            return (stream.ApplyChanges(updates), messages);
         }
         catch (Exception ex)
         {
-            subActivity?.LogError(ex, "Error updating Data Stream {Stream}: {Message}", stream.StreamIdentity,
-                ex.Message);
             logger.LogError(ex, "Error updating Data Stream {Stream}: {Message}", stream.StreamIdentity, ex.Message);
             stream.OnError(ex);
-            return null;
-        }
-        finally
-        {
-            subActivity?.Complete();
+            return (null, messages.Add(new LogMessage(
+                $"Error updating Data Stream {stream.StreamIdentity}: {ex.Message}", LogLevel.Error)));
         }
     }
 

--- a/src/MeshWeaver.Data/WorkspaceOperations.cs
+++ b/src/MeshWeaver.Data/WorkspaceOperations.cs
@@ -37,9 +37,8 @@ public static class WorkspaceOperations
     /// </summary>
     /// <param name="workspace">The workspace to apply the change to.</param>
     /// <param name="change">The change request to validate and apply.</param>
-    /// <param name="request">Optional originating message delivery for failure propagation.</param>
     /// <returns>A single-emission observable carrying the finished <see cref="ActivityLog"/>.</returns>
-    public static IObservable<ActivityLog> Change(this IWorkspace workspace, DataChangeRequest change, IMessageDelivery? request)
+    public static IObservable<ActivityLog> Change(this IWorkspace workspace, DataChangeRequest change)
     {
         var logger = workspace.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger(typeof(WorkspaceOperations));
@@ -51,7 +50,7 @@ public static class WorkspaceOperations
 
         logger.LogDebug("Update called: Creations={Creations}, Updates={Updates}, Deletions={Deletions}",
             change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
-        return workspace.UpdateStreams(change, request, messages, logger);
+        return workspace.UpdateStreams(change, messages, logger);
     }
 
     /// <summary>
@@ -94,14 +93,8 @@ public static class WorkspaceOperations
         return (isValid, messages);
     }
 
-    private static void UpdateFailed(IMessageDelivery? delivery, Exception? exception)
-    {
-        if (exception != null)
-            throw new DataException($"Data update failed: {exception.Message}", exception);
-    }
-
     private static IObservable<ActivityLog> UpdateStreams(this IWorkspace workspace, DataChangeRequest change,
-        IMessageDelivery? request, ImmutableList<LogMessage> messages, ILogger logger)
+        ImmutableList<LogMessage> messages, ILogger logger)
     {
         logger.LogDebug("Updating streams for workspace {Address} with {Creations} creations, {Updates} updates, {Deletions} deletions", workspace.Hub.Address, change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
 
@@ -119,7 +112,7 @@ public static class WorkspaceOperations
         // ToArray() forces the writes NOW — Change is eager by contract; the observables only
         // report when each stream has applied its part.
         var applied = groups.Where(g => g.Key.DataSource is not null)
-            .Select(group => UpdateStream(change, group, request, logger))
+            .Select(group => UpdateStream(change, group, logger))
             .ToArray();
 
         if (applied.Length == 0)
@@ -135,17 +128,16 @@ public static class WorkspaceOperations
     /// The <see cref="AsyncSubject{T}"/> replays, so a subscriber that arrives after the write
     /// already committed still gets the log.
     ///
-    /// <para>🚨 Completion is scheduled on the stream hub's action block, NOT signalled inline from
-    /// the transform: the transform's result is applied by the SAME turn that runs it, so completing
-    /// inline would report "committed" to a subscriber (and post the DataChangeResponse) while the
+    /// <para>🚨 Completion rides the stream's post-apply seam (<c>applied</c>), NOT the transform
+    /// itself: the transform's result is applied by the same turn that runs it, so completing from
+    /// inside it would report "committed" to a subscriber (and post the DataChangeResponse) while the
     /// store still holds the pre-change state — ack-on-accept, the shape that raced read-after-write.
-    /// The next turn runs after the apply.</para>
+    /// The seam runs after the apply, in that same turn, so it costs no extra hub message.</para>
     /// </summary>
     private static IObservable<ImmutableList<LogMessage>> UpdateStream(
         DataChangeRequest change,
         IGrouping<(IDataSource? DataSource, object? Partition), (object Instance, OperationType Op, ITypeSource?
             TypeSource, IDataSource? DataSource, object? Partition)> group,
-        IMessageDelivery? request,
         ILogger logger)
     {
         var stream = group.Key.DataSource!.GetStreamForPartition(group.Key.Partition);
@@ -158,48 +150,38 @@ public static class WorkspaceOperations
 
         // Synchronous update — the transform is pure in-memory; the stream's
         // handler serializes UpdateStreamRequests, so no retry logic is needed.
+        var streamMessages = ImmutableList<LogMessage>.Empty;
         stream.Update(store =>
             {
                 var (result, messages) = UpdateDataChangeRequest(store, change, logger, stream, group);
-                Report(stream.Hub, applied, messages);
+                streamMessages = messages;
                 return result;
             },
             ex =>
             {
+                // The failure is REPORTED, never rethrown: every invocation of this callback is
+                // wrapped by the stream in a log-only try/catch, so a throw here could reach no
+                // caller — it only produced a secondary "exceptionCallback threw" ERROR. The log
+                // below is what the caller actually sees.
+                //
                 // A DISPOSED stream is the benign teardown marker the rest of the stream classifies
                 // as Debug-only ("stop the source"), so it stays a WARNING — which still commits
                 // (DataChangeResponse maps Warning → Committed) and keeps shutdown quiet. Any other
                 // failure is a real one and must surface as Failed rather than the silent
                 // "Succeeded" the sub-activity used to report.
+                logger.LogError(ex, "Update of {Stream} failed", stream.StreamIdentity);
                 applied.OnNext([new LogMessage(
                     $"Update of {stream.StreamIdentity} failed: {ex.Message}",
                     ex is ObjectDisposedException ? LogLevel.Warning : LogLevel.Error)]);
                 applied.OnCompleted();
-                UpdateFailed(request, ex);
+            },
+            () =>
+            {
+                applied.OnNext(streamMessages);
+                applied.OnCompleted();
             }
         );
         return applied;
-    }
-
-    /// <summary>
-    /// Reports one stream's messages on the stream hub's NEXT turn, so the change this turn
-    /// returned is already applied when a subscriber sees the log. Falls back to reporting inline
-    /// once the hub is tearing down — there is no later turn then, and an unreported change would
-    /// leave the caller's response pending until its request timeout.
-    /// </summary>
-    private static void Report(IMessageHub streamHub, AsyncSubject<ImmutableList<LogMessage>> applied,
-        ImmutableList<LogMessage> messages)
-    {
-        void Emit()
-        {
-            applied.OnNext(messages);
-            applied.OnCompleted();
-        }
-
-        if (streamHub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
-            Emit();
-        else
-            streamHub.InvokeAsync(Emit);
     }
 
     /// <summary>Finishes a data-update log: status is rolled up from the message levels.</summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -460,13 +460,13 @@ return stream
             return Observable.Return(DeleteUnifiedReferenceResponse.Fail(...));
 
         var changeRequest = new DataChangeRequest { Deletions = [entityValue.Value], ... };
-        workspace.RequestChange(changeRequest, activity, null);
 
-        return Observable.Create<DeleteUnifiedReferenceResponse>(observer =>
-        {
-            activity.Complete(log => { observer.OnNext(...); observer.OnCompleted(); });
-            return Disposable.Empty;
-        });
+        // RequestChange issues the write eagerly and REPORTS through its observable:
+        // one ActivityLog once every affected stream applied its part, then completes.
+        return workspace.RequestChange(changeRequest, null)
+            .Select(log => new DataChangeResponse(hub.Version, log).Status == DataChangeStatus.Committed
+                ? DeleteUnifiedReferenceResponse.Ok()
+                : DeleteUnifiedReferenceResponse.Fail(log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
     });
 ```
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
@@ -90,7 +90,7 @@ var newTodo = new TodoItem
 };
 
 var request = DataChangeRequest.Create([newTodo], changedBy: "user-123");
-workspace.RequestChange(request, activity, delivery);
+workspace.RequestChange(request, delivery);
 ```
 
 ## Create Flow
@@ -216,7 +216,7 @@ var updatedTodo = existingTodo with
 };
 
 var request = DataChangeRequest.Update([updatedTodo], changedBy: "user-123");
-workspace.RequestChange(request, activity, delivery);
+workspace.RequestChange(request, delivery);
 ```
 
 ## Update Options
@@ -261,10 +261,10 @@ Convenience wrappers for the most common patterns:
 
 ```csharp
 // Single entity
-workspace.Update(updatedTodo, activity, delivery);
+workspace.Update(updatedTodo, delivery);
 
 // Multiple entities
-workspace.Update([todo1, todo2, todo3], activity, delivery);
+workspace.Update([todo1, todo2, todo3], delivery);
 ```
 
 ---
@@ -277,14 +277,14 @@ Pass the full entity object (not just the ID) so the workspace can resolve and r
 
 ```csharp
 var request = DataChangeRequest.Delete([todoToDelete], changedBy: "user-123");
-workspace.RequestChange(request, activity, delivery);
+workspace.RequestChange(request, delivery);
 ```
 
 ## Workspace Extension Methods
 
 ```csharp
-workspace.Delete(todoToDelete, activity, delivery);
-workspace.Delete([todo1, todo2], activity, delivery);
+workspace.Delete(todoToDelete, delivery);
+workspace.Delete([todo1, todo2], delivery);
 ```
 
 Deleting a **node** (as opposed to an entity in a collection) is a lifecycle operation: `hub.Observe<DeleteNodeResponse>(new DeleteNodeRequest(path)).Subscribe(...)` — see [Node Operations](/Doc/DataMesh/NodeOperations).

--- a/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
@@ -240,12 +240,12 @@ public static class AccessAssignmentLayoutAreas
             if (roles.Count == 0)
             {
                 host.Workspace.RequestChange(
-                    new DataChangeRequest().WithDeletions(node), null, null);
+                    new DataChangeRequest().WithDeletions(node), null);
             }
             else
             {
                 var updated = node with { Content = assignment with { Roles = roles } };
-                host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null, null);
+                host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
             }
         });
     }
@@ -260,7 +260,7 @@ public static class AccessAssignmentLayoutAreas
             var roles = assignment.Roles.ToList();
             roles.Add(new RoleAssignment { Role = selectedRole, Denied = false });
             var updated = node with { Content = assignment with { Roles = roles } };
-            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null, null);
+            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
         });
     }
 
@@ -361,7 +361,7 @@ public static class AccessAssignmentLayoutAreas
             var assignment = AccessControlLayoutArea.DeserializeAssignment(node);
             if (assignment == null) return;
             var updated = node with { Content = assignment with { AccessObject = newAccessObject } };
-            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null, null);
+            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
         });
     }
 }

--- a/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
@@ -239,13 +239,12 @@ public static class AccessAssignmentLayoutAreas
             roles.RemoveAt(indexToRemove);
             if (roles.Count == 0)
             {
-                host.Workspace.RequestChange(
-                    new DataChangeRequest().WithDeletions(node), null);
+                host.Workspace.RequestChange(new DataChangeRequest().WithDeletions(node));
             }
             else
             {
                 var updated = node with { Content = assignment with { Roles = roles } };
-                host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
+                host.Workspace.RequestChange(DataChangeRequest.Update([updated]));
             }
         });
     }
@@ -260,7 +259,7 @@ public static class AccessAssignmentLayoutAreas
             var roles = assignment.Roles.ToList();
             roles.Add(new RoleAssignment { Role = selectedRole, Denied = false });
             var updated = node with { Content = assignment with { Roles = roles } };
-            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
+            host.Workspace.RequestChange(DataChangeRequest.Update([updated]));
         });
     }
 
@@ -361,7 +360,7 @@ public static class AccessAssignmentLayoutAreas
             var assignment = AccessControlLayoutArea.DeserializeAssignment(node);
             if (assignment == null) return;
             var updated = node with { Content = assignment with { AccessObject = newAccessObject } };
-            host.Workspace.RequestChange(DataChangeRequest.Update([updated]), null);
+            host.Workspace.RequestChange(DataChangeRequest.Update([updated]));
         });
     }
 }

--- a/src/MeshWeaver.Import/Implementation/ImportManager.cs
+++ b/src/MeshWeaver.Import/Implementation/ImportManager.cs
@@ -44,6 +44,16 @@ public class ImportManager
     }
 
     /// <summary>
+    /// Folds a data change's <see cref="ActivityLog"/> into the import activity, so a save
+    /// failure or warning is reported where the user reads it — on the import's own log.
+    /// </summary>
+    private static void ForwardToActivity(Activity activity, ActivityLog changeLog)
+    {
+        foreach (var message in changeLog.Messages)
+            activity.LogMessage(message.Message, message.LogLevel, message.Scopes);
+    }
+
+    /// <summary>
     /// Handles an incoming import request: runs the (cold) import pipeline under an activity,
     /// saves the resulting instances on success, and posts an <see cref="ImportResponse"/>
     /// (with the activity log) on completion or failure.
@@ -95,14 +105,16 @@ public class ImportManager
                                 Hub.Post(new ImportResponse(Hub.Version, log), o => o.ResponseFor(request));
                                 return;
                             }
+                            // The save reports into the IMPORT activity — the activity is the unit
+                            // of INTENT ("import this file"); the data change itself no longer
+                            // spins one up, it just hands its log back here.
                             Configuration.Workspace.RequestChange(
                                 DataChangeRequest.Update(
                                     objectsToSave.ToArray(),
                                     null,
                                     request.Message.UpdateOptions),
-                                activity,
                                 request
-                            );
+                            ).Subscribe(saveLog => ForwardToActivity(activity, saveLog));
 
                             // Check if ImportConfiguration should be saved
                             if (request.Message.Configuration != null)
@@ -112,9 +124,8 @@ public class ImportManager
                                 {
                                     Configuration.Workspace.RequestChange(
                                         DataChangeRequest.Update([configToSave]),
-                                        activity,
                                         request
-                                    );
+                                    ).Subscribe(saveLog => ForwardToActivity(activity, saveLog));
                                     activity.LogInformation("Including ImportConfiguration in save operation: {ConfigType}", configToSave.GetType().Name);
                                 }
                             }

--- a/src/MeshWeaver.Import/Implementation/ImportManager.cs
+++ b/src/MeshWeaver.Import/Implementation/ImportManager.cs
@@ -112,9 +112,9 @@ public class ImportManager
                                 DataChangeRequest.Update(
                                     objectsToSave.ToArray(),
                                     null,
-                                    request.Message.UpdateOptions),
-                                request
-                            ).Subscribe(saveLog => ForwardToActivity(activity, saveLog));
+                                    request.Message.UpdateOptions))
+                                .Subscribe(saveLog => ForwardToActivity(activity, saveLog),
+                                    ex => activity.LogError($"Saving the imported instances failed: {ex.Message}"));
 
                             // Check if ImportConfiguration should be saved
                             if (request.Message.Configuration != null)
@@ -123,9 +123,9 @@ public class ImportManager
                                 if (configToSave != null)
                                 {
                                     Configuration.Workspace.RequestChange(
-                                        DataChangeRequest.Update([configToSave]),
-                                        request
-                                    ).Subscribe(saveLog => ForwardToActivity(activity, saveLog));
+                                        DataChangeRequest.Update([configToSave]))
+                                        .Subscribe(saveLog => ForwardToActivity(activity, saveLog),
+                                            ex => activity.LogError($"Saving the ImportConfiguration failed: {ex.Message}"));
                                     activity.LogInformation("Including ImportConfiguration in save operation: {ConfigType}", configToSave.GetType().Name);
                                 }
                             }

--- a/test/MeshWeaver.Data.Test/DataChangeLogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataChangeLogTest.cs
@@ -45,7 +45,7 @@ public class DataChangeLogTest(ITestOutputHelper output) : HubTestBase(output)
         var workspace = GetHost().GetWorkspace();
 
         var notifications = await workspace
-            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("2", "Second")]), null)
+            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("2", "Second")]))
             .Materialize()
             .ToArray()
             .Timeout(10.Seconds())
@@ -69,7 +69,7 @@ public class DataChangeLogTest(ITestOutputHelper output) : HubTestBase(output)
         var workspace = GetHost().GetWorkspace();
 
         var log = await workspace
-            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("3", null)]), null)
+            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("3", null)]))
             .Timeout(10.Seconds())
             .ToTask();
 

--- a/test/MeshWeaver.Data.Test/DataChangeLogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataChangeLogTest.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>Test entity whose <c>Name</c> is required, so a null makes the change fail validation.</summary>
+/// <param name="Id">The key.</param>
+/// <param name="Name">Required — a null value fails DataAnnotations validation.</param>
+public record ChangeLogRecord(string Id, [property: Required] string? Name);
+
+/// <summary>
+/// Pins the contract of the reactive data change (<see cref="WorkspaceOperations.Change"/>):
+/// the write is issued eagerly, the returned observable reports the outcome exactly once, the
+/// <see cref="ActivityLog"/> carries the validation failures — and no <see cref="Activity"/> hub
+/// is spun up per change.
+///
+/// <para>What this replaced: every <c>DataChangeRequest</c> used to construct an
+/// <see cref="Activity"/>, which hosts a HUB (plus one more per data source, via
+/// <c>StartSubActivity</c>), purely to latch "all streams applied" and accumulate messages.</para>
+/// </summary>
+public class DataChangeLogTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration) =>
+        base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(source =>
+                source.WithType<ChangeLogRecord>(type => type
+                    .WithKey(instance => instance.Id)
+                    .WithInitialData(_ => Observable.Return<IEnumerable<ChangeLogRecord>>(
+                        [new ChangeLogRecord("1", "First")])))));
+
+    [Fact]
+    public async Task Change_ReportsOnce_ThenCompletes()
+    {
+        var workspace = GetHost().GetWorkspace();
+
+        var notifications = await workspace
+            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("2", "Second")]), null)
+            .Materialize()
+            .ToArray()
+            .Timeout(10.Seconds())
+            .ToTask();
+
+        notifications.Select(n => n.Kind).Should()
+            .Equal([NotificationKind.OnNext, NotificationKind.OnCompleted],
+                "the change reports its log exactly once, then completes");
+        var log = notifications[0].Value;
+        log.Status.Should().Be(ActivityStatus.Succeeded);
+        log.End.Should().NotBeNull("the log is finished, not left running");
+
+        var records = await workspace.GetObservable<ChangeLogRecord>()
+            .Should().Within(5.Seconds()).Match(x => x.Any(r => r.Id == "2"));
+        records.Should().Contain(r => r.Id == "2" && r.Name == "Second");
+    }
+
+    [Fact]
+    public async Task Change_WhenValidationFails_ReportsTheFailure_AndDoesNotWrite()
+    {
+        var workspace = GetHost().GetWorkspace();
+
+        var log = await workspace
+            .RequestChange(DataChangeRequest.Update([new ChangeLogRecord("3", null)]), null)
+            .Timeout(10.Seconds())
+            .ToTask();
+
+        log.Status.Should().Be(ActivityStatus.Failed);
+        log.Messages.Should().Contain(m =>
+            m.LogLevel == LogLevel.Error && m.Message.Contains("Name") && m.Message.Contains("invalid"));
+
+        var records = await workspace.GetObservable<ChangeLogRecord>()
+            .FirstAsync().Timeout(5.Seconds()).ToTask();
+        records.Should().NotContain(r => r.Id == "3", "a change that fails validation is not applied");
+    }
+
+    [Fact]
+    public async Task DataChangeRequest_DoesNotHostAnActivityHub()
+    {
+        var host = GetHost();
+        var hostedHubs = host.ServiceProvider.GetRequiredService<HostedHubsCollection>();
+        int ActivityHubCount() => hostedHubs.Hubs.Count(h => h.Address.Type == AddressExtensions.ActivityType);
+
+        var before = ActivityHubCount();
+
+        var response = await GetClient()
+            .Observe(new DataChangeRequest { Updates = [new ChangeLogRecord("4", "Fourth")] },
+                o => o.WithTarget(CreateHostAddress()))
+            .Should().Within(10.Seconds()).Emit();
+
+        response.Message.Should().BeOfType<DataChangeResponse>()
+            .Which.Status.Should().Be(DataChangeStatus.Committed);
+        ActivityHubCount().Should().Be(before,
+            "a data change reports through its observable — it does not host an Activity hub to latch completion");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
@@ -92,7 +92,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[0] = roles[0] with { Denied = true };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Assert â€” stream should reflect the change
         var updatedNodes = await nodeStream!
@@ -135,7 +135,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[0] = roles[0] with { Denied = false };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -180,7 +180,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles.RemoveAt(0);
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -218,7 +218,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         initialNodes.Should().HaveCount(1);
         var node = initialNodes!.First();
 
-        _ = workspace.RequestChange(new DataChangeRequest().WithDeletions(node), null);
+        _ = workspace.RequestChange(new DataChangeRequest().WithDeletions(node));
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items => items == null || items.Length == 0);
@@ -252,7 +252,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles.Add(new RoleAssignment { Role = "Editor", Denied = false });
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -299,7 +299,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[1] = roles[1] with { Denied = true };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
@@ -92,7 +92,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[0] = roles[0] with { Denied = true };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Assert â€” stream should reflect the change
         var updatedNodes = await nodeStream!
@@ -135,7 +135,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[0] = roles[0] with { Denied = false };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -180,7 +180,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles.RemoveAt(0);
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -218,7 +218,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         initialNodes.Should().HaveCount(1);
         var node = initialNodes!.First();
 
-        workspace.RequestChange(new DataChangeRequest().WithDeletions(node), null, null);
+        _ = workspace.RequestChange(new DataChangeRequest().WithDeletions(node), null);
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items => items == null || items.Length == 0);
@@ -252,7 +252,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles.Add(new RoleAssignment { Role = "Editor", Denied = false });
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
@@ -299,7 +299,7 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var roles = initial.Roles.ToList();
         roles[1] = roles[1] with { Denied = true };
         var updatedNode = node with { Content = initial with { Roles = roles } };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>

--- a/test/MeshWeaver.Graph.Test/ContentPropertySyncTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentPropertySyncTest.cs
@@ -127,7 +127,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
             Content = updatedTodo,
             Name = "Updated Title"
         };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for update to be reflected in the stream (reactive query)
         await nodeStream!
@@ -217,7 +217,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
         var currentNode = nodes!.First();
         var updatedContent = new MinimalItem { Id = "1", Data = "updated data" };
         var updatedNode = currentNode with { Content = updatedContent };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for update to be reflected in the stream (reactive query)
         // Since MinimalItem has no [MeshNodeProperty] mappings, we wait for Content change
@@ -270,7 +270,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
             Icon = "Star",
             Category = "Premium"
         };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for update to be reflected in the stream (reactive query)
         await nodeStream!

--- a/test/MeshWeaver.Graph.Test/ContentPropertySyncTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentPropertySyncTest.cs
@@ -127,7 +127,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
             Content = updatedTodo,
             Name = "Updated Title"
         };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for update to be reflected in the stream (reactive query)
         await nodeStream!
@@ -217,7 +217,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
         var currentNode = nodes!.First();
         var updatedContent = new MinimalItem { Id = "1", Data = "updated data" };
         var updatedNode = currentNode with { Content = updatedContent };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for update to be reflected in the stream (reactive query)
         // Since MinimalItem has no [MeshNodeProperty] mappings, we wait for Content change
@@ -270,7 +270,7 @@ public class ContentPropertySyncTest(ITestOutputHelper output) : HubTestBase(out
             Icon = "Star",
             Category = "Premium"
         };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for update to be reflected in the stream (reactive query)
         await nodeStream!

--- a/test/MeshWeaver.Graph.Test/MeshNodeTypeSourceTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeTypeSourceTest.cs
@@ -126,7 +126,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
         {
             Name = "Updated Name"
         };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for the update to be reflected in the stream (reactive query)
         await meshNodeStream!
@@ -171,7 +171,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
             Content = updatedContent,
             Name = "Synced Title"
         };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for the update to be reflected in the stream (reactive query)
         await nodeStream!
@@ -242,7 +242,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
         var currentNode = nodes!.First();
         var updatedContent = new TestContent { Id = "1", Title = "Updated Title", Notes = "Notes" };
         var updatedNode = currentNode with { Content = updatedContent, Name = "Updated Title" };
-        workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null, null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
 
         // Wait for the update to be reflected in the stream (reactive query)
         await nodeStream!

--- a/test/MeshWeaver.Graph.Test/MeshNodeTypeSourceTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeTypeSourceTest.cs
@@ -126,7 +126,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
         {
             Name = "Updated Name"
         };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for the update to be reflected in the stream (reactive query)
         await meshNodeStream!
@@ -171,7 +171,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
             Content = updatedContent,
             Name = "Synced Title"
         };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for the update to be reflected in the stream (reactive query)
         await nodeStream!
@@ -242,7 +242,7 @@ public class MeshNodeTypeSourceTest(ITestOutputHelper output) : HubTestBase(outp
         var currentNode = nodes!.First();
         var updatedContent = new TestContent { Id = "1", Title = "Updated Title", Notes = "Notes" };
         var updatedNode = currentNode with { Content = updatedContent, Name = "Updated Title" };
-        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]), null);
+        _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
         // Wait for the update to be reflected in the stream (reactive query)
         await nodeStream!


### PR DESCRIPTION
## The defect

**Every `DataChangeRequest` constructed an `Activity` — and an `Activity` is not a log, it is a HUB.** Its constructor calls `GetHostedHub` (`Activity.cs:38`), and `StartSubActivity` hosts one more per data source (`Activity.cs:148`), wired together with a C# `event` plus an `autoClose` heuristic that fires when "all sub-activities are no longer Running".

That whole apparatus answered one question — *tell me when the writes committed, and hand me the accumulated messages* — which is exactly what `IObservable<ActivityLog>` expresses natively. It predates the reactive API.

**It was already vestigial.** Of ~20 `RequestChange` call sites, all but three passed `activity: null` — including the mainline cross-hub node write (`ApplyMeshNodePatchInTurn`, `DataExtensions.cs:1259`). The three holdouts were `HandleDataChangeRequest` and the unified-reference update/delete. Meanwhile the validation-failure path already built its `ActivityLog` **by hand, with no Activity at all** (`DataExtensions.cs:1636`) — the proof that the log works standalone — and the sub-activity tree it produced was read by exactly one thing: a `LogDebug` line.

Per Roland's decision 2026-08-04 (*"I'm ok taking the activity wrap away — it is overkill"*): an activity is the unit of **intent** (import, GitSync, compile — a persisted node with live progress), never a per-write record.

## The change

- **`IWorkspace.RequestChange` / `Update` / `Delete` drop the `Activity?` parameter and return `IObservable<ActivityLog>`.** The write is still issued **EAGERLY on call**, so a caller that ignores the result still writes — no call site can silently stop writing, which is why this is not the usual cold `RequireSubscribeObservable` write shape. The observable *reports*: one finished `ActivityLog` after every affected stream applied its part, replayed to late subscribers.
- **Per-stream completion is an `AsyncSubject` scheduled on the stream hub's NEXT turn.** The transform's result is applied by the same turn that runs it, so signalling inline would report "committed" — and post the `DataChangeResponse` — while the store still held the pre-change state. That is ack-on-accept, the shape `ApplyMeshNodePatchInTurn` already documents as having raced read-after-write.
- **`Activity` is untouched** and still used for intent-level work. `ImportManager` folds the save's log into the import activity instead of passing the activity down.

### Three behaviours that were wrong and are now right

1. **Validation failures were dropped for every `activity: null` caller** — they went only to the Activity. They now always land on the returned log, with one consistent `"<members> invalid: <error>"` shape (the three branches previously each formatted differently, one of them as `"Validation error in activityId {message}"`).
2. **A failed stream write reported Succeeded.** The old exception path completed the sub-activity with no error message, so the activity rolled up to Succeeded → `DataChangeStatus.Committed`. It now reports Failed. A **disposed** stream stays a Warning — the benign teardown marker the stream classifies as Debug-only — and Warning still commits.
3. **The activity hub got a synthetic "Succeeded" response** (`activity is null` → post Succeeded immediately), because an Activity created on an activity hub would have recursed. With no Activity involved, every hub reports its real log.

`DataChangeResponse` is unchanged, so consumers reading `.Log` / `.Status` see the same shape — now with the real status behind it.

## Tests

- **`DataChangeLogTest`** (new) pins the contract: reports exactly once then completes; a validation failure is reported *and not applied*; and a `DataChangeRequest` leaves the host hub's activity-typed hosted-hub count unchanged — the direct pin on "no hub per write".
- Green locally, Release + `-warnaserror`: solution build, **Monolith 471** (2 pre-existing skips), **Graph 812**, **Data 304**, **GitSync 153** (the activity/`ActivityLiveProgress` suites), **Layout 343**, **Import 21**, doc link integrity.

## Notes for review

- `MeshWeaver.Reinsurance`'s **`legacy/`** tree has 5 call sites passing an Activity to `RequestChange`. That tree has no solution file and its CI only compile-checks source nodes, so nothing builds it today — but it would need the one-line update if revived.
- Docs updated: `AsynchronousCalls.md` (the read-modify-write example) and `DataMesh/CRUD.md` signatures.

## Release note

Skipped deliberately: internal plumbing with no user-visible surface (same call as #794).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3GuX6pWYWHMCP7NbWbcf9