### PR TITLE
Installer establishes the manifest's declared access — free public, segments scoped, paid gated (#920)

### DIFF
--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -2,6 +2,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -10,8 +11,9 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
-/// Re-runs the <see cref="IPartitionInstallHook"/>s for every ALREADY-installed package, once, at
-/// startup — the REPAIR pass.
+/// Reconciles every ALREADY-installed package, once, at startup — the REPAIR pass: re-runs the
+/// <see cref="IPartitionInstallHook"/>s AND re-asserts the access shape each package's recorded
+/// manifest declares (<see cref="PackageInstaller.EnsureDeclaredAccess"/>).
 ///
 /// <para><b>Why a repair pass is needed at all.</b> Hooks now run on install, but every package
 /// installed before they existed never ran them, and every account created since inherited the gap.
@@ -19,10 +21,18 @@ namespace MeshWeaver.PluginCatalog;
 /// mesh and invisible in every picker. Waiting for the next package update to fix it would leave
 /// users broken for however long that takes, for a defect they cannot see or work around.</para>
 ///
-/// <para><b>Safe to run every boot.</b> Hooks are required to be idempotent, and the AI hook writes
-/// only when a user's sources actually change — so on an already-repaired instance this reads and
-/// writes nothing. It is deliberately fire-and-forget and failure-tolerant: repair must never delay
-/// or fail startup.</para>
+/// <para><b>Why the access re-assert lives here too.</b> The boot install pass
+/// (<see cref="InstanceAutoRegistrationService"/>) only revisits the pre-installed baseline and — on
+/// a FRESH instance — the operator's default seed; a free package installed any other way (the seed
+/// on an earlier boot, the catalog button, an update) is never a candidate again, so a lost policy
+/// or grant would stay lost forever. The install records are the one complete inventory, and each
+/// record carries the manifest whose declarations drive the shape — so "re-asserted on boot, a lost
+/// policy self-heals" holds for EVERY installed package, not just the baseline (#920).</para>
+///
+/// <para><b>Safe to run every boot.</b> Hooks are required to be idempotent, and the access shape is
+/// create-only — so on an already-consistent instance this reads and writes nothing. It is
+/// deliberately fire-and-forget and failure-tolerant: repair must never delay or fail startup (the
+/// hard failure-propagation contract lives on the install paths themselves).</para>
 /// </summary>
 /// <param name="hub">Hub supplying the workspace and the registered hooks.</param>
 public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedService
@@ -35,22 +45,27 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<InstalledPackageRepairService>();
 
-        // Nothing to repair when no hook is registered — skip the query entirely.
-        if (!hub.ServiceProvider.GetServices<IPartitionInstallHook>().Any())
-            return Task.CompletedTask;
-
-        subscription = InstalledPartitions(logger)
-            .SelectMany(partitions => partitions.Count == 0
+        subscription = InstalledRecords(logger)
+            .SelectMany(records => records.Count == 0
                 ? Observable.Return(Unit.Default)
-                : partitions
-                    .Select(partition => PackageInstaller.RunInstallHooks(hub, partition, logger))
+                : records
+                    .Select(record => PackageInstaller
+                        .EnsureDeclaredAccess(hub, record.Manifest, record.Partition, logger)
+                        .Catch<Unit, Exception>(ex =>
+                        {
+                            logger?.LogWarning(ex,
+                                "[PackageRepair] re-asserting declared access for {Partition} failed",
+                                record.Partition);
+                            return Observable.Return(Unit.Default);
+                        })
+                        .SelectMany(_ => PackageInstaller.RunInstallHooks(hub, record.Partition, logger)))
                     .ToObservable()
                     .Concat()
                     .DefaultIfEmpty(Unit.Default)
                     .LastAsync()
                     .Do(_ => logger?.LogInformation(
-                        "[PackageRepair] reconciled install hooks for {Count} installed partition(s)",
-                        partitions.Count)))
+                        "[PackageRepair] reconciled declared access + install hooks for {Count} "
+                        + "installed partition(s)", records.Count)))
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex, "[PackageRepair] repair pass failed"));
@@ -58,47 +73,45 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
         return Task.CompletedTask;
     }
 
+    /// <summary>One recorded install: its target partition and the manifest recorded for it.</summary>
+    private sealed record InstalledRecord(string Partition, PackageManifest Manifest);
+
     /// <summary>
-    /// The partitions of every recorded install. Reads the <c>Package</c> records the installer
-    /// writes, so the repair covers exactly what is installed — no hard-coded package list.
+    /// Every recorded install, one entry per partition. Reads the <c>Package</c> records the
+    /// installer writes, so the repair covers exactly what is installed — no hard-coded package
+    /// list. The record's content IS the manifest as installed (id, partition, price, declared
+    /// public segments), which is what drives the access re-assert.
     /// </summary>
-    private IObservable<IReadOnlyList<string>> InstalledPartitions(ILogger? logger) =>
+    private IObservable<IReadOnlyList<InstalledRecord>> InstalledRecords(ILogger? logger) =>
         hub.GetWorkspace()
             .GetQuery("installed-packages-repair",
                 $"namespace:{PackageInstaller.InstalledPartition} "
                 + $"nodeType:{PackageInstaller.PackageNodeType} select:path,id,name,nodeType,content")
             .Take(1)
             .Timeout(TimeSpan.FromMinutes(2))
