### PR TITLE
Eliminate the Rx lock-order-inversion class, not just the one instance (#899)

### DIFF
--- a/src/MeshWeaver.Hosting/MeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting/MeshChangeFeed.cs
@@ -1,6 +1,5 @@
+using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.Logging;
 
@@ -50,28 +49,22 @@ namespace MeshWeaver.Hosting;
 public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
 {
     /// <summary>
-    /// Publisher-facing inbox. <see cref="Subject.Synchronize{T}(ISubject{T})"/> because ANY
-    /// hub action block may publish concurrently (two per-node hubs deleting at the same
-    /// time is the normal case in a recursive delete) and a bare <see cref="Subject{T}"/>
-    /// is not safe under concurrent <c>OnNext</c>.
+    /// The bus itself: enqueue-and-dispatch fan-out with per-subscriber isolation. Safe under
+    /// concurrent publish from ANY hub action block (two per-node hubs deleting at the same
+    /// time is the normal case in a recursive delete).
     /// </summary>
-    private readonly Subject<MeshChangeEvent> _inboxCore = new();
-
-    private readonly ISubject<MeshChangeEvent> _inbox;
-
-    /// <summary>Subscriber-facing fan-out, pumped exclusively by <see cref="_dispatcher"/>.</summary>
-    private readonly Subject<MeshChangeEvent> _outbox = new();
+    private readonly DispatchedChangeFeed<MeshChangeEvent> _feed;
 
     /// <summary>
     /// The single dispatch thread. A dedicated <see cref="EventLoopScheduler"/> rather than
     /// the thread pool: change-feed delivery drives cache invalidation and synced-query
-    /// folds, and must not queue behind (or be starved by) unrelated pool work.
+    /// folds, and must not queue behind (or be starved by) unrelated pool work. There is
+    /// exactly ONE of these per mesh, so the dedicated thread is affordable here — storage
+    /// adapters (one feed per partition schema) use the pool-backed default instead.
     /// </summary>
     private readonly EventLoopScheduler _dispatcher =
         new(start => new Thread(start) { IsBackground = true, Name = "mesh-change-feed" });
 
-    private readonly IDisposable _pump;
-    private readonly ILogger<InProcessMeshChangeFeed>? _logger;
     private bool _disposed;
 
     /// <summary>
@@ -80,29 +73,10 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     /// <param name="logger">Optional logger; a subscriber that throws is reported here.</param>
     public InProcessMeshChangeFeed(ILogger<InProcessMeshChangeFeed>? logger = null)
     {
-        _logger = logger;
-        _inbox = Subject.Synchronize(_inboxCore);
-        _pump = _inboxCore
-            .ObserveOn(_dispatcher)
-            .Subscribe(
-                change =>
-                {
-                    try
-                    {
-                        _outbox.OnNext(change);
-                    }
-                    catch (Exception ex)
-                    {
-                        // A faulting subscriber must not tear the bus down for everyone
-                        // else — but it is never swallowed silently: it is reported at
-                        // Error so the defect is visible in logs and CI.
-                        _logger?.LogError(ex,
-                            "Mesh change-feed subscriber threw for {Path} {Kind}",
-                            change.Path, change.Kind);
-                    }
-                },
-                ex => _logger?.LogError(ex,
-                    "Mesh change-feed dispatch loop faulted — change events stopped"));
+        // 🚨 The dispatch + isolation semantics live in DispatchedChangeFeed — the ONE
+        // fan-out primitive shared with every storage adapter, so "publishers only enqueue"
+        // is a property of the mesh, not a property of this one class.
+        _feed = new DispatchedChangeFeed<MeshChangeEvent>(logger, "mesh-change-feed", _dispatcher);
     }
 
     /// <summary>
@@ -114,7 +88,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     public void Publish(MeshChangeEvent change)
     {
         if (!_disposed)
-            _inbox.OnNext(change);
+            _feed.OnNext(change);
     }
 
     /// <summary>
@@ -125,7 +99,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     public void PublishLocal(MeshChangeEvent change)
     {
         if (!_disposed)
-            _inbox.OnNext(change);
+            _feed.OnNext(change);
     }
 
     /// <summary>
@@ -138,14 +112,14 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
     {
         if (filter == null)
-            return _outbox.Subscribe(handler);
+            return _feed.Subscribe(Observer.Create(handler));
 
         var kind = filter.Value;
-        return _outbox.Subscribe(e =>
+        return _feed.Subscribe(Observer.Create<MeshChangeEvent>(e =>
         {
             if (e.Kind == kind)
                 handler(e);
-        });
+        }));
     }
 
     /// <inheritdoc />
@@ -153,12 +127,9 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        // Stop the pump BEFORE completing the outbox so the loop cannot push into a
-        // completed subject, then release the dispatch thread.
-        _pump.Dispose();
-        _outbox.OnCompleted();
-        _outbox.Dispose();
-        _inboxCore.Dispose();
+        // Stop the feed BEFORE releasing the dispatch thread so the loop cannot schedule
+        // onto a disposed scheduler.
+        _feed.Dispose();
         _dispatcher.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/src/MeshWeaver.Hosting/MeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting/MeshChangeFeed.cs
@@ -1,27 +1,120 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting;
 
 /// <summary>
-/// In-process implementation of <see cref="IMeshChangeFeed"/>.
-/// Uses Rx Subject for local pub/sub. Suitable for monolith mode.
-/// In Orleans, <c>OrleansMeshChangeFeed</c> wraps this and adds
-/// BroadcastChannel for cross-silo propagation.
+/// In-process implementation of <see cref="IMeshChangeFeed"/> — the mesh-wide
+/// create/update/delete event bus. In Orleans, <c>OrleansMeshChangeFeed</c> wraps
+/// this and adds the cross-silo broadcast.
+///
+/// <para>🚨 <b>Fan-out runs on ONE dedicated dispatch loop, never on the publisher's
+/// thread</b> (issue #899). <see cref="Publish"/> only enqueues; the subscriber
+/// graph is walked by the single <c>mesh-change-feed</c> thread. This is a
+/// correctness requirement, not a performance choice:</para>
+///
+/// <para>A publisher is always some hub's action block, and it typically calls
+/// <c>Publish</c> from deep inside a <c>SelectMany</c> continuation that is itself
+/// executing INSIDE another operator's gate — e.g. the whole
+/// <c>HandleDeleteNodeRequest</c> pipeline runs inside the
+/// <c>Observable.CombineLatest</c> lock of <c>PermissionEvaluator</c>'s effective-
+/// permission fold (the fold emits synchronously during <c>Subscribe</c> because its
+/// sources are cached <c>ReplaySubject</c>s). A synchronous fan-out from there takes
+/// the gates of every subscriber's chain — including the SHARED synced-query
+/// <c>Merge</c> gates that other hubs' folds also sit behind — while still holding
+/// its own. Two hubs publishing concurrently therefore acquired
+/// {permission-fold gate, synced-query merge gate} in opposite orders and
+/// deadlocked: both action blocks parked forever, the recursive delete could
+/// neither succeed nor fail, and no <c>DeleteNodeResponse</c> was ever posted
+/// (issue #899 — a recursive space delete wedging ~2 in 12 runs).</para>
+///
+/// <para>Handing the fan-out to its own serial loop breaks the cycle by
+/// construction: a publisher never acquires a foreign gate, so no lock-order
+/// inversion is possible no matter what subscribers do. Ordering is preserved —
+/// the loop is single-threaded and FIFO — and this mirrors what
+/// <c>OrleansMeshChangeFeed</c> already does for the cross-silo half (a
+/// <c>Subject</c> + serial queue), so local and cross-silo delivery now have the
+/// same "enqueue, never run on the caller's turn" semantics.</para>
+///
+/// <para>What callers may still rely on: the event is enqueued only AFTER the
+/// storage commit that produced it (see <c>StorageAdapterChangeFeedExtensions</c>),
+/// and events are delivered to subscribers in publish order. What they may NOT
+/// rely on: a subscriber having finished processing by the time <c>Publish</c>
+/// returns. Nothing in the mesh does — the delete path invalidates
+/// <c>IMeshNodeStreamCache</c> and disposes the per-node hub explicitly, and
+/// cross-silo delivery was already asynchronous.</para>
 /// </summary>
 public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
 {
-    private readonly Subject<MeshChangeEvent> _subject = new();
+    /// <summary>
+    /// Publisher-facing inbox. <see cref="Subject.Synchronize{T}(ISubject{T})"/> because ANY
+    /// hub action block may publish concurrently (two per-node hubs deleting at the same
+    /// time is the normal case in a recursive delete) and a bare <see cref="Subject{T}"/>
+    /// is not safe under concurrent <c>OnNext</c>.
+    /// </summary>
+    private readonly Subject<MeshChangeEvent> _inboxCore = new();
+
+    private readonly ISubject<MeshChangeEvent> _inbox;
+
+    /// <summary>Subscriber-facing fan-out, pumped exclusively by <see cref="_dispatcher"/>.</summary>
+    private readonly Subject<MeshChangeEvent> _outbox = new();
+
+    /// <summary>
+    /// The single dispatch thread. A dedicated <see cref="EventLoopScheduler"/> rather than
+    /// the thread pool: change-feed delivery drives cache invalidation and synced-query
+    /// folds, and must not queue behind (or be starved by) unrelated pool work.
+    /// </summary>
+    private readonly EventLoopScheduler _dispatcher =
+        new(start => new Thread(start) { IsBackground = true, Name = "mesh-change-feed" });
+
+    private readonly IDisposable _pump;
+    private readonly ILogger<InProcessMeshChangeFeed>? _logger;
     private bool _disposed;
 
     /// <summary>
-    /// Publishes a mesh change event to all local subscribers (no-op once disposed).
+    /// Creates the feed and starts its serial dispatch loop.
+    /// </summary>
+    /// <param name="logger">Optional logger; a subscriber that throws is reported here.</param>
+    public InProcessMeshChangeFeed(ILogger<InProcessMeshChangeFeed>? logger = null)
+    {
+        _logger = logger;
+        _inbox = Subject.Synchronize(_inboxCore);
+        _pump = _inboxCore
+            .ObserveOn(_dispatcher)
+            .Subscribe(
+                change =>
+                {
+                    try
+                    {
+                        _outbox.OnNext(change);
+                    }
+                    catch (Exception ex)
+                    {
+                        // A faulting subscriber must not tear the bus down for everyone
+                        // else — but it is never swallowed silently: it is reported at
+                        // Error so the defect is visible in logs and CI.
+                        _logger?.LogError(ex,
+                            "Mesh change-feed subscriber threw for {Path} {Kind}",
+                            change.Path, change.Kind);
+                    }
+                },
+                ex => _logger?.LogError(ex,
+                    "Mesh change-feed dispatch loop faulted — change events stopped"));
+    }
+
+    /// <summary>
+    /// Enqueues a mesh change event for delivery to all local subscribers (no-op once
+    /// disposed). Returns immediately: subscribers run on the feed's dispatch loop, never
+    /// on the calling hub's thread — see the type doc for why that is mandatory.
     /// </summary>
     /// <param name="change">The change event to publish.</param>
     public void Publish(MeshChangeEvent change)
     {
         if (!_disposed)
-            _subject.OnNext(change);
+            _inbox.OnNext(change);
     }
 
     /// <summary>
@@ -32,11 +125,12 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     public void PublishLocal(MeshChangeEvent change)
     {
         if (!_disposed)
-            _subject.OnNext(change);
+            _inbox.OnNext(change);
     }
 
     /// <summary>
     /// Subscribes a handler to mesh change events, optionally filtered by change kind.
+    /// The handler is invoked on the feed's dispatch loop, in publish order.
     /// </summary>
     /// <param name="handler">The callback invoked for each matching change event.</param>
     /// <param name="filter">When set, only events of this kind are delivered; otherwise all events are delivered.</param>
@@ -44,10 +138,10 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
     {
         if (filter == null)
-            return _subject.Subscribe(handler);
+            return _outbox.Subscribe(handler);
 
         var kind = filter.Value;
-        return _subject.Subscribe(e =>
+        return _outbox.Subscribe(e =>
         {
             if (e.Kind == kind)
                 handler(e);
@@ -59,7 +153,13 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        _subject.OnCompleted();
-        _subject.Dispose();
+        // Stop the pump BEFORE completing the outbox so the loop cannot push into a
+        // completed subject, then release the dispatch thread.
+        _pump.Dispose();
+        _outbox.OnCompleted();
+        _outbox.Dispose();
+        _inboxCore.Dispose();
+        _dispatcher.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -22,10 +22,31 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
     private readonly ConcurrentDictionary<string, MeshNode> _nodes;
     private readonly ConcurrentDictionary<string, List<object>> _partitionObjects;
     private readonly ILogger? _logger;
-    private readonly Subject<DataChangeNotification> _changes = new();
+
+    /// <summary>
+    /// 🚨 A <see cref="DispatchedChangeFeed{T}"/>, NEVER a plain <c>Subject&lt;T&gt;</c>
+    /// (issue #899). This adapter is the ONE storage backend whose whole pipeline is
+    /// synchronous — every other backend publishes from inside <c>IIoPool</c>, i.e. already
+    /// off the calling hub's thread. A bare <c>Subject.OnNext</c> here therefore ran the
+    /// ENTIRE subscriber graph on the writer's thread: <c>PersistenceService.Changes</c>'s
+    /// shared <c>Merge</c> gate → each synced query's <c>Concat</c> gate → the process-wide
+    /// <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c> → other hubs'
+    /// <c>PermissionEvaluator</c> <c>CombineLatest</c> folds → for per-node hubs,
+    /// <c>MeshDataSource</c>'s <c>GetMeshNodeStream().Update(...)</c> into a FOREIGN hub.
+    /// Since a permission-gated handler body itself runs inside its own fold's
+    /// <c>CombineLatest</c> gate, two concurrent writers took {own fold gate, shared gate} in
+    /// opposite orders and deadlocked — both action blocks parked forever and the operation
+    /// posted neither success nor failure.
+    ///
+    /// <para>The feed enqueues and returns, so a writer can never acquire a foreign Rx gate
+    /// while holding its own. It also replaces the <c>catch { /* never throw */ }</c> that
+    /// used to wrap each publish: a throwing subscriber is now isolated AND logged instead of
+    /// silently aborting delivery to every later subscriber (issue #889).</para>
+    /// </summary>
+    private readonly DispatchedChangeFeed<DataChangeNotification> _changes;
 
     /// <inheritdoc />
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// Creates an adapter with its own fresh, case-insensitive backing
@@ -56,6 +77,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         _nodes = nodes;
         _partitionObjects = partitionObjects;
         _logger = logger;
+        _changes = new DispatchedChangeFeed<DataChangeNotification>(logger, "in-memory");
     }
 
     private static string Norm(string? path) => path?.Trim('/') ?? "";
@@ -79,7 +101,9 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
                 _nodes[Norm(node.Path)] = node;
                 _logger?.LogDebug("[InMemoryAdapter#{Id:X}] Write {Path} (count={Count})",
                     GetHashCode(), Norm(node.Path), _nodes.Count);
-                try { _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node)); } catch { /* never throw */ }
+                // No try/catch: the feed enqueues (it cannot throw on the writer's behalf) and
+                // isolates + LOGS a faulty subscriber. The old swallow hid exactly that.
+                _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node));
             }
             return Observable.Return(node);
         });
