### PR TITLE
Data source streams: dropped unattributed changes are logged, never silent (#678)

### DIFF
--- a/src/MeshWeaver.Data/GenericUnpartitionedDataSource.cs
+++ b/src/MeshWeaver.Data/GenericUnpartitionedDataSource.cs
@@ -641,13 +641,28 @@ public abstract record TypeSourceBasedUnpartitionedDataSource<TDataSource, TType
         stream.RegisterForDisposal(
             stream
                 .Synchronize()
-                .Where(x => isFirst || (x.ChangedBy is not null && !x.ChangedBy.Equals(Id)))
+                .Where(x => isFirst || x.ChangedBy is null || !x.ChangedBy.Equals(Id))
                 .Subscribe(change =>
                 {
                     if (isFirst)
                     {
                         isFirst = false;
                         return; // Skip processing on first emission (initialization)
+                    }
+                    // #678: every local producer attributes ChangedBy (ApplyChanges falls back
+                    // to StreamId, BuildChangeItem/patch adoption to ClientId) — the one
+                    // remaining null producer is cross-hub Full adoption, which never targets a
+                    // data-source stream. An unattributed change here is therefore an invariant
+                    // breach, and it used to be dropped by the Where with NO trace —
+                    // indistinguishable from a write that never happened. Keep the drop (a
+                    // change we cannot attribute must not be echoed into the type sources,
+                    // where it could double-apply as someone else's write), but make it LOUD.
+                    if (change.ChangedBy is null)
+                    {
+                        Logger.LogWarning(
+                            "Data source stream {Id}: DROPPED an unattributed change (ChangedBy=null, ChangeType={ChangeType}, Version={Version}) — invariant breach, see #678",
+                            Id, change.ChangeType, change.Version);
+                        return;
                     }
                     // A single bad change must NOT kill the data-source sync
                     // subscription — if it does, every query/catalog fed by this
@@ -765,13 +780,28 @@ public abstract record TypeSourceBasedPartitionedDataSource<TDataSource, TTypeSo
         stream.RegisterForDisposal(
             stream
                 .Synchronize()
-                .Where(x => isFirst || (x.ChangedBy is not null && !x.ChangedBy.Equals(Id)))
+                .Where(x => isFirst || x.ChangedBy is null || !x.ChangedBy.Equals(Id))
                 .Subscribe(change =>
                 {
                     if (isFirst)
                     {
                         isFirst = false;
                         return; // Skip processing on first emission (initialization)
+                    }
+                    // #678: every local producer attributes ChangedBy (ApplyChanges falls back
+                    // to StreamId, BuildChangeItem/patch adoption to ClientId) — the one
+                    // remaining null producer is cross-hub Full adoption, which never targets a
+                    // data-source stream. An unattributed change here is therefore an invariant
+                    // breach, and it used to be dropped by the Where with NO trace —
+                    // indistinguishable from a write that never happened. Keep the drop (a
+                    // change we cannot attribute must not be echoed into the type sources,
+                    // where it could double-apply as someone else's write), but make it LOUD.
+                    if (change.ChangedBy is null)
+                    {
+                        Logger.LogWarning(
+                            "Data source stream {Id}: DROPPED an unattributed change (ChangedBy=null, ChangeType={ChangeType}, Version={Version}) — invariant breach, see #678",
+                            Id, change.ChangeType, change.Version);
+                        return;
                     }
                     // A single bad change must NOT kill the data-source sync
                     // subscription — if it does, every query/catalog fed by this


### PR DESCRIPTION
## Summary

Fixes #678: the data-source sync subscription (`TypeSourceBasedUnpartitionedDataSource.SetupDataSourceStream` and its partitioned twin) silently discarded any post-init change with `ChangedBy == null` — no persistence, no log, indistinguishable from a write that never happened.

## Reachability (the issue's question 1)

Every local producer attributes `ChangedBy`: `ApplyChanges` falls back to `StreamId` (since c3871a662, 2024-11), `UpdateDataChangeRequest`'s Remove branch to `stream.StreamId`, `BuildChangeItem`/`BuildFullChangeItem` stamp `ClientId`, cross-hub Patch adoption uses `delivery.ChangedBy ?? ClientId`. The one remaining null producer is cross-hub **Full adoption** (`SynchronizationStream.UpdateStream`'s Full path, 3-arg ctor) — which only lands on subscriber-side mirrors, never on a data-source stream. So the drop is unreachable by analysis today.

## Change (the issue's question 2)

Keep the drop semantics — an unattributed change must not be echoed into the type sources where it could double-apply — but make it **loud**: a post-init `ChangedBy == null` change now logs a WARNING naming the stream id, change type and version, converting the reachability analysis into a monitored invariant.

`DataTest.Update` already pins that a `DataChangeRequest` with `changedBy: null` persists end-to-end via the `StreamId` fallback. Side notes from the issue (WithUpdate transform contract, `Committed` naming) split out to #886.

## Verification

MeshWeaver.Data.Test: 303/303 green. `dotnet build -c Release -warnaserror` clean on MeshWeaver.Data and MeshWeaver.Data.Test.

No What's New entry: internal observability change, no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)