-            .Select(nodes => (IReadOnlyList<string>)nodes
-                .Select(PartitionOf)
-                .Where(p => !string.IsNullOrWhiteSpace(p))
-                .Select(p => p!)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(nodes => (IReadOnlyList<InstalledRecord>)nodes
+                .Select(node => (Node: node,
+                    Manifest: node.ContentAs<PackageManifest>(hub.JsonSerializerOptions)))
+                .Where(x => x.Manifest is not null)
+                .Select(x => new InstalledRecord(PartitionOf(x.Node, x.Manifest!), x.Manifest!))
+                .Where(r => !string.IsNullOrWhiteSpace(r.Partition))
+                .GroupBy(r => r.Partition, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
                 .ToList())
             .Catch((Exception ex) =>
             {
                 logger?.LogWarning(ex, "[PackageRepair] listing installed packages failed");
-                return Observable.Return((IReadOnlyList<string>)[]);
+                return Observable.Return((IReadOnlyList<InstalledRecord>)[]);
             });
 
     /// <summary>
     /// The target partition of an install record. The record's id IS the package id, and the
-    /// installer targets a partition of that name — read from content when present so a package
-    /// whose partition differs from its id still repairs correctly.
+    /// installer targets a partition of that name — the recorded manifest's
+    /// <see cref="PackageManifest.TargetPartition"/> wins when present so a package whose partition
+    /// differs from its id still repairs correctly.
     /// </summary>
-    private string? PartitionOf(MeshWeaver.Mesh.MeshNode node)
-    {
-        if (node.Content is System.Text.Json.JsonElement json
-            && json.ValueKind == System.Text.Json.JsonValueKind.Object
-            && json.TryGetProperty("targetPartition", out var value)
-            && value.ValueKind == System.Text.Json.JsonValueKind.String)
-        {
-            var declared = value.GetString();
-            if (!string.IsNullOrWhiteSpace(declared))
-                return declared;
-        }
-        return node.Id;
-    }
+    private static string PartitionOf(MeshWeaver.Mesh.MeshNode node, PackageManifest manifest) =>
+        string.IsNullOrWhiteSpace(manifest.TargetPartition) ? node.Id : manifest.TargetPartition!;
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -552,10 +552,11 @@ public sealed class InstanceAutoRegistrationService(
                     .Do(result => logger.LogInformation(
                         "[DefaultInstall] {Id} → {Partition}: {Written} written, {Unchanged} unchanged",
                         package.Id, partition, result.Written, result.Unchanged))
-                    // Publication is re-asserted even when nothing installed — that is what heals an
-                    // instance whose partition was left unreadable, and it is free once in place.
+                    // The declared access is re-asserted even when nothing installed — that is what
+                    // heals an instance whose partition was left unreadable, and it is free once in
+                    // place.
                     .SelectMany(result => PackageInstaller
-                        .EnsurePreInstalledPublicRead(hub, package, partition, logger)
+                        .EnsureDeclaredAccess(hub, package, partition, logger)
                         .Select(_ => result)))
             .Select(result => new DefaultInstallSummary(
                 Installed: result.Written > 0 ? 1 : 0,

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -143,6 +143,9 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         // The package's own declaration that it belongs to the platform's default
                         // install — read off the ROOT's content, where the plugins repo authors it.
                         PreInstalled = peeked.PreInstalled,
+                        // The declared public surface — what the installer's access step scopes a
+                        // free package's public read to.
+                        PublicSegments = peeked.PublicSegments,
                     });
                 }
                 return (IReadOnlyList<PackageManifest>)manifests
@@ -165,7 +168,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
     private readonly record struct PeekedRoot(
         string? NodeType, string? Name, string? Description,
         string? Category, string? Icon, decimal? Price, string? Currency, string? Poster,
-        bool PreInstalled, ImmutableList<string> Requires);
+        bool PreInstalled, ImmutableList<string> Requires, ImmutableList<string> PublicSegments);
 
     // Reads the node's type/name/description — plus the storefront card fields (category/icon on
     // the node, price/currency/poster inside the content) — straight from the JSON: no MeshNode
@@ -182,6 +185,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
             string? poster = null;
             var preInstalled = false;
             var requires = ImmutableList<string>.Empty;
+            var publicSegments = ImmutableList<string>.Empty;
             if (r.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Object)
             {
                 if (content.TryGetProperty("price", out var p) && p.ValueKind == JsonValueKind.Number
@@ -206,6 +210,15 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         .Where(e => e.ValueKind == JsonValueKind.String)
                         .Select(e => e.GetString()!)
                         .ToImmutableList();
+                // The plugin's declared public surface ("publicSegments"). Read here because the
+                // INSTALLER establishes the declared access at install time — a free package with
+                // declared segments gets those public and the rest gated, and leaving the field
+                // unread made it dead metadata (the same defect class `preInstalled` was, #920).
+                if (content.TryGetProperty("publicSegments", out var pub) && pub.ValueKind == JsonValueKind.Array)
+                    publicSegments = pub.EnumerateArray()
+                        .Where(e => e.ValueKind == JsonValueKind.String)
+                        .Select(e => e.GetString()!)
+                        .ToImmutableList();
             }
             return new PeekedRoot(
                 r.TryGetProperty("nodeType", out var nt) ? nt.GetString() : null,
@@ -213,7 +226,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
                 r.TryGetProperty("description", out var d) ? d.GetString() : null,
                 r.TryGetProperty("category", out var cat) ? cat.GetString() : null,
                 r.TryGetProperty("icon", out var ic) ? ic.GetString() : null,
-                price, currency, poster, preInstalled, requires);
+                price, currency, poster, preInstalled, requires, publicSegments);
         }
         catch (JsonException ex)
         {

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -126,6 +126,20 @@ public record PackageManifest
     /// <summary>The store-card picture URL (the root content's <c>poster</c>).</summary>
     public string? Poster { get; init; }
 
+    /// <summary>
+    /// The partition's declared PUBLIC child segments (the root content's <c>publicSegments</c>).
+    /// For a FREE package (<see cref="Price"/> 0 or absent) that declares any, the installer scopes
+    /// the public read to exactly these segments: root Public+Anonymous Viewer grants (the cover and
+    /// the declared segments become readable by everyone) plus Public+Anonymous Viewer DENIES on
+    /// every other child segment — the same shape the Store's <c>CatalogGate</c>/<c>PluginGate</c>
+    /// seed. Empty (the default) on a free package means the WHOLE partition is public
+    /// (<c>_Policy · PublicRead = true</c>); on a priced package the field is advisory to the
+    /// entitlement machinery and the installer writes nothing. Read off the root node while listing
+    /// (<see cref="NodeRepoPackageSource"/>) or straight from a <c>package.json</c>; empty default
+    /// round-trips loss-free under default-suppressing serialization.
+    /// </summary>
+    public ImmutableList<string> PublicSegments { get; init; } = [];
+
     // ── install-record metadata (null on catalog entries; set when written to the registry) ──
 
     /// <summary>The git ref (commit/branch) this package was installed from. Null until installed.</summary>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -115,10 +115,11 @@ public static class PackageInstaller
                 logger?.LogInformation(
                     "Installed package {Id} v{Version}: {Written} written, {Unchanged} unchanged into {Partition} @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, partition, installedFromRef);
-                // The public-read policy lands BEFORE the roots are warmed: warming ACTIVATES each
-                // root hub, whose gating pass seeds the partition's access table — it must see the
-                // policy this package declares, not a partition nobody can read.
-                return EnsurePreInstalledPublicRead(hub, manifest, partition, logger)
+                // The declared-access shape lands BEFORE the roots are warmed: warming ACTIVATES
+                // each root hub, whose gating pass seeds the partition's access table — it must see
+                // the shape this package declares, not a partition nobody can read.
+                return EnsureDeclaredAccess(hub, manifest, partition, logger,
+                        nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef, nodes.Length))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
                     .SelectMany(_ => RunInstallHooks(hub, partition!, logger))
@@ -220,33 +221,100 @@ public static class PackageInstaller
             .LastAsync();
     }
 