@@ -89,7 +113,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         => Observable.Defer(() =>
         {
             _nodes.TryRemove(Norm(path), out var removed);
-            try { _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed)); } catch { /* never throw */ }
+            _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed));
             return Observable.Return(path);
         });
 
@@ -104,9 +128,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         {
             var won = _nodes.TryRemove(Norm(path), out var removed);
             if (won)
-            {
-                try { _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed)); } catch { /* never throw */ }
-            }
+                _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed));
             return Observable.Return(won);
         });
 

--- a/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -112,6 +113,68 @@ public static class HubPermissionExtensions
         return hub.GetEffectivePermissions(PermissionEvaluator.AdminScope, userId)
             .Select(p => p.HasFlag(Permission.All));
     }
+
+    /// <summary>
+    /// Takes ONE permission answer and <b>leaves the evaluator's Rx gate</b> before the
+    /// caller's pipeline runs. Use this — never a bare <c>.Take(1)</c> — whenever the
+    /// continuation does REAL WORK (storage I/O, a hub write, a change-feed publish, invoking
+    /// a downstream handler) rather than just projecting to a value or a UI control.
+    ///
+    /// <para><b>Why (issue #899).</b>
+    /// <see cref="PermissionEvaluator.GetEffectivePermissions(IMessageHub,string,string)"/>
+    /// is an <c>Observable.CombineLatest</c> fold over cached <c>Replay(1)</c> queries, so on
+    /// a warm cache it emits <b>synchronously during <c>Subscribe</c>, while holding the
+    /// CombineLatest gate</b> (one gate per ancestor scope, nested). A bare
+    /// <c>.Take(1).SelectMany(&lt;whole handler&gt;)</c> therefore executes the ENTIRE handler
+    /// body inside that lock. If the body then publishes a change, the fan-out walks shared
+    /// gates (<c>PersistenceService.Changes</c>'s <c>Merge</c>, the process-wide
+    /// <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c>) and on into ANOTHER hub's fold — two
+    /// hubs doing that concurrently take {own fold gate, shared gate} in opposite orders and
+    /// deadlock, with neither a success nor a failure response ever posted.</para>
+    ///
+    /// <para>The decision is still TAKEN inside the fold (the evaluation is unchanged and the
+    /// answer is the same); only the continuation is moved off the gate, onto
+    /// <see cref="System.Reactive.Concurrency.Scheduler.Default"/>. This is what a pipeline
+    /// that already hops through <c>IIoPool</c> gets for free — which is exactly why the
+    /// Postgres-backed paths never reproduced the wedge and the fully-synchronous in-memory
+    /// path did.</para>
+    ///
+    /// <para>🚨 Not needed for pure projections (a <c>CombineLatest</c> source feeding a
+    /// layout area, <c>.Select(p =&gt; control)</c>): those finish inside the gate and touch
+    /// nothing shared. Adding a hop there would only cost a scheduler round-trip.</para>
+    /// </summary>
+    public static IObservable<Permission> TakeDecisionOutsideGate(this IObservable<Permission> permissions)
+    {
+        ArgumentNullException.ThrowIfNull(permissions);
+        return permissions.Take(1).SelectMany(HopOffGate);
+    }
+
+    /// <summary>
+    /// <c>bool</c> overload of
+    /// <see cref="TakeDecisionOutsideGate(IObservable{Permission})"/> — for
+    /// <see cref="CheckPermission(IMessageHub,string,Permission)"/> /
+    /// <see cref="IsGlobalAdmin(IMessageHub)"/> chains whose continuation does real work.
+    /// </summary>
+    public static IObservable<bool> TakeDecisionOutsideGate(this IObservable<bool> decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        return decision.Take(1).SelectMany(HopOffGate);
+    }
+
+    /// <summary>
+    /// Re-emits <paramref name="value"/> on <see cref="Scheduler.Default"/>, so the
+    /// subscriber's continuation runs on a pool thread instead of on the emitting (gate-
+    /// holding) thread.
+    ///
+    /// <para>🚨 <c>Observable.Return(value, scheduler)</c> inside <c>SelectMany</c>, NOT
+    /// <c>ObserveOn(scheduler)</c>. Both leave the gate, but Rx's <c>ObserveOn</c> prefers
+    /// <c>ISchedulerLongRunning</c> and parks a DEDICATED thread for the life of the
+    /// subscription — measured at 64 extra threads for 64 concurrent subscriptions. A
+    /// permission check is subscribed per call, so that shape would cost a thread per check.
+    /// A single scheduled work item costs none.</para>
+    /// </summary>
+    private static IObservable<T> HopOffGate<T>(T value)
+        => Observable.Return(value, Scheduler.Default);
 
     /// <summary>
     /// Resolve a role definition (built-in or custom) by id.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2109,11 +2109,23 @@ public static class MeshExtensions
     {
         var pathToCheck = node.MainNode ?? node.Path;
 
-        // Take(1) closes the inner observable — GetEffectivePermissions rides
-        // the live AccessAssignment synced query and is hot, so without Take(1)
-        // the .Select chain never completes and the handler hangs.
+        // 🚨 TakeDecisionOutsideGate, NOT a bare Take(1) — issue #899.
+        //
+        // Take(1) is still required (GetEffectivePermissions rides the live AccessAssignment
+        // synced query and is hot, so without it the chain never completes and the handler
+        // hangs), but it is NOT sufficient. The caller chains
+        // `.SelectMany(denied => <the entire delete pipeline>)` onto this, and on a warm
+        // permission cache the fold emits synchronously during Subscribe while holding its
+        // Observable.CombineLatest gate — so storage delete, cache invalidation and the
+        // change-feed publish all ran INSIDE that lock. Two per-node hubs deleting
+        // concurrently then acquired {own fold gate, shared synced-query gate} in opposite
+        // orders and deadlocked: both action blocks parked forever and the recursive delete
+        // posted neither a DeleteNodeResponse nor a failure.
+        //
+        // The decision is unchanged — it is still taken inside the fold; only the pipeline
+        // that follows is moved off the gate.
         return hub.GetEffectivePermissions(pathToCheck, userId)
-            .Take(1)
+            .TakeDecisionOutsideGate()
             .Select(perms =>
             {
                 var denied = !perms.HasFlag(Permission.Delete);

--- a/src/MeshWeaver.Mesh.Contract/Services/DispatchedChangeFeed.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/DispatchedChangeFeed.cs
@@ -1,0 +1,247 @@
+using System.Collections.Immutable;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// The mesh's ONE fan-out primitive for change feeds: a hot broadcast that (a) never runs a
+/// subscriber on the publisher's thread and (b) never lets one faulty subscriber starve the
+/// others. Every place that pushes change events to arbitrary subscribers uses this instead
+/// of a bare <see cref="Subject{T}"/>.
+///
+/// <para><b>Why (a) — the lock-order inversion (issue #899).</b> A publisher is always some
+/// hub's action block or an I/O leaf, and it typically calls <see cref="OnNext"/> from deep
+/// inside a <c>SelectMany</c> continuation that is itself executing INSIDE another Rx
+/// operator's gate. The proven case: the whole <c>HandleDeleteNodeRequest</c> pipeline runs
+/// inside the <c>Observable.CombineLatest</c> lock of <c>PermissionEvaluator</c>'s
+/// effective-permission fold, because that fold emits synchronously during <c>Subscribe</c>
+/// (its sources are cached <c>ReplaySubject</c>s). A synchronous fan-out from there walks the
+/// subscriber graph and takes every gate in it — including SHARED gates that other hubs' folds
+/// also sit behind (<c>PersistenceService.Changes</c>'s <c>Merge</c>, the per-query
+/// <c>Concat</c>, the process-wide <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c>) — while
+/// still holding its own. Two hubs doing that concurrently acquire
+/// {own fold gate, shared gate} in opposite orders and deadlock: both action blocks park
+/// forever and the operation can neither succeed nor fail — no response is ever posted.
+///
+/// <para>Handing the fan-out to a dispatch loop breaks the cycle BY CONSTRUCTION: a publisher
+/// only enqueues, so it can never acquire a foreign gate while holding its own, no matter what
+/// subscribers do.</para></para>
+///
+/// <para><b>Why (b) — the swallowed fault (issue #889).</b> <c>Subject&lt;T&gt;.OnNext</c>
+/// delivers to its observers in subscription order and the first observer that throws aborts
+/// delivery to every observer after it; publishers then wrapped the call in
+/// <c>catch { /* never throw */ }</c>, turning that into silence. A synced query being torn
+/// down disposes its buffer before the subscription feeding it, so a write landing in that
+/// window threw <see cref="ObjectDisposedException"/> into the fan-out and every OTHER live
+/// subscriber — including the <c>$security-access</c> query the permission evaluator folds —
+/// never saw the notification, leaving a permanently stale security cache. So: deliver to a
+/// SNAPSHOT of the observers, isolate each one, and LOG rather than swallow.</para>
+///
+/// <para><b>Ordering</b> is preserved — one FIFO dispatch chain. <b>What callers may rely
+/// on:</b> the event is enqueued only after the commit that produced it, and subscribers see
+/// events in publish order. <b>What they may NOT rely on:</b> a subscriber having finished (or
+/// even started) by the time <see cref="OnNext"/> returns. Nothing in the mesh does — this is
+/// the same contract cross-silo delivery has always had.</para>
+///
+/// <para><b>Scheduler choice.</b> The default is <see cref="Scheduler.Default"/>: the dispatch
+/// chain is <c>Select(v =&gt; Observable.Return(v, scheduler)).Concat()</c>, which serialises on
+/// the thread pool WITHOUT holding a thread — measured at ~0 extra threads for 64 concurrent
+/// feeds, where <c>ObserveOn(Scheduler.Default)</c> costs one dedicated (long-running) thread
+/// EACH. That matters because there is one feed per storage adapter and Postgres creates one
+/// adapter per partition schema. Pass an <see cref="EventLoopScheduler"/> explicitly where a
+/// dedicated, named dispatch thread is wanted and there is exactly one feed (the mesh-wide
+/// change feed does this, so change delivery is never starved by unrelated pool work).</para>
+/// </summary>
+/// <typeparam name="T">The event type broadcast by this feed.</typeparam>
+public sealed class DispatchedChangeFeed<T> : IObservable<T>, IObserver<T>, IDisposable
+{
+    private readonly ILogger? logger;
+    private readonly string name;
+    private readonly object gate = new();
+
+    /// <summary>
+    /// Immutable so the fan-out iterates a stable snapshot with NO lock held — a subscriber
+    /// that subscribes or disposes DURING a publish can never disturb the walk, and the feed
+    /// itself is therefore never a gate that a foreign thread can be blocked on.
+    /// </summary>
+    private ImmutableList<IObserver<T>> observers = ImmutableList<IObserver<T>>.Empty;
+
+    /// <summary>
+    /// Publisher-facing inbox. Wrapped in <see cref="Subject.Synchronize{T}(ISubject{T})"/>
+    /// because ANY hub action block or I/O leaf may publish concurrently (two per-node hubs
+    /// deleting at the same time is the normal case in a recursive delete) and a bare
+    /// <see cref="Subject{T}"/> is not safe under concurrent <c>OnNext</c>.
+    /// </summary>
+    private readonly Subject<T> inboxCore = new();
+
+    private readonly ISubject<T> inbox;
+    private readonly IDisposable pump;
+    private bool disposed;
+
+    /// <summary>
+    /// Creates the feed and wires its serial dispatch chain.
+    /// </summary>
+    /// <param name="logger">Optional logger; a subscriber that throws is reported here.</param>
+    /// <param name="name">
+    /// Short identifier of the publishing component (adapter/schema name), used in log
+    /// messages so a faulty subscriber can be attributed to the feed it starved.
+    /// </param>
+    /// <param name="dispatcher">
+    /// Scheduler the fan-out runs on. Defaults to <see cref="Scheduler.Default"/> (thread
+    /// pool, no dedicated thread). NEVER pass a scheduler that runs inline on the caller —
+    /// that reinstates the inversion this type exists to prevent.
+    /// </param>
+    public DispatchedChangeFeed(ILogger? logger, string name, IScheduler? dispatcher = null)
+    {
+        this.logger = logger;
+        this.name = name;
+        var scheduler = dispatcher ?? Scheduler.Default;
+        inbox = Subject.Synchronize(inboxCore);
+        // 🚨 Select(Return(v, scheduler)).Concat() — NOT ObserveOn(scheduler). Both preserve
+        // FIFO and both leave the publisher's thread, but Rx's ObserveOn prefers
+        // ISchedulerLongRunning and therefore parks ONE DEDICATED THREAD per live
+        // subscription; Concat over per-item Return(scheduler) uses a plain scheduled work
+        // item, so N feeds cost O(1) threads instead of O(N). Concat subscribes the next item
+        // only after the previous one completed, which IS the ordering guarantee.
+        pump = inboxCore
+            .Select(change => Observable.Return(change, scheduler))
+            .Concat()
+            .Subscribe(
+                FanOut,
+                ex => logger?.LogError(ex,
+                    "Change-feed dispatch loop faulted ({Adapter}) — change events stopped.", name));
+    }
+
+    /// <summary>
+    /// Enqueues an event for delivery to every subscriber and returns IMMEDIATELY (no-op once
+    /// disposed). Subscribers run on the dispatch chain, never on the calling thread — see the
+    /// type doc for why that is a correctness requirement, not a performance choice.
+    /// </summary>
+    public void OnNext(T value)
+    {
+        if (!disposed)
+            inbox.OnNext(value);
+    }
+
+    /// <summary>
+    /// Reports a terminal fault to every subscriber, isolated per subscriber. Delivered
+    /// directly (not through the dispatch chain) so a fault is never queued behind a backlog.
+    /// </summary>
+    public void OnError(Exception error)
+    {
+        foreach (var observer in Volatile.Read(ref observers))
+        {
+            try { observer.OnError(error); }
+            catch (Exception ex) { logger?.LogWarning(ex, "Change-feed observer threw on OnError ({Adapter}).", name); }
+        }
+    }
+
+    /// <summary>Completes every subscriber, isolated per subscriber.</summary>
+    public void OnCompleted()
+    {
+        foreach (var observer in Volatile.Read(ref observers))
+        {
+            try { observer.OnCompleted(); }
+            catch (Exception ex) { logger?.LogWarning(ex, "Change-feed observer threw on OnCompleted ({Adapter}).", name); }
+        }
+    }
+
+    /// <summary>
+    /// Subscribes <paramref name="observer"/>. It is invoked on the dispatch chain, in publish
+    /// order, and its exceptions cannot reach any other subscriber.
+    /// </summary>
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+        lock (gate)
+        {
+            if (disposed)
+                return NullDisposable.Instance;
+            observers = observers.Add(observer);
+        }
+        return new Subscription(this, observer);
+    }
+
+    /// <summary>Stops the dispatch chain and drops every subscriber.</summary>
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed) return;
+            disposed = true;
+            observers = ImmutableList<IObserver<T>>.Empty;
+        }
+        // Only the pump is disposed. Disposing `inboxCore` would make a publisher that raced
+        // past the `disposed` check throw ObjectDisposedException back into its own write —
+        // and "fix" that with a swallow. With the pump gone and the observer list empty, a
+        // late OnNext is already a no-op, and the subject dies with this object.
+        pump.Dispose();
+    }
+
+    private void FanOut(T value)
+    {
+        // Snapshot OUTSIDE the delivery loop: an observer is free to subscribe or dispose
+        // while we are publishing, and neither may disturb this fan-out.
+        var snapshot = Volatile.Read(ref observers);
+        foreach (var observer in snapshot)
+        {
+            try
+            {
+                observer.OnNext(value);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // PROVABLY DEAD, so drop it: the subscriber's sink is disposed and every later
+                // notification would throw again. This is the shape the disposal-order race
+                // produces (a CompositeDisposable killing a change buffer while its feed is live).
+                Remove(observer);
+                logger?.LogWarning(ex,
+                    "Change-feed observer {Observer} was disposed while still subscribed ({Adapter}); dropped from the feed. "
+                    + "Delivery to the other {Remaining} observer(s) was NOT affected.",
+                    observer.GetType().Name, name, snapshot.Count - 1);
+            }
+            catch (Exception ex)
+            {
+                // ISOLATED but KEPT. A transient throw must not permanently disable a live
+                // subscriber — dropping it here would starve it of every future change, which is
+                // the very failure this class exists to prevent, just moved. Only a disposed sink
+                // (above) is provably unrecoverable. Warning, not Debug: a subscriber that missed
+                // a change has a stale view of the mesh, and on the security-fold path that means
+                // stale permissions.
+                logger?.LogWarning(ex,
+                    "Change-feed observer {Observer} threw ({Adapter}) and MISSED that notification; it remains subscribed. "
+                    + "Delivery to the other {Remaining} observer(s) was NOT affected.",
+                    observer.GetType().Name, name, snapshot.Count - 1);
+            }
+        }
+    }
+
+    private void Remove(IObserver<T> observer)
+    {
+        lock (gate)
+        {
+            observers = observers.Remove(observer);
+        }
+    }
+
+    private sealed class Subscription(DispatchedChangeFeed<T> feed, IObserver<T> observer) : IDisposable
+    {
+        private IObserver<T>? current = observer;
+
+        public void Dispose()
+        {
+            var o = Interlocked.Exchange(ref current, null);
+            if (o is not null)
+                feed.Remove(o);
+        }
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static readonly IDisposable Instance = new NullDisposable();
+        public void Dispose() { }
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/StorageAdapterChangeFeedExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/StorageAdapterChangeFeedExtensions.cs
@@ -31,6 +31,15 @@ namespace MeshWeaver.Mesh.Services;
 /// the operation's response message, version-history writes,
 /// in-process change-feed notifications, etc., knowing the
 /// mesh-change-feed publish already happened.</para>
+///
+/// <para>🚨 "Published" means <b>handed to the feed</b>, not "every subscriber has
+/// finished". <c>InProcessMeshChangeFeed</c> fans out on its own serial dispatch loop —
+/// it MUST NOT run subscriber chains on the publishing hub's thread, because that thread
+/// is typically already inside another operator's gate (see issue #899: a synchronous
+/// fan-out from inside <c>PermissionEvaluator</c>'s <c>CombineLatest</c> lock deadlocked
+/// two concurrently-deleting hubs). The guarantee these helpers provide is the
+/// commit-then-publish ORDER; delivery to subscribers is ordered but asynchronous, exactly
+/// as the cross-silo Orleans broadcast has always been.</para>
 /// </summary>
 public static class StorageAdapterChangeFeedExtensions
 {

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,15 +55,32 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
         response.Message.Error.Should().BeNullOrEmpty();
     }
 
+    /// <summary>
+    /// Waits until <paramref name="events"/> contains a match. 🚨 The change feed dispatches on
+    /// its OWN serial loop, never on the publishing hub's thread (issue #899 — a synchronous
+    /// fan-out deadlocked two concurrently-deleting hubs), so a subscriber's list is NOT
+    /// guaranteed to be populated the instant the create/delete request returns. Wait on the
+    /// condition, never read straight after the await.
+    /// </summary>
+    private static Task<MeshChangeEvent[]> Delivered(
+        ConcurrentQueue<MeshChangeEvent> events,
+        Func<MeshChangeEvent, bool> predicate,
+        string because)
+        => Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Select(_ => events.ToArray())
+            .Should().Within(TimeSpan.FromSeconds(15))
+            .Match(snapshot => snapshot.Any(predicate), because);
+
     [Fact]
     public async Task CreateNode_PublishesCreatedEvent()
     {
-        var events = new List<MeshChangeEvent>();
-        using var sub = ChangeFeed.Subscribe(e => events.Add(e));
+        var events = new ConcurrentQueue<MeshChangeEvent>();
+        using var sub = ChangeFeed.Subscribe(events.Enqueue);
 
         await CreateTestNode("feed-create-1");
 
-        events.Should().Contain(e => e.Kind == MeshChangeKind.Created && e.Id == "feed-create-1");
+        await Delivered(events, e => e.Kind == MeshChangeKind.Created && e.Id == "feed-create-1",
+            "creating a node must publish a Created event");
     }
 
     [Fact]
@@ -68,28 +88,48 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
     {
         var created = await CreateTestNode("feed-del-1");
 
-        var events = new List<MeshChangeEvent>();
-        using var sub = ChangeFeed.Subscribe(e => events.Add(e));
+        var events = new ConcurrentQueue<MeshChangeEvent>();
+        using var sub = ChangeFeed.Subscribe(events.Enqueue);
 
         await DeleteTestNode(created.Path);
 
-        events.Should().Contain(e => e.Kind == MeshChangeKind.Deleted && e.Path.Contains("feed-del-1"));
+        await Delivered(events, e => e.Kind == MeshChangeKind.Deleted && e.Path.Contains("feed-del-1"),
+            "deleting a node must publish a Deleted event");
     }
 
     [Fact]
     public async Task FilteredSubscription_OnlyReceivesMatchingEvents()
     {
-        var createEvents = new List<MeshChangeEvent>();
-        var deleteEvents = new List<MeshChangeEvent>();
-        using var createSub = ChangeFeed.Subscribe(e => createEvents.Add(e), MeshChangeKind.Created);
-        using var deleteSub = ChangeFeed.Subscribe(e => deleteEvents.Add(e), MeshChangeKind.Deleted);
+        var createEvents = new ConcurrentQueue<MeshChangeEvent>();
+        var deleteEvents = new ConcurrentQueue<MeshChangeEvent>();
+        using var createSub = ChangeFeed.Subscribe(createEvents.Enqueue, MeshChangeKind.Created);
+        using var deleteSub = ChangeFeed.Subscribe(deleteEvents.Enqueue, MeshChangeKind.Deleted);
 
         var created = await CreateTestNode("feed-filter-1");
         await DeleteTestNode(created.Path);
 
+        // Wait for BOTH kinds to have been delivered before asserting the filtering —
+        // otherwise "only creates in createEvents" would pass vacuously on an empty queue.
+        await Delivered(createEvents, e => e.Id == "feed-filter-1", "the Created event must arrive");
+        await Delivered(deleteEvents, e => e.Path.Contains("feed-filter-1"), "the Deleted event must arrive");
+
         createEvents.Should().OnlyContain(e => e.Kind == MeshChangeKind.Created);
         deleteEvents.Should().OnlyContain(e => e.Kind == MeshChangeKind.Deleted);
     }
+
+    /// <summary>
+    /// Re-resolves <paramref name="path"/> until it satisfies <paramref name="predicate"/>. The
+    /// resolution cache is invalidated by the change feed, which delivers on its own dispatch
+    /// loop (#899) — and on a distributed deployment that invalidation has always been
+    /// asynchronous (the Orleans cross-silo broadcast). Resolution after a write is therefore
+    /// eventually consistent: wait for it rather than reading once.
+    /// </summary>
+    private Task<AddressResolution?> Resolves(
+        string path, Func<AddressResolution?, bool> predicate, string because)
+        => Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .SelectMany(_ => PathResolver.ResolvePath(path).Take(1))
+            .Should().Within(TimeSpan.FromSeconds(15))
+            .Match(predicate, because);
 
     [Fact]
     public async Task CreateNode_PathResolverFindsIt()
@@ -100,10 +140,10 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
         await CreateTestNode("feed-resolve-1");
 
         // After create Ã¢â‚¬â€ cache was invalidated/pre-warmed by change event
-        var after = await PathResolver.ResolvePath("feed-resolve-1").Should().Emit();
+        var after = await Resolves("feed-resolve-1",
+            r => r is not null && r.Prefix.Contains("feed-resolve-1") && string.IsNullOrEmpty(r.Remainder),
+            "a created node must become resolvable at its exact path");
         after.Should().NotBeNull();
-        after!.Prefix.Should().Contain("feed-resolve-1");
-        after.Remainder.Should().BeNullOrEmpty();
     }
 
     [Fact]
