### PR TITLE
GitSync: gate the auto-import on a green build instead of the push

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -343,6 +343,23 @@ public sealed class GitHubWebhookProcessor
             return Observable.Return(0);
         if (!string.Equals(GetString(run, "conclusion"), "success", StringComparison.OrdinalIgnoreCase))
             return Observable.Return(0);
+
+        // 🚨 The run must have been triggered BY A PUSH. `workflow_run` fires for far more than the
+        // repo's content CI: measured on the education hook, GitHub's own Copilot reviewer arrives as
+        // action=completed / conclusion=success with event="dynamic", and every `pull_request` run of
+        // the content workflow arrives green too. Those are green builds of code the default branch
+        // has not accepted; importing on one would publish a feature branch. The branch check below
+        // catches most of them, but only because a PR's head_branch is its source branch — filtering
+        // on the trigger states the actual requirement instead of relying on that coincidence.
+        var runEvent = GetString(run, "event") ?? "";
+        if (!string.Equals(runEvent, "push", StringComparison.OrdinalIgnoreCase))
+        {
+            logger?.LogDebug(
+                "workflow_run webhook: green '{Workflow}' run was triggered by '{Event}', not a push — "
+                + "not a publish signal.", GetString(run, "name"), runEvent);
+            return Observable.Return(0);
+        }
+
         if (!TryGetRepoUrl(payload, out var repoUrl))
             return Observable.Return(0);
 

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -24,15 +24,24 @@ namespace MeshWeaver.GitSync;
 /// synced. The write runs under the system identity (an infrastructure mirror update, the same
 /// identity model as the instance-sync pull and <c>StaticRepoImporter</c>).
 ///
-/// <para><c>push</c> events keep GitSync'd Spaces CURRENT without polling: every Space whose
-/// sync config targets the pushed repository + branch — and, when the config scopes a
-/// subdirectory, whose subdirectory the push actually touched — gets the same headless
-/// "Update to latest" the GUI button and the MCP <c>git_hub_sync</c> tool run
+/// <para><b><c>workflow_run</c> success keeps GitSync'd Spaces CURRENT without polling — and only
+/// ever with content CI accepted.</b> A green build of a repository's DEFAULT branch gives every
+/// Space whose sync config targets that repository + branch the same headless "Update to latest"
+/// the GUI button and the MCP <c>git_hub_sync</c> tool run
 /// (<see cref="GitHubActivityExtensions.UpdateToLatestFromGitHub"/>, <c>force: false</c> so
 /// two-way conflict resolution still protects server-side edits). The mesh writes run under
 /// the system identity; the GitHub pull authenticates as the sync config's CREATOR (their
-/// connected credential, or the GitHub App when they have none). Register the repo webhook
-/// with the <c>Pushes</c> event next to <c>Issues</c>/<c>Issue comments</c>.</para>
+/// connected credential, or the GitHub App when they have none).</para>
+///
+/// <para>🚨 <b>The import is gated on CI, so <c>push</c> imports nothing.</b> A push event arrives
+/// BEFORE the build it starts, so importing on push shipped content to live Spaces seconds ahead of
+/// the gate meant to vet it. Because a repo's own content CI is the only thing that knows whether a
+/// commit is installable, the green build — not the merge — is the publish signal. A repository with
+/// NO CI workflow therefore never auto-imports: give it one, or sync it by hand.</para>
+///
+/// <para>Register the repo webhook with <c>Workflow runs</c> (required — it is the trigger) and
+/// <c>Pushes</c> (optional; logged only, and the breadcrumb that tells you a repo's pushes are
+/// arriving while its green builds are not) next to <c>Issues</c>/<c>Issue comments</c>.</para>
 ///
 /// <para>Pull-request events are intentionally ignored: PR state is read LIVE (delegated) and
 /// never materialized, so there is no node to refresh. Reactive end-to-end — no
@@ -173,48 +182,57 @@ public sealed class GitHubWebhookProcessor
     }
 
     /// <summary>