+    /// <summary>The read-only role the declared-access grants and denies carry.</summary>
+    private const string ViewerRole = "Viewer";
+
     /// <summary>
-    /// Establishes the PUBLIC READ a <see cref="PackageManifest.PreInstalled"/> package promises —
-    /// a <c>PartitionAccessPolicy { PublicRead = true }</c> at <c>{partition}/_Policy</c>, written
-    /// by the INSTALLER as part of installing the package.
-    ///
-    /// <para><b>Why the installer owns it.</b> A pre-installed package is platform content: it is
-    /// written entirely under SYSTEM (so no creator grant is ever minted) into a partition no user
-    /// holds a role on, and a platform admin's grant is scoped to the <c>Admin</c> partition. Without
-    /// a policy NOBODY can read what was just installed — which is exactly how the <c>Skill</c>
-    /// catalog came to depend on a hand-placed <c>_Policy</c> node while <c>Agent</c>, which never
-    /// got that hand-treatment, was simply unreachable (#902). Declaring <c>preInstalled</c> is the
-    /// package's whole statement of intent; the grant that makes it true must come from the install,
-    /// not from an operator remembering to place a node.</para>
-    ///
-    /// <para>The shape is the one every built-in catalog already ships (the <c>Plugins</c> records
-    /// partition, the built-in Agent/Model/Documentation namespaces): read-only publication, no
-    /// secrets. CREATE-ONLY — an existing policy (shipped by the package itself, or tuned by an
-    /// operator) is left completely alone, so this can never silently widen or narrow a deliberate
-    /// choice. Failure PROPAGATES: an install that could not establish its declared public read has
-    /// not installed properly, and swallowing that is the defect class this closes.</para>
+    /// The well-known PUBLIC child segment of a partition: <c>{partition}/Public/…</c> is always a
+    /// public surface on a scoped-public package — the same convention the Store's
+    /// <c>PluginGate</c> keys on, so the installer's denies and the plugin machinery's reconcile
+    /// never fight over it.
     /// </summary>
