### PR TITLE
Recursive delete: authoritative plan, gap traversal, storage-verified drain, creation guard (#839)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -249,10 +249,11 @@ public static class GraphConfigurationExtensions
                     // PartitionDefinition.DefaultActivityParentPath without
                     // bridging an async catalog query into the sync handler.
                     services.AddSingleton<PartitionRegistry>();
-                    // Mesh-scoped "delete wins" tombstone shared across every per-node hub —
-                    // stops a hub that (re)activates after a delete from resurrecting the row
-                    // via its activation-triggered save. See RecentlyDeletedRegistry.
-                    services.AddSingleton<RecentlyDeletedRegistry>();
+                    // RecentlyDeletedRegistry is registered at the MESH ROOT (MeshBuilder.Register)
+                    // — NOT here. A hub-level registration created a second instance, and the
+                    // SubtreeDeletionGuardStorageAdapter (persistence container) then guarded a
+                    // registry no delete handler ever opened a scope on (#839). Hub SPs fall back
+                    // to the root, so consumers here resolve the shared root instance.
                     // Mesh-scoped deck sibling-slide cache: one shared, replayed sibling
                     // query per deck so slide navigation never re-runs the query per
                     // slide render (see DeckSlidesCache / SlideLayoutAreas.ObserveDeckSlides).

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
@@ -251,6 +251,17 @@ internal sealed class PostgreSqlPathRoutingAdapter : IStorageAdapter
                 ? a.ListChildPaths(parentPath)
                 : Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(([], []));
 
+    /// <summary>
+    /// Routes to the per-schema adapter's native satellite-UNION descendant
+    /// enumeration (every strict descendant shares the root's first segment, so
+    /// one schema answers the whole subtree). Unroutable segment → nothing stored
+    /// here → empty.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => AdapterForRead(rootPath) is { } a
+            ? a.ListDescendantPaths(rootPath)
+            : Observable.Return<IReadOnlyCollection<string>>([]);
+
     public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
         => AdapterForRead(nodePath) is { } a
             ? a.ListPartitionSubPaths(nodePath)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -720,6 +720,84 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         return (paths, Enumerable.Empty<string>());
     }
 
+    /// <summary>
+    /// Native authoritative descendant enumeration: ONE round-trip UNION across the
+    /// partition's primary <c>mesh_nodes</c> table AND every satellite table named in
+    /// <see cref="PartitionDefinition.TableMappings"/> (threads, access, activities,
+    /// annotations, code, …), matching every row whose namespace equals the root or is
+    /// prefixed by it. This is what the recursive-delete planner and its post-delete
+    /// verification run on — the interface default's <see cref="ListChildPaths"/> walk
+    /// cannot work here because the PG child listing is a flat single-table
+    /// namespace-equality scan with no directory levels, so it would never descend into
+    /// node-less intermediate segments (<c>{path}/_Thread/{id}</c>,
+    /// <c>{nodeType}/Release/{version}</c>) — exactly the rows that survived (issue #839).
+    /// An absent (never-provisioned) schema means nothing to enumerate → empty.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => _readPool.Invoke(ct => ListDescendantPathsAsyncCore(rootPath, ct))
+            .Catch<IReadOnlyCollection<string>, Exception>(ex => IsUndefinedTable(ex)
+                ? Observable.Return<IReadOnlyCollection<string>>([])
+                : Observable.Throw<IReadOnlyCollection<string>>(ex));
+
+    private async Task<IReadOnlyCollection<string>> ListDescendantPathsAsyncCore(
+        string rootPath, CancellationToken ct)
+    {
+        var normalizedRoot = NormalizePath(rootPath);
+
+        // Primary + every distinct satellite table (case-insensitive dedup —
+        // multiple suffixes can map to the same table, e.g. _Comment / _Approval /
+        // _Tracking all → annotations). Same table set as ResolvePathAsyncCore.
+        var tables = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "mesh_nodes" };
+        if (_partitionDefinition?.TableMappings is { } mappings)
+            foreach (var t in mappings.Values)
+                if (!string.IsNullOrEmpty(t))
+                    tables.Add(t);
+
+        // A descendant row's namespace either equals the root (direct children) or is
+        // prefixed by `{root}/`. 🚨 The prefix predicate is LIKE with an explicit
+        // ESCAPE and an escaped pattern: mesh paths routinely contain `_`
+        // (`X/_Thread`), which is a single-char LIKE wildcard — unescaped it would
+        // match sibling subtrees (`X/aThread/…`) into the DELETION plan.
+        var branches = tables.Select(t =>
+        {
+            var qualified = string.IsNullOrEmpty(_schemaName)
+                ? $"\"{t}\""
+                : $"\"{_schemaName}\".\"{t}\"";
+            return string.IsNullOrEmpty(normalizedRoot)
+                ? $"SELECT namespace, id FROM {qualified}"
+                : $"SELECT namespace, id FROM {qualified} WHERE namespace = $1 OR namespace LIKE $2 ESCAPE '\\'";
+        });
+        var sql = string.Join("\n UNION ALL\n", branches);
+
+        await using var cmd = _dataSource.CreateCommand(sql);
+        if (!string.IsNullOrEmpty(normalizedRoot))
+        {
+            cmd.Parameters.AddWithValue(normalizedRoot);
+            cmd.Parameters.AddWithValue(EscapeLikePattern(normalizedRoot) + "/%");
+        }
+
+        var paths = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var ns = reader.GetString(0);
+            var id = reader.GetString(1);
+            paths.Add(string.IsNullOrEmpty(ns) ? id : $"{ns}/{id}");
+        }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Escapes the LIKE wildcards (<c>\</c>, <c>%</c>, <c>_</c>) in a literal path so it can
+    /// be used as a LIKE prefix with <c>ESCAPE '\'</c>.
+    /// </summary>
+    private static string EscapeLikePattern(string literal)
+        => literal
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
+
     /// <inheritdoc />
     public IObservable<bool> Exists(string path)
         => WithTransientRetry(() => _ioPool.Invoke(ct => ExistsAsyncCore(path, ct)), "Exists")

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
@@ -312,6 +312,16 @@ internal sealed class SnowflakePathRoutingAdapter : IStorageAdapter
                 ? a.ListChildPaths(parentPath)
                 : Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(([], []));
 
+    /// <summary>
+    /// Routes to the per-schema adapter's native satellite-UNION descendant
+    /// enumeration (every strict descendant shares the root's first segment).
+    /// Unroutable segment → nothing stored here → empty.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => AdapterForRead(rootPath) is { } a
+            ? a.ListDescendantPaths(rootPath)
+            : Observable.Return<IReadOnlyCollection<string>>([]);
+
     /// <inheritdoc/>
     public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
         => AdapterForRead(nodePath) is { } a

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
@@ -984,6 +984,69 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
         return (paths, Enumerable.Empty<string>());
     }
 
+    /// <summary>
+    /// Native authoritative descendant enumeration — the Snowflake twin of the PG
+    /// implementation: ONE round-trip UNION across the partition's primary
+    /// <c>mesh_nodes</c> table AND every satellite table in
+    /// <see cref="PartitionDefinition.TableMappings"/>, matching every row whose
+    /// namespace equals the root or is prefixed by it. The interface default's
+    /// <see cref="ListChildPaths"/> walk cannot work here — the child listing is a
+    /// flat namespace-equality scan with no directory levels. Absent schema → empty.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => _readPool.Invoke(ct => ListDescendantPathsAsyncCore(rootPath, ct))
+            .Catch<IReadOnlyCollection<string>, Exception>(ex => IsUndefinedObject(ex)
+                ? Observable.Return<IReadOnlyCollection<string>>([])
+                : Observable.Throw<IReadOnlyCollection<string>>(ex));
+
+    private async Task<IReadOnlyCollection<string>> ListDescendantPathsAsyncCore(
+        string rootPath, CancellationToken ct)
+    {
+        var normalizedRoot = NormalizePath(rootPath);
+
+        var tables = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "mesh_nodes" };
+        if (_partitionDefinition?.TableMappings is { } mappings)
+            foreach (var t in mappings.Values)
+                if (!string.IsNullOrEmpty(t))
+                    tables.Add(t);
+
+        // 🚨 LIKE prefix with explicit ESCAPE + escaped pattern: mesh paths routinely
+        // contain `_` (`X/_Thread`), a single-char LIKE wildcard — unescaped it would
+        // match sibling subtrees into the deletion plan. In a Snowflake string literal
+        // the backslash itself is written escaped ('\\').
+        var branches = tables.Select(t =>
+        {
+            var qualified = QualifyTable(t);
+            return string.IsNullOrEmpty(normalizedRoot)
+                ? $"SELECT \"namespace\", \"id\" FROM {qualified}"
+                : $"SELECT \"namespace\", \"id\" FROM {qualified} WHERE \"namespace\" = :ns OR \"namespace\" LIKE :pat ESCAPE '\\\\'";
+        });
+        var sql = string.Join("\n UNION ALL\n", branches);
+
+        await using var connection = await _source.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        if (!string.IsNullOrEmpty(normalizedRoot))
+        {
+            SnowflakeConnectionSource.AddParam(cmd, "ns", normalizedRoot, DbType.String);
+            SnowflakeConnectionSource.AddParam(
+                cmd, "pat",
+                normalizedRoot.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_") + "/%",
+                DbType.String);
+        }
+
+        var paths = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var ns = reader.GetString(0);
+            var id = reader.GetString(1);
+            paths.Add(ComputePath(ns, id));
+        }
+
+        return paths;
+    }
+
     /// <inheritdoc />
     public IObservable<bool> Exists(string path)
         => _ioPool.Invoke(ct => ExistsAsyncCore(path, ct))

--- a/src/MeshWeaver.Hosting/Persistence/Http/PathRemappingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Http/PathRemappingStorageAdapter.cs
@@ -112,6 +112,10 @@ public sealed class PathRemappingStorageAdapter : IStorageAdapter
         => _inner.ListChildPaths(parentPath is null ? null : Remap(parentPath));
 
     /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => _inner.ListDescendantPaths(Remap(rootPath));
+
+    /// <inheritdoc />
     public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
         => _inner.GetPartitionObjects(Remap(nodePath), subPath, options);
 

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -154,6 +155,26 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
 
             return Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(
                 (nodePaths, directoryPaths));