@@ -118,8 +158,8 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
         await DeleteTestNode(created.Path);
 
         // After delete Ã¢â‚¬â€ cache evicted, resolver should not find it at that exact path
-        var gone = await PathResolver.ResolvePath(created.Path).Should().Emit();
-        (gone == null || gone.Prefix != created.Path).Should().BeTrue(
+        await Resolves(created.Path,
+            r => r == null || r.Prefix != created.Path,
             "deleted node should not resolve to its exact path");
     }
 
@@ -136,10 +176,9 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
         await CreateTestNode("nest-child-1", parent.Path);
 
         // Now nested path should resolve to child (stale cache evicted by Created event)
-        var afterChild = await PathResolver.ResolvePath($"{parent.Path}/nest-child-1").Should().Emit();
-        afterChild.Should().NotBeNull();
-        afterChild!.Prefix.Should().Be($"{parent.Path}/nest-child-1");
-        afterChild.Remainder.Should().BeNullOrEmpty();
+        await Resolves($"{parent.Path}/nest-child-1",
+            r => r is not null && r.Prefix == $"{parent.Path}/nest-child-1" && string.IsNullOrEmpty(r.Remainder),
+            "the stale parent partial match must be evicted once the child exists");
     }
 }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheRecycleResetTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheRecycleResetTest.cs