-    /// Whether one sync source should update for <paramref name="push"/>: the branch must match,
-    /// the source must be allowed to import, and — when the source scopes a subdirectory and the
-    /// push's change set is known — the push must have touched that subdirectory.
-    /// </summary>
-    internal static bool ConfigMatchesPush(GitHubSyncConfig? cfg, PushEvent push)
-    {
-        if (cfg is null || cfg.Direction == SyncDirection.ExportOnly)
-            return false;
-        if (!string.Equals(cfg.Branch, push.Branch, StringComparison.OrdinalIgnoreCase))
-            return false;
-        if (push.ChangedPaths is null)
-            return true;
-        var sub = cfg.Subdirectory?.Trim('/') ?? "";
-        if (sub.Length == 0)
-            return push.ChangedPaths.Count > 0;
-        return push.ChangedPaths.Any(p =>
-            p.Equals(sub, StringComparison.OrdinalIgnoreCase)
-            || p.StartsWith(sub + "/", StringComparison.OrdinalIgnoreCase));
-    }
-
-    /// <summary>
-    /// A verified <c>push</c> → the same headless "Update to latest" for every matching sync
-    /// source. TRIGGERS the updates (each runs as its own activity, fire-and-forget with error
-    /// logging) and emits the number triggered — it does NOT await the imports, so the webhook
-    /// response returns within GitHub's delivery timeout.
+    /// A verified <c>push</c> → nothing. **The import is gated on CI**, so it is triggered by the
+    /// repository's GREEN build (<see cref="ProcessWorkflowRun"/>), not by the push that started it.
+    ///
+    /// <para>🚨 This used to import on every push, and that is precisely the hole it left: the push
+    /// event arrives BEFORE the build it triggers, so a red main reached production seconds ahead
+    /// of the gate meant to stop it (observed 2026-08-07 — a merge synced at 09:20:53, its CI failed
+    /// at 09:52). Content repos are GitSync'd straight into live Spaces, so "imported, then found
+    /// broken" is indistinguishable from shipping broken content to users.</para>
+    ///
+    /// <para>The push is still parsed and logged: it is the signal that a build is COMING, and the
+    /// log line is what makes "the merge landed but nothing synced" diagnosable — a repo whose
+    /// pushes are seen but whose green builds never arrive has no CI workflow, and will never
+    /// auto-import until it gets one.</para>
     /// </summary>
     private IObservable<int> ProcessPush(JsonElement payload)
     {
         if (!TryParsePush(payload, out var push) || !TryGetRepoUrl(payload, out var repoUrl))
             return Observable.Return(0);
 
-        return MatchingSyncTargets(repoUrl, push).Select(targets =>
+        logger?.LogInformation(
+            "GitHub push webhook ({Repo}@{Branch}) — no import: the sync is CI-gated and waits for a "
+            + "green build of this ref (workflow_run/success on the default branch).",
+            repoUrl, push.Branch);
+        return Observable.Return(0);
+    }
+
+    /// <summary>
+    /// A verified GREEN build of the default branch → the headless "Update to latest" for every sync
+    /// source that targets this repo + branch and is not already at this commit. TRIGGERS the updates
+    /// (each its own activity, fire-and-forget with error logging) and emits the number triggered — it
+    /// does NOT await the imports, so the webhook response returns within GitHub's delivery timeout.
+    ///
+    /// <para>Scoping differs from the old push path in one way that matters: a <c>workflow_run</c>
+    /// payload carries no file list, so a source's <c>Subdirectory</c> cannot be used to skip it.
+    /// Every source of the repo is brought to latest; an unchanged subdirectory imports as a no-op.
+    /// The <c>lastSyncCommitSha</c> check below is what keeps that cheap — it makes a re-run of an
+    /// already-imported commit (a flake re-run, a manual re-dispatch) trigger nothing at all.</para>
+    /// </summary>
+    private IObservable<int> TriggerSyncForGreenBuild(string repoUrl, string branch, string headSha)
+        => MatchingBuildTargets(repoUrl, branch, headSha).Select(targets =>
         {
             if (targets.Count == 0)
             {
                 logger?.LogInformation(
-                    "GitHub push webhook for {Repo}@{Branch} matched no synced Space.", repoUrl, push.Branch);
+                    "Green build of {Repo}@{Branch} ({Sha}) matched no sync source that needs updating.",
+                    repoUrl, branch, headSha);
                 return 0;
             }
             logger?.LogInformation(
-                "GitHub push webhook ({Repo}@{Branch}) → updating {Count} sync source(s) to latest.",
-                repoUrl, push.Branch, targets.Count);
+                "Green build of {Repo}@{Branch} ({Sha}) → updating {Count} sync source(s) to latest.",
+                repoUrl, branch, headSha, targets.Count);
             var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
             foreach (var t in targets)
                 Observable.Using(
@@ -223,24 +241,39 @@ public sealed class GitHubWebhookProcessor
                             t.SpacePath, t.UserId, sourceId: t.SourceId))
                     .Subscribe(
                         activity => logger?.LogInformation(
-                            "Push-triggered update of {Space} completed ({Activity}).", t.SpacePath, activity),
+                            "Build-triggered update of {Space} completed ({Activity}).", t.SpacePath, activity),
                         exception => logger?.LogWarning(exception,
-                            "Push-triggered update of {Space} (source {Source}) failed.",
+                            "Build-triggered update of {Space} (source {Source}) failed.",
                             t.SpacePath, t.SourceId ?? "(primary)"));
             return targets.Count;
         });
