### PR TITLE
A scoped query watched one schema's change feed while the write landed in another

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -1,4 +1,4 @@
-using MeshWeaver.Hosting.Embeddings;
+﻿using MeshWeaver.Hosting.Embeddings;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -64,6 +64,31 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private readonly IIoPool _ioPool;
 
     /// <summary>
+    /// The change feed this query watches to invalidate its cached snapshot.
+    ///
+    /// <para>🚨 NOT necessarily <c>_adapter.Changes</c>. Under
+    /// <see cref="PostgreSqlPathRoutingAdapter"/> there is ONE adapter PER SCHEMA, each with its
+    /// own change Subject, and a scoped query is served by the adapter for its own partition. But
+    /// a write that changes this query's RESULTS can land in a DIFFERENT schema: the global
+    /// satellite namespaces (<c>_Access</c>, <c>_Activity</c>, …) resolve to their own schemas
+    /// (<c>system_access</c>, …), so an AccessAssignment written at <c>{Partition}/_Access/x</c>
+    /// publishes on the <c>system_access</c> adapter's Subject — which the partition's query was
+    /// never subscribed to. The notification was delivered to a feed nobody in that fold was
+    /// listening on, so the <c>$security-access</c> snapshot stayed frozen at its Initial value
+    /// and permissions were evaluated stale, with no reconciliation path (the pg_notify LISTEN
+    /// fallback is disabled for partitioned PG). That is the residual PaywallRealGateShapeTests
+    /// flake that survived both #849 and #853.</para>
+    ///
+    /// <para>So the partitioned host passes the routing adapter's MERGED feed (every per-schema
+    /// adapter is subscribed into it). Correctness is unaffected: every subscriber already filters
+    /// with <c>PathMatcher.ShouldNotifyForQuery</c>, so a notification from an unrelated schema is
+    /// discarded exactly as before. The direction of the change is deliberately the safe one —
+    /// under-notifying leaves permissions stale, while over-notifying can only cost a redundant
+    /// re-query.</para>
+    /// </summary>
+    private readonly IObservable<DataChangeNotification> _changeFeed;
+
+    /// <summary>
     /// Initializes the PostgreSQL native query provider.
     /// </summary>
     /// <param name="adapter">The storage adapter that translates parsed queries into SQL.</param>
@@ -78,9 +103,13 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
         MeshConfiguration? meshConfiguration = null,
         IEnumerable<string>? excludedNamespaces = null,
         IEmbeddingProvider? embeddingProvider = null,
-        IoPoolRegistry? ioPoolRegistry = null)
+        IoPoolRegistry? ioPoolRegistry = null,
+        IObservable<DataChangeNotification>? changeFeed = null)
     {
         _adapter = adapter;
+        // The feed this query watches for invalidation. Defaults to the adapter's own, but a
+        // PARTITIONED host passes the routing adapter's MERGED feed — see _changeFeed.
+        _changeFeed = changeFeed ?? adapter.Changes;
         _accessService = accessService;
         _meshConfiguration = meshConfiguration;
         _excludedNamespaces = (excludedNamespaces ?? Enumerable.Empty<string>())
@@ -662,7 +691,7 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
             var earlyLock = new object();
             var initialDone = false;
 
-            var earlySubscription = _adapter.Changes
+            var earlySubscription = _changeFeed
                 .Where(n => parsedFilters.Any(f =>
                     PathMatcher.ShouldNotifyForQuery(n.Path, f.BasePath, f.Scope, f.Namespaces)))
                 .Subscribe(n =>
@@ -697,7 +726,7 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                     // adapter's fan-out. That is what starved the $security-access query of its
                     // notification and froze the permission fold (see IsolatedChangeFeed).
                     disposables.Add(
-                        _adapter.Changes
+                        _changeFeed
                             .Where(n => parsedFilters.Any(f =>
                                 PathMatcher.ShouldNotifyForQuery(n.Path, f.BasePath, f.Scope, f.Namespaces)))
                             .Subscribe(changeBuffer));

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
@@ -1,4 +1,4 @@
-using MeshWeaver.Hosting.Embeddings;
+﻿using MeshWeaver.Hosting.Embeddings;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reactive;
@@ -84,6 +84,15 @@ public sealed class PostgreSqlPartitionStorageProvider : IPartitionStorageProvid
     /// own scoped query serving by delegating to a per-schema <see cref="PostgreSqlMeshQuery"/>.
     /// </summary>
     internal PostgreSqlStorageAdapter? GetSchemaAdapter(string path) => _adapter.GetSchemaAdapter(path);
+
+    /// <summary>
+    /// The routing adapter's MERGED change feed — every per-schema adapter's <c>Changes</c> is
+    /// subscribed into it. A SCOPED query must watch this rather than only its own partition's
+    /// adapter, because a write that changes its results can land in a different schema: the
+    /// global satellite namespaces (<c>_Access</c> → <c>system_access</c>, …) have their own.
+    /// See <c>PostgreSqlMeshQuery._changeFeed</c> for the failure this closes.
+    /// </summary>
+    internal IObservable<DataChangeNotification> MergedChanges => _adapter.Changes;
 
     /// <summary>Embedding provider for vector scoring, shared with the per-schema delegate.</summary>
     internal IEmbeddingProvider? EmbeddingProvider => _embeddingProvider;

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+﻿using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Hosting.Persistence.Query;
 using MeshWeaver.Mesh;
@@ -130,7 +130,13 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
         return _scopedDelegates.GetOrAdd(adapter, a =>
             new PostgreSqlMeshQuery(a, _accessService, meshConfiguration: null,
                 excludedNamespaces: null, embeddingProvider: _partitionProvider.EmbeddingProvider,
-                ioPoolRegistry: _ioPoolRegistry));
+                ioPoolRegistry: _ioPoolRegistry,
+                // 🚨 The MERGED feed, not `a.Changes`. This delegate is the adapter for ONE schema,
+                // but writes that change its results land in others — an AccessAssignment at
+                // {Partition}/_Access/x publishes on the `system_access` adapter. Watching only
+                // `a.Changes` meant that notification reached nobody in this fold, the
+                // $security-access snapshot stayed frozen, and permissions evaluated stale.
+                changeFeed: _partitionProvider.MergedChanges));
     }
 
     /// <summary>