@@ -56,12 +56,29 @@ public class MeshNodeStreamCacheRecycleResetTest(ITestOutputHelper output) : Mon
         return path;
     }
 
-    /// <summary>The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a
-    /// recycled path (Updated kind, NodeType-path marker, version 0).</summary>
-    private void PublishRecycleBroadcast(string path)
+    /// <summary>
+    /// The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a recycled path
+    /// (Updated kind, NodeType-path marker, version 0), and returns only once the cache has
+    /// SEEN it.
+    ///
+    /// <para>🚨 The feed dispatches on its own serial loop, never on the publisher's thread
+    /// (issue #899 — a synchronous fan-out deadlocked two concurrently-deleting hubs). The probe
+    /// below subscribes AFTER <c>MeshNodeStreamCache</c> did (it subscribes when the mesh is
+    /// built), and one FIFO loop notifies observers in subscription order — so the probe firing
+    /// proves the cache already reset this path. That keeps "the VERY NEXT read heals" exact
+    /// instead of degrading it into a retry loop.</para>
+    /// </summary>
+    private async Task PublishRecycleBroadcast(string path)
     {
         var segments = path.Split('/');
-        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var seenByCache = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var probe = feed.Subscribe(e =>
+        {
+            if (e.Path == path)
+                seenByCache.TrySetResult();
+        });
+        feed.Publish(new MeshChangeEvent(
             Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
             Id: segments.Length > 0 ? segments[^1] : path,
             Path: path,
@@ -69,6 +86,7 @@ public class MeshNodeStreamCacheRecycleResetTest(ITestOutputHelper output) : Mon
             NodeType: MeshNode.NodeTypePath,
             Version: 0,
             Timestamp: DateTimeOffset.UtcNow));
+        await seenByCache.Task.WaitAsync(TimeSpan.FromSeconds(15));
     }
 
     /// <summary>