+
+    /// <summary>
+    /// Whether one sync source should import for a green build of <paramref name="branch"/> at
+    /// <paramref name="headSha"/>: the branch must match, the source must be allowed to import, and
+    /// the source must not already sit on that commit.
+    /// </summary>
+    internal static bool ConfigMatchesBuild(GitHubSyncConfig? cfg, string branch, string headSha)
+    {
+        if (cfg is null || cfg.Direction == SyncDirection.ExportOnly)
+            return false;
+        if (!string.Equals(cfg.Branch, branch, StringComparison.OrdinalIgnoreCase))
+            return false;
+        // Already imported this exact commit — a re-run of the same green build must be a no-op.
+        return !string.Equals(cfg.LastSyncCommitSha, headSha, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>The distinct sync sources whose config targets <paramref name="repoUrl"/> AND
-    /// matches the push's branch + touched paths.</summary>
-    private IObservable<IReadOnlyList<PushTarget>> MatchingSyncTargets(string repoUrl, PushEvent push)
+    /// matches the green build's branch, minus those already at <paramref name="headSha"/>.</summary>
+    private IObservable<IReadOnlyList<PushTarget>> MatchingBuildTargets(
+        string repoUrl, string branch, string headSha)
     {
         var target = ParseSafe(repoUrl);
         return QueryConfigNodesAsSystem()
             .Select(c => (IReadOnlyList<PushTarget>)c.Items
                 .Where(n => RepoMatches(n, target))
-                .Where(n => ConfigMatchesPush(
-                    n.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger), push))
+                .Where(n => ConfigMatchesBuild(
+                    n.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger), branch, headSha))
                 .Select(ToPushTarget)
                 .Where(t => t is not null)
                 .Select(t => t!)
@@ -373,16 +406,27 @@ public sealed class GitHubWebhookProcessor
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
                 _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
-            .Select(d =>
+            .SelectMany(d =>
             {
                 if (!d.Message.Success)
                 {
                     // Never throw: GitHub retries a non-2xx delivery, so a write failure would turn
                     // into a delivery storm. Surface it and report "nothing recorded".
                     logger?.LogWarning("Recording build completion at {Path} failed: {Error}", path, d.Message.Error);
-                    return 0;
+                    return Observable.Return(0);
                 }
-                return 1;
+                // The build record is the CI gate's verdict; the import is what the verdict authorises.
+                // Both hang off this one green-build event so they cannot disagree about what shipped.
+                return TriggerSyncForGreenBuild(repoUrl, completion.Branch, headSha)
+                    .Select(_ => 1)
+                    .Catch((Exception ex) =>
+                    {
+                        // A failed import must not fail the delivery — the build record is already
+                        // written, and a non-2xx would make GitHub redeliver and re-import.
+                        logger?.LogWarning(ex,
+                            "Green build of {Repo} recorded, but triggering the sync failed.", repoUrl);
+                        return Observable.Return(1);
+                    });
             });
     }
 

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -247,7 +247,7 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
               "repository": { "full_name": "test/push-auto", "default_branch": "main" },
               "workflow_run": { "conclusion": "failure", "head_branch": "main",
                                 "head_sha": "deadbeef", "id": 1, "run_number": 1,
-                                "name": "CI", "updated_at": "2026-08-07T10:00:00Z" } }
+                                "name": "CI", "event": "push", "updated_at": "2026-08-07T10:00:00Z" } }
             """).RootElement;
             Assert.Equal(0, await Webhooks.Process("workflow_run", redBuild).Timeout(60.Seconds()).ToTask());
 
@@ -257,7 +257,7 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
               "repository": { "full_name": "test/push-auto", "default_branch": "main" },
               "workflow_run": { "conclusion": "success", "head_branch": "main",
                                 "head_sha": "cafebabe", "id": 2, "run_number": 2,
-                                "name": "CI", "updated_at": "2026-08-07T10:05:00Z" } }
+                                "name": "CI", "event": "push", "updated_at": "2026-08-07T10:05:00Z" } }
             """).RootElement;
             recorded = await Webhooks.Process("workflow_run", greenBuild).Timeout(60.Seconds()).ToTask();
         }
