### PR TITLE
ExecuteScript dispatch answers the caller — nine swallow points closed (#841)

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -3692,12 +3692,31 @@ public class MeshOperations
     }
 
     /// <summary>
-    /// Runs an executable Code node's C# through the kernel (Microsoft.DotNet.Interactive)
-    /// and returns status JSON. The target node must have
-    /// <c>CodeConfiguration.IsExecutable == true</c>. Emits once when the kernel signals
-    /// completion (the kernel hub posts a response to <see cref="SubmitCodeRequest"/>
-    /// after the code finishes) or on timeout.
+    /// Dispatches an executable Code node's script to its per-node hub and emits dispatch
+    /// status JSON. The target node must have <c>CodeConfiguration.IsExecutable == true</c>.
+    ///
+    /// <para>The emission is the <b>dispatch acknowledgement</b>, not run completion: on
+    /// success it carries the <c>activityPath</c> the owning hub ACTUALLY created, which the
+    /// caller then polls / subscribes for live messages and the terminal status.</para>
+    ///
+    /// <para>🚨 #841 — every failure mode in the chain surfaces here as
+    /// <c>status: "Error"</c>. This method used to <c>hub.Post</c> the request
+    /// fire-and-forget and return a <c>Dispatched</c> envelope carrying a
+    /// <i>locally guessed</i> activity path, so three whole classes of failure were
+    /// invisible to the caller: (a) the request never routed (the Code node's per-node hub
+    /// did not activate, the path does not exist) — a <c>DeliveryFailure</c> nobody observed;
+    /// (b) the owning hub answered <c>Success = false</c> (not executable, unreadable node,
+    /// activity creation refused) — a response nobody observed; (c) the guessed path was
+    /// simply wrong, because the owning hub resolves the activity parent through
+    /// <c>CodeConfiguration.ActivityParentPath</c> / the partition default / the
+    /// <c>{viewer}</c> sentinel, none of which the caller can see. In case (c) a fully
+    /// SUCCESSFUL run still left the caller polling a path that would never exist.</para>
     /// </summary>
+    /// <param name="path">Path of the executable Code node (a leading <c>@</c> is stripped).</param>
+    /// <param name="timeoutSeconds">
+    /// Wall-clock budget for the dispatch acknowledgement (not for the script run). Elapsing
+    /// is reported as an error, never as a silent success.
+    /// </param>
     public IObservable<string> ExecuteScript(string path, int timeoutSeconds = 120)
     {
         logger.LogInformation("ExecuteScript called with path={Path}", path);
@@ -3707,22 +3726,7 @@ public class MeshOperations
                 hub.JsonSerializerOptions));
 
         var resolvedPath = ResolvePath(path);
-
-        // Fire-and-forget dispatch. The Code hub creates an Activity at
-        // `{partition}/_Activity/{submissionId}` (the kernel runs inside the
-        // Activity hub) and writes ActivityLog.Messages + Status as the script
-        // executes. We pre-generate the SubmissionId here so we can return the
-        // Activity path immediately — callers poll `get @{activityPath}` to
-        // observe progress and final status without waiting for an ack.
-        //
-        // Why no wait? The ack `ExecuteScriptResponse` from the Code hub is a
-        // throw-away "got it, here's the activity path" — but routing it back
-        // to a hosted MCP session hub is fragile (we lost ~half a day chasing
-        // it). The Activity itself is the source of truth: live messages,
-        // terminal Status, error details — everything's there. So just return
-        // the activity path and let the caller observe.
-        var partition = resolvedPath.Split('/', 2)[0];
-        if (string.IsNullOrEmpty(partition))
+        if (string.IsNullOrEmpty(resolvedPath.Split('/', 2)[0]))
             return Observable.Return(JsonSerializer.Serialize(
                 new
                 {
@@ -3732,33 +3736,86 @@ public class MeshOperations
                 },
                 hub.JsonSerializerOptions));
 