@@ -120,7 +138,7 @@ public class MeshNodeStreamCacheRecycleResetTest(ITestOutputHelper output) : Mon
         writeFail.Exception!.Message.Should().Contain("activation failed");
 
         // The recycle: the SAME broadcast RecycleCore publishes.
-        PublishRecycleBroadcast(path);
+        await PublishRecycleBroadcast(path);
 
         // Fresh resolution attempt IMMEDIATELY — no waiting out the 5-minute
         // window. This is the exact step that never healed on memex-cloud.

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheTransientBreakerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheTransientBreakerTest.cs
@@ -50,12 +50,29 @@ public class MeshNodeStreamCacheTransientBreakerTest(ITestOutputHelper output) :
         return path;
     }
 
-    /// <summary>The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a
-    /// recycled path (Updated kind, NodeType-path marker, version 0).</summary>
-    private void PublishRecycleBroadcast(string path)
+    /// <summary>
+    /// The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a recycled path
+    /// (Updated kind, NodeType-path marker, version 0), and returns only once the cache has
+    /// SEEN it.
+    ///
+    /// <para>🚨 The feed dispatches on its own serial loop, never on the publisher's thread
+    /// (issue #899 — a synchronous fan-out deadlocked two concurrently-deleting hubs). The probe
+    /// below subscribes AFTER <c>MeshNodeStreamCache</c> did (it subscribes when the mesh is
+    /// built), and one FIFO loop notifies observers in subscription order — so the probe firing
+    /// proves the cache already reset this path. That keeps "the VERY NEXT read heals" exact
+    /// instead of degrading it into a retry loop.</para>
+    /// </summary>
+    private async Task PublishRecycleBroadcast(string path)
     {
         var segments = path.Split('/');
-        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var seenByCache = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var probe = feed.Subscribe(e =>
+        {
+            if (e.Path == path)
+                seenByCache.TrySetResult();
+        });
+        feed.Publish(new MeshChangeEvent(
             Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
             Id: segments.Length > 0 ? segments[^1] : path,
             Path: path,
@@ -63,6 +80,7 @@ public class MeshNodeStreamCacheTransientBreakerTest(ITestOutputHelper output) :
             NodeType: MeshNode.NodeTypePath,
             Version: 0,
             Timestamp: DateTimeOffset.UtcNow));
+        await seenByCache.Task.WaitAsync(TimeSpan.FromSeconds(15));
     }
 
     /// <summary>The poisoned-activation failure shape as it reached the cache on memex-cloud:
@@ -144,7 +162,7 @@ public class MeshNodeStreamCacheTransientBreakerTest(ITestOutputHelper output) :
                 n => n.Kind == NotificationKind.OnError,
                 "precondition: the window must be open before the recycle");
 
-        PublishRecycleBroadcast(path);
+        await PublishRecycleBroadcast(path);
 
         var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
             .Where(n => n is not null)

--- a/test/MeshWeaver.Hosting.Test/EventLogTest.cs
+++ b/test/MeshWeaver.Hosting.Test/EventLogTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Hosting;
@@ -11,16 +12,32 @@ namespace MeshWeaver.Hosting.Test;
 /// Unit tests for the app-level event-log outbox (in-memory store): the writer persists every
 /// change-feed event (idempotent by Path/Kind/Version), and the replay service redelivers
 /// not-yet-processed entries into the feed and advances the cursor.
+///
+/// <para>🚨 The change feed fans out on its OWN dispatch loop, never on the publisher's thread
+/// (issue #899 — a synchronous fan-out deadlocked two concurrently-deleting hubs). So every
+/// assertion here waits for the delivery it depends on instead of reading straight after
+/// <c>Publish</c>; the pre-#899 shape only passed because publish and delivery shared a thread.</para>
 /// </summary>
 public class EventLogTest
 {
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(10);
+
     private static MeshChangeEvent Created(string id) =>
         MeshChangeEvent.Created(new MeshNode(id) { NodeType = "X" });
 
-    [Fact]
+    /// <summary>Waits until the store holds at least <paramref name="expected"/> rows.</summary>
+    private static Task<IReadOnlyList<EventLogEntry>> RowsReach(IEventLogStore store, int expected) =>
+        Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .SelectMany(_ => store.ReadFrom(0))
+            .Where(rows => rows.Count >= expected)
+            .FirstAsync()
+            .Timeout(DeliveryTimeout)
+            .ToTask();
+
+    [Fact(Timeout = 30000)]
     public async Task Writer_persists_and_dedups()
     {
-        var feed = new InProcessMeshChangeFeed();
+        using var feed = new InProcessMeshChangeFeed();
         var store = new InMemoryEventLogStore();
         var writer = new EventLogWriter(feed, store);
         await writer.StartAsync(default);
@@ -28,18 +45,21 @@ public class EventLogTest
         var a = Created("A");
         feed.Publish(a);
         feed.Publish(Created("B"));
-        Assert.Equal(2, (await store.ReadFrom(0).FirstAsync().ToTask()).Count);
+        (await RowsReach(store, 2)).Count.Should().Be(2);
 
-        // Re-publishing the SAME event (same Path/Kind/Version) does not add a row.
+        // Re-publishing the SAME event (same Path/Kind/Version) must not add a row. The feed
+        // delivers in publish order on a single loop, so once the LATER "C" has landed the
+        // duplicate has provably already been processed — no sleep, no polling for absence.
         feed.Publish(a);
-        Assert.Equal(2, (await store.ReadFrom(0).FirstAsync().ToTask()).Count);
-        Assert.Equal(2, await store.MaxSeq().FirstAsync().ToTask());
+        feed.Publish(Created("C"));
+        (await RowsReach(store, 3)).Count.Should().Be(3, "the duplicate must not have added a row");
+        (await store.MaxSeq().FirstAsync().ToTask()).Should().Be(3);
     }
 
-    [Fact]
+    [Fact(Timeout = 30000)]
     public async Task Replay_redelivers_unprocessed_and_advances_cursor()
     {
-        var feed = new InProcessMeshChangeFeed();
+        using var feed = new InProcessMeshChangeFeed();
         var store = new InMemoryEventLogStore();
 
         // Two events already durably logged (as if written before this consumer existed).
@@ -47,26 +67,39 @@ public class EventLogTest
         await store.Append(Created("B")).ToTask();
 
         // A fresh subscriber (stands in for the runner) attached AFTER those were logged.
-        var received = new List<string>();
-        using var sub = feed.Subscribe(c => received.Add(c.Path));
+        var received = new ConcurrentQueue<string>();
+        var bothDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var sub = feed.Subscribe(c =>
+        {
+            received.Enqueue(c.Path);
+            if (received.Count >= 2)
+                bothDelivered.TrySetResult();
+        });
 
         var replay = new EventLogReplayService(feed, store);
-        await replay.StartAsync(default);   // synchronous store ops → publishes on start
+        await replay.StartAsync(default);
 
-        Assert.Contains("A", received);
-        Assert.Contains("B", received);
-        Assert.Equal(2, await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask());
+        await bothDelivered.Task.WaitAsync(DeliveryTimeout);
+        received.Should().Contain("A").And.Contain("B");
+        (await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask()).Should().Be(2);
 
         // A second replay (e.g. another restart) with the cursor already at 2 redelivers nothing.
+        // Publish a marker afterwards and wait for IT: because the loop is FIFO, the marker's
+        // arrival proves any replayed event would already have landed.
         received.Clear();
+        var markerSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var marker = feed.Subscribe(c => { if (c.Path == "marker") markerSeen.TrySetResult(); });
         await new EventLogReplayService(feed, store).StartAsync(default);
-        Assert.Empty(received);
+        feed.Publish(Created("marker"));
+
+        await markerSeen.Task.WaitAsync(DeliveryTimeout);
+        received.Should().Equal("marker");
     }
 
-    [Fact]
+    [Fact(Timeout = 30000)]
     public async Task Replay_drains_all_pages_when_backlog_exceeds_one_page()
     {
-        var feed = new InProcessMeshChangeFeed();
+        using var feed = new InProcessMeshChangeFeed();
         var store = new InMemoryEventLogStore();
 
         // A backlog LARGER than the replay page size (500): a single ReadFrom page would leave the
@@ -75,12 +108,19 @@ public class EventLogTest
         for (var i = 0; i < count; i++)
             await store.Append(Created($"N{i}")).ToTask();
 
-        var received = new List<string>();
-        using var sub = feed.Subscribe(c => received.Add(c.Path));
+        var received = new ConcurrentQueue<string>();
+        var allDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var sub = feed.Subscribe(c =>
+        {
+            received.Enqueue(c.Path);
+            if (received.Count >= count)
+                allDelivered.TrySetResult();
+        });
 
         await new EventLogReplayService(feed, store).StartAsync(default);
 
-        Assert.Equal(count, received.Count);   // every page drained, not just the first 500
-        Assert.Equal(count, await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask());
+        await allDelivered.Task.WaitAsync(DeliveryTimeout);
+        received.Count.Should().Be(count, "every page must drain, not just the first 500");
+        (await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask()).Should().Be(count);
     }
 }

--- a/test/MeshWeaver.Hosting.Test/MeshChangeFeedDispatchTests.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshChangeFeedDispatchTests.cs
@@ -77,60 +77,44 @@ public class MeshChangeFeedDispatchTests
     }
 
     /// <summary>