@@ -275,19 +275,21 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
     }
 
     /// <summary>
-    /// 🚨 Only the DEFAULT branch's green builds become <c>BuildCompletion</c> records. A PR-branch
-    /// run is green UNMERGED code — recording it would make the plugin-update watcher offer (or,
-    /// for an opted-in record, unattended-install) content the default branch never accepted, at
-    /// that branch's sha. Fail-closed: a payload whose branch cannot be read records nothing either.
+    /// 🚨 Only the DEFAULT branch's PUSH-triggered green builds become <c>BuildCompletion</c> records
+    /// (and, since the import is CI-gated, only those import). A PR-branch run is green UNMERGED code
+    /// — recording it would make the plugin-update watcher offer (or, for an opted-in record,
+    /// unattended-install) content the default branch never accepted, at that branch's sha.
+    /// Fail-closed: a payload whose branch cannot be read records nothing either.
     /// </summary>
     [Fact(Timeout = 120000)]
-    public async Task Process_WorkflowRun_RecordsOnlyDefaultBranchGreenBuilds()
+    public async Task Process_WorkflowRun_RecordsOnlyDefaultBranchPushTriggeredGreenBuilds()
     {
-        static JsonElement Run(string branchJson) => JsonDocument.Parse($$"""
+        static JsonElement Run(string branchJson, string runEvent = "push", string name = "ci")
+            => JsonDocument.Parse($$"""
             { "action": "completed",
               "repository": { "full_name": "test/plugins-repo", "default_branch": "main" },
               "workflow_run": { "conclusion": "success", "head_sha": "abc1234def", {{branchJson}}
-                                "name": "ci", "id": 7, "run_number": 42,
+                                "name": "{{name}}", "id": 7, "run_number": 42, "event": "{{runEvent}}",
                                 "updated_at": "2026-08-05T12:00:00Z" } }
             """).RootElement;
 
@@ -298,7 +300,18 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
         Assert.Equal(0, await Webhooks.Process("workflow_run", Run(""))
             .Timeout(60.Seconds()).ToTask());
 
-        // The default branch's green run IS the publish signal — recorded at the stable path.
+        // 🚨 GitHub's Copilot reviewer completes green on the DEFAULT branch with event="dynamic"
+        // (observed on the education hook). It is not a build of the branch's content and must not
+        // publish anything — the trigger check is what rejects it.
+        Assert.Equal(0, await Webhooks.Process("workflow_run",
+                Run("\"head_branch\": \"main\",", runEvent: "dynamic", name: "Running Copilot Code Review"))
+            .Timeout(60.Seconds()).ToTask());
+        // A pull_request run of the CONTENT workflow can also report head_branch=main; still not a push.
+        Assert.Equal(0, await Webhooks.Process("workflow_run",
+                Run("\"head_branch\": \"main\",", runEvent: "pull_request"))
+            .Timeout(60.Seconds()).ToTask());
+
+        // The default branch's push-triggered green run IS the publish signal.
         Assert.Equal(1, await Webhooks.Process("workflow_run", Run("\"head_branch\": \"main\","))
             .Timeout(60.Seconds()).ToTask());
         var record = await WaitForNode("Admin/_Build/test.plugins-repo");

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -259,6 +259,11 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
                                 "head_sha": "cafebabe", "id": 2, "run_number": 2,
                                 "name": "CI", "event": "push", "updated_at": "2026-08-07T10:05:00Z" } }
             """).RootElement;
+            // 🚨 The return codes above say "nothing was TRIGGERED"; this says "nothing was
+            // IMPORTED". Without it, a regression that imports on push while still returning 0
+            // would sail through — the assertion below would find the node already there and pass.
+            Assert.Null(await ReadNode($"{b}/Welcome").Timeout(30.Seconds()).ToTask());
+
             recorded = await Webhooks.Process("workflow_run", greenBuild).Timeout(60.Seconds()).ToTask();
         }
         finally

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -167,38 +167,44 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
     }
 
     [Fact]