-    public static IObservable<Unit> EnsurePreInstalledPublicRead(
-        IMessageHub hub, PackageManifest manifest, string? partition, ILogger? logger)
+    private const string WellKnownPublicSegment = "Public";
+
+    /// <summary>
+    /// Establishes the access a package's MANIFEST declares — the ONE access-establishment step of
+    /// an install, applied on every install path (content, node-repo full, node-repo delta) and
+    /// re-asserted on boot so a lost policy self-heals. "Public pages public, protected pages
+    /// protected, without any grants needed — just by getting the catalog" (#920):
+    ///
+    /// <list type="bullet">
+    ///   <item><b>Pre-installed</b> (<see cref="PackageManifest.PreInstalled"/>) — platform
+    ///     baseline, fully public: <c>PartitionAccessPolicy { PublicRead = true }</c> at
+    ///     <c>{partition}/_Policy</c> (#902). Declared segments are irrelevant — everything is
+    ///     readable.</item>
+    ///   <item><b>Free</b> (<see cref="PackageManifest.Price"/> 0 or absent) with no declared
+    ///     <see cref="PackageManifest.PublicSegments"/> — the same fully-public policy: a free
+    ///     package that a catalog hands out must be readable by everyone, signed in or not.</item>
+    ///   <item><b>Free with declared <see cref="PackageManifest.PublicSegments"/></b> — public read
+    ///     SCOPED to the declaration: Public+Anonymous Viewer grants at the partition root (the
+    ///     cover and, by downward inheritance, the declared segments) plus Public+Anonymous Viewer
+    ///     DENIES on every other child segment — the exact root-grant + per-child-deny shape the
+    ///     Store's <c>CatalogGate</c> seeds for <c>/Store</c> (#200/#204). Underscore satellites
+    ///     and the well-known <c>Public</c> segment follow the <c>PluginGate</c> conventions so the
+    ///     two mechanisms converge instead of fighting.</item>
+    ///   <item><b>Priced</b> (any non-zero <see cref="PackageManifest.Price"/> — positive =
+    ///     purchasable, negative = coupon-only) — the installer writes NOTHING: the partition lands
+    ///     gated, readable only via the entitlement machinery (PluginGate / purchase), which is
+    ///     exactly the point of a price.</item>
+    /// </list>
+    ///
+    /// <para><b>Why the installer owns it.</b> An installed package is written entirely under
+    /// SYSTEM (so no creator grant is ever minted) into a partition no user holds a role on, and a
+    /// platform admin's grant is scoped to the <c>Admin</c> partition. Without this step NOBODY can
+    /// read what was just installed — which is exactly how the <c>Skill</c> catalog came to depend
+    /// on a hand-placed <c>_Policy</c> node while <c>Agent</c> was simply unreachable (#902), and
+    /// how every free plugin the unattended installer landed came up admin-only (#920: "Access
+    /// denied … lacks Read permission on 'DoublePendulum/Live'"). The manifest is the package's
+    /// whole statement of intent; the shape that makes it true must come from the install, not from
+    /// an operator remembering to place nodes.</para>
+    ///
+    /// <para>Every node is CREATE-ONLY — an existing policy / grant / deny (shipped by the package
+    /// itself, or tuned by an operator) is left completely alone, so this can never silently widen
+    /// or narrow a deliberate choice, and a steady-state re-run writes nothing. Failure PROPAGATES:
+    /// an install that could not establish its declared access has not installed properly, and
+    /// swallowing that is the defect class this closes.</para>
+    /// </summary>
+    /// <param name="hub">The installing hub.</param>
+    /// <param name="manifest">The package manifest whose declarations drive the shape.</param>
+    /// <param name="partition">The installed partition (null/blank no-ops).</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <param name="installedPaths">The node paths THIS install just wrote, when the caller has
+    /// them. The scoped shape derives its child-segment walk from these UNIONED with a query of the
+    /// partition's current children — the query alone can lag the writes it would have to see
+    /// (CQRS), and the installer is the one component that always knows what it just wrote.</param>
+    public static IObservable<Unit> EnsureDeclaredAccess(
+        IMessageHub hub, PackageManifest manifest, string? partition, ILogger? logger,
+        IEnumerable<string>? installedPaths = null)
     {
-        if (!manifest.PreInstalled || string.IsNullOrWhiteSpace(partition))
+        if (string.IsNullOrWhiteSpace(partition))
             return Observable.Return(Unit.Default);
 
+        // A priced package (positive = purchasable, negative = coupon-only) installs GATED: no
+        // public read of any kind — entitlement (PluginGate / purchase / coupon) is the only way
+        // in. Pre-installed overrides a price: platform baseline is public by definition.
+        if (!manifest.PreInstalled && manifest.Price is { } price && price != 0m)
+        {
+            logger?.LogDebug(
+                "[PackageInstaller] {Id} is priced — {Partition} stays gated (entitlement only)",
+                manifest.Id, partition);
+            return Observable.Return(Unit.Default);
+        }
+
+        var declared = DeclaredPublicSegments(manifest);
+        return !manifest.PreInstalled && declared.Count > 0
+            ? EnsureScopedPublicRead(hub, manifest, partition!, declared, installedPaths, logger)
+            : EnsurePartitionPublicRead(hub, manifest, partition!, logger);
+    }
+
+    /// <summary>
+    /// The fully-public shape — <c>PartitionAccessPolicy { PublicRead = true }</c> at
+    /// <c>{partition}/_Policy</c>, create-only (the shape every built-in catalog already ships:
+    /// read-only publication, no secrets).
+    /// </summary>
+    private static IObservable<Unit> EnsurePartitionPublicRead(
+        IMessageHub hub, PackageManifest manifest, string partition, ILogger? logger)
+    {
         var policyPath = $"{partition}/{PartitionPolicyId}";
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         var existing = persistence is not null
@@ -255,7 +323,7 @@ public static class PackageInstaller
 
         return existing.SelectMany(current => current is not null
             ? Observable.Return(Unit.Default)
-            : Upsert(hub, new MeshNode(PartitionPolicyId, partition!)
+            : Upsert(hub, new MeshNode(PartitionPolicyId, partition)
                 {
                     NodeType = PartitionAccessPolicyNodeType.NodeType,
                     Name = "Access Policy",
@@ -263,10 +331,160 @@ public static class PackageInstaller
                     Content = new PartitionAccessPolicy { PublicRead = true },
                 })
                 .Do(_ => logger?.LogInformation(
-                    "[PackageInstaller] {Id} is pre-installed — published {Partition} read-only to "
-                    + "everyone via {Path}", manifest.Id, partition, policyPath))
+                    "[PackageInstaller] {Id} declares public content — published {Partition} "
+                    + "read-only to everyone via {Path}", manifest.Id, partition, policyPath))
                 .Select(_ => Unit.Default));
     }
