### PR TITLE
Operator docs for the red-log watcher

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -169,6 +169,68 @@ kubectl -n monitoring port-forward svc/loki-grafana 3000:80    # http://localhos
 In Grafana → Explore → Loki, the portal logs are `{namespace="memex"}` (e.g. add
 `|= "error"` or `|~ "signin-microsoft"`).
 
+### 6b. Red-log ticketing (optional) — every `fail:`/`crit:` opens exactly one issue
+
+Once Loki is up, `mw-log-watcher` can turn production errors into GitHub issues: it reads red lines
+from a persisted cursor, groups them by fault, and reports each distinct fingerprint to the portal,
+which triages it with an agent and opens one ticket. A burst of ten thousand identical errors is one
+issue; recurrences comment on it. **It is off until all four steps below are done** — the ingest
+endpoint is not even mapped without a token.
+
+It runs in `monitoring`, NOT in the portal's namespace, on purpose: the thing that notices the portal
+is throwing errors must not be hosted by the portal.
+
+```bash
+# 1. ONE shared secret, both sides. The watcher presents it; the portal requires it.
+TOKEN=$(openssl rand -hex 32)
+az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
+  "kubectl -n monitoring create secret generic mw-log-watcher --from-literal=ingest-token=$TOKEN"
+#    …then set LogWatch__IngestToken to the SAME value on the portal (KeyVault → its secret store).
+
+# 2. Where tickets go. Without at least one route the control plane idles by design —
+#    it will not spend agent rounds on incidents it could never file.
+#      LogWatch__DefaultRepository = Systemorph/MeshWeaver
+#      LogWatch__Routes__0__Prefix = MeshWeaver.     Routes__0__Repository = Systemorph/MeshWeaver
+#      LogWatch__Routes__1__Prefix = Memex.          Routes__1__Repository = Systemorph/Memex
+#    Issues are opened as the GitHub App (GitHub:App), never a user's OAuth token.
+
+# 3. Build + push the watcher image.
+dotnet publish tools/MeshWeaver.LogWatcher/MeshWeaver.LogWatcher.csproj -c Release \
+  -t:PublishContainer -p:ContainerRegistry=meshweaver.azurecr.io \
+  -p:ContainerRepository=memex-log-watcher -p:ContainerImageTag=<tag>
+
+# 4. Apply the Deployment + PVC (edit the image tag + watched namespaces in the manifest first).
+az aks command invoke -g memex-aks-rg -n memexaks-cluster \
+  --command "kubectl apply -f log-watcher.yaml" \
+  --file manifests/observability/log-watcher.yaml
+```
+
+**Verify — and know what each failure looks like:**
+
+```bash
+az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
+  "kubectl -n monitoring logs deploy/mw-log-watcher --tail=50"
+```
+
+| What the log says | Meaning |
+|---|---|
+| `Loki: N red line(s) …` then `Reported <fp> … — 200` | Working end to end. |
+| `Log watcher is not configured` | Step 1 missed — `PortalUrl`/`IngestToken` unset. |
+| `401` from the portal | The two tokens differ, or the portal's is unset (which un-maps the route entirely → also 404). |
+| `Loki: 0 red line(s)` forever | Nothing red in the watched namespaces, or `Namespaces` names the wrong ones. |
+| Incidents appear but stay `New` | Step 2 missed — no repository routed, so the control plane idles. |
+
+Then browse `Admin/_LogIncident` in the portal: every incident links to the ticket it opened and to
+the triage thread that wrote it.
+
+**🚨 The state directory must be a real volume.** On an `emptyDir` a pod restart replays the lookback
+window and re-reports. The manifest ships a PVC for this reason.
+
+**To turn it off**: `kubectl -n monitoring scale deploy/mw-log-watcher --replicas=0`. Clearing the
+portal's `LogWatch__IngestToken` also closes the ingest endpoint. Neither deletes existing incidents.
+
+Full reference: [LogWatchTriage.md](../../src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md)
+
 ## 7. Rolling a new image — and the traps
 
 ```bash

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -189,9 +189,13 @@ az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
 
 # 2. Where tickets go. Without at least one route the control plane idles by design —
 #    it will not spend agent rounds on incidents it could never file.
-#      LogWatch__DefaultRepository = Systemorph/MeshWeaver
-#      LogWatch__Routes__0__Prefix = MeshWeaver.     Routes__0__Repository = Systemorph/MeshWeaver
-#      LogWatch__Routes__1__Prefix = Memex.          Routes__1__Repository = Systemorph/Memex
+#      LogWatch__DefaultRepository    = Systemorph/MeshWeaver
+#      LogWatch__Routes__0__Prefix    = MeshWeaver.
+#      LogWatch__Routes__0__Repository = Systemorph/MeshWeaver
+#      LogWatch__Routes__1__Prefix    = Memex.
+#      LogWatch__Routes__1__Repository = Systemorph/Memex
+#    Every key carries the LogWatch__ prefix — a bare Routes__0__Repository does not bind, and an
+#    unbound route reads exactly like "no route configured": incidents pile up at New, silently.
 #    Issues are opened as the GitHub App (GitHub:App), never a user's OAuth token.
 
 # 3. Build + push the watcher image.
@@ -216,7 +220,8 @@ az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
 |---|---|
 | `Loki: N red line(s) …` then `Reported <fp> … — 200` | Working end to end. |
 | `Log watcher is not configured` | Step 1 missed — `PortalUrl`/`IngestToken` unset. |
-| `401` from the portal | The two tokens differ, or the portal's is unset (which un-maps the route entirely → also 404). |
+| `Portal REJECTED report … with 401` | The two tokens differ — the watcher's secret and the portal's `LogWatch__IngestToken` must be the same string. |
+| `Portal REJECTED report … with 404` | The portal's `LogWatch__IngestToken` is unset, so `/api/log-incidents` is not mapped at all — step 1 was done on the watcher side only. |
 | `Loki: 0 red line(s)` forever | Nothing red in the watched namespaces, or `Namespaces` names the wrong ones. |
 | Incidents appear but stay `New` | Step 2 missed — no repository routed, so the control plane idles. |
 

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -24,7 +24,8 @@ markdown only** — no application code changes.
 | Shared storage | **Azure Files (RWX)** drives mounted at explicit paths: `/data` (caches), `/mnt/content` (content collection), `/mnt/attachments`, `/mnt/users` — via a custom `azurefile-memex` StorageClass tuned for the non-root portal (uid 1654) |
 | Database | Self-managed **Postgres (pgvector) StatefulSet** on a Premium-SSD PVC |
 | Backup / PITR | **pgBackRest** → **Azure Blob** (full + diff CronJobs + WAL archiving) → restore `--type=time` |
-| Observability | **OpenTelemetry Collector DaemonSet** captures cluster-wide pod logs + portal OTLP → **Azure Files** log archive (`/mnt/otel-logs`) |
+| Observability | **OpenTelemetry Collector DaemonSet** captures cluster-wide pod logs + portal OTLP → **Azure Files** log archive (`/mnt/otel-logs`); **Grafana + Loki + Promtail + Prometheus** in `monitoring` for search and dashboards |
+| Error ticketing | **`mw-log-watcher`** (optional, `monitoring`) reads red logs from Loki and opens one triaged GitHub issue per distinct fault — off until configured |
 | Identity | **Workload Identity (OIDC)** so pgBackRest reaches Blob **keyless** |
 
 ### Topology
@@ -494,6 +495,42 @@ the Prometheus / Grafana / Loki stack). `values.aks.yaml` sets
 `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`, so the portal exports metrics/traces to the
 in-cluster collector. Application logs reach Loki out-of-band via Promtail
 scraping pod stdout (no app wiring).
+
+### Red-log ticketing — `mw-log-watcher` (optional, off by default)
+
+Loki makes errors *findable*; this makes them *reported*. `mw-log-watcher` is a small Deployment in
+`monitoring` that reads `fail:`/`crit:` lines from Loki, groups them by fault, and POSTs each
+distinct fingerprint to the portal — which triages it with an agent and opens **one** GitHub issue in
+the repository that owns the code. Ten thousand identical errors are one ticket; recurrences comment
+on it and reopen it if it was closed.
+
+```
+Loki ──query_range from a persisted cursor──▶ mw-log-watcher ──POST /api/log-incidents──▶ portal
+        (ns monitoring, own PVC)                                                            │
+                                                          Admin/_LogIncident/{fingerprint} ◀┘
+                                                          agent triage ─▶ GitHub App ─▶ issue
+```
+
+Three properties worth knowing before you operate it:
+
+- **It is not in the portal's namespace, deliberately.** The component that notices the portal is
+  throwing errors must survive the portal being the thing that is broken. When the portal is wedged
+  the watcher keeps reading Loki and queues to its PVC; delivery is delayed, nothing is lost.
+- **Its state directory must be a persistent volume.** The cursor and the undelivered queue live
+  there. On an `emptyDir` a pod restart replays the lookback window and re-reports.
+- **It is off until configured, in two independent ways.** No `LogWatch:IngestToken` on the portal ⇒
+  the ingest endpoint is not mapped at all (reaching it spends model budget and opens issues, so
+  absence means off, never open). No repository routed ⇒ the control plane idles rather than running
+  agent rounds that could never end in a ticket.
+
+Deploy steps, verification table, and how to turn it off: **[DEPLOY-RUNBOOK.md § 6b](DEPLOY-RUNBOOK.md)**.
+Design and configuration reference:
+**[LogWatchTriage.md](../../src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md)**.
+
+A provisioned Grafana alert rule (`dashboards/memex-red-log-alerts.yaml`) covers the human-facing
+half — it shows red-log volume in Grafana but deliberately does **not** open tickets. Ticketing hangs
+off the watcher's cursor instead, because an alert notification that fires while its receiver is down
+is simply lost: acceptable for a nudge, not for "every distinct error gets a ticket".
 
 ### Apply it
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
@@ -28,6 +28,7 @@ MeshWeaver has **two distinct deploy routes**. They target different infrastruct
 | Run a **prod-like memex locally on a Mac** (Colima k3s, arm64) | [LocalColimaMac.md](/Doc/Architecture/LocalColimaMac) |
 | Instance-specific configuration options (`memex.systemorph.com`) | [DeploymentOptions.md](/Doc/Architecture/DeploymentOptions) |
 | Reclaim space — delete old ACR images / prune local Docker, safely | [ImageCleanup.md](/Doc/Architecture/ImageCleanup) |
+| Turn production errors into tickets automatically — deploy the red-log watcher, route incidents to repositories, or work out why nothing is being reported | [LogWatchTriage.md](/Doc/Architecture/LogWatchTriage) |
 
 The two routes provision and run on different platforms (raw AKS deployments + Helm vs. ACA via Aspire), with different update mechanics; they are not interchangeable. The sections below (local run, Azure AD, secrets, project layout) are **shared** across both routes.
 


### PR DESCRIPTION
The design doc landed with #908, but nothing an **operator** actually reads mentioned the watcher. Someone deploying or debugging the cluster would look in the AKS README's Observability section, the deploy runbook, or the Deployment router — and find only the OTel collector and Loki, with no hint that error ticketing exists, how to switch it on, or why nothing is being reported.

| File | What it gains |
|---|---|
| `deploy/aks/README.md` | The component table now lists the watcher — and names the Grafana/Loki/Promtail/Prometheus stack, which was running but unlisted. The Observability section explains the three things that bite in operation. |
| `deploy/aks/DEPLOY-RUNBOOK.md` | New § 6b: the four deploy steps in order, a symptom→cause table, and how to turn it off. |
| `Doc/Architecture/Deployment.md` | A row in the "which doc do I need" table, phrased as the question an operator would ask rather than the feature's name. |

## What the operator sections actually say

The three properties that are non-obvious and cost time if unknown:

- **It is not in the portal's namespace, deliberately** — the component that notices the portal is throwing errors must survive the portal being the broken thing.
- **Its state directory must be a persistent volume** — on an `emptyDir` a restart replays the lookback window and re-reports.
- **It is off in two independent ways** — no ingest token ⇒ the endpoint isn't mapped at all; no repository routed ⇒ the control plane idles instead of spending agent rounds on incidents it could never file.

The runbook maps what the watcher's log *says* to what is actually wrong, because each of these fails quietly rather than loudly:

| Log | Meaning |
|---|---|
| `Reported <fp> … — 200` | Working end to end |
| `Log watcher is not configured` | Step 1 missed |
| `401` | The two tokens differ, or the portal's is unset |
| Incidents appear but stay `New` | No repository routed |

Each entry also says **why the Grafana alert rule does not open tickets** — an alert that fires while its receiver is down is lost, which is fine for a nudge and not for "every distinct error gets a ticket". That asymmetry is the first thing someone will want to change, so the reason travels with it.

Docs only; no code. `DocumentationLinkIntegrityTest` passes and every referenced path was verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK