### PR TITLE
PlatformVersion goes to 3.0.0-rc1 so CI builds sort ABOVE 3.0.0-preview1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,8 +49,22 @@
          +build.<ticks> suffix below keeps every build distinct (NodeType cache invalidation).
          It is also the content-version for static-repo / GitHub data-sync
          (Doc/Architecture/DataSyncSetup.md §3): a release tagged v$(PlatformVersion) is what
-         a deployed binary syncs from. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0</PlatformVersion>
+         a deployed binary syncs from.
+
+         🚨 The -rc1 label is NOT cosmetic — dropping it breaks SemVer PRECEDENCE against the
+         already-published v3.0.0-preview1. Pre-release identifiers compare ASCII-lexically
+         (SemVer §11.4), and "ci" < "preview1", so a bare 3.0.0 core yields:
+
+             3.0.0-ci.2054      <  3.0.0-preview1      ← every CI build sorts BELOW the old preview
+             3.0.0-rc1.ci.2054  >  3.0.0-preview1      ← correct
+
+         The self-updater picks the NEWEST version off the registry (ReleaseStrategy.md), so with
+         a bare core it would pin to 3.0.0-preview1 the moment that image reached the registry and
+         never roll forward again. Keep a pre-release label on the core until 3.0.0 ships clean.
+
+         It also has to RESOLVE: data-sync pulls content from the tag v$(PlatformVersion), and
+         v3.0.0 does not exist (only v3.0.0-preview1 and now v3.0.0-rc1). -->
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc1</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-07-platform-version-rc1.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-07-platform-version-rc1.md
@@ -1,0 +1,16 @@
+---
+Name: The platform version is now 3.0.0-rc1
+Category: What's New
+Description: Builds carry a release-candidate version, so portals always update to the newest one.
+Icon: Sparkle
+---
+
+# The platform version is now 3.0.0-rc1
+
+Builds are now versioned `3.0.0-rc1` instead of a bare `3.0.0`. Version numbers are
+compared piece by piece, and under those rules the old numbering sorted every new
+build *below* an older preview release — which meant a portal could have decided the
+old preview was the newer one and stopped updating itself.
+
+The release-candidate label restores the correct order, so portals always move forward
+to the newest build. Nothing changes in how the product looks or behaves.


### PR DESCRIPTION
A bare `3.0.0` core made every CI build sort **below** the already-published `v3.0.0-preview1`. SemVer §11.4 compares pre-release identifiers ASCII-lexically, and `ci` < `preview1`:

```
3.0.0-ci.2054      <  3.0.0-preview1      ← verified
3.0.0-rc1.ci.2060  >  3.0.0-preview1      ← verified
```

The **self-updater picks the newest version off the registry** (ReleaseStrategy.md), so with the bare core it would have pinned to `3.0.0-preview1` the moment that image reached the registry — and never rolled forward again. Latent today only because `preview1` is not in ACR; nothing prevents it from being pushed.

## Second defect, same root

Data-sync pulls content from the tag `v$(PlatformVersion)`. That resolved to **`v3.0.0`, which does not exist** — the repo has `v3.0.0-preview1` and now `v3.0.0-rc1`.

Both `Directory.Build.props`' own comment and `DataSyncSetup.md` already use `3.0.0-rc1` as the worked example. The property had simply drifted from its own documentation.

## Verified against the actual build

| channel | version |
|---|---|
| default (CI) | `3.0.0-rc1.ci.2060` |
| `-p:PublicRelease=true` | `3.0.0-rc1` |
| `AssemblyVersion` | `3.0.0.0` (label stripped, unchanged) |

And the three orderings that matter:

- `3.0.0-rc1.ci.2060` > `3.0.0-ci.2054` — **deployed portals roll forward across the switch**
- `3.0.0-rc1.ci.2060` > `3.0.0-preview1` — the bug this fixes
- `3.0.0-rc1.ci.2060` > `3.0.0-rc1.ci.2059` — still monotonic

Release build clean with `-warnaserror`.

## Follow-up (not in this PR)

Data-sync needs the tag to exist: `v3.0.0-rc1` should be created on the release commit. Tagging is a release action, so it stays out of a code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx6BiUYBu5U2Zdnom4Uz4X