-        var submissionId = Guid.NewGuid().ToString("N");
-        var activityPath = $"{partition}/_Activity/{submissionId}";
-
-        try
+        // Defer so the post happens on Subscribe — MeshOperations' documented cold-observable
+        // contract (hub.Observe posts eagerly when called).
+        return Observable.Defer(() =>
         {
-            hub.Post(
-                new ExecuteScriptRequest { SubmissionId = submissionId },
-                o => o.WithTarget(new Address(resolvedPath)));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "ExecuteScript failed to dispatch for {Path}", resolvedPath);
-            return Observable.Return(JsonSerializer.Serialize(
-                new { status = "Error", path = resolvedPath, message = ex.Message },
-                hub.JsonSerializerOptions));
-        }
+            var submissionId = Guid.NewGuid().ToString("N");
+            return hub
+                .Observe<ExecuteScriptResponse>(
+                    new ExecuteScriptRequest { SubmissionId = submissionId },
+                    o => o.WithTarget(new Address(resolvedPath)))
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(Math.Max(1, timeoutSeconds)))
+                .Select(delivery =>
+                {
+                    var response = delivery.Message;
+                    if (!response.Success)
+                    {
+                        // The owning hub refused or faulted. It has already logged the WHY
+                        // (with exception type + stack where there was one); relay the
+                        // verdict verbatim so the caller is never told "Dispatched" for a
+                        // run that will never exist.
+                        logger.LogWarning(
+                            "ExecuteScript dispatch refused for {Path}: {Error}",
+                            resolvedPath, response.Error);
+                        return JsonSerializer.Serialize(
+                            new
+                            {
+                                status = "Error",
+                                path = resolvedPath,
+                                submissionId,
+                                message = response.Error
+                                    ?? "The Code node's hub refused the dispatch without a reason."
+                            },
+                            hub.JsonSerializerOptions);
+                    }
 
-        return Observable.Return(JsonSerializer.Serialize(
-            new
-            {
-                status = "Dispatched",
-                path = resolvedPath,
-                submissionId,
-                activityPath,
-                message = $"Script dispatched. Poll `get @{activityPath}` for live messages " +
-                          "and final status (Running → Succeeded/Failed)."
-            },
-            hub.JsonSerializerOptions));
+                    // AUTHORITATIVE path — where the owning hub actually created the
+                    // Activity, never a locally reconstructed guess.
+                    var activityPath = response.ActivityLog;
+                    if (string.IsNullOrEmpty(activityPath))
+                        return JsonSerializer.Serialize(
+                            new
+                            {
+                                status = "Error",
+                                path = resolvedPath,
+                                submissionId,
+                                message = "The dispatch succeeded but the Code node's hub "
+                                    + "returned no activity path, so the run cannot be observed."
+                            },
+                            hub.JsonSerializerOptions);
+
+                    return JsonSerializer.Serialize(
+                        new
+                        {
+                            status = "Dispatched",
+                            path = resolvedPath,
+                            submissionId = response.SubmissionId ?? submissionId,
+                            activityPath,
+                            message = $"Script dispatched. Poll `get @{activityPath}` for live "
+                                + "messages and final status (Running → Succeeded/Failed)."
+                        },
+                        hub.JsonSerializerOptions);
+                })
+                .Catch<string, Exception>(ex =>
+                {
+                    // Undeliverable (no such node / the per-node hub never activated), the
+                    // budget elapsed, or the hub is shutting down. Exception TYPE + full
+                    // STACK to the logger, TYPE + message + detail to the caller — a caller
+                    // that cannot tell "pending" from "dropped" is the defect this fixes.
+                    logger.LogError(ex, "ExecuteScript dispatch failed for {Path}", resolvedPath);
+                    return Observable.Return(JsonSerializer.Serialize(
+                        new
+                        {
+                            status = "Error",
+                            path = resolvedPath,
+                            errorType = ex.GetType().FullName,
+                            message = ex.Message,
+                            detail = ex.ToString()
+                        },
+                        hub.JsonSerializerOptions));
+                });
+        });
     }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -142,6 +142,29 @@ Agents call the same path as `ExecuteScriptRequest` but through the MCP tool sur
 }
 ```
 
+The tool returns the **dispatch verdict**, not the run's result — it comes back as soon as the run is accepted, and the script keeps going:
+
+```jsonc
+// Accepted. `activityPath` is what the OWNING hub created — never a path the caller
+// reconstructed, so it is correct even when ActivityParentPath / the partition default /
+// the {viewer} sentinel route the activity somewhere other than the Code node's partition.
+{ "status": "Dispatched", "path": "rbuergi/daily-rollup",
+  "submissionId": "…", "activityPath": "rbuergi/_Activity/…" }
+
+// Refused or faulted. There is NO activityPath — nothing was created, and nothing is pending.
+{ "status": "Error", "path": "rbuergi/daily-rollup",
+  "message": "Not executable: 'rbuergi/daily-rollup' has CodeConfiguration.IsExecutable = false." }
+```
+
+`Dispatched` therefore means "an Activity node exists at `activityPath`", and every way the
+dispatch can fail — the node is missing or unreadable, it is not executable, the Activity could not
+be created, the request never routed, the acknowledgement never came — arrives as `status: "Error"`
+carrying the reason (and the exception type where there was one). The owning hub logs the same
+verdict at `Warning`/`Error` on the `MeshWeaver.Graph.CodeNodeType` channel, so an operator can find
+a failed dispatch in pod stdout without the caller's transcript. Poll `get @{activityPath}` for
+progress and the terminal status; a script's own exception surfaces there, not in the dispatch
+verdict.
+
 ---
 
 ## Creating typed / restricted-partition nodes — the `execute_script` escape hatch

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -95,6 +95,68 @@ public static class CodeNodeType
     private static bool IsForeignLanguage(string? language) =>
         language?.ToLowerInvariant() is "python" or "javascript" or "typescript";
 
+    /// <summary>Log channel for every dispatch-side diagnostic emitted by this type.</summary>
+    private const string LoggerCategory = "MeshWeaver.Graph.CodeNodeType";
+
+    /// <summary>
+    /// Wall-clock budget for the <see cref="PartitionDefinition"/> lookup that decides where a
+    /// run's Activity node is written. The lookup is a LIVE workspace query
+    /// (<see cref="PartitionRegistry.GetPartition"/>) and a live query that never converges
+    /// simply never emits — before #841 the dispatch chain sat on that non-emission forever:
+    /// no Activity node, no response, no log line, nothing at Warning+. The budget converts
+    /// that silent stop into a <see cref="TimeoutException"/> that reaches the caller AND the
+    /// logger. It is a diagnosability boundary, not a retry: nothing is re-attempted.
+    /// </summary>
+    private static readonly TimeSpan ActivityParentLookupTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Resolves the namespace a script run's <c>Activity</c> node is written under. Three
+    /// layers, in order: the Code node's own <see cref="CodeConfiguration.ActivityParentPath"/>,
+    /// the partition's <see cref="PartitionDefinition.DefaultActivityParentPath"/>, then the
+    /// partition root. The <c>{viewer}</c> sentinel at either configured layer expands to
+    /// <paramref name="viewerHome"/> (falling back to <paramref name="partitionRoot"/> when no
+    /// viewer identity is available).
+    ///
+    /// <para>Extracted so the ONE way this can stop without producing an answer — a partition
+    /// lookup that never emits — is pinned by a test rather than discovered in production. The
+    /// stream is bounded by <paramref name="lookupBudget"/> and an empty completion resolves to
+    /// "no definition" instead of completing without an emission; either way exactly one of
+    /// <c>OnNext</c> / <c>OnError</c> always reaches the subscriber.</para>
+    /// </summary>
+    /// <param name="partitionDefinitions">Live stream of the partition's definition (null when none).</param>
+    /// <param name="codeActivityParentPath">The Code node's configured override, if any.</param>
+    /// <param name="viewerHome">The calling user's home partition, used to expand <c>{viewer}</c>.</param>
+    /// <param name="partitionRoot">The Code node's own partition — the default and the fallback.</param>
+    /// <param name="lookupBudget">Wall-clock budget for the partition lookup.</param>
+    public static IObservable<string> ResolveActivityParent(
+        IObservable<PartitionDefinition?> partitionDefinitions,
+        string? codeActivityParentPath,
+        string? viewerHome,
+        string partitionRoot,
+        TimeSpan lookupBudget) =>
+        partitionDefinitions
+            .Take(1)
+            // A source that COMPLETES without emitting means "no partition definition", which
+            // is the default case — not a reason to end the dispatch chain in silence.
+            .DefaultIfEmpty()
+            .Timeout(lookupBudget, Observable.Throw<PartitionDefinition?>(
+                new TimeoutException(
+                    $"Activity-parent resolution stalled: the PartitionDefinition lookup for "
+                    + $"partition '{partitionRoot}' produced no answer within "
+                    + $"{lookupBudget.TotalSeconds:F0}s. The script was NOT started and no Activity "
+                    + "node was created.")))
+            .Select(partition =>
+            {
+                var unresolved = codeActivityParentPath ?? partition?.DefaultActivityParentPath;
+                return unresolved switch
+                {
+                    null => partitionRoot,
+                    "{viewer}" when !string.IsNullOrEmpty(viewerHome) => viewerHome!,
+                    "{viewer}" => partitionRoot,
+                    var p => p
+                };
+            });
+
     /// <summary>
     /// Runs the Code node's own script. Reads the local workspace for the node's
     /// <see cref="CodeConfiguration"/>, validates <c>IsExecutable</c>, dispatches
@@ -106,6 +168,40 @@ public static class CodeNodeType
     private static IMessageDelivery HandleExecuteScript(
         IMessageHub hub, IMessageDelivery<ExecuteScriptRequest> request)
     {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(LoggerCategory);
+
+        // 🚨 #841 — THE dispatch sink. Every branch that ends this dispatch without an
+        // Activity node goes through one of these two, and both do BOTH things: answer
+        // the caller AND leave a Warning+ trace. Before the fix the branches only posted
+        // a response, and the canonical caller (MCP execute_script) never observed it —
+        // a dispatch that produced no Activity node produced no evidence anywhere, which
+        // is exactly what made this issue undiagnosable in production.
+        void RefuseDispatch(string error)
+        {
+            logger?.LogWarning(
+                "ExecuteScript refused on {Hub}: {Error} No Activity node was created.",
+                hub.Address, error);
+            hub.Post(new ExecuteScriptResponse { Success = false, Error = error },
+                o => o.ResponseFor(request));
+        }
+
+        // Same sink for a FAULT rather than a refusal: the exception TYPE and full STACK
+        // go to the logger, and the wire error keeps the type name. Reducing an abort to
+        // `.Message` is what made the sibling compile NRE (#890) undiagnosable — see #892.
+        void FaultDispatch(Exception exception, string context)
+        {
+            logger?.LogError(exception,
+                "ExecuteScript faulted on {Hub}: {Context}. No Activity node was created.",
+                hub.Address, context);
+            hub.Post(
+                new ExecuteScriptResponse
+                {
+                    Success = false,
+                    Error = $"{context}: {exception.GetType().Name}: {exception.Message}"
+                },
+                o => o.ResponseFor(request));
+        }
+
         // One-shot read of this hub's own MeshNode via GetDataRequest (posted to self) â€”
         // true request/response, no SubscribeRequest+immediate-unsubscribe. Handler
         // itself returns Processed() immediately; the callback below fires when the
@@ -118,15 +214,29 @@ public static class CodeNodeType
         hub.GetMeshNode(hub.Address.ToString())
             .Subscribe(node =>
             {
-                if (node?.Content is not CodeConfiguration code || !code.IsExecutable)
+                // Three distinct facts, three distinct verdicts. Folding them into one
+                // "Not executable" line told a caller whose node had merely become
+                // unreadable that their script was misconfigured.
+                if (node is null)
                 {
-                    hub.Post(
-                        new ExecuteScriptResponse
-                        {
-                            Success = false,
-                            Error = "Not executable (IsExecutable=false or content is not a CodeConfiguration)"
-                        },
-                        o => o.ResponseFor(request));
+                    RefuseDispatch(
+                        $"No readable node at '{hub.Address}': it does not exist, or the caller "
+                        + "may not read it.");
+                    return;
+                }
+
+                if (node.Content is not CodeConfiguration code)
+                {
+                    RefuseDispatch(
+                        $"Node '{hub.Address}' carries {node.Content?.GetType().Name ?? "no content"}, "
+                        + "not a CodeConfiguration — there is nothing to execute.");
+                    return;
+                }
+
+                if (!code.IsExecutable)
+                {
+                    RefuseDispatch(
+                        $"Not executable: '{hub.Address}' has CodeConfiguration.IsExecutable = false.");
                     return;
                 }
 
@@ -169,19 +279,12 @@ public static class CodeNodeType
                     ?? Observable.Return<PartitionDefinition?>(null);
 
                 var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
-                partitionDefaultStream
-                    .Take(1)
-                    .Select(partition =>
-                    {
-                        var unresolved = code.ActivityParentPath ?? partition?.DefaultActivityParentPath;
-                        return unresolved switch
-                        {
-                            null => partitionRoot,
-                            "{viewer}" when !string.IsNullOrEmpty(viewerHome) => viewerHome!,
-                            "{viewer}" => partitionRoot,
-                            var p => p
-                        };
-                    })
+                ResolveActivityParent(
+                        partitionDefaultStream,
+                        code.ActivityParentPath,
+                        viewerHome,
+                        partitionRoot,
+                        ActivityParentLookupTimeout)
                     .SelectMany(activityParentPath =>
                     {
                         var activityId = submissionId;
@@ -259,7 +362,8 @@ public static class CodeNodeType
                                             // The delivery faulted (target unreachable / disconnected)
                                             // before any terminal write — reconcile so the run ends.
                                             ex => FailActivity(hub, activityPath,
-                                                $"{submit.Language} run failed: {ex.Message}"));
+                                                $"{submit.Language} run failed: "
+                                                + $"{ex.GetType().Name}: {ex.Message}", ex));
                                 }
                             }
                             else
@@ -277,8 +381,7 @@ public static class CodeNodeType
                             try
                             {
                                 var workspace = hub.GetWorkspace();
-                                var stampLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
-                                    ?.CreateLogger("MeshWeaver.Graph.CodeNodeType");
+                                var stampLogger = logger;
                                 // .Subscribe is mandatory: Update is Observable.Create â€”
                                 // the partition write only runs on Subscribe. Discarding
                                 // the observable silently drops the stamp.
@@ -307,11 +410,15 @@ public static class CodeNodeType
                                             "CodeNodeType: stamp UpdateMeshNode failed for {Hub}",
                                             hub.Address));
                             }
-                            catch
+                            catch (Exception stampEx)
                             {
-                                // Workspace might not be ready (cold-start race)
-                                // â€” missing fields are a UI nicety, not a
-                                // correctness invariant. Activity log still written.
+                                // The workspace might not be ready (cold-start race) — the
+                                // missing stamp is a UI nicety, not a correctness invariant,
+                                // and the Activity log IS written. But a bare `catch {}` here
+                                // hid whatever went wrong; name it, with type + stack.
+                                logger?.LogWarning(stampEx,
+                                    "CodeNodeType: could not stamp last-execution fields on {Hub} "
+                                    + "(run {Activity} is unaffected)", hub.Address, activityPath);
                             }
 
                             hub.Post(
@@ -324,29 +431,18 @@ public static class CodeNodeType
                                 },
                                 o => o.ResponseFor(request));
                         },
-                        err =>
-                        {
-                            hub.Post(
-                                new ExecuteScriptResponse
-                                {
-                                    Success = false,
-                                    Error = $"Failed to create ActivityLog node: {err.Message}"
-                                },
-                                o => o.ResponseFor(request));
-                        });
+                        // Covers BOTH pre-create stages: a stalled activity-parent resolution
+                        // (TimeoutException from ResolveActivityParent) and a refused/failed
+                        // CreateNode (UnauthorizedAccessException / InvalidOperationException
+                        // from IMeshService). Previously this sink posted a `.Message`-only
+                        // response that nobody observed and logged NOTHING — the exact shape
+                        // of #841's "no Activity node, nothing at Warning+".
+                        err => FaultDispatch(err, "Could not start the script run"));
             },
-            readError =>
-            {
-                // The self-read failed (timeout / access denial). Answer the caller with what
-                // actually happened instead of the misleading "Not executable" verdict above.
-                hub.Post(
-                    new ExecuteScriptResponse
-                    {
-                        Success = false,
-                        Error = $"Could not read the code node to execute: {readError.Message}"
-                    },
-                    o => o.ResponseFor(request));
-            });
+            // The self-read failed (timeout / access denial). Answer the caller with what
+            // actually happened instead of the misleading "Not executable" verdict above,
+            // and log it — a stalled mesh read is an infrastructure fault, not a config error.
+            readError => FaultDispatch(readError, "Could not read the Code node to execute"));
         return request.Processed();
     }
 
@@ -357,10 +453,23 @@ public static class CodeNodeType
     /// carries the caller's AccessContext across the Subscribe boundary); <see cref="ActivityLog.Fail"/>
     /// appends the error and stamps <c>End</c>, so the Output pane leaves "Running…" with the reason.
     /// </summary>
-    private static void FailActivity(IMessageHub hub, string activityPath, string error)
+    private static void FailActivity(IMessageHub hub, string activityPath, string error,
+        Exception? exception = null)
     {
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
-            ?.CreateLogger("MeshWeaver.Graph.CodeNodeType");
+            ?.CreateLogger(LoggerCategory);
+        // Log the REASON, not only a failure to record it: the activity content is visible
+        // to whoever opens that node, but an operator grepping stdout for a run that never
+        // produced output had nothing to find (#841). When a delivery fault drove us here,
+        // the exception object carries type + stack to the logger — never just `.Message`.
+        if (exception is null)
+            logger?.LogWarning(
+                "CodeNodeType: failing run {Activity} dispatched from {Hub}: {Error}",
+                activityPath, hub.Address, error);
+        else
+            logger?.LogWarning(exception,
+                "CodeNodeType: failing run {Activity} dispatched from {Hub}: {Error}",
+                activityPath, hub.Address, error);
         hub.GetWorkspace().GetMeshNodeStream(activityPath).Update(curr =>
             curr.Content is ActivityLog log
                 ? curr with { Content = log.Fail(error) }

--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -769,17 +769,19 @@ Returns `{ok: true|false, diagnostics: [...]}` — same shape as `lsp_check_node
     }
 
     /// <summary>
