### PR TITLE
Make the paywall gate-fold barrier report WHY it timed out

### DIFF
--- a/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
+++ b/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
@@ -194,14 +194,14 @@ public class ObservableAssertions<T>
         catch (AssertionWaitTimeoutException)
         {
             throw new ObservableAssertionException(
-                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it did not. {seen.Describe()}");
+                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it did not. {seen.Describe(predicate is not null)}");
         }
         catch (InvalidOperationException)
         {
             // Source completed without producing a (matching) value — Take(1).ToTask() throws
             // InvalidOperationException("Sequence contains no elements"). Same "did not" outcome.
             throw new ObservableAssertionException(
-                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it completed without one. {seen.Describe()}");
+                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it completed without one. {seen.Describe(predicate is not null)}");
         }
         catch (Exception ex)
         {
@@ -266,13 +266,30 @@ public class ObservableAssertions<T>
             lock (gate) { last = value; count++; }
         }
 
-        public string Describe()
+        /// <param name="hasPredicate">
+        /// Whether the assertion itself was given the predicate (<c>Match</c>) or is just waiting
+        /// for any value (<c>Emit</c>). It changes what "nothing was emitted" can mean, and so what
+        /// the reader should do next.
+        /// </param>
+        public string Describe(bool hasPredicate)
         {
             lock (gate)
             {
-                return count == 0
+                if (count > 0)
+                    return $"Last of {count} emission(s) was: {Render(last)}.";
+
+                // 🚨 With no predicate here, "nothing emitted" is ambiguous, because the caller may
+                // have filtered UPSTREAM: `src.Where(p).Should().Emit()` hands us the already-
+                // filtered stream, so a source emitting a steady stream of non-matching values is
+                // indistinguishable from one that is wedged. Those have completely different causes
+                // and fixes, so say so rather than let the reader assume a wedge — that ambiguity
+                // sent several CI investigations (PaywallRealGateShapeTests) back to zero.
+                return hasPredicate
                     ? "The observable emitted nothing at all."
-                    : $"Last of {count} emission(s) was: {Render(last)}.";
+                    : "The observable emitted nothing at all. NOTE: if you filtered upstream "
+                      + "(.Where(...).Should().Emit()), this counts only values that PASSED the "
+                      + "filter — switch to .Should().Match(predicate) to report what the source "
+                      + "actually produced.";
             }
         }
     }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PaywallRealGateShapeTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PaywallRealGateShapeTests.cs
@@ -160,24 +160,39 @@ public class PaywallRealGateShapeTests(PostgreSqlFixture fixture, ITestOutputHel
     /// the second wait was silently truncated by the Fact timeout instead of reporting — the
     /// mirror image of the halved compile budget fixed in 459b4403c.</para>
     /// </summary>
+    /// <remarks>
+    /// 🚨 Every wait uses <c>.Match(pred)</c>, NEVER <c>.Where(pred).Emit()</c>. The two are
+    /// equivalent when they pass and worlds apart when they fail: <c>Where</c> filters BEFORE the
+    /// assertion sees the stream, so the assertion can only report "the observable emitted nothing
+    /// at all" — true of the filtered stream whether the fold was wedged or simply folded to the
+    /// wrong permission. <c>Match</c> hands the predicate to the assertion, which taps the
+    /// UNFILTERED source and names the last permission actually observed.
+    ///
+    /// <para>That distinction is the whole diagnosis here. This barrier has flaked repeatedly on
+    /// CI shard 5 (#825/#849/#853) and every report was the same contentless timeout, so each
+    /// investigation had to start from zero. The permissions this fold DID produce are the
+    /// evidence: <c>Permission.None</c> means the scope walk never folded, while a non-None value
+    /// missing <c>Read</c> means it folded but the grant under test was absent — a stale query
+    /// snapshot, a different root cause with a different fix.</para>
+    /// </remarks>
     private async Task AwaitGateFolded()
     {
         var budget = 45.Seconds();
 
         // 1) The root grants folded: Public can read the cover.
         await Mesh.GetEffectivePermissions(Plugin, WellKnownUsers.Public)
-            .Where(p => p.HasFlag(Permission.Read))
-            .Should().Within(budget).Emit();
+            .Should().Within(budget).Match(p => p.HasFlag(Permission.Read),
+                $"Public must inherit Read on the cover {Plugin}");
 
         // 2) The child deny folded and beats the inherited root grant.
         await Mesh.GetEffectivePermissions(Gated, WellKnownUsers.Public)
-            .Where(p => !p.HasFlag(Permission.Read))
-            .Should().Within(budget).Emit();
+            .Should().Within(budget).Match(p => !p.HasFlag(Permission.Read),
+                $"the child DENY on {Gated} must strip Public's inherited Read");
 
         // 3) The buyer's root grant folded and SURVIVED the child deny.
         await Mesh.GetEffectivePermissions(Gated, Buyer)
-            .Where(p => p.HasFlag(Permission.Read))
-            .Should().Within(budget).Emit();
+            .Should().Within(budget).Match(p => p.HasFlag(Permission.Read),
+                $"the buyer's root grant must survive the child deny on {Gated}");
     }
 
     /// <summary>Reads through the same entry point the MCP `get` tool uses.</summary>

--- a/test/MeshWeaver.Reactive.Assertions.Test/AssertionTests.cs
+++ b/test/MeshWeaver.Reactive.Assertions.Test/AssertionTests.cs
@@ -204,6 +204,26 @@ public class AssertionTests
                 .Should().Within(50.Milliseconds()).Match(x => x == 99));
 
         Assert.Contains("emitted nothing at all", ex.Message);
+        // Match OWNS the predicate, so the count is honest and needs no caveat.
+        Assert.DoesNotContain("filtered upstream", ex.Message);
+    }
+
+    /// <summary>
+    /// `src.Where(p).Should().Emit()` hands the assertion an ALREADY-filtered stream, so a source
+    /// emitting a steady stream of non-matching values looks identical to a wedged one. The message
+    /// must say so — assuming a wedge sends the reader hunting a race that isn't there.
+    /// </summary>
+    [Fact]
+    public async Task TimedOutEmit_WarnsThatAnUpstreamFilterHidesTheSourcesValues()
+    {
+        var ex = await Assert.ThrowsAnyAsync<ObservableAssertionException>(
+            async () => await Observable.Range(1, 3).Concat(Observable.Never<int>())
+                .Where(x => x == 99)                      // the trap: filtered BEFORE Should()
+                .Should().Within(50.Milliseconds()).Emit());
+
+        Assert.Contains("emitted nothing at all", ex.Message);
+        Assert.Contains("filtered upstream", ex.Message);
+        Assert.Contains(".Should().Match(predicate)", ex.Message);
     }
 
     /// <summary>


