### PR TITLE
CI cannot report green on zero evidence, and a starved job must not block delivery

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -190,10 +190,18 @@ jobs:
   build:
     name: "Build solution (once)"
     needs: precheck
-    # Skipped when this exact tree is already green (see the file header). `test`
+    # Skipped ONLY when this exact tree is already green (see the file header). `test`
     # needs `build`, so it skips with it; `collect-results` is if:always() and
     # reports the reused result.
-    if: needs.precheck.outputs.skip != 'true'
+    #
+    # 🚨 `!cancelled()` is what makes the skip FAIL-OPEN. A `needs` job that ends
+    # cancelled — the probe waiting 15 min for a runner and being killed with zero
+    # steps executed, main 2026-08-06 — skips every dependent REGARDLESS of this `if`,
+    # unless the condition contains always()/!cancelled(). That silently skipped the
+    # build and all six shards, and the run still reported a green required check.
+    # With !cancelled(), an unanswerable probe means "we don't know" ⇒ TEST IT; only a
+    # genuine workflow cancellation (where !cancelled() is false) still stops the run.
+    if: ${{ !cancelled() && needs.precheck.outputs.skip != 'true' }}
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
@@ -672,9 +680,25 @@ jobs:
             done <<< "$fails"
           fi
         done
+        # 🚨 EVIDENCE GATE: "no failures" is only green if tests actually RAN. With zero
+        # trx anywhere, this step used to exit 0 — so a run in which the probe was
+        # starved, build skipped and no shard executed still published a SUCCESSFUL
+        # required check. A required check that passes on no evidence is worse than a
+        # flaky one: it lets an untested tree merge and ship.
+        trx_count=$(find all-results -name '*.trx' 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$trx_count" = "0" ]; then
+          echo "::error::No test results found in any shard — the suite did not run, so this run proves nothing. Failing (the reuse path is the ONLY sanctioned way to skip tests)."
+          {
+            echo "### ❌ No test evidence"
+            echo
+            echo "Zero \`.trx\` files across all shards, and this was not a green-tree reuse."
+            echo "The suite did not execute — refusing to report success."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
         if [ "$any" = "0" ]; then
-          echo "_No failed tests in trx (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
-          echo "No failed tests found in trx across all shards."
+          echo "_No failed tests in ${trx_count} trx file(s) (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
+          echo "No failed tests found in trx across all shards (${trx_count} result files)."
         else
           # 🚨 GATE (TRX-based, reporter-independent): the consolidated run pass/fail
           # gate. Fail on any test failure across shards, independent of the Publish

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -49,13 +49,56 @@ jobs:
   # Two parallel legs, one per image. No `dotnet workload restore` in either:
   # CI logs prove it installs nothing ("No workloads installed for this feature
   # band … Successfully updated workload(s): .") and burned ~75 s per run.
+  # ─────────────────────────────── DELIVERY GATE ───────────────────────────────
+  # 🚨 Gate on the REQUIRED CHECK, not on the workflow run's umbrella conclusion.
+  # A run's conclusion is `failure` if ANY job ends cancelled — including a job that
+  # never executed a step because it waited 15 minutes for a runner and was killed
+  # (main 2026-08-06: three consecutive main commits shipped no image for exactly this
+  # reason, with every test that did run green). Keying delivery on that conclusion
+  # means infrastructure noise silently stops the pull-based self-update, which is the
+  # failure mode the merge gate exists to prevent.
+  #
+  # "Consolidate test results" is the repo's single required check (ruleset
+  # `main pr protection`) and, since the evidence gate in dotnet-test.yml, it can only
+  # be green if tests actually ran (or a proven green-tree marker was reused). So it is
+  # both necessary and sufficient — and strictly stronger than the umbrella conclusion,
+  # which a starved job can poison in either direction.
+  gate:
+    name: "Verify the required check is green"
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      green: ${{ steps.required.outputs.green }}
+    steps:
+      - name: "Read the required check for this commit"
+        id: required
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          # Latest run of the required check on this SHA (a re-run appends another).
+          concl=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name=="Consolidate test results")]
+                  | sort_by(.completed_at) | last | .conclusion // "missing"')
+          echo "Required check 'Consolidate test results' on $SHA → $concl"
+          echo "run conclusion (umbrella, informational) → ${{ github.event.workflow_run.conclusion }}"
+          if [ "$concl" = "success" ]; then
+            echo "green=true" >> "$GITHUB_OUTPUT"
+            echo "### ✅ Required check green — shipping images" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "green=false" >> "$GITHUB_OUTPUT"
+            echo "### ⛔ Required check is \`$concl\` — no image will be built" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   portal-image:
     name: "Build + push portal-ai image"
     # Gate: only a SUCCESSFUL test run, from a PUSH (not a PR), on main.
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main'
+    needs: gate
+    if: needs.gate.outputs.green == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -144,10 +187,8 @@ jobs:
 
   migration-image:
     name: "Build + push migration image"
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main'
+    needs: gate
+    if: needs.gate.outputs.green == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -223,10 +264,8 @@ jobs:
   # it — `latest` is the stable tag that variable pins.
   plugin-test-image:
     name: "Build + push mw-plugin-test image"
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main'
+    needs: gate
+    if: needs.gate.outputs.green == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/test/MeshWeaver.Content.Test/VersionHistoryTest.cs
+++ b/test/MeshWeaver.Content.Test/VersionHistoryTest.cs
@@ -55,6 +55,21 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
     /// raw call returns whatever's on disk at the moment of invocation and can
     /// race the WriteVersion side of the just-completed save.
     /// </summary>