-    /// Runs an executable Code node's C# through the kernel and returns stdout /
-    /// return value / errors, blocking until the kernel signals completion.
+    /// Dispatches an executable Code node's script to its per-node hub and returns the
+    /// dispatch verdict as JSON: <c>status: "Dispatched"</c> with the activity path the
+    /// owning hub actually created, or <c>status: "Error"</c> with the reason. The script
+    /// keeps running after this returns; the activity node is the source of truth.
     /// </summary>
     /// <param name="path">Path to an executable Code node (must be <c>IsExecutable=true</c>).</param>
-    /// <param name="timeoutSeconds">Execution timeout in seconds (default 120).</param>
-    /// <returns>The script output as a string.</returns>
+    /// <param name="timeoutSeconds">Budget for the dispatch acknowledgement (default 120).</param>
+    /// <returns>Dispatch-status JSON.</returns>
     [McpServerTool(Title = "Execute a Code node", Destructive = true, Idempotent = false, OpenWorld = false)]
-    [Description("Runs an executable Code node's C# through the kernel (Microsoft.DotNet.Interactive) and returns stdout / return value / errors. The target node must have `CodeConfiguration.IsExecutable == true`. Blocks until the kernel signals completion (side-effects — e.g. mesh.CreateNode calls inside the script — have happened by the time this returns). Use to run import/test scripts from MCP without needing a UI click.")]
+    [Description("Runs an executable Code node's C# on the mesh kernel. The target node must have `CodeConfiguration.IsExecutable == true`. Returns as soon as the run has been ACCEPTED, not when it finishes: `{status:'Dispatched', activityPath}` — poll `get @{activityPath}` for the live log messages and the terminal status (Running → Succeeded/Failed), which is also where a script's own exception surfaces. Any dispatch failure (node missing or unreadable, not executable, activity could not be created, request undeliverable) comes back as `{status:'Error', message}` — a 'Dispatched' reply always means a real activity exists. Use to run import/test scripts from MCP without needing a UI click.")]
     public Task<string> ExecuteScript(
         [Description("Path to an executable Code node (e.g., @Systemorph/FutuRe/EuropeRe/AcmeSubmission2025/Script/ImportLargeClaims). Must be `IsExecutable=true`.")] string path,
-        [Description("Timeout in seconds. Default 120.")] int timeoutSeconds = 120)
+        [Description("Seconds to wait for the dispatch acknowledgement (NOT for the script to finish). Default 120.")] int timeoutSeconds = 120)
         => ops.ExecuteScript(path, timeoutSeconds).FirstAsync().ToTask();
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/ExecuteScriptDispatchDiagnosticsTest.cs
+++ b/test/MeshWeaver.AI.Test/ExecuteScriptDispatchDiagnosticsTest.cs
@@ -1,0 +1,374 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins issue #841 — <c>ExecuteScript</c> dispatch must never die silently.
+///
+/// <para>The reported symptom was "MCP <c>execute_script</c> answers <c>Dispatched</c>, the
+/// activity node at the returned path never appears, and the pod emits nothing at Warning or
+/// above." Three independent defects produced it, and each has its own test here:</para>
+///
+/// <list type="number">
+///   <item><b>The caller GUESSED the activity path.</b> <c>MeshOperations.ExecuteScript</c>
+///     returned <c>{partition}/_Activity/{submissionId}</c> reconstructed locally, while the
+///     owning hub resolves the activity parent through <c>ActivityParentPath</c> / the
+///     partition default / the <c>{viewer}</c> sentinel. A completely SUCCESSFUL run then
+///     left the caller polling a path that would never exist —
+///     <see cref="Dispatch_ViewerRoutedActivity_ReturnsThePathTheActivityActuallyLandsAt"/>.</item>
+///   <item><b>The dispatch was fire-and-forget.</b> Every <c>Success = false</c> verdict the
+///     owning hub posted — not executable, unreadable node, activity creation refused — went
+///     to a caller that never observed it, as did any <c>DeliveryFailure</c> —
+///     <see cref="Dispatch_NonExecutableNode_SurfacesRefusalToCaller"/>,
+///     <see cref="Dispatch_MissingNode_SurfacesErrorToCaller"/>,
+///     <see cref="Dispatch_ActivityCreationRefused_SurfacesFaultToCallerAndLogger"/>.</item>
+///   <item><b>The handler logged nothing.</b> None of those branches wrote a log line, so with
+///     the caller not listening the failure left no evidence anywhere. Every test below asserts
+///     the Warning+ trace as well as the caller-visible verdict.</item>
+/// </list>
+///
+/// <para>The fourth defect — an activity-parent lookup that never emits, ending the chain in
+/// total silence — is pinned by <see cref="ResolveActivityParentTest"/>.</para>
+/// </summary>
+public class ExecuteScriptDispatchDiagnosticsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string UserHome = "rbuergi";
+
+    /// <summary>
+    /// Captures what the mesh's own <see cref="ILoggerFactory"/> emits, so "the failure is
+    /// visible at Warning+" is an assertion rather than a claim. Instance-owned (its lifetime
+    /// is this test's mesh), never static.
+    /// </summary>
+    private readonly CapturingLoggerProvider logs = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(logs));
+
+    /// <summary>Layout client so <c>GetMeshNodeStream</c> can follow the activity.</summary>
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    // ---- the caller must be told the path the run ACTUALLY landed at ---------------
+
+    /// <summary>
+    /// A Code node configured with <c>ActivityParentPath = "{viewer}"</c> writes its activity
+    /// into the CALLER's home, not the Code node's partition. The old caller-side guess
+    /// (<c>{codePartition}/_Activity/{id}</c>) is therefore wrong by construction — the run
+    /// succeeds and the caller polls a path that never materialises, which is the reported
+    /// "activity node is never created" exactly. The dispatch verdict must carry the owning
+    /// hub's own answer.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Dispatch_ViewerRoutedActivity_ReturnsThePathTheActivityActuallyLandsAt()
+    {
+        var codePath = await SeedCode(
+            "Log.LogInformation(\"ping\"); 1", activityParentPath: "{viewer}");
+
+        var verdict = await DispatchAsync(codePath);
+
+        verdict.GetProperty("status").GetString().Should().Be("Dispatched", verdict.ToString());
+        var activityPath = verdict.GetProperty("activityPath").GetString()!;
+
+        activityPath.Should().StartWith($"{TestUsers.Admin.ObjectId}/_Activity/",
+            "the reported path must be the one the OWNING hub resolved ({viewer} → the caller's "
+            + "home); a caller-side guess from the Code node's partition points at a node that "
+            + "will never exist");
+
+        // …and there is really a node there, which really finishes.
+        var log = (await GetClient().GetWorkspace()
+            .GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds())
+            .Match(l => l is not null && l!.Status != ActivityStatus.Running))!;
+        log.Status.Should().Be(ActivityStatus.Succeeded);
+    }
+
+    /// <summary>
+    /// The plain success contract: a dispatch that answers <c>Dispatched</c> always names a real
+    /// Activity node that reaches a terminal status.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Dispatch_Succeeds_NamesAnActivityThatReachesATerminalStatus()
+    {
+        var codePath = await SeedCode("Log.LogInformation(\"working\"); 41 + 1");
+
+        var verdict = await DispatchAsync(codePath);
+
+        verdict.GetProperty("status").GetString().Should().Be("Dispatched", verdict.ToString());
+        var activityPath = verdict.GetProperty("activityPath").GetString()!;
+        activityPath.Should().StartWith($"{UserHome}/_Activity/");
+
+        var log = (await GetClient().GetWorkspace()
+            .GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds())
+            .Match(l => l is not null && l!.Status != ActivityStatus.Running))!;
+        log.Status.Should().Be(ActivityStatus.Succeeded);
+        log.Messages.Select(m => m.Message).Should().Contain(m => m.Contains("working"));
+    }
+
+    // ---- every failure branch reaches the caller AND the logger --------------------
+
+    /// <summary>
+    /// <c>IsExecutable = false</c>: the owning hub refuses before creating anything. The caller
+    /// used to get <c>Dispatched</c> plus a path that would never exist; it must get the refusal.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Dispatch_NonExecutableNode_SurfacesRefusalToCaller()
+    {
+        var codePath = await SeedCode("\"never runs\"", isExecutable: false);
+
+        var verdict = await DispatchAsync(codePath);
+
+        verdict.GetProperty("status").GetString().Should().Be("Error", verdict.ToString());
+        verdict.GetProperty("message").GetString().Should().Contain("IsExecutable",
+            "the caller must be told WHY, in terms of the thing they can fix");
+        verdict.TryGetProperty("activityPath", out _).Should().BeFalse(
+            "an error verdict must never hand the caller a path to poll — there is no activity");
+
+        AssertLogged(LogLevel.Warning, "ExecuteScript refused");
+    }
+
+    /// <summary>
+    /// A path with no node behind it. Whether routing answers with a DeliveryFailure or the
+    /// per-node hub activates and finds nothing, the caller must end up with an error — never
+    /// "Dispatched", never a hang.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Dispatch_MissingNode_SurfacesErrorToCaller()
+    {
+        var ghost = $"{UserHome}/ghost-{Guid.NewGuid():N}";
+
+        var verdict = await DispatchAsync(ghost, timeoutSeconds: 20, budget: 60);
+
+        verdict.GetProperty("status").GetString().Should().Be("Error", verdict.ToString());
+        verdict.TryGetProperty("activityPath", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The induced-failure pin for the deepest swallow point: activity CREATION fails.
+    /// <c>Auth</c> is a system-managed mirror partition, so <c>PartitionWriteGuardValidator</c>
+    /// refuses any interactive create there — routing a run's activity into it makes
+    /// <c>IMeshService.CreateNode</c> throw inside the dispatch chain.
+    ///
+    /// <para>Before the fix that sink posted a <c>.Message</c>-only response to a caller who was
+    /// not listening and logged NOTHING: no activity node, no response, nothing at Warning+ —
+    /// the exact picture reported in #841. Now the caller gets the reason and the logger gets
+    /// the exception object (type + stack), per the standard set in #892.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Dispatch_ActivityCreationRefused_SurfacesFaultToCallerAndLogger()
+    {
+        var codePath = await SeedCode("1", activityParentPath: "Auth");
+
+        var verdict = await DispatchAsync(codePath);
+
+        verdict.GetProperty("status").GetString().Should().Be("Error", verdict.ToString());
+        var message = verdict.GetProperty("message").GetString()!;
+        message.Should().Contain("Could not start the script run");
+        message.Should().Contain(nameof(UnauthorizedAccessException),
+            "the wire error keeps the exception TYPE — '.Message' alone is what made this "
+            + "class of failure undiagnosable");
+        verdict.TryGetProperty("activityPath", out _).Should().BeFalse();
+
+        var faulted = AssertLogged(LogLevel.Error, "ExecuteScript faulted");
+        faulted.Exception.Should().NotBeNull(
+            "the logger must receive the exception OBJECT so the stack reaches the operator");
+        faulted.Exception!.Should().BeOfType<UnauthorizedAccessException>();
+    }
+
+    // ---- helpers -------------------------------------------------------------------
+
+    private async Task<string> SeedCode(
+        string code, bool isExecutable = true, string? activityParentPath = null)
+    {
+        var id = $"exec841-{Guid.NewGuid():N}";
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService.CreateNode(new MeshNode(id, UserHome)
+        {
+            Name = "Dispatch diagnostics",
+            NodeType = "Code",
+            Content = new CodeConfiguration
+            {
+                Code = code,
+                IsExecutable = isExecutable,
+                ActivityParentPath = activityParentPath
+            }
+        }).Should().Within(30.Seconds()).Emit();
+        return $"{UserHome}/{id}";
+    }
+
+    private async Task<JsonElement> DispatchAsync(
+        string path, int timeoutSeconds = 45, int budget = 90)
+    {
+        var json = await new MeshOperations(Mesh)
+            .ExecuteScript(path, timeoutSeconds)
+            .Should().Within(TimeSpan.FromSeconds(budget)).Emit();
+        Output.WriteLine($"execute_script({path}) → {json}");
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private CapturedLog AssertLogged(LogLevel level, string fragment)
+    {
+        var match = logs.Records.FirstOrDefault(
+            r => r.Level >= level && r.Message.Contains(fragment, StringComparison.Ordinal));
+        match.Should().NotBeNull(
+            $"a dispatch failure must leave a {level}+ trace containing '{fragment}' — the whole "
+            + "point of #841 is that the pod emitted NOTHING at Warning or above. Captured: ["
+            + string.Join(" | ", logs.Records.Select(r => $"{r.Level} {r.Category}: {r.Message}"))
+            + "]");
+        return match!;
+    }
+
+    // ---- log capture ---------------------------------------------------------------
+
+    private sealed record CapturedLog(
+        LogLevel Level, string Category, string Message, Exception? Exception);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        // Instance field on an instance owned by the test's mesh — never static state.
+        private readonly ConcurrentQueue<CapturedLog> records = new();
+
+        public IReadOnlyList<CapturedLog> Records => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, records);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, ConcurrentQueue<CapturedLog> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+                => sink.Enqueue(new CapturedLog(
+                    logLevel, category, formatter(state, exception), exception));
+        }
+    }
+}
+
+/// <summary>
+/// Unit pins for <see cref="CodeNodeType.ResolveActivityParent"/> — the stage that decides where a
+/// run's Activity node is written.
+///
+/// <para>It reads a LIVE workspace query (<c>PartitionRegistry.GetPartition</c>), and a live query
+/// that never converges simply never emits. The dispatch chain used to be
+/// <c>partitionStream.Take(1).SelectMany(CreateNode).Subscribe(…)</c> with no bound at all, so a
+/// non-emitting lookup ended the whole run in perfect silence: no Activity node, no response, no
+/// log line — indistinguishable from "still pending" forever. That is the wedges-to-zero
+/// violation behind #841's distributed-only reproduction, and it is what
+/// <see cref="PartitionLookupNeverEmits_ErrorsInsteadOfHangingForever"/> pins.</para>
+/// </summary>
+public class ResolveActivityParentTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromMilliseconds(250);
+
+    [Fact(Timeout = 30_000)]
+    public async Task PartitionLookupNeverEmits_ErrorsInsteadOfHangingForever()
+    {
+        Func<Task> act = async () => await CodeNodeType.ResolveActivityParent(
+                Observable.Never<PartitionDefinition?>(),
+                codeActivityParentPath: null,
+                viewerHome: "Roland",
+                partitionRoot: "rbuergi",
+                Budget)
+            .FirstAsync()
+            .ToTask();
+
+        (await act.Should().ThrowAsync<TimeoutException>(
+                "a partition lookup that never answers must surface — silence here means the "
+                + "script run stops with no activity, no response and no log line"))
+            .Which.Message.Should()
+                .Contain("rbuergi", "the operator must be told WHICH partition stalled").And
+                .Contain("no Activity node was created",
+                    "…and what the consequence for the run was");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PartitionLookupCompletesEmpty_ResolvesToPartitionRoot()
+    {
+        var parent = await CodeNodeType.ResolveActivityParent(
+                Observable.Empty<PartitionDefinition?>(),
+                codeActivityParentPath: null,
+                viewerHome: "Roland",
+                partitionRoot: "rbuergi",
+                Budget)
+            .FirstAsync()
+            .ToTask();
+
+        parent.Should().Be("rbuergi",
+            "a source that COMPLETES without emitting means 'no partition definition' — the "
+            + "default case, not another way for the chain to end without an answer");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task CodeNodeOverride_WinsOverPartitionDefault()
+    {
+        var parent = await CodeNodeType.ResolveActivityParent(
+                Observable.Return<PartitionDefinition?>(
+                    new PartitionDefinition { Namespace = "Doc", DefaultActivityParentPath = "Doc/Runs" }),
+                codeActivityParentPath: "Somewhere/Else",
+                viewerHome: "Roland",
+                partitionRoot: "Doc",
+                Budget)
+            .FirstAsync()
+            .ToTask();
+
+        parent.Should().Be("Somewhere/Else");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ViewerSentinel_OnThePartitionDefault_ExpandsToTheCallersHome()
+    {
+        var parent = await CodeNodeType.ResolveActivityParent(
+                Observable.Return<PartitionDefinition?>(
+                    new PartitionDefinition { Namespace = "Doc", DefaultActivityParentPath = "{viewer}" }),
+                codeActivityParentPath: null,
+                viewerHome: "Roland",
+                partitionRoot: "Doc",
+                Budget)
+            .FirstAsync()
+            .ToTask();
+
+        parent.Should().Be("Roland");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ViewerSentinel_WithNoViewerIdentity_FallsBackToPartitionRoot()
+    {
+        var parent = await CodeNodeType.ResolveActivityParent(
+                Observable.Return<PartitionDefinition?>(null),
+                codeActivityParentPath: "{viewer}",
+                viewerHome: null,
+                partitionRoot: "Doc",
+                Budget)
+            .FirstAsync()
+            .ToTask();
+
+        parent.Should().Be("Doc");
+    }
+}

--- a/test/MeshWeaver.AI.Test/McpReadYourWritesTest.cs
+++ b/test/MeshWeaver.AI.Test/McpReadYourWritesTest.cs
@@ -240,8 +240,39 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
 
     // ---- ExecuteScript --------------------------------------------------------
 
+    /// <summary>
+    /// 🐛 CHARACTERIZATION TEST for a data-loss defect this class's mesh exposes — read the
+    /// whole comment before "fixing" the assertion.
+    ///
+    /// <para>This class persists to the FILE SYSTEM (<c>AddFileSystemPersistence</c>). A node whose
+    /// Content is a <c>CodeConfiguration</c> is serialized by
+    /// <c>CSharpFileParser.Serialize</c> → <c>SerializeCodeConfiguration</c>
+    /// (<c>src/MeshWeaver.Hosting/Persistence/Parsers/CSharpFileParser.cs:100</c>), which writes
+    /// <b>only <c>config.Code</c></b> — no <c>&lt;meshweaver&gt;</c> header. The read side
+    /// (<c>ParseNode</c>, same file) therefore rebuilds <c>CodeConfiguration { Code, Language }</c>
+    /// and every other field is silently lost: <c>IsExecutable</c>, <c>ActivityParentPath</c>, the
+    /// <c>Last*</c> execution stamps. So a Code node created here with
+    /// <c>IsExecutable = true</c> reads back <b>false</b>, and the run is legitimately refused.</para>
+    ///
+    /// <para>That is a genuine bug, and it is NOT this test's or #841's to fix: repairing it means
+    /// emitting a header block from <c>SerializeCodeConfiguration</c>, and that same serializer is
+    /// what <c>GitSync</c> uses to write <c>.cs</c> files into users' git repositories
+    /// (<c>GitHubSyncService</c>, <c>NodeFileMapper</c>) — a cross-repo format change that needs its
+    /// own decision. Track it separately.</para>
+    ///
+    /// <para>What #841 changed, and what this test now pins: the refusal <b>reaches the caller</b>.
+    /// Before, <c>ExecuteScript</c> was fire-and-forget and answered <c>Dispatched</c> plus a guessed
+    /// activity path for this very node — so this exact data-loss bug had been live and completely
+    /// invisible, and the old assertion (<c>NotContain("status":"Error")</c>) passed vacuously
+    /// because the old code could not produce an Error verdict at all.</para>
+    ///
+    /// <para><b>When the serializer is fixed, this test SHOULD fail</b> — flip it back to asserting
+    /// <c>status: "Dispatched"</c> with a real activity path. The happy path itself is covered on an
+    /// in-memory mesh by
+    /// <c>ExecuteScriptDispatchDiagnosticsTest.Dispatch_Succeeds_NamesAnActivityThatReachesATerminalStatus</c>.</para>
+    /// </summary>
     [Fact]
-    public async Task ExecuteScript_ForIsExecutableCodeNode_CompletesWithoutError()
+    public async Task ExecuteScript_ForIsExecutableCodeNode_SurfacesTheFileSystemRoundTripLoss()
     {
         // Seed the script directly via IMeshService (the "created through
         // IMeshService" path per our testing rule â€” script nodes skip the MCP
@@ -264,13 +295,16 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
         var result = await ops.ExecuteScript($"@Scripts/{id}", timeoutSeconds: 30)
             .Should().Within(35.Seconds()).Emit();
 
-        // Budget is 30s on the kernel completion callback. The key assertion is
-        // that ExecuteScript does NOT hang beyond the budget AND doesn't return
-        // "Not found" (which would signal the content-read path failed). Either
-        // "Executed" (kernel actually ran) or "Timeout" (kernel took longer)
-        // means the routing worked.
-        result.Should().NotContain("\"status\":\"Error\"",
-            because: "the content read of an existing Code node must succeed â€” Error here means the script wasn't found or wasn't recognised as executable");
+        var verdict = JsonDocument.Parse(result).RootElement;
+
+        // The routing worked (we got a real verdict from the owning hub, not a timeout or a
+        // "not found"), and the verdict is TRUTHFUL about what the hub actually saw.
+        verdict.GetProperty("status").GetString().Should().Be("Error", result);
+        verdict.GetProperty("message").GetString().Should().Contain("IsExecutable = false",
+            "the file-system round-trip drops IsExecutable, and the caller must be TOLD that "
+            + "rather than handed a 'Dispatched' for a run that never starts");
+        verdict.TryGetProperty("activityPath", out _).Should().BeFalse(
+            "no activity exists, so no path may be offered to poll");
     }
 
     // NOTE: There used to be an `ExecuteScript_ForBrokenScript_ReportsErrorStatus`
@@ -286,6 +320,13 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     /// path: HandleExecuteScript reads the local workspace, sees IsExecutable=false,
     /// and posts the error response â€” should be milliseconds. Anything slower means
     /// an await/deadlock has slipped into the read path.
+    ///
+    /// <para>Pre-#841 this test asserted the DEFECT: ExecuteScript was fire-and-forget, so
+    /// the refusal went to a caller that never observed it, the reply still said
+    /// "Dispatched", and the only way to detect the rejection was to poll the (guessed)
+    /// activity path and confirm nothing ever appeared. The dispatch now waits for the
+    /// owning hub's verdict, so the refusal is asserted where it belongs — in the reply —
+    /// and the "sleep then check nothing happened" probe is gone.</para>
     /// </summary>
     // Timeout includes the cold class init for the first [Fact] in this
     // ShareMeshAcrossTests class â€” building the SP + AddGraph + AddAI is
@@ -308,34 +349,15 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
             });
 
         var ops = new MeshOperations(Mesh);
-        var result = await ops.ExecuteScript($"@Scripts/{id}", timeoutSeconds: 10)
+        var result = await ops.ExecuteScript($"@Scripts/{id}", timeoutSeconds: 30)
             .FirstAsync().ToTask();
 
-        // ExecuteScript is fire-and-forget: it returns a "Dispatched" envelope
-        // with the ActivityLog path before the per-node Code hub finishes its
-        // own gate check (CodeNodeType.HandleExecuteScript verifies
-        // CodeConfiguration.IsExecutable). For a non-executable node the
-        // dispatch reply still says "Dispatched", but no Activity ever gets
-        // written â€” the rejection lands in the response that ExecuteScript
-        // doesn't await. Verify the rejection path: read the would-be
-        // activity path and assert no activity was created.
-        var dispatched = JsonDocument.Parse(result);
-        var activityPath = dispatched.RootElement.GetProperty("activityPath").GetString();
-        activityPath.Should().NotBeNull();
-
-        // Allow a short window for any background activity creation; assert
-        // the activity was NEVER created for a non-executable node.
-        await Task.Delay(500, TestContext.Current.CancellationToken);
-        MeshNode? activityNode = null;
-        await foreach (var node in meshService
-            .QueryAsync<MeshNode>($"path:{activityPath}", ct: TestContext.Current.CancellationToken))
-        {
-            activityNode = node;
-            break;
-        }
-        activityNode.Should().BeNull(
-            "non-executable Code nodes must NOT spawn an ActivityLog â€” the " +
-            "per-node hub's IsExecutable=false gate must reject before activity creation.");
+        var verdict = JsonDocument.Parse(result).RootElement;
+        verdict.GetProperty("status").GetString().Should().Be("Error", result);
+        verdict.GetProperty("message").GetString().Should().Contain("IsExecutable");
+        verdict.TryGetProperty("activityPath", out _).Should().BeFalse(
+            "non-executable Code nodes must NOT spawn an ActivityLog, so the caller must not "
+            + "be handed a path to poll — the refusal itself is the answer.");
     }
 
     // ---- Delete + Get --------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #841 — the dispatch could die with **no Activity node created and no failure mode observable by anyone**.

