### PR TITLE
ClrMD leak guards: inconclusive analysis skips loudly instead of passing vacuously (#674)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/ClrMdRootAnalysisOutcome.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ClrMdRootAnalysisOutcome.cs
@@ -1,0 +1,22 @@
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Result of a ClrMD GC-root analysis. Tri-state on purpose (#674): on macOS
+/// <c>DataTarget.CreateSnapshotAndAttach</c> throws <c>PlatformNotSupportedException</c>,
+/// and folding that into a bare <c>false</c> made the leak guards pass unconditionally
+/// on every Mac — a probe run alongside showed the hub demonstrably alive while the
+/// assertion stayed green, and the false assurance derailed the #664/#673 investigations
+/// (22 green macOS runs "refuted" a correlation that Linux then reproduced 3/3).
+/// <see cref="Unavailable"/> must never satisfy a leak assertion; tests skip loudly on it.
+/// </summary>
+internal enum ClrMdRootAnalysisOutcome
+{
+    /// <summary>The analysis could not run (platform, snapshot, or runtime failure) — inconclusive, never a pass.</summary>
+    Unavailable,
+
+    /// <summary>The analysis ran and found no target object reachable from a non-stack root.</summary>
+    NotDetected,
+
+    /// <summary>The analysis ran and found the target object rooted — the leak signature.</summary>
+    Detected,
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
@@ -139,10 +139,19 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
             "ServiceProvider are disposed — a surviving context means the per-cell script " +
             "assemblies leak for the process lifetime (the memory-fatigue wall)");
 
-        var (pinned, report) = AnalyzeScriptRoots();
+        var (outcome, report) = AnalyzeScriptRoots();
         Output.WriteLine(report);
 
-        pinned.Should().BeFalse(
+        // The ALC-unload assertion above already ran and needs no ClrMD. The script-object
+        // pin check below does — where the analysis cannot run (macOS snapshot-attach) the
+        // verdict is INCONCLUSIVE (#674) and must skip loudly instead of passing vacuously;
+        // Linux (CI) runs the real analysis.
+        Assert.SkipWhen(outcome == ClrMdRootAnalysisOutcome.Unavailable,
+            "kernel ScriptSession load-context unload WAS verified above, but the ClrMD root " +
+            "analysis could not run on this platform/process — the script-object pin check is " +
+            "inconclusive here, not green (#674). " + report);
+
+        (outcome == ClrMdRootAnalysisOutcome.Detected).Should().BeFalse(
             "no per-session Roslyn script object (ScriptState / submission CSharpCompilation) may stay " +
             "reachable from a non-stack GC root after the mesh and its ServiceProvider are disposed — a " +
             "pinned session graph retains its compilation and submission state (~tens of MiB/run); the " +
@@ -154,10 +163,9 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
     /// BFS from non-stack GC roots to the first instance of each Roslyn script
     /// object kind, printing root kind + type chain per surviving kind.
     /// </summary>
-    private static (bool Pinned, string Report) AnalyzeScriptRoots()
+    private static (ClrMdRootAnalysisOutcome Outcome, string Report) AnalyzeScriptRoots()
     {
         var sb = new StringBuilder();
-        var pinned = false;
         try
         {
             // 🚨 Pin the DAC for process lifetime BEFORE ClrMD loads it: DataTarget.Dispose
@@ -166,7 +174,8 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
             // (the endemic exit=139). See ClrMdDacPin / ClrMdDacUnloadCrashTest.
             ClrMdDacPin.EnsurePinned();
             using var dt = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
-            if (dt.ClrVersions.Length == 0) return (false, "[clrmd] no CLR runtime found in snapshot");
+            if (dt.ClrVersions.Length == 0)
+                return (ClrMdRootAnalysisOutcome.Unavailable, "[clrmd] no CLR runtime found in snapshot");
             using var runtime = dt.ClrVersions[0].CreateRuntime();
             var heap = runtime.Heap;
 
@@ -240,7 +249,7 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
             // memo is BY DESIGN (one materialization per assembly per process — the fix
             // for the ~200 MiB-per-session leak). The leak signature this probe guards
             // is the SESSION graph surviving: ScriptState / submission compilation.
-            pinned = found.ContainsKey("ScriptState") || found.ContainsKey("CSharpCompilation");
+            var pinned = found.ContainsKey("ScriptState") || found.ContainsKey("CSharpCompilation");
 
             var liveBytes = byType.Values.Sum(v => v.Bytes);
             sb.AppendLine($"[clrmd] live-from-non-stack-roots total={liveBytes / 1024 / 1024}MiB; top types by retained size:");
@@ -294,12 +303,16 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
                 chain.Reverse();
                 foreach (var line in chain) sb.AppendLine("   " + line);
             }
+            return (pinned ? ClrMdRootAnalysisOutcome.Detected : ClrMdRootAnalysisOutcome.NotDetected,
+                sb.ToString());
         }
         catch (Exception ex)
         {
+            // Snapshot-attach unsupported (macOS PlatformNotSupportedException) or any other
+            // analysis fault: the probe DID NOT LOOK — that is Unavailable, never NotDetected.
             sb.AppendLine($"[clrmd] analysis failed: {ex.GetType().Name}: {ex.Message}");
+            return (ClrMdRootAnalysisOutcome.Unavailable, sb.ToString());
         }
-        return (pinned, sb.ToString());
     }
 
     public override async ValueTask DisposeAsync()

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
@@ -109,11 +109,20 @@ public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTes
         // which clears once the process resumes). We do NOT hold a strong ref to the
         // survivor during analysis (that would add our own stack root); ClrMD reads the
         // live process heap directly.
-        var (staticRooted, report) = AnalyzeMeshHubRoots();
+        var (outcome, report) = AnalyzeMeshHubRoots();
         Output.WriteLine("=== MESH HUB SURVIVED DISPOSAL — ClrMD GC-root analysis ===");
         Output.WriteLine(report);
 
-        staticRooted.Should().BeFalse(
+        // A guard that could not LOOK must not report "no leak" (#674): on macOS the
+        // snapshot-attach throws PlatformNotSupportedException, and folding that into
+        // false let this assertion pass while the hub was demonstrably alive.
+        // Inconclusive is a SKIP, never a pass — Linux (CI) runs the real analysis.
+        Assert.SkipWhen(outcome == ClrMdRootAnalysisOutcome.Unavailable,
+            "the mesh hub SURVIVED disposal but the ClrMD root analysis could not run on this " +
+            "platform/process — the verdict is inconclusive here, not green (#674); run on Linux " +
+            "for the GC-root chain. " + report);
+
+        (outcome == ClrMdRootAnalysisOutcome.Detected).Should().BeFalse(
             "the mesh hub is pinned by a NON-stack root (static field / TimerQueue timer / GC handle) " +
             "— a real leak that accumulates across disposed meshes; the chain above names it. A hub " +
             "held ONLY by a transient stack root (snapshot artifact) is acceptable and not failed on.");
@@ -124,10 +133,9 @@ public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTes
     /// first <c>MessageHub</c> on the heap, printing the root kind + the type chain
     /// from the root down to the hub. The top of the chain is the pin.
     /// </summary>
-    private static (bool StaticRooted, string Report) AnalyzeMeshHubRoots()
+    private static (ClrMdRootAnalysisOutcome Outcome, string Report) AnalyzeMeshHubRoots()
     {
         var sb = new StringBuilder();
-        var staticRooted = false;
         try
         {
             // 🚨 Pin the DAC for process lifetime BEFORE ClrMD loads it: DataTarget.Dispose
@@ -136,7 +144,8 @@ public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTes
             // (the endemic exit=139). See ClrMdDacPin / ClrMdDacUnloadCrashTest.
             ClrMdDacPin.EnsurePinned();
             using var dt = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
-            if (dt.ClrVersions.Length == 0) return (false, "[clrmd] no CLR runtime found in snapshot");
+            if (dt.ClrVersions.Length == 0)
+                return (ClrMdRootAnalysisOutcome.Unavailable, "[clrmd] no CLR runtime found in snapshot");
             using var runtime = dt.ClrVersions[0].CreateRuntime();
             var heap = runtime.Heap;
 
@@ -185,7 +194,6 @@ public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTes
             }
 
             sb.AppendLine($"[clrmd] visited={visited} hubFound={found != 0}");
-            staticRooted = found != 0;
             if (found != 0)
             {
                 var chain = new List<string>();
@@ -252,12 +260,16 @@ public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTes
                 sb.AppendLine("[clrmd] no MessageHub reached from non-stack roots within budget.");
                 sb.AppendLine("[clrmd] non-stack root kinds seen: " + string.Join(", ", kinds));
             }
+            return (found != 0 ? ClrMdRootAnalysisOutcome.Detected : ClrMdRootAnalysisOutcome.NotDetected,
+                sb.ToString());
         }
         catch (Exception ex)
         {
+            // Snapshot-attach unsupported (macOS PlatformNotSupportedException) or any other
+            // analysis fault: the probe DID NOT LOOK — that is Unavailable, never NotDetected.
             sb.AppendLine($"[clrmd] analysis failed: {ex.GetType().Name}: {ex.Message}");
+            return (ClrMdRootAnalysisOutcome.Unavailable, sb.ToString());
         }
-        return (staticRooted, sb.ToString());
     }
 
     public override async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary

Fixes #674: `MeshHubDisposalLeakTest` and `KernelScriptMemoryLeakTest` could not fail on macOS — `DataTarget.CreateSnapshotAndAttach` throws `PlatformNotSupportedException` there, the analyzers' `catch` folded that into "nothing rooted", and the assertions passed **because the analysis never ran**. That false assurance misled the #664/#673 investigations (22 green macOS runs "refuted" a correlation Linux reproduced 3/3).

## Change

- New tri-state `ClrMdRootAnalysisOutcome` (`Detected` / `NotDetected` / `Unavailable`) replaces the bare bool both analyzers returned.
- `Unavailable` (platform, snapshot, or runtime failure — the probe did not look) never satisfies a leak assertion: the tests `Assert.Skip` with the analyzer report in the reason.
- `KernelScriptMemoryLeakTest`'s ClrMD-free ALC-unload assertion still runs unconditionally before the skip.
- Linux (CI) behavior unchanged — the analysis runs and asserts as before.

## Verification

Ran both tests on macOS: both now **skip** naming `PlatformNotSupportedException` in the reason (and the mesh hub does survive disposal here — previously that state read as a green pass). `dotnet build -c Release -warnaserror` clean.

No What's New entry: test-infrastructure only, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)