### PR TITLE
Gate /static behind the same access check as the canonical read path (#587)

### DIFF
--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -85,6 +85,14 @@ app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
     var filePath = string.Join('/', path[(slash + 1)..].Split('/').Select(Uri.UnescapeDataString));
     var content = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IContentService>();
     if (content is null) return Results.NotFound();
+    // 🚨 PUBLIC MOUNTS ONLY (issue #587). This sidecar resolves no identity at all — there is no
+    // UserContextMiddleware and no caller to attribute a read to — so it may serve exactly the
+    // collections that are declared both mounted on /static AND world-readable, i.e. the shipped
+    // icon/doc assets this endpoint exists for. Anything access-controlled (user content,
+    // attachments, per-Space collections) is not servable here and answers 404; it is reachable
+    // through the portal's gated /static endpoint instead.
+    var config = content.GetCollectionConfig(collection);
+    if (config is not { IsStatic: true, IsPublic: true }) return Results.NotFound();
     // HTTP-boundary await: the read leaf runs on the collection's IIoPool; the endpoint awaits
     // the replayed single emission only.
     var stream = await content.GetContent(collection, filePath).Take(1);

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -832,6 +832,16 @@ public static class MemexConfiguration
                             Name = "content",
                             IsEditable = true,
                             ExposeInChildren = true,
+                            // Mounted on /static: images, thumbnails and PDFs in this Space are
+                            // fetched as /static/{Space}/content/{file} (MeshNodeLayoutAreas'
+                            // image renderer, ContentLayoutArea's PDF viewer) and as
+                            // /static/storage/content/{Space}/{file} through the mesh-level store.
+                            // The mount does NOT make them public — every request is attributed to
+                            // the owning node and gated on Read (issue #587).
+                            IsStatic = true,
+                            // Never inherited from the Storage config section: user content is
+                            // access-controlled, full stop.
+                            IsPublic = false,
                             BasePath = basePath,
                             Settings = contentStorageConfig.Settings is { } src
                                 ? new Dictionary<string, string>(src) { ["BasePath"] = basePath }
@@ -841,8 +851,10 @@ public static class MemexConfiguration
                     }
 
                     // Map "attachments" to "storage" with per-node subdirectory
-                    // (needed by FutuRe and other samples that store datacube.csv, etc.)
-                    config = config.MapContentCollection("attachments", "storage", $"attachments/{nodePath}");
+                    // (needed by FutuRe and other samples that store datacube.csv, etc.).
+                    // isStatic: the file browser's download links are /static/{node}/attachments/…
+                    config = config.MapContentCollection(
+                        "attachments", "storage", $"attachments/{nodePath}", isStatic: true);
 
                     // Shared large static assets (e.g. the on-device Whisper models the native client
                     // downloads) live in a FileSystem content collection on the MeshWeaver space, backed
@@ -860,6 +872,9 @@ public static class MemexConfiguration
                             Address = config.Address,
                             IsEditable = true,
                             ExposeInChildren = true,
+                            // The native client downloads these over /static/MeshWeaver/static/… —
+                            // a real mount, still gated on Read of the MeshWeaver node.
+                            IsStatic = true,
                             Settings = new Dictionary<string, string> { ["BasePath"] = staticAssetsMount },
                         });
 

--- a/samples/Insurance/MeshWeaver.Insurance.Domain/InsuranceApplicationExtensions.cs
+++ b/samples/Insurance/MeshWeaver.Insurance.Domain/InsuranceApplicationExtensions.cs
@@ -39,7 +39,8 @@ public static class InsuranceApplicationExtensions
         /// </summary>
         public MessageHubConfiguration ConfigureInsuranceApplication()
             => configuration
-                .AddEmbeddedResourceContentCollection("Insurance", typeof(InsuranceApplicationExtensions).Assembly, "Content")
+                // isStatic: markdown-embedded resources render as /static/{address}/Insurance/{file}.
+                .AddEmbeddedResourceContentCollection("Insurance", typeof(InsuranceApplicationExtensions).Assembly, "Content", isStatic: true)
                 .WithTypes(typeof(ImportConfiguration), typeof(ExcelImportConfiguration), typeof(ReinsuranceAcceptance), typeof(ReinsuranceSection), typeof(ImportRequest), typeof(CollectionSource), typeof(GeocodingRequest), typeof(GeocodingResponse))
                 .WithServices(services => services.AddScoped<IAutocompleteProvider, PricingAutocompleteProvider>())
                 .AddData(data =>
@@ -108,7 +109,11 @@ public static class InsuranceApplicationExtensions
                     return globalConfig with
                     {
                         Name = localizedName,
-                        BasePath = fullPath
+                        BasePath = fullPath,
+                        // isStatic: submission files are downloaded / PDF-rendered through
+                        // /static/{pricing/company/year}/{Submissions@…}/{file}. Access-controlled —
+                        // gated on Read of the pricing node.
+                        IsStatic = true,
                     };
                 })
                 .AddData(data =>

--- a/samples/Northwind/MeshWeaver.Northwind.Application/NorthwindApplicationExtensions.cs
+++ b/samples/Northwind/MeshWeaver.Northwind.Application/NorthwindApplicationExtensions.cs
@@ -20,7 +20,10 @@ public static class NorthwindApplicationExtensions
 
         =>
             application
-                .AddEmbeddedResourceContentCollection("Northwind", typeof(NorthwindApplicationAttribute).Assembly, "Markdown")
+                // isStatic: the sample's markdown embeds resources that render as
+                // /static/{address}/Northwind/{file} (ContentCollectionsExtensions.AdaptResourceUrl).
+                // Access-controlled — gated on Read of the Northwind node, not public.
+                .AddEmbeddedResourceContentCollection("Northwind", typeof(NorthwindApplicationAttribute).Assembly, "Markdown", isStatic: true)
                 .AddNorthwindViewModels()
                 .AddNorthwindEmployees()
                 .AddNorthwindOrders()

--- a/samples/Todo/MeshWeaver.Todo/TodoApplicationExtensions.cs
+++ b/samples/Todo/MeshWeaver.Todo/TodoApplicationExtensions.cs
@@ -21,7 +21,8 @@ public static class TodoApplicationExtensions
     public static MessageHubConfiguration ConfigureTodoApplication(this MessageHubConfiguration configuration)
     {
         return configuration
-                .AddEmbeddedResourceContentCollection("Todo", typeof(TodoApplicationAttribute).Assembly, "Content")
+                // isStatic: markdown-embedded resources render as /static/{address}/Todo/{file}.
+                .AddEmbeddedResourceContentCollection("Todo", typeof(TodoApplicationAttribute).Assembly, "Content", isStatic: true)
                 .WithTypes(
                     typeof(TodoStatus)
                 )

--- a/src/MeshWeaver.ContentCollections/ContentCollectionConfig.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionConfig.cs
@@ -47,6 +47,29 @@ public record ContentCollectionConfig
     public bool IsStatic { get; set; }
 
     /// <summary>
+    /// 🚨 ACCESS CLASSIFICATION for the <c>/static</c> route. <c>true</c> declares the
+    /// collection's files WORLD-READABLE: served to any caller with no authentication, no
+    /// permission check, and shared-cacheable (<c>Cache-Control: public</c>) headers.
+    ///
+    /// <para>Default <c>false</c> = ACCESS-CONTROLLED: every file is attributed to the mesh node
+    /// that owns it and the caller must hold <see cref="MeshWeaver.Mesh.Security.Permission.Read"/>
+    /// on that node — the same decision <c>AccessControlPipeline</c> applies to the
+    /// <c>GetDataRequest</c> behind the ordinary <c>/content/{address}/{collection}/{file}</c>
+    /// read. Public exposure is therefore a DELIBERATE declaration, never the default (issue
+    /// #587: everything under a content collection — per-partition uploads, attachments, PDFs —
+    /// was world-readable to anyone with or guessing a URL).</para>
+    ///
+    /// <para>Set it only for asset classes that are public by construction — assets compiled into
+    /// the shipped assembly and needed before sign-in (<c>NodeTypeIcons</c>, <c>DocContent</c>).
+    /// Anything sourced from user storage MUST stay <c>false</c>.</para>
+    ///
+    /// <para>The <c>bool</c> type-default is <c>false</c>, which is also the safe value, so the
+    /// wire-default suppression noted on <see cref="IsEditable"/> can only ever drop a
+    /// <c>false</c> — a dropped value fails CLOSED.</para>
+    /// </summary>
+    public bool IsPublic { get; set; }
+
+    /// <summary>
     /// Whether this collection should be visible to child nodes in the hierarchy.
     /// When false, only the node that owns the collection can see it.
     /// <para>Default <c>false</c> for the same wire-default reason as <see cref="IsEditable"/>:

--- a/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
@@ -501,10 +501,24 @@ public static class ContentCollectionsExtensions
         /// <param name="collectionName">The name of the collection to register.</param>
         /// <param name="assembly">The assembly whose embedded resources back the collection.</param>
         /// <param name="relativePath">The resource path prefix (relative to the assembly's default namespace).</param>
+        /// <param name="isStatic">
+        /// MOUNTS the collection on the <c>/static</c> route — see
+        /// <see cref="ContentCollectionConfig.IsStatic"/>. Default <c>false</c>: not mounted, and
+        /// <c>/static</c> answers 404 for it.
+        /// </param>
+        /// <param name="isPublic">
+        /// Declares the mounted collection WORLD-READABLE — see
+        /// <see cref="ContentCollectionConfig.IsPublic"/>. Default <c>false</c> (access-controlled).
+        /// Pass <c>true</c> only for assets that are public by construction and needed before
+        /// sign-in (node-type icons, shipped documentation assets); being an embedded resource is
+        /// NOT on its own a reason — a plugin can embed private content.
+        /// </param>
         /// <returns>The configured message hub configuration.</returns>
         public MessageHubConfiguration AddEmbeddedResourceContentCollection(string collectionName,
             Assembly assembly,
-            string relativePath)
+            string relativePath,
+            bool isStatic = false,
+            bool isPublic = false)
             => configuration.WithServices(services =>
             {
                 var resourcePrefix = $"{assembly.GetName().Name}.{relativePath}";
@@ -522,6 +536,10 @@ public static class ContentCollectionsExtensions
                         SourceType = "EmbeddedResource",
                         // IsEditable defaults to false — embedded resources are read-only.
                         // ExposeInChildren defaults to false — backing store, hidden by design.
+                        // IsStatic defaults to false — /static serves only what is mounted.
+                        // IsPublic defaults to false — a mount is access-controlled unless declared.
+                        IsStatic = isStatic,
+                        IsPublic = isPublic,
                         Settings = new Dictionary<string, string>
                         {
                             ["AssemblyName"] = assembly.GetName().Name ?? "",
@@ -540,9 +558,18 @@ public static class ContentCollectionsExtensions
         /// </summary>
         /// <param name="collectionName">The name of the collection</param>
         /// <param name="pathFactory">Factory function to compute the path based on service provider</param>
+        /// <param name="isStatic">
+        /// MOUNTS the collection on the <c>/static</c> route — see
+        /// <see cref="ContentCollectionConfig.IsStatic"/>. Default <c>false</c>: not mounted, and
+        /// <c>/static</c> answers 404 for it. A mount is still access-controlled (the file is
+        /// attributed to its owning node) unless <see cref="ContentCollectionConfig.IsPublic"/> is
+        /// also declared — which this builder never does, because a file-system collection is
+        /// backed by writable user storage.
+        /// </param>
         /// <returns>The configured message hub configuration</returns>
         public MessageHubConfiguration AddFileSystemContentCollection(string collectionName,
-            Func<IServiceProvider, string> pathFactory)
+            Func<IServiceProvider, string> pathFactory,
+            bool isStatic = false)
             => configuration
                 .AddContentCollections()
                 .WithServices(services =>
@@ -565,6 +592,7 @@ public static class ContentCollectionsExtensions
                             // Filesystem collections registered via this builder
                             // are user-facing and meant to surface in children.
                             ExposeInChildren = true,
+                            IsStatic = isStatic,
                             Settings = new Dictionary<string, string> { ["BasePath"] = basePath }
                         };
 
@@ -639,10 +667,17 @@ public static class ContentCollectionsExtensions
         /// <param name="targetCollectionName">The name of the mapped collection (e.g., "avatars")</param>
         /// <param name="sourceCollectionName">The name of the registered source collection (e.g., "storage")</param>
         /// <param name="subdirectory">The subdirectory within storage (e.g., "persons" or dynamic path)</param>
+        /// <param name="isStatic">
+        /// MOUNTS the mapped collection on the <c>/static</c> route — see
+        /// <see cref="ContentCollectionConfig.IsStatic"/>. Default <c>false</c>: not mounted, and
+        /// <c>/static</c> answers 404 for it. Mounted files are still access-controlled (attributed
+        /// to the node the mapping hangs off).
+        /// </param>
         /// <returns>The configured message hub configuration</returns>
         public MessageHubConfiguration MapContentCollection(string targetCollectionName,
             string sourceCollectionName,
-            string subdirectory)
+            string subdirectory,
+            bool isStatic = false)
             => configuration
                 .AddContentCollections() // Registers $Content, $FileBrowser, $Collection layout areas
                 .WithServices(services =>
@@ -654,7 +689,8 @@ public static class ContentCollectionsExtensions
                             targetCollectionName,
                             sourceCollectionName,
                             subdirectory,
-                            configuration.Address));
+                            configuration.Address,
+                            isStatic));
 
                     return services;
                 });