+        });
+
+    /// <summary>
+    /// Native descendant enumeration: a direct prefix scan over the path-keyed
+    /// store — exact and race-free against the dictionary that IS the storage of
+    /// record. Declared on this class (not inherited from the base) for the same
+    /// interface-slot reason as <see cref="ResolvePath"/> below.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => Observable.Defer(() =>
+        {
+            var root = Norm(rootPath);
+            if (string.IsNullOrEmpty(root))
+                return Observable.Return<IReadOnlyCollection<string>>(
+                    _nodes.Keys.ToImmutableList());
+            var prefix = root + "/";
+            return Observable.Return<IReadOnlyCollection<string>>(
+                _nodes.Keys
+                    .Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    .ToImmutableList());
         });
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -193,6 +193,15 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
         => inner.ListChildPaths(parentPath);
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Explicit forward — the interface default would walk <c>this.ListChildPaths</c>
+    /// level by level and strip the backend's native prefix enumeration (the Postgres
+    /// satellite-UNION), the same trap <see cref="ResolvePath"/> documents.
+    /// </remarks>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
+    /// <inheritdoc />
     public IObservable<bool> Exists(string path) => inner.Exists(path);
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageHubExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageHubExtensions.cs
@@ -40,7 +40,8 @@ public static class PartitionStorageHubExtensions
             .WithHandler<DeleteBatchRequest>(HandleDeleteBatch)
             .WithHandler<ReadNodeRequest>(HandleReadNode)
             .WithHandler<ExistsRequest>(HandleExists)
-            .WithHandler<ListChildPathsRequest>(HandleListChildPaths);
+            .WithHandler<ListChildPathsRequest>(HandleListChildPaths)
+            .WithHandler<ListDescendantPathsRequest>(HandleListDescendantPaths);
     }
 
     // ── Handlers ─────────────────────────────────────────────────────────
@@ -112,6 +113,26 @@ public static class PartitionStorageHubExtensions
             .Subscribe(
                 exists => hub.Post(new ExistsResponse(exists), o => o.ResponseFor(request)),
                 _ => hub.Post(new ExistsResponse(false), o => o.ResponseFor(request)));
+
+        return request.Processed();
+    }
+
+    private static IMessageDelivery HandleListDescendantPaths(
+        IMessageHub hub, IMessageDelivery<ListDescendantPathsRequest> request)
+    {
+        var adapter = hub.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+        // Errors are FORWARDED (unlike ListChildPaths' empty fallback): the caller is
+        // the recursive-delete verifier, and an enumeration that failed must fail the
+        // delete loudly — an empty answer here would falsely verify a drained subtree.
+        adapter.ListDescendantPaths(request.Message.RootPath)
+            .Subscribe(
+                paths => hub.Post(
+                    new ListDescendantPathsResponse(paths.ToImmutableList()),
+                    o => o.ResponseFor(request)),
+                ex => hub.Post(
+                    new ListDescendantPathsResponse(ImmutableList<string>.Empty, Error: ex.Message),
+                    o => o.ResponseFor(request)));
 
         return request.Processed();
     }

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageMessages.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageMessages.cs
@@ -58,3 +58,18 @@ public record ListChildPathsRequest(string? ParentPath)
 public record ListChildPathsResponse(
     ImmutableList<string> NodePaths,
     ImmutableList<string> DirectoryPaths);
+
+/// <summary>
+/// Enumerates every strict descendant node path under a root inside this
+/// partition — the routed twin of <see cref="Mesh.Services.IStorageAdapter.ListDescendantPaths"/>,
+/// so the partition hub answers with its adapter's NATIVE prefix enumeration
+/// (Postgres: one UNION across primary + satellite tables) instead of the
+/// caller degrading to a level-by-level <see cref="ListChildPathsRequest"/> walk.
+/// </summary>
+public record ListDescendantPathsRequest(string RootPath)
+    : IRequest<ListDescendantPathsResponse>;
+
+/// <summary>Result of a <see cref="ListDescendantPathsRequest"/>.</summary>
+public record ListDescendantPathsResponse(
+    ImmutableList<string> Paths,
+    string? Error = null);

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
@@ -184,6 +184,29 @@ public sealed class RoutingProxyAdapter : IStorageAdapter
                     .Select(d => ((IEnumerable<string>)d.Message.NodePaths, (IEnumerable<string>)d.Message.DirectoryPaths)));
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Routed to the partition hub owning the root's partition (every strict
+    /// descendant shares the root's first segment) so the answer comes from the
+    /// backing adapter's NATIVE prefix enumeration — the interface default would
+    /// degrade into a level-by-level <see cref="ListChildPathsRequest"/> walk that
+    /// under-enumerates flat single-level backends. A reported error is re-thrown:
+    /// the caller is the recursive-delete verifier and must fail loudly rather
+    /// than treat an unenumerated subtree as drained.
+    /// </remarks>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => _router.AddressFor(rootPath).SelectMany(addr =>
+            addr is null
+                ? Observable.Return<IReadOnlyCollection<string>>(ImmutableList<string>.Empty)
+                : _callerHub
+                    .Observe<ListDescendantPathsResponse>(
+                        new ListDescendantPathsRequest(rootPath), o => o.WithTarget(addr))
+                    .Take(1)
+                    .SelectMany(d => d.Message.Error != null
+                        ? Observable.Throw<IReadOnlyCollection<string>>(
+                            new InvalidOperationException(d.Message.Error))
+                        : Observable.Return<IReadOnlyCollection<string>>(d.Message.Paths)));
+
     // ── Partition objects: not yet routed via hub messages. ─────────────
     //
     // The new partition-storage hub config does not yet carry partition-

--- a/src/MeshWeaver.Hosting/Persistence/PathFilteringStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PathFilteringStorageAdapter.cs
@@ -61,6 +61,14 @@ public sealed class PathFilteringStorageAdapter(IStorageAdapter inner, Func<stri
         => inner.ListChildPaths(parentPath);
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Forwarded unfiltered like <see cref="ListChildPaths"/> — the inner store only
+    /// ever holds paths the predicate accepted, so its enumeration is already scoped.
+    /// </remarks>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
+    /// <inheritdoc />
     public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
         string fullPath, JsonSerializerOptions options)
         => matches(fullPath)

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -89,16 +89,23 @@ public static class PersistenceExtensions
             return;
         }
 
-        // 🚨 MonotonicWriteGuard is the OUTERMOST decorator — a refused (backward) write must
-        // not produce a version-history snapshot either, so it has to sit ABOVE the
-        // version writer, not below it. See MonotonicWriteGuardStorageAdapter for why a
-        // regressing MeshNode.Version is never a legitimate newer state.
+        // 🚨 SubtreeDeletionGuard is the OUTERMOST decorator — a write refused because its
+        // subtree is being recursively deleted must produce NO side effect anywhere below
+        // (no monotonic high-water observation, no version-history snapshot). Below it,
+        // MonotonicWriteGuard sits ABOVE the version writer for the same reason: a refused
+        // (backward) write must not produce a version-history snapshot either. The deletion
+        // guard resolves RecentlyDeletedRegistry lazily (null on meshes without Graph →
+        // pass-through) — the SAME mesh-scoped instance the delete handler opens its
+        // BeginSubtreeDeletion scope on.
         services.AddSingleton<IStorageAdapter>(sp =>
-            new MonotonicWriteGuardStorageAdapter(
-                new VersionWritingStorageAdapter(
-                    sp.GetRequiredKeyedService<IStorageAdapter>(InnerStorageAdapterKey),
-                    sp.GetService<IVersionQuery>()),
-                sp.GetService<ILogger<MonotonicWriteGuardStorageAdapter>>()));
+            new SubtreeDeletionGuardStorageAdapter(
+                new MonotonicWriteGuardStorageAdapter(
+                    new VersionWritingStorageAdapter(
+                        sp.GetRequiredKeyedService<IStorageAdapter>(InnerStorageAdapterKey),
+                        sp.GetService<IVersionQuery>()),
+                    sp.GetService<ILogger<MonotonicWriteGuardStorageAdapter>>()),
+                sp.GetService<MeshWeaver.Mesh.Services.RecentlyDeletedRegistry>(),
+                sp.GetService<ILogger<SubtreeDeletionGuardStorageAdapter>>()));
 
         // Sentinel so repeat calls (Orleans default + host-explicit persistence)
         // see the prior decoration and bail above instead of stacking another

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
@@ -257,6 +257,28 @@ public sealed class PersistenceService : IStorageAdapter
                 })
             .Select(acc => ((IEnumerable<string>)acc.Nodes, (IEnumerable<string>)acc.Dirs));
 
+    /// <summary>
+    /// Authoritative subtree enumeration for the recursive-delete planner and its
+    /// post-delete verification: union of every WRITABLE provider's
+    /// <see cref="IStorageAdapter.ListDescendantPaths"/>. Writable-only is deliberate —
+    /// the set answers "what must a recursive delete remove / what survived it", and
+    /// read-only providers (Embedded, Static) can neither be deleted from nor leak
+    /// survivors. Errors propagate: an enumeration that fails must fail the delete
+    /// loudly instead of reporting a drained subtree it never actually saw.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => _writable
+            .Select(p => p.Adapter.ListDescendantPaths(rootPath))
+            .Merge()
+            .Aggregate(
+                seed: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                accumulator: (acc, paths) =>
+                {
+                    foreach (var path in paths ?? Array.Empty<string>()) acc.Add(path);
+                    return acc;
+                })
+            .Select(acc => (IReadOnlyCollection<string>)acc);
+
     /// <inheritdoc />
     public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
         => _allOrdered

--- a/src/MeshWeaver.Hosting/Persistence/SimpleMeshNodeStorage.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SimpleMeshNodeStorage.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.Hosting.Persistence;
 /// embedded-resource — whose only way to enumerate descendants is to walk
 /// the parent→children tree recursively. Subclasses provide the
 /// <see cref="IStorageAdapter"/> primitives against their backing store;
-/// the base layers the public <see cref="ListDescendantPaths"/> walk on top
+/// the base layers the public <see cref="WalkDescendantPaths"/> walk on top
 /// for the pedestrian query provider's use.
 ///
 /// <para>