## Nine swallow points

| # | Location | Mechanism |
|---|---|---|
| 1 | `MeshOperations.cs:3740` | `hub.Post` **fire-and-forget** — "Dispatched" meant only *"Post did not throw"*. Every `Success=false` response and every routing `DeliveryFailure` reached a caller with no callback and was dropped. |
| 2 | `MeshOperations.cs:3736` | The caller **reconstructed** `activityPath` as `{partition}/_Activity/{id}`, while the owning hub resolves the parent via `ActivityParentPath` / `DefaultActivityParentPath` / `{viewer}`. With any of those, a **fully successful** run left the caller polling a path that can never exist — and it raced `CreateNode`, so even the default case 404s if polled immediately. |
| 3 | `CodeNodeType.cs:172` | `.Take(1)` on a live pathless query with **no timeout, no empty-guard** — if it never converges the chain stops dead: no node, no response, no log. The wedges-to-zero violation. |
| 4-8 | `CodeNodeType.cs` create / self-read / not-executable / stamp / `FailActivity` | Response-only, **no logging**, faults flattened to `.Message`, one bare `catch { }`. |
| 9 | `McpMeshPlugin.cs:781` | Tool description promised *"blocks until the kernel signals completion"*; `timeoutSeconds` was **entirely unused**. |