-    /// The actual #899 deadlock, deterministically. Two publishers each hold their OWN
-    /// gate (the per-call permission fold) while publishing; the subscriber chain walks
-    /// through a SHARED gate (the cached synced query both folds sit behind) into the
-    /// OTHER publisher's gate. With a synchronous fan-out that is a guaranteed
-    /// lock-order inversion — this test hangs and fails on the pre-fix feed. With the
-    /// dispatch loop, both publishes return immediately and the loop takes the gates
-    /// serially, so no cycle can form.
+    /// The actual #899 deadlock, deterministically — driven by the shared
+    /// <see cref="RxFanOutInversionHarness"/> so the SAME probe pins every fan-out point in
+    /// the mesh (see <c>StorageAdapterDispatchTests</c>, <c>PermissionFoldGateTests</c>).
+    /// With a synchronous fan-out this hangs and fails; with enqueue-and-dispatch both
+    /// publishes return immediately and the dispatch chain takes the gates serially.
     /// </summary>
     [Fact(Timeout = 30000)]
     public async Task Concurrent_publishers_holding_their_own_gates_cannot_deadlock()
     {
         using var feed = new InProcessMeshChangeFeed();
 
-        var ownGateOfPublisher1 = new object();   // publisher 1's CombineLatest fold gate
-        var ownGateOfPublisher2 = new object();   // publisher 2's CombineLatest fold gate
-        var sharedQueryGate = new object();       // the shared synced-query Merge gate
+        await RxFanOutInversionHarness.AssertCannotDeadlock(
+            subscribe: handler => feed.Subscribe(e => handler(e.Path)),
+            publish: tag => feed.Publish(MeshChangeEvent.Deleted(tag)),
+            because:
+                "Publish must not run the subscriber graph on the publisher's thread — doing so "
+                + "takes foreign gates while the publisher still holds its own, which is the "
+                + "#899 deadlock between two concurrent per-node-hub deletes");
+    }
 
-        // The subscriber graph: every event walks the shared query gate and, from there,
-        // into the OTHER publisher's fold — exactly the shape the real graph has, because
-        // both folds subscribe to the same cached query.
-        using var subscription = feed.Subscribe(e =>
-        {
-            var otherFoldGate = e.Path == "p1" ? ownGateOfPublisher2 : ownGateOfPublisher1;
-            lock (sharedQueryGate)
-                lock (otherFoldGate) { }
-        });
+    /// <summary>
+    /// A subscriber that throws must not starve the OTHERS (the #889 half of the contract,
+    /// now inherited from <c>DispatchedChangeFeed</c>). The pre-#899 feed delivered through a
+    /// plain <c>Subject</c>, where the first throwing observer aborted delivery to every
+    /// observer subscribed after it — and the publisher's <c>catch</c> turned that into
+    /// silence.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task A_throwing_subscriber_does_not_starve_the_others()
+    {
+        using var feed = new InProcessMeshChangeFeed();
 
-        // Both publishers must be inside their own gate at the same time — otherwise the
-        // inversion cannot form and the test would pass vacuously.
-        using var bothInsideTheirGate = new Barrier(2);
+        using var faulty = feed.Subscribe(_ => throw new InvalidOperationException("boom"));
+        var reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var healthy = feed.Subscribe(_ => reached.TrySetResult());
 
-        Task PublishHolding(object ownGate, string path) => Task.Run(() =>
-        {
-            lock (ownGate)
-            {
-                bothInsideTheirGate.SignalAndWait(TimeSpan.FromSeconds(10));
-                feed.Publish(MeshChangeEvent.Deleted(path));
-            }
-        });
+        feed.Publish(MeshChangeEvent.Deleted("space/Overview"));
 
-        var publishers = new[]
-        {
-            PublishHolding(ownGateOfPublisher1, "p1"),
-            PublishHolding(ownGateOfPublisher2, "p2")
-        };
-
-        // Task.Delay is the DEADLOCK bound here, not a wait-for-propagation sleep: the
-        // only way both publishers fail to finish is a genuine cycle.
-        var bothPublished = Task.WhenAll(publishers);
-        var finished = await Task.WhenAny(bothPublished, Task.Delay(TimeSpan.FromSeconds(10)));
-
-        finished.Should().BeSameAs(bothPublished,
-            "Publish must not run the subscriber graph on the publisher's thread — doing so "
-            + "takes foreign gates while the publisher still holds its own, which is the "
-            + "#899 deadlock between two concurrent per-node-hub deletes");
+        await reached.Task.WaitAsync(TimeSpan.FromSeconds(10));
     }
 }