+    /// <summary>
+    /// Per-STEP wait budget. Every await in this class is bounded by it, and the sum of the
+    /// steps on any path stays inside the 20 s method timeout.
+    ///
+    /// <para>🚨 Why this exists: the awaits used to run on <c>Emit()</c>'s 10 s default, and the
+    /// rollback poll claimed <c>ReadNodeTimeout</c> (60 s) — inside a <c>Timeout = 20000</c> test.
+    /// Those bounds contradict each other: the method timeout always fired first, so a slow step
+    /// produced "Test execution timed out after 20000 milliseconds" naming NOTHING (main
+    /// 2026-08-06, shard 4). A bound larger than the method timeout is not a bound; it is a
+    /// guarantee of an undiagnosable failure. 4 s is ~10x the observed per-operation cost in this
+    /// project (246 tests in 96 s), so a step that exceeds it is stuck, not slow — and it now says
+    /// which step.</para>
+    /// </summary>
+    private static TimeSpan Step => TimeSpan.FromSeconds(4);
+
     private IObservable<IList<MeshNodeVersion>> WaitForVersions(
         string path, Func<IList<MeshNodeVersion>, bool> predicate)
     {
@@ -70,21 +85,21 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
     {
         // Arrange
         var node = MeshNode.FromPath("test/mynode") with { Name = "V1", State = MeshNodeState.Active, NodeType = "Markdown" };
-        var created = await NodeFactory.CreateNode(node).Should().Emit();
+        var created = await NodeFactory.CreateNode(node).Should().Within(Step).Emit();
 
         // Update 3 times
         var updated1 = created with { Name = "V2" };
-        await NodeFactory.UpdateNode(updated1).Should().Emit();
+        await NodeFactory.UpdateNode(updated1).Should().Within(Step).Emit();
 
         var updated2 = updated1 with { Name = "V3" };
-        await NodeFactory.UpdateNode(updated2).Should().Emit();
+        await NodeFactory.UpdateNode(updated2).Should().Within(Step).Emit();
 
         var updated3 = updated2 with { Name = "V4" };
-        await NodeFactory.UpdateNode(updated3).Should().Emit();
+        await NodeFactory.UpdateNode(updated3).Should().Within(Step).Emit();
 
         // Act — wait for at least one snapshot to land (writes are async via the
         // version-writing storage decorator; polling Where() avoids racing them).
-        var versions = await WaitForVersions("test/mynode", v => v.Count >= 1).Should().Within(5.Seconds()).Emit();
+        var versions = await WaitForVersions("test/mynode", v => v.Count >= 1).Should().Within(Step).Emit();
 
         // Assert
         versions.Should().NotBeEmpty("node was created and updated 3 times");
@@ -96,24 +111,24 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
     {
         // Arrange
         var node = MeshNode.FromPath("test/snapshot") with { Name = "V1", State = MeshNodeState.Active, NodeType = "Markdown" };
-        var created = await NodeFactory.CreateNode(node).Should().Emit();
+        var created = await NodeFactory.CreateNode(node).Should().Within(Step).Emit();
 
         // Get the version of the first save — wait for it to land
         var versionQuery = Mesh.ServiceProvider.GetRequiredService<IVersionQuery>();
         var options = Mesh.JsonSerializerOptions;
 
-        var versionsAfterCreate = await WaitForVersions("test/snapshot", v => v.Count >= 1).Should().Within(5.Seconds()).Emit();
+        var versionsAfterCreate = await WaitForVersions("test/snapshot", v => v.Count >= 1).Should().Within(Step).Emit();
 
         // Update to V2
         var updated = created with { Name = "V2" };
-        await NodeFactory.UpdateNode(updated).Should().Emit();
+        await NodeFactory.UpdateNode(updated).Should().Within(Step).Emit();
 
         // Act - get the first version
         var firstVersion = versionsAfterCreate.LastOrDefault();
         firstVersion.Should().NotBeNull("there should be at least one version after create");
 
         var historicalNode = await versionQuery.GetVersion("test/snapshot", firstVersion!.Version, options)
-            .Should().Emit();
+            .Should().Within(Step).Emit();
 
         // Assert
         historicalNode.Should().NotBeNull("the first version should be retrievable");
@@ -125,43 +140,43 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
     {
         // Arrange
         var node = MeshNode.FromPath("test/before") with { Name = "V1", State = MeshNodeState.Active, NodeType = "Markdown" };
-        var created = await NodeFactory.CreateNode(node).Should().Emit();
+        var created = await NodeFactory.CreateNode(node).Should().Within(Step).Emit();
 
         var versionQuery = Mesh.ServiceProvider.GetRequiredService<IVersionQuery>();
         var options = Mesh.JsonSerializerOptions;
 
         // Capture version after v1 create — wait for snapshot to land
-        var versionsAfterV1 = await WaitForVersions("test/before", v => v.Count >= 1).Should().Within(5.Seconds()).Emit();
+        var versionsAfterV1 = await WaitForVersions("test/before", v => v.Count >= 1).Should().Within(Step).Emit();
         var v1Version = versionsAfterV1.LastOrDefault();
         v1Version.Should().NotBeNull("there should be a version after create");
         Output.WriteLine($"After Create: versions = [{string.Join(", ", versionsAfterV1.Select(v => v.Version))}]");
 
         // Update to V2
-        await NodeFactory.UpdateNode(created with { Name = "V2" }).Should().Emit();
+        await NodeFactory.UpdateNode(created with { Name = "V2" }).Should().Within(Step).Emit();
 
         // Update to V3
-        await NodeFactory.UpdateNode(created with { Name = "V3" }).Should().Emit();
+        await NodeFactory.UpdateNode(created with { Name = "V3" }).Should().Within(Step).Emit();
 
         // Capture all versions — wait for all three snapshots to land
-        var allVersions = await WaitForVersions("test/before", v => v.Count >= 3).Should().Within(5.Seconds()).Emit();
+        var allVersions = await WaitForVersions("test/before", v => v.Count >= 3).Should().Within(Step).Emit();
         Output.WriteLine($"After all updates: versions = [{string.Join(", ", allVersions.Select(v => v.Version))}]");
         foreach (var v in allVersions)
         {
-            var snapshot = await versionQuery.GetVersion("test/before", v.Version, options).Should().Emit();
+            var snapshot = await versionQuery.GetVersion("test/before", v.Version, options).Should().Within(Step).Emit();
             Output.WriteLine($"  Version {v.Version}: Name='{snapshot?.Name}'");
         }
         var v3Version = allVersions.FirstOrDefault();
         v3Version.Should().NotBeNull("there should be a latest version");
 
         // Act - get the version before v3 (should be v2)
-        var beforeV3 = await versionQuery.GetVersionBefore("test/before", v3Version!.Version, options).Should().Emit();
+        var beforeV3 = await versionQuery.GetVersionBefore("test/before", v3Version!.Version, options).Should().Within(Step).Emit();
 
         // Assert
         beforeV3.Should().NotBeNull("there should be a version before v3");
         beforeV3!.Name.Should().Be("V2", "the version before v3 should be v2");
 
         // Act - get the version before v1 (should be null since v1 is the first)
-        var beforeV1 = await versionQuery.GetVersionBefore("test/before", v1Version!.Version, options).Should().Emit();
+        var beforeV1 = await versionQuery.GetVersionBefore("test/before", v1Version!.Version, options).Should().Within(Step).Emit();
 
         // Assert
         beforeV1.Should().BeNull("there should be no version before the first one");
@@ -179,14 +194,14 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
             Content = activityLog,
             MainNode = "test/primary"
         };
-        var created = await NodeFactory.CreateNode(node).Should().Emit();
+        var created = await NodeFactory.CreateNode(node).Should().Within(Step).Emit();
 
         // Update multiple times
-        await NodeFactory.UpdateNode(created with { Name = "Satellite V2" }).Should().Emit();
-        await NodeFactory.UpdateNode(created with { Name = "Satellite V3" }).Should().Emit();
+        await NodeFactory.UpdateNode(created with { Name = "Satellite V2" }).Should().Within(Step).Emit();
+        await NodeFactory.UpdateNode(created with { Name = "Satellite V3" }).Should().Within(Step).Emit();
 
         // Act — wait for the satellite's snapshot to land
-        var versions = await WaitForVersions("test/satellite", v => v.Count >= 1).Should().Within(5.Seconds()).Emit();
+        var versions = await WaitForVersions("test/satellite", v => v.Count >= 1).Should().Within(Step).Emit();
 
         // Assert - satellite content should now be included in version history
         versions.Should().NotBeEmpty("satellite content nodes should now have version history");
@@ -197,19 +212,19 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
     {
         // Arrange
         var node = new MeshNode("rollback", TestPartition) { Name = "Original", NodeType = "Markdown", State = MeshNodeState.Active };
-        var created = await NodeFactory.CreateNode(node).Should().Emit();
+        var created = await NodeFactory.CreateNode(node).Should().Within(Step).Emit();
 
         var versionQuery = Mesh.ServiceProvider.GetRequiredService<IVersionQuery>();
         var options = Mesh.JsonSerializerOptions;
 
         // Capture the original version — wait for snapshot to land
         var nodePath = $"{TestPartition}/rollback";
-        var versionsAfterCreate = await WaitForVersions(nodePath, v => v.Count >= 1).Should().Within(5.Seconds()).Emit();
+        var versionsAfterCreate = await WaitForVersions(nodePath, v => v.Count >= 1).Should().Within(Step).Emit();
         var originalVersion = versionsAfterCreate.LastOrDefault();
         originalVersion.Should().NotBeNull("there should be a version after create");
 
         // Update to "Modified"
-        await NodeFactory.UpdateNode(created with { Name = "Modified" }).Should().Emit();
+        await NodeFactory.UpdateNode(created with { Name = "Modified" }).Should().Within(Step).Emit();
 
         // Act - post RollbackNodeRequest to the node hub
         var client = GetClient();
@@ -224,7 +239,9 @@ public class VersionHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase
             .SelectMany(_ => Mesh.GetMeshNode(nodePath, ReadNodeTimeout))
             .Where(n => n?.Name == "Original")
             .Should()
-            .Within(ReadNodeTimeout)
+            // NOT ReadNodeTimeout (60 s): a bound three times the method timeout can never
+            // fire, so the failure was always the bare method timeout with no diagnosis.
+            .Within(Step)
             .Emit();
 
         currentNode.Should().NotBeNull("the node should still exist after rollback");


### PR DESCRIPTION
## What today's "flakes" actually were

I went looking for flaky tests across the last 14 failed CI runs. Across all of them there were **two** test-level failures, one occurrence each. Everything else was **GitHub Actions runner starvation**: jobs sat **15 minutes with zero steps executed** and were then cancelled — main's `Check for an already-green tree` (twice) and `Build solution (once)` on #868.

The pipeline turned that infrastructure event into both **false reds** and, worse, a **false green**.

## 1. The skip was fail-CLOSED into silence

A `needs` job that ends `cancelled` skips every dependent **regardless of the dependent's `if`**, unless the condition contains `always()` / `!cancelled()`. So a starved probe silently skipped `build` and all six shards.

`build` is now `!cancelled() && needs.precheck.outputs.skip != 'true'`: an unanswerable probe means *"we don't know"* ⇒ **test it**. Only a genuine workflow cancellation (where `!cancelled()` is false) still stops the run.

## 2. The required check passed with no tests run 🚨

`Consolidate test results` is the single required check (ruleset `main pr protection`). Its trx gate exits 0 when it finds no failures — and **"no trx at all" is not a failure**, so a run in which *nothing executed* published a **green required check**. Verified on main run `31120801452`: probe cancelled, build skipped, all shards skipped, `Consolidate test results: success`.

That is how an untested tree can satisfy the merge gate and ship. It is strictly worse than a flaky check, because it fails silently in the safe-looking direction. The gate now requires **positive evidence**: at least one `.trx`, or the sanctioned green-tree reuse path.

## 3. Delivery keyed on a conclusion any cancelled job poisons

`main-cd.yml` gated on `workflow_run.conclusion == 'success'`. One cancelled job makes the run `failure` even when everything that ran was green — so **main built no image from ~14:50 onward** and the pull-based self-update sat on its last image (CD shows `skipped` on `e365679a7`, `6343b8218`, …).

CD now runs a `gate` job that reads the **required check for the head SHA** and only then builds images. After #2 that check cannot be green without evidence, so this is strictly stronger than the umbrella conclusion — and immune to a starved job.

## VersionHistoryTest — bounds that contradicted each other

`RollbackNode_RestoresHistoricalState` timed out on main shard 4 with `Test execution timed out after 20000 milliseconds`, naming nothing. Cause: its awaits ran on `Emit()`'s 10 s default and the rollback poll claimed `ReadNodeTimeout` — **60 s** — inside a `[Fact(Timeout = 20000)]`. A bound three times the method timeout can never fire, so the method timeout always won and the failure was undiagnosable by construction.

Every wait in the class now uses one declared **4 s step budget** (~10× the observed per-operation cost — 246 tests in 96 s) and names what it was waiting for. This is a *narrowed* bound, not a widened one: a stuck step now fails fast and says which step.

## Not in this PR

`PaywallRealGateShapeTests` — the other test-level failure — is already root-caused and fixed in **#868** (`MeshNodeListPathEquality` compared assignment snapshots by path set while the fold reads content, so `DistinctUntilChanged` permanently discarded content-only changes; in prod a revoked permission kept working until reload). Its CI was one of the runs killed by the runner starvation above; I re-triggered it.

## Tests

- `MeshWeaver.Content.Test`: **245 passed**, 1 pre-existing skip.
- Both workflow files validated as YAML; job graph unchanged apart from the new `gate`.
- `alert-on-failure` still behaves: image jobs *skip* when the gate is not green, and `failure()` does not fire on skipped.

## Release note

Skipped deliberately: CI/delivery plumbing, no user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3GuX6pWYWHMCP7NbWbcf9