### PR TITLE
Space delete-cleanup wait sat below the delete operation's own 30s contract

### DIFF
--- a/test/MeshWeaver.NodeOperations.Test/SpaceMenuAndAccessTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/SpaceMenuAndAccessTest.cs
@@ -122,7 +122,12 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         typeNames.Should().Contain("Thread", "Thread should be creatable under Space");
         typeNames.Should().Contain("Agent", "Agent should be creatable under Space");
 
-        await NodeFactory.DeleteNode(spaceId).Should().Emit();
+        // The recursive delete fans out a DeleteNodeRequest per descendant (here: the creator
+        // _Access grant), each ACTIVATING that leaf's per-node hub — 5-45s cold start on a loaded
+        // CI shard (HandleDeleteNodeRequest). The operation's own ceiling is
+        // MeshOperationOptions.Timeout (30s); waiting only the 10s assertion default sat BELOW the
+        // operation's contract and was the shard-5 red on otherwise-green runs.
+        await NodeFactory.DeleteNode(spaceId).Should().Within(30.Seconds()).Emit();
     }
 
     [Fact(Timeout = 60000)]
@@ -153,6 +158,8 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         children.Should().Contain(c => c.NodeType == "Markdown" && c.Path == $"{spaceId}/Overview",
             "Overview markdown page should exist as child");
 
-        await NodeFactory.DeleteNode(spaceId).Should().Emit();
+        // Same wait-to-the-operation's-contract as above — this delete additionally fans out to
+        // the Overview child's hub, so two cold per-node activations sit inside the wait.
+        await NodeFactory.DeleteNode(spaceId).Should().Within(30.Seconds()).Emit();
     }
 }


### PR DESCRIPTION
## The flake, root-caused

`SpaceMenuAndAccessTest.Space_ChildrenAreQueryable` redded main's post-merge run (31160623759, shard 5) with two `DeleteNodeRequest` callbacks pending 10.3s at dispose — while the test's actual assertions had already passed.

The cleanup `NodeFactory.DeleteNode(spaceId)` is a recursive delete: it fans out a `DeleteNodeRequest` per descendant (the `Overview` child and the auto-minted creator `_Access` grant), and each fan-out **activates that leaf's per-node hub** — a cold start `HandleDeleteNodeRequest` itself documents as 5–45s on a loaded CI runner. The operation's own ceiling is `MeshOperationOptions.Timeout` = **30s**. The test waited only the assertion default of **10s** — an assertion budget below the operation's documented contract. On a saturated shard the delete completes normally a moment after the assertion gives up; locally (and in bulk) the suite runs 85/85 in 12s.

Fix: both cleanup waits in the class now wait to the operation's contract (`Within(30s)`), with the reasoning in a comment. This is not a widened bound to make a wedge pass — nothing wedges; the wait simply contradicted the operation's own defined ceiling (the callbacks were observed live at 10.3s, inside the 30s budget).

Test-only change — no What's New entry.

## Verification

- `MeshWeaver.NodeOperations.Test` 85/85 in bulk (Release, one process)
- Release `-warnaserror` build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)