### PR TITLE
New instances get the platform plugin repo by default

### DIFF
--- a/.claude/skills/plugins/SKILL.md
+++ b/.claude/skills/plugins/SKILL.md
@@ -67,6 +67,10 @@ pluginCatalog:
   sources:
     - {name: Plugins,   repoPath: "https://github.com/Systemorph/MeshWeaver.Plugins", ref: main}
     - {name: Education, repoPath: "https://github.com/Systemorph/education",          ref: main}
+  # Sources every NEW instance registration is granted automatically (seeded into the instance's
+  # Admin/_PluginGrant node — admins can still revoke per instance). Platform repo only; never
+  # list private/paid sources here. Empty = registering grants nothing (the strict default).
+  defaultGrants: ["Plugins/*"]
 secrets:
   memex_portal:
     PluginCatalog__RegistryTokens: ["<token-for-install-a>", "<token-for-install-b>"]

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -239,6 +239,9 @@ data:
   PluginCatalog__Sources__{{ $i }}__Ref: "{{ $s.ref | default "main" }}"
   PluginCatalog__Sources__{{ $i }}__Format: "{{ $s.format | default "node-repo" }}"
   {{- end }}
+  {{- range $i, $g := .Values.pluginCatalog.defaultGrants }}
+  PluginCatalog__DefaultGrants__{{ $i }}: "{{ $g }}"
+  {{- end }}
   # ---- System email (Microsoft Graph) — BIDIRECTIONAL. Outbound invitations + notifications
   # (/sendMail, Mail.Send app permission) AND optional inbound email→agent channel (inbox
   # change-notification subscription, Mail.ReadWrite app permission). Non-secret here;

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -56,6 +56,12 @@ pluginCatalog:
   # REGISTRY: the git repos whose plugins this install serves — [{name, repoPath, ref, format}].
   # format: node-repo (default, <Folder>/index.json Space root) | package-json.
   sources: []
+  # REGISTRY: Source/Package entries every NEW instance registration is seeded with, e.g.
+  # ["Plugins/*"] so a fresh install gets the platform plugin repo without an admin grant step.
+  # Registration writes them into the instance's Admin/_PluginGrant node, so admins can still
+  # revoke per instance. Empty = strict default: registering grants nothing. Never list
+  # private/paid sources here.
+  defaultGrants: []
 # ---- Platform-admin Instances overview -------------------------------------
 # The admin "Instances" tab lists every portal on the cluster by querying the k8s API. Reading
 # deployments/ingresses ACROSS namespaces needs a cluster-scoped read grant — enable it ONLY on the

--- a/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -17,13 +18,23 @@ namespace Memex.Portal.Shared.Authentication;
 /// <c>ApiTokenService</c>, built on the same mechanism (mint → hash → write the node → write a
 /// routing index under System identity) and deliberately NOT on the same node type.
 ///