-    public void ConfigMatchesPush_BranchDirectionAndSubdirectory()
+    public void ConfigMatchesBuild_BranchDirectionAndAlreadySyncedSha()
     {
-        var main = new GitHubWebhookProcessor.PushEvent("main", ["Store/index.json", "README.md"]);
+        const string sha = "abc123def456";
         var cfg = new GitHubSyncConfig { RepositoryUrl = "https://github.com/o/r", Branch = "main" };
 
         // Branch must match; export-only sources never import.
-        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg, main));
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Branch = "develop" }, main));
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(
-            cfg with { Direction = SyncDirection.ExportOnly }, main));
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(null, main));
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesBuild(cfg, "main", sha));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(cfg, "develop", sha));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(cfg with { Branch = "develop" }, "main", sha));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(
+            cfg with { Direction = SyncDirection.ExportOnly }, "main", sha));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(null, "main", sha));
 
-        // A subdirectory-scoped source updates only when the push touched its subdirectory.
-        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Store" }, main));
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Chess" }, main));
-        // Prefix must be segment-aligned: "Store" must not match "StoreFront/…".
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(
-            cfg with { Subdirectory = "Store" },
-            new GitHubWebhookProcessor.PushEvent("main", ["StoreFront/index.json"])));
+        // 🚨 A source already sitting on this commit imports nothing — this is what makes a RE-RUN
+        // of an already-imported green build (a flake re-run, a manual re-dispatch) a no-op instead
+        // of a repeat import of every Space in the repo.
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(
+            cfg with { LastSyncCommitSha = sha }, "main", sha));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesBuild(
+            cfg with { LastSyncCommitSha = sha.ToUpperInvariant() }, "main", sha));
+        // A different commit is a real update.
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesBuild(
+            cfg with { LastSyncCommitSha = "0000000000" }, "main", sha));
 
-        // UNKNOWN change set (truncated push) → every candidate syncs rather than missing one.
-        var unknown = new GitHubWebhookProcessor.PushEvent("main", null);
-        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Chess" }, unknown));
-
-        // An empty change set (no-op push) syncs nothing.
-        var empty = new GitHubWebhookProcessor.PushEvent("main", []);
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg, empty));
-        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Store" }, empty));
+        // Subdirectory scoping does NOT apply: a workflow_run payload carries no file list, so every
+        // source of the repo is brought to latest and an untouched subdirectory imports as a no-op.
+        // Skipping here would strand a Space whose files changed in a commit we cannot inspect.
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesBuild(cfg with { Subdirectory = "Chess" }, "main", sha));
     }
 
