### PR TITLE
Stop stacking a LayoutAreaHost per write — the render leak that killed pods (#606)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -671,6 +671,40 @@ public static class JsonSynchronizationStream
         var logger = GetLogger(hub.ServiceProvider);
         var request = delivery.Message with { Subscriber = delivery.Sender };
 
+        // 🚨 RE-SUBSCRIBE IS A REFRESH, NOT A SECOND SUBSCRIPTION (issue #606).
+        //
+        // Resubscribe() re-posts a SubscribeRequest carrying the SAME StreamId — it means
+        // "re-assert my stream", not "open another one". Building a second reduced stream here
+        // left the FIRST one live and rendering forever (nothing but an UnsubscribeRequest ever
+        // disposes a server-side stream, and a resubscribe never sends one). For a
+        // LayoutAreaReference each of those is a whole LayoutAreaHost + render graph, so every
+        // change-feed pulse on the owner path permanently added one more render pipeline —
+        // the unbounded growth that killed the pod.
+        //
+        // Serve the refresh off the stream we ALREADY have: re-assert its current state as a
+        // Full, which the outbound forwarding subscription below (registered when that stream
+        // was created) delivers to the subscriber — exactly the "fresh snapshot" the caller
+        // asked for, and exactly what its ExpectResubscribeFull latch is armed to accept.
+        // A genuinely orphaned mirror (owner recycled ⇒ new workspace ⇒ empty registry) still
+        // takes the full create path below.
+        if (workspace is Workspace registry
+            && registry.GetClientSubscription(request.Subscriber, request.StreamId, request.Reference)
+                is ISynchronizationStream<TReduced> alreadyServing)
+        {
+            logger.LogDebug(
+                "Owner {Owner} already serves stream {StreamId} for {Subscriber} — re-asserting the current snapshot instead of creating a second stream",
+                hub.Address, request.StreamId, request.Subscriber);
+            if (alreadyServing.Current is { Value: not null } snapshot)
+                alreadyServing.Update(
+                    _ => new ChangeItem<TReduced>(snapshot.Value, alreadyServing.StreamId, alreadyServing.Hub.Version),
+                    ex => logger.LogWarning(ex,
+                        "Stream {StreamId}: could not re-assert snapshot for resubscribing subscriber {Subscriber}",
+                        alreadyServing.StreamId, request.Subscriber));
+            // Nothing yet to re-assert (the initial subscribe is still hydrating) — its own
+            // first Full is already on its way to this subscriber; do NOT build a second stream.
+            return alreadyServing;
+        }
+
         var fromWorkspace = workspace
             .ReduceManager
             .ReduceStream<TReduced>(
@@ -756,6 +790,13 @@ public static class JsonSynchronizationStream
         //             reduced.Host.GetWorkspace().RequestChange(e);
         //         })
         // );
+
+        // Record it as THE stream for this (subscriber, StreamId) so a later resubscribe
+        // refreshes it instead of stacking another one (see the guard at the top). Registered
+        // AFTER the outbound forwarding subscription exists, so a re-assert can never find a
+        // stream that has no way to reach the subscriber. Unregisters itself on disposal.
+        (workspace as Workspace)?.RegisterClientSubscription(
+            request.Subscriber, request.StreamId, request.Reference, reduced);
 
         return reduced;
     }

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -664,5 +664,88 @@ public class Workspace : IWorkspace
         this.CreateSynchronizationStream<TReduced, TReference>(delivery);
     }
 