-/// <para>Registering grants nothing. A new instance authenticates and is entitled to nothing until
-/// a platform admin writes it a <see cref="PluginGrant"/> in the Admin partition, which the
-/// registering user cannot reach.</para>
+/// <para>Registering grants nothing — unless the registry operator has opted specific sources into
+/// every new registration via <c>PluginCatalog:DefaultGrants</c> (a list of <c>Source/Package</c>
+/// entries, e.g. <c>Plugins/*</c>). Registration then seeds those entries into the instance's
+/// <see cref="PluginGrant"/> node in the Admin partition — the grant node stays the single
+/// authority, so a platform admin can still revoke or extend per instance, and anything NOT in the
+/// default list (private/paid sources) remains admin-granted as before. The registering user still
+/// cannot reach the grant node either way.</para>
 /// </summary>
 public sealed class MeshWeaverInstanceService(
-    IMeshService nodeFactory, IMessageHub hub, ILogger<MeshWeaverInstanceService> logger)
+    IMeshService nodeFactory, IMessageHub hub, ILogger<MeshWeaverInstanceService> logger,
+    IConfiguration? configuration = null)
 {
+    /// <summary>Config key listing the <c>Source/Package</c> entries every new registration is
+    /// seeded with (<c>PluginCatalog:DefaultGrants:0</c>, …). Absent/empty → registration grants
+    /// nothing, the strict default.</summary>
+    public const string DefaultGrantsConfigKey = "PluginCatalog:DefaultGrants";
+
     /// <summary>Namespace holding a user's registered instances, inside their own partition.</summary>
     public const string InstanceNamespace = "MeshWeaverInstance";
 
@@ -92,6 +103,7 @@ public sealed class MeshWeaverInstanceService(
 
             return nodeFactory.CreateNode(instanceNode)
                 .SelectMany(created => WriteIndex(hash, created.Path, instanceId)
+                    .SelectMany(_ => SeedDefaultGrants(instanceId))
                     .Select(_ =>
                     {
                         logger.LogInformation(
@@ -100,6 +112,82 @@ public sealed class MeshWeaverInstanceService(
                         return new InstanceRegistrationResult(rawKey, created, instance);
                     }));
         });
+    }
+
+    /// <summary>The default grant entries the operator configured, parsed and de-blanked.
+    /// Empty when no <see cref="DefaultGrantsConfigKey"/> list is set — the strict default.</summary>
+    private IReadOnlyList<PluginGrantEntry> DefaultGrantEntries() =>
+        configuration is null
+            ? []
+            : configuration.GetSection(DefaultGrantsConfigKey).GetChildren()
+                .Select(c => PluginGrantEntry.TryParse(c.Value))
+                .Where(e => e is not null)
+                .Select(e => e!)
+                .ToList();
+
+    /// <summary>
+    /// Seeds the operator-configured default grant entries into
+    /// <c>Admin/_PluginGrant/{instanceId}</c> as part of registration. No defaults configured →
+    /// no write at all, preserving "registering is identity, not entitlement" exactly.
+    ///
+    /// <para>Runs as System on BOTH the read and the write: the grant lives in the Admin partition,
+    /// which the registering user cannot reach — that unreachability is the security model, and the
+    /// seed is registry policy, not a user action. Read-then-<c>CreateOrUpdateNode</c>, never
+    /// <c>stream.Update</c>: the node does not exist yet for a fresh id, and Update aborts on a
+    /// missing node (the first-grant failure observed live 2026-08-06). Existing entries — e.g. an
+    /// admin re-seeding after an orphan cleanup — are preserved; defaults merge in idempotently.</para>
+    /// </summary>
+    private IObservable<Unit> SeedDefaultGrants(string instanceId)
+    {
+        var defaults = DefaultGrantEntries();
+        if (defaults.Count == 0)
+            return Observable.Return(Unit.Default);
+
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var path = MeshWeaverInstanceNodeType.GrantPath(instanceId);
+
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => hub.GetMeshNode(path, TimeSpan.FromSeconds(10)))
+            .Take(1)
+            .SelectMany(existing => Observable.Defer(() =>
+            {
+                var grant = existing?.ContentAs<PluginGrant>(hub.JsonSerializerOptions)
+                            ?? new PluginGrant { InstanceId = instanceId };
+                var entries = grant.Entries.Concat(defaults
+                        .Where(d => !grant.Entries.Any(e =>
+                            string.Equals(e.Source, d.Source, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(e.PackageId, d.PackageId, StringComparison.Ordinal))))
+                    .ToList();
+
+                var node = new MeshNode(instanceId, MeshWeaverInstanceNodeType.GrantNamespace)
+                {
+                    Name = $"Plugin grant: {instanceId}",
+                    NodeType = MeshWeaverInstanceNodeType.GrantNodeType,
+                    State = MeshNodeState.Active,
+                    Content = grant with
+                    {
+                        InstanceId = instanceId,
+                        Entries = entries,
+                        GrantedByUserId = WellKnownUsers.System,
+                        UpdatedAt = DateTimeOffset.UtcNow,
+                    },
+                };
+
+                // Same Defer/Finally discipline as WriteIndex: the System context must be active
+                // when CreateOrUpdateNode captures it, and the SelectMany continuation may land on
+                // a thread the earlier Using scope never touched.
+                var disposable = accessService.ImpersonateAsSystem();
+                return nodeFactory.CreateOrUpdateNode(node)
+                    .Select(_ =>
+                    {
+                        logger.LogInformation(
+                            "Seeded default plugin grants [{Entries}] for instance {InstanceId}",
+                            string.Join(", ", defaults), instanceId);
+                        return Unit.Default;
+                    })
+                    .Finally(() => disposable.Dispose());
+            }));
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
@@ -154,11 +154,18 @@ public sealed class MeshWeaverInstanceService(
             {
                 var grant = existing?.ContentAs<PluginGrant>(hub.JsonSerializerOptions)
                             ?? new PluginGrant { InstanceId = instanceId };
-                var entries = grant.Entries.Concat(defaults
-                        .Where(d => !grant.Entries.Any(e =>
-                            string.Equals(e.Source, d.Source, StringComparison.OrdinalIgnoreCase)
-                            && string.Equals(e.PackageId, d.PackageId, StringComparison.Ordinal))))
+                var missing = defaults
+                    .Where(d => !grant.Entries.Any(e =>
+                        string.Equals(e.Source, d.Source, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(e.PackageId, d.PackageId, StringComparison.Ordinal)))
                     .ToList();
+                // Nothing to add → no write at all. Writing a no-op would still re-stamp
+                // GrantedByUserId/UpdatedAt to System/now, silently erasing WHO last decided an
+                // existing admin-written grant — and a grant is an access decision, so the
+                // attribution is part of the record.
+                if (missing.Count == 0)
+                    return Observable.Return(Unit.Default);
+                var entries = grant.Entries.Concat(missing).ToList();
 
                 var node = new MeshNode(instanceId, MeshWeaverInstanceNodeType.GrantNamespace)
                 {
@@ -183,7 +190,7 @@ public sealed class MeshWeaverInstanceService(
                     {
                         logger.LogInformation(
                             "Seeded default plugin grants [{Entries}] for instance {InstanceId}",
-                            string.Join(", ", defaults), instanceId);
+                            string.Join(", ", missing), instanceId);
                         return Unit.Default;
                     })
                     .Finally(() => disposable.Dispose());

--- a/memex/Memex.Portal.Shared/Instances/InstanceProvisioningPlan.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstanceProvisioningPlan.cs
@@ -77,7 +77,19 @@ deploy/aks/envs/{{ns}}/deploy.sh
 **5. DNS + sign-in:** point `{{host}}` at the ingress IP (zone `{{o.DnsZone}}`), then add the OAuth
 redirect URIs (`https://{{host}}/signin-microsoft`, `/signin-google`, …) and invitation/email config.
 
-**6. Verify:**
+**6. Plugins:** on the **registry** portal, Settings ▸ Instances → register `{{ns}}` and copy the
+issued `mwi_` key (shown once). Sources in the registry's `PluginCatalog:DefaultGrants` — the
+platform `Plugins/*` repo — are granted automatically at registration; anything else stays a
+per-instance admin grant (Settings ▸ Administration ▸ Instance grants). Wire the consumer side in
+`values.{{ns}}.yaml` + the Key Vault CSI secret, then install from Settings ▸ Administration ▸
+Plugin Catalog:
+```yaml
+pluginCatalog:
+  registryUrl: https://<registry-host>
+# secret (never in values): PluginCatalog__RegistryToken = the mwi_ key
+```
+
+**7. Verify:**
 ```bash
 az aks command invoke -g {{o.ResourceGroup}} -n {{o.ClusterName}} --command \
   "kubectl -n {{ns}} rollout status deployment/memex-portal-deployment --timeout=300s"

--- a/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
@@ -141,12 +141,21 @@ secrets:
     PluginCatalog__RegistryToken: "<token issued to this installation>"
 ```
 
+The consumer's token is the `mwi_` instance key issued when the new installation is **registered**
+on the registry portal (Settings ▸ Instances — self-service, shown once). Registration grants
+nothing by itself; what the instance may pull is decided per `(source, package)` by a platform
+admin on the registry — except sources the registry opted into `PluginCatalog:DefaultGrants`
+(typically the platform `Plugins/*` repo), which every new registration is granted automatically.
+So with defaults configured, a fresh environment needs no admin grant step to see the platform
+plugins — install them from the Plugin Catalog tab once the consumer wiring lands.
+
 Registry (only when this environment *is* the registry):
 
 ```yaml
 pluginCatalog:
   sources:
     - {name: Plugins, repoPath: "https://github.com/<org>/<plugins-repo>", ref: main}
+  defaultGrants: ["Plugins/*"]   # granted to every NEW registration; never private/paid sources
 secrets:
   memex_portal:
     PluginCatalog__RegistryTokens: ["<token-per-registered-installation>"]

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -42,8 +42,19 @@ issuing it a token and adding that token to the registry's `PluginCatalog:Regist
 `PluginCatalog:RegistryToken`, or per-registry `Registries:N:Token`), and a request without a valid
 token is 401 (validated fixed-time by `PluginRegistryTokens`, the shared producer/consumer contract).
 Only when **no** tokens are configured — the local-dev / e2e-stub mode — does the registry answer
-anonymously; a production registry always configures tokens. What a registered instance can then
-read is **curated plugins** only:
+anonymously; a production registry always configures tokens.
+
+Registration itself is self-service (Settings ▸ Instances issues an `mwi_` instance key), but it is
+**identity, not entitlement**: what an instance may pull is decided per `(source, package)` by a
+platform admin in `Admin/_PluginGrant/{instanceId}` nodes the instance's owner cannot write
+(Settings ▸ Administration ▸ Instance grants). The one qualification: the registry operator may opt
+specific sources into every **new** registration via `PluginCatalog:DefaultGrants` (a list of
+`Source/Package` entries, e.g. `["Plugins/*"]` so a fresh install gets the platform plugin repo
+with no admin step). Registration then *seeds* those entries into the grant node — the node stays
+the single authority, so an admin can still revoke or extend per instance — and private/paid
+sources are never listed there. With no defaults configured, registering grants exactly nothing.
+
+What a registered instance can then read is **curated plugins** only:
 by default the node-native repos the [`MeshWeaver.Plugins`](/Doc/Architecture/Plugins) repo ships —
 `<Plugin>/index.json` **Store/Plugin** roots carrying a `PluginContent`, node-per-file — via a
 `NodeRepoPackageSource` (`PluginCatalog:SourceFormat=node-repo`, the default). A `package.json`-manifest

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-07-default-plugin-grants.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-07-default-plugin-grants.md
@@ -1,0 +1,18 @@
+---
+Name: New installations get the platform plugins automatically
+Category: What's New
+Description: Registering a new MeshWeaver installation now grants it the platform plugin repo by default — no admin grant step before its Plugin Catalog fills.
+Icon: Sparkle
+---
+
+# New installations get the platform plugins automatically
+
+Until now, registering a new MeshWeaver installation gave it an identity but no entitlements: a
+platform admin had to grant every source by hand before the new install's Plugin Catalog showed
+anything. The registry operator can now opt sources into every new registration — typically the
+platform plugin repo — and registration seeds those grants automatically.
+
+The grant record stays the single authority: admins can still revoke or extend any instance
+individually, and private or paid sources are never granted by default. The guided provisioning
+plan in the Instances administration tab now walks through the plugin wiring as part of standing up
+a new installation.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1523,30 +1523,25 @@ internal class MeshNodeCompilationService(
     }
 
     /// <summary>
-    /// Runs the in-process Roslyn source generators over a dynamic-node
-    /// compilation before Emit — currently the MeshWeaver.BusinessRules
-    /// <c>ScopeCodeGenerator</c>, which emits the concrete implementations for
-    /// <c>IScope&lt;TIdentity, TState&gt;</c> interfaces declared in node Source.
-    /// A compilation that doesn't reference <c>IScope</c> passes through
-    /// unchanged (the generator no-ops), so this costs nothing for ordinary
-    /// node types. This is what lets Source code nodes use the business-rules
-    /// scopes framework: declare the interface, the compiler generates the
-    /// proxy, and <c>services.AddBusinessRules(assembly)</c> discovers it.
+    /// Paths of source-generator assemblies fed to EVERY dynamic-node compilation, resolved once
+    /// per process. 🚨 The platform does NOT ship any — business rules / scopes moved OUT of the
+    /// platform (see the comment blocks in <c>MeshWeaver.Graph.csproj</c> and
+    /// <c>Memex.Portal.Distributed.csproj</c>): the scope runtime is a shared-source library node
+    /// in the <c>MeshWeaver.Plugins/BusinessRules</c> plugin, pulled into a consumer's compilation
+    /// via <c>shared=@BusinessRules/Scope/Source</c>, and the plugin carries the
+    /// <c>ScopeCodeGenerator</c> SOURCE for the generator-injection seam. So on a deployed image
+    /// this list is EMPTY. It only fills when a <c>MeshWeaver.BusinessRules.Generator.dll</c> is
+    /// physically present next to the app (a dev/self-host tree that placed one there) — kept as
+    /// graceful degradation for such trees, and because the legacy-<c>#r</c> strip below keys off it.
     /// </summary>
-    // The BusinessRules scope generator ships WITH the platform — its DLL is copied into the Graph
-    // runtime output (see MeshWeaver.Graph.csproj) and always fed to the compile. So an IScope<,>
-    // node compiles with NO `#r "nuget:MeshWeaver.BusinessRules.Generator"` and NO NuGet round-trip
-    // (no mesh-local feed, no BakeMeshLocalFeed). It runs as a build TOOL only — never a project
-    // analyzer, so it does NOT propagate to downstream builds. A node may still `#r` a DIFFERENT
-    // generator; those add to this built-in one. Resolved once (the file is stable per process).
     private static readonly IReadOnlyList<string> BuiltInGeneratorPaths = ResolveBuiltInGenerators();
 
     /// <summary>
     /// NuGet package id (and, with <c>.dll</c>, assembly file name) of the BusinessRules scope
-    /// source generator. It ships BUILT-IN with the platform, so a legacy
-    /// <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> is redundant and is filtered out of
-    /// BOTH the generator list (avoid a double-run → CS0101, see <see cref="RunSourceGenerators"/>)
-    /// and the NuGet resolve set (avoid a round-trip to the removed mesh-local feed, see
+    /// source generator. When a copy is present in the app base (<see cref="BuiltInGeneratorPaths"/>
+    /// non-empty), a legacy <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> is redundant and is
+    /// filtered out of BOTH the generator list (avoid a double-run → CS0101, see
+    /// <see cref="RunSourceGenerators"/>) and the NuGet resolve set (avoid a dead round-trip, see
     /// <see cref="AssembleCompilationInputs"/>).
     /// </summary>
     private const string BuiltInScopeGeneratorId = "MeshWeaver.BusinessRules.Generator";

--- a/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
@@ -10,7 +10,11 @@ namespace MeshWeaver.Mesh.Security;
 /// (<c>hub.IsGlobalAdmin()</c>) writes these.</para>
 ///
 /// <para>An instance with no grant node, or an empty <see cref="Entries"/> list, gets <b>nothing</b>.
-/// Registering is identity, not entitlement.</para>
+/// Registering is identity, not entitlement. The one qualification: a registry operator may opt
+/// specific sources into every new registration via <c>PluginCatalog:DefaultGrants</c> (e.g. the
+/// platform's own <c>Plugins/*</c>) — registration then SEEDS those entries into this node, so the
+/// grant node stays the single authority and an admin can still revoke per instance. Private/paid
+/// sources are never defaulted; they remain admin-granted.</para>
 /// </summary>
 public record PluginGrant
 {
@@ -65,4 +69,24 @@ public record PluginGrantEntry
     /// <summary>Renders the entry the way it is written in docs and the admin UI —
     /// <c>Plugins/*</c>, <c>Reinsurance/UWDeepfield</c>.</summary>
     public override string ToString() => $"{Source}/{PackageId}";
+
+    /// <summary>
+    /// Parses the <c>Source/Package</c> notation used in config and docs — <c>Plugins/*</c>,
+    /// <c>Reinsurance/UWDeepfield</c>, or a bare <c>Plugins</c> meaning the whole source.
+    /// Returns <c>null</c> for a blank or malformed value (no source, or nothing after the
+    /// separator) instead of throwing: these are operator-typed config values, and one bad list
+    /// entry must not take the registration surface down with it.
+    /// </summary>
+    public static PluginGrantEntry? TryParse(string? text)
+    {
+        var trimmed = text?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return null;
+        var slash = trimmed.IndexOf('/');
+        var source = (slash < 0 ? trimmed : trimmed[..slash]).Trim();
+        var packageId = slash < 0 ? AllPackages : trimmed[(slash + 1)..].Trim();
+        if (source.Length == 0 || packageId.Length == 0)
+            return null;
+        return new PluginGrantEntry { Source = source, PackageId = packageId };
+    }
 }

--- a/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
@@ -145,6 +145,10 @@ public class InstancesServiceTest
         Assert.Contains("-d acme", plan);
         Assert.Contains("portalNamespaces", plan);
         Assert.Contains("deploy/aks/envs/acme/deploy.sh", plan);
+        // A new instance is wired to the plugin registry as part of provisioning — register for an
+        // mwi_ key (DefaultGrants sources land automatically), then consume via registryUrl + token.
+        Assert.Contains("PluginCatalog:DefaultGrants", plan);
+        Assert.Contains("PluginCatalog__RegistryToken", plan);
     }
 
     [Fact]

--- a/test/MeshWeaver.Auth.Test/InstanceRegistrationDefaultGrantsTest.cs
+++ b/test/MeshWeaver.Auth.Test/InstanceRegistrationDefaultGrantsTest.cs
@@ -105,6 +105,43 @@ public class InstanceRegistrationDefaultGrantsTest(ITestOutputHelper output) : M
     }
 
     [Fact]
+    public async Task Register_GrantAlreadyCoveringDefaults_KeepsAdminAttribution()
+    {
+        // A grant node can pre-exist its instance (an admin re-provisioning after an orphan
+        // cleanup). When it already covers every configured default, the seed must not write at
+        // all — a no-op write would re-stamp GrantedByUserId/UpdatedAt to System/now and erase
+        // WHO last made the access decision.
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var preexisting = new MeshNode("dg-attributed-instance", MeshWeaverInstanceNodeType.GrantNamespace)
+        {
+            Name = "Plugin grant: dg-attributed-instance",
+            NodeType = MeshWeaverInstanceNodeType.GrantNodeType,
+            State = MeshNodeState.Active,
+            Content = new PluginGrant
+            {
+                InstanceId = "dg-attributed-instance",
+                Entries = [new PluginGrantEntry { Source = "Plugins" }],
+                GrantedByUserId = "admin-someone",
+                UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            },
+        };
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(preexisting).Should().Emit();
+
+        await Service("Plugins/*").Register(
+                "user-defaults", "Default Grants", "defaults@test.com",
+                "dg-attributed-instance", "Attributed instance")
+            .Should().Emit();
+
+        var grantNode = await ReadGrantNode("dg-attributed-instance").Should().Emit();
+        var grant = grantNode!.ContentAs<PluginGrant>(Mesh.JsonSerializerOptions)!;
+        grant.GrantedByUserId.Should().Be("admin-someone",
+            "a seed that adds nothing must leave the admin's attribution untouched");
+        grant.Allows("Plugins", "Store").Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Register_MalformedDefaultEntries_AreSkippedNotFatal()
     {
         // Operator-typed config: one bad entry must neither fail registration nor poison the list.

--- a/test/MeshWeaver.Auth.Test/InstanceRegistrationDefaultGrantsTest.cs
+++ b/test/MeshWeaver.Auth.Test/InstanceRegistrationDefaultGrantsTest.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Auth.Test;
+
+/// <summary>
+/// Pins the <c>PluginCatalog:DefaultGrants</c> seed of instance registration: a registry operator
+/// may opt sources into every NEW registration (e.g. <c>Plugins/*</c>, so a fresh install gets the
+/// platform plugin repo with no admin step), and registration then writes those entries into the
+/// instance's <c>Admin/_PluginGrant</c> node. The grant node stays the single authority — an admin
+/// can still revoke per instance — and with NO defaults configured, registration keeps granting
+/// exactly nothing ("identity, not entitlement", the strict default).
+/// </summary>
+public class InstanceRegistrationDefaultGrantsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshWeaverInstanceService Service(params string[] defaultGrants)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(defaultGrants.Select((entry, i) => new KeyValuePair<string, string?>(
+                $"{MeshWeaverInstanceService.DefaultGrantsConfigKey}:{i}", entry)))
+            .Build();
+        return new MeshWeaverInstanceService(
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+            configuration);
+    }
+
+    /// <summary>Reads the grant node as System — the grant lives in the Admin partition, which is
+    /// exactly why the seed itself must run as System (the registering user cannot reach it).</summary>
+    private IObservable<MeshNode?> ReadGrantNode(string instanceId)
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => Mesh.GetMeshNode(
+                    MeshWeaverInstanceNodeType.GrantPath(instanceId), TimeSpan.FromSeconds(10)))
+            .Take(1);
+    }
+
+    [Fact]
+    public async Task Register_WithConfiguredDefaults_SeedsTheGrantNode()
+    {
+        var service = Service("Plugins/*", "Reinsurance/UWDeepfield");
+
+        var registration = await service.Register(
+                "user-defaults", "Default Grants", "defaults@test.com",
+                "dg-seeded-instance", "Seeded instance")
+            .Should().Emit();
+
+        var grantNode = await ReadGrantNode("dg-seeded-instance").Should().Emit();
+        grantNode.Should().NotBeNull("registration must seed the configured default grants");
+        var grant = grantNode!.ContentAs<PluginGrant>(Mesh.JsonSerializerOptions)!;
+
+        grant.InstanceId.Should().Be("dg-seeded-instance");
+        // Policy wrote it, not a person — the attribution must say so.
+        grant.GrantedByUserId.Should().Be(WellKnownUsers.System);
+        grant.Allows("Plugins", "Store").Should().BeTrue("Plugins/* is a configured default");
+        grant.Allows("Reinsurance", "UWDeepfield").Should().BeTrue("the single-package default");
+        grant.Allows("Reinsurance", "ClaimsDeepfield").Should().BeFalse("only the granted package");
+        grant.Allows("Education", "AgenticEngineering").Should().BeFalse(
+            "sources outside the default list stay admin-granted");
+
+        // End to end: the key issued at registration must resolve to a grant that ALLOWS the
+        // defaults — the same path the registry's /api/plugins surface authenticates through.
+        var authenticator = new InstanceRegistryAuthenticator(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>());
+        var authenticated = await authenticator
+            .Authenticate($"Bearer {registration.RawKey}")
+            .Should().Emit();
+        authenticated.Should().NotBeNull();
+        authenticated!.Allows("Plugins", "Agent").Should().BeTrue(
+            "a freshly registered instance must be able to pull the defaulted source immediately");
+    }
+
+    [Fact]
+    public async Task Register_WithNoDefaultsConfigured_GrantsNothing()
+    {
+        var service = Service();
+
+        await service.Register(
+                "user-defaults", "Default Grants", "defaults@test.com",
+                "dg-strict-instance", "Strict instance")
+            .Should().Emit();
+
+        // The strict default is preserved exactly: no grant node is written at all, so the
+        // authenticator resolves the empty grant ("registering is identity, not entitlement").
+        var grantNode = await ReadGrantNode("dg-strict-instance").Should().Emit();
+        grantNode.Should().BeNull("no defaults configured → registration must not write a grant");
+    }
+
+    [Fact]
+    public async Task Register_MalformedDefaultEntries_AreSkippedNotFatal()
+    {
+        // Operator-typed config: one bad entry must neither fail registration nor poison the list.
+        var service = Service("  ", "/", "Plugins/*");
+
+        await service.Register(
+                "user-defaults", "Default Grants", "defaults@test.com",
+                "dg-tolerant-instance", "Tolerant instance")
+            .Should().Emit();
+
+        var grantNode = await ReadGrantNode("dg-tolerant-instance").Should().Emit();
+        grantNode.Should().NotBeNull();
+        var grant = grantNode!.ContentAs<PluginGrant>(Mesh.JsonSerializerOptions)!;
+        grant.Entries.Should().HaveCount(1);
+        grant.Allows("Plugins", "Store").Should().BeTrue();
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/PluginGrantTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginGrantTest.cs
@@ -100,5 +100,39 @@ public class PluginGrantTest
             new PluginGrantEntry { Source = "Reinsurance", PackageId = "UWDeepfield" }.ToString());
     }
 
+    // TryParse reads the Source/Package notation off PluginCatalog:DefaultGrants config — the list
+    // a registry operator uses to opt sources into every new registration. Operator-typed, so a
+    // malformed entry must parse to null (skipped), never throw the registration surface down.
+    [Theory]
+    [InlineData("Plugins/*", "Plugins", "*")]
+    [InlineData("Plugins", "Plugins", "*")] // bare source = whole source
+    [InlineData("Reinsurance/UWDeepfield", "Reinsurance", "UWDeepfield")]
+    [InlineData("  Plugins / * ", "Plugins", "*")] // operator-typed: whitespace tolerated
+    public void TryParse_ReadsTheSourceSlashPackageNotation(string text, string source, string package)
+    {
+        var entry = PluginGrantEntry.TryParse(text);
+        Assert.NotNull(entry);
+        Assert.Equal(source, entry!.Source);
+        Assert.Equal(package, entry.PackageId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("/")] // separator only — no source
+    [InlineData("/Store")] // no source
+    [InlineData("Plugins/")] // separator but nothing after it
+    public void TryParse_MalformedEntry_IsNullNotAThrow(string? text)
+        => Assert.Null(PluginGrantEntry.TryParse(text));
+
+    [Fact]
+    public void TryParse_RoundTripsToString()
+    {
+        // The notation is symmetric: what an entry renders as, TryParse reads back identically.
+        var entry = new PluginGrantEntry { Source = "Reinsurance", PackageId = "UWDeepfield" };
+        Assert.Equal(entry, PluginGrantEntry.TryParse(entry.ToString()));
+    }
+
     private static bool MemexAllows(string source, string package) => MemexGrant.Allows(source, package);
 }