@@ -21,7 +21,7 @@ namespace MeshWeaver.Hosting.Persistence;
 /// per-adapter query provider (<c>StorageAdapterMeshQueryProvider</c>) know
 /// nothing about it.
 /// Only a dedicated <see cref="IMeshQueryProvider"/> registered for
-/// pedestrian-backed partitions consumes <see cref="ListDescendantPaths"/>.
+/// pedestrian-backed partitions consumes <see cref="WalkDescendantPaths"/>.
 /// Postgres / Cosmos / blob backends don't extend this — they route queries
 /// through their own native push-down provider.
 /// </para>
@@ -70,7 +70,7 @@ public abstract class SimpleMeshNodeStorage : IStorageAdapter
     /// Subscribers do <see cref="IStorageAdapter.Read"/> per path when they actually need
     /// content. Cold observable; the walk fires on Subscribe.
     /// </summary>
-    public IObservable<string> ListDescendantPaths(string? parentPath)
+    public IObservable<string> WalkDescendantPaths(string? parentPath)
         => Observable.Defer(() => WalkPaths(parentPath));
 
     private IObservable<string> WalkPaths(string? parent)

--- a/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
@@ -1,0 +1,146 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Persistence;
+
+/// <summary>
+/// Outermost <see cref="IStorageAdapter"/> decorator that REFUSES a write whose path lies at
+/// or under a subtree whose recursive deletion is currently in flight.
+///
+/// <para><b>Why.</b> <c>HandleDeleteNodeRequest</c> builds its plan, deletes bottom-up, and
+/// verifies against storage — but a writer racing the delete (the NodeType compile watcher
+/// creating <c>Release</c> satellites seconds into the tear-down, issue #839) used to land
+/// rows under the half-deleted subtree between plan and commit. The
+/// <see cref="RecentlyDeletedRegistry"/> TTL tombstone only drops per-node-hub RESURRECTION
+/// saves; it never covered brand-new creations. This guard closes that hole as a hard
+/// invariant, not a timer: the delete handler opens a
+/// <see cref="RecentlyDeletedRegistry.BeginSubtreeDeletion"/> scope BEFORE enumerating its
+/// plan and releases it when the operation completes (success or failure), and while the
+/// scope is open every in-process write under the root is refused with an error the writer's
+/// error sink surfaces. Cross-process writers are caught by the delete handler's
+/// storage-verified drain loop instead.</para>
+///
+/// <para><b>Refusal is an OnError, deliberately.</b> Unlike
+/// <see cref="MonotonicWriteGuardStorageAdapter"/> (which returns the stored node because a
+/// durable "current truth" exists for the caller's contract), there is NO legitimate outcome
+/// for a write into a subtree being deleted — emitting the node as if saved would tell the
+/// creator "created" about a row that must not and will not exist. Callers' standard
+/// <c>.Subscribe(_ => …, ex => log)</c> shape surfaces the refusal; a create request fails
+/// with a clear message instead of silently minting a doomed node.</para>
+///
+/// <para>Pass-through when no <see cref="RecentlyDeletedRegistry"/> is registered (meshes
+/// without Graph) and O(active deletions) — i.e. effectively free — on the write hot path.</para>
+/// </summary>
+internal sealed class SubtreeDeletionGuardStorageAdapter(
+    IStorageAdapter inner,
+    RecentlyDeletedRegistry? registry,
+    ILogger<SubtreeDeletionGuardStorageAdapter>? logger = null) : IStorageAdapter
+{
+    /// <summary>
+    /// 🚨 Decorators MUST forward Changes — the interface default is
+    /// <c>Observable.Empty</c>, which silently starves every synced-query subscriber.
+    /// </summary>
+    public IObservable<DataChangeNotification> Changes => inner.Changes;
+
+    /// <inheritdoc />
+    public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+        => registry is null
+            ? inner.Write(node, options)
+            : Observable.Defer(() =>
+            {
+                if (registry.IsUnderActiveDeletion(node.Path, out var root))
+                {
+                    logger?.LogWarning(
+                        "[SubtreeDeletionGuard] REFUSED write to {Path}: the subtree '{Root}' is being "
+                        + "deleted. Nodes must not be created under a subtree while its recursive "
+                        + "deletion is in flight.",
+                        node.Path, root);
+                    return Observable.Throw<MeshNode?>(new InvalidOperationException(
+                        $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
+                }
+                return inner.Write(node, options);
+            });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+        IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+        => registry is null
+            ? inner.WriteMany(nodes, options)
+            : Observable.Defer(() =>
+            {
+                foreach (var node in nodes)
+                {
+                    if (registry.IsUnderActiveDeletion(node.Path, out var root))
+                    {
+                        logger?.LogWarning(
+                            "[SubtreeDeletionGuard] REFUSED batch write: {Path} lies under the subtree "
+                            + "'{Root}' whose deletion is in flight.",
+                            node.Path, root);
+                        return Observable.Throw<IReadOnlyList<MeshNode>>(new InvalidOperationException(
+                            $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
+                    }
+                }
+                return inner.WriteMany(nodes, options);
+            });
+
+    /// <inheritdoc />
+    public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+        => inner.Read(path, options);
+
+    /// <inheritdoc />
+    public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+        => inner.ReadMany(paths, options);
+
+    /// <inheritdoc />
+    public IObservable<string> Delete(string path) => inner.Delete(path);
+
+    /// <inheritdoc />
+    public IObservable<bool> DeleteIfExists(string path) => inner.DeleteIfExists(path);
+
+    /// <inheritdoc />
+    public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath)
+        => inner.ListChildPaths(parentPath);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
+    /// <inheritdoc />
+    public IObservable<bool> Exists(string path) => inner.Exists(path);
+
+    /// <inheritdoc />
+    public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
+        string fullPath, JsonSerializerOptions options)
+        => inner.FindBestPrefixMatch(fullPath, options);
+
+    /// <inheritdoc />
+    public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
+        string fullPath, JsonSerializerOptions options)
+        => inner.ResolvePath(fullPath, options);
+
+    /// <inheritdoc />
+    public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
+        => inner.ListPartitionSubPaths(nodePath);
+
+    /// <inheritdoc />
+    public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
+        => inner.GetPartitionObjects(nodePath, subPath, options);
+
+    /// <inheritdoc />
+    public IObservable<Unit> SavePartitionObjects(
+        string nodePath, string? subPath,
+        IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+        => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+    /// <inheritdoc />
+    public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+        => inner.DeletePartitionObjects(nodePath, subPath);
+
+    /// <inheritdoc />
+    public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+        => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+}

--- a/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
@@ -63,6 +63,14 @@ internal class VersionWritingStorageAdapter(
     public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath)
         => inner.ListChildPaths(parentPath);
 
+    /// <summary>
+    /// Explicit forward — the interface default would walk <c>this.ListChildPaths</c>
+    /// and strip the backend's native prefix enumeration (same reason as
+    /// <see cref="ResolvePath"/> below).
+    /// </summary>
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
     public IObservable<bool> Exists(string path) => inner.Exists(path);
 
     public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -242,6 +242,18 @@ public record DeleteNodeRequest(string Path) : IRequest<DeleteNodeResponse>
     /// UI can render a confirmation dialog. The second call — with this flag set — proceeds.
     /// </summary>
     public bool ConfirmWarnings { get; init; }
+
+    /// <summary>
+    /// Root of the recursive delete this request is a leaf of, set ONLY by the subtree fan-out.
+    /// Per-leaf validators use it the same way <see cref="ValidateDeleteRequest.RootPath"/> is
+    /// used in pre-flight: an invariant that is moot when the whole subtree is going away (e.g.
+    /// the space-admin "keep at least one admin" rule for an <c>_Access</c> grant whose space is
+    /// itself being deleted) exempts the leaf. Without this, the fan-out's per-leaf delete
+    /// re-enters the handler with no cascade context and the validator refuses the grant —
+    /// pre-flight (which carries the root) passes while the actual delete fails. Guard-rail,
+    /// not a security boundary: the leaf's own Delete permission check still applies.
+    /// </summary>
+    public string? CascadeRootPath { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/HierarchicalPathDeletion.cs
+++ b/src/MeshWeaver.Mesh.Contract/HierarchicalPathDeletion.cs
@@ -16,6 +16,18 @@ namespace MeshWeaver.Mesh;
 /// tree progress independently — a leaf at depth 5 doesn't have to wait for
 /// an unrelated leaf at the same depth to finish.</para>
 ///
+/// <para><b>Virtual (node-less) levels are traversed, not skipped.</b> A path
+/// set routinely contains descendants whose intermediate segments carry no
+/// node of their own — satellite dictionaries like <c>{path}/_Thread/{id}</c>,
+/// compile-watcher releases at <c>{nodeType}/Release/{version}</c>, source
+/// folders at <c>{space}/Source/{file}</c>. The traversal recurses through
+/// those virtual levels (grouping descendants by their next path segment) and
+/// invokes <c>deleteOne</c> ONLY for paths actually present in the
+/// set. The previous shape recursed only into paths present in the set, so an
+/// entire branch anchored under a node-less segment was silently never visited
+/// — the delete reported success while the branch survived in storage
+/// (issue #839).</para>
+///
 /// <para>Fail-fast semantics: when the per-node delegate fires
 /// <c>OnError</c> for some descendant, the per-subtree <c>Observable.Merge</c>
 /// propagates the error, sibling subtrees cancel, and the parent is **not**
@@ -35,15 +47,16 @@ public static class HierarchicalPathDeletion
     /// </summary>
     /// <param name="rootPath">The subtree root. Added to the path set if absent.</param>
     /// <param name="descendantPaths">
-    /// Strict descendants of <paramref name="rootPath"/> (i.e., results of a
-    /// <c>scope:descendants</c> query). The root itself MUST NOT be included
+    /// Strict descendants of <paramref name="rootPath"/> (i.e., results of an
+    /// authoritative storage enumeration). The root itself MUST NOT be included
     /// to avoid an infinite re-entry through the same delete request.
     /// </param>
     /// <param name="deleteOne">
     /// Per-node delete delegate. Returns <c>IObservable&lt;Unit&gt;</c> that
     /// emits once + <c>OnCompleted</c> on success, or <c>OnError</c> on
     /// failure. Called once per path in the set, only after all that path's
-    /// descendants have already completed.
+    /// descendants have already completed. Never called for virtual
+    /// (node-less) intermediate levels.
     /// </param>
     /// <returns>
     /// An observable emitting (once) the ordered list of paths that were
@@ -79,22 +92,38 @@ public static class HierarchicalPathDeletion
         ImmutableList<string>.Builder deleted)
     {
         var prefix = nodePath + "/";
-        var children = allPaths
-            .Where(p => p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                && p.IndexOf('/', prefix.Length) < 0)
+        // Every direct child LEVEL under nodePath that anchors at least one
+        // path in the set — whether or not the level itself is in the set.
+        // Grouping by the next path segment (rather than filtering the set for
+        // exact depth+1 members) is what carries the traversal across virtual
+        // node-less levels (`{path}/_Thread`, `{nodeType}/Release`, …) so the
+        // real descendants beneath them are still visited and deleted.
+        var childLevels = allPaths
+            .Where(p => p.Length > prefix.Length
+                && p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .Select(p =>
+            {
+                var next = p.IndexOf('/', prefix.Length);
+                return next < 0 ? p : p[..next];
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToImmutableList();
 
-        var childOps = children.Count == 0
+        var childOps = childLevels.Count == 0
             ? Observable.Return(string.Empty)
             : Observable
-                .Merge(children.Select(c =>
+                .Merge(childLevels.Select(c =>
                     DeleteSubtreeImpl(c, allPaths, deleteOne, deleted)))
                 .LastOrDefaultAsync();
 
-        return childOps.SelectMany(_ => deleteOne(nodePath)
-            .Do(deletedPath =>
-            {
-                lock (deleted) deleted.Add(deletedPath);
-            }));
+        return childOps.SelectMany(_ => allPaths.Contains(nodePath)
+            ? deleteOne(nodePath)
+                .Do(deletedPath =>
+                {
+                    lock (deleted) deleted.Add(deletedPath);
+                })
+            // Virtual level: no node lives here — nothing to delete, just
+            // propagate completion upward after the descendants are gone.
+            : Observable.Return(nodePath));
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -191,6 +191,15 @@ public record MeshBuilder
             })
             .AddSingleton(BuildHub)
             .AddSingleton<AccessService>()
+            // Mesh-ROOT "delete wins" tombstone + subtree-deletion scope. ONE instance,
+            // registered at the root deliberately: the delete handler resolves it off a
+            // hub ServiceProvider (which falls back to the root) while the
+            // SubtreeDeletionGuardStorageAdapter resolves it inside the persistence
+            // container — a hub-level registration (the previous home, in AddGraph)
+            // created a SECOND instance there, so the guard checked a registry no delete
+            // ever opened a scope on and silently passed every write under a subtree
+            // being deleted (#839's write-guard test caught it).
+            .AddSingleton<Services.RecentlyDeletedRegistry>()
             // Controlled I/O pools — mesh-scoped governor over the shared
             // ThreadPool for genuinely-async / sync-blocking leaves (file system,
             // blob, …). Resolved by leaf adapters via IoPoolRegistry; dies with

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1527,7 +1527,19 @@ public static class MeshExtensions
                                 lock (collectedMessages) collectedMessages.AddRange(warningMsgs);
 
                                 // 3. Collect descendant paths (paths only — no content).
-                                return CollectPathsForDelete(hub, path, capturedRequest.Recursive, opts.Timeout, logger)
+                                //    🚨 The subtree-deletion scope opens BEFORE the plan is
+                                //    enumerated: from here until the operation completes
+                                //    (success or failure — Observable.Using releases the
+                                //    scope on OnError / OnCompleted / unsubscribe alike),
+                                //    the storage write guard refuses every in-process write
+                                //    at or under `path`, so nothing can be created between
+                                //    planning and commit (issue #839's mid-flight Release
+                                //    satellites). Cross-process writers are covered by the
+                                //    storage-verified drain loop in DeleteSubtreeUntilDrained.
+                                return Observable.Using(
+                                    () => recentlyDeleted?.BeginSubtreeDeletion(path)
+                                          ?? System.Reactive.Disposables.Disposable.Empty,
+                                    _ => CollectPathsForDelete(hub, path, capturedRequest.Recursive, opts.Timeout, logger)
                                     .SelectMany(collected =>
                                     {
                                         if (!capturedRequest.Recursive && collected.HasUnlistedChildren)
@@ -1569,30 +1581,25 @@ public static class MeshExtensions
                                                 return Observable.Empty<System.Reactive.Unit>();
                                             }
 
-                                        // 4. Bottom-up fan-out. Descendants → per-node hubs (each
-                                        //    re-enters this handler with Recursive=false);
-                                        //    root → local storage delete (already validated above,
-                                        //    no need to re-enter via hub.Observe and avoid recursion).
+                                        // 4. Bottom-up fan-out with storage-verified drain.
+                                        //    Descendants → per-node hubs (each re-enters this
+                                        //    handler with Recursive=false); root → local storage
+                                        //    delete (already validated above). After each pass the
+                                        //    subtree is RE-ENUMERATED from storage; anything that
+                                        //    appeared mid-flight is deleted in a follow-up pass
+                                        //    (bounded), and success is only reported once the
+                                        //    enumeration comes back empty. The "delete wins"
+                                        //    tombstones are marked per pass inside
+                                        //    DeleteSubtreeUntilDrained, BEFORE any leaf hub is
+                                        //    activated (see the resurrect-race note there).
                                         logger.LogDebug(
                                             "[DeleteNode] committing path={Path} count={Count}",
                                             path, collected.ToDelete.Count);
 
-                                        // 🚨 "Delete wins" — tombstone every path BEFORE the fan-out.
-                                        // FanOutDeleteSubtree ACTIVATES each leaf's per-node hub to
-                                        // process its own delete, and that activation's save (the
-                                        // workspace sees the just-loaded node as an "add") is exactly
-                                        // what resurrects the row. Marking here — before any leaf hub
-                                        // is activated — guarantees the resurrecting save's guard
-                                        // already sees the tombstone. Marking only on success (after
-                                        // the delete) lost a check-before-mark race: the activation
-                                        // save checked ~14 ms before the mark and slipped through.
-                                        foreach (var dp in collected.ToDelete)
-                                            recentlyDeleted?.MarkDeleted(dp);
-                                        recentlyDeleted?.MarkDeleted(path);
-
-                                        return FanOutDeleteSubtree(
+                                        return DeleteSubtreeUntilDrained(
                                                 meshHub, storage, path, collected.ToDelete,
-                                                capturedRequest, request.AccessContext, logger, collectedMessages)
+                                                capturedRequest, request.AccessContext,
+                                                recentlyDeleted, logger, collectedMessages)
                                             .Timeout(opts.Timeout)
                                             // 5. Post-deletion side effects for the ROOT node — e.g.
                                             //    dropping the backing partition store when a
@@ -1655,7 +1662,7 @@ public static class MeshExtensions
                                             })
                                             .Select(_ => System.Reactive.Unit.Default);
                                         });
-                                    });
+                                    }));
                             });
                     });
             })