+
+    /// <summary>
+    /// The SCOPED-public shape for a free package with declared
+    /// <see cref="PackageManifest.PublicSegments"/>: Public+Anonymous Viewer GRANTS at the
+    /// partition root (grants inherit strictly downward, so the cover and the declared segments
+    /// become readable by everyone) plus Public+Anonymous Viewer DENIES on every OTHER child
+    /// segment. A deny only ever removes the role for the Public/Anonymous subjects — an admin or
+    /// an entitled viewer holds their own grant and is never touched by it, which is what keeps
+    /// "protected" meaning gated rather than blacked out.
+    ///
+    /// <para>The child walk follows the <c>PluginGate</c> conventions — underscore satellites are
+    /// never gated here (their protection is the plugin machinery's <c>ProtectedSegments</c>
+    /// concern) and the well-known <c>Public</c> segment is always public — so the installer's
+    /// shape and the Store's reconcile converge on the same nodes instead of fighting. Segments
+    /// come from the paths this install wrote UNIONED with the partition's current children (read
+    /// as System); every node is create-only and the writes run SEQUENTIALLY (the access table
+    /// deadlocks under parallel writers, 40P01).</para>
+    /// </summary>
+    private static IObservable<Unit> EnsureScopedPublicRead(
+        IMessageHub hub, PackageManifest manifest, string partition,
+        IReadOnlyCollection<string> declared, IEnumerable<string>? installedPaths, ILogger? logger)
+    {
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+
+        // The partition's current immediate children, read as SYSTEM (this runs inside an install
+        // pipeline / a boot pass with no user identity; the freshly written partition has no user
+        // grants yet by definition).
+        var currentChildren = meshService is null
+            ? Observable.Return<IReadOnlyList<string>>([])
+            : Observable.Using(
+                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                        $"path:{partition} scope:subtree limit:{QueryLimit}")))
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30))
+                .Select(change => (IReadOnlyList<string>)change.Items.Select(n => n.Path).ToList());
+
+        return currentChildren.SelectMany(children =>
+        {
+            var gated = GatedChildRoots(
+                children.Concat(installedPaths ?? []), partition, declared);
+
+            var shape = new List<MeshNode>
+            {
+                ViewerAssignment(partition, WellKnownUsers.Public, denied: false),
+                ViewerAssignment(partition, WellKnownUsers.Anonymous, denied: false),
+            };
+            foreach (var child in gated)
+            {
+                shape.Add(ViewerAssignment(child, WellKnownUsers.Public, denied: true));
+                shape.Add(ViewerAssignment(child, WellKnownUsers.Anonymous, denied: true));
+            }
+
+            // Create-only, sequential; a failed write propagates (Upsert throws on !Success).
+            return shape
+                .Select(node =>
+                {
+                    var existing = persistence is not null
+                        ? persistence.Read(node.Path, hub.JsonSerializerOptions).Take(1)
+                        : Observable.Return<MeshNode?>(null);
+                    return existing.SelectMany(current => current is not null
+                        ? Observable.Return(0)
+                        : Upsert(hub, node));
+                })
+                .ToObservable()
+                .Concat()
+                .Sum()
+                .Do(written => logger?.LogInformation(
+                    "[PackageInstaller] {Id} declares public segments [{Segments}] — {Partition} "
+                    + "cover published, {Gated} other child(ren) gated ({Written} access node(s) "
+                    + "written)",
+                    manifest.Id, string.Join(", ", declared), partition, gated.Count, written))
+                .Select(_ => Unit.Default);
+        });
+    }
+
+    /// <summary>Query cap for the scoped-access child walk (mirrors the snapshot-query bound the
+    /// Store's gates use).</summary>
+    private const int QueryLimit = 10_000;
+
+    /// <summary>
+    /// The manifest's declared public segments, SANITIZED: one path segment each, inside the
+    /// partition — blank entries, traversals and anything containing a slash are dropped;
+    /// leading/trailing slashes are tolerated; duplicates collapse case-insensitively. Pure.
+    /// </summary>
+    internal static IReadOnlyCollection<string> DeclaredPublicSegments(PackageManifest manifest)
+    {
+        if (manifest.PublicSegments is not { Count: > 0 } segments)
+            return [];
+        var seen = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in segments)
+        {
+            var segment = (raw ?? string.Empty).Trim().Trim('/');
+            if (segment.Length == 0 || segment.Contains('/') || segment is "." or "..")
+                continue;
+            seen.Add(segment);
+        }
+        return seen;
+    }
+
+    /// <summary>
+    /// The GATED child roots of a scoped-public partition: the immediate child segments present in
+    /// <paramref name="paths"/> that are neither a declared public segment, nor the well-known
+    /// <see cref="WellKnownPublicSegment"/>, nor an underscore satellite. Pure.
+    /// </summary>
+    internal static IReadOnlyList<string> GatedChildRoots(
+        IEnumerable<string> paths, string partition, IReadOnlyCollection<string> declared)
+    {
+        var prefix = partition + "/";
+        var roots = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var path in paths)
+        {
+            if (path is null || !path.StartsWith(prefix, StringComparison.Ordinal))
+                continue;
+            var rel = path[prefix.Length..];
+            var firstSlash = rel.IndexOf('/');
+            var segment = firstSlash < 0 ? rel : rel[..firstSlash];
+            if (segment.Length == 0 || segment.StartsWith('_'))
+                continue;                       // internal satellite — never gated by the installer
+            if (string.Equals(segment, WellKnownPublicSegment, StringComparison.OrdinalIgnoreCase)
+                || declared.Contains(segment, StringComparer.OrdinalIgnoreCase))
+                continue;                       // a public surface — stays readable
+            roots.Add(prefix + segment);
+        }
+        return roots.ToList();
+    }
+
+    /// <summary>
+    /// A Viewer <c>AccessAssignment</c> for <paramref name="subject"/> at <paramref name="scope"/>
+    /// — GRANT when <paramref name="denied"/> is false, DENY when true. The node lands at
+    /// <c>{scope}/_Access/{subject}_Access</c> with <c>MainNode = {scope}</c> — the two placement
+    /// rules the permission evaluator keys on (a grant with <c>mainNode</c> on the container
+    /// stores cleanly and silently does nothing — the #204 trap). Pure.
+    /// </summary>
+    internal static MeshNode ViewerAssignment(string scope, string subject, bool denied) =>
+        new($"{subject}_Access", $"{scope}/_Access")
+        {
+            NodeType = AccessAssignmentNodeType.NodeType,
+            Name = denied ? $"{subject} — Viewer DENIED (gated)" : $"{subject} — Viewer",
+            State = MeshNodeState.Active,
+            MainNode = scope,
+            Content = new AccessAssignment
+            {
+                AccessObject = subject,
+                DisplayName = subject,
+                Roles = [new RoleAssignment { Role = ViewerRole, Denied = denied }],
+            },
+        };
 
     private static IObservable<Unit> WarmInstalledRoots(
         IMessageHub hub, IEnumerable<string> paths, ILogger? logger)
@@ -1023,8 +1241,9 @@ public static class PackageInstaller
                                 onError: msg => logger?.LogWarning("Release request for {Path} failed: {Msg}", path, msg));
                 }
                 // Same order as the content path: publish the partition BEFORE warming its roots