--- a/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
+++ b/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
@@ -186,30 +186,29 @@ public sealed class PortalImageFacility : IAsyncLifetime
     }
 
     /// <summary>
-    /// The image ships <c>MeshWeaver.BusinessRules.dll</c> (the <c>IScope&lt;,&gt;</c> runtime surface)
-    /// AND lists it in the app's <c>.deps.json</c> — i.e. it is part of the runtime reference set the
-    /// host turns into TRUSTED_PLATFORM_ASSEMBLIES (TPA), which IS the mesh compiler's scope-compile
-    /// reference set. That's why the mesh-local <c>#r</c> feed (BakeMeshLocalFeed) could be removed: a
-    /// live-compiled scope node resolves those types from TPA, not from a baked feed. This guards that
-    /// safety net — if a future change drops the runtime lib from the portal's published deps, scope
-    /// nodes would silently fail to compile in prod, and this fails first. File presence alone would
-    /// not prove the assembly is a resolvable reference; deps.json membership does.
+    /// The image ships NO <c>MeshWeaver.BusinessRules</c> assembly — the platform starts with zero
+    /// business-rules dependency, deliberately (f7a8c086c, and the comment blocks in
+    /// <c>MeshWeaver.Graph.csproj</c> / <c>Memex.Portal.Distributed.csproj</c>). Scopes ship as the
+    /// <c>MeshWeaver.Plugins/BusinessRules</c> PLUGIN, whose runtime (<c>IScope&lt;,&gt;</c>,
+    /// <c>ScopeBase</c>, <c>ScopeRegistry</c>) is a shared-source library node type consumers pull
+    /// into their own compilation via <c>shared=@BusinessRules/Scope/Source</c> — no DLL in the
+    /// image, no TPA reliance, no <c>#r</c>/feed. This test used to assert the OPPOSITE (the
+    /// withdrawn ships-in-TPA design) and failed on every post-removal image; now it pins the
+    /// removal, so an accidental re-introduction — which would put scope types back on the platform
+    /// startup path that once wedged silos — fails here first.
     /// </summary>
     [Fact]