--- a/test/MeshWeaver.Hosting.Test/MeshChangeFeedDispatchTests.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshChangeFeedDispatchTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression tests for issue #899 — the mesh change feed must fan out on its OWN
+/// serial dispatch loop, never on the publishing hub's thread.
+///
+/// <para>Why this matters (the wedge these tests pin): a publisher is always some
+/// hub's action block, and it calls <c>Publish</c> from inside a <c>SelectMany</c>
+/// continuation that is itself running INSIDE another Rx operator's gate — in the
+/// real failure, the whole <c>HandleDeleteNodeRequest</c> pipeline executed inside
+/// the <c>Observable.CombineLatest</c> lock of <c>PermissionEvaluator</c>'s
+/// effective-permission fold. When the fan-out ran synchronously, it acquired the
+/// SHARED synced-query <c>Merge</c> gate and then walked into ANOTHER hub's fold —
+/// while that hub was doing the mirror image. The two hubs took
+/// {own fold gate, shared merge gate} in opposite orders and deadlocked: both
+/// action blocks parked forever and the recursive delete could neither succeed nor
+/// fail (no <c>DeleteNodeResponse</c> ever posted).</para>
+/// </summary>
+public class MeshChangeFeedDispatchTests
+{
+    /// <summary>
+    /// The invariant: <see cref="InProcessMeshChangeFeed.Publish"/> hands the event to the
+    /// dispatch loop and returns — the subscriber runs on a DIFFERENT thread. Everything
+    /// else in this file follows from this one property.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Publish_runs_subscribers_off_the_publisher_thread()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+
+        var seen = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = feed.Subscribe(_ => seen.TrySetResult(Environment.CurrentManagedThreadId));
+
+        var publisherThread = Environment.CurrentManagedThreadId;
+        feed.Publish(MeshChangeEvent.Deleted("space/Overview"));
+
+        var handlerThread = await seen.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        handlerThread.Should().NotBe(publisherThread,
+            "a subscriber that runs on the publisher's thread runs inside whatever locks the "
+            + "publishing hub already holds — that is the #899 lock-order inversion");
+    }
+
+    /// <summary>
+    /// Ordering is part of the contract: one dispatch loop, FIFO. A feed that fanned out
+    /// on the thread pool could reorder Created/Deleted for the same path.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Events_are_delivered_in_publish_order()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+
+        const int count = 200;
+        var received = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = feed.Subscribe(e =>
+        {
+            received.Enqueue(e.Path);
+            if (received.Count == count)
+                done.TrySetResult();
+        });
+
+        var expected = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            expected[i] = $"space/node{i}";
+            feed.Publish(MeshChangeEvent.Deleted(expected[i]));
+        }
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        received.ToArray().Should().Equal(expected);
+    }
+
+    /// <summary>
+    /// The actual #899 deadlock, deterministically. Two publishers each hold their OWN
+    /// gate (the per-call permission fold) while publishing; the subscriber chain walks
+    /// through a SHARED gate (the cached synced query both folds sit behind) into the
+    /// OTHER publisher's gate. With a synchronous fan-out that is a guaranteed
+    /// lock-order inversion — this test hangs and fails on the pre-fix feed. With the
+    /// dispatch loop, both publishes return immediately and the loop takes the gates
+    /// serially, so no cycle can form.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Concurrent_publishers_holding_their_own_gates_cannot_deadlock()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+
+        var ownGateOfPublisher1 = new object();   // publisher 1's CombineLatest fold gate
+        var ownGateOfPublisher2 = new object();   // publisher 2's CombineLatest fold gate
+        var sharedQueryGate = new object();       // the shared synced-query Merge gate
+
+        // The subscriber graph: every event walks the shared query gate and, from there,
+        // into the OTHER publisher's fold — exactly the shape the real graph has, because
+        // both folds subscribe to the same cached query.
+        using var subscription = feed.Subscribe(e =>
+        {
+            var otherFoldGate = e.Path == "p1" ? ownGateOfPublisher2 : ownGateOfPublisher1;
+            lock (sharedQueryGate)
+                lock (otherFoldGate) { }
+        });
+
+        // Both publishers must be inside their own gate at the same time — otherwise the
+        // inversion cannot form and the test would pass vacuously.
+        using var bothInsideTheirGate = new Barrier(2);
+
+        Task PublishHolding(object ownGate, string path) => Task.Run(() =>
+        {
+            lock (ownGate)
+            {
+                bothInsideTheirGate.SignalAndWait(TimeSpan.FromSeconds(10));
+                feed.Publish(MeshChangeEvent.Deleted(path));
+            }
+        });
+
+        var publishers = new[]
+        {
+            PublishHolding(ownGateOfPublisher1, "p1"),
+            PublishHolding(ownGateOfPublisher2, "p2")
+        };
+
+        // Task.Delay is the DEADLOCK bound here, not a wait-for-propagation sleep: the
+        // only way both publishers fail to finish is a genuine cycle.
+        var bothPublished = Task.WhenAll(publishers);
+        var finished = await Task.WhenAny(bothPublished, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        finished.Should().BeSameAs(bothPublished,
+            "Publish must not run the subscriber graph on the publisher's thread — doing so "
+            + "takes foreign gates while the publisher still holds its own, which is the "
+            + "#899 deadlock between two concurrent per-node-hub deletes");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/PermissionFoldGateTests.cs
+++ b/test/MeshWeaver.Hosting.Test/PermissionFoldGateTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression tests for the OTHER half of issue #899 — the half that GENERATES the inversion
+/// rather than completing it.
+///
+/// <para><c>PermissionEvaluator.GetEffectivePermissions</c> is an
+/// <c>Observable.CombineLatest</c> fold whose sources are cached <c>Replay(1)</c> queries, so
+/// on a warm cache it emits <b>synchronously during <c>Subscribe</c>, while holding the
+/// CombineLatest gate</b> (one per ancestor scope, nested). A handler written as
+/// <c>GetEffectivePermissions(...).Take(1).SelectMany(&lt;whole handler body&gt;)</c> therefore
+/// runs its ENTIRE body inside that lock — storage writes, cache invalidation, change-feed
+/// publishes and all. That shape is a latent inversion generator at every one of its call
+/// sites, not just on the delete path where it was caught.</para>
+///
+/// <para>These tests pin the cure —
+/// <see cref="HubPermissionExtensions.TakeDecisionOutsideGate(IObservable{Permission})"/> —
+/// against a fold modelled on the real one: a source that emits synchronously during Subscribe
+/// while holding a gate. That is the only property of <c>CombineLatest</c> that matters here,
+/// and modelling it explicitly makes the gate observable to the test.</para>
+/// </summary>
+public class PermissionFoldGateTests
+{
+    /// <summary>
+    /// The evaluator's emission shape: value already buffered upstream ⇒ <c>OnNext</c> fires
+    /// on the SUBSCRIBING thread, inside the fold's gate, before <c>Subscribe</c> returns.
+    /// </summary>
+    private static IObservable<Permission> FoldEmittingInsideGate(object gate, Permission value)
+        => Observable.Create<Permission>(observer =>
+        {
+            lock (gate)
+            {
+                observer.OnNext(value);
+                observer.OnCompleted();
+            }
+            return Disposable.Empty;
+        });
+
+    /// <summary>
+    /// Precondition — proves the tests below are not vacuous: the PRE-FIX shape
+    /// (<c>.Take(1)</c> and nothing else) really does run the continuation inside the fold's
+    /// gate, on the subscribing thread. If this ever stops being true the whole #899 analysis
+    /// needs revisiting.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void Take1_alone_runs_the_continuation_INSIDE_the_folds_gate()
+    {
+        var foldGate = new object();
+        var insideGate = false;
+        var onSubscriberThread = false;
+        var subscriberThread = Environment.CurrentManagedThreadId;
+
+        FoldEmittingInsideGate(foldGate, Permission.All)
+            .Take(1)
+            .Subscribe(_ =>
+            {
+                insideGate = Monitor.IsEntered(foldGate);
+                onSubscriberThread = Environment.CurrentManagedThreadId == subscriberThread;
+            });
+
+        insideGate.Should().BeTrue(
+            "the fold emits during Subscribe while holding its CombineLatest gate, so a bare "
+            + "Take(1) hands the whole handler body that lock");
+        onSubscriberThread.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The fix: the decision is still TAKEN inside the fold, but the continuation runs
+    /// outside it — on another thread, holding none of the fold's locks.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TakeDecisionOutsideGate_runs_the_continuation_OUTSIDE_the_folds_gate()
+    {
+        var foldGate = new object();
+        var subscriberThread = Environment.CurrentManagedThreadId;
+        var observed = new TaskCompletionSource<(bool InsideGate, int Thread, Permission Value)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        FoldEmittingInsideGate(foldGate, Permission.All)
+            .TakeDecisionOutsideGate()
+            .Subscribe(p => observed.TrySetResult(
+                (Monitor.IsEntered(foldGate), Environment.CurrentManagedThreadId, p)));
+
+        var result = await observed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        result.InsideGate.Should().BeFalse("the continuation must not hold the fold's gate");
+        result.Thread.Should().NotBe(subscriberThread,
+            "leaving the gate requires leaving the emitting thread");
+        result.Value.Should().Be(Permission.All,
+            "the decision itself is unchanged — only where the continuation runs moved");
+    }
+
+    /// <summary>
+    /// The generator, deterministically. Two handlers each gated on their OWN permission fold;
+    /// each body then walks a SHARED gate (the process-wide synced-query <c>Replay(1)</c> /
+    /// <c>PersistenceService.Changes</c> <c>Merge</c>) and into the OTHER handler's fold —
+    /// which is exactly what a change-feed publish from inside a handler body does, because
+    /// both folds subscribe the same cached queries.
+    ///
+    /// <para>With a bare <c>Take(1)</c> both bodies run INSIDE their own fold gate, so they
+    /// acquire {own fold gate, shared gate} in opposite orders and deadlock — this test hangs
+    /// to its bound and fails. With <c>TakeDecisionOutsideGate</c> the bodies hold no fold
+    /// gate, so no cycle can form no matter what they touch.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Two_handlers_gated_on_their_own_fold_cannot_deadlock()
+    {
+        var foldGate1 = new object();
+        var foldGate2 = new object();
+        var sharedQueryGate = new object();
+
+        // Both bodies must be running at the same moment — otherwise the inversion cannot
+        // form and the test would pass vacuously.
+        using var bothInsideTheirBody = new Barrier(2);
+        var bound = TimeSpan.FromSeconds(10);
+
+        Task RunGatedHandler(object ownFoldGate, object otherFoldGate)
+        {
+            var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return Task.Run(() =>
+            {
+                FoldEmittingInsideGate(ownFoldGate, Permission.All)
+                    .TakeDecisionOutsideGate()
+                    .Subscribe(_ =>
+                    {
+                        bothInsideTheirBody.SignalAndWait(bound);
+                        lock (sharedQueryGate)
+                            lock (otherFoldGate) { }
+                        completed.TrySetResult();
+                    });
+                return completed.Task;
+            });
+        }
+
+        var bothFinished = Task.WhenAll(
+            RunGatedHandler(foldGate1, foldGate2),
+            RunGatedHandler(foldGate2, foldGate1));
+
+        // Task.Delay is the DEADLOCK BOUND, not a wait-for-propagation sleep: the only way
+        // both handlers fail to finish is a genuine cycle.
+        var finished = await Task.WhenAny(bothFinished, Task.Delay(bound));
+
+        finished.Should().BeSameAs(bothFinished,
+            "a permission-gated handler must not run its body inside the evaluator's fold "
+            + "gate — doing so makes every shared gate it touches half of a lock-order "
+            + "inversion (#899)");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/RxFanOutInversionHarness.cs
+++ b/test/MeshWeaver.Hosting.Test/RxFanOutInversionHarness.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The reusable probe for the issue-#899 bug CLASS: an Rx fan-out point that walks its
+/// subscriber graph on the PUBLISHER'S thread lets a publisher acquire foreign gates while
+/// still holding its own, and two publishers doing that concurrently deadlock.
+///
+/// <para>Point it at any fan-out point (mesh change feed, a storage adapter's
+/// <c>Changes</c>, a permission fold's continuation) by supplying how to subscribe and how to
+/// publish. The harness recreates the exact shape of the real graph:</para>
+///
+/// <list type="number">
+///   <item>each publisher holds its OWN gate — the per-call
+///   <c>Observable.CombineLatest</c> lock of <c>PermissionEvaluator</c>'s effective-permission
+///   fold, which is held for the whole handler body because the fold emits synchronously
+///   during <c>Subscribe</c>;</item>
+///   <item>a <see cref="Barrier"/> guarantees BOTH are inside their own gate at the same
+///   moment — without it the inversion cannot form and the test would pass vacuously;</item>
+///   <item>the subscriber chain walks a SHARED gate (<c>PersistenceService.Changes</c>'s
+///   <c>Merge</c>, the process-wide <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c>) and from
+///   there into the OTHER publisher's fold — because both folds subscribe the same cached
+///   query.</item>
+/// </list>
+///
+/// <para>With a synchronous fan-out that is a guaranteed lock-order inversion and the probe
+/// hangs. With enqueue-and-dispatch both publishes return immediately and the dispatch chain
+/// takes the gates serially, so no cycle can form.</para>
+/// </summary>
+internal static class RxFanOutInversionHarness
+{
+    /// <summary>Bound on the whole probe. A genuine cycle is the only way to exceed it.</summary>
+    private static readonly TimeSpan DeadlockBound = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Asserts that two publishers, each holding its own gate, cannot deadlock through
+    /// <paramref name="publish"/>.
+    /// </summary>
+    /// <param name="subscribe">
+    /// Attaches a handler to the fan-out point under test. The handler receives the tag the
+    /// publisher passed, so it can walk into the OTHER publisher's gate.
+    /// </param>
+    /// <param name="publish">Publishes one event carrying the given tag.</param>
+    /// <param name="because">What the assertion proves, for the failure message.</param>
+    public static async Task AssertCannotDeadlock(
+        Func<Action<string>, IDisposable> subscribe,
+        Action<string> publish,
+        string because)
+    {
+        const string tag1 = "p1";
+        const string tag2 = "p2";
+
+        var ownGateOfPublisher1 = new object();   // publisher 1's CombineLatest fold gate
+        var ownGateOfPublisher2 = new object();   // publisher 2's CombineLatest fold gate
+        var sharedQueryGate = new object();       // the shared synced-query / Merge gate
+
+        using var subscription = subscribe(tag =>
+        {
+            var otherFoldGate = tag == tag1 ? ownGateOfPublisher2 : ownGateOfPublisher1;
+            lock (sharedQueryGate)
+                lock (otherFoldGate) { }
+        });
+
+        using var bothInsideTheirGate = new Barrier(2);
+
+        Task PublishHolding(object ownGate, string tag) => Task.Run(() =>
+        {
+            lock (ownGate)
+            {
+                bothInsideTheirGate.SignalAndWait(DeadlockBound);
+                publish(tag);
+            }
+        });
+
+        var bothPublished = Task.WhenAll(
+            PublishHolding(ownGateOfPublisher1, tag1),
+            PublishHolding(ownGateOfPublisher2, tag2));
+
+        // Task.Delay is the DEADLOCK BOUND here, not a wait-for-propagation sleep: the only
+        // way both publishers fail to finish is a genuine cycle.
+        var finished = await Task.WhenAny(bothPublished, Task.Delay(DeadlockBound));
+
+        finished.Should().BeSameAs(bothPublished, because);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/StorageAdapterDispatchTests.cs
+++ b/test/MeshWeaver.Hosting.Test/StorageAdapterDispatchTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression tests for the SECOND fan-out point of issue #899:
+/// <see cref="IStorageAdapter.Changes"/>. PR #910 moved the mesh change feed off the
+/// publisher's thread and flagged this one as the nearest remaining inversion candidate —
+/// <c>InMemoryStorageAdapter.Write</c>/<c>Delete</c> pushed into a plain
+/// <see cref="System.Reactive.Subjects.Subject{T}"/> INLINE, and
+/// <c>StorageAdapterMeshQueryProvider</c> feeds the very same synced-query merges the change
+/// feed does.
+///
+/// <para>The in-memory adapter is the one backend where this is reachable: every other one
+/// (Postgres, Sqlite, Snowflake, Cosmos) publishes from inside <c>IIoPool</c>, i.e. already
+/// off the calling hub's thread and outside whatever gate the caller holds. The in-memory
+/// path is fully synchronous — <c>Observable.Defer</c> straight through — so a writer's
+/// thread walked the ENTIRE subscriber graph: <c>PersistenceService.Changes</c>'s shared
+/// <c>Merge</c> gate → each synced query's <c>Concat</c> gate → the process-wide
+/// <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c> → other hubs' <c>PermissionEvaluator</c>
+/// folds → <c>MeshDataSource</c>'s <c>GetMeshNodeStream().Update(...)</c> into a FOREIGN
+/// hub.</para>
+/// </summary>
+public class StorageAdapterDispatchTests
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode Node(string id) => new(id) { NodeType = "X" };
+
+    /// <summary>
+    /// The invariant everything else follows from: a write hands the notification to the
+    /// feed's dispatch chain and returns — the subscriber runs on a DIFFERENT thread.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Write_runs_change_subscribers_off_the_writer_thread()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        var seen = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = adapter.Changes.Subscribe(
+            _ => seen.TrySetResult(Environment.CurrentManagedThreadId));
+
+        var writerThread = Environment.CurrentManagedThreadId;
+        adapter.Write(Node("a"), Options).Subscribe();
+
+        var handlerThread = await seen.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        handlerThread.Should().NotBe(writerThread,
+            "a change subscriber that runs on the writer's thread runs inside whatever locks "
+            + "the writing hub already holds — that is the #899 lock-order inversion");
+    }
+
+    /// <summary>
+    /// Ordering is part of the contract: one FIFO dispatch chain. A feed that fanned out with
+    /// unordered thread-pool work items could reorder Updated/Deleted for the same path and
+    /// resurrect a deleted node in every downstream synced query.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Change_events_are_delivered_in_write_order()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        const int count = 200;
+        var received = new ConcurrentQueue<string>();
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = adapter.Changes.Subscribe(n =>
+        {
+            received.Enqueue(n.Path);
+            if (received.Count == count)
+                done.TrySetResult();
+        });
+
+        var expected = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            expected[i] = $"space/node{i}";
+            adapter.Write(Node(expected[i]), Options).Subscribe();
+        }
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        received.ToArray().Should().Equal(expected);
+    }
+
+    /// <summary>
+    /// The #899 inversion on the storage feed, deterministically — same probe as the mesh
+    /// change feed's, pointed at <c>Write</c>. Fails (hangs to the 10 s deadlock bound) on the
+    /// pre-fix adapter, which published inline via <c>Subject.OnNext</c>.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Concurrent_writers_holding_their_own_gates_cannot_deadlock()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        await RxFanOutInversionHarness.AssertCannotDeadlock(
+            subscribe: handler => adapter.Changes.Subscribe(n => handler(n.Path)),
+            publish: tag => adapter.Write(Node(tag), Options).Subscribe(),
+            because:
+                "a storage write must not run the change-feed subscriber graph on the writer's "
+                + "thread — doing so takes the shared synced-query gates while the writer still "
+                + "holds its own permission-fold gate, which is the #899 deadlock");
+    }
+
+    /// <summary>Same probe over <c>Delete</c> — the operation the wedge was actually observed on.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task Concurrent_deleters_holding_their_own_gates_cannot_deadlock()
+    {
+        var adapter = new InMemoryStorageAdapter();
+        adapter.Write(Node("p1"), Options).Subscribe();
+        adapter.Write(Node("p2"), Options).Subscribe();
+
+        await RxFanOutInversionHarness.AssertCannotDeadlock(
+            subscribe: handler => adapter.Changes.Subscribe(n => handler(n.Path)),
+            publish: tag => adapter.Delete(tag).Subscribe(),
+            because:
+                "a recursive delete fans out per-leaf deletes across per-node hubs; each leaf's "
+                + "storage delete must not walk the subscriber graph while its hub holds the "
+                + "permission fold's gate (#899)");
+    }
+
+    /// <summary>
+    /// A throwing subscriber must not starve the others. The pre-fix adapter published through
+    /// a plain <c>Subject</c> — where the first throwing observer aborts delivery to every
+    /// observer subscribed after it — and wrapped the publish in
+    /// <c>catch { /* never throw */ }</c>, so the starvation was completely silent (#889: a
+    /// permanently stale <c>$security-access</c> fold).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task A_throwing_change_subscriber_does_not_starve_the_others()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        using var faulty = adapter.Changes.Subscribe(_ => throw new InvalidOperationException("boom"));
+        var reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var healthy = adapter.Changes.Subscribe(_ => reached.TrySetResult());
+
+        adapter.Write(Node("a"), Options).Subscribe();
+
+        await reached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+}

