### PR TITLE
Attribute Cancelled/Error token usage to the resolved model, and log the no-op (#595)

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -2394,7 +2394,7 @@ internal static class ThreadExecution
                         // after the terminal Cancelled status). Fail-open + no-op on zero tokens.
                         TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                             AgentPickerProjection.PartitionOf(threadPath),
-                            request.ModelName, inputTokens, outputTokens, execLogger,
+                            actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
                             cacheReadTokens, cacheWriteTokens)
                         .Subscribe(
                             _ => { },
@@ -2502,7 +2502,7 @@ internal static class ThreadExecution
                                 // Fail-open + no-op on zero tokens.
                                 TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                                     AgentPickerProjection.PartitionOf(threadPath),
-                                    request.ModelName, inputTokens, outputTokens, execLogger,
+                                    actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
                                     cacheReadTokens, cacheWriteTokens)
                                 .Subscribe(
                                     _ => { },

--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -145,7 +145,16 @@ public static class TokenUsageNodeType
         long cacheReadTok = cacheReadTokens ?? 0;
         long cacheWriteTok = cacheWriteTokens ?? 0;
         if (inTok == 0 && outTok == 0 && cacheReadTok == 0 && cacheWriteTok == 0)
+        {
+            // #595: make the silent no-op diagnosable. A terminal (Cancelled/Error) round whose
+            // provider never emitted usage lands here with all-zero counts and vanishes from
+            // accounting — "provider returned no counts" was indistinguishable from "no work done".
+            // Debug, not Information: this fires on every zero-token round, so it must stay off the
+            // Loki hot path (AGENTS.md log-cost rule).
+            logger?.LogDebug("[TokenUsage] RecordUsage no-op for {ThreadPath} (model {ModelId}): "
+                + "provider reported no tokens", threadPath, modelId ?? "(unknown)");
             return Observable.Return(System.Reactive.Unit.Default); // no-token round → no-op
+        }
 
         var model = string.IsNullOrWhiteSpace(modelId) ? "(unknown)" : modelId!;
         var key = new string(model.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());


### PR DESCRIPTION
Addresses part of #595 — does **not** close it (see below).

## Context
Since #595 was filed, the Cancelled and Error terminal paths were updated to **record consumed tokens** (they call `RecordUsage` with the captured counts), and `ThreadTokenUsageTest` covers it (Cancelled + Error, passing). So the headline "tokens lost on cancel/error" is already fixed for providers that emit incremental usage. This PR closes the two remaining **surgical** gaps.

## Fixes
1. **Model attribution.** Cancelled and Error keyed the `_Usage` satellite by bare `request.ModelName`, so a delegation sub-thread (null `request.ModelName`) mis-keyed to `(unknown)`. Now `actualModel ?? request.ModelName`, matching the Completed path.
2. **No-op diagnosability.** `RecordUsage` silently returned on all-zero counts. Added a `Debug` log (kept off the Loki hot path per AGENTS.md's log-cost rule) so "provider reported no counts" is diagnosable.

## Not in this PR — the remaining scope of #595
OpenAI-compatible providers emit usage **only in the terminal chunk**, so a round cancelled/errored before it arrives records `null` counts → `RecordUsage` no-ops → the consumed input tokens (real billed spend) are still lost for that provider class. Fixing needs an **input-token estimate** from the sent prompt, marked as an estimate on the record — a feature, not a surgical change. #595 stays open for it (see my comment there).

## Scope / verification
- `src/` framework: `MeshWeaver.AI` only (`ThreadExecution.cs`, `TokenUsage.cs`). +11/−2.
- Release `-warnaserror` build clean; `ThreadTokenUsageTest` **6/6** pass (the attribution change doesn't regress the recording tests).
- **No new test:** the fix only differs from prior behavior when `actualModel ≠ request.ModelName` (a cancelled/errored delegation sub-thread); the existing fake providers leave `actualModel` null, so exercising it needs a new fake provider — deferred with the estimate work rather than adding a race-prone integration test.
- **What's New:** skipped — internal accounting-accuracy refinement + a Debug diagnostic; the visible token-recording already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