@@ -1713,18 +1720,31 @@ public static class MeshExtensions
     }
 
     /// <summary>
-    /// Phase 1 — enumerate the paths to delete. **Paths only** via the catalog
-    /// query with <c>select:path</c> projection — <see cref="MeshNode.Content"/>
-    /// is stale on a query row and must never be read (per
-    /// <c>Doc/Architecture/CqrsAndContentAccess.md</c>). Validators that need a
-    /// live node use <c>workspace.GetMeshNodeStream(path)</c> downstream.
+    /// Phase 1 — enumerate the paths to delete, AUTHORITATIVELY from storage via
+    /// <see cref="IStorageAdapter.ListDescendantPaths"/>. **Paths only** — no
+    /// content is loaded; validators that need a live node use
+    /// <c>workspace.GetMeshNodeStream(path)</c> downstream.
     ///
-    /// <para>Uses <c>scope:descendants</c> (strictly children-and-below — root
-    /// excluded) so the bottom-up fan-out in
-    /// <see cref="HierarchicalPathDeletion.DeleteSubtree"/>
-    /// terminates at the root rather than re-entering through it. The root
-    /// path is added to the returned set after the query so it is deleted
-    /// last (when it becomes a leaf).</para>
+    /// <para>🚨 The plan must NOT come from the catalog query (<c>IMeshService.Query</c>):
+    /// that index is eventually consistent — stale after writes per
+    /// <c>Doc/Architecture/CqrsAndContentAccess.md</c> — and planning off it let
+    /// dozens of live descendants survive a "successful" recursive delete
+    /// (issue #839: 32/~90 and 68 survivors on 2026-08-05/06). Storage enumeration
+    /// needs no RLS exemption either — it is infrastructure below the security
+    /// layer, and the handler already gated the operation on the caller's Delete
+    /// permission at the root (Phase 2); per-leaf checks fire at each descendant's
+    /// own hub via the recursive DeleteNodeRequest fan-out.</para>
+    ///
+    /// <para>The enumeration is strict descendants (root excluded) so the
+    /// bottom-up fan-out in <see cref="HierarchicalPathDeletion.DeleteSubtree"/>
+    /// terminates at the root rather than re-entering through it. The root path
+    /// is added to the returned set afterwards so it is deleted last (when it
+    /// becomes a leaf).</para>
+    ///
+    /// <para><c>HasUnlistedChildren</c> counts DIRECT children only (one extra
+    /// path segment) — the pre-existing non-recursive contract. Deeper satellite
+    /// descendants under node-less segments (<c>{path}/_Thread/{id}</c>) never
+    /// blocked a non-recursive delete and still don't.</para>
     /// </summary>
     private static IObservable<(bool RootExists, ImmutableHashSet<string> ToDelete, bool HasUnlistedChildren)>
         CollectPathsForDelete(
@@ -1734,50 +1754,27 @@ public static class MeshExtensions
             TimeSpan timeout,
             ILogger logger)
     {
-        var meshService = hub.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>();
+        var storage = hub.ServiceProvider.GetRequiredService<IStorageAdapter>();
         var empty = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
 
-        // 🚨 Descendant enumeration is INFRASTRUCTURE — the handler already gated
-        // the operation on the caller's Delete permission at the ROOT (Phase 2:
-        // CheckDeletePermissionForNode). Subtree enumeration is then just routing:
-        // "what paths am I about to delete?". User-level RLS filtering on this
-        // query would HIDE descendants the caller can't see, making non-recursive
-        // delete proceed (HasUnlistedChildren=false) and recursive delete miss
-        // entire branches from AffectedPaths. Run the query as System; per-leaf
-        // delete checks fire at each descendant's own hub via the recursive
-        // DeleteNodeRequest fan-out.
         if (!recursive)
         {
-            // Non-recursive: only delete the root if it has no children. The
-            // children-scope query with `select:path` projects each match to a
-            // dict — use `Query<object>` so the projected items survive
-            // the type filter (a `MeshNode` cast would drop every dict).
-            return meshService
-                .Query<object>(MeshQueryRequest.FromQuery(
-                    $"namespace:{path} scope:children select:path",
-                    MeshWeaver.Mesh.Security.WellKnownUsers.System))
+            // Non-recursive: only delete the root if it has no DIRECT children.
+            return storage.ListDescendantPaths(path)
                 .Take(1)
-                .Select(change => (RootExists: true, empty.Add(path), change.Items.Count > 0))
+                .Select(descendants => (
+                    RootExists: true,
+                    empty.Add(path),
+                    descendants.Any(d => IsDirectChildOf(d, path))))
                 .Timeout(timeout);
         }
 
-        // Recursive: enumerate strict descendants via `scope:descendants`.
-        // `select:path` projects each result to a dict (`{ "path": "..." }`),
-        // so Query<object> is required — `Query<MeshNode>` would
-        // silently drop every dict at the type filter. Root is added
-        // explicitly so it is deleted last (after its subtree).
-        return meshService
-            .Query<object>(MeshQueryRequest.FromQuery(
-                $"namespace:{path} scope:descendants select:path",
-                MeshWeaver.Mesh.Security.WellKnownUsers.System))
+        return storage.ListDescendantPaths(path)
             .Take(1)
-            .Select(change =>
+            .Select(descendants =>
             {
                 var set = empty
-                    .Union(change.Items
-                        .OfType<IDictionary<string, object?>>()
-                        .Select(d => d.TryGetValue("path", out var v) ? v as string : null)
-                        .Where(p => !string.IsNullOrEmpty(p))!)
+                    .Union(descendants.Where(p => !string.IsNullOrEmpty(p)))
                     .Add(path);
                 logger.LogDebug("[DeleteNode] collected path={Path} total={Count}", path, set.Count);
                 return (RootExists: true, set, false);
@@ -1786,12 +1783,137 @@ public static class MeshExtensions
     }
 
     /// <summary>
+    /// True when <paramref name="candidate"/> is exactly one path segment below
+    /// <paramref name="parent"/> (i.e. a direct child, not a deeper descendant).
+    /// </summary>
+    private static bool IsDirectChildOf(string candidate, string parent)
+        => candidate.Length > parent.Length + 1
+           && candidate[parent.Length] == '/'
+           && candidate.StartsWith(parent, StringComparison.OrdinalIgnoreCase)
+           && candidate.IndexOf('/', parent.Length + 1) < 0;
+
+    /// <summary>
+    /// Upper bound on enumerate → delete passes in <see cref="DeleteSubtreeUntilDrained"/>.
+    /// Each pass beyond the first only runs when the post-pass storage enumeration found
+    /// survivors (mid-flight creations from another process); a subtree that cannot be
+    /// drained within this bound fails the operation LOUDLY instead of reporting success
+    /// over live descendants.
+    /// </summary>
+    private const int MaxDeleteDrainPasses = 5;
+
+    /// <summary>
+    /// Runs <see cref="FanOutDeleteSubtree"/> passes until storage VERIFIES the subtree is
+    /// empty. After each pass the subtree is re-enumerated authoritatively
+    /// (<see cref="IStorageAdapter.ListDescendantPaths"/>); survivors — nodes that appeared
+    /// mid-flight, e.g. compile-watcher <c>Release</c> satellites written from another
+    /// process — are tombstoned and deleted in a follow-up pass. Success is ONLY reported
+    /// once an enumeration comes back empty; exhausting <see cref="MaxDeleteDrainPasses"/>
+    /// with survivors still present fails the operation (issue #839: the previous shape
+    /// reported success off a point-in-time plan and never looked back at storage).
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> DeleteSubtreeUntilDrained(
+        IMessageHub meshHub,
+        IStorageAdapter storage,
+        string rootPath,
+        ImmutableHashSet<string> plannedPaths,
+        DeleteNodeRequest baseRequest,
+        AccessContext? callerAccessContext,
+        RecentlyDeletedRegistry? recentlyDeleted,
+        ILogger logger,
+        ImmutableList<LogMessage>.Builder collectedMessages)
+        => RunDeletePass(
+            meshHub, storage, rootPath, plannedPaths, baseRequest, callerAccessContext,
+            recentlyDeleted, logger, collectedMessages,
+            pass: 1, deletedSoFar: ImmutableList<string>.Empty);
+
+    private static IObservable<IReadOnlyList<string>> RunDeletePass(
+        IMessageHub meshHub,
+        IStorageAdapter storage,
+        string rootPath,
+        ImmutableHashSet<string> toDelete,
+        DeleteNodeRequest baseRequest,
+        AccessContext? callerAccessContext,
+        RecentlyDeletedRegistry? recentlyDeleted,
+        ILogger logger,
+        ImmutableList<LogMessage>.Builder collectedMessages,
+        int pass,
+        ImmutableList<string> deletedSoFar)
+    {
+        // 🚨 "Delete wins" — tombstone every path of THIS pass BEFORE the fan-out.
+        // FanOutDeleteSubtree ACTIVATES each leaf's per-node hub to process its own
+        // delete, and that activation's save (the workspace sees the just-loaded node
+        // as an "add") is exactly what resurrects the row. Marking here — before any
+        // leaf hub is activated — guarantees the resurrecting save's guard already
+        // sees the tombstone. Marking only on success (after the delete) lost a
+        // check-before-mark race: the activation save checked ~14 ms before the mark
+        // and slipped through.
+        foreach (var dp in toDelete)
+            recentlyDeleted?.MarkDeleted(dp);
+        recentlyDeleted?.MarkDeleted(rootPath);
+
+        return FanOutDeleteSubtree(
+                meshHub, storage, rootPath, toDelete, baseRequest, callerAccessContext,
+                logger, collectedMessages, rootAlreadyDeleted: pass > 1)
+            .Catch<IReadOnlyList<string>, Exception>(ex =>
+            {
+                // Fold this pass's partial deletions into the accumulated total so
+                // the caller's failure response reports every path actually removed.
+                var passDeleted = ex.Data["DeletedPaths"] as IReadOnlyList<string>
+                    ?? Array.Empty<string>();
+                ex.Data["DeletedPaths"] = (IReadOnlyList<string>)deletedSoFar.AddRange(passDeleted);
+                return Observable.Throw<IReadOnlyList<string>>(ex);
+            })
+            .SelectMany(deletedPaths =>
+            {
+                var acc = deletedSoFar.AddRange(deletedPaths);
+
+                // VERIFY against storage — the plan was a point-in-time snapshot;
+                // only an empty re-enumeration proves the subtree is actually gone.
+                return storage.ListDescendantPaths(rootPath)
+                    .Take(1)
+                    .SelectMany(survivors =>
+                    {
+                        var survivorSet = survivors
+                            .Where(p => !string.IsNullOrEmpty(p))
+                            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
+                            .Remove(rootPath);
+                        if (survivorSet.IsEmpty)
+                            return Observable.Return((IReadOnlyList<string>)acc);
+
+                        if (pass >= MaxDeleteDrainPasses)
+                        {
+                            var ex = new InvalidOperationException(
+                                $"Recursive delete of '{rootPath}' could not drain the subtree after "
+                                + $"{pass} pass(es): {survivorSet.Count} descendant(s) still present "
+                                + $"(e.g. '{survivorSet.First()}'). A writer keeps re-creating nodes "
+                                + "under the subtree faster than they can be deleted.");
+                            ex.Data["DeletedPaths"] = (IReadOnlyList<string>)acc;
+                            return Observable.Throw<IReadOnlyList<string>>(ex);
+                        }
+
+                        logger.LogInformation(
+                            "[DeleteNode] drain pass {Pass} path={Path} survivors={Count} — "
+                            + "nodes appeared mid-flight; deleting them too",
+                            pass + 1, rootPath, survivorSet.Count);
+
+                        return RunDeletePass(
+                            meshHub, storage, rootPath, survivorSet, baseRequest,
+                            callerAccessContext, recentlyDeleted, logger, collectedMessages,
+                            pass + 1, acc);
+                    });
+            });
+    }
+
+    /// <summary>
     /// Bottom-up traversal of the path set via <see cref="HierarchicalPathDeletion"/>.
     /// <para>
     /// <b>Root path:</b> deleted via local <see cref="IStorageAdapter.Delete"/>
     /// — already validated by the calling handler before fan-out. This avoids
     /// self-recursion that would arise if we posted <see cref="DeleteNodeRequest"/>
-    /// at our own address (the same handler would re-enter).
+    /// at our own address (the same handler would re-enter). On drain passes
+    /// (<paramref name="rootAlreadyDeleted"/>) the root row is usually gone —
+    /// <see cref="IStorageAdapter.DeleteIfExists"/> makes the re-delete idempotent
+    /// while still removing (and publishing) a root that was re-created mid-flight.
     /// </para>
     /// <para>
     /// <b>Descendant paths:</b> posted as non-recursive <see cref="DeleteNodeRequest"/>
@@ -1812,7 +1934,8 @@ public static class MeshExtensions
         DeleteNodeRequest baseRequest,
         AccessContext? callerAccessContext,
         ILogger logger,
-        ImmutableList<LogMessage>.Builder collectedMessages)
+        ImmutableList<LogMessage>.Builder collectedMessages,
+        bool rootAlreadyDeleted = false)
     {
         return HierarchicalPathDeletion.DeleteSubtree(
             rootPath,
@@ -1832,6 +1955,19 @@ public static class MeshExtensions
                     // branch for THEIR own path, so each leaf publishes once.
                     logger.LogDebug("[DeleteNode] storage.Delete (root) {Path}", path);
                     var changeFeed = meshHub.ServiceProvider.GetService<IMeshChangeFeed>();
+
+                    if (rootAlreadyDeleted)
+                        // Drain pass: the root row was deleted in pass 1. DeleteIfExists
+                        // is the idempotent variant — a no-op when the row is gone, a
+                        // real delete + publish when something re-created it mid-flight.
+                        return storage.DeleteIfExists(path)
+                            .Do(removed =>
+                            {
+                                if (removed)
+                                    changeFeed?.Publish(MeshChangeEvent.Deleted(path));
+                            })
+                            .Select(_ => path);
+
                     return storage.DeleteAndPublish(path, changeFeed)
                         .Do(_ =>
                         {
@@ -2799,19 +2935,19 @@ public static class MeshExtensions
 
         // Move = Copy (with satellites + descendants) → reactive delete of every source path.
         // Delete only fires after Copy succeeds (SelectMany short-circuits on copy error).
+        // Source-subtree enumeration is AUTHORITATIVE from storage (ListDescendantPaths),
+        // never the eventually-consistent catalog query — the same stale-plan defect that
+        // left recursive-delete survivors (issue #839) would leave source rows behind here.
         meshService.CopyNode(sourcePath, targetPath, includeDescendants: true, includeSatellites: true)
             .SelectMany(copied =>
-                meshService.Query<object>(MeshQueryRequest.FromQuery(
-                        $"path:{sourcePath} scope:subtree select:path"))
+                storage.ListDescendantPaths(sourcePath)
                     .Take(1)
                     .Timeout(TimeSpan.FromSeconds(15))
-                    .SelectMany(change =>
+                    .SelectMany(descendants =>
                     {
-                        var paths = change.Items
-                            .OfType<IDictionary<string, object?>>()
-                            .Select(d => d.TryGetValue("path", out var v) ? v as string : null)
+                        var paths = descendants
                             .Where(p => !string.IsNullOrEmpty(p))
-                            .Select(p => p!)
+                            .Append(sourcePath)
                             .ToImmutableList();
 
                         if (paths.IsEmpty)

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2013,7 +2013,10 @@ public static class MeshExtensions
                 // whatever hub-self identity is ambient (`sync/<id>`).
                 logger.LogDebug("[DeleteNode] post leaf delete {Path}", path);
                 return meshHub.Observe(
-                        baseRequest with { Path = path, Recursive = false },
+                        // CascadeRootPath rides to the leaf's handler so per-leaf validators
+                        // exempt space-teardown invariants (last-admin) exactly like the
+                        // pre-flight ValidateDeleteRequest(p, rootPath) already does.
+                        baseRequest with { Path = path, Recursive = false, CascadeRootPath = rootPath },
                         o => callerAccessContext is null
                             ? o.WithTarget(new Address(path))
                             : o.WithTarget(new Address(path)).WithAccessContext(callerAccessContext))
@@ -2481,9 +2484,11 @@ public static class MeshExtensions
             Node = node,
             Request = request,
             AccessContext = accessService?.Context ?? accessService?.CircuitContext,
-            // This runner validates the ROOT node of the delete, so the cascade root is the
-            // request path itself.
-            DeleteCascadeRootPath = request.Path
+            // This runner validates the ROOT node of the delete. For a standalone delete the
+            // cascade root is the request path itself; a leaf delete issued by the subtree
+            // fan-out carries the ORIGINAL root so validators exempt space-teardown invariants
+            // (see DeleteNodeRequest.CascadeRootPath).
+            DeleteCascadeRootPath = request.CascadeRootPath ?? request.Path
         };
 
         var validators = hub.ServiceProvider.GetServices<INodeValidator>()

--- a/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Text.Json;
 
@@ -114,6 +115,54 @@ public interface IStorageAdapter
     /// </summary>
     /// <param name="parentPath">Parent path (empty/null for root level).</param>
     IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath);
+
+    /// <summary>
+    /// Enumerates every STRICT descendant node path under <paramref name="rootPath"/>
+    /// (the root itself is excluded), straight from storage — the AUTHORITATIVE
+    /// subtree enumeration the recursive-delete planner and its post-delete
+    /// verification are built on (issue #839: planning off the eventually-consistent
+    /// query catalog let stale/late rows survive a "successful" recursive delete).
+    /// Emits one complete snapshot and completes.
+    ///
+    /// <para>The default walks <see cref="ListChildPaths"/> level by level, recursing
+    /// into node paths AND directory paths — correct for backends whose child listing
+    /// surfaces intermediate directory levels (FileSystem, InMemory, Caching).
+    /// Backends whose listing is a flat single-level row scan (Postgres and friends)
+    /// MUST override with a native prefix enumeration across every table of the
+    /// partition, and decorators MUST forward to their inner adapter so the native
+    /// override survives the chain (same rule as <see cref="ResolvePath"/>).</para>
+    /// </summary>
+    IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => System.Reactive.Linq.Observable.Select(
+            WalkDescendantPaths(this, rootPath),
+            set => (IReadOnlyCollection<string>)set.ToImmutableList());
+
+    /// <summary>
+    /// Level-by-level descendant walk over <see cref="ListChildPaths"/>: node paths at
+    /// each level are collected, and BOTH node paths and directory paths are recursed
+    /// into (a node can have children of its own; a directory is a node-less
+    /// intermediate level that still anchors real descendants).
+    /// </summary>
+    private static IObservable<System.Collections.Immutable.ImmutableHashSet<string>> WalkDescendantPaths(
+        IStorageAdapter adapter, string parentPath)
+        => System.Reactive.Linq.Observable.SelectMany(
+            System.Reactive.Linq.Observable.Take(adapter.ListChildPaths(parentPath), 1),
+            level =>
+            {
+                var nodes = (level.NodePaths ?? Enumerable.Empty<string>())
+                    .Where(p => !string.IsNullOrEmpty(p))
+                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+                var recurseInto = nodes.Union(
+                    (level.DirectoryPaths ?? Enumerable.Empty<string>())
+                        .Where(p => !string.IsNullOrEmpty(p)));
+                if (recurseInto.Count == 0)
+                    return System.Reactive.Linq.Observable.Return(nodes);
+                return System.Reactive.Linq.Observable.Aggregate(
+                    System.Reactive.Linq.Observable.Merge(
+                        recurseInto.Select(child => WalkDescendantPaths(adapter, child))),
+                    nodes,
+                    (acc, sub) => acc.Union(sub));
+            });
 
     /// <summary>Existence check for a single node path.</summary>
     IObservable<bool> Exists(string path);

--- a/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
@@ -86,4 +86,94 @@ public sealed class RecentlyDeletedRegistry
         }
         return true;
     }
+
+    // ─── Active subtree deletions ────────────────────────────────────────────
+    //
+    // Unlike the TTL tombstones above (a backstop against the resurrect-save
+    // race), an ACTIVE subtree deletion is a hard invariant with an explicit
+    // lifetime: HandleDeleteNodeRequest opens a scope BEFORE it enumerates the
+    // deletion plan and closes it when the operation completes (success OR
+    // failure — the scope rides an Observable.Using, so error/timeout/unsubscribe
+    // all release it). While the scope is open, the storage write guard
+    // (SubtreeDeletionGuardStorageAdapter) refuses every write at or under the
+    // root — so a node created mid-delete (e.g. a compile-watcher Release
+    // satellite) cannot land under a subtree that is being torn down. No timer,
+    // no TTL: the invariant holds exactly as long as the delete is in flight.
+
+    private readonly ConcurrentDictionary<string, int> _activeSubtreeDeletions =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Marks <paramref name="rootPath"/>'s subtree as being deleted. Ref-counted, so two
+    /// concurrent deletes of the same root (double-click) each hold the scope independently.
+    /// Dispose the returned scope when the delete operation completes — success or failure.
+    /// </summary>
+    public IDisposable BeginSubtreeDeletion(string rootPath)
+    {
+        if (string.IsNullOrEmpty(rootPath))
+            return EmptyScope.Instance;
+        _activeSubtreeDeletions.AddOrUpdate(rootPath, 1, (_, count) => count + 1);
+        return new SubtreeDeletionScope(this, rootPath);
+    }
+
+    /// <summary>
+    /// True when <paramref name="path"/> equals — or lies under — a subtree root whose
+    /// deletion is currently in flight. <paramref name="deletionRoot"/> carries the matching
+    /// root for diagnostics. The active-set is empty outside delete operations, so the scan
+    /// is O(active deletes), i.e. effectively free on the write hot path.
+    /// </summary>
+    public bool IsUnderActiveDeletion(string? path, out string? deletionRoot)
+    {
+        deletionRoot = null;
+        if (string.IsNullOrEmpty(path) || _activeSubtreeDeletions.IsEmpty)
+            return false;
+        foreach (var kv in _activeSubtreeDeletions)
+        {
+            var root = kv.Key;
+            if (path.Length < root.Length
+                || !path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (path.Length == root.Length || path[root.Length] == '/')
+            {
+                deletionRoot = root;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void EndSubtreeDeletion(string rootPath)
+    {
+        while (true)
+        {
+            if (!_activeSubtreeDeletions.TryGetValue(rootPath, out var count))
+                return;
+            if (count <= 1)
+            {
+                if (_activeSubtreeDeletions.TryRemove(
+                        new KeyValuePair<string, int>(rootPath, count)))
+                    return;
+            }
+            else if (_activeSubtreeDeletions.TryUpdate(rootPath, count - 1, count))
+                return;
+        }
+    }
+
+    private sealed class SubtreeDeletionScope(RecentlyDeletedRegistry registry, string rootPath)
+        : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                registry.EndSubtreeDeletion(rootPath);
+        }
+    }
+
+    private sealed class EmptyScope : IDisposable
+    {
+        public static readonly EmptyScope Instance = new();
+        public void Dispose() { }
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/RecursiveDeleteAuthoritativeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RecursiveDeleteAuthoritativeTest.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repros for issue #839 — recursive delete reported success while leaving
+/// descendants alive in storage. Three mechanisms are pinned:
+/// <list type="number">
+/// <item><description><b>Stale / gap-blind plan.</b> The plan now comes from AUTHORITATIVE
+/// storage enumeration (<see cref="IStorageAdapter.ListDescendantPaths"/>), and
+/// <see cref="HierarchicalPathDeletion"/> traverses node-less intermediate levels
+/// (<c>{root}/nt/Release/{v}</c>, <c>{root}/sub/deep/…</c>) instead of silently skipping
+/// every branch anchored under them.</description></item>
+/// <item><description><b>Mid-flight creation from another process.</b> The commit is followed
+/// by a storage-verified drain loop: after each pass the subtree is re-enumerated and
+/// survivors are deleted too; success is only reported once the enumeration is empty.</description></item>
+/// <item><description><b>Mid-flight creation in-process.</b> While the delete is in flight
+/// the outermost storage decorator (<c>SubtreeDeletionGuardStorageAdapter</c>) refuses every
+/// write under the subtree — a hard invariant scoped to the operation, not a timer.</description></item>
+/// </list>
+/// All post-delete assertions go against STORAGE (adapter reads / descendant enumeration),
+/// never the eventually-consistent query catalog.
+/// </summary>
+public class RecursiveDeleteAuthoritativeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IMessageHub Client => _client ??= GetClient();
+    private IMessageHub? _client;
+
+    /// <summary>The decorated storage chain (deletion guard outermost) — what the mesh writes through.</summary>
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    private async Task<DeleteNodeResponse> Delete(DeleteNodeRequest req)
+        => (await Client.Observe(req, o => o.WithTarget(Mesh.Address))
+            .Should().Within(60.Seconds()).Emit()).Message;
+
+    // ─── 1. Authoritative plan + gap traversal ────────────────────────────────
+
+    [Fact(Timeout = 30_000)]
+    public async Task RecursiveDelete_DescendantsBehindNodelessSegments_AreDeleted_AndStorageVerifiedEmpty()
+    {
+        var root = $"{TestPartition}/authdel1";
+        await NodeFactory.CreateNode(new MeshNode("authdel1", TestPartition)
+        { Name = "Root", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("nt", root)
+        { Name = "NT", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        // Satellite-shaped rows behind NODE-LESS intermediate segments, written the way
+        // satellite writers produce them (straight through storage): no node exists at
+        // {root}/nt/Release or {root}/sub/deep. The old catalog-driven plan + set-connected
+        // traversal skipped exactly these — they survived a "successful" recursive delete.
+        var options = Client.JsonSerializerOptions;
+        await Storage.Write(new MeshNode("1", $"{root}/nt/Release")
+        { Name = "Release 1", NodeType = "Markdown" }, options).Should().Within(30.Seconds()).Emit();
+        await Storage.Write(new MeshNode("leaf", $"{root}/sub/deep")
+        { Name = "Deep leaf", NodeType = "Markdown" }, options).Should().Within(30.Seconds()).Emit();
+
+        var response = await Delete(new DeleteNodeRequest(root) { Recursive = true });
+
+        response.Success.Should().BeTrue($"expected OK, got: {response.Error}");
+        response.Log!.AffectedPaths.Should().Contain($"{root}/nt/Release/1");
+        response.Log.AffectedPaths.Should().Contain($"{root}/sub/deep/leaf");
+
+        // AUTHORITATIVE verification — zero descendants in storage, not "query says gone".
+        var survivors = await Storage.ListDescendantPaths(root).Should().Within(30.Seconds()).Emit();
+        survivors.Should().BeEmpty(
+            $"recursive delete must drain the subtree; still present: {string.Join(", ", survivors)}");
+        (await Storage.Read(root, options).Should().Within(30.Seconds()).Emit()).Should().BeNull();
+        (await Storage.Read($"{root}/nt/Release/1", options).Should().Within(30.Seconds()).Emit()).Should().BeNull();
+        (await Storage.Read($"{root}/sub/deep/leaf", options).Should().Within(30.Seconds()).Emit()).Should().BeNull();
+    }
+
+    // ─── 2. Mid-flight creation bypassing the in-process guard → drain loop ───
+
+    [Fact(Timeout = 30_000)]
+    public async Task RecursiveDelete_NodeCreatedMidFlightBypassingGuard_IsDrainedBeforeSuccess()
+    {
+        var root = $"{TestPartition}/authdel2";
+        await NodeFactory.CreateNode(new MeshNode("authdel2", TestPartition)
+        { Name = "Root", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("c1", root)
+        { Name = "C1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("c2", root)
+        { Name = "C2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        // Simulate a CROSS-PROCESS writer (a second silo sharing the store): the first
+        // Deleted commit under the root triggers a write through the UNDECORATED inner
+        // adapter — bypassing the in-process SubtreeDeletionGuard exactly like another
+        // process would. Only the storage-verified drain loop can catch this one.
+        var inner = Mesh.ServiceProvider.GetRequiredKeyedService<IStorageAdapter>("inner");
+        var options = Client.JsonSerializerOptions;
+        var midflight = $"{root}/midflight";
+        var wrote = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hook = Storage.Changes
+            .Where(c => c.Kind == DataChangeKind.Deleted
+                && c.Path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            .Take(1)
+            .SelectMany(_ => inner.Write(new MeshNode("midflight", root)
+            { Name = "Mid-flight", NodeType = "Markdown" }, options))
+            .Subscribe(
+                node => wrote.TrySetResult(node!.Path),
+                ex => wrote.TrySetException(ex));
+
+        var response = await Delete(new DeleteNodeRequest(root) { Recursive = true });
+
+        response.Success.Should().BeTrue($"expected OK, got: {response.Error}");
+        // The racing write really landed mid-delete (synchronously inside the first
+        // Deleted commit — strictly before the first pass completed).
+        (await wrote.Task).Should().Be(midflight);
+        // The drain pass found it in the post-pass re-enumeration and deleted it too.
+        response.Log!.AffectedPaths.Should().Contain(midflight);
+
+        var survivors = await Storage.ListDescendantPaths(root).Should().Within(30.Seconds()).Emit();
+        survivors.Should().BeEmpty(
+            $"a node created mid-delete must not survive; still present: {string.Join(", ", survivors)}");
+        (await Storage.Read(midflight, options).Should().Within(30.Seconds()).Emit()).Should().BeNull();
+    }
+
+    // ─── 3. Mid-flight creation in-process → refused by the deletion guard ────
+
+    [Fact(Timeout = 30_000)]
+    public async Task Write_UnderSubtreeBeingDeleted_IsRefused_AndNodeDoesNotSurvive()
+    {
+        var root = $"{TestPartition}/authdel3";
+        await NodeFactory.CreateNode(new MeshNode("authdel3", TestPartition)
+        { Name = "Root", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("c1", root)
+        { Name = "C1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        // In-process mid-flight creation goes through the DECORATED chain — the
+        // SubtreeDeletionGuard must refuse it while the delete scope is open.
+        var options = Client.JsonSerializerOptions;
+        var refusal = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hook = Storage.Changes
+            .Where(c => c.Kind == DataChangeKind.Deleted
+                && c.Path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            .Take(1)
+            .SelectMany(_ => Storage.Write(new MeshNode("blocked", root)
+            { Name = "Blocked", NodeType = "Markdown" }, options))
+            .Subscribe(
+                node => refusal.TrySetException(new InvalidOperationException(
+                    $"write unexpectedly succeeded for '{node!.Path}' while its subtree was being deleted")),
+                ex => refusal.TrySetResult(ex));
+
+        var response = await Delete(new DeleteNodeRequest(root) { Recursive = true });
+        response.Success.Should().BeTrue($"expected OK, got: {response.Error}");
+
+        var ex = await refusal.Task;
+        ex.Message.Should().Contain("currently being deleted");
+
+        (await Storage.Read($"{root}/blocked", options).Should().Within(30.Seconds()).Emit()).Should().BeNull();
+        var survivors = await Storage.ListDescendantPaths(root).Should().Within(30.Seconds()).Emit();
+        survivors.Should().BeEmpty(
+            $"the refused write must leave nothing behind; still present: {string.Join(", ", survivors)}");
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ListDescendantPathsTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ListDescendantPathsTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Tests for <see cref="PostgreSqlStorageAdapter.ListDescendantPaths"/> — the native
+/// authoritative subtree enumeration the recursive-delete planner and its post-delete
+/// verification run on (issue #839). One UNION round-trip must return every strict
+/// descendant across the primary <c>mesh_nodes</c> table AND every satellite table,
+/// including rows behind node-less intermediate segments, with LIKE wildcards in the
+/// root escaped so <c>_</c>-bearing roots never leak sibling subtrees into a deletion plan.
+/// </summary>
+[Collection("PostgreSql")]
+public class ListDescendantPathsTests : IAsyncLifetime
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly JsonSerializerOptions _options = new();
+    private Npgsql.NpgsqlDataSource _schemaDs = null!;
+    private PostgreSqlStorageAdapter _adapter = null!;
+
+    private static readonly PartitionDefinition Partition = new()
+    {
+        Namespace = "DescOrg",
+        DataSource = "default",
+        Schema = "descendant_paths_test",
+        Versioned = true,
+        TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+        NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings(),
+    };
+
+    public ListDescendantPathsTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var (ds, adapter) = await _fixture.CreateSchemaAdapterAsync(
+            "descendant_paths_test", Partition, TestContext.Current.CancellationToken);
+        _schemaDs = ds;
+        _adapter = adapter;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _schemaDs?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Enumerates_Satellites_And_NodelessGaps_InOneCall()
+    {
+        await _adapter.Write(new MeshNode("a", "DescOrg/Space")
+        { Name = "A", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+        // Gap descendant: no node at DescOrg/Space/a/b.
+        await _adapter.Write(new MeshNode("c", "DescOrg/Space/a/b")
+        { Name = "C", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+        // Satellite descendant: routed to the `threads` table by the _Thread segment.
+        await _adapter.Write(new MeshNode("t1", "DescOrg/Space/a/_Thread")
+        { Name = "T1", NodeType = "Thread" }, _options).Should().Within(30.Seconds()).Emit();
+        // Outside the subtree — must not appear.
+        await _adapter.Write(new MeshNode("other", "DescOrg/Space")
+        { Name = "Other", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+
+        var descendants = await _adapter.ListDescendantPaths("DescOrg/Space/a")
+            .Should().Within(30.Seconds()).Emit();
+
+        descendants.Should().BeEquivalentTo(new[]
+        {
+            "DescOrg/Space/a/b/c",
+            "DescOrg/Space/a/_Thread/t1"
+        }, JsonSerializerOptions.Default);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Escapes_LikeWildcards_In_Root_So_Sibling_Subtrees_Never_Leak()
+    {
+        // `_` is a single-char LIKE wildcard: an unescaped prefix pattern for the root
+        // 'DescOrg/W_X' would also match 'DescOrg/WaX/…' — pulling a SIBLING subtree
+        // into a deletion plan.
+        await _adapter.Write(new MeshNode("n1", "DescOrg/W_X")
+        { Name = "N1", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+        await _adapter.Write(new MeshNode("n2", "DescOrg/WaX")
+        { Name = "N2", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+
+        var descendants = await _adapter.ListDescendantPaths("DescOrg/W_X")
+            .Should().Within(30.Seconds()).Emit();
+
+        descendants.Should().BeEquivalentTo(new[] { "DescOrg/W_X/n1" }, JsonSerializerOptions.Default);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Root_Itself_Is_Excluded()
+    {
+        await _adapter.Write(new MeshNode("root", "DescOrg/Solo")
+        { Name = "Root", NodeType = "Markdown" }, _options).Should().Within(30.Seconds()).Emit();
+
+        var descendants = await _adapter.ListDescendantPaths("DescOrg/Solo/root")
+            .Should().Within(30.Seconds()).Emit();
+
+        descendants.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/HierarchicalPathDeletionTests.cs
+++ b/test/MeshWeaver.Hosting.Test/HierarchicalPathDeletionTests.cs
@@ -273,4 +273,42 @@ public class HierarchicalPathDeletionTests
         deleted.Should().Equal("a/b", "a");
         fake.Started.Count(p => p == "a/b").Should().Be(1);
     }
+
+    // ─── Virtual (node-less) intermediate levels — issue #839 ────────────────
+
+    [Fact]
+    public async Task Descendants_behind_nodeless_intermediate_levels_are_deleted()
+    {
+        // The set contains 'a/x/y/z' but NO node at 'a/x' or 'a/x/y' — the shape every
+        // satellite dictionary produces ({path}/_Thread/{id}, {nodeType}/Release/{v}).
+        // The old set-connected recursion never visited the branch: 'a/x/y/z' was
+        // counted in the plan, silently skipped, and survived a "successful" delete.
+        var fake = new FakeDeleter();
+        var deleted = await HierarchicalPathDeletion
+            .DeleteSubtree("a", new[] { "a/x/y/z", "a/b" }, fake.Delete)
+            .Should().Emit();
+
+        deleted.Should().HaveCount(3);
+        deleted.Should().Contain("a/x/y/z");
+        deleted.Should().Contain("a/b");
+        deleted.Last().Should().Be("a", "root must be deleted last");
+        // Virtual levels carry no node — deleteOne must never fire for them.
+        fake.Started.Should().NotContain("a/x");
+        fake.Started.Should().NotContain("a/x/y");
+    }
+
+    [Fact]
+    public async Task Nodeless_level_descendant_deleted_before_its_ancestor_node()
+    {
+        // Node at 'a/nt' AND a release satellite at 'a/nt/Release/1' with no node at
+        // 'a/nt/Release': bottom-up order must still hold across the virtual level —
+        // the satellite goes first, then 'a/nt', then the root.
+        var fake = new FakeDeleter();
+        var deleted = await HierarchicalPathDeletion
+            .DeleteSubtree("a", new[] { "a/nt", "a/nt/Release/1" }, fake.Delete)
+            .Should().Emit();
+
+        deleted.Should().Equal("a/nt/Release/1", "a/nt", "a");
+        fake.Started.Should().NotContain("a/nt/Release");
+    }
 }

--- a/test/MeshWeaver.Hosting.Test/RecentlyDeletedRegistrySubtreeScopeTests.cs
+++ b/test/MeshWeaver.Hosting.Test/RecentlyDeletedRegistrySubtreeScopeTests.cs
@@ -1,0 +1,71 @@
+using System;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Unit tests for the active-subtree-deletion scope on
+/// <see cref="RecentlyDeletedRegistry"/> — the hard invariant (no timer) the
+/// storage write guard enforces while a recursive delete is in flight
+/// (issue #839: mid-flight creations under a subtree being deleted).
+/// </summary>
+public class RecentlyDeletedRegistrySubtreeScopeTests
+{
+    [Fact]
+    public void Scope_covers_root_and_descendants_only()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        using var scope = registry.BeginSubtreeDeletion("a/b");
+
+        registry.IsUnderActiveDeletion("a/b", out var root1).Should().BeTrue();
+        root1.Should().Be("a/b");
+        registry.IsUnderActiveDeletion("a/b/c", out _).Should().BeTrue();
+        registry.IsUnderActiveDeletion("a/b/c/d", out _).Should().BeTrue();
+
+        // Ancestors and prefix-sharing SIBLINGS are outside the scope — the boundary
+        // is the path separator, never a raw string prefix.
+        registry.IsUnderActiveDeletion("a", out _).Should().BeFalse();
+        registry.IsUnderActiveDeletion("a/bc", out _).Should().BeFalse();
+        registry.IsUnderActiveDeletion("a/bc/d", out _).Should().BeFalse();
+        registry.IsUnderActiveDeletion("unrelated", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispose_releases_the_scope()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        var scope = registry.BeginSubtreeDeletion("x/y");
+        registry.IsUnderActiveDeletion("x/y/z", out _).Should().BeTrue();
+
+        scope.Dispose();
+        registry.IsUnderActiveDeletion("x/y/z", out _).Should().BeFalse();
+
+        // Idempotent — a second Dispose must not throw or corrupt the ref-count.
+        scope.Dispose();
+        registry.IsUnderActiveDeletion("x/y/z", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Concurrent_scopes_on_same_root_are_refcounted()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        var first = registry.BeginSubtreeDeletion("p");
+        var second = registry.BeginSubtreeDeletion("p");
+
+        first.Dispose();
+        registry.IsUnderActiveDeletion("p/q", out _).Should().BeTrue(
+            "the second concurrent delete still holds the scope");
+
+        second.Dispose();
+        registry.IsUnderActiveDeletion("p/q", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_root_is_a_noop_scope()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        using var scope = registry.BeginSubtreeDeletion("");
+        registry.IsUnderActiveDeletion("anything", out _).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #839 — `DeleteNodeRequest { Recursive = true }` reported success while leaving descendants alive (observed twice: 32 and 68 survivors on "successful" deletes, including `Release` satellites written seconds INTO the delete). **Three distinct mechanisms**, each pinned by a test:

1. **Stale plan source.** `CollectPathsForDelete` enumerated the subtree via the eventually-consistent catalog query — rows the index hadn't caught up on silently survived, and completion was never verified. The plan now derives from authoritative storage via new `IStorageAdapter.ListDescendantPaths`: native single-query overrides for PostgreSQL (one `UNION ALL` across `mesh_nodes` + every satellite table, with LIKE-wildcard escaping so `_` in mesh paths can never pull a *sibling* subtree into a deletion plan) and Snowflake; default level-walk for the rest; the routed partition-storage mode gets a `ListDescendantPathsRequest/Response` pair with errors forwarded. `HandleMoveNodeRequest`'s source-subtree enumeration had the same defect and now uses the same surface.
2. **Gap-blind traversal (previously unreported).** `HierarchicalPathDeletion` recursed only into children that were themselves members of the path set — a branch under a node-less level (`{nodeType}/Release/{version}`, `{path}/_Thread/{id}`, `{space}/Source/{file}`) was counted in the plan but **never visited**. Traversal now groups by next segment and recurses through virtual levels, invoking the delete only for real set members.
3. **Mid-flight creations.** Two complementary invariants (no timers): `RecentlyDeletedRegistry.BeginSubtreeDeletion` — a ref-counted scope opened before plan enumeration (`Observable.Using`, released on every exit path) enforced by the new outermost `SubtreeDeletionGuardStorageAdapter` that refuses in-process writes under an active deletion root with OnError; plus a **storage-verified drain loop** — after each bottom-up pass the subtree is re-enumerated from storage, survivors tombstoned and deleted in a follow-up pass, success reported ONLY when an enumeration returns empty (bound 5 passes; exhaustion fails loudly naming the survivors). Guard covers in-process writers; drain covers cross-process.

**Found during verification:** the write-guard test exposed that `RecentlyDeletedRegistry` existed as TWO instances — AddGraph registered it hub-level while the storage guard resolves it in the persistence container, so the guard checked a registry no delete ever opened a scope on and passed every write. It now registers once at the mesh root (`MeshBuilder.Register`); hub SPs fall back to the root, so all existing consumers share the instance. `SimpleMeshNodeStorage`'s uncalled streaming walk is renamed `WalkDescendantPaths` to clear the CS0108 collision.

## Verification

- `RecursiveDeleteAuthoritativeTest` 3/3 — node-less-gap shapes verified empty **against storage**; deterministic mid-flight creation drained before success; guarded write refused with nothing surviving (fails without the registry-root fix).
- `HierarchicalPathDeletionTests` + `RecentlyDeletedRegistrySubtreeScopeTests` 16/16; PG `ListDescendantPathsTests` 3/3 (satellite+gap enumeration, LIKE-escape containment, root exclusion); `DeleteNodeBehaviorTest` 10/10 (existing contract); NodeOperations `DeletionTests` 7/7.
- Re-verified after merging current main; `dotnet build -c Release -warnaserror` clean on every touched project.

Behavior note: an activation save fired during pre-validation is now refused and logged (`SAVE FAILED`) instead of silently re-persisting a row about to be deleted — expect that new warning line in delete-heavy logs.

No What's New entry: bug fix; the user-visible effect (recursive delete actually deletes) rides the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)