--- a/test/MeshWeaver.Query.Test/SyncedQueryInitialGateTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryInitialGateTest.cs
@@ -33,9 +33,12 @@ namespace MeshWeaver.Query.Test;
 /// <para><b>Determinism:</b> the subscribe→Initial race is made deterministic by a
 /// delaying DECORATOR over the REAL <see cref="IMeshQueryCore"/> (no mock): it defers
 /// the inner <c>Query</c> subscription for exactly the gated query string until the
-/// test fires <see cref="initialGate"/>. Both side-channels deliver synchronously
-/// (Rx <c>Subject</c> / in-process change feed), so "fire the side-channel while
-/// Initial is held" is exact, not timing-dependent.</para>
+/// test fires <see cref="initialGate"/>. <see cref="SyncedQueryMeshNodes.NotifyDeleted"/>
+/// delivers synchronously (a plain Rx <c>Subject</c>); the change feed dispatches on its
+/// own serial loop (issue #899 — a synchronous fan-out deadlocked concurrent deletes), so
+/// the feed test WAITS for the event to have been delivered before releasing the gate.
+/// Either way "fire the side-channel while Initial is held" is exact, not
+/// timing-dependent.</para>
 /// </summary>
 public class SyncedQueryInitialGateTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
@@ -205,9 +208,22 @@ public class SyncedQueryInitialGateTest(ITestOutputHelper output)
         using (recorder)
         {
             // While Initial is HELD, publish a Deleted change-feed event for an
-            // unrelated path — the in-process feed delivers synchronously.
+            // unrelated path. The feed dispatches on its own serial loop (#899), so wait
+            // for the event to be DELIVERED before releasing the gate — our probe
+            // subscribes AFTER the synced query, and one FIFO loop notifies observers in
+            // subscription order, so seeing it here proves the synced query already
+            // folded it in the subscribe→Initial window.
             var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
-            changeFeed.Publish(MeshChangeEvent.Deleted("Unrelated/FeedPath"));
+            var delivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (changeFeed.Subscribe(e =>
+                   {
+                       if (e.Path == "Unrelated/FeedPath")
+                           delivered.TrySetResult();
+                   }))
+            {
+                changeFeed.Publish(MeshChangeEvent.Deleted("Unrelated/FeedPath"));
+                await delivered.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            }
 
             initialGate.OnNext(Unit.Default);
 


### PR DESCRIPTION
## Summary

**Supersedes #910** (cherry-picked here) and closes #899 **at the class level**.

## An empirical correction to the model

I measured which Rx operators actually hold a gate while delivering `OnNext` (Rx 6.1.0):

| construct | holds a gate during downstream delivery? |
|---|---|
| `Merge` | **yes** |
| `CombineLatest` | **yes** |
| `Concat` / `Replay(1)` | yes |
| bare `Subject<T>` | **no** — lock-free snapshot fan-out |
| `IsolatedChangeFeed` | no |

So a `Subject` **is not a gate** — it is the *conduit* that lets a gate-holding publisher walk into someone else's gate. Every verdict below therefore turns on **which thread publishes**, not on the subject type. That reframing is what made the inventory decidable rather than guesswork.

It also explains why **PG never reproduced the wedge while in-memory did**: any step that hops through `IIoPool` (`SubscribeOn(TaskPoolScheduler)` on every path, including `IoPool.Unbounded`) has already left the fold gate. The in-memory path is the only fully synchronous one in the repo.

## Inventory + fixes

Exactly **one** true inversion source beyond the one #910 fixed: `InMemoryStorageAdapter.Write`/`Delete`/`DeleteIfExists`, publishing on the caller's hub thread through a fully synchronous `Observable.Defer` pipeline. **Fixed.** Sqlite, Snowflake, the Snowflake router and Cosmos publish off-thread via `IIoPool` — safe for inversion, but they carry the #889-shaped isolation gap (plain `Subject` + `catch {}`); left deliberately, because their suites cannot run here and an untested delivery-semantics change to a storage backend is worse than a reported one.

New shared primitive **`DispatchedChangeFeed`** generalises #910's one-off loop and PG's `IsolatedChangeFeed` into one type (enqueue-and-dispatch + per-subscriber isolation). The dispatch shape is deliberately **not** `ObserveOn`: measured, it prefers `ISchedulerLongRunning` and parks **one dedicated thread per live subscription** (64 feeds → +65 threads), and PG creates one adapter per partition schema — a thread-per-schema leak. `Select(v => Observable.Return(v, scheduler)).Concat()` is FIFO, off-thread, **+2 threads for 64 feeds**, and is AGENTS.md's own sanctioned serialisation idiom. `InProcessMeshChangeFeed` is rebuilt on it and **gains per-subscriber isolation it did not have** — #910 caught around the whole fan-out, so the first throwing subscriber still aborted every later one.

## Ingredient 2 — the generator, not just the conduit

New `HubPermissionExtensions.TakeDecisionOutsideGate()`: the permission decision is still **taken** inside the fold, but re-emitted via `Observable.Return(value, Scheduler.Default)` so only the continuation leaves the gate. Applied to `CheckDeletePermissionForNode`.

All **47** `GetEffectivePermissions` call sites classified by a structural rule and verified individually: layout areas / menu providers projecting into a `UiControl` are **safe** (they finish inside the gate and touch nothing shared); message-pipeline, validator and node-operation sites are **dangerous**. Named dangerous and deliberately deferred: **`AccessControlPipeline.cs:123`** — every `[RequiresPermission]` handler still runs its body inside the fold's gate, the broadest exposure in the repo, needing its own full-suite cycle; `RlsNodeValidator` is flagged as the cheapest high-leverage follow-up (one call covers every validated write).

## Tests

`RxFanOutInversionHarness` — the reusable two-publisher / `Barrier` / shared-gate probe, parameterised by `subscribe` + `publish` so it points at any fan-out point; #910's inline version folds into it. **12 tests, 9 fail pre-fix** (three deadlock at 10 s). `Take1_alone_runs_the_continuation_INSIDE_the_folds_gate` is a deliberate **precondition** test asserting the pre-fix shape really does hand the handler body the lock, so the others cannot pass vacuously.

## Verification

Whole solution  → **0 warnings, 0 errors**. Hosting **121/121** · NodeOperations **85/85** · Query **361/361** · Monolith **477 passed / 4 skipped** · Data **303/303**. Independently re-verified **12/12** after merging current main.

Unlike #910, **no existing test needed adapting** — which matters, because in-memory is the default monolith storage and making its feed asynchronous was the highest-blast-radius part of this change.

## Found, not fixed (separate class — worth their own issues)

1. `CachingStorageAdapter`, `PathRemappingStorageAdapter` and `RoutingProxyAdapter` **do not forward `inner.Changes`** — they fall through to the `Observable.Empty` default, so writes behind them are invisible to every synced query.
2. `CosmosStorageAdapter._changes` has **no `OnNext` anywhere** — Cosmos writes emit no change notification at all.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)