-    public async Task InjectedImage_ShipsBusinessRulesRuntime_ForFeedlessScopeCompile()
+    public async Task InjectedImage_ShipsNoBusinessRulesAssembly_ScopesComeFromThePlugin()
     {
         SkipIfUnavailable();
 
-        // (a) the runtime DLL is physically present in the image.
-        var file = await _portal!.ExecAsync(new[] { "test", "-f", "/app/MeshWeaver.BusinessRules.dll" });
-        Assert.Equal(0L, file.ExitCode);
+        var file = await _portal!.ExecAsync(new[]
+            { "sh", "-c", "ls /app/MeshWeaver.BusinessRules*.dll 2>/dev/null" });
+        Assert.NotEqual(0L, file.ExitCode);
 
-        // (b) it is listed in the published .deps.json — the runtime-assembly list the host resolves
-        //     into TPA, and thus the mesh compiler's scope-compile reference set. This is the assertion
-        //     that actually backs the "resolves from TPA, no #r feed needed" claim above.
         var deps = await _portal!.ExecAsync(new[]
-            { "sh", "-c", "grep -q '\"MeshWeaver.BusinessRules.dll\"' /app/*.deps.json" });
-        Assert.Equal(0L, deps.ExitCode);
+            { "sh", "-c", "grep -q '\"MeshWeaver.BusinessRules' /app/*.deps.json" });
+        Assert.NotEqual(0L, deps.ExitCode);
     }
 
     public async ValueTask DisposeAsync() => await SafeDisposeAsync();

