### PR TITLE
A read budget that outlives its Fact timeout makes every hang undiagnosable

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1018,19 +1018,41 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
 
     private static readonly Address ReadHubAddress = new("test-reader", "shared");
 
+    /// <summary>The ceiling for a mesh read: what a COLD per-node hub activation may take.</summary>
+    private static readonly TimeSpan ReadNodeCeiling = TimeSpan.FromSeconds(60);
+
     /// <summary>
-    /// Default upper bound for a single-node read in tests. Bounded so a misrouted
-    /// request fails the test loudly with a <see cref="TimeoutException"/> instead
-    /// of hanging the whole CI run until the inactivity guard aborts. 30 seconds
-    /// is generous — typical per-node-hub activation + persistence load is sub-second.
+    /// The budget a mesh read gets — the ceiling above, CLAMPED so it always expires INSIDE the
+    /// running test's declared <c>[Fact(Timeout)]</c>.
+    ///
+    /// <para>🚨 This is the same invariant <see cref="EffectiveHardDeadline"/> enforces for the
+    /// watchdog, applied to the other end: <i>the operation's own loud, specific timeout must win
+    /// the race against a generic backstop.</i> It was previously only per-test discipline, and a
+    /// scan found ~123 test files declaring a Fact timeout at or below the operation budget they
+    /// contain. When that inverts, the harness kills the test first and the ONLY output is
+    /// <c>"Test execution timed out after N milliseconds"</c> with no assertion text — you never
+    /// learn WHICH read never came back. That is what made the CI-only hangs in
+    /// VersionHistoryTest / CreatableTypesFileSystemTest / DynamicGraphFileSystemPersistenceTest
+    /// undiagnosable: every one of them reported the harness message, never the operation's.</para>
+    ///
+    /// <para>Clamping does NOT weaken an assertion and does NOT hide a slow read: the test still
+    /// fails, it just fails NAMING the read instead of the harness. A test that genuinely needs to
+    /// tolerate a cold 35-45 s activation must declare a Fact timeout above
+    /// <see cref="ReadNodeCeiling"/> — and now gets the full ceiling when it does.</para>
+    ///
+    /// <para>80% of the declared timeout, leaving headroom for the assertion to be built and
+    /// reported before the harness fires.</para>
     /// </summary>
-    // Wall-clock cap on ReadNodeAsync. 60s matches the mesh hub's RequestTimeout
-    // bump (ConfigureMeshBase) — keeps the watchdog above the underlying
-    // hub-level Timeout so a slow-but-successful activation finishes inside
-    // the budget on CI cold starts (Linux runners commonly take 35-45s for
-    // the first per-node hub activation; the prior 30s tripped before the
-    // hub responded — symptom: FullFlow_CreateThread + similar AI tests).
-    protected static readonly TimeSpan ReadNodeTimeout = TimeSpan.FromSeconds(60);
+    protected static TimeSpan ReadNodeTimeout
+    {
+        get
+        {
+            if (CurrentFactTimeout() is not { } declared)
+                return ReadNodeCeiling;
+            var fitted = declared * 0.8;
+            return fitted < ReadNodeCeiling ? fitted : ReadNodeCeiling;
+        }
+    }
 
     /// <summary>
     /// Recognise the two routing-failure flavours that mean "this path has no


### PR DESCRIPTION
`ReadNodeTimeout` is 60 s — deliberately, because *"Linux runners commonly take 35-45 s for the first per-node hub activation"*. But tests routinely declare `[Fact(Timeout = 20000)]` around reads that use it. When the inner budget can't elapse inside the outer one, **the harness wins the race** and the only output is:

```
Test execution timed out after 20000 milliseconds
```

No assertion text. You never learn *which* read never came back.

That is exactly why the CI-only hangs in `VersionHistoryTest.RollbackNode_RestoresHistoricalState`, `CreatableTypesFileSystemTest` and `DynamicGraphFileSystemPersistenceTest` were undiagnosable: every one reported the harness message, never the operation's.

## The invariant already exists — this applies it to the other end

`MonolithMeshTestBase` documents it, and says why it matters:

> *"MUST stay strictly ABOVE every in-test operation budget … that collision hid the real cause of a whole class of failures … **The operation's own loud, specific timeout must win the race** … Widening it does not weaken any assertion — the test still fails, it just fails naming the operation instead of the harness."*

`EffectiveHardDeadline` already enforces this for the watchdog. This applies the same rule to the read budget, from the other direction.

## Why not just raise the Fact timeouts

A scan found **~123 test files** whose declared Fact timeout is at or below an operation budget they contain — 398 tests. Per-test discipline has clearly not held, and bulk-editing that many tests to raise their timeouts would risk masking genuine failures.

Instead `ReadNodeTimeout` is **clamped to fit the running test**: `min(60 s ceiling, 80% of the declared [Fact(Timeout)])`. One change, every call site.

## What this does and does not do

- **Does not hide a slow read, does not weaken an assertion.** The test still fails — it fails *naming the read*, with the operation's own message, instead of an opaque harness kill.
- **Does not by itself let a test tolerate a cold 35-45 s activation.** A test that must do that still has to declare a Fact timeout above the ceiling — and now gets the full 60 s when it does, instead of being silently cut short.
- The 80% leaves headroom for the assertion to be built and reported before the harness fires.

## Verification

`MeshWeaver.Hosting.Monolith.TestBase` and `MeshWeaver.Content.Test` build clean at `-c Release -warnaserror`; `Content.Test` **245 passed / 0 failed / 1 skipped** (skip is pre-existing and unrelated).

Test-infrastructure change, no product code — no What's New entry.

## Follow-up this makes possible

With failures now naming the operation, the next CI occurrence of the compile/activation cluster (`StaleActivationSeedRollbackTest`, `CompileFinishAndDisposeTest`, `CompileSingleDriverConsistencyTest`, `CodeEditRecompileTest`) should identify *which* read hangs — currently they all report the same opaque harness message.