### PR DESCRIPTION
The residual `PaywallRealGateShapeTests` flake — the one that survived **both** #849 (the test's own defects) and #853 (the fan-out starvation).

**Proof it is neither the test nor #853:** PR #864 changes exactly one file — `.github/workflows/main-cd.yml` — and failed on `PaywallRealGateShapeTests.DbRoleClaim_DoesNotGrantNodeRead`. A workflow YAML cannot break a Postgres access test.

## The defect

Under `PostgreSqlPathRoutingAdapter` there is **one adapter per schema**, each with its own change Subject, and `PostgreSqlPartitionedMeshQuery` serves a scoped query from the adapter for *its own* partition — watching only `_adapter.Changes`.

But a write that changes that query's results routinely lands in a **different schema**. The global satellite namespaces resolve to their own: `_Access` → `system_access`. So an `AccessAssignment` written at `{Partition}/_Access/x` publishes on the **`system_access`** adapter's Subject — which the partition's `$security-access` fold was never subscribed to.

The notification went to a feed nobody in that fold was listening on. The `Replay(1)` snapshot stayed frozen at its Initial value and permissions were evaluated **stale**, with no reconciliation path, because the pg_notify LISTEN fallback is disabled for partitioned PG (`PostgreSqlExtensions.cs:347`).

That also corrects the premise in that TODO's own comment:

> *"each adapter publishes from its own Write/Delete … which is enough for the in-process test scenarios"*

Only true when writer and reader share a schema — which `_Access` guarantees they do **not**.

**Why it's intermittent:** it only fails when the query's Initial snapshot is taken *before* the assignments land. Otherwise the snapshot already contains them and no delta is needed.

## The fix

A scoped delegate now watches the routing adapter's **merged** feed — every per-schema adapter is already subscribed into it — instead of only its own partition's. `PostgreSqlMeshQuery` takes the feed as an injectable dependency defaulting to `adapter.Changes`, so every non-partitioned caller is unchanged.

**Correctness is unaffected:** every subscriber already filters with `PathMatcher.ShouldNotifyForQuery`, so a notification from an unrelated schema is discarded exactly as before.

**The direction is deliberately the safe one:** under-notifying leaves permissions stale; over-notifying can only cost a redundant re-query.

## Verification

- Builds clean at `-c Release -warnaserror`.
- `MeshWeaver.Hosting.PostgreSql.Test`: **631 passed / 3 failed**. Those 3 are `GroupMembershipRecomputeTests` — the fresh-DB `auth` provisioning bug fixed by **#859**, which isn't merged into this branch's base yet. **`PaywallRealGateShapeTests` passes.**

Local green does not by itself prove a CI-only flake is gone; the honest claim here is a root cause with a mechanism that explains every observation, plus no regression across the suite.

## Relationship to the other PRs

- #849 — fixed the test's vacuous barrier, static state and budget. Working: this failure now reports an honest `ObservableAssertionException` instead of an opaque harness kill.
- #853 — closed fan-out starvation *within* one adapter (a throwing observer aborting delivery).
- **This** — closes the gap *between* adapters. Different mechanism, same symptom.

Internal correctness fix in the access path; no user-visible behaviour change — no What's New entry.