### PR TITLE
Release the permission-fold gate — kill the #899 deadlock at its generator

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1108,13 +1108,31 @@ internal static class ThreadExecution
                 // that doesn't carry the latest text (because the caller built
                 // its `text` from a stale snapshot of the streamed-so-far buffer
                 // BEFORE more tokens arrived) would shrink the field — visible
-                // to UI subscribers as a flicker / regression. While Status is
-                // terminal-locked above, Text is otherwise free to shrink. Cap:
-                // while Status is Streaming, only allow grow OR same length.
-                // Once terminal, the final text from the streaming loop's
-                // completion is the source of truth — let it through.
-                var nextText = nextStatus == ThreadMessageStatus.Streaming
-                               && text.Length < current.Text.Length
+                // to UI subscribers as a flicker / regression. Cap: while Status
+                // is Streaming, only allow grow OR same length. The push that
+                // CARRIES the terminal status is the source of truth — let it
+                // through.
+                //
+                // 🚨 …and Text is terminal-locked too, for exactly the reason
+                // Status/ToolCalls/UpdatedNodes are (see the merges above and
+                // below): a STREAMING push can still land AFTER the terminal one.
+                // The trailing Sample(100ms) emission flushes on
+                // snapshots.OnCompleted, and the framework's own
+                // "Generating response..." placeholder is pushed from a SelectMany
+                // continuation on the history/context read, which a slow or
+                // Catch-recovered read can delay past the end of a round that
+                // faulted early (an unresolvable agent selection ends the round in
+                // milliseconds). `terminalLocked` is precisely the case the Status
+                // guard already caught — a Streaming request arriving at an
+                // already-terminal cell — so this costs nothing on the normal
+                // path. Without it that late push writes its own stale `text`
+                // verbatim and the user is left staring at "Generating
+                // response..." on a cell that is Completed/Error and whose Summary
+                // already carries the real answer.
+                var terminalLocked = nextStatus != requestedStatus;
+                var nextText = terminalLocked
+                               || (nextStatus == ThreadMessageStatus.Streaming
+                                   && text.Length < current.Text.Length)
                     ? current.Text
                     : text;
                 // 🚨 UpdatedNodes accumulate — never replace. Like ToolCalls (merged

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -102,6 +102,19 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
         // (lives on the live AccessAssignment synced query). Without Take(1)
         // the .Concat() in RunCreationValidatorsObs would wait forever on the
         // first validator and the create handler would never post a response.
+        //
+        // 🚨 …and it is TakeDecisionOutsideGate, not a bare Take(1) — issue #899. This is the
+        // single highest-leverage placement in the repo: every validated create / update /
+        // delete funnels through here, and the CALLER chains the REAL WRITE onto this
+        // verdict (RunCreationValidatorsObs → persist + WriteAndPublishCreated;
+        // RunDeletionValidatorsObs → the delete + its publish). Both remaining branches
+        // reach the permission fold — CheckCustomRule's INodeTypeAccessRule implementations
+        // (SatelliteAccessRule, Space/User/PartitionNodeType) call hub.CheckPermission just
+        // as CheckPermission does — and on a warm cache that fold emits synchronously during
+        // Subscribe while holding its CombineLatest gate. Without the hop the write and its
+        // (synchronous, by contract) change-feed fan-out run inside that lock, which is one
+        // half of the two-hub lock-order inversion. Placing it here rather than inside
+        // CheckPermission covers the custom-rule path too.
         return CheckHubRule(context, userId)
             .SelectMany(hubResult => hubResult != null
                 ? Observable.Return<NodeValidationResult?>(hubResult)
@@ -109,7 +122,7 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
             .SelectMany(customResult => customResult != null
                 ? Observable.Return(customResult)
                 : CheckPermission(context, userId, requiredPermission))
-            .Take(1);
+            .TakeDecisionOutsideGate();
     }
 
     private IObservable<NodeValidationResult?> CheckHubRule(NodeValidationContext context, string? userId)

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -121,11 +121,6 @@ public static class AccessControlPipeline
                 var effectiveUserId = userId ?? WellKnownUsers.Anonymous;
                 pendingChecks.ToObservable()
                     .Select(check => hub.CheckPermission(check.Path, effectiveUserId, check.Permission)
-                        // HasPermission rides the live AccessAssignment synced
-                        // stream — a hot, never-completing observable. Take(1)
-                        // closes each inner so Concat below actually advances
-                        // through the check list and OnCompleted fires.
-                        //
                         // No Timeout here: the access cache must always be a
                         // reactive Subscribe over the hierarchical union
                         // (self + ancestors) of AccessAssignment streams,
@@ -135,7 +130,6 @@ public static class AccessControlPipeline
                         // fix the cache, don't ceiling-block here. If the
                         // cache genuinely never emits, that's a framework
                         // bug to surface, not paper over with a deny.
-                        .Take(1)
                         .Catch<bool, Exception>(ex =>
                         {
                             logger?.LogWarning(ex,
@@ -144,6 +138,24 @@ public static class AccessControlPipeline
                                 check.Path, check.Permission, hub.Address, delivery.Message.GetType().Name);
                             return Observable.Return(false);
                         })
+                        // 🚨 TakeDecisionOutsideGate, NOT a bare Take(1) — issue #899. This is
+                        // the BROADEST generator of the Rx lock-order inversion in the repo:
+                        // the onCompleted branch below invokes `next`, i.e. the ENTIRE
+                        // downstream handler for EVERY [RequiresPermission] message. On a warm
+                        // permission cache the fold emits synchronously during Subscribe while
+                        // holding its CombineLatest gate, so with a bare Take(1) that whole
+                        // handler body — storage writes, cache invalidation, the (synchronous,
+                        // by contract) change-feed fan-out — ran inside the lock, and two hubs
+                        // doing it at once deadlock on {own fold gate, shared synced-query
+                        // gate}. The Take(1) is still needed (CheckPermission rides the live
+                        // AccessAssignment synced stream and never completes, so Concat below
+                        // would never advance); TakeDecisionOutsideGate keeps it and adds the
+                        // hop. Placed AFTER the Catch so the fail-closed path leaves the gate
+                        // too. Identity is unaffected: the inner UserServiceDeliveryPipeline
+                        // re-stamps AccessService.Context from delivery.AccessContext before
+                        // the handler body runs, and the pool hop flows ExecutionContext
+                        // anyway. See HubPermissionExtensions.TakeDecisionOutsideGate.
+                        .TakeDecisionOutsideGate()
                         .Select(ok => (Check: check, Ok: ok)))
                     .Concat()
                     .Subscribe(

--- a/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -112,6 +113,75 @@ public static class HubPermissionExtensions
         return hub.GetEffectivePermissions(PermissionEvaluator.AdminScope, userId)
             .Select(p => p.HasFlag(Permission.All));
     }