--- a/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
+++ b/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
@@ -202,13 +202,19 @@ public sealed class PortalImageFacility : IAsyncLifetime
     {
         SkipIfUnavailable();
 
-        var file = await _portal!.ExecAsync(new[]
-            { "sh", "-c", "ls /app/MeshWeaver.BusinessRules*.dll 2>/dev/null" });
-        Assert.NotEqual(0L, file.ExitCode);
+        // Assert the condition POSITIVELY (probe exits 0, count is 0) rather than off a non-zero
+        // `ls` exit — a broken probe (wrong path, missing shell) would also exit non-zero and make
+        // an absence assertion pass vacuously. The `ls /app/MeshWeaver.*.dll` guard proves the
+        // probe is looking at a real app directory full of platform assemblies.
+        var file = await _portal!.ExecAsync(new[] { "sh", "-c",
+            "ls /app/MeshWeaver.*.dll >/dev/null && ls /app/MeshWeaver.BusinessRules*.dll 2>/dev/null | wc -l" });
+        Assert.Equal(0L, file.ExitCode);
+        Assert.Equal("0", file.Stdout.Trim());
 
-        var deps = await _portal!.ExecAsync(new[]
-            { "sh", "-c", "grep -q '\"MeshWeaver.BusinessRules' /app/*.deps.json" });
-        Assert.NotEqual(0L, deps.ExitCode);
+        var deps = await _portal!.ExecAsync(new[] { "sh", "-c",
+            "ls /app/*.deps.json >/dev/null && grep -l 'MeshWeaver.BusinessRules' /app/*.deps.json | wc -l" });
+        Assert.Equal(0L, deps.ExitCode);
+        Assert.Equal("0", deps.Stdout.Trim());
     }
 
     public async ValueTask DisposeAsync() => await SafeDisposeAsync();