@@ -670,7 +706,8 @@ internal class MappedContentCollectionConfigProvider(
     string targetCollectionName,
     string sourceCollectionName,
     string subdirectory,
-    Address address)
+    Address address,
+    bool isStatic = false)
     : IContentCollectionConfigProvider
 {
     public const string MappedSourceType = "Mapped";
@@ -688,6 +725,10 @@ internal class MappedContentCollectionConfigProvider(
         // bind it — the resolved config picks IsEditable from this wrapper.)
         IsEditable = true,
         ExposeInChildren = true,
+        // /static exposure is the MAPPING's decision, not the backing store's: the store is
+        // mounted static so the mesh-level `/static/storage/…` shape works, but that must not
+        // silently publish every per-node view over it.
+        IsStatic = isStatic,
         Settings = new Dictionary<string, string>
         {
             [SourceCollectionKey] = sourceCollectionName,

--- a/src/MeshWeaver.ContentCollections/ContentService.cs
+++ b/src/MeshWeaver.ContentCollections/ContentService.cs
@@ -159,6 +159,11 @@ public class ContentService : IContentService
             BasePath = fullPath,
             Address = mappedConfig.Address,
             IsEditable = mappedConfig.IsEditable,
+            // 🚨 /static exposure comes from the MAPPING, never the source. The mesh-level backing
+            // store is mounted static so the `/static/storage/…` shape resolves; inheriting that
+            // here would silently publish every per-node view over it on /static as well.
+            IsStatic = mappedConfig.IsStatic,
+            IsPublic = mappedConfig.IsPublic,
             Settings = sourceConfig.Settings is { } src
                 ? new Dictionary<string, string>(src) { ["BasePath"] = fullPath }
                 : new Dictionary<string, string> { ["BasePath"] = fullPath }

--- a/src/MeshWeaver.Documentation/DocumentationExtensions.cs
+++ b/src/MeshWeaver.Documentation/DocumentationExtensions.cs
@@ -68,11 +68,18 @@ public static class DocumentationExtensions
             }
         });
 
+        // isPublic: the shipped platform documentation. Its assets are embedded in this
+        // assembly (published on nuget.org) and the Doc partition itself carries static
+        // Anonymous/Public Read grants (DocumentationNodeProvider), so serving them
+        // anonymously over /static discloses nothing that isn't already public. Declared
+        // rather than assumed — every other collection is access-controlled (issue #587).
         builder.ConfigureHub(config => config
             .AddEmbeddedResourceContentCollection(
                 "DocContent",
                 typeof(DocumentationExtensions).Assembly,
-                "Content"));
+                "Content",
+                isStatic: true,
+                isPublic: true));
 
         // Give every Doc-partition CHILD node hub a node-scoped, READ-ONLY "content" collection backed
         // DIRECTLY by the shipped embedded assets under Content/<node-subpath>/. This is what makes a
@@ -101,10 +108,15 @@ public static class DocumentationExtensions
             var subPath = address[prefix.Length..].Replace('/', '.');
             return config
                 .AddContentCollections()
+                // isStatic: doc-page assets (the @@content/ diagrams, logos and images) are
+                // fetched as /static/{Doc/Page}/content/{file}, so this is a /static mount.
+                // NOT isPublic: it stays access-controlled and inherits the Doc partition's own
+                // Anonymous/Public Read grants — one decision, not a parallel one.
                 .AddEmbeddedResourceContentCollection(
                     ContentCollectionsExtensions.DefaultCollectionName,
                     typeof(DocumentationExtensions).Assembly,
-                    $"Content.{subPath}");
+                    $"Content.{subPath}",
+                    isStatic: true);
         });
 
         // Doc namespace caps: read-only docs (no Create/Update/Delete) but

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -204,8 +204,17 @@ public static class GraphConfigurationExtensions
             builder.ConfigureHub(config => config
                 .AddDefaultLayoutAreas()
                 .AddContentCollections()
+                // isStatic: every node card, menu and React client builds
+                // /static/NodeTypeIcons/{icon}.svg — this collection IS a /static mount.
+                // isPublic: node-type icons are the ONE asset class that must serve before any
+                // identity exists — the login page, public course covers, the nav and every
+                // anonymous card render them. They are SVGs compiled into this assembly (i.e.
+                // already public in the shipped package), carry no user data, and are declared
+                // public so /static serves them anonymously with shared-cacheable headers. Every
+                // other collection is access-controlled by default (issue #587).
                 .AddEmbeddedResourceContentCollection("NodeTypeIcons",
-                    typeof(GraphConfigurationExtensions).Assembly, "Icons")
+                    typeof(GraphConfigurationExtensions).Assembly, "Icons",
+                    isStatic: true, isPublic: true)
                 // High-level subtree-copy operation. Relays NodeCopyDispatchRequest
                 // through the Templates/Import/NodeCopy script template via
                 // ScriptDispatch.RelayToScript so callers see request/response

--- a/src/MeshWeaver.Hosting.AzureBlob/ArticleConfigurationExtensions.cs
+++ b/src/MeshWeaver.Hosting.AzureBlob/ArticleConfigurationExtensions.cs
@@ -50,12 +50,19 @@ public static class ArticleConfigurationExtensions
     /// <param name="collectionName">The name of the collection</param>
     /// <param name="containerName">The Azure Blob container name</param>
     /// <param name="clientName">The name of the Azure client (default: "default")</param>