+
+    /// <summary>
+    /// Takes ONE authorization answer and <b>leaves the evaluator's Rx gate</b> before the
+    /// caller's continuation runs. Use this — never a bare <c>.Take(1)</c> — whenever what
+    /// follows the decision does REAL WORK (storage I/O, a hub write, a change-feed publish,
+    /// invoking a downstream handler) rather than just projecting to a value or a UI control.
+    ///
+    /// <para><b>Why (issue #899).</b>
+    /// <see cref="PermissionEvaluator.GetEffectivePermissions(IMessageHub,string,string)"/> is
+    /// a <c>seed.Concat(enriched)</c> chain over an <c>Observable.CombineLatest</c> fold whose
+    /// sources are cached <c>Replay(1)</c> queries. On a warm cache it therefore emits
+    /// <b>synchronously during <c>Subscribe</c>, while holding that gate</b> (one gate per
+    /// ancestor scope, nested). A bare <c>.Take(1).SelectMany(&lt;whole handler&gt;)</c> runs
+    /// the ENTIRE handler body inside the lock. If the body then publishes a change, the
+    /// (synchronous, by contract) fan-out walks shared gates — <c>PersistenceService.Changes</c>'s
+    /// <c>Merge</c>, the process-wide <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c> — and on
+    /// into ANOTHER hub's fold. Two hubs doing that concurrently take {own fold gate, shared
+    /// gate} in opposite orders and deadlock, with neither a success nor a failure response
+    /// ever posted (the recursive-delete wedge in #899).</para>
+    ///
+    /// <para><b>This is the half that is safe to remove.</b> Synchronous change-feed delivery
+    /// is a load-bearing contract — <c>PathResolutionService</c>'s resolution cache
+    /// ("runs synchronously on the publisher's thread"), <c>MeshNodeStreamCache</c>'s
+    /// failure-state reset ("the VERY NEXT read heals") and <c>Workspace</c>'s remote-stream
+    /// eviction all depend on the invalidation landing before the writing call returns. Making
+    /// the fan-out asynchronous breaks read-your-own-writes; releasing the gate does not. A
+    /// cycle needs BOTH ingredients, so killing this one is sufficient.</para>
+    ///
+    /// <para>The decision is still TAKEN inside the fold — the evaluation and the answer are
+    /// unchanged; only the continuation is moved off the gate, onto
+    /// <see cref="Scheduler.Default"/>. This is what any pipeline that already hops through
+    /// <c>IIoPool</c> gets for free, which is exactly why the Postgres-backed paths never
+    /// reproduced the wedge and the fully-synchronous in-memory path did.</para>
+    ///
+    /// <para>🚨 Not needed for pure projections (a fold feeding a layout area,
+    /// <c>.Select(p =&gt; control)</c>): those finish inside the gate and touch nothing shared.
+    /// A hop there would only cost a scheduler round-trip. And like any <c>Take(1)</c>, this
+    /// CLOSES the stream — never put it on a hot observable that a live data-bound view reads.</para>
+    /// </summary>
+    /// <typeparam name="T">The decision type — <see cref="Permission"/>, <c>bool</c>, or a
+    /// validation result projected from one.</typeparam>
+    /// <param name="decision">The authorization decision stream (hot and never-completing —
+    /// it rides the live <c>AccessAssignment</c> synced query, hence the <c>Take(1)</c>).</param>
+    public static IObservable<T> TakeDecisionOutsideGate<T>(this IObservable<T> decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        return decision.Take(1).SelectMany(HopOffGate);
+    }
+
+    /// <summary>
+    /// Re-emits <paramref name="value"/> on <see cref="Scheduler.Default"/> so the subscriber's
+    /// continuation runs on a pool thread instead of on the emitting (gate-holding) thread.
+    ///
+    /// <para>🚨 <c>Observable.Return(value, scheduler)</c> inside <c>SelectMany</c>, NOT
+    /// <c>ObserveOn(scheduler)</c>. Both leave the gate, but Rx's <c>ObserveOn</c> runs a
+    /// long-running scheduled loop per subscription: measured on Rx 6.1.0, 64 live
+    /// <c>ObserveOn(Scheduler.Default)</c> subscriptions took the process from 13 to <b>77</b>
+    /// threads (released on dispose), while the <c>Observable.Return</c> form cost <b>3</b>. A
+    /// permission check is subscribed per call, so <c>ObserveOn</c> would be a thread per
+    /// in-flight check.</para>
+    ///
+    /// <para><b>Identity survives the hop.</b> <see cref="Scheduler.Default"/> queues through
+    /// the thread pool with <c>ExecutionContext</c> capture, so the <c>AsyncLocal</c>
+    /// <c>AccessService.Context</c> that is live on the emitting thread is still live in the
+    /// continuation (verified against Rx 6.1.0). No <c>CarryAccessContext</c> wrap is needed
+    /// on top of this — see Doc/Architecture/AccessContextPropagation.md.</para>
+    /// </summary>
+    private static IObservable<T> HopOffGate<T>(T value)
+        => Observable.Return(value, Scheduler.Default);
 
     /// <summary>
     /// Resolve a role definition (built-in or custom) by id.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1199,8 +1199,14 @@ public static class MeshExtensions
                 // System short-circuits to Permission.All; an unauthorized creator gets no heal,
                 // so the requested child is denied by the validators exactly as before.
                 var effectiveUser = string.IsNullOrEmpty(creator) ? WellKnownUsers.Anonymous : creator;