+    // 🚨 ONE server-side stream per (subscriber, StreamId) — issue #606.
+    //
+    // A SubscribeRequest carries the SUBSCRIBER's StreamId, and a resubscribe deliberately
+    // REUSES it ("refresh MY stream" — JsonSynchronizationStream.Resubscribe). Before this
+    // registry the owner treated every arrival as a brand-new subscription and built another
+    // reduced stream — for a LayoutAreaReference that is a whole new LayoutAreaHost + render
+    // graph (LayoutExtensions' AddWorkspaceReferenceStream factory) — while the previous one
+    // kept running, kept rendering and kept pushing DataChangedEvents to the same subscriber.
+    // Nothing ever released it: only an UnsubscribeRequest disposes a server-side stream, and
+    // a resubscribe never sends one.
+    //
+    // That made the accumulation unbounded on the ordinary serving path: the layout-area
+    // stream's staleness gate is INERT for EntityStore reductions (EntityStore has no
+    // `long Version`, so `receivedVersion` never advances while `announcedVersion` is
+    // fabricated as received+1 — see the version gate in JsonSynchronizationStream), so
+    // EVERY change-feed event on the owner path resubscribes. Measured: one write to a node
+    // added one more live render pipeline, so a single subsequent write produced 1 → 10 Full
+    // frames after 8 writes, each leaked host holding its EntityStore, its menu/node-stream
+    // subscriptions (which pin MeshNodeStreamCache entries so their upstream sync streams can
+    // never be idle-released) and its whole control tree.
+    //
+    // The registry is an INSTANCE field on the workspace, so its lifetime IS the owner hub's
+    // (no static state, and an owner recycle correctly starts from empty → a genuinely
+    // orphaned mirror still gets a fresh stream).
+    private readonly ConcurrentDictionary<(string Subscriber, string StreamId), ClientSubscription>
+        _clientSubscriptions = new();
+
+    // 🚨 A CLASS, never a record: SynchronizationStream is itself a record whose generated
+    // GetHashCode/Equals recurse into StreamConfiguration (which holds the stream back) — a
+    // record wrapper around one stack-overflows the process the moment the dictionary hashes
+    // or compares it. See the _evictedRemoteStreams field note.
+    private sealed class ClientSubscription(WorkspaceReference reference, ISynchronizationStream stream)
+    {
+        public WorkspaceReference Reference { get; } = reference;
+        public ISynchronizationStream Stream { get; } = stream;
+    }
+
+    /// <summary>
+    /// Returns the server-side stream already serving <paramref name="streamId"/> for
+    /// <paramref name="subscriber"/> under the SAME reference, or <c>null</c>. A hit means the
+    /// arriving SubscribeRequest is a RE-subscribe of a stream this owner still serves, so the
+    /// caller must re-assert the current snapshot on it instead of building a second one.
+    /// </summary>
+    internal ISynchronizationStream? GetClientSubscription(
+        Address? subscriber, string? streamId, WorkspaceReference reference)
+    {
+        if (subscriber is null || string.IsNullOrEmpty(streamId))
+            return null;
+        if (!_clientSubscriptions.TryGetValue((subscriber.ToString(), streamId), out var existing))
+            return null;
+        if (!Equals(existing.Reference, reference))
+            return null;
+        // A stream whose sync hub is past Started is tearing down — its registry entry is
+        // removed at ShutDown, so this window is short; treat it as absent and let the caller
+        // build a fresh stream rather than re-asserting into a corpse.
+        return existing.Stream.Hub is { RunLevel: <= MessageHubRunLevel.Started }
+            ? existing.Stream
+            : null;
+    }
+
+    /// <summary>
+    /// Records <paramref name="stream"/> as THE server-side stream for
+    /// (<paramref name="subscriber"/>, <paramref name="streamId"/>) and unregisters it when the
+    /// stream is disposed, so the entry can never outlive what it points at.
+    /// </summary>
+    internal void RegisterClientSubscription(
+        Address? subscriber, string? streamId, WorkspaceReference reference, ISynchronizationStream stream)
+    {
+        if (subscriber is null || string.IsNullOrEmpty(streamId))
+            return;
+        var key = (subscriber.ToString(), streamId);
+        _clientSubscriptions[key] = new ClientSubscription(reference, stream);
+        // Pair-exact removal by REFERENCE identity (never value equality — see ClientSubscription):
+        // a later stream that legitimately took over this key must not be unregistered by an
+        // earlier stream's teardown.
+        stream.RegisterForDisposal(System.Reactive.Disposables.Disposable.Create(() =>
+        {
+            if (_clientSubscriptions.TryGetValue(key, out var current)
+                && ReferenceEquals(current.Stream, stream))
+                _clientSubscriptions.TryRemove(key, out _);
+        }));
+    }
+
 
 }