### PR DESCRIPTION
The `PaywallRealGateShapeTests` flake (shard 5, across #825/#849/#853) always reported the same contentless message:

```
Expected the observable to emit a value within 45s, but it did not.
The observable emitted nothing at all.
```

## Why that message was useless

The waits filtered **upstream** of the assertion:

```csharp
Mesh.GetEffectivePermissions(Gated, Buyer)
    .Where(p => p.HasFlag(Permission.Read))   // ← filters HERE
    .Should().Within(budget).Emit();          // ← assertion only ever sees matches
```

So "emitted nothing at all" describes the **filtered** stream. Two completely different failures collapse into that one message:

| what actually happened | real cause | fix |
|---|---|---|
| fold produced `Permission.None` | scope walk never folded | a wedge / cold-start race |
| fold produced a real permission **without** `Read` | the grant under test was absent | stale query snapshot |

They need opposite investigations, and the message distinguished neither — so each triage restarted from zero.

## Change

All three waits use `.Match(pred, because)`, which hands the predicate to the assertion so it taps the **unfiltered** source and names the last permission observed. The most recent failure was **step 3, the buyer's grant** (`PaywallRealGateShapeTests.cs:178`) — the next occurrence will say whether the fold produced `None` or a non-`None` value missing `Read`.

I also closed the same blind spot for the **~79 other call sites** that filter before `.Should().Emit()`, without touching any of them: when `Emit()` times out having seen zero values, the message now notes that an upstream `.Where(...)` produces exactly this text and to switch to `.Match(predicate)`. `Match` keeps the unqualified wording — it owns the predicate, so its count is honest.

## This is not a band-aid

No bound widened, no retry added, no sleep. A genuinely wedged fold still fails at the same 45s. This makes the failure **name its cause** so the underlying race can be fixed from evidence rather than guesswork.

I also checked the test for flaky async as requested: no `Task.Delay`, no `.Result`/`.Wait()`, no `SemaphoreSlim`, no static mutable state (that was already removed). `PermissionEvaluator` is likewise free of `async`/`await`/`FromAsync`. The fold is a recursive `CombineLatest` up the scope chain, so it emits only once **every** level's query has — which is the shape worth watching once we have real evidence.

## Verification

| suite | result |
|---|---|
| `MeshWeaver.Reactive.Assertions.Test` | **16/16** (2 new tests pin both message shapes) |
| `PaywallRealGateShapeTests` | **7/7** in 2 s |

Release build with `-warnaserror` clean on both projects.

_What's New skipped: internal test/diagnostics change, no user-visible effect._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx6BiUYBu5U2Zdnom4Uz4X