### PR DESCRIPTION
## What

**`PluginCatalog:DefaultGrants`** — a registry-side list of `Source/Package` entries (e.g. `["Plugins/*"]`) that every NEW instance registration is granted automatically. `MeshWeaverInstanceService.Register` seeds the entries into the instance's `Admin/_PluginGrant/{instanceId}` node (as System, read-then-`CreateOrUpdateNode` — `stream.Update` aborts on a missing node, the first-grant failure seen live 2026-08-06), merging idempotently with any existing entries.

The security posture is unchanged where it matters:
- **No config → registration grants exactly nothing** ("identity, not entitlement"), pinned by test.
- The grant node stays the **single authority** — admins still revoke/extend per instance in the Instance grants tab.
- Private/paid sources (Education, Reinsurance) are never defaulted; the operator opts in per source.

Supporting pieces:
- The guided **Instances provisioning plan** gains the missing plugins step (register for the `mwi_` key → defaults granted automatically → wire `registryUrl` + token → install).
- The Helm chart now **templates `pluginCatalog.defaultGrants`** (the chart only emits keys it templates — an un-templated key is silently dropped).
- Docs: PluginRegistry.md, OnboardingNewEnvironment.md, the /plugins skill, and a What's New entry.

## Also: the portal-image plugin contract was stale