+    /// <param name="isStatic">
+    /// MOUNTS the collection on the <c>/static</c> route — see
+    /// <see cref="ContentCollectionConfig.IsStatic"/>. Default <c>false</c>: not mounted, and
+    /// <c>/static</c> answers 404 for it. Mounted files stay access-controlled (attributed to the
+    /// owning node and gated on Read).
+    /// </param>
     /// <returns>The configured message hub configuration</returns>
     public static MessageHubConfiguration AddAzureBlobContentCollection(
         this MessageHubConfiguration configuration,
         string collectionName,
         string containerName,
-        string clientName = "default")
+        string clientName = "default",
+        bool isStatic = false)
         => configuration
             .AddContentCollections()
             .WithServices(services =>
@@ -71,6 +78,7 @@ public static class ArticleConfigurationExtensions
                     {
                         Name = collectionName,
                         SourceType = AzureBlobStreamProviderFactory.SourceType,
+                        IsStatic = isStatic,
                         Settings = new Dictionary<string, string>
                         {
                             ["ContainerName"] = containerName,

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace MeshWeaver.Hosting.Blazor;
@@ -171,6 +172,19 @@ public static class BlazorHostingExtensions
     /// The endpoint first checks if the first segment matches a registered collection name.
     /// If yes, serves from the mesh hub's content service directly.
     /// If no, uses address-based resolution via IMeshCatalog.ResolvePath.
+    ///
+    /// <para>🚨 TWO EXPLICIT DECLARATIONS gate this route (issue #587), both defaulting to the
+    /// closed value:</para>
+    /// <list type="number">
+    /// <item><see cref="ContentCollectionConfig.IsStatic"/> — is the collection MOUNTED here at
+    ///   all? Not declared ⇒ 404, for every caller alike. Content must be mounted explicitly;
+    ///   merely being registered on a hub never publishes it.</item>
+    /// <item><see cref="ContentCollectionConfig.IsPublic"/> — is the mount world-readable? Not
+    ///   declared ⇒ the file is attributed to its owning mesh node and the caller must hold
+    ///   <see cref="MeshWeaver.Mesh.Security.Permission.Read"/> on it (<see cref="StaticContentGate"/>),
+    ///   the same decision <c>AccessControlPipeline</c> applies to the <c>GetDataRequest</c> behind
+    ///   an ordinary <c>/content/…</c> read.</item>
+    /// </list>
     /// </summary>
     private static void MapStaticContent(this IEndpointRouteBuilder app, IServiceProvider services)
     {
@@ -188,11 +202,17 @@ public static class BlazorHostingExtensions
             if (string.IsNullOrEmpty(path))
                 return Task.FromResult(Results.NotFound("Path is required"));
 
+            // 🚨 Resolve the caller SYNCHRONOUSLY, before any scheduler hop. AccessContext is an
+            // AsyncLocal and does not survive the Rx hops below, and concurrent /static requests
+            // carry different users — so the identity is captured here per request and threaded
+            // explicitly through the chain, never re-read from the ambient service downstream.
+            var caller = ResolveStaticCaller(context, mainHub);
+
             // Compose the entire endpoint as IObservable<IResult>; the HTTP framework
             // boundary mandates Task<IResult>, so we ToTask once at the very end.
             // No await on hub round-trips — chain via SelectMany; deadlock surface
             // (await pathResolver.ResolvePath / hub.Observe) eliminated.
-            return ResolveStatic(context, mainHub, path, collectionCache)
+            return ResolveStatic(context, mainHub, path, caller, collectionCache)
                 .Catch<IResult, Exception>(ex =>
                     Observable.Return(Results.Problem($"Error retrieving static content: {ex.Message}")))
                 .FirstAsync()
@@ -200,16 +220,41 @@ public static class BlazorHostingExtensions
         });
     }
 
+    /// <summary>
+    /// The identity of a <c>/static</c> request. NEVER null — an unauthenticated caller resolves to
+    /// the well-known Anonymous context, whose permissions are exactly the Anonymous grants.
+    ///
+    /// <para><c>UserContextMiddleware</c> runs for <c>/static</c> (it is deliberately NOT in its
+    /// <c>ExcludedPrefixes</c> — #666) and stamps the fully-resolved identity on the mesh-wide
+    /// <c>AccessService</c>, including the Bearer-token path that a claims principal alone cannot
+    /// see. Prefer that. Fall back to resolving the claims principal directly for hosts that do not
+    /// run the middleware, so the gate can never be silently defeated by a missing middleware.</para>
+    /// </summary>
+    private static AccessContext ResolveStaticCaller(HttpContext context, IMessageHub mainHub)
+    {
+        // The mesh registers ONE AccessService singleton and every hosted hub inherits it
+        // (MessageHubConfiguration only adds its own when the parent scope has none), so this is
+        // the very instance the middleware wrote to.
+        var ambient = mainHub.ServiceProvider.GetService<AccessService>()?.Context;
+        return ambient is not null && !string.IsNullOrEmpty(ambient.ObjectId)
+            ? ambient
+            : UserContextMiddleware.ResolveHttpCaller(context.User, mainHub.ServiceProvider);
+    }
+
     private static IObservable<IResult> ResolveStatic(
         HttpContext context,
         IMessageHub mainHub,
         string path,
+        AccessContext caller,
         System.Collections.Concurrent.ConcurrentDictionary<string, ContentCollectionConfig> collectionCache)
     {
         var pathParts = path.Split('/');
         if (pathParts.Length < 2)
             return Observable.Return(Results.NotFound(
                 "Invalid path format. Expected: /static/{collection}/{filePath} or /static/{address}/{collection}/{filePath}"));
+
+        var logger = mainHub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(StaticContentGate));
 
         var firstSegment = pathParts[0];
         var decodedFirstSegment = DecodeCollectionName(firstSegment);
@@ -220,9 +265,31 @@ public static class BlazorHostingExtensions
         {
             // Pattern 1: /static/{collection}/{filePath}
             var collectionName = decodedFirstSegment;
+
+            // 🚨 MOUNT CHECK. /static serves ONLY collections that explicitly declare
+            // IsStatic — anything else is not on this route at all. IsStatic existed but was
+            // read NOWHERE, so every collection registered anywhere on the mesh hub was
+            // servable by URL. Being unmounted is not an access decision, so it answers 404
+            // ahead of the gate and discloses nothing about the caller's rights.
+            if (!knownCollection.IsStatic)
+                return Observable.Return(NotMounted(collectionName));
+
             var filePath = DecodeContentPath(string.Join("/", pathParts.Skip(1)));
-            return (mainHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded)
-                .Run(_ => ServeFromCollection(context, mainHub, collectionName, filePath, collectionCache));
+            var serve = Observable.Defer(() =>
+                (mainHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded)
+                    .Run(_ => ServeFromCollection(context, mainHub, collectionName, filePath, knownCollection.IsPublic)));
+
+            // 🚨 A collection declared IsPublic serves to anyone — that is the deliberate
+            // opt-in (node-type icons must render on the login page). Everything else is
+            // attributed to its owning node and gated on Read.
+            if (knownCollection.IsPublic)
+                return serve;
+
+            return StaticContentGate
+                .Authorize(mainHub, caller, StaticContentGate.RootStoreOwnerCandidate(filePath), logger)
+                .SelectMany(verdict => verdict == StaticContentGate.Verdict.Allowed
+                    ? serve
+                    : Observable.Return(StaticContentGate.DenyResult(verdict)));
         }
 
         // Pattern 2: /static/{address}/{collection}/{filePath} — observable chain.
@@ -247,18 +314,13 @@ public static class BlazorHostingExtensions
             var targetAddress = (Address)resolution.Prefix;
             var qualifiedCollectionName = $"{resolution.Prefix}/{addressCollectionName}";
 
-            // 🚨 STAMP THE CALLER on the post. The user-context middleware deliberately skips
-            // /static/ (perf), so nothing has resolved an identity for this request — and a hub
-            // post with no AccessContext is refused by the never-null PostPipeline guard. That
-            // refusal is INVISIBLE at one replica (local delivery) and killed ~half of all /static
-            // requests at two: whenever the target partition's hub lived on the OTHER silo, the
-            // cross-silo post died with "AccessContext must never be null" and the file 500'd
-            // (#694 — the reason memex runs single-replica). Resolve the caller here (claims →
-            // mesh user; anonymous otherwise) and stamp the DELIVERY — per-request, never the
-            // ambient AccessService (concurrent static requests carry different users). Identity
-            // only names WHO is asking; the owning hub's RLS still decides what they may read, so
-            // anonymous gets exactly the Anonymous grants and gated files stay gated.
-            var caller = UserContextMiddleware.ResolveHttpCaller(context.User, mainHub.ServiceProvider);
+            // 🚨 STAMP THE CALLER on the post (#694). A hub post with no AccessContext is refused
+            // by the never-null PostPipeline guard — invisible at one replica (local delivery) and
+            // fatal at two, where whenever the target partition's hub lived on the OTHER silo the
+            // cross-silo post died with "AccessContext must never be null" and the file 500'd (the
+            // reason memex ran single-replica). The identity was resolved per-request at the
+            // endpoint and threaded in as `caller` — never re-read from the ambient AccessService
+            // here, which the Rx hops above have already left behind.
 
             // Cached collection config — short-circuit; otherwise compose hub.Observe.
             IObservable<ContentCollectionConfig?> configObs = collectionCache.TryGetValue(qualifiedCollectionName, out var cached)
@@ -275,7 +337,17 @@ public static class BlazorHostingExtensions
                                 {
                                     Name = e.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? "" : "",
                                     SourceType = e.TryGetProperty("sourceType", out var typeProp) ? typeProp.GetString() ?? "" : "",
-                                    BasePath = e.TryGetProperty("basePath", out var pathProp) ? pathProp.GetString() : null
+                                    BasePath = e.TryGetProperty("basePath", out var pathProp) ? pathProp.GetString() : null,
+                                    // 🚨 The serving classification MUST survive the wire. This hand-rolled
+                                    // projection copied only name/sourceType/basePath, so a remote
+                                    // collection arrived with IsStatic/IsPublic silently false — the mount
+                                    // check would then 404 every legitimately-mounted remote collection.
+                                    // Both are suppressed when false (WhenWritingDefault), so an absent
+                                    // property means false, which is the safe value either way.
+                                    IsStatic = e.TryGetProperty("isStatic", out var staticProp)
+                                               && staticProp.ValueKind == JsonValueKind.True,
+                                    IsPublic = e.TryGetProperty("isPublic", out var publicProp)
+                                               && publicProp.ValueKind == JsonValueKind.True,
                                 })
                                 .ToArray(),
                             GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