## Fix

`ExecuteScript` now uses `hub.Observe<ExecuteScriptResponse>` inside `Observable.Defer` (cold), bounded by the caller's `timeoutSeconds`, and returns the hub's **authoritative** activity path. `Success=false` → `Error` + reason; `OnError` → `errorType` + `message` + `detail` **and** `LogError` with the exception object, so type and stack reach the logger — the diagnosability standard set by #892. **"Dispatched" now means an Activity node exists.**

`CodeNodeType` gets two sinks — `RefuseDispatch` (Warning) and `FaultDispatch` (LogError **with the exception**) — both of which always answer the caller *and* log; three distinct refusal verdicts replace the conflated one; the bare `catch` logs. New extracted `ResolveActivityParent` applies `.Take(1).DefaultIfEmpty().Timeout(15s)` naming the partition, so exactly one of OnNext/OnError always reaches the subscriber.

## Verification

**Fail-without** (src reverted, tests unchanged): **6 failed / 0 passed** — the viewer-routed case reported the guessed path; the happy path errored *"No node found at rbuergi/_Activity/…"* because the guess raced creation; all three refusal cases reported `Dispatched` instead of `Error`. Reverting **only** `ResolveActivityParent`'s body: the stall test **timed out after 30 s** (the silent stop reproduced) and the empty-completion test threw *"Sequence contains no elements"*.

**Pass-with:** AI.Test 77/77 · `ResolveActivityParent` 5/5 · Documentation 1/1 · Markdown.Export 19/19. Independently re-verified **10/10** on the new classes after merging current main. `-c Release -warnaserror` clean on all touched projects.

## Notes

- `ExecuteScript` now blocks for the dispatch ack (previously returned instantly), bounded by `timeoutSeconds`; the ack is posted right after `CreateNode` — ~200 ms in-process.
- The 15 s parent-lookup timeout is a **diagnosability boundary, not a retry**: a genuinely stalled `Admin/Partition` query now fails loudly instead of hanging.
- Orleans/gRPC suites use `Mesh.Observe<ExecuteScriptResponse>` directly — contract unchanged, but they need real infra, so CI is their first run.
- **Separate defect exposed, filed as #912 and deliberately not fixed here:** `CSharpFileParser.SerializeCodeConfiguration` writes only the code, so `IsExecutable`/`ActivityParentPath` are silently lost on every FS/blob/GitSync round-trip — a cross-repo file-format decision. A labelled characterization test pins the truthful current behaviour.

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)