### PR TITLE
Rollback wrote Version=0, the monotonic guard refused it, and nothing said so

### DIFF
--- a/src/MeshWeaver.Graph/VersionLayoutArea.cs
+++ b/src/MeshWeaver.Graph/VersionLayoutArea.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
@@ -368,14 +368,33 @@ public static class VersionLayoutArea
                     return;
                 }
 
-                // Post the historical node as an update (version 0 forces a new save), then answer
-                // the caller — without a success response an Observe on RollbackNodeRequest waited
-                // forever even though the rollback landed.
-                hub.Post(
-                    new DataChangeRequest { ChangedBy = "rollback" }.WithUpdates(historicalNode with { Version = 0 }),
-                    o => o.WithTarget(hub.Address));
-                hub.Post(new DataChangeResponse(hub.Version, new ActivityLog("Rollback")),
-                    o => o.ResponseFor(request));
+                // 🚨 Restore through GetMeshNodeStream(path).Update — the ONE mutation API — NOT a
+                // raw DataChangeRequest post.
+                //
+                // The old shape posted the historical node with `Version = 0` ("forces a new save")
+                // straight at the hub, bypassing the owner's version mint. That raw node reached
+                // MonotonicWriteGuardStorageAdapter, which REFUSES a backward write — and rightly
+                // so: it cannot tell a rollback from the stale-snapshot corruption it exists to
+                // stop ("do not relax this guard"). The refusal returns the STORED node rather than
+                // an error, and the post was fire-and-forget, so the rollback silently did nothing:
+                // the node never reverted, and any caller polling for the restored content waited
+                // until its harness killed it (VersionHistoryTest.RollbackNode_RestoresHistoricalState,
+                // a CI-only hang — the guard's fast path lets the write through while its
+                // high-water mark is cold, so it only bites once earlier writes have warmed it).
+                //
+                // Update stamps Version = NextVersion(Math.Max(current.Version, updated.Version)),
+                // so restoring HISTORICAL CONTENT becomes an ordinary FORWARD write: the node's
+                // content goes back, its revision counter keeps climbing, and the guard is
+                // untouched. A rollback is a new revision that happens to carry old content — it
+                // was never a backward write.
+                hub.GetMeshNodeStream(msg.Path)
+                    .Update(_ => historicalNode with { Version = 0 })
+                    .Subscribe(
+                        _ => hub.Post(new DataChangeResponse(hub.Version, new ActivityLog("Rollback")),
+                            o => o.ResponseFor(request)),
+                        updateEx => hub.Post(new DataChangeResponse(hub.Version,
+                            new ActivityLog("Rollback").Fail($"Rollback write failed: {updateEx.Message}")),
+                            o => o.ResponseFor(request)));
             },
             ex => hub.Post(new DataChangeResponse(hub.Version,
                 new ActivityLog("Rollback").Fail($"Rollback error: {ex.Message}")),


### PR DESCRIPTION
The CI-only hang in `VersionHistoryTest.RollbackNode_RestoresHistoricalState` — the flake that has been failing **#864** — and a real product bug behind it: **node rollback silently does nothing.**

## What happened

`HandleRollbackNodeRequest` posted the historical node straight at the hub with `Version = 0` (*"version 0 forces a new save"*), bypassing the owner's version mint. That raw node reached `MonotonicWriteGuardStorageAdapter`, which **refuses a backward `Version` write** — correctly, since it cannot distinguish a rollback from the stale-snapshot corruption it exists to stop. Its own log text:

> *"a regressing write is a STALE snapshot about to destroy acknowledged data … **do not relax this guard**."*

Two things then hid the refusal completely:

- the guard returns the **stored** node rather than an error, and
- the write was a fire-and-forget `hub.Post`, so nobody was listening anyway.

So the rollback silently did not happen. The node never reverted, and any caller polling for the restored content waited until its harness killed it — with **no assertion text**, because the harness won that race. That is why this failure has always been undiagnosable.

## Why CI-only and intermittent

The guard has a fast path — `node.Version >= mark` writes straight through — and only performs a verification read once its in-memory high-water mark for that path is **warm**.

| high-water mark | outcome |
|---|---|
| cold | write slips through → test green |
| warm | confirmed backward → refused → hang |

Exactly the order-dependent, bulk-only signature, and why it never reproduced in a single local run.

## The fix

Restore through **`GetMeshNodeStream(path).Update(...)`** — the one mutation API, which this handler should have been using anyway (AGENTS.md: application code never hand-posts `DataChangeRequest`).

`Update` stamps `Version = NextVersion(Math.Max(current.Version, updated.Version))`, so restoring historical **content** becomes an ordinary **forward** write: the content goes back, the revision counter keeps climbing, and the guard is untouched and un-weakened.

**A rollback is a new revision that happens to carry old content.** It was never a backward write — the old code just told the store it was.

The `Subscribe` now also answers the caller on **both** paths, so a write failure surfaces as a failed `ActivityLog` instead of silence.

## Verification

- `MeshWeaver.Graph` builds clean at `-c Release -warnaserror`.
- `VersionHistoryTest` **5/5**.
- `MeshWeaver.Content.Test` **245 passed / 0 failed / 1 skipped** (pre-existing, unrelated).

## Blast radius

Also fixes rollback for every other caller of `RollbackNodeRequest` — notably the **thread-undo** path in `ThreadLayoutAreas`, which posts one per affected node and would have been refused the same way. Undo of a thread's node changes was silently a no-op wherever the guard's mark was warm.