Running `test/MeshWeaver.PluginImage.Test` against the newest image (`3.0.0-ci.2054`, current main) failed its BusinessRules assertion: it required `MeshWeaver.BusinessRules.dll` in the image — the ships-in-TPA design that f7a8c086c withdrew (scopes ship as the `MeshWeaver.Plugins/BusinessRules` plugin's shared-source runtime, `shared=@BusinessRules/Scope/Source`). CI never caught it because the facility only runs with an injected `MW_TEST_IMAGE`. The test now pins the *removal* (re-introducing the platform dependency fails first), and the misleading "ships WITH the platform" comment in `MeshNodeCompilationService` is rewritten to match reality (comment-only).

## Verification

- Release `-warnaserror` builds clean: Auth.Test closure (Mesh.Contract, Graph, Portal.Shared), PluginCatalog.Test, Portal.Shared.Test, PluginImage.Test
- `PluginGrantTest` 25/25 (incl. new `TryParse` cases) · `InstancesServiceTest` 20/20 · new `InstanceRegistrationDefaultGrantsTest` 3/3 (register → seed → authenticate round-trip, strict no-config default, malformed-entry tolerance)
- `PortalImageFacility` 4/4 against `meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.2054`
- `DocumentationLinkIntegrityTest` green · `helm lint` + `helm template` verified both with and without `defaultGrants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)