+    /// <summary>
+    /// 🚨 The import is CI-GATED: a push imports NOTHING, and the repository's green build imports
+    /// every matching Space. Pinning both halves in one test is deliberate — the failure this guards
+    /// against is a push that quietly keeps importing, which is invisible unless the same fixture
+    /// proves the green build is what moved the content.
+    /// </summary>
     [Fact(Timeout = 120000)]
-    public async Task Process_PushEvent_TriggersUpdateToLatestOnMatchingSpaces()
+    public async Task Process_GreenBuild_TriggersUpdateToLatest_AndPushDoesNot()
     {
         await Connect();
         var repo = "https://github.com/test/push-auto";
@@ -223,32 +229,46 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
         accessService.ClearPersistentCircuitContext();
         accessService.SetCircuitContext(null);
         accessService.SetContext(null);
-        int triggered;
+        int recorded;
         try
         {
-            // A push on a DIFFERENT branch matches nothing.
-            var otherBranch = JsonDocument.Parse("""
-            { "ref": "refs/heads/develop", "size": 1,
-              "repository": { "full_name": "test/push-auto" },
-              "commits": [ { "added": ["Welcome.md"], "modified": [], "removed": [] } ] }
-            """).RootElement;
-            Assert.Equal(0, await Webhooks.Process("push", otherBranch).Timeout(60.Seconds()).ToTask());
-
-            // The main-branch push triggers the headless update for BOTH sync sources.
-            var payload = JsonDocument.Parse("""
+            // 🚨 A push imports NOTHING — not even on the right branch. The build it starts has not
+            // run yet, so importing here would ship content the gate has not vetted.
+            var pushPayload = JsonDocument.Parse("""
             { "ref": "refs/heads/main", "size": 1,
               "repository": { "full_name": "test/push-auto" },
               "commits": [ { "added": [], "modified": ["Welcome.md"], "removed": [] } ] }
             """).RootElement;
-            triggered = await Webhooks.Process("push", payload).Timeout(60.Seconds()).ToTask();
+            Assert.Equal(0, await Webhooks.Process("push", pushPayload).Timeout(60.Seconds()).ToTask());
+
+            // A RED build imports nothing either — that is the whole point of the gate.
+            var redBuild = JsonDocument.Parse("""
+            { "action": "completed",
+              "repository": { "full_name": "test/push-auto", "default_branch": "main" },
+              "workflow_run": { "conclusion": "failure", "head_branch": "main",
+                                "head_sha": "deadbeef", "id": 1, "run_number": 1,
+                                "name": "CI", "updated_at": "2026-08-07T10:00:00Z" } }
+            """).RootElement;
+            Assert.Equal(0, await Webhooks.Process("workflow_run", redBuild).Timeout(60.Seconds()).ToTask());
+
+            // The GREEN build of the default branch is what imports — for BOTH sync sources.
+            var greenBuild = JsonDocument.Parse("""
+            { "action": "completed",
+              "repository": { "full_name": "test/push-auto", "default_branch": "main" },
+              "workflow_run": { "conclusion": "success", "head_branch": "main",
+                                "head_sha": "cafebabe", "id": 2, "run_number": 2,
+                                "name": "CI", "updated_at": "2026-08-07T10:05:00Z" } }
+            """).RootElement;
+            recorded = await Webhooks.Process("workflow_run", greenBuild).Timeout(60.Seconds()).ToTask();
         }
         finally
         {
             accessService.SetCircuitContext(new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
         }
-        Assert.Equal(2, triggered);
+        Assert.Equal(1, recorded);   // the build completion was recorded
 
-        // The import runs as a background activity — observe the node landing in Space B.
+        // The import runs as a background activity — observe the node landing in Space B, which is
+        // the proof that the GREEN BUILD (and nothing before it) moved the content.
         var imported = await WaitForNode($"{b}/Welcome");
         Assert.Equal("Markdown", imported.NodeType);
         Assert.Contains("Pushed content.", MarkdownBody(imported));


### PR DESCRIPTION
## The hole

The `push` webhook imported straight into live Spaces — and a push event arrives **before** the build it triggers. So content reached production ahead of the gate meant to vet it.

Observed end-to-end today: an `education` merge synced to memex at **09:20:53**, seven seconds after the push, written by `system-security`. Its CI did not fail until **09:52**. Content repos are GitSync'd into live Spaces, so "imported, then found broken" is indistinguishable from shipping broken content to users.

## The change

The trigger moves onto the `workflow_run` handler, which already had the right predicates and was only writing a `BuildCompletion` record. Now the same green-build event both records the verdict and performs the import, so the two cannot disagree about what shipped.

The gate requires **all** of: `action == completed` and `conclusion == success` and `event == push` and `head_branch == repository.default_branch`.

That last pair matters more than it looks. `workflow_run` fires for far more than a repo's content CI — from this repo's own delivered payloads, GitHub's Copilot reviewer completes green with `event: "dynamic"`, and `pull_request` runs of the content workflow complete green too. Those are green results for code `main` never accepted. The branch check alone caught most of them only by coincidence (a PR's `head_branch` is its *source* branch), so the trigger check states the real requirement.

Two behavioural differences worth review attention:

- **No subdirectory scoping.** A `workflow_run` payload carries no file list, so a source's `Subdirectory` can't be used to skip it. Every source of the repo goes to latest; an untouched subdirectory imports as a no-op. Skipping on a payload we can't inspect would strand the Space whose files actually changed.
- **Already-synced commits are skipped** (`lastSyncCommitSha == head_sha`), which keeps the above cheap: a re-run of an already-imported green build — a flake re-run, a manual re-dispatch — now triggers nothing.

`push` is still parsed and logged. It's the breadcrumb that makes "the merge landed but nothing synced" diagnosable: a repo whose pushes arrive while its green builds never do has no CI workflow and won't auto-import until it gets one. `ConfigMatchesPush`/`MatchingSyncTargets` are deleted rather than left dead — their subdirectory semantics don't exist on this path.

## Tests

`MeshWeaver.GitSync.Test` 8/8 green.

- `ConfigMatchesBuild` — branch, direction, and the already-synced sha (case-insensitively), plus the deliberate *non*-scoping of `Subdirectory`.
- `Process_WorkflowRun_RecordsOnlyDefaultBranchPushTriggeredGreenBuilds` — now also rejects the dynamic Copilot run and a `pull_request` run, both reporting `head_branch=main`.
- `Process_GreenBuild_TriggersUpdateToLatest_AndPushDoesNot` — one fixture pinning all three halves: a push imports nothing, a **red** build imports nothing, and the green build lands the node in a second Space.

## Operational prerequisite before merging

This changes when production content moves, and an audit of all 42 `GitHubSyncConfig` nodes on memex found one blocker and one pre-existing outage:

1. **`Systemorph/education`'s `main` is red — 7 consecutive failed pushes, last green `ee439ca` on 2026-08-06T08:10Z.** Under this gate its **10 Spaces (every paid course)** would freeze at that commit. The failures are the disposable-mesh gate (Orleans starvation on the runner), not content. **Get education main green before this merges**, or accept the freeze knowingly.
2. **`MeshWeaver.Reinsurance` and `MeshWeaver.SocialMedia` have no webhook at all** — 15 Spaces are already stale today (verified: `X`/`YouTube` missed commit `846ecfb` from 2026-08-06 and sit 4 days behind). That outage is independent of this change and needs hooks with `push` + `workflow_run`.

Also worth knowing: sync latency moves from ~2–7s after push to CI completion — ~2–3 min for Plugins, ~6 min for Reinsurance, **28–45 min for education**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
