### PR TITLE
Network-dependent tests skip loudly on feed outage; watchdog measures monotonic time (#679)

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -653,6 +653,16 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     // past the deadline and xUnit eventually reports Passed with the actual
     // (multi-minute) duration. The watchdog below catches that uniformly.
     private DateTimeOffset _testMethodStartedAt;
+    // Monotonic twin of the wall-clock stamp above (#679): wall-clock keeps counting
+    // through host suspension (laptop sleep, frozen runner) — a window in which the
+    // test could not have made progress — and the sweep of 2026-07 recorded "hangs" of
+    // 5523 s and 7288 s against a 720 s cap that all passed under caffeinate. Stopwatch
+    // does not advance across suspension on Linux (CLOCK_MONOTONIC) and Intel macOS
+    // (mach_absolute_time), so deadlines are enforced on it; on Apple-Silicon macOS the
+    // OS monotonic clock may tick through sleep, making the divergence report below
+    // best-effort there — but enforcement can never be WORSE than the wall clock it
+    // replaces.
+    private Stopwatch? _testMethodStopwatch;
     /// <summary>Soft cap — anything above this gets a warning in the test log.</summary>
     protected virtual TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(30);
     /// <summary>
@@ -793,6 +803,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // compute actual test-method duration and apply the soft/hard
             // deadlines (see TestSoftDeadline / TestHardDeadline).
             _testMethodStartedAt = DateTimeOffset.UtcNow;
+            _testMethodStopwatch = Stopwatch.StartNew();
         }
         catch (Exception ex)
         {
@@ -1186,9 +1197,24 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         // [Fact(Timeout=N)] is cooperative — a test that ignores the ct
         // happily blocks past its declared timeout and gets reported as
         // Passed. We catch every such silent deadlock here, uniformly.
-        TimeSpan? testMethodElapsed = _testMethodStartedAt == default
+        TimeSpan? wallElapsed = _testMethodStartedAt == default
             ? null
             : DateTimeOffset.UtcNow - _testMethodStartedAt;
+        var monotonicElapsed = _testMethodStopwatch?.Elapsed;
+        // Enforce on the monotonic clock (#679): the wall clock includes host-suspension
+        // windows in which the test could not have made progress — failing it for that
+        // time misattributes a sleep/stall to the test's CancellationToken handling.
+        var testMethodElapsed = monotonicElapsed ?? wallElapsed;
+        if (wallElapsed is { } wall && monotonicElapsed is { } mono &&
+            wall - mono > TimeSpan.FromSeconds(10))
+        {
+            FileOutput.WriteLine(
+                $"[WATCHDOG-SUSPEND] {testName}: wall-clock elapsed {wall.TotalSeconds:F1}s vs " +
+                $"monotonic {mono.TotalSeconds:F1}s — the host was suspended ~" +
+                $"{(wall - mono).TotalSeconds:F0}s during this test (laptop sleep / runner stall). " +
+                "Deadlines are enforced on the monotonic clock, so the suspension window alone " +
+                "cannot fail the test.");
+        }
         if (testMethodElapsed is { } elapsed)
         {
             var hardDeadline = EffectiveHardDeadline;

--- a/test/MeshWeaver.Graph.Test/NuGetAssemblyResolverTest.cs
+++ b/test/MeshWeaver.Graph.Test/NuGetAssemblyResolverTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.NuGet;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,19 +10,46 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// End-to-end test of NuGet restore against api.nuget.org. Requires network access.
-/// Disable with environment variable MESHWEAVER_SKIP_NUGET=1.
+/// End-to-end test of NuGet restore against api.nuget.org. Requires network access:
+/// each test probes the live feed first and SKIPS with an explicit reason when it is
+/// unreachable (#679) — a feed outage must present as a skip, never as a red that
+/// points at NuGet internals. Disable outright with MESHWEAVER_SKIP_NUGET=1.
 /// </summary>
 [Collection("NuGetNetwork")]
 public class NuGetAssemblyResolverTest
 {
-    private static bool ShouldSkip =>
-        Environment.GetEnvironmentVariable("MESHWEAVER_SKIP_NUGET") == "1";
+    /// <summary>
+    /// Loud gate for the live-feed dependency (#679): when nuget.org has a bad minute
+    /// these tests used to fail with a FatalProtocolException naming NuGet internals —
+    /// a phantom flake someone then triages. Skipping with the cause on the result is
+    /// honest; a silent early-return would be a vacuous pass. Probed per test on
+    /// purpose: no cached static state, and the serialized collection makes the cost
+    /// one round-trip per test against 180 s budgets.
+    /// </summary>
+    private static async Task SkipUnlessNuGetOrgReachable(CancellationToken ct)
+    {
+        Assert.SkipWhen(Environment.GetEnvironmentVariable("MESHWEAVER_SKIP_NUGET") == "1",
+            "NuGet end-to-end tests disabled via MESHWEAVER_SKIP_NUGET=1");
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        try
+        {
+            using var response = await http.GetAsync("https://api.nuget.org/v3/index.json", ct);
+            Assert.SkipUnless(response.IsSuccessStatusCode,
+                $"api.nuget.org service index answered {(int)response.StatusCode} — feed unhealthy; " +
+                "this end-to-end test needs the live feed (#679)");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            Assert.Skip($"api.nuget.org unreachable ({ex.GetType().Name}: {ex.Message}) — this " +
+                "end-to-end test needs the live feed; a network outage presents as a SKIP, not a " +
+                "phantom test failure (#679)");
+        }
+    }
 
     [Fact(Timeout = 180_000)]
     public async Task Resolve_Humanizer_ReturnsExistingDllPaths()
     {
-        if (ShouldSkip) return;
+        await SkipUnlessNuGetOrgReachable(TestContext.Current.CancellationToken);
         var resolver = new NuGetAssemblyResolver(NullLogger<NuGetAssemblyResolver>.Instance);
 
         var result = await resolver.ResolveAsync(
@@ -37,7 +66,7 @@ public class NuGetAssemblyResolverTest
     [Fact(Timeout = 180_000)]
     public async Task Resolve_MathNetNumerics_LoadsTransitiveDeps()
     {
-        if (ShouldSkip) return;
+        await SkipUnlessNuGetOrgReachable(TestContext.Current.CancellationToken);
         var resolver = new NuGetAssemblyResolver(NullLogger<NuGetAssemblyResolver>.Instance);
 
         var result = await resolver.ResolveAsync(
@@ -53,7 +82,7 @@ public class NuGetAssemblyResolverTest
     [Fact(Timeout = 30_000)]
     public async Task Resolve_UnknownPackage_Throws()
     {
-        if (ShouldSkip) return;
+        await SkipUnlessNuGetOrgReachable(TestContext.Current.CancellationToken);
         var resolver = new NuGetAssemblyResolver(NullLogger<NuGetAssemblyResolver>.Instance);
 
         var act = () => resolver.ResolveAsync(
@@ -66,7 +95,7 @@ public class NuGetAssemblyResolverTest
     [Fact(Timeout = 180_000)]
     public async Task Resolve_TwiceWithSameInputs_HitsCache()
     {
-        if (ShouldSkip) return;
+        await SkipUnlessNuGetOrgReachable(TestContext.Current.CancellationToken);
         var resolver = new NuGetAssemblyResolver(NullLogger<NuGetAssemblyResolver>.Instance);
         var refs = new[] { new NuGetPackageReference("Humanizer", "2.14.1") };
 

--- a/test/MeshWeaver.MemexTemplate.Test/MemexTemplateGeneratorTest.cs
+++ b/test/MeshWeaver.MemexTemplate.Test/MemexTemplateGeneratorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Xunit;
@@ -30,8 +31,37 @@ public class MemexTemplateGeneratorTest : IDisposable
     private string GeneratorScript =>
         Path.Combine(RepoRoot, "tools", "generate-memex-template.cs");
 
+    /// <summary>
+    /// Loud gate for the hidden network dependency (#679): <c>dotnet run script.cs</c>
+    /// implicitly RESTORES the file-based app, so an unreachable nuget.org fails every
+    /// test here with an NU1900 that points at NuGet internals — a phantom flake someone
+    /// then triages. Skipping with the cause on the result is honest. (Deliberately
+    /// duplicated from NuGetAssemblyResolverTest — this project is standalone, with no
+    /// shared test-utility reference to host a common helper.)
+    /// </summary>
+    private static async Task SkipUnlessNuGetOrgReachable()
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        try
+        {
+            using var response = await http.GetAsync("https://api.nuget.org/v3/index.json",
+                TestContext.Current.CancellationToken);
+            Assert.SkipUnless(response.IsSuccessStatusCode,
+                $"api.nuget.org service index answered {(int)response.StatusCode} — feed unhealthy; " +
+                "the generator's implicit restore needs the live feed (#679)");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            Assert.Skip($"api.nuget.org unreachable ({ex.GetType().Name}: {ex.Message}) — the " +
+                "generator's implicit `dotnet run` restore needs the live feed; a network outage " +
+                "presents as a SKIP, not a phantom test failure (#679)");
+        }
+    }
+
     private async Task RunGenerator(string version = "0.0.0-test")
     {
+        await SkipUnlessNuGetOrgReachable();
+
         var psi = new ProcessStartInfo("dotnet", $"run \"{GeneratorScript}\" -- {version} \"{RepoRoot}\" \"{_outputPath}\"")
         {
             WorkingDirectory = RepoRoot,
@@ -43,6 +73,19 @@ public class MemexTemplateGeneratorTest : IDisposable
         var stdout = await process.StandardOutput.ReadToEndAsync();
         var stderr = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
+
+        // The feed can die BETWEEN the probe above and the restore. NU1900 / "unable to
+        // load the service index" name exactly that condition and nothing the generator
+        // itself can cause — so it is the outage skip, not a masked generator defect.
+        if (process.ExitCode != 0)
+        {
+            var combined = stdout + stderr;
+            Assert.SkipWhen(
+                combined.Contains("NU1900") ||
+                combined.Contains("Unable to load the service index", StringComparison.OrdinalIgnoreCase),
+                "nuget.org became unreachable during the generator's implicit restore — network " +
+                $"outage, not a generator defect (#679).\nstdout: {stdout}\nstderr: {stderr}");
+        }
 
         process.ExitCode.Should().Be(0, $"generator failed.\nstdout: {stdout}\nstderr: {stderr}");
         _lastStdout = stdout;


### PR DESCRIPTION
## Summary

Fixes #679: when nuget.org has a bad minute, `NuGetAssemblyResolverTest` (3 tests) and `MemexTemplateGeneratorTest` (7 tests) went red with failures naming NuGet internals — phantom flakes an engineer then triages. And the `MonolithMeshTestBase` watchdog measured wall-clock time, so host suspension (laptop sleep / runner stall) produced impossible 5000+s "hangs" against a 720 s cap, all green on re-run under `caffeinate`.

## Changes

**Feed reachability → loud skip, never phantom red**
- Each `NuGetAssemblyResolverTest` test probes `api.nuget.org/v3/index.json` (10 s budget) and `Assert.Skip`s with the cause when unreachable/unhealthy. The `MESHWEAVER_SKIP_NUGET=1` opt-out was a silent `return` (vacuous pass) — now an explicit skip.
- `MemexTemplateGeneratorTest.RunGenerator` gets the same probe (the network edge is `dotnet run`'s implicit restore of the generator script), plus a detector for the probe-passed-then-feed-died window: a non-zero exit whose output names NU1900 / "unable to load the service index" skips as an outage; any other failure still fails as a generator defect.

**Watchdog: monotonic enforcement + suspension report**
- Deadlines are enforced on a `Stopwatch` (does not advance across suspension on Linux `CLOCK_MONOTONIC` / Intel macOS) instead of `DateTimeOffset.UtcNow` deltas.
- Wall-vs-monotonic divergence > 10 s logs `[WATCHDOG-SUSPEND]` naming the suspension window. (On Apple-Silicon macOS the OS monotonic clock may tick through sleep, making the report best-effort there — noted in the code; enforcement can never be worse than the wall clock it replaces.)

## Verification

- Live feed: both families fully green (4/4, 7/7), so the probe is inert on a healthy network.
- `MESHWEAVER_SKIP_NUGET=1` → explicit `Skipped`, not a silent pass.
- `dotnet build -c Release -warnaserror` clean on Graph.Test, MemexTemplate.Test, Hosting.Monolith.Test (TestBase dependent).

No What's New entry: test-infrastructure only, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)