@@ -288,11 +360,17 @@ public static class BlazorHostingExtensions
                         return built;
                     });
 
-            return configObs.SelectMany(collectionConfig =>
+            var serve = configObs.SelectMany(collectionConfig =>
             {
                 if (collectionConfig == null)
                     return Observable.Return(Results.NotFound(
                         $"Content collection '{addressCollectionName}' not found at {resolution.Prefix}"));
+
+                // 🚨 MOUNT CHECK — the owning node's collection must declare IsStatic. See the
+                // pattern-1 note; the address shape needs the remote config first, so this runs
+                // after the read gate rather than before it.
+                if (!collectionConfig.IsStatic)
+                    return Observable.Return(NotMounted(addressCollectionName));
 
                 var portal = mainHub.ServiceProvider.GetRequiredService<PortalApplication>().Hub;
                 var portalContentService = portal.ServiceProvider.GetService<IContentService>();
@@ -305,10 +383,64 @@ public static class BlazorHostingExtensions
                 return portalContentService.GetCollection(qualifiedCollectionName)
                     .SelectMany(contentCollection => contentCollection == null
                         ? Observable.Return(Results.NotFound($"Content collection '{addressCollectionName}' not found"))
-                        : ServeFile(context, contentCollection, addressFilePath));
+                        : ServeFile(context, contentCollection, addressFilePath, collectionConfig.IsPublic));
             });
+
+            // 🚨 GATE FIRST — before the collection config is even looked up.
+            //
+            // Two reasons it has to be here and not deeper. (1) The config lookup is the only step
+            // that ever touched access control (its GetDataRequest carries
+            // [RequiresPermission(Read)]), and `collectionCache` SHORT-CIRCUITS it: once any
+            // authorized caller populated the cache, every later caller — anonymous included —
+            // skipped the permission-bearing hop entirely and the file was read locally from the
+            // resolved BasePath. That cache hit was a standing bypass. (2) The bytes are read by
+            // the PORTAL's content service straight off the resolved BasePath, so nothing
+            // downstream consults the owning partition at all.
+            //
+            // The collection is mounted on `resolution.Prefix`, so that node is the owner floor;
+            // appending the file path lets the resolver attribute the file to a deeper node when
+            // the content mirrors the node tree (a paid lesson's media stays gated).
+            return StaticContentGate
+                .Authorize(mainHub, caller,
+                    StaticContentGate.AddressOwnerCandidate(resolution.Prefix, addressFilePath), logger)
+                .SelectMany(verdict => verdict == StaticContentGate.Verdict.Allowed
+                    ? serve
+                    : Observable.Return(StaticContentGate.DenyResult(verdict)));
         });
     }
+
+    /// <summary>
+    /// The <c>Cache-Control</c> value for a served file.
+    ///
+    /// <para>🚨 Only an explicitly-PUBLIC collection may be stored by a SHARED cache. Everything
+    /// else is <c>private</c>: a CDN, corporate proxy or any intermediary that once saw an
+    /// authorized fetch would otherwise keep serving that partition's file to callers this gate
+    /// denies — the leak survives the fix (issue #587, point 4). Gated content stays cacheable in
+    /// the caller's OWN browser but revalidates, so a revoked grant takes effect within
+    /// <see cref="GatedCacheSeconds"/> instead of the 30 days <c>immutable</c> promised.</para>
+    /// </summary>
+    /// <param name="isPublic">Whether the owning collection declared <see cref="ContentCollectionConfig.IsPublic"/>.</param>
+    /// <returns>The header value.</returns>
+    internal static string CacheControlFor(bool isPublic) =>
+        isPublic
+            ? $"public, max-age={(int)TimeSpan.FromDays(30).TotalSeconds}, immutable"
+            : $"private, max-age={GatedCacheSeconds}, must-revalidate";
+
+    /// <summary>Browser-local lifetime of an access-controlled static file, in seconds.</summary>
+    internal const int GatedCacheSeconds = 300;
+
+    /// <summary>
+    /// The response for a collection that exists but is not mounted on <c>/static</c>
+    /// (<see cref="ContentCollectionConfig.IsStatic"/> not declared). 404, not 403: whether a
+    /// collection is published on this route is a hosting decision, identical for every caller, so
+    /// the answer must not vary with identity.
+    /// </summary>
+    /// <param name="collectionName">The collection that is not mounted.</param>
+    /// <returns>The 404 result.</returns>
+    internal static IResult NotMounted(string collectionName) =>
+        Results.NotFound(
+            $"Content collection '{collectionName}' is not served under /static. "
+            + "Mount it explicitly (IsStatic) to publish it on this route.");
 
     /// <summary>
     /// Serves a file from a known collection (pattern: /static/{collection}/{filePath}).
@@ -318,7 +450,7 @@ public static class BlazorHostingExtensions
         IMessageHub hub,
         string collectionName,
         string filePath,
-        System.Collections.Concurrent.ConcurrentDictionary<string, ContentCollectionConfig> _)
+        bool isPublic)
     {
         if (string.IsNullOrEmpty(filePath))
         {
@@ -335,7 +467,7 @@ public static class BlazorHostingExtensions
         return await contentService.GetCollection(collectionName)
             .SelectMany(contentCollection => contentCollection == null
                 ? Observable.Return(Results.NotFound($"Content collection '{collectionName}' not found"))
-                : ServeFile(context, contentCollection, filePath))
+                : ServeFile(context, contentCollection, filePath, isPublic))
             .Take(1);
     }
 
@@ -344,7 +476,12 @@ public static class BlazorHostingExtensions
     /// read (including the small-file buffering for the ETag hash) runs on the collection's pool;
     /// this layer only shapes the HTTP result on the emissions.
     /// </summary>
-    private static IObservable<IResult> ServeFile(HttpContext context, ContentCollection contentCollection, string filePath)
+    /// <param name="context">The current request.</param>
+    /// <param name="contentCollection">The resolved collection.</param>
+    /// <param name="filePath">The file's path within the collection.</param>
+    /// <param name="isPublic">Whether the collection is declared public — decides shared vs private caching.</param>
+    private static IObservable<IResult> ServeFile(
+        HttpContext context, ContentCollection contentCollection, string filePath, bool isPublic)
         => contentCollection.GetContent(filePath)
             .SelectMany(stream =>
             {
@@ -377,9 +514,13 @@ public static class BlazorHostingExtensions
                         {
                             if (bytes is null)
                                 return Results.NotFound("File not found");
-                            var cacheDuration = TimeSpan.FromDays(30);
-                            context.Response.Headers.CacheControl = $"public, max-age={cacheDuration.TotalSeconds}, immutable";
-                            context.Response.Headers.Expires = DateTime.UtcNow.AddDays(30).ToString("R");
+                            context.Response.Headers.CacheControl = CacheControlFor(isPublic);
+                            // Expires is the HTTP/1.0 twin of max-age; a shared cache that honours
+                            // it must not be handed a 30-day promise for gated content either.
+                            context.Response.Headers.Expires = (isPublic
+                                    ? DateTime.UtcNow.AddDays(30)
+                                    : DateTime.UtcNow.AddSeconds(GatedCacheSeconds))
+                                .ToString("R");
                             var hash = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(bytes));
                             context.Response.Headers.ETag = $"\"{hash}\"";
                             // Range processing on this branch too: a file under the buffering
@@ -390,6 +531,11 @@ public static class BlazorHostingExtensions
                             return FileResultFor(bytes, filePath, isDownloadRequested);
                         });
                 }