+                // 🚨 TakeDecisionOutsideGate, not a bare Take(1) — #899. The continuation
+                // below CREATES the partition root and mints the creator grant, i.e. it
+                // writes and publishes to the change feed. Running that inside the
+                // permission fold's CombineLatest gate makes every shared gate the
+                // (synchronous, by contract) fan-out touches half of a lock-order inversion.
+                // See HubPermissionExtensions.TakeDecisionOutsideGate.
                 return hub.CheckPermission(partition, effectiveUser, Permission.Create)
-                    .Take(1)
+                    .TakeDecisionOutsideGate()
                     .Timeout(TimeSpan.FromSeconds(15))
                     .Catch<bool, Exception>(ex =>
                     {
@@ -1560,7 +1566,7 @@ public static class MeshExtensions
                                 return Observable.Using(
                                     () => recentlyDeleted?.BeginSubtreeDeletion(path)
                                           ?? System.Reactive.Disposables.Disposable.Empty,
-                                    _ => CollectPathsForDelete(hub, path, capturedRequest.Recursive, opts.Timeout, logger)
+                                    subtreeScope => CollectPathsForDelete(hub, path, capturedRequest.Recursive, opts.Timeout, logger)
                                     .SelectMany(collected =>
                                     {
                                         if (!capturedRequest.Recursive && collected.HasUnlistedChildren)
@@ -1677,6 +1683,40 @@ public static class MeshExtensions
                                                 // DeleteNodeRequest > 30000ms" → the delete wedges).
                                                 // PostFailed already uses ResponseFor, so failure
                                                 // responses were fine — only success wedged.
+                                                // 🚨 RELEASE THE SUBTREE-DELETION GUARD BEFORE THE SUCCESS
+                                                // RESPONSE — the response IS the "torn down" signal, so a
+                                                // caller that recreates the same path the moment it lands
+                                                // (delete → recreate is ordinary usage; see
+                                                // WorkspaceCacheEvictionTest.NewSubscriber_AfterRecreate_
+                                                // GetsFreshSnapshot) must not be refused by the guard.
+                                                //
+                                                // Observable.Using alone CANNOT give that ordering: Rx
+                                                // disposes the resource only when the subscription is torn
+                                                // down, which happens AFTER OnCompleted has propagated
+                                                // downstream — so the scope outlived the response by ~5 ms
+                                                // (measured), and every write in that window was refused
+                                                // with "the subtree '…' is currently being deleted".
+                                                //
+                                                // That window was always there; it was MASKED because the
+                                                // whole delete used to run inline on the per-node hub's
+                                                // TURN, so the caller's follow-up create was queued behind
+                                                // it and could never interleave. The moment the permission
+                                                // decision hops off the fold's gate (#899,
+                                                // TakeDecisionOutsideGate) the pipeline leaves the turn and
+                                                // the race is real and near-certain — the accidental
+                                                // serialisation is gone. Fixing the ORDERING is the root
+                                                // cause; keeping the pipeline pinned to the turn would only
+                                                // restore the accident.
+                                                //
+                                                // Everything the guard protects (plan, commit, drain,
+                                                // post-deletion handlers) has completed above. The
+                                                // enclosing Observable.Using stays as the safety net for
+                                                // the error / timeout / unsubscribe paths, and
+                                                // SubtreeDeletionScope.Dispose is Interlocked-idempotent,
+                                                // so this early release plus the Using's release is one
+                                                // decrement, never two.
+                                                subtreeScope.Dispose();
+
                                                 meshHub.Post(
                                                     DeleteNodeResponse.Ok() with { Log = okLog },
                                                     o => o.ResponseFor(request));
@@ -2130,11 +2170,24 @@ public static class MeshExtensions
     {
         var pathToCheck = node.MainNode ?? node.Path;
 
-        // Take(1) closes the inner observable — GetEffectivePermissions rides
-        // the live AccessAssignment synced query and is hot, so without Take(1)
-        // the .Select chain never completes and the handler hangs.
+        // 🚨 TakeDecisionOutsideGate, NOT a bare Take(1) — issue #899.
+        //
+        // Take(1) is still required (GetEffectivePermissions rides the live AccessAssignment
+        // synced query and is hot, so without it the chain never completes and the handler
+        // hangs), but it is NOT sufficient. HandleDeleteNodeRequest chains
+        // `.SelectMany(denied => <the entire delete pipeline>)` onto this, and on a warm
+        // permission cache the fold emits synchronously during Subscribe while holding its
+        // CombineLatest gate — so the validator run, the storage delete, the cache
+        // invalidation and the change-feed publish ALL ran inside that lock. Two per-node
+        // hubs deleting concurrently (a recursive space delete fans one DeleteNodeRequest per
+        // leaf) then acquired {own fold gate, shared synced-query gate} in opposite orders and
+        // deadlocked: both action blocks parked forever and the delete posted neither a
+        // DeleteNodeResponse nor a failure.
+        //
+        // The decision is unchanged — still taken inside the fold; only the pipeline that
+        // follows is moved off the gate.
         return hub.GetEffectivePermissions(pathToCheck, userId)
-            .Take(1)
+            .TakeDecisionOutsideGate()
             .Select(perms =>
             {
                 var denied = !perms.HasFlag(Permission.Delete);
@@ -2728,8 +2781,12 @@ public static class MeshExtensions
         {
             (string.IsNullOrEmpty(requestedBy)
                     ? Observable.Return(false)
+                    // 🚨 TakeDecisionOutsideGate, not a bare Take(1) — #899. Both branches of
+                    // the Subscribe below do real work (PostOk, or ApplyUpdateViaStream — a
+                    // cross-hub stream write that publishes). See
+                    // HubPermissionExtensions.TakeDecisionOutsideGate.
                     : hub.GetEffectivePermissions(node.Path, requestedBy!)
-                        .Take(1)
+                        .TakeDecisionOutsideGate()
                         .Timeout(NodeOpForwardTimeout)
                         .Select(p => p.HasFlag(Permission.Update) || p.HasFlag(Permission.Sync))
                         .Catch((Exception _) => Observable.Return(false)))

--- a/test/MeshWeaver.Hosting.Test/PermissionFoldGateTests.cs
+++ b/test/MeshWeaver.Hosting.Test/PermissionFoldGateTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression tests for issue #899 — the recursive delete that parked forever, posting neither a
+/// success nor a failure and wedging both per-node hubs.
+///
+/// <para>The deadlock is an Rx <b>lock-order inversion</b> that needs two ingredients:
+/// a fan-out point that delivers on the publisher's thread, AND a publisher holding an Rx gate
+/// while it publishes. <b>The first is a contract, not a defect</b> — three framework caches
+/// (<c>PathResolutionService._resolutionCache</c>, <c>MeshNodeStreamCache</c>'s failure-state
+/// reset, <c>Workspace</c>'s remote-stream eviction) are invalidated ONLY by the change feed and
+/// depend on the invalidation landing before the writing call returns. Making delivery
+/// asynchronous breaks read-your-own-writes (a create routed against a stale resolution starves).
+/// So the cure is the SECOND ingredient:
+/// <see cref="HubPermissionExtensions.TakeDecisionOutsideGate{T}"/>, which takes the permission
+/// decision inside the fold exactly as before and moves only the continuation off the gate.</para>
+///
+/// <para><c>PermissionEvaluator.GetEffectivePermissions</c> is a <c>seed.Concat(enriched)</c>
+/// chain over an <c>Observable.CombineLatest</c> fold whose sources are cached <c>Replay(1)</c>
+/// queries, so on a warm cache it emits <b>synchronously during <c>Subscribe</c>, while holding
+/// the gate</b>. A handler written as <c>GetEffectivePermissions(…).Take(1).SelectMany(&lt;whole
+/// body&gt;)</c> therefore runs its ENTIRE body inside that lock — storage writes, cache
+/// invalidation, change-feed publishes and all. That shape is a latent inversion generator at
+/// every one of its call sites, not just on the delete path where it was caught.</para>
+/// </summary>
+public class PermissionFoldGateTests
+{
+    /// <summary>
+    /// Precondition — proves the tests below are not vacuous: the PRE-FIX shape
+    /// (<c>.Take(1)</c> and nothing else) really does run the continuation inside the fold's
+    /// gate, on the subscribing thread. If this ever stops being true the whole #899 analysis
+    /// needs revisiting.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void Take1_alone_runs_the_continuation_INSIDE_the_folds_gate()
+    {
+        var foldGate = new object();
+        var insideGate = false;
+        var onSubscriberThread = false;
+        var subscriberThread = Environment.CurrentManagedThreadId;
+
+        RxFanOutInversionHarness.FoldEmittingInsideGate(foldGate, Permission.All)
+            .Take(1)
+            .Subscribe(_ =>
+            {
+                insideGate = Monitor.IsEntered(foldGate);
+                onSubscriberThread = Environment.CurrentManagedThreadId == subscriberThread;
+            });
+
+        insideGate.Should().BeTrue(
+            "the fold emits during Subscribe while holding its CombineLatest gate, so a bare "
+            + "Take(1) hands the whole handler body that lock");
+        onSubscriberThread.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The fix: the decision is still TAKEN inside the fold, but the continuation runs outside
+    /// it — on another thread, holding none of the fold's locks.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TakeDecisionOutsideGate_runs_the_continuation_OUTSIDE_the_folds_gate()
+    {
+        var foldGate = new object();
+        var subscriberThread = Environment.CurrentManagedThreadId;
+        var observed = new TaskCompletionSource<(bool InsideGate, int Thread, Permission Value)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        RxFanOutInversionHarness.FoldEmittingInsideGate(foldGate, Permission.All)
+            .TakeDecisionOutsideGate()
+            .Subscribe(p => observed.TrySetResult(
+                (Monitor.IsEntered(foldGate), Environment.CurrentManagedThreadId, p)));
+
+        var result = await observed.Task.WaitAsync(RxFanOutInversionHarness.DeadlockBound);
+
+        result.InsideGate.Should().BeFalse("the continuation must not hold the fold's gate");
+        result.Thread.Should().NotBe(subscriberThread,
+            "leaving the gate requires leaving the emitting thread");
+        result.Value.Should().Be(Permission.All,
+            "the decision itself is unchanged — only where the continuation runs moved");
+    }
+
+    /// <summary>
+    /// The hop must not drop the identity baton. <c>AccessService.Context</c> is an
+    /// <c>AsyncLocal</c>, and a write in the continuation (which is the whole point of the hop)
+    /// posts under it — a lost context fails the delivery closed. <c>Scheduler.Default</c> queues
+    /// through the thread pool WITH <c>ExecutionContext</c> capture, so the AsyncLocal that is
+    /// live on the emitting thread is still live in the continuation. Pinning it here means no
+    /// call site needs a <c>CarryAccessContext</c> wrap on top of
+    /// <see cref="HubPermissionExtensions.TakeDecisionOutsideGate{T}"/>.
+    /// See Doc/Architecture/AccessContextPropagation.md.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TakeDecisionOutsideGate_carries_the_ambient_AsyncLocal_across_the_hop()
+    {
+        var identity = new AsyncLocal<string?> { Value = "user-1" };
+        var foldGate = new object();
+        var observed = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        RxFanOutInversionHarness.FoldEmittingInsideGate(foldGate, Permission.Read)
+            .TakeDecisionOutsideGate()
+            .Subscribe(_ => observed.TrySetResult(identity.Value));
+
+        var seen = await observed.Task.WaitAsync(RxFanOutInversionHarness.DeadlockBound);
+
+        seen.Should().Be("user-1",
+            "the continuation performs writes under the caller's identity — an AsyncLocal that "
+            + "did not survive the hop would fail every one of them closed");
+    }
+
+    /// <summary>
+    /// The generator, deterministically. Two handlers each gated on their OWN permission fold;
+    /// each body then publishes through a SYNCHRONOUS fan-out whose subscriber walks a SHARED
+    /// gate (the process-wide synced-query <c>Replay(1)</c> / <c>PersistenceService.Changes</c>
+    /// <c>Merge</c>) and into the OTHER handler's fold — exactly what a change-feed publish from
+    /// inside a handler body does, because both folds subscribe the same cached queries.
+    ///
+    /// <para>With a bare <c>Take(1)</c> both bodies run INSIDE their own fold gate, acquire
+    /// {own fold gate, shared gate} in opposite orders and deadlock — this test then hangs to its
+    /// bound and fails. With <c>TakeDecisionOutsideGate</c> the bodies hold no fold gate, so no
+    /// cycle can form no matter what they touch, <b>and delivery stays synchronous</b>.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Two_handlers_gated_on_their_own_fold_cannot_deadlock_through_a_synchronous_fanout()
+    {
+        // A bare Subject — the same lock-free, publisher-thread fan-out InProcessMeshChangeFeed
+        // is built on. Nothing here is asynchronous.
+        var fanOut = new Subject<string>();
+
+        var bothCompleted = await RxFanOutInversionHarness.BothGatedHandlersComplete(
+            gatedDecision: ownFoldGate => RxFanOutInversionHarness
+                .FoldEmittingInsideGate(ownFoldGate, Permission.All)
+                .TakeDecisionOutsideGate(),
+            subscribe: handler => fanOut.Subscribe(handler),
+            publish: tag => fanOut.OnNext(tag));
+
+        bothCompleted.Should().BeTrue(
+            "a permission-gated handler must not run its body inside the evaluator's fold gate — "
+            + "doing so makes every shared gate the (synchronous) fan-out touches half of a "
+            + "lock-order inversion (#899)");
+    }
+
+    /// <summary>
+    /// The same probe pointed at the PRODUCTION fan-out point,
+    /// <see cref="InProcessMeshChangeFeed"/> — the one the wedged delete actually published
+    /// through. Nothing about the feed changed; the cycle is impossible because the publisher no
+    /// longer arrives holding a gate.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Two_handlers_cannot_deadlock_through_the_real_mesh_change_feed()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+
+        var bothCompleted = await RxFanOutInversionHarness.BothGatedHandlersComplete(
+            gatedDecision: ownFoldGate => RxFanOutInversionHarness
+                .FoldEmittingInsideGate(ownFoldGate, Permission.All)
+                .TakeDecisionOutsideGate(),
+            subscribe: handler => feed.Subscribe(e => handler(e.Path)),
+            publish: tag => feed.Publish(MeshChangeEvent.Deleted(tag)));
+
+        bothCompleted.Should().BeTrue(
+            "two per-node hubs deleting concurrently must both complete — this is the exact "
+            + "shape of the recursive space delete that parked forever in #899");
+    }
+
+    /// <summary>
+    /// 🚨 The half that must NOT change. Change-feed delivery is SYNCHRONOUS, on the publisher's
+    /// thread, and complete before <see cref="IMeshChangeFeed.Publish"/> returns.
+    ///
+    /// <para>Three framework caches are invalidated ONLY by this feed and each states the
+    /// dependency in its own doc comment: <c>PathResolutionService._resolutionCache</c> ("runs
+    /// synchronously on the publisher's thread"; positive-only, and a Created event can deepen
+    /// the resolution of a path and of every descendant), <c>MeshNodeStreamCache</c>'s
+    /// failure-state reset ("the VERY NEXT read heals") and <c>Workspace</c>'s remote-stream
+    /// eviction. Dispatching the fan-out onto a loop moves the eviction an unbounded moment
+    /// later, so a create that first resolved its own path (caching the shallower ancestor
+    /// address to route the write) is followed by a query routed against the stale address —
+    /// read-your-own-writes is gone and the query starves. That was measured: SearchResultStorm /
+    /// PandasExplorer / HarnessInstallGate went from green to failing about half the time, with
+    /// the failing set shifting every run.</para>
+    ///
+    /// <para>If this test ever needs "adapting", the change under review is re-introducing that
+    /// regression — fix the publisher's gate instead (see the tests above).</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void Mesh_change_feed_delivers_synchronously_on_the_publishers_thread()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+
+        var publisherThread = Environment.CurrentManagedThreadId;
+        var deliveredOnThread = 0;
+        var deliveredBeforePublishReturned = false;
+
+        using var subscription = feed.Subscribe(_ =>
+        {
+            deliveredOnThread = Environment.CurrentManagedThreadId;
+            deliveredBeforePublishReturned = true;
+        });
+
+        feed.Publish(MeshChangeEvent.Deleted("TestData/storm"));
+
+        deliveredBeforePublishReturned.Should().BeTrue(
+            "cache invalidation must land before the writing call returns — read-your-own-writes");
+        deliveredOnThread.Should().Be(publisherThread,
+            "delivery runs inline on the publisher's thread; a dispatch loop would break the "
+            + "three caches that depend on it");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/RxFanOutInversionHarness.cs
+++ b/test/MeshWeaver.Hosting.Test/RxFanOutInversionHarness.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The reusable probe for the issue-#899 bug CLASS — an Rx <b>lock-order inversion</b> between
+/// two permission-gated handlers.
+///
+/// <para>The cycle needs TWO ingredients at once:</para>
+/// <list type="number">
+///   <item><b>A fan-out point that delivers synchronously on the publisher's thread.</b> That is
+///   a deliberate, load-bearing contract here — <c>PathResolutionService</c>'s resolution cache,
+///   <c>MeshNodeStreamCache</c>'s failure-state reset and <c>Workspace</c>'s remote-stream
+///   eviction are all invalidated ONLY by the change feed and each documents that the
+///   invalidation lands before the writing call returns (read-your-own-writes). This half is
+///   NOT the bug and must not be "fixed".</item>
+///   <item><b>A publisher that holds an Rx gate while it publishes.</b>
+///   <c>PermissionEvaluator.GetEffectivePermissions</c> emits synchronously during
+///   <c>Subscribe</c> from inside its <c>CombineLatest</c>/<c>Concat</c> gate on a warm cache, so
+///   a handler written as <c>…Take(1).SelectMany(&lt;whole body&gt;)</c> runs its ENTIRE body —
+///   storage write, cache invalidation, change-feed publish — while holding that lock. THIS half
+///   is the bug, and <c>HubPermissionExtensions.TakeDecisionOutsideGate</c> removes it.</item>
+/// </list>
+///
+/// <para>The harness reconstructs the real graph exactly: each handler is reached through a fold
+/// that emits while holding its OWN gate; a <see cref="Barrier"/> guarantees both bodies are
+/// running at the same moment (without it the inversion cannot form and the probe would pass
+/// vacuously); and the subscriber chain walks a SHARED gate (<c>PersistenceService.Changes</c>'s
+/// <c>Merge</c>, the process-wide <c>Replay(1)</c> in <c>IMeshNodeStreamCache</c>) and from there
+/// into the OTHER handler's fold — because both folds subscribe the same cached queries.</para>
+///
+/// <para>Point it at any fan-out point by supplying how to subscribe and how to publish; supply
+/// the composition under test as <c>gatedDecision</c> (a bare <c>Take(1)</c> reproduces the wedge,
+/// <c>TakeDecisionOutsideGate()</c> makes it impossible).</para>
+/// </summary>
+internal static class RxFanOutInversionHarness
+{
+    /// <summary>Bound on the whole probe. A genuine cycle is the only way to exceed it.</summary>
+    internal static readonly TimeSpan DeadlockBound = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// A fold modelled on <c>PermissionEvaluator.GetEffectivePermissions</c>'s emission shape:
+    /// the value is already buffered upstream (warm <c>Replay(1)</c> sources), so <c>OnNext</c>
+    /// fires on the SUBSCRIBING thread, inside the fold's gate, before <c>Subscribe</c> returns.
+    /// That single property is the whole reason the inversion exists; modelling it explicitly
+    /// makes the gate observable to the test.
+    /// </summary>
+    internal static IObservable<Permission> FoldEmittingInsideGate(object gate, Permission value)
+        => Observable.Create<Permission>(observer =>
+        {
+            lock (gate)
+            {
+                observer.OnNext(value);
+                observer.OnCompleted();
+            }
+            return Disposable.Empty;
+        });
+
+    /// <summary>
+    /// Runs two concurrent permission-gated handler bodies against <paramref name="publish"/> and
+    /// reports whether BOTH finished within <see cref="DeadlockBound"/>.
+    /// </summary>
+    /// <param name="gatedDecision">
+    /// Given a handler's own fold gate, returns the decision stream the handler subscribes —
+    /// i.e. <c>FoldEmittingInsideGate(gate, …)</c> composed with the operator under test.
+    /// </param>
+    /// <param name="subscribe">
+    /// Attaches a handler to the fan-out point under test. The handler receives the tag its
+    /// publisher passed, so it can walk into the OTHER publisher's fold gate.
+    /// </param>
+    /// <param name="publish">Publishes one event carrying the given tag, synchronously.</param>
+    internal static async Task<bool> BothGatedHandlersComplete(
+        Func<object, IObservable<Permission>> gatedDecision,
+        Func<Action<string>, IDisposable> subscribe,
+        Action<string> publish)
+    {
+        const string tag1 = "p1";
+        const string tag2 = "p2";
+
+        var foldGateOfHandler1 = new object();   // handler 1's CombineLatest fold gate
+        var foldGateOfHandler2 = new object();   // handler 2's CombineLatest fold gate
+        var sharedQueryGate = new object();      // the shared synced-query / Merge gate
+
+        using var subscription = subscribe(tag =>
+        {
+            var otherFoldGate = tag == tag1 ? foldGateOfHandler2 : foldGateOfHandler1;
+            lock (sharedQueryGate)
+                lock (otherFoldGate) { }
+        });
+
+        using var bothInsideTheirBody = new Barrier(2);
+
+        Task RunGatedHandler(object ownFoldGate, string tag)
+        {
+            var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ = Task.Run(() => gatedDecision(ownFoldGate).Subscribe(
+                _ =>
+                {
+                    try
+                    {
+                        // Both bodies must be live at the same instant, or no cycle can form.
+                        bothInsideTheirBody.SignalAndWait(DeadlockBound);
+                        publish(tag);
+                        completed.TrySetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        completed.TrySetException(ex);
+                    }
+                },
+                ex => completed.TrySetException(ex)));
+            return completed.Task;
+        }
+
+        var bothFinished = Task.WhenAll(
+            RunGatedHandler(foldGateOfHandler1, tag1),
+            RunGatedHandler(foldGateOfHandler2, tag2));
+
+        // Task.Delay is the DEADLOCK BOUND here, not a wait-for-propagation sleep: the only way
+        // both handlers fail to finish is a genuine cycle.
+        var finished = await Task.WhenAny(bothFinished, Task.Delay(DeadlockBound));
+        return ReferenceEquals(finished, bothFinished) && bothFinished.IsCompletedSuccessfully;
+    }
+}


### PR DESCRIPTION
Fixes #899. **Supersedes #910 and #917**, whose approach (making change-feed fan-out asynchronous) CI proved breaks three documented synchronous cache-invalidation contracts. This removes the **generator** instead and leaves delivery synchronous.

## The change

The cycle needs two ingredients. Ingredient 2: `CheckDeletePermissionForNode` is `GetEffectivePermissions().Take(1).SelectMany(<entire delete pipeline>)`, and the fold's `CombineLatest` emits **synchronously during Subscribe** (cached `ReplaySubject` sources) — so storage delete, cache invalidation and change-feed publish all ran while holding that gate. New `TakeDecisionOutsideGate<T>()` takes the decision inside the fold and re-emits via `Observable.Return(v, Scheduler.Default)`, so only the continuation leaves it.

Both of #917's claims were **re-measured, not inherited**: `ObserveOn` takes 64 subscriptions from 13 → 77 threads while the `Return` form goes 13 → 16; and the hop **preserves the AsyncLocal `AccessContext`** (`Scheduler.Default` queues with `ExecutionContext` capture) — pinned as a test.

**Five dangerous sites fixed:** `CheckDeletePermissionForNode`; **`AccessControlPipeline.cs:123`** (broadest in the repo — invokes the whole downstream handler for *every* `[RequiresPermission]` message; the hop sits after the `Catch` so the fail-closed path leaves the gate too); `RlsNodeValidator.Validate`'s final `Take(1)` (every validated write, placed at the end so the custom-rule path is covered); `EnsurePartitionBootstrap`; `SkipNoOpIfAuthorized`.

Change-feed delivery is **untouched**, and a new test pins that it stays synchronous so a future async attempt fails loudly. Also lands #910's **`Text` terminal-lock guard** — `Status`/`ToolCalls`/`UpdatedNodes` were protected against a late push regressing them, `Text` was not, so a delayed placeholder could overwrite a finished answer.

## A regression I introduced, found, and root-caused

Monolith run 2 failed `WorkspaceCacheEvictionTest`. Baselined at 15 iterations per arm: pristine main **0/15**, my hop alone **14/15**, hop + fix **0/15**.

**Mechanism** (instrumented): the delete handler posts `DeleteNodeResponse` *inside* the `Observable.Using` subtree-deletion guard, and Rx disposes a `Using` resource only after OnCompleted propagates — so the guard **outlived the response by ~5 ms**. That latent bug was masked because the delete used to run inline on the per-node hub's **turn**, queuing a caller's follow-up create behind it; leaving the fold's gate also leaves the turn, so the race became near-certain. **Fixed the ordering** — release the guard explicitly just before posting success (`Dispose` is `Interlocked`-idempotent, so the enclosing `Using` stays the error/timeout safety net). The test was not adapted and the pipeline was not pinned back onto the turn.

## Verification

**Soak 15/15** consecutive full `NodeOperations` runs at 85/85 · **Monolith ×4** · Hosting 115/115 · Query 361/361 · Data 303/303 · Graph 818+2 · Orleans 136/136 · AI 1037+5. Deadlock proof: same binaries with the idiom's body swapped to a bare `Take(1)` → **3 failed** (both probes hang to the 10 s bound); with it → **6/6 in 36 ms**. The precondition test is kept so the others cannot pass vacuously.

**The six tests the async approach disturbed all pass UNMODIFIED** — `SearchResultStormTest`, `PandasExplorerLayoutAreaTest`, `HarnessInstallGateTest`, `CreateNodesRequestTest`, `MeshNodeStreamCacheIdleReleaseTest`, `GrainActivationFailureRegistryTest`. Zero existing test files touched.

## Residual

- `StaleActivationSeedRollbackTest` is red on **main** at 8/15 (pre-existing, filed via #910); this change makes it *less* frequent (4/15) but it will still red CI intermittently.
- Dangerous sites deliberately deferred: `NodeTypeReleaseExtensions.cs:93`, `MeshNodeStreamCache.cs:1406`, `AccessControlPipeline.HandleGetPermission:245`.
- The guard-ordering class may exist elsewhere — any `Observable.Using` whose resource is a *guard* and whose inner pipeline posts the done signal. One instance fixed; not audited repo-wide.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)