--- a/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
@@ -187,7 +187,9 @@ public static class GitHubSyncSettingsTab
         // Editable commit + re-import. Prefill from the Space's saved config once it arrives (same
         // synced-query empty-first-emission caveat as the repo form).
         host.UpdateData(CommitFormId, new Dictionary<string, object?> { ["commit"] = "main" });
-        host.RegisterForDisposal("gh-commit-prefill", sync.WatchConfig(spacePath)
+        // ReplaceDisposable (not the appending RegisterForDisposal) — BuildContent runs per render,
+        // and a synthetic key like this is never reaped by the area teardown (issue #606).
+        host.ReplaceDisposable("gh-commit-prefill", sync.WatchConfig(spacePath)
             .Where(c => c is not null)
             .Take(1)
             .Subscribe(cfg => host.UpdateData(CommitFormId, new Dictionary<string, object?>

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -98,8 +98,29 @@ public static class NodeMenuItemsExtensions
             // Default (unnamed) context lands on "$Menu"; named contexts on "$Menu:{context}".
             var area = context.Length == 0 ? MenuControl.MenuArea : MenuControl.GetMenuArea(context);
             var areaContext = new RenderingContext(area);
-            host.RegisterForDisposal(
-                MenuControl.MenuArea,
+            // 🚨 ReplaceDisposable keyed on the WRITTEN area — never the appending
+            // RegisterForDisposal, and never one shared key for every context (issue #606).
+            //
+            // RenderMenus is a GLOBAL predicate renderer (`WithRenderer(_ => true, …)`), so it runs
+            // on EVERY area render — and a render re-runs on every emission of the node/permission
+            // stream the providers themselves are built on. The appending overload therefore stacked
+            // one MORE live GetMeshNodeStream+permissions subscription per re-render, under the
+            // constant key "$Menu" which no area teardown ever reaps (DisposeExistingAreas /
+            // DisposeChildAreas only remove keys that StartsWith(context.Area), and "$Menu" never
+            // starts with "Overview"/"Edit"/…). Every stacked subscription stayed live for the
+            // host's whole lifetime, each one holding the node stream + the permission stream (and
+            // so pinning a MeshNodeStreamCache entry, which blocks the idle release of that path's
+            // upstream sync stream), and each one an additional writer of the SAME $Menu area.
+            //
+            // Keyed PER CONTEXT (not the shared MenuArea constant): each menu context writes its
+            // OWN area, so one live writer per area is exactly right — two live subscriptions
+            // writing the same area were racing writers, not a feature. The shared constant would
+            // make context B's registration dispose context A's. The key is deliberately NOT the
+            // bare area name either: RenderArea registers the rendered UiControls under the area
+            // key, and replacing that bucket would dispose the live menu control alongside the
+            // stale subscription.
+            host.ReplaceDisposable(
+                $"menu-subscription:{area}",
                 items
                     .DistinctUntilChanged(MenuItemsSequenceComparer.Instance)
                     .Subscribe(

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1778,7 +1778,12 @@ public static class MeshNodeLayoutAreas
         // no SetupAutoSave save subscription. The one-way /data projection below keeps the
         // derived-label read views (dimension/options/date) correct from the Layout layer.
         var boundContext = LayoutAreaReference.GetMeshNodeDataContext(nodePath, bindContent: true);
-        host.RegisterForDisposal($"editnode-content-projection_{dataId}",
+        // 🚨 ReplaceDisposable, NEVER RegisterForDisposal — see the identical seam in
+        // OverviewLayoutArea.BuildPropertyOverview (issue #606). BuildEditNodeContent re-runs on
+        // every emission of the node/permission CombineLatest, and the appending overload would
+        // stack one more live node-stream subscription per render under a key no area teardown
+        // reaps.
+        host.ReplaceDisposable($"editnode-content-projection_{dataId}",
             host.Workspace.GetMeshNodeStream(nodePath)
                 .Select(n => n?.Content)
                 .Where(c => c is not null)

--- a/src/MeshWeaver.Graph/OverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/OverviewLayoutArea.cs
@@ -49,7 +49,17 @@ public static class OverviewLayoutArea
         // node's Content (node → /data, NEVER /data → node) so those labels stay correct. This is a
         // pure read mirror — there is no save loop and no drift: it follows the node, and all WRITES
         // still go straight to the node via the node-bound DataContext above.
-        host.RegisterForDisposal($"overview-content-projection_{dataId}",
+        // 🚨 ReplaceDisposable, NEVER RegisterForDisposal (issue #606). This method runs INSIDE the
+        // area's render — once per emission of the node/permission stream — so an APPENDING
+        // registration adds one more live node-stream subscription per re-render, under a synthetic
+        // key that no area teardown reaps (DisposeExistingAreas / DisposeChildAreas only remove keys
+        // that StartsWith(context.Area), and "overview-content-projection_…" never does). Every
+        // accumulated projection stays live: it fires ANOTHER UpdateData on every subsequent node
+        // emission, and it pins a MeshNodeStreamCache entry so that path's upstream sync stream can
+        // never be idle-released. Nothing frees any of it until the whole host dies.
+        // ReplaceDisposable disposes the previous projection for this key first, so exactly ONE is
+        // ever live regardless of render count.
+        host.ReplaceDisposable($"overview-content-projection_{dataId}",
             host.Workspace.GetMeshNodeStream(node.Path)
                 .Select(n => n?.Content)
                 .Where(c => c is not null)

--- a/test/MeshWeaver.Hosting.Monolith.Test/LayoutAreaResubscribeHostAccumulationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LayoutAreaResubscribeHostAccumulationTest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Memory-leak guard for the layout-area subscribe protocol (issue #606 — "untyped
+/// live-compiled content render hot-loop leaks memory until the pod is killed").
+///
+/// <para><b>The defect.</b> A <c>SubscribeRequest</c> carries the SUBSCRIBER's
+/// <c>StreamId</c>, and <c>JsonSynchronizationStream.Resubscribe</c> deliberately REUSES it
+/// ("refresh MY stream"). The owner nevertheless treated every arrival as a brand-new
+/// subscription: <c>Workspace.SubscribeToClient</c> → <c>CreateSynchronizationStream</c> →
+/// <c>ReduceStream</c>, which for a <c>LayoutAreaReference</c> constructs a WHOLE NEW
+/// <c>LayoutAreaHost</c> (the <c>AddWorkspaceReferenceStream</c> factory in
+/// <c>LayoutExtensions</c>). The previous host was never disposed — only an
+/// <c>UnsubscribeRequest</c> disposes a server-side stream, and a resubscribe never sends
+/// one — so it kept rendering and kept pushing frames to the same subscriber forever.</para>
+///
+/// <para><b>Why it ran away on the ordinary serving path.</b> The mirror's staleness gate
+/// ("resubscribe only when demonstrably behind") is INERT for <c>EntityStore</c> reductions:
+/// <c>EntityStore</c> has no <c>long Version</c>, so <c>receivedVersion</c> never advances
+/// while <c>announcedVersion</c> is fabricated as <c>received + 1</c> for every version-less
+/// change-feed event. The gate is therefore permanently open and EVERY change on the owner
+/// path resubscribes — so every write to a node that somebody is looking at permanently added
+/// one more live render pipeline, each holding its own EntityStore, its menu/node-stream
+/// subscriptions (which pin <c>MeshNodeStreamCache</c> entries so their upstream sync streams
+/// can never be idle-released) and its whole control tree. Untyped content made it continuous
+/// rather than occasional; the accumulation itself is content-agnostic, which is what this
+/// test pins.</para>
+///
+/// <para><b>The measurement.</b> Every live server-side <c>LayoutAreaHost</c> pushes its own
+/// <c>Full</c> frame on each node change, so the number of <c>Full</c> frames the client
+/// receives for ONE write IS the number of live render pipelines on the owner — a managed,
+/// deterministic count that needs no heap walk (the ClrMD probes cannot run on macOS, #674).
+/// Before the fix that count grew by one per write (measured 1, 4, 5, 6, 7, 8, 9, 10 …);
+/// after it, it is flat.</para>
+/// </summary>
+public class LayoutAreaResubscribeHostAccumulationTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>Number of node writes driven through the subscribed area.</summary>
+    private const int Writes = 10;
+
+    /// <summary>Settle window after each write — the render + any resubscribe refresh land inside it.</summary>
+    private static readonly TimeSpan Settle = TimeSpan.FromMilliseconds(1500);
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    [Fact(Timeout = 180_000)]
+    public async Task RepeatedWrites_DoNotStackLayoutAreaHosts_OnTheOwner()
+    {
+        var id = $"resub-accum-{Guid.NewGuid():N}"[..24];
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Resubscribe Accumulation Guard",
+            NodeType = "Markdown",
+            Content = new MeshWeaver.Markdown.MarkdownContent { Content = "# guard" },
+        }).Should().Emit();
+
+        var client = GetClient(c => c.AddData(data => data));
+        var address = new Address(path);
+        await client.Observe(new PingRequest(), o => o.WithTarget(address)).Should().Emit();
+
+        var workspace = client.GetWorkspace();
+        var areaStream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            address, new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea));
+
+        var first = await areaStream.Should().Within(30.Seconds()).Emit();
+        first.Value.ValueKind.Should().NotBe(JsonValueKind.Undefined,
+            "the Overview area must render before the accumulation can be measured");
+
+        var fulls = 0;
+        using var areaSub = areaStream.Subscribe(
+            ci => { if (ci.ChangeType == ChangeType.Full) Interlocked.Increment(ref fulls); },
+            _ => { });
+
+        // Let the initial render settle so the first measured write starts from a quiet stream.
+        await Task.Delay(Settle);
+
+        var fullsPerWrite = new int[Writes];
+        for (var i = 0; i < Writes; i++)
+        {
+            Interlocked.Exchange(ref fulls, 0);
+            var revision = i;
+            await workspace.GetMeshNodeStream(path)
+                .Update(cur => cur with { Description = $"rev{revision}" })
+                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+            await Task.Delay(Settle);
+            fullsPerWrite[i] = Volatile.Read(ref fulls);
+        }
+
+        Output.WriteLine($"Full frames per write: [{string.Join(", ", fullsPerWrite)}]");
+
+        // Compare STEADY STATE to STEADY STATE: write 0 can legitimately differ (the very first
+        // change-feed pulse arms machinery that is already armed for every later write), so the
+        // baseline is write 1. The invariant is that the count does not GROW — a growing count
+        // means one more live LayoutAreaHost per write on the owner, none of them ever released.
+        var baseline = fullsPerWrite[1];
+        var last = fullsPerWrite[^1];
+        var peak = fullsPerWrite.Skip(1).Max();
+
+        last.Should().BeLessThanOrEqualTo(baseline + 2,
+            $"a resubscribe must REFRESH the server-side stream for its StreamId, never stack a second "
+            + $"LayoutAreaHost — one Full frame per live render pipeline means the count per write must "
+            + $"stay flat, not grow with the number of writes. Measured per-write Full frames: "
+            + $"[{string.Join(", ", fullsPerWrite)}]");
+
+        peak.Should().BeLessThanOrEqualTo(baseline + 2,
+            $"no single write may fan out to materially more render pipelines than the steady-state "
+            + $"baseline. Measured per-write Full frames: [{string.Join(", ", fullsPerWrite)}]");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #606 — the portal leaked until the pod was killed (memex-cloud ballooned ~1 GB/min while serving).

## Root cause: every write stacked another live render pipeline on the owner

**`Workspace.SubscribeToClient` (Workspace.cs:661-665) had no registry and no dedup by `StreamId`.** Every arriving `SubscribeRequest` unconditionally ran `ReduceManager.ReduceStream<TReduced>(...)`, which for a `LayoutAreaReference` reaches `LayoutExtensions.cs:114` → **`new LayoutAreaHost(...)`**. The previously-created stream for that same `StreamId` was never disposed — only an `UnsubscribeRequest` disposes a server-side stream, and a resubscribe never sends one.

**Retaining reference:** each leaked `LayoutAreaHost` is held by its own `SynchronizationStream<EntityStore>` on the owner's `sync/{ClientId}` hub, and itself holds `disposablesByArea` (LayoutAreaHost.cs:784) — node-stream + permission subscriptions that register as `SharedView` subscribers on `MeshNodeStreamCache` entries, so the idle sweep can **never** release those upstream sync streams either. It also keeps rendering and keeps pushing frames.

**The trigger — why it fires on every write:** `JsonSynchronizationStream.cs:615` resolves the mirror's staleness `Version` **by name** (`GetProperty("Version", typeof(long))`). `EntityStore` has no such property, so `receivedVersion` stays `0` forever while `announcedVersion` is fabricated as `receivedVersion + 1` for every version-less event. The gate `receivedVersion < announcedVersion` is therefore **permanently open** for every layout-area stream, so every change-feed event on the owner path calls `Resubscribe`, re-posting `SubscribeRequest` with the **same StreamId** and no unsubscribe.

Net: **one write to any node somebody is viewing = one more permanent `LayoutAreaHost` + full render graph.** Untyped `PluginContent` did not create this; it made the pulses continuous (renders never reach a terminal state), which is why it presented as an untyped-content problem.

**Controlled A/B:** disarming only the change-feed resubscribe took per-write frames from `1,4,5,6,7,8,9,10` to a flat `1 Full + 4 menu patches` on all 8 writes. Instrumentation reverted; no A/B code remains.

## Fix

1. **`Workspace.cs`** — instance `ConcurrentDictionary<(Subscriber, StreamId), ClientSubscription>` with register/lookup. **Instance, not static**, so lifetime is the owner hub (an owner recycle correctly starts empty; a genuinely orphaned mirror still gets a fresh stream). `ClientSubscription` is a **class, not a record**: `SynchronizationStream` is a record whose generated `GetHashCode`/`Equals` recurse into `StreamConfiguration` and stack-overflow the process — the same trap already documented on `_evictedRemoteStreams`. Removal is pair-exact by reference identity.
2. **`JsonSynchronizationStream.CreateSynchronizationStream`** — a repeat `SubscribeRequest` for a `(subscriber, StreamId)` already served under the same reference now **re-asserts the existing stream's state as a `Full`** (delivered by the already-registered outbound forwarder, and the client's `ExpectResubscribeFull` latch is armed for it) and returns that stream instead of building a second host. It deliberately does **not** dispose the old stream: `SynchronizationStream.Dispose` tears down the shared `sync/{ClientId}` hub and `HostedHubsCollection.GetHub` has no disposal check, so dispose-then-recreate races a disposing hub.

**Three secondary accumulators of the same class** — subscriptions created inside a per-emission render body, appended under a synthetic key no area teardown reaps (`DisposeExistingAreas`/`DisposeChildAreas` only remove keys that `StartsWith(context.Area)`) — switched to the framework's existing `LayoutAreaHost.ReplaceDisposable`, documented for exactly this:

- `NodeMenuItemsExtensions.cs:101` — the worst: a **global** predicate renderer (`WithRenderer(_ => true, RenderMenus)`) appending under the constant key `"$Menu"` for every context. Now keyed `menu-subscription:{area}` (deliberately not the bare area name, since `LayoutAreaHost.RenderArea:557` registers rendered controls under the area key and replacing that bucket would dispose the live menu control).
- `OverviewLayoutArea.cs:52` and `MeshNodeLayoutAreas.cs:1781` — content projections; the comment at `MeshNodeLayoutAreas.cs:1749` already notes the body "re-runs on every render".
- `GitHubSyncSettingsTab.cs:190` — same shape.

**Honest attribution:** the host-stacking fix is **measured**; the four `ReplaceDisposable` changes are **code-reasoned and suite-verified**, not independently measured (their accumulated subscriptions are silenced by their own `DistinctUntilChanged`, so they leak memory without producing countable wire traffic).

## Verification

`LayoutAreaResubscribeHostAccumulationTest.RepeatedWrites_DoNotStackLayoutAreaHosts_OnTheOwner` — managed measurement only, no ClrMD, so it works on macOS where those guards now skip (#674). Every live server-side `LayoutAreaHost` emits its own `Full` per node change, so **Full frames per write == live render pipelines**.

- **Fails pre-fix:** `Full frames per write: [1, 4, 5, 6, 7, 8, 9, 10, 11, 12]` → *"Expected 12 to be less than or equal to 6"*.
- **Passes post-fix:** `[1, 2, 2, 2, 2, 2, 2, 2, 2, 2]` (the 2 = 1 render Full + 1 resubscribe re-assert Full).

Suites on the final tree: **Hosting.Monolith 478 passed / 0 failed** (4 skipped) · **Graph 820/820** · **Layout 343/343** · **Data 303/303**. `-c Release -warnaserror` clean on Data, Graph, GitSync and the test project.

## Residual risks

1. **Rebuild-as-recovery is gone.** A resubscribe no longer rebuilds the server-side render; if a host is genuinely stuck with `Current == null`, the guard returns it without asserting anything. The dedicated recovery path (`ArmOverlaySelfHeal` → `DisposeRequest` → recycle) still covers this, but it is a real behavioural change worth a reviewer's eye.
2. **The inert staleness gate is untouched** (`JsonSynchronizationStream.cs:615`). Layout-area streams still resubscribe on every owner-path change — now cheap (a Full re-assert) instead of leaking, but still one extra round-trip per write per viewer. Making the gate evidence-based for version-less reductions is a worthwhile follow-up.
3. **Same defect class not swept exhaustively.** Four further `RegisterForDisposal`-inside-a-render sites were found and deliberately **not** touched: `EditLayoutArea.cs:193`, `DomainCatalogLayoutArea.cs:50` (also mints a fresh `Guid` data id per render), `ThreadLayoutAreas.cs:221` and `:285`, `PartitionSyncAdminLayoutArea.cs:286`. Widening into the chat path without measurement was more blast radius than could be verified here.
4. **Untyped-content half not fixed** (separate finding): `MeshNodeStreamCache.ConvertContentJsonElementToTyped` and `MeshNodeStreamExtensions.EnsureTypedContent` return `node with { Content = deserialized }` over a freshly cloned `JsonElement`. `JsonElement` has no `Equals` override, so `MeshNode` record equality is **always false** for untyped content and every `DistinctUntilChanged` degrades to a no-op — including the persistence sampler's. The sibling `GetQuery` seam already does the right thing. Symmetry looks high-value; it needs a NodeType whose content type is registered only on its per-node hub to repro faithfully.

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