+
+                // Large files stream straight through. They previously carried NO Cache-Control at
+                // all, which lets a shared cache apply its own heuristic freshness — the same leak
+                // as an explicit `public`. Classify them too.
+                context.Response.Headers.CacheControl = CacheControlFor(isPublic);
 
                 // Return the stream directly without loading it all into memory
                 return Observable.Return(Results.Stream(

--- a/src/MeshWeaver.Hosting.Blazor/StaticContentGate.cs
+++ b/src/MeshWeaver.Hosting.Blazor/StaticContentGate.cs
@@ -1,0 +1,241 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Blazor;
+
+/// <summary>
+/// The access decision for the <c>/static/**</c> content endpoint (issue #587).
+///
+/// <para><b>The hole this closes.</b> <c>MapStaticContent</c> resolved a collection and streamed
+/// the file with no authorization anywhere in <c>ResolveStatic</c> → <c>ServeFromCollection</c> →
+/// <c>ServeFile</c>. Both URL shapes leaked: <c>/static/storage/content/{node}/{file}</c> read the
+/// mesh-level backing store directly (every partition's uploads, attachments, PDFs — flat and
+/// world-readable), and <c>/static/{address}/{collection}/{file}</c> resolved ANY address and
+/// served that hub's collections without ever consulting the partition's policy. "The URL is
+/// unguessable" was the only protection, and the scheme is predictable.</para>
+///
+/// <para><b>The decision.</b> Exactly the one the ordinary content read makes. A file is OWNED by
+/// the mesh node whose collection it lives in; reading it through
+/// <c>/content/{address}/{collection}/{file}</c> posts a <c>GetDataRequest</c>, which carries
+/// <c>[RequiresPermission(Permission.Read)]</c>, and <c>AccessControlPipeline</c> checks that Read
+/// against the OWNING HUB'S OWN PATH. This gate checks the same thing: <c>Read</c> on the owning
+/// node, folded by the same <c>PermissionEvaluator</c> (via <c>hub.GetEffectivePermissions</c>) —
+/// so partition scoping, group expansion, <c>PartitionAccessPolicy.PublicRead</c>, and the
+/// paywall's per-subject deny/allow assignments all apply verbatim. No parallel rule set.</para>
+///
+/// <para><b>Attribution is the deepest node, not the partition root.</b> The owner candidate is run
+/// through <see cref="IPathResolver"/>, which returns the LONGEST path prefix that is a real mesh
+/// node. Where content mirrors the node tree (the <c>content:</c> convention) a paid lesson's media
+/// under <c>{Course}/{Lesson}/…</c> is therefore attributed to <c>{Course}/{Lesson}</c> and the
+/// lesson's <c>Public</c>/<c>Anonymous</c> deny applies — while the cover under <c>{Course}/…</c>
+/// stays anonymous. Read folds hierarchically, so checking the deepest node is never weaker than
+/// checking its ancestors.</para>
+///
+/// <para><b>Fail closed, with one deliberate exception.</b> No owner ⇒ deny. Resolution or
+/// permission failure ⇒ deny. The exception is a mesh with no
+/// <see cref="EffectivePermissionsDelegate"/> registered (RLS not installed): there the canonical
+/// read path does not check either — <c>AccessControlPipeline</c> invokes <c>next</c> outright when
+/// the delegate is absent — so allowing matches it. That is the ABSENCE of a policy, not a bypass
+/// of one; a mesh that installs RLS is gated everywhere.</para>
+/// </summary>
+internal static class StaticContentGate
+{
+    /// <summary>The gate's verdict for one <c>/static</c> request.</summary>
+    internal enum Verdict
+    {
+        /// <summary>Serve the file.</summary>
+        Allowed,
+
+        /// <summary>Anonymous caller, and anonymous access does not suffice → 401.</summary>
+        NotAuthenticated,
+
+        /// <summary>Authenticated caller without Read on the owning node → 403.</summary>
+        Forbidden,
+    }
+
+    /// <summary>
+    /// Ceiling for the caller's POSITIVE Read grant to surface on the live permission stream.
+    /// The wait must be positive-shaped: the fold's first emission can be the premature empty
+    /// seed, so a "wait for any emission" would deny a legitimately-entitled caller. A caller with
+    /// no grant pays the full wait and is then denied. Same rationale and window as
+    /// <c>CourseAssetEndpoints.GrantWait</c>, the sibling gated-asset endpoint.
+    /// </summary>
+    internal static readonly TimeSpan GrantWait = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Rejects a <c>/static</c> path whose segments cannot be safely attributed to an owner.
+    /// Empty segments (<c>//</c>) and dot segments (<c>.</c> / <c>..</c>) are path traversal —
+    /// <c>FileSystemStreamProvider</c> does a bare <c>Path.Combine</c>, so
+    /// <c>content/PublicSpace/../PrivateSpace/secret.pdf</c> would read another partition's file
+    /// while this gate attributed it to <c>PublicSpace</c>. A double quote would break out of the
+    /// quoting <see cref="IPathResolver"/> puts around each path segment when it builds its
+    /// <c>path:</c> query. Pure — the rule is pinned without touching a file system.
+    /// </summary>
+    /// <param name="path">A decoded <c>/static</c> path or path fragment.</param>
+    /// <returns><c>true</c> when every segment is safe to attribute and serve.</returns>
+    internal static bool IsSafePath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        foreach (var segment in path.Split('/'))
+        {
+            if (segment.Length == 0 || segment == "." || segment == ".." || segment.Contains('"'))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The owner-path CANDIDATE for <c>/static/{collection}/{filePath}</c> served from a
+    /// MESH-LEVEL collection — the raw backing store (<c>storage</c>) that every per-node
+    /// collection is mounted against.
+    ///
+    /// <para>The store has no owner of its own: its address is the mesh root, where nobody holds
+    /// Read, so attributing files to it would deny every icon and thumbnail in the portal. It does
+    /// however have a known layout, because the per-node mounts are what create it —
+    /// <c>MemexConfiguration</c> mounts each Space's writable <c>content</c> collection at
+    /// <c>{store}/content/{nodePath}</c> and <c>MapContentCollection("attachments", "storage",
+    /// $"attachments/{nodePath}")</c> mounts attachments at <c>{store}/attachments/{nodePath}</c>.
+    /// Every mount is <c>{mount}/{nodePath}/…</c>, so dropping the single mount segment leaves the
+    /// owning node path followed by the file's path within it. That inverse is exactly what
+    /// <c>MeshNodeImageHelper</c>, <c>MarkdownFileParser</c>, <c>MeshNodeThumbnailControl</c> and
+    /// <c>BrandingResolver</c> assume when they BUILD <c>/static/storage/content/{nodePath}/{file}</c>
+    /// URLs.</para>
+    ///
+    /// <para>A path with no mount segment (a file at the store root) has no owner and yields
+    /// <c>null</c> → denied.</para>
+    /// </summary>
+    /// <param name="filePath">The decoded path within the collection (e.g. <c>content/ACME/logo.svg</c>).</param>
+    /// <returns>The candidate owner path, or <c>null</c> when the file cannot be attributed.</returns>
+    internal static string? RootStoreOwnerCandidate(string? filePath)
+    {
+        if (!IsSafePath(filePath))
+            return null;
+        var trimmed = filePath!.Trim('/');
+        var slash = trimmed.IndexOf('/');
+        if (slash <= 0)
+            return null;
+        var rest = trimmed[(slash + 1)..];
+        return string.IsNullOrEmpty(rest) ? null : rest;
+    }
+
+    /// <summary>
+    /// The owner-path CANDIDATE for <c>/static/{address}/{collection}/{filePath}</c>. The
+    /// collection is mounted ON <paramref name="addressPrefix"/>, so that node is the owner floor;
+    /// appending the file path lets <see cref="IPathResolver"/> attribute the file to a DEEPER node
+    /// when the content mirrors the node tree (see the type remarks).
+    /// </summary>
+    /// <param name="addressPrefix">The resolved node path the collection is mounted on.</param>
+    /// <param name="filePath">The decoded path within the collection.</param>
+    /// <returns>The candidate owner path, or <c>null</c> when either part is unsafe.</returns>
+    internal static string? AddressOwnerCandidate(string? addressPrefix, string? filePath)
+    {
+        if (string.IsNullOrEmpty(addressPrefix) || !IsSafePath(addressPrefix))
+            return null;
+        if (!IsSafePath(filePath))
+            return null;
+        return $"{addressPrefix.Trim('/')}/{filePath!.Trim('/')}";
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="ownerCandidate"/> to its owning mesh node and answers whether
+    /// <paramref name="caller"/> may read it. See the type remarks for why this is the same
+    /// decision the ordinary content read makes.
+    /// </summary>
+    /// <param name="hub">The hub to evaluate on — any hub works, the evaluator is a pure function over the process-wide node-stream cache.</param>
+    /// <param name="caller">The request's resolved identity; never null, anonymous when unauthenticated.</param>
+    /// <param name="ownerCandidate">The candidate owner path from one of the two <c>*OwnerCandidate</c> helpers.</param>
+    /// <param name="logger">Optional logger for denials and infrastructure faults.</param>
+    /// <returns>A single-emission observable carrying the verdict.</returns>
+    internal static IObservable<Verdict> Authorize(
+        IMessageHub hub,
+        AccessContext? caller,
+        string? ownerCandidate,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+
+        // No RLS installed ⇒ no policy to enforce. The canonical read path does exactly this:
+        // AccessControlPipeline invokes next() without a check when the delegate is absent.
+        if (hub.Configuration.Get<EffectivePermissionsDelegate>() is null)
+            return Observable.Return(Verdict.Allowed);
+
+        var userId = caller?.ObjectId;
+        var isAuthenticated = !string.IsNullOrEmpty(userId)
+                              && caller?.IsVirtual != true
+                              && !string.Equals(userId, WellKnownUsers.Anonymous, StringComparison.Ordinal);
+        if (!isAuthenticated)
+            userId = WellKnownUsers.Anonymous;
+        var denied = isAuthenticated ? Verdict.Forbidden : Verdict.NotAuthenticated;
+
+        if (string.IsNullOrEmpty(ownerCandidate))
+        {
+            logger?.LogInformation(
+                "StaticContentGate: request denied — the file cannot be attributed to an owning node (caller={Caller})",
+                userId);
+            return Observable.Return(denied);
+        }
+
+        var resolver = hub.ServiceProvider.GetService<IPathResolver>();
+        if (resolver is null)
+        {
+            logger?.LogWarning(
+                "StaticContentGate: no IPathResolver registered — cannot attribute '{Candidate}'; denying",
+                ownerCandidate);
+            return Observable.Return(denied);
+        }
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+
+        return resolver.ResolvePath(ownerCandidate)
+            .Take(1)
+            .SelectMany(resolution => string.IsNullOrEmpty(resolution?.Prefix)
+                ? Observable.Return(denied)
+                // Observable.Using re-establishes the CALLER's identity for the whole cold
+                // evaluation: the resolver hops schedulers, and AccessContext is an AsyncLocal
+                // that does not flow across them — without this the evaluator's capability
+                // checks (IsApiToken, claim roles) would read a null/foreign ambient context.
+                // The SUBJECT is passed explicitly as userId, so the fold itself never depends
+                // on the ambient value.
+                : Observable.Using(
+                        () => accessService?.SwitchAccessContext(caller)
+                              ?? System.Reactive.Disposables.Disposable.Empty,
+                        _ => hub.GetEffectivePermissions(resolution!.Prefix, userId!))
+                    // Positive-shaped wait — see GrantWait.
+                    .Where(p => p.HasFlag(Permission.Read))
+                    .Take(1)
+                    .Select(_ => Verdict.Allowed))
+            .Timeout(GrantWait)
+            .Catch((Exception ex) =>
+            {
+                if (ex is TimeoutException)
+                    logger?.LogInformation(
+                        "StaticContentGate: no Read grant for {Caller} on '{Candidate}' within {Wait} — denying",
+                        userId, ownerCandidate, GrantWait);
+                else
+                    logger?.LogWarning(ex,
+                        "StaticContentGate: authorization of '{Candidate}' for {Caller} failed — failing closed",
+                        ownerCandidate, userId);
+                return Observable.Empty<Verdict>();
+            })
+            .DefaultIfEmpty(denied);
+    }
+
+    /// <summary>
+    /// The HTTP result for a denial: 401 for an anonymous caller (sign in and retry), 403 for an
+    /// authenticated one (signing in again will not help). Mirrors the sibling gated-asset
+    /// endpoint <c>CourseAssetEndpoints</c>.
+    /// </summary>
+    /// <param name="verdict">A non-<see cref="Verdict.Allowed"/> verdict.</param>
+    /// <returns>The 401/403 result.</returns>
+    internal static IResult DenyResult(Verdict verdict) =>
+        verdict == Verdict.NotAuthenticated
+            ? Results.Unauthorized()
+            : Results.StatusCode(StatusCodes.Status403Forbidden);
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
@@ -9,5 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <!-- StaticContentAccessTest drives the REAL /static endpoint over a real monolith mesh
+         (real PermissionEvaluator, real AccessAssignments) — no mocks. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Hosting.Blazor.Test/StaticContentAccessTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/StaticContentAccessTest.cs
@@ -1,0 +1,369 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Hosting.Blazor;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 THE SECURITY BOUNDARY of the <c>/static/**</c> content endpoint (issue #587), driven over
+/// REAL HTTP against a REAL monolith mesh — real <c>PermissionEvaluator</c>, real
+/// <c>AccessAssignment</c> nodes, real content collections. No mocks.
+///
+/// <para><b>What was broken.</b> The endpoint resolved a collection and streamed the file with no
+/// authorization anywhere. <c>/static/storage/content/{node}/{file}</c> read the mesh-level backing
+/// store directly, so every partition's uploads, attachments and PDFs were world-readable to anyone
+/// with (or guessing) a URL — and the scheme is entirely predictable. The fixture below reproduces
+/// exactly that shape: one mesh-level <c>storage</c> collection whose <c>content/{nodePath}/…</c>
+/// layout is what the per-Space mounts create in production.</para>
+///
+/// <para><b>What must hold now.</b> A file is owned by the mesh node whose collection it lives in,
+/// and the caller needs <see cref="Permission.Read"/> on that node — the same decision
+/// <c>AccessControlPipeline</c> applies to the <c>GetDataRequest</c> behind an ordinary
+/// <c>/content/…</c> read. The gate therefore inherits the paywall for free: the seed is the
+/// production paywall shape (root allow for Anonymous/Public = the public cover, per-child DENY =
+/// the paywall, per-buyer allow at the root = the entitlement), so the cover asset stays anonymous
+/// while the lesson's media does not.</para>
+/// </summary>
+public class StaticContentAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output), IAsyncDisposable
+{
+    private const string Course = "GatedCourse";
+    private const string PaidLesson = Course + "/PaidLesson";
+    private const string PrivateSpace = "PrivateSpace";
+    private const string Buyer = "buyer";
+    private const string Stranger = "stranger";
+    private const string UnmountedCollection = "internal-store";
+
+    private const string CoverBody = "cover-bytes";
+    private const string LessonBody = "paid-lesson-bytes";
+    private const string SecretBody = "confidential-bytes";
+
+    /// <summary>Header the test pipeline reads to stamp the request's identity (see BuildPortal).</summary>
+    private const string UserHeader = "X-Test-User";
+
+    // The backing store, laid out exactly as production does it: the mesh-level "storage"
+    // collection's BasePath, with each Space's content under content/{nodePath}/…. Built in a field
+    // initializer because ConfigureMesh (which needs the path) runs from the base construction.
+    private readonly string storageRoot = CreateStorageFixture();
+
+    private WebApplication? portal;
+    private HttpClient client = null!;
+
+    private static string CreateStorageFixture()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "static-gate-store-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(Path.Combine(root, "content", Course, "PaidLesson"));
+        Directory.CreateDirectory(Path.Combine(root, "content", PrivateSpace));
+        File.WriteAllText(Path.Combine(root, "content", Course, "cover.png"), CoverBody);
+        File.WriteAllText(Path.Combine(root, "content", Course, "PaidLesson", "lesson.mp4"), LessonBody);
+        File.WriteAllText(Path.Combine(root, "content", PrivateSpace, "secret.pdf"), SecretBody);
+        return root;
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        // ConfigureMeshBase, NOT ConfigureMesh: the default seeds a root Public/Admin grant, which
+        // would make every assertion below vacuous.
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(Course) { Name = "Gated Course", NodeType = "Markdown" },
+                new MeshNode("PaidLesson", Course) { Name = "Paid Lesson", NodeType = "Markdown" },
+                new MeshNode(PrivateSpace) { Name = "Private Space", NodeType = "Markdown" },
+                // ── the production paywall shape ──────────────────────────────────────────────
+                // The public cover: the course root grants Anonymous (and Public) Viewer.
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", Course, accessObject: WellKnownUsers.Anonymous),
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Public, "Viewer", Course, accessObject: WellKnownUsers.Public),
+                // The paywall: a per-child DENY for the un-entitled subjects.
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", PaidLesson, denied: true,
+                    accessObject: WellKnownUsers.Anonymous),
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Public, "Viewer", PaidLesson, denied: true,
+                    accessObject: WellKnownUsers.Public),
+                // The entitlement: the buyer's own grant at the ROOT reaches the gated child,
+                // because a deny binds only the subject it names.
+                AssignmentNodeFactory.UserRole(Buyer, "Viewer", Course))
+            // The mesh-level raw backing store — the exact registration memex makes
+            // (Memex.Portal.Monolith/Program.cs, Memex.Portal.Distributed/Program.cs).
+            .ConfigureHub(hub => hub.AddContentCollection(_ => new ContentCollectionConfig
+            {
+                Name = "storage",
+                SourceType = "FileSystem",
+                BasePath = storageRoot,
+                IsStatic = true,
+            }))
+            // A collection that is NOT mounted on /static. It resolves perfectly well for every
+            // other consumer ($Content, the file browser, autocomplete) — /static must still
+            // refuse to publish it.
+            .ConfigureHub(hub => hub.AddContentCollection(_ => new ContentCollectionConfig
+            {
+                Name = UnmountedCollection,
+                SourceType = "FileSystem",
+                BasePath = storageRoot,
+            }));
+
+    // Granular permissions — skip the harness's blanket PublicAdmin seed.
+    /// <inheritdoc />
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        portal = BuildPortal();
+        await portal.StartAsync(TestContext.Current.CancellationToken);
+        client = portal.GetTestClient();
+    }
+
+    /// <summary>
+    /// The portal's HTTP surface: the REAL <c>MapMeshWeaver()</c> endpoints over the test mesh,
+    /// preceded by an identity middleware that does what <c>UserContextMiddleware</c> does in
+    /// production — stamp the request's <see cref="AccessContext"/> on the mesh-wide
+    /// <c>AccessService</c>, NEVER null, anonymous when unauthenticated.
+    /// </summary>
+    private WebApplication BuildPortal()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        // The endpoint resolves its mesh hub from the web app's provider.
+        builder.Services.AddSingleton(Mesh);
+
+        var app = builder.Build();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        app.Use(async (ctx, next) =>
+        {
+            var userId = ctx.Request.Headers[UserHeader].ToString();
+            accessService.SetContext(new AccessContext
+            {
+                ObjectId = string.IsNullOrEmpty(userId) ? WellKnownUsers.Anonymous : userId,
+                Name = string.IsNullOrEmpty(userId) ? WellKnownUsers.Anonymous : userId,
+            });
+            await next();
+        });
+        app.MapMeshWeaver();
+        return app;
+    }
+
+    private async Task<HttpResponseMessage> GetAsync(string url, string? asUser = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        if (asUser is not null)
+            request.Headers.Add(UserHeader, asUser);
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  Pattern 1 — /static/{collection}/{file} against the mesh-level backing store.
+    //  This is the URL shape every icon, thumbnail and uploaded asset uses in production
+    //  (MeshNodeImageHelper, MarkdownFileParser, BrandingResolver all build it), and the one
+    //  that had no access control at all.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE VULNERABILITY. An unauthenticated caller with nothing but the URL read any
+    /// partition's uploaded file. It must now be refused.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AnonymousRequest_ForAPrivatePartitionsFile_IsDenied()
+    {
+        var response = await GetAsync($"/static/storage/content/{PrivateSpace}/secret.pdf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an anonymous caller holds no grant on PrivateSpace — the URL is not the access control");
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody, "the bytes must never reach an unauthorized caller");
+    }
+
+    /// <summary>An authenticated caller without a grant is forbidden — signing in is not access.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task SignedInCallerWithoutAGrant_IsForbidden()
+    {
+        var response = await GetAsync($"/static/storage/content/{PrivateSpace}/secret.pdf", asUser: Stranger);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "403 (not 401) — this caller is authenticated; signing in again would not help");
+    }
+
+    /// <summary>
+    /// Anonymous access is a REAL case and must keep working: the course cover's asset carries an
+    /// explicit Anonymous Viewer grant at the Space root. A gate that broke this would break every
+    /// public landing page.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task PublicCoverAsset_IsStillServedAnonymously()
+    {
+        var response = await GetAsync($"/static/storage/content/{Course}/cover.png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().Be(CoverBody);
+    }
+
+    /// <summary>
+    /// 🚨 THE PAYWALL. The lesson's media sits one level below the anonymously-readable cover. The
+    /// file is attributed to the DEEPEST node its path maps to (<c>GatedCourse/PaidLesson</c>), so
+    /// the per-child deny applies — attributing it to the Space root instead would serve every paid
+    /// video to the internet.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GatedLessonAsset_IsDeniedToAnAnonymousVisitor()
+    {
+        var response = await GetAsync($"/static/storage/content/{PaidLesson}/lesson.mp4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(LessonBody);
+    }
+
+    /// <summary>
+    /// …and the over-strictness catcher: the BUYER's grant at the course root reaches the gated
+    /// child (a deny binds only the subject it names), so the entitled caller is served.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GatedLessonAsset_IsServedToTheEntitledBuyer()
+    {
+        var response = await GetAsync($"/static/storage/content/{PaidLesson}/lesson.mp4", asUser: Buyer);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().Be(LessonBody);
+    }
+
+    /// <summary>
+    /// An explicitly-public collection (<c>NodeTypeIcons</c> — SVGs compiled into MeshWeaver.Graph,
+    /// needed on the login page before any identity exists) still serves anonymously. This is the
+    /// deliberate opt-in; everything else defaults to gated.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ExplicitlyPublicCollection_IsServedAnonymously()
+    {
+        var response = await GetAsync("/static/NodeTypeIcons/box.svg");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.CacheControl!.Public.Should().BeTrue(
+            "only a declared-public asset class may be stored by a shared cache");
+    }
+
+    /// <summary>
+    /// Access-controlled bytes must never be stored by a CDN / corporate proxy: a single authorized
+    /// fetch would otherwise keep being replayed to callers this gate denies. The response is
+    /// <c>private</c> and revalidates.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GatedContent_IsNeverSharedCacheable()
+    {
+        var response = await GetAsync($"/static/storage/content/{Course}/cover.png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var cacheControl = response.Headers.CacheControl!;
+        cacheControl.Private.Should().BeTrue("a shared cache must not store access-controlled content");
+        cacheControl.Public.Should().BeFalse();
+        cacheControl.MustRevalidate.Should().BeTrue("a revoked grant must take effect quickly");
+    }
+
+    /// <summary>
+    /// A file the endpoint cannot attribute to any node (directly at the store root, below the
+    /// per-node mount layout) is refused rather than served — the gate fails CLOSED.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task UnattributableFile_IsDenied()
+    {
+        var response = await GetAsync("/static/storage/loose.txt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// 🚨 EXPLICIT MOUNT. <c>/static</c> publishes only collections that declare
+    /// <see cref="ContentCollectionConfig.IsStatic"/>. The flag existed but was read NOWHERE, so
+    /// every collection registered anywhere on the mesh hub was reachable by URL. An unmounted
+    /// collection is 404 — for the admin too, because being unmounted is a hosting decision, not
+    /// an access decision, and must not vary with identity.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task UnmountedCollection_IsNotServedAtAll()
+    {
+        var anonymous = await GetAsync($"/static/{UnmountedCollection}/content/{Course}/cover.png");
+        anonymous.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a collection that is not mounted on /static is not on this route");
+
+        var buyer = await GetAsync($"/static/{UnmountedCollection}/content/{Course}/cover.png", asUser: Buyer);
+        buyer.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the mount is a hosting decision — it must not depend on who is asking");
+        var body = await buyer.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(CoverBody);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  Pattern 2 — /static/{address}/{collection}/{file}.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The address-based shape resolved ANY address and served that hub's collections — a
+    /// cross-partition read that never consulted the partition's policy. Anonymous is refused.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AddressPattern_AnonymousRequestForAPrivatePartition_IsDenied()
+    {
+        var response = await GetAsync($"/static/{PrivateSpace}/content/secret.pdf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody);
+    }
+
+    /// <summary>
+    /// 🚨 REGRESSION GUARD for the cache short-circuit. The address pattern's ONLY brush with access
+    /// control used to be the collection-config lookup (its <c>GetDataRequest</c> carries
+    /// <c>[RequiresPermission(Read)]</c>) — and <c>collectionCache</c> skips that lookup on a hit.
+    /// So once ANY caller warmed the cache for a collection, every later caller bypassed the check
+    /// entirely. The gate now runs BEFORE the config lookup: warming the cache with an authorized
+    /// request must not open the door for the next anonymous one.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AddressPattern_WarmingTheCollectionCache_DoesNotOpenTheGate()
+    {
+        // Warm whatever can be warmed as the entitled buyer…
+        await GetAsync($"/static/{Course}/content/PaidLesson/lesson.mp4", asUser: Buyer);
+
+        // …then the un-entitled visitor must still be refused.
+        var response = await GetAsync($"/static/{Course}/content/PaidLesson/lesson.mp4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(LessonBody);
+    }
+
+    /// <inheritdoc />
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        client?.Dispose();
+        if (portal is not null)
+            await portal.DisposeAsync();
+        await base.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(storageRoot))
+                Directory.Delete(storageRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover fixture directory under the test bin folder is harmless.
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/StaticContentGateRulesTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/StaticContentGateRulesTest.cs
@@ -1,0 +1,122 @@
+using MeshWeaver.Hosting.Blazor;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// The PURE rules behind the <c>/static</c> gate (issue #587): which mesh node a served file is
+/// attributed to, which paths are refused outright, and how the response may be cached. Pinned
+/// without a file system or a hub, so a regression shows up as a failing rule rather than as a
+/// leak that only a full integration run would notice.
+/// </summary>
+public class StaticContentGateRulesTest
+{
+    // ── Attribution: the raw mesh-level backing store ───────────────────────────────────────
+
+    /// <summary>
+    /// The store's layout is <c>{mount}/{nodePath}/…</c> because the per-node mounts are what
+    /// create it (<c>content/{nodePath}</c>, <c>attachments/{nodePath}</c>). Dropping the mount
+    /// segment is the exact inverse of the URL every producer builds.
+    /// </summary>
+    [Theory]
+    [InlineData("content/ACME/logo.svg", "ACME/logo.svg")]
+    [InlineData("content/GatedCourse/PaidLesson/video.mp4", "GatedCourse/PaidLesson/video.mp4")]
+    [InlineData("attachments/ACME/Project/datacube.csv", "ACME/Project/datacube.csv")]
+    public void OwnerCandidate_DropsTheMountSegment(string filePath, string expected) =>
+        StaticContentGate.RootStoreOwnerCandidate(filePath).Should().Be(expected);
+
+    /// <summary>
+    /// A file directly at the store root belongs to no node. There is nothing to check a
+    /// permission against, so the gate must have nothing to work with — and deny.
+    /// </summary>
+    [Theory]
+    [InlineData("loose.txt")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void OwnerCandidate_IsNullWhenTheFileCannotBeAttributed(string? filePath) =>
+        StaticContentGate.RootStoreOwnerCandidate(filePath).Should().BeNull();
+
+    // ── Attribution: the address-based pattern ──────────────────────────────────────────────
+
+    /// <summary>
+    /// The collection is mounted on the resolved node, so that node is the owner FLOOR; appending
+    /// the file path lets the resolver attribute the file to a deeper node when the content
+    /// mirrors the node tree — which is what keeps a paid lesson's media gated.
+    /// </summary>
+    [Fact]
+    public void AddressOwnerCandidate_AppendsTheFilePathToTheMountedNode() =>
+        StaticContentGate.AddressOwnerCandidate("GatedCourse", "PaidLesson/video.mp4")
+            .Should().Be("GatedCourse/PaidLesson/video.mp4");
+
+    // ── The traversal guard ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE ATTRIBUTION BYPASS. <c>FileSystemStreamProvider</c> does a bare
+    /// <c>Path.Combine(basePath, path)</c>, and the catch-all route hands this endpoint
+    /// percent-encoded segments that <c>DecodeContentPath</c> un-escapes — so a
+    /// <c>%2E%2E</c> segment reaches the gate as <c>..</c> AFTER the server's own URL
+    /// normalization. Without this rule the candidate <c>PublicSpace/../PrivateSpace/secret.pdf</c>
+    /// resolves to <c>PublicSpace</c>, borrows its anonymous grant, and then reads the OTHER
+    /// partition's file. Dot and empty segments are refused, so the candidate is null and the
+    /// request is denied.
+    /// </summary>
+    [Theory]
+    [InlineData("content/PublicSpace/../PrivateSpace/secret.pdf")]
+    [InlineData("content/PublicSpace/./secret.pdf")]
+    [InlineData("content/PublicSpace//secret.pdf")]
+    public void OwnerCandidate_RefusesTraversalAndEmptySegments(string filePath) =>
+        StaticContentGate.RootStoreOwnerCandidate(filePath).Should().BeNull(
+            "a traversal segment would let a file borrow another node's grant");
+
+    /// <summary>
+    /// The same guard on the address shape — the mounted node must not be able to lend its grant
+    /// to a path that walks out of its own subtree.
+    /// </summary>
+    [Fact]
+    public void AddressOwnerCandidate_RefusesTraversal() =>
+        StaticContentGate.AddressOwnerCandidate("PublicSpace", "../PrivateSpace/secret.pdf")
+            .Should().BeNull();
+
+    /// <summary>
+    /// A double quote would break out of the quoting <c>IPathResolver</c> puts around each segment
+    /// when it builds its <c>path:</c> query — the attribution query is not a place to accept
+    /// caller-controlled quoting.
+    /// </summary>
+    [Fact]
+    public void OwnerCandidate_RefusesAQuoteThatWouldBreakTheResolverQuery() =>
+        StaticContentGate.RootStoreOwnerCandidate("content/AC\"ME/logo.svg").Should().BeNull();
+
+    /// <summary>Ordinary names — dots inside a segment, spaces, unicode — must still resolve.</summary>
+    [Theory]
+    [InlineData("content/ACME/module1-intro.poster.png", "ACME/module1-intro.poster.png")]
+    [InlineData("content/Data Analytics/report.pdf", "Data Analytics/report.pdf")]
+    [InlineData("content/Übersicht/plan.pdf", "Übersicht/plan.pdf")]
+    public void OwnerCandidate_AcceptsOrdinaryFileNames(string filePath, string expected) =>
+        StaticContentGate.RootStoreOwnerCandidate(filePath).Should().Be(expected);
+
+    // ── Caching ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Access-controlled bytes must never be stored by a CDN / corporate proxy — an intermediary
+    /// that saw one authorized fetch would keep replaying it to callers the gate denies, so the
+    /// leak would survive the fix. Only the declared-public asset class is shared-cacheable.
+    /// </summary>
+    [Fact]
+    public void CacheControl_IsPrivateForGatedContent()
+    {
+        var gated = BlazorHostingExtensions.CacheControlFor(isPublic: false);
+        gated.Should().Contain("private");
+        gated.Should().NotContain("public");
+        gated.Should().NotContain("immutable",
+            "an immutable 30-day promise outlives any revocation of the grant");
+    }
+
+    /// <summary>The public asset class keeps its long, shared-cacheable, immutable response.</summary>
+    [Fact]
+    public void CacheControl_StaysPublicAndImmutableForDeclaredPublicCollections()
+    {
+        var declaredPublic = BlazorHostingExtensions.CacheControlFor(isPublic: true);
+        declaredPublic.Should().Contain("public");
+        declaredPublic.Should().Contain("immutable");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #587 — `/static/**` served content collections with **no authentication and no access control**.

## Three distinct holes (all in `BlazorHostingExtensions`)

1. **No authorization anywhere.** `ResolveStatic → ServeFromCollection → ServeFile` resolved a collection and streamed the file. The `/static/storage/content/{node}/{file}` form reads the mesh-level store directly — every partition's uploads flat and world-readable at a **fully predictable** URL (`MeshNodeImageHelper`, `MarkdownFileParser` and `ContentAssetMapper` all build that scheme).
2. **`IsStatic` was declared but read nowhere** — set at 2 sites, consulted at 0 — so every collection registered on the mesh hub was servable by URL.
3. **A cache short-circuit bypass.** The only brush with access control in the address pattern was the collection-config lookup (`GetDataRequest` carries `[RequiresPermission(Read)]`), and `collectionCache.TryGetValue` skipped it on a hit. **Once any caller warmed the cache, every later caller — anonymous included — bypassed the check entirely.**

Found while building the gate: `DecodeContentPath` un-escapes `%2E%2E` **after** the server's URL normalization, and `FileSystemStreamProvider` does a bare `Path.Combine` — so `content/PublicSpace/%2E%2E/PrivateSpace/secret.pdf` would borrow PublicSpace's anonymous grant to read another partition. Guarded.

## The gate

Two explicit declarations, **both defaulting closed**:

- **`IsStatic`** — is the collection mounted on `/static` at all? Not declared ⇒ 404, identically for every caller (a hosting decision must not vary with identity).
- **`IsPublic`** (new) — is that mount world-readable? Not declared ⇒ gated.

**It matches the canonical read path rather than inventing rules.** The ordinary content read posts `GetDataRequest`, whose `[RequiresPermission(Read)]` pipeline checks the owning hub's own path; the gate calls `hub.GetEffectivePermissions(ownerPath, userId)` through the same `PermissionEvaluator`. Partition/RLS scoping, group expansion, `PublicRead` policies and the paywall's per-subject deny/allow therefore apply verbatim. Owner attribution goes through `IPathResolver` (longest node prefix), so a file under `{Course}/{Lesson}` attributes to the lesson and the per-child deny bites, while the cover under `{Course}` stays anonymous; Read folds hierarchically, so deepest-node attribution is never weaker than the root. Fail-open only where `AccessControlPipeline` itself does (no `EffectivePermissionsDelegate` registered) — absence of policy, not bypass of one.

Also: gated content is now `private, max-age=300, must-revalidate` (was `public, immutable` — a CDN or proxy would have kept replaying it), and the large-file streaming path, which previously carried **no** `Cache-Control` at all, is classified too. 401 anonymous / 403 authenticated, mirroring the sibling `CourseAssetEndpoints`.

Deliberately public: `NodeTypeIcons` (compiled into MeshWeaver.Graph, needed before any identity exists — login page, nav, every anonymous card) and `DocContent` (shipped in the nuget package; the Doc partition already carries Anonymous/Public Read grants).

## Verification

`StaticContentAccessTest` drives **real HTTP over TestServer against a real mesh** seeded with the production paywall shape — 11 tests: anonymous denied, signed-in-without-grant forbidden, public cover still anonymous, gated lesson denied to a visitor and served to the entitled buyer, explicitly-public collection served, gated content never shared-cacheable, unattributable file denied, unmounted collection not served, plus both address-pattern cases including *"warming the collection cache does not open the gate"*. `StaticContentGateRulesTest` adds 17 pure-rule tests (attribution, traversal/quote guard, cache classification).

**Fail-without:** disabling the gate flipped 5 of 11 to failures — *"Expected Unauthorized because an anonymous caller holds no grant on PrivateSpace — the URL is not the access control, but found OK"* — and disabling the second pattern failed both `AddressPattern_*` with 0 passed.

**Pass-with:** 28/28 here, ContentCollections.Test 28/28, Content.Test 245 passed / 1 pre-existing skip, Documentation.Test 19/19. Independently re-verified **28/28 after merging current main**. `-c Release -warnaserror` clean on every touched project.

## 🚨 Deployment risks — please review before merge

1. **Login-page logos.** `CorporateIdentity.LogoPath` / `BrandingResolver` build `/static/storage/content/{node}/…`, now gated on Read of the owning node. Correct — but if a portal's logo lives in a space without an Anonymous grant, **the login page shows a broken image**. The fix is a grant or a public collection, not code. Worth a prod smoke-check right after deploy.
2. **`Memex.LocalMesh` now serves public mounts only** — that sidecar resolves no identity at all, so anything else would be ungated. If it was relied on for non-public assets, those 404.
3. **Per-file gating below the owning node is not expressible** where content does not mirror the node tree (e.g. lesson media flat under `content/{Space}/videos/`); those attribute to the Space. `_Entitlements`-gated course media is served by the separate `/assets` endpoint and is unaffected.
4. **5 s `GrantWait` on denial** (matching `CourseAssetEndpoints`) — a denied request holds a request slot that long. The positive-shaped wait is required because the permission fold's first emission can be a premature empty seed.
5. No docs written — `AccessControl.md` has no section on the `/static` contract; worth adding as a follow-up.

No What's New entry: security hardening; no intended user-visible change beyond correctly denying what was never meant to be public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