-                // (activation's gating pass must see the declared policy).
-                return EnsurePreInstalledPublicRead(hub, manifest, manifest.TargetPartition ?? manifest.Id, logger)
+                // (activation's gating pass must see the declared shape).
+                return EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
+                        logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
@@ -1170,11 +1389,12 @@ public static class PackageInstaller
                             hub.RequestNodeTypeRelease(path,
                                 onError: msg => logger?.LogWarning("Release request for {Path} failed: {Msg}", path, msg));
                 }
-                // An UPDATE re-asserts the declared public read too: a package that only just
-                // flipped to preInstalled (or whose policy was lost) must converge on the next
-                // sync rather than wait for a full re-install. Create-only, so an existing policy
-                // is untouched and this is free on the common path.
-                return EnsurePreInstalledPublicRead(hub, manifest, manifest.TargetPartition ?? manifest.Id, logger)
+                // An UPDATE re-asserts the declared access too: a package that only just flipped
+                // its declaration (or whose policy was lost) must converge on the next sync rather
+                // than wait for a full re-install. Create-only, so an existing shape is untouched
+                // and this is free on the common path.
+                return EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
+                        logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef,
                         newManifest.Files.Count, newManifest))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))

--- a/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
@@ -1,0 +1,313 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// THE MANIFEST-DECLARED ACCESS (#920). Installing a package must establish the access model its
+/// manifest declares — "public pages public, protected pages protected, without any grants needed —
+/// just by getting the catalog":
+///
+/// <list type="bullet">
+///   <item>a FREE package (<c>price: 0</c> or absent) lands publicly readable — the installer writes
+///     <c>{partition}/_Policy · PublicRead = true</c>;</item>
+///   <item>a free package with declared <c>publicSegments</c> lands with exactly those segments
+///     public (root Public+Anonymous Viewer grants) and every other child gated (Public+Anonymous
+///     Viewer denies);</item>
+///   <item>a PRICED package lands gated — the installer writes nothing, entitlement is the only way
+///     in;</item>
+///   <item>a package-shipped <c>_Policy</c> survives (create-only), and a second install pass writes
+///     no access node at all.</item>
+/// </list>
+///
+/// <para>This is the regression that left DoublePendulum — a free Showcase plugin the unattended
+/// installer landed — admin-only on a fresh instance: "Access denied: user 'user' lacks Read
+/// permission on 'DoublePendulum/Live'". The manifest declared <c>price: 0</c> and
+/// <c>publicSegments</c>, and no code read either (#920, the same dead-metadata class as
+/// <c>preInstalled</c> before #902).</para>
+///
+/// <para>Built on <see cref="MonolithMeshTestBase.ConfigureMeshBase"/>, NOT the default
+/// <c>ConfigureMesh</c>: the latter seeds a root-scope <c>Public → Admin</c> grant that would make
+/// every partition readable by everyone and void every assertion here.</para>
+/// </summary>
+public class DeclaredAccessInstallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A signed-in principal holding NOTHING — no role, no grant, anywhere.</summary>
+    private const string PlainUser = "plain-user";
+
+    /// <summary>The not-logged-in reader (the well-known Anonymous permission bucket).</summary>
+    private const string Anonymous = WellKnownUsers.Anonymous;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddPluginCatalog();
+
+    // A node-native plugin repo in the shape MeshWeaver.Plugins ships, covering the four declared
+    // access models: free-open, free-scoped (publicSegments), priced (gated) and free with a
+    // package-shipped _Policy of its own.
+    private static readonly IReadOnlyList<RepoFile> Repo = new List<RepoFile>
+    {
+        // FREE, nothing declared beyond price 0 — the DoublePendulum shape: the whole partition
+        // must land publicly readable, its Live child included.
+        new("FreePlug/index.json",
+            """
+            {"$type":"MeshNode","id":"FreePlug","namespace":"","path":"FreePlug","mainNode":"FreePlug",
+             "name":"Free Plug","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Free for everyone.","price":0,
+                        "publicSegments":[]}}
+            """),
+        new("FreePlug/Live.json",
+            """
+            {"$type":"MeshNode","id":"Live","namespace":"FreePlug","path":"FreePlug/Live",
+             "mainNode":"FreePlug/Live","name":"Live","nodeType":"Markdown","state":"Active",
+             "content":"# Live\n\nThe area-backing node the live defect denied."}
+            """),
+        // FREE with DECLARED public segments — "Open" is public, "Hidden" is not.
+        new("SegPlug/index.json",
+            """
+            {"$type":"MeshNode","id":"SegPlug","namespace":"","path":"SegPlug","mainNode":"SegPlug",
+             "name":"Seg Plug","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Partially public.","price":0,
+                        "publicSegments":["Open"]}}
+            """),
+        new("SegPlug/Open.json",
+            """
+            {"$type":"MeshNode","id":"Open","namespace":"SegPlug","path":"SegPlug/Open",
+             "mainNode":"SegPlug/Open","name":"Open","nodeType":"Markdown","state":"Active",
+             "content":"# Open\n\nDeclared public."}
+            """),
+        new("SegPlug/Hidden.json",
+            """
+            {"$type":"MeshNode","id":"Hidden","namespace":"SegPlug","path":"SegPlug/Hidden",
+             "mainNode":"SegPlug/Hidden","name":"Hidden","nodeType":"Markdown","state":"Active",
+             "content":"# Hidden\n\nNot declared — must stay gated."}
+            """),
+        // PRICED — installs GATED: no policy, no grants; entitlement is the only way in.
+        new("PaidPlug/index.json",
+            """
+            {"$type":"MeshNode","id":"PaidPlug","namespace":"","path":"PaidPlug","mainNode":"PaidPlug",
+             "name":"Paid Plug","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Bought, not given.","price":25.0,
+                        "currency":"CHF"}}
+            """),
+        new("PaidPlug/Doc.json",
+            """
+            {"$type":"MeshNode","id":"Doc","namespace":"PaidPlug","path":"PaidPlug/Doc",
+             "mainNode":"PaidPlug/Doc","name":"Doc","nodeType":"Markdown","state":"Active",
+             "content":"# Paid content"}
+            """),
+        // FREE, but the package SHIPS ITS OWN _Policy — the installer's step is create-only and
+        // must leave the shipped shape completely alone.
+        new("ShippedPolicy/index.json",
+            """
+            {"$type":"MeshNode","id":"ShippedPolicy","namespace":"","path":"ShippedPolicy",
+             "mainNode":"ShippedPolicy","name":"Shipped Policy","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Brings its own policy.","price":0}}
+            """),
+        new("ShippedPolicy/Doc.json",
+            """
+            {"$type":"MeshNode","id":"Doc","namespace":"ShippedPolicy","path":"ShippedPolicy/Doc",
+             "mainNode":"ShippedPolicy/Doc","name":"Doc","nodeType":"Markdown","state":"Active",
+             "content":"# Doc"}
+            """),
+        new("ShippedPolicy/_Policy.json",
+            """
+            {"$type":"MeshNode","id":"_Policy","namespace":"ShippedPolicy",
+             "path":"ShippedPolicy/_Policy","mainNode":"ShippedPolicy/_Policy","name":"Access Policy",
+             "nodeType":"PartitionAccessPolicy","state":"Active",
+             "content":{"$type":"PartitionAccessPolicy","publicRead":false,
+                        "redirectOnDenied":"ShippedPolicy/Subscribe"}}
+            """),
+    };
+
+    private static NodeRepoPackageSource Source()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-declared-access", Repo));
+        return new NodeRepoPackageSource(fetch, "https://github.com/acme/plugins");
+    }
+
+    /// <summary>
+    /// Installs one package THROUGH the real listing (so <c>price</c>/<c>publicSegments</c> are the
+    /// values <see cref="NodeRepoPackageSource"/> actually parsed off the root, not hand-built) and
+    /// the real installer.
+    /// </summary>
+    private async Task<InstallResult> Install(string id)
+    {
+        var source = Source();
+        var manifests = await source.ListPackages("HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        var pkg = manifests.Single(m => m.Id == id);
+        var files = await source.FetchPackageFiles(pkg, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        return await PackageInstaller.Install(Mesh, pkg, files, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+    }
+
+    /// <summary>Authoritative single-node read straight off storage (never the lagging index).</summary>
+    private Task<MeshNode?> Read(string path) =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+    [Fact(Timeout = 120_000)]
+    public async Task FreePackage_LandsPubliclyReadable_ForANonAdminAndAnonymously()
+    {
+        var result = await Install("FreePlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        // The policy is written BY THE INSTALLER, from the manifest's price declaration alone.
+        var policy = await Read($"FreePlug/{PackageInstaller.PartitionPolicyId}");
+        policy.Should().NotBeNull("a free package's partition must be published by the installer");
+        policy!.ContentAs<PartitionAccessPolicy>(Mesh.JsonSerializerOptions)!.PublicRead
+            .Should().BeTrue();
+
+        // The reported defect, exactly: a signed-in principal holding nothing, and an anonymous
+        // visitor, can read the partition AND the area-backing child ({pkg}/Live).
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            await Mesh.GetEffectivePermissions("FreePlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must be able to read a free package's partition");
+            await Mesh.GetEffectivePermissions("FreePlug/Live", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must be able to read the area-backing node — the exact denial "
+                    + "reported live (#920)");
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task PublicSegments_ScopeThePublicRead_UndeclaredSiblingStaysGated()
+    {
+        var result = await Install("SegPlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        // Scoped publication is grants+denies, never a blanket policy.
+        (await Read($"SegPlug/{PackageInstaller.PartitionPolicyId}"))
+            .Should().BeNull("a scoped-public package must not be blanket-opened");
+
+        // The shape: root Public+Anonymous Viewer grants, denies on the undeclared child only.
+        (await Read("SegPlug/_Access/Public_Access")).Should().NotBeNull();
+        (await Read("SegPlug/_Access/Anonymous_Access")).Should().NotBeNull();
+        (await Read("SegPlug/Hidden/_Access/Public_Access")).Should().NotBeNull();
+        (await Read("SegPlug/Hidden/_Access/Anonymous_Access")).Should().NotBeNull();
+        (await Read("SegPlug/Open/_Access/Public_Access"))
+            .Should().BeNull("a DECLARED public segment must not be denied");
+        (await Read("SegPlug/Open/_Access/Anonymous_Access")).Should().BeNull();
+
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            // The cover and the declared segment are public …
+            await Mesh.GetEffectivePermissions("SegPlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read the cover of a scoped-public package");
+            await Mesh.GetEffectivePermissions("SegPlug/Open", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read the declared public segment");
+            // … and the undeclared sibling is NOT readable.
+            await Mesh.GetEffectivePermissions("SegPlug/Hidden", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must NOT read an undeclared segment of a scoped-public package");
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task PaidPackage_InstallsGated_AndStaysGated()
+    {
+        var result = await Install("PaidPlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        // The installer opens NOTHING for a priced package — no policy, no grants.
+        (await Read($"PaidPlug/{PackageInstaller.PartitionPolicyId}"))
+            .Should().BeNull("a priced package must not get a public-read policy");
+        (await Read("PaidPlug/_Access/Public_Access"))
+            .Should().BeNull("a priced package must not get a Public grant");
+        (await Read("PaidPlug/_Access/Anonymous_Access"))
+            .Should().BeNull("a priced package must not get an Anonymous grant");
+
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            await Mesh.GetEffectivePermissions("PaidPlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must be denied on a priced package's partition");
+            await Mesh.GetEffectivePermissions("PaidPlug/Doc", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must be denied on a priced package's content");
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task PackageShippedPolicy_Survives_CreateOnly()
+    {
+        await Install("ShippedPolicy");
+
+        // The package is free — the installer WOULD publish it — but the package ships its own
+        // policy, and create-only means the shipped shape wins, byte for byte.
+        var policy = await Read($"ShippedPolicy/{PackageInstaller.PartitionPolicyId}");
+        policy.Should().NotBeNull();
+        var content = policy!.ContentAs<PartitionAccessPolicy>(Mesh.JsonSerializerOptions);
+        content.Should().NotBeNull();
+        content!.PublicRead.Should().BeFalse(
+            "the package-shipped policy must never be overwritten by the installer's public read");
+        content.RedirectOnDenied.Should().Be("ShippedPolicy/Subscribe");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task SecondInstallPass_WritesNoAccessNode()
+    {
+        await Install("FreePlug");
+        await Install("SegPlug");
+
+        var accessPaths = new[]
+        {
+            $"FreePlug/{PackageInstaller.PartitionPolicyId}",
+            "SegPlug/_Access/Public_Access",
+            "SegPlug/_Access/Anonymous_Access",
+            "SegPlug/Hidden/_Access/Public_Access",
+            "SegPlug/Hidden/_Access/Anonymous_Access",
+        };
+        var before = new Dictionary<string, (long Version, DateTimeOffset LastModified)>();
+        foreach (var path in accessPaths)
+        {
+            var node = await Read(path);
+            node.Should().NotBeNull($"the first install must have established {path}");
+            before[path] = (node!.Version, node.LastModified);
+        }
+
+        // The self-update shape: a re-install of the unchanged snapshot writes nothing — content
+        // NOR access. Create-only means the access nodes are not even touched.
+        (await Install("FreePlug")).Written.Should().Be(0,
+            "a re-install of an unchanged free package must write nothing");
+        (await Install("SegPlug")).Written.Should().Be(0,
+            "a re-install of an unchanged scoped-public package must write nothing");
+
+        foreach (var path in accessPaths)
+        {
+            var node = await Read(path);
+            node.Should().NotBeNull();
+            node!.Version.Should().Be(before[path].Version,
+                $"the second pass must not rewrite {path}");
+            node.LastModified.Should().Be(before[path].LastModified,
+                $"the second pass must not touch {path}");
+        }
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/PlatformAgentsVisibleInPickerTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PlatformAgentsVisibleInPickerTest.cs
@@ -14,7 +14,7 @@ namespace MeshWeaver.Portal.E2E;
 /// <para>Two identities, because the regression was about who could see them: the installing
 /// admin, and a SECOND signed-in person who installed nothing and holds no grant anywhere. The
 /// platform's agents are published read-only to everyone BY THE INSTALLER
-/// (<c>PackageInstaller.EnsurePreInstalledPublicRead</c>), so the second person must see exactly
+/// (<c>PackageInstaller.EnsureDeclaredAccess</c>), so the second person must see exactly
 /// the same catalog. If the partition's <c>_Policy</c> is missing or unreadable, that user's
 /// picker is the one that comes up empty.</para>
 ///


### PR DESCRIPTION
Fixes #920. The unattended installer established access **only** for the 8 `preInstalled` packages; every other package landed with **no grants and no policy** — the #200/#204 shape reproduced per plugin (live repro: a fresh instance's dev user denied on `DoublePendulum/Live`). The manifest fields declaring the intent — `price` and `publicSegments` — were dead metadata (`publicSegments` read by no code).

## One manifest-driven step

`PackageInstaller.EnsureDeclaredAccess` **replaces** `EnsurePreInstalledPublicRead` (zero references remain), called on every install path (content `:121`, node-repo `:1245`, delta `:1396`) plus two boot re-asserts (`InstanceAutoRegistrationService:559`, and `InstalledPackageRepairService:53` — which now re-asserts access for **every** installed record, so a lost policy self-heals even for packages installed on earlier boots).

## Mapping (the maintainer's ruling: public pages public, protected protected — no grants needed, just by getting the catalog)

| Manifest | Installer writes |
|---|---|
| `preInstalled` | `_Policy PublicRead` (unchanged #902 semantics) |
| Free, no segments | same `PublicRead` — **the DoublePendulum fix** |
| Free + `publicSegments` | Public+Anonymous Viewer **grants** at root + **denies** on every undeclared child — the CatalogGate shape, chosen because a policy's `PublicRead` cannot be child-denied while grants+denies can (verified against `PermissionEvaluator.ComputeRoleState`'s root-to-leaf walk). Deny set = System subtree query ∪ paths this install wrote, closing the CQRS lag window. |
| Priced | **nothing** — entitlement is the only way in |

Everything create-only (package-shipped/operator policy wins byte-for-byte), sequential writes, failure propagates on install paths; the repair pass logs-and-continues per its never-fail-startup contract. `PublicSegments` is parsed into `PackageManifest` (node-repo `Peek`, `package.json`, and the registry HTTP wire).

## Verification

`DeclaredAccessInstallTest` (5 tests) drives the **real** `NodeRepoPackageSource` listing into the **real** installer on `ConfigureMeshBase` (no root grant masking): free readable for a plain user AND anonymously incl. `{pkg}/Live`; `publicSegments` scoped with an undeclared sibling at `Permission.None` and the grant/deny node shape asserted; paid stays gated; shipped `_Policy` survives; second pass writes zero access nodes.

**Fail-without:** the free-package test fails — *"a free package's partition must be published by the installer"*. **Pass-with:** full `PluginCatalog.Test` **161/161**, including the #902 pins (`PreInstalledPackageInstallTest`, `GhostPartitionRootRecoveryTest`) that this generalizes; independently re-verified **12/12** after merging current main. `-c Release -warnaserror` clean.

## Residual

MeshWeaver.Plugins' `PluginGate` still gates free non-preInstalled Store roots ("a product without a price has no self-service way in") and would rewrite an open policy where it runs — convergent, not a loop; aligning its price semantics with this ruling is a Plugins-repo follow-up. Negative price (coupon-only marker) maps to gated-write-nothing.

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
