### PR TITLE
Permission projection follows every permission-changing event (#603)

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -452,6 +452,37 @@ public static class PostgreSqlSchemaInitializer
         """;
 
     /// <summary>
+    /// Body of the per-partition <c>trg_policy_or_role_changed()</c> trigger function — fires the
+    /// permission re-projection when a <c>PartitionAccessPolicy</c> (<c>{ns}/_Policy</c>) or a
+    /// custom <c>Role</c> node changes. Both are REGULAR <c>mesh_nodes</c> rows
+    /// (<see cref="SatelliteTableMapping"/> deliberately excludes <c>_Policy</c> from the
+    /// satellite segments), yet both are INPUTS to <c>rebuild_user_effective_permissions()</c>:
+    /// the policy fold projects <c>_Policy</c> caps + PublicRead grants, and every grant row
+    /// resolves its permission mask from <c>Role</c> nodes (<c>content-&gt;&gt;'permissions'</c>).
+    /// The <c>access_changed</c> trigger watches only the <c>access</c> satellite, so before this
+    /// trigger existed an ordinary policy/role write changed the LIVE evaluator's answer (the ~1s
+    /// synced query in <c>PermissionEvaluator</c>) while the denormalized projection stayed stale
+    /// until the next unrelated <c>_Access</c> write in the same schema or the next boot's
+    /// self-heal — a node stayed readable by exact path but vanished from (or wrongly lingered
+    /// in) every query-backed listing, silently (issue #603; a step of the #919 Store lockout).
+    ///
+    /// <para><b>Full rebuild, not per-subject:</b> a policy applies to every subject and a role
+    /// mask change affects every grant referencing the role, so the affected users are not
+    /// knowable from the single changed row. Policy/Role writes are infrequent admin operations,
+    /// and the installing triggers' <c>WHEN</c> clauses keep this off every other
+    /// <c>mesh_nodes</c> write. Schema-qualified via <c>TG_TABLE_SCHEMA</c> — an unqualified call
+    /// resolves through the WRITING SESSION's <c>search_path</c> (<c>public</c> on the shared
+    /// base pool) and silently rebuilds the wrong schema (the 2026-07-13 incident class; see
+    /// <see cref="AccessChangedTriggerFunctionBody"/>).</para>
+    /// </summary>
+    internal const string PolicyOrRoleChangedTriggerFunctionBody = """
+        BEGIN
+            EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', TG_TABLE_SCHEMA);
+            RETURN NULL;
+        END;
+        """;
+
+    /// <summary>
     /// One-shot server-side reconciliation of the auth mirror AND the permission projection:
     /// per partition schema it (a) installs the <c>mesh_node_mirror_access_objects</c> trigger
     /// where missing, (a2) CREATE OR REPLACEs the schema's <c>trg_access_changed()</c> with the
@@ -464,7 +495,13 @@ public static class PostgreSqlSchemaInitializer
     /// <c>zzz_group_recompute_*</c> triggers on <c>auth.mesh_nodes</c>
     /// (<see cref="GroupChangedTriggerFunctionBody"/>) so a Group/GroupMembership change — which
     /// mirrors into <c>auth</c> — recomputes every schema that grants the affected group
-    /// (cross-partition group licensing), (b) upserts every mirrored
+    /// (cross-partition group licensing), (a2b) re-applies the CURRENT
+    /// <c>rebuild_user_effective_permissions()</c> / <c>rebuild_user_permissions_for()</c> bodies
+    /// per schema so projection-fold changes converge on existing partitions each boot,
+    /// (a5) heals the <c>trg_policy_or_role_changed()</c> function + the three
+    /// <c>policy_or_role_changed_*</c> triggers on <c>mesh_nodes</c>
+    /// (<see cref="PolicyOrRoleChangedTriggerFunctionBody"/> — issue #603: policy/role writes
+    /// must re-project), (b) upserts every mirrored
     /// node type (<c>User/Group/Role/VUser/ApiToken/Space/GroupMembership</c>) into <c>auth.mesh_nodes</c>, and
     /// (c) re-runs the schema's <c>rebuild_user_effective_permissions()</c> so <c>_Access</c>
     /// grants and <c>_Policy</c> rows are projected into <c>user_effective_permissions</c> +
@@ -490,6 +527,24 @@ public static class PostgreSqlSchemaInitializer
         {{AccessChangedTriggerFunctionBody}}
         $trg_access$ LANGUAGE plpgsql
         $acfix$;
+            -- The CURRENT permission-rebuild function bodies + the policy/role trigger function
+            -- (single-sourced from the same C# building blocks the partition DDL embeds), so a
+            -- body change (e.g. the issue-#603 PublicRead projection) converges on every existing
+            -- partition at the next boot instead of depending on a one-time migration.
+            -- __mw_partition__ sits inside SQL literals ('__mw_partition__') → replace()d with
+            -- the bare schema name; __mw_schema__ is an identifier slot → quote_ident. Plain
+            -- replace, NOT format() — the bodies carry their own %I/%L format specs.
+            uep_fn text := $uepfix$
+        {{GetUepRebuildFunctionScript($"'{PartitionNameSentinel}'")}}
+        $uepfix$;
+            peruser_fn text := $userfix$
+        {{GetPerUserRebuildFunctionScript($"'{PartitionNameSentinel}'")}}
+        $userfix$;
+            polrole_fn text := $prfix$
+        CREATE OR REPLACE FUNCTION __mw_schema__.trg_policy_or_role_changed() RETURNS TRIGGER AS $trg_polrole$
+        {{PolicyOrRoleChangedTriggerFunctionBody}}
+        $trg_polrole$ LANGUAGE plpgsql
+        $prfix$;
         BEGIN
             IF to_regclass('"auth".mesh_nodes') IS NULL THEN
                 RETURN;
@@ -572,6 +627,48 @@ public static class PostgreSqlSchemaInitializer
                             'CREATE TRIGGER access_changed '
                             || 'AFTER INSERT OR UPDATE OR DELETE ON %I.access '
                             || 'FOR EACH ROW EXECUTE FUNCTION %I.trg_access_changed()', s, s);
+                    END IF;
+
+                    -- (a2b) Re-apply the CURRENT permission-rebuild function bodies so body
+                    --     changes (the issue-#603 PublicRead projection; any future fold) reach
+                    --     EXISTING partitions on every boot instead of depending on a one-time
+                    --     migration. The DDL is unqualified — the same text every installer
+                    --     ships — so route it into the partition via search_path exactly like
+                    --     public.ensure_partition_schema does, then reset.
+                    EXECUTE format('SET LOCAL search_path TO %I, public', s);
+                    EXECUTE replace(uep_fn, '__mw_partition__', s);
+                    EXECUTE replace(peruser_fn, '__mw_partition__', s);
+                    EXECUTE 'SET LOCAL search_path TO public';
+
+                    -- (a5) Policy/Role → projection triggers (issue #603): _Policy and Role rows
+                    --     live in mesh_nodes, which access_changed never watches — without these
+                    --     a policy/role write left the projection stale until the next _Access
+                    --     write or reboot. Heal the function on every pass; install the three
+                    --     WHEN-gated triggers where missing.
+                    EXECUTE replace(polrole_fn, '__mw_schema__', quote_ident(s));
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_trigger tg
+                        JOIN pg_class c ON c.oid = tg.tgrelid
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        WHERE tg.tgname = 'policy_or_role_changed_ins'
+                          AND c.relname = 'mesh_nodes' AND n.nspname = s)
+                    THEN
+                        EXECUTE format(
+                            'CREATE TRIGGER policy_or_role_changed_ins '
+                            || 'AFTER INSERT ON %I.mesh_nodes '
+                            || 'FOR EACH ROW WHEN (NEW.node_type IN (''PartitionAccessPolicy'',''Role'')) '
+                            || 'EXECUTE FUNCTION %I.trg_policy_or_role_changed()', s, s);
+                        EXECUTE format(
+                            'CREATE TRIGGER policy_or_role_changed_upd '
+                            || 'AFTER UPDATE ON %I.mesh_nodes '
+                            || 'FOR EACH ROW WHEN (OLD.node_type IN (''PartitionAccessPolicy'',''Role'') '
+                            || 'OR NEW.node_type IN (''PartitionAccessPolicy'',''Role'')) '
+                            || 'EXECUTE FUNCTION %I.trg_policy_or_role_changed()', s, s);
+                        EXECUTE format(
+                            'CREATE TRIGGER policy_or_role_changed_del '
+                            || 'AFTER DELETE ON %I.mesh_nodes '
+                            || 'FOR EACH ROW WHEN (OLD.node_type IN (''PartitionAccessPolicy'',''Role'')) '
+                            || 'EXECUTE FUNCTION %I.trg_policy_or_role_changed()', s, s);
                     END IF;
                 END IF;
 
@@ -689,6 +786,16 @@ public static class PostgreSqlSchemaInitializer
                 -- 4. Satellite tables (schema-agnostic; land in the partition via search_path).
                 satellite_ddl := $satellite${satelliteDdl}$satellite$;
                 EXECUTE satellite_ddl;
+
+                -- 5. Reconcile the permission projection for this partition (issue #603:
+                --    partition provisioning is itself an event that changes effective
+                --    permissions). Idempotent and cheap on a fresh schema (no grants yet);
+                --    on a RE-provisioned partition it purges the stale
+                --    public.partition_access rows a previous DROP SCHEMA left behind (the
+                --    from-scratch rebuild deletes partition rows whose users no longer hold
+                --    a Read grant), so a recreated partition never inherits the old one's
+                --    fan-out visibility.
+                EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', partition_name);
             END;
             $ensure_partition_schema$ LANGUAGE plpgsql;
             """;
@@ -1196,149 +1303,7 @@ public static class PostgreSqlSchemaInitializer
             CREATE INDEX IF NOT EXISTS idx_access_node_type_lower ON access (LOWER(node_type));
             CREATE INDEX IF NOT EXISTS idx_access_main_node_lower ON access (LOWER(main_node));
 
-            -- Per-user permission rebuild: concurrent-safe, only touches one user's rows.
-            CREATE OR REPLACE FUNCTION rebuild_user_permissions_for(p_user_id TEXT) RETURNS void AS $$
-            BEGIN
-                EXECUTE format('SET LOCAL search_path TO %I, public', '{{schemaName}}');
-                DELETE FROM user_effective_permissions WHERE user_id = p_user_id;
-
-                -- Direct entries from AccessAssignment nodes for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT
-                    p_user_id,
-                    COALESCE(aa.main_node, aa.namespace),
-                    perm.permission,
-                    NOT COALESCE((role_entry->>'denied')::boolean, false)
-                FROM access aa
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
-                         WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145 ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->>'accessObject' = p_user_id
-                  AND aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- Group expansion for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM "auth".mesh_nodes gm
-                    CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
-                    WHERE gm.node_type = 'GroupMembership'
-                    UNION
-                    SELECT am.group_path, gm.content->>'member'
-                    FROM all_members am
-                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
-                    WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g WHERE g->>'group' = am.member_id)
-                ),
-                user_groups AS (
-                    SELECT DISTINCT group_path FROM all_members WHERE member_id = p_user_id
-                )
-                SELECT p_user_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
-                       NOT COALESCE((role_entry->>'denied')::boolean, false)
-                FROM access aa
-                JOIN user_groups ug ON aa.content->>'accessObject' = ug.group_path
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
-                         WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145 ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- access_control entries for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT subject, node_path, permission, is_allow FROM access_control WHERE subject = p_user_id
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- PartitionAccessPolicy caps for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT DISTINCT p_user_id, policy.namespace, perm.permission, false
-                FROM mesh_nodes policy
-                CROSS JOIN (
-                    SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
-                           unnest(ARRAY['read','create','update','delete','comment']) AS field
-                ) perm
-                WHERE policy.node_type = 'PartitionAccessPolicy' AND policy.id = '_Policy'
-                  AND (policy.content->>perm.field)::boolean = false
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
-
-                -- Sync partition_access for this user
-                BEGIN
-                    IF EXISTS (SELECT 1 FROM user_effective_permissions
-                               WHERE user_id = p_user_id AND permission = 'Read' AND is_allow = true) THEN
-                        INSERT INTO public.partition_access (user_id, partition)
-                        VALUES (p_user_id, '{{schemaName}}') ON CONFLICT DO NOTHING;
-                    ELSE
-                        DELETE FROM public.partition_access
-                        WHERE user_id = p_user_id AND partition = '{{schemaName}}';
-                    END IF;
-                EXCEPTION WHEN undefined_table THEN NULL;
-                END;
-            END;
-            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
-            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
-            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
-            -- _Access write and once per schema in the boot self-heal sweep.
-            $$ LANGUAGE plpgsql SET jit = off;
+            {{GetPerUserRebuildFunctionScript(schemaRef)}}
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
             -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is
@@ -1356,6 +1321,36 @@ public static class PostgreSqlSchemaInitializer
             CREATE TRIGGER access_changed
                 AFTER INSERT OR UPDATE OR DELETE ON access
                 FOR EACH ROW EXECUTE FUNCTION trg_access_changed();
+
+            -- Policy/Role → projection triggers (issue #603). PartitionAccessPolicy ({ns}/_Policy)
+            -- and custom Role nodes are REGULAR mesh_nodes rows (no satellite table), yet both are
+            -- INPUTS to the rebuild: the policy fold projects _Policy caps + PublicRead grants, and
+            -- grant rows resolve role permission masks from Role nodes. access_changed above never
+            -- sees them, so without these triggers an ordinary policy/role write changed the LIVE
+            -- evaluator's answer while the denormalized projection stayed stale until the next
+            -- _Access write or boot self-heal — readable but unlistable (or wrongly still listed).
+            -- Body single-sourced from PolicyOrRoleChangedTriggerFunctionBody (TG_TABLE_SCHEMA-
+            -- qualified rebuild); the WHEN clauses keep this off every non-policy/role write.
+            CREATE OR REPLACE FUNCTION trg_policy_or_role_changed() RETURNS TRIGGER AS $trg_polrole$
+            {{PolicyOrRoleChangedTriggerFunctionBody}}
+            $trg_polrole$ LANGUAGE plpgsql;
+
+            DROP TRIGGER IF EXISTS policy_or_role_changed_ins ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_ins
+                AFTER INSERT ON mesh_nodes
+                FOR EACH ROW WHEN (NEW.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
+            DROP TRIGGER IF EXISTS policy_or_role_changed_upd ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_upd
+                AFTER UPDATE ON mesh_nodes
+                FOR EACH ROW WHEN (OLD.node_type IN ('PartitionAccessPolicy','Role')
+                                OR NEW.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
+            DROP TRIGGER IF EXISTS policy_or_role_changed_del ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_del
+                AFTER DELETE ON mesh_nodes
+                FOR EACH ROW WHEN (OLD.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
 
             -- Group/GroupMembership recompute is NOT installed per-partition: it is driven from the
             -- global auth mirror (see GetAuthMirrorSelfHealScript / trg_group_changed) so a group
@@ -1518,10 +1513,11 @@ public static class PostgreSqlSchemaInitializer
     /// DDL for the schema-scoped <c>rebuild_user_effective_permissions()</c> function —
     /// single-sourced because THREE installers ship it: <see cref="GetMeshSchemaScript"/>,
     /// <see cref="GetVersionedPartitionDdl"/> (and through it the
-    /// <c>public.ensure_partition_schema</c> proc), and the V47 migration that re-applies
-    /// the current body to every EXISTING partition schema (the schema script only runs
-    /// for the boot schema + newly provisioned partitions, so a body change needs the
-    /// migration to reach already-provisioned schemas).
+    /// <c>public.ensure_partition_schema</c> proc), and the per-boot
+    /// <see cref="GetAuthMirrorSelfHealScript"/>, which re-applies the current body to every
+    /// EXISTING partition schema (the schema script only runs for the boot schema + newly
+    /// provisioned partitions, so a body change converges on already-provisioned schemas via
+    /// the self-heal on the next boot — historically a one-time migration, e.g. V47, did this).
     ///
     /// <para><paramref name="schemaRef"/> is the SQL literal/expression for the owning
     /// schema — same contract as <see cref="GetVersionedPartitionDdl"/> (a quoted literal
@@ -1735,6 +1731,27 @@ public static class PostgreSqlSchemaInitializer
               AND (policy.content->>perm.field)::boolean = false
             ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
 
+            -- PublicRead policy GRANTS (issue #603): the live evaluator ORs a PublicRead policy's
+            -- Read in for EVERY viewer, AFTER roles ∩ cap (PermissionEvaluator.ComputeRoleState:
+            -- p |= publicGrant). Project the same grant as allow-Read rows for the well-known
+            -- 'Public' (every authenticated user — the query folds user IN (user,'Public')) and
+            -- 'Anonymous' subjects. Without these rows a partition whose ONLY read surface is a
+            -- PublicRead _Policy (e.g. a plugin-installed catalog — PackageInstaller writes
+            -- exactly this) had NO uep row → NO partition_access row → the whole schema dropped
+            -- out of the fan-out: every node readable by exact path yet absent from every
+            -- listing. Runs AFTER the policy-cap deny fold with DO UPDATE is_allow = true so at
+            -- the SAME prefix the public grant wins — matching the live override order. (A deny
+            -- at a LONGER prefix still wins the per-subject longest-prefix query fold; that is
+            -- the store-gating shape and it is intentional.)
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT DISTINCT subj.user_id, policy.namespace, 'Read', true
+            FROM mesh_nodes policy
+            CROSS JOIN (SELECT unnest(ARRAY['Public','Anonymous']) AS user_id) subj
+            WHERE policy.node_type = 'PartitionAccessPolicy'
+              AND policy.id = '_Policy'
+              AND (policy.content->>'publicRead')::boolean = true
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = true;
+
             -- Atomic swap
             ALTER TABLE user_effective_permissions RENAME TO user_effective_permissions_old;
             ALTER TABLE user_effective_permissions_shadow RENAME TO user_effective_permissions;
@@ -1757,6 +1774,184 @@ public static class PostgreSqlSchemaInitializer
             EXCEPTION WHEN undefined_table THEN
                 -- partition_access table may not exist yet (first migration)
                 NULL;
+            END;
+        END;
+        -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+        -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+        -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+        -- _Access write and once per schema in the boot self-heal sweep.
+        $$ LANGUAGE plpgsql SET jit = off;
+        """;
+
+    /// <summary>
+    /// DDL for the schema-scoped per-user <c>rebuild_user_permissions_for(p_user_id)</c>
+    /// function — the subject-scoped fast path <c>trg_access_changed()</c> takes for a non-group
+    /// grant write. Single-sourced (same <paramref name="schemaRef"/> contract as
+    /// <see cref="GetUepRebuildFunctionScript"/>) because THREE installers ship it:
+    /// <see cref="GetMeshSchemaScript"/>, <see cref="GetVersionedPartitionDdl"/> (and through it
+    /// the <c>public.ensure_partition_schema</c> proc), and the per-boot
+    /// <see cref="GetAuthMirrorSelfHealScript"/>, which re-applies the current body to every
+    /// existing partition schema so a body change converges on restart without a migration.
+    ///
+    /// <para>🚨 Must stay fold-for-fold consistent with
+    /// <see cref="GetUepRebuildFunctionScript"/> for the subject being rebuilt — this function
+    /// DELETEs every row of <c>p_user_id</c> first, so a fold present in the full rebuild but
+    /// missing here silently WIPES that fold's rows on the next per-subject rebuild (a
+    /// projection divergence of exactly the issue-#603 class; the PublicRead re-derivation below
+    /// exists for this reason).</para>
+    /// </summary>
+    public static string GetPerUserRebuildFunctionScript(string schemaRef) => $$"""
+        -- Per-user permission rebuild: concurrent-safe, only touches one user's rows.
+        CREATE OR REPLACE FUNCTION rebuild_user_permissions_for(p_user_id TEXT) RETURNS void AS $$
+        BEGIN
+            EXECUTE format('SET LOCAL search_path TO %I, public', {{schemaRef}});
+            DELETE FROM user_effective_permissions WHERE user_id = p_user_id;
+
+            -- Direct entries from AccessAssignment nodes for this user
+            INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            SELECT
+                p_user_id,
+                COALESCE(aa.main_node, aa.namespace),
+                perm.permission,
+                NOT COALESCE((role_entry->>'denied')::boolean, false)
+            FROM access aa
+            CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(
+                    (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
+                     WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
+                    CASE role_entry->>'role'
+                        WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
+                        WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
+                        WHEN 'Commenter' THEN 145 ELSE 0
+                    END
+                ) AS permissions
+            ) r
+            CROSS JOIN LATERAL (
+                SELECT unnest(
+                    CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
+                ) AS permission
+            ) perm
+            WHERE aa.content->>'accessObject' = p_user_id
+              AND aa.content->'roles' IS NOT NULL
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
+
+            -- Group expansion for this user
+            INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            WITH RECURSIVE all_members AS (
+                SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
+                FROM "auth".mesh_nodes gm
+                CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
+                WHERE gm.node_type = 'GroupMembership'
+                UNION
+                SELECT am.group_path, gm.content->>'member'
+                FROM all_members am
+                JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g WHERE g->>'group' = am.member_id)
+            ),
+            user_groups AS (
+                SELECT DISTINCT group_path FROM all_members WHERE member_id = p_user_id
+            )
+            SELECT p_user_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
+                   NOT COALESCE((role_entry->>'denied')::boolean, false)
+            FROM access aa
+            JOIN user_groups ug ON aa.content->>'accessObject' = ug.group_path
+            CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(
+                    (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
+                     WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
+                    CASE role_entry->>'role'
+                        WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
+                        WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
+                        WHEN 'Commenter' THEN 145 ELSE 0
+                    END
+                ) AS permissions
+            ) r
+            CROSS JOIN LATERAL (
+                SELECT unnest(
+                    CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
+                ) AS permission
+            ) perm
+            WHERE aa.content->'roles' IS NOT NULL
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
+
+            -- access_control entries for this user
+            INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            SELECT subject, node_path, permission, is_allow FROM access_control WHERE subject = p_user_id
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
+
+            -- PartitionAccessPolicy caps for this user
+            INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+            SELECT DISTINCT p_user_id, policy.namespace, perm.permission, false
+            FROM mesh_nodes policy
+            CROSS JOIN (
+                SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
+                       unnest(ARRAY['read','create','update','delete','comment']) AS field
+            ) perm
+            WHERE policy.node_type = 'PartitionAccessPolicy' AND policy.id = '_Policy'
+              AND (policy.content->>perm.field)::boolean = false
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
+
+            -- PublicRead policy grants (see rebuild_user_effective_permissions, issue #603):
+            -- re-derive the allow-Read rows when the rebuilt subject IS a public subject. This
+            -- function starts by DELETING every row of p_user_id, so without this branch a
+            -- per-subject rebuild of 'Public'/'Anonymous' (any _Access grant write naming them)
+            -- would wipe the policy-derived public rows and re-hide the partition from every
+            -- listing. AFTER the caps fold with DO UPDATE is_allow = true — the public grant
+            -- wins at the same prefix, matching the live evaluator's override order.
+            INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+            SELECT DISTINCT p_user_id, policy.namespace, 'Read', true
+            FROM mesh_nodes policy
+            WHERE p_user_id IN ('Public','Anonymous')
+              AND policy.node_type = 'PartitionAccessPolicy' AND policy.id = '_Policy'
+              AND (policy.content->>'publicRead')::boolean = true
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = true;
+
+            -- Sync partition_access for this user
+            BEGIN
+                IF EXISTS (SELECT 1 FROM user_effective_permissions
+                           WHERE user_id = p_user_id AND permission = 'Read' AND is_allow = true) THEN
+                    INSERT INTO public.partition_access (user_id, partition)
+                    VALUES (p_user_id, {{schemaRef}}) ON CONFLICT DO NOTHING;
+                ELSE
+                    DELETE FROM public.partition_access
+                    WHERE user_id = p_user_id AND partition = {{schemaRef}};
+                END IF;
+            EXCEPTION WHEN undefined_table THEN NULL;
             END;
         END;
         -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
@@ -1965,149 +2160,7 @@ public static class PostgreSqlSchemaInitializer
             CREATE INDEX IF NOT EXISTS idx_access_node_type_lower ON access (LOWER(node_type));
             CREATE INDEX IF NOT EXISTS idx_access_main_node_lower ON access (LOWER(main_node));
 
-            -- Per-user permission rebuild: concurrent-safe, only touches one user's rows.
-            CREATE OR REPLACE FUNCTION rebuild_user_permissions_for(p_user_id TEXT) RETURNS void AS $$
-            BEGIN
-                EXECUTE format('SET LOCAL search_path TO %I, public', {{schemaRef}});
-                DELETE FROM user_effective_permissions WHERE user_id = p_user_id;
-
-                -- Direct entries from AccessAssignment nodes for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT
-                    p_user_id,
-                    COALESCE(aa.main_node, aa.namespace),
-                    perm.permission,
-                    NOT COALESCE((role_entry->>'denied')::boolean, false)
-                FROM access aa
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
-                         WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145 ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->>'accessObject' = p_user_id
-                  AND aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- Group expansion for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM "auth".mesh_nodes gm
-                    CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
-                    WHERE gm.node_type = 'GroupMembership'
-                    UNION
-                    SELECT am.group_path, gm.content->>'member'
-                    FROM all_members am
-                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
-                    WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g WHERE g->>'group' = am.member_id)
-                ),
-                user_groups AS (
-                    SELECT DISTINCT group_path FROM all_members WHERE member_id = p_user_id
-                )
-                SELECT p_user_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
-                       NOT COALESCE((role_entry->>'denied')::boolean, false)
-                FROM access aa
-                JOIN user_groups ug ON aa.content->>'accessObject' = ug.group_path
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (rn.content->>'permissions')::int FROM mesh_nodes rn
-                         WHERE rn.node_type = 'Role' AND rn.id = role_entry->>'role' LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535 WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527 WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145 ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- access_control entries for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT subject, node_path, permission, is_allow FROM access_control WHERE subject = p_user_id
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
-
-                -- PartitionAccessPolicy caps for this user
-                INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
-                SELECT DISTINCT p_user_id, policy.namespace, perm.permission, false
-                FROM mesh_nodes policy
-                CROSS JOIN (
-                    SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
-                           unnest(ARRAY['read','create','update','delete','comment']) AS field
-                ) perm
-                WHERE policy.node_type = 'PartitionAccessPolicy' AND policy.id = '_Policy'
-                  AND (policy.content->>perm.field)::boolean = false
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
-
-                -- Sync partition_access for this user
-                BEGIN
-                    IF EXISTS (SELECT 1 FROM user_effective_permissions
-                               WHERE user_id = p_user_id AND permission = 'Read' AND is_allow = true) THEN
-                        INSERT INTO public.partition_access (user_id, partition)
-                        VALUES (p_user_id, {{schemaRef}}) ON CONFLICT DO NOTHING;
-                    ELSE
-                        DELETE FROM public.partition_access
-                        WHERE user_id = p_user_id AND partition = {{schemaRef}};
-                    END IF;
-                EXCEPTION WHEN undefined_table THEN NULL;
-                END;
-            END;
-            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
-            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
-            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
-            -- _Access write and once per schema in the boot self-heal sweep.
-            $$ LANGUAGE plpgsql SET jit = off;
+            {{GetPerUserRebuildFunctionScript(schemaRef)}}
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
             -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is
@@ -2125,6 +2178,36 @@ public static class PostgreSqlSchemaInitializer
             CREATE TRIGGER access_changed
                 AFTER INSERT OR UPDATE OR DELETE ON access
                 FOR EACH ROW EXECUTE FUNCTION trg_access_changed();
+
+            -- Policy/Role → projection triggers (issue #603). PartitionAccessPolicy ({ns}/_Policy)
+            -- and custom Role nodes are REGULAR mesh_nodes rows (no satellite table), yet both are
+            -- INPUTS to the rebuild: the policy fold projects _Policy caps + PublicRead grants, and
+            -- grant rows resolve role permission masks from Role nodes. access_changed above never
+            -- sees them, so without these triggers an ordinary policy/role write changed the LIVE
+            -- evaluator's answer while the denormalized projection stayed stale until the next
+            -- _Access write or boot self-heal — readable but unlistable (or wrongly still listed).
+            -- Body single-sourced from PolicyOrRoleChangedTriggerFunctionBody (TG_TABLE_SCHEMA-
+            -- qualified rebuild); the WHEN clauses keep this off every non-policy/role write.
+            CREATE OR REPLACE FUNCTION trg_policy_or_role_changed() RETURNS TRIGGER AS $trg_polrole$
+            {{PolicyOrRoleChangedTriggerFunctionBody}}
+            $trg_polrole$ LANGUAGE plpgsql;
+
+            DROP TRIGGER IF EXISTS policy_or_role_changed_ins ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_ins
+                AFTER INSERT ON mesh_nodes
+                FOR EACH ROW WHEN (NEW.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
+            DROP TRIGGER IF EXISTS policy_or_role_changed_upd ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_upd
+                AFTER UPDATE ON mesh_nodes
+                FOR EACH ROW WHEN (OLD.node_type IN ('PartitionAccessPolicy','Role')
+                                OR NEW.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
+            DROP TRIGGER IF EXISTS policy_or_role_changed_del ON mesh_nodes;
+            CREATE TRIGGER policy_or_role_changed_del
+                AFTER DELETE ON mesh_nodes
+                FOR EACH ROW WHEN (OLD.node_type IN ('PartitionAccessPolicy','Role'))
+                EXECUTE FUNCTION trg_policy_or_role_changed();
 
             -- Group/GroupMembership recompute is NOT installed per-partition: it is driven from the
             -- global auth mirror (see GetAuthMirrorSelfHealScript / trg_group_changed) so a group

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PermissionProjectionSyncTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PermissionProjectionSyncTests.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins that <b>every event that changes effective permissions reaches the denormalized
+/// projection</b> (<c>user_effective_permissions</c> + <c>public.partition_access</c>) — the
+/// tables every query-backed listing (search, space navigator, chat picker, autocomplete)
+/// filters on — with NO manual rebuild, NO reboot (issue #603).
+///
+/// <para><b>The divergence being guarded.</b> Access is evaluated by two surfaces: the LIVE
+/// reactive <c>PermissionEvaluator</c> (direct node opens, <c>RlsNodeValidator</c>) and the
+/// denormalized projection (SQL listing filter). Both derive from the same nodes, but by
+/// different mechanisms. <c>AccessAssignment</c> writes land in the <c>access</c> satellite
+/// (covered by <c>trg_access_changed</c>) and Group/GroupMembership changes ride the auth
+/// mirror's <c>zzz_group_recompute_*</c> triggers (pinned by
+/// <see cref="GroupMembershipRecomputeTests"/>) — but <c>PartitionAccessPolicy</c>
+/// (<c>{ns}/_Policy</c>) and custom <c>Role</c> nodes are REGULAR <c>mesh_nodes</c> rows
+/// (<see cref="SatelliteTableMapping"/> deliberately excludes <c>_Policy</c>), and
+/// <c>mesh_nodes</c> had NO projection trigger: a policy/role write changed the live
+/// evaluator's answer (~1s synced query) while the projection stayed stale until the next
+/// unrelated <c>_Access</c> write in the same schema or the next boot's self-heal. A node then
+/// stayed readable by exact path but vanished from — or wrongly lingered in — every listing,
+/// silently, admin-invisibly (the #919 Store-lockout step). These tests drive each event
+/// through the PRODUCTION write shape (the shared base <see cref="Npgsql.NpgsqlDataSource"/>,
+/// default <c>search_path</c> = <c>public</c>, schema-qualified statements) and assert the
+/// LISTING converges, so they also pin the <c>TG_TABLE_SCHEMA</c> qualification.</para>
+///
+/// <para>Polling shape per WritingTests.md ("Polling loops around QueryAsync"): re-query on an
+/// interval, filter on the predicate, bounded timeout — the projection rebuild is asynchronous
+/// relative to the originating write's transaction visibility from another connection.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class PermissionProjectionSyncTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    // camelCase — the naming policy the mesh hub uses for node content. The rebuild reads
+    // camelCase JSON keys (content->>'accessObject', content->>'publicRead', content->>'read').
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public PermissionProjectionSyncTests(PostgreSqlFixture fixture) => _fixture = fixture;
+
+    // ── Production-shaped fixtures (mirrors AccessTriggerSchemaResolutionTests) ─────────────
+
+    private async Task<PostgreSqlStorageAdapter> ProvisionProdShapeAdapterAsync(
+        string space, string schema, CancellationToken ct)
+    {
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT public.ensure_partition_schema('{schema}')", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var def = new PartitionDefinition
+        {
+            Namespace = space,
+            Schema = schema,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        return new PostgreSqlStorageAdapter(_fixture.DataSource, partitionDefinition: def);
+    }
+
+    private Task WriteSpaceRootAsync(PostgreSqlStorageAdapter adapter, string space, CancellationToken ct)
+        => adapter.WriteAsync(new MeshNode(space)
+        {
+            Name = $"{space} Inc.",
+            NodeType = SpaceNodeType.NodeType,
+            State = MeshNodeState.Active,
+            MainNode = space,
+            Content = new Space()
+        }, _options, ct);
+
+    /// <summary>A plain content node — "Document" is NOT public_read in node_type_permissions,
+    /// so the node-level projection fold (not the nodeType bypass) decides listing visibility.</summary>
+    private Task WriteDocAsync(PostgreSqlStorageAdapter adapter, string space, string id, CancellationToken ct)
+        => adapter.WriteAsync(new MeshNode(id, space)
+        {
+            Name = id,
+            NodeType = "Document",
+            State = MeshNodeState.Active,
+            MainNode = $"{space}/{id}"
+        }, _options, ct);
+
+    /// <summary>A <c>PartitionAccessPolicy</c> node at <c>{ns}/_Policy</c> written through the
+    /// ORDINARY node pipeline (a regular <c>mesh_nodes</c> row — no satellite table).</summary>
+    private Task WritePolicyAsync(
+        PostgreSqlStorageAdapter adapter, string ns, PartitionAccessPolicy policy, CancellationToken ct)
+        => adapter.WriteAsync(AssignmentNodeFactory.Policy(ns, policy) with
+        {
+            State = MeshNodeState.Active,
+            MainNode = $"{ns}/_Policy"
+        }, _options, ct);
+
+    // ── Listing probe: the permission-gated cross-schema fan-out every listing rides ────────
+
+    private Task<List<string>> VisiblePathsAsync(string schema, string userId, CancellationToken ct)
+    {
+        var provider = new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource);
+        var query = new QueryParser().Parse("nodeType:Document is:main");
+        return provider
+            .QueryAcrossSchemasAsync(query, _options, [schema], "mesh_nodes", userId, activityUserId: null, ct)
+            .Collect(ct)
+            .Select(nodes => nodes.Select(n => n.Path).ToList())
+            .Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>
+    /// Waits until the user's LISTING satisfies <paramref name="predicate"/>, then returns it.
+    /// A single read is not a valid assertion — the projection rebuild is event-driven and lands
+    /// after the originating write commits; polling the real condition removes the timing
+    /// dependence (sanctioned shape, WritingTests.md).
+    /// </summary>
+    private Task<List<string>> VisibleUntil(
+        string schema, string userId, Func<List<string>, bool> predicate, string because, CancellationToken ct)
+        => Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .StartWith(0L)
+            .SelectMany(_ => Observable.FromAsync(() => VisiblePathsAsync(schema, userId, ct)))
+            .Where(predicate)
+            .Should().Within(30.Seconds()).Emit(because);
+
+    // ── 1. AccessAssignment create/delete (access satellite → trg_access_changed) ───────────
+
+    /// <summary>
+    /// Matrix row 1 (regression pin — this path was already event-driven): an <c>_Access</c>
+    /// grant written through the shared base pool makes the node appear in the granted user's
+    /// listing with no manual rebuild; deleting the grant makes it disappear again.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task GrantAndRevoke_ThroughAccessSatellite_SyncListings()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "projgrant";
+        const string space = "ProjGrant";
+        const string alice = "proj_alice";
+        var docPath = $"{space}/Alpha";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteDocAsync(adapter, space, "Alpha", ct);
+
+        await VisibleUntil(schema, alice, paths => !paths.Contains(docPath),
+            "no grant yet — the listing must not show the node", ct);
+
+        var grant = AssignmentNodeFactory.UserRole(alice, "Editor", space);
+        await adapter.WriteAsync(grant, _options, ct);
+
+        await VisibleUntil(schema, alice, paths => paths.Contains(docPath),
+            "writing the _Access grant must project into user_effective_permissions and surface " +
+            "the node in the listing — no manual rebuild", ct);
+
+        await adapter.DeleteAsync(grant.Path, ct);
+
+        await VisibleUntil(schema, alice, paths => !paths.Contains(docPath),
+            "deleting the _Access grant must remove the projection rows and hide the node again", ct);
+    }
+
+    // ── 2. PartitionAccessPolicy write/delete (mesh_nodes → policy_or_role_changed_*) ───────
+
+    /// <summary>
+    /// THE #603 event gap: a <c>_Policy</c> written through the ordinary node pipeline (a
+    /// <c>mesh_nodes</c> row — the shape every application writer produces; the test-only
+    /// <c>PostgreSqlAccessControl.SetPolicyAsync</c> convenience was the ONLY writer that
+    /// rebuilt) must, on its own, re-project the partition's permissions. A Read-deny policy
+    /// hides the granted user's listing; deleting the policy restores it. Without the
+    /// <c>policy_or_role_changed_*</c> triggers the projection stayed stale in BOTH directions
+    /// until an unrelated <c>_Access</c> write or reboot.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task PolicyReadDeny_WrittenThroughNodePipeline_SyncsListings_WithoutManualRebuild()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "projpolicy";
+        const string space = "ProjPolicy";
+        const string alice = "projpol_alice";
+        var docPath = $"{space}/Alpha";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteDocAsync(adapter, space, "Alpha", ct);
+        await adapter.WriteAsync(AssignmentNodeFactory.UserRole(alice, "Editor", space), _options, ct);
+
+        await VisibleUntil(schema, alice, paths => paths.Contains(docPath),
+            "precondition: the Editor grant surfaces the node", ct);
+
+        // The policy write — live evaluator caps Read within ~1s; the projection must follow.
+        await WritePolicyAsync(adapter, space, new PartitionAccessPolicy { Read = false }, ct);
+
+        await VisibleUntil(schema, alice, paths => !paths.Contains(docPath),
+            "writing the Read-deny _Policy through the node pipeline must re-project the " +
+            "partition's permissions and hide the node from the listing — no manual rebuild, " +
+            "no reboot (issue #603)", ct);
+
+        // The inverse event: deleting the policy must also re-project.
+        await adapter.DeleteAsync($"{space}/_Policy", ct);
+
+        await VisibleUntil(schema, alice, paths => paths.Contains(docPath),
+            "deleting the _Policy must re-project and restore the listing", ct);
+    }
+
+    // ── 3. PublicRead policy (grant-side projection parity with the live evaluator) ─────────
+
+    /// <summary>
+    /// The grant-side half of the same divergence: the live evaluator ORs a
+    /// <c>PublicRead = true</c> policy's Read grant in for EVERY viewer
+    /// (<c>PermissionEvaluator.ComputeRoleState</c> — <c>p |= publicGrant</c>), so a partition
+    /// whose only read surface is a PublicRead <c>_Policy</c> (e.g. a plugin-installed catalog —
+    /// <c>PackageInstaller</c> writes exactly this shape) is READABLE node-by-node. The
+    /// projection carried no corresponding allow rows at all — no uep row → no
+    /// <c>partition_access</c> row → the whole schema dropped out of the fan-out: readable but
+    /// unlistable for every role-less user. The rebuild must project PublicRead as allow-Read
+    /// rows for the well-known <c>Public</c>/<c>Anonymous</c> subjects, and the policy write
+    /// itself must trigger that rebuild.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task PublicReadPolicy_WrittenThroughNodePipeline_MakesPartitionListable_ForRolelessUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "projpublic";
+        const string space = "ProjPublic";
+        const string visitor = "projpub_visitor";   // authenticated, role-less — folds via 'Public'
+        var docPath = $"{space}/Alpha";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteDocAsync(adapter, space, "Alpha", ct);
+
+        await VisibleUntil(schema, visitor, paths => !paths.Contains(docPath),
+            "no grant, no policy — nothing is listable", ct);
+
+        await WritePolicyAsync(adapter, space, new PartitionAccessPolicy { PublicRead = true }, ct);
+
+        await VisibleUntil(schema, visitor, paths => paths.Contains(docPath),
+            "a PublicRead _Policy grants Read to every viewer on the LIVE evaluator; the " +
+            "projection must carry the same grant so listings agree (issue #603 family)", ct);
+
+        // partition_access synced for the public subject — the fan-out's schema gate.
+        var publicAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = 'Public' AND partition = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        publicAccess.Should().Be(1, "the rebuild syncs partition_access for the PublicRead grant");
+
+        // Withdrawing the public surface must re-project too (UPDATE arm of the trigger).
+        await WritePolicyAsync(adapter, space, new PartitionAccessPolicy { PublicRead = false }, ct);
+
+        await VisibleUntil(schema, visitor, paths => !paths.Contains(docPath),
+            "flipping PublicRead off must remove the projected public grant and hide the listing again", ct);
+    }
+
+    // ── 4. Custom Role mask change (mesh_nodes → policy_or_role_changed_*) ───────────────────
+
+    /// <summary>
+    /// The other <c>mesh_nodes</c>-resident projection input: grant rows resolve their
+    /// permission mask from custom <c>Role</c> nodes at REBUILD time
+    /// (<c>content-&gt;&gt;'permissions'</c>), so editing a role's mask changes every grant that
+    /// references it. Without the trigger the projection kept the OLD mask until an unrelated
+    /// event — here, revoking Read from the role must hide the listing on its own.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task CustomRoleMaskChange_SyncsGrantedListings()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "projrole";
+        const string space = "ProjRole";
+        const string bob = "projrole_bob";
+        const string roleId = "ProjReader";
+        var docPath = $"{space}/Alpha";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteDocAsync(adapter, space, "Alpha", ct);
+
+        Task WriteRoleAsync(Permission permissions) => adapter.WriteAsync(new MeshNode(roleId, space)
+        {
+            Name = roleId,
+            NodeType = "Role",
+            State = MeshNodeState.Active,
+            MainNode = $"{space}/{roleId}",
+            Content = new Role { Id = roleId, Permissions = permissions }
+        }, _options, ct);
+
+        await WriteRoleAsync(Permission.Read);
+        await adapter.WriteAsync(AssignmentNodeFactory.UserRole(bob, roleId, space), _options, ct);
+
+        await VisibleUntil(schema, bob, paths => paths.Contains(docPath),
+            "precondition: the custom-role grant (mask = Read) surfaces the node", ct);
+
+        // Edit the ROLE, not the grant: strip Read from the mask.
+        await WriteRoleAsync(Permission.Comment);
+
+        await VisibleUntil(schema, bob, paths => !paths.Contains(docPath),
+            "changing the Role node's permission mask must re-project every grant that " +
+            "references it — no manual rebuild (issue #603)", ct);
+    }
+
+    // ── 5. Drift purge: orphan projection rows die on the next from-scratch rebuild ─────────
+
+    /// <summary>
+    /// Issue #603's observed instance, end to end: a projection-only per-node deny with NO
+    /// backing <c>_Access</c>/<c>_Policy</c> node (the injected drift) hides exactly one sibling
+    /// from the listing while the authoritative model is untouched. The full rebuild is
+    /// from-scratch (TRUNCATE shadow + atomic swap), so the orphan cannot survive ANY
+    /// subsequent projection event — and because policy writes now trigger that rebuild, an
+    /// ordinary admin action (touching the partition's <c>_Policy</c>) heals the drift without
+    /// a raw DB session or a reboot.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task OrphanProjectionDeny_IsPurged_ByNextPolicyEvent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "projdrift";
+        const string space = "ProjDrift";
+        const string carol = "projdrift_carol";
+        var hiddenPath = $"{space}/Gamma";
+        var siblingPath = $"{space}/Alpha";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteDocAsync(adapter, space, "Alpha", ct);
+        await WriteDocAsync(adapter, space, "Gamma", ct);
+        await adapter.WriteAsync(AssignmentNodeFactory.UserRole(carol, "Editor", space), _options, ct);
+
+        await VisibleUntil(schema, carol,
+            paths => paths.Contains(siblingPath) && paths.Contains(hiddenPath),
+            "precondition: the space grant lists BOTH siblings", ct);
+
+        // Inject the drift: a per-node Read deny for carol at Gamma's exact prefix, with no
+        // backing node anywhere (issue #603, repro step B3 — simulates a materialization desync).
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"INSERT INTO \"{schema}\".user_effective_permissions (user_id, node_path_prefix, permission, is_allow) " +
+            $"VALUES ('{carol}', '{hiddenPath}', 'Read', false) " +
+            "ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false", ct)
+            .Should().Within(30.Seconds()).Emit();
+
+        await VisibleUntil(schema, carol,
+            paths => paths.Contains(siblingPath) && !paths.Contains(hiddenPath),
+            "the longest-prefix deny hides exactly the drifted sibling — the observed #603 shape", ct);
+
+        // An ordinary admin action — touching the partition's policy — must run the
+        // from-scratch rebuild and purge the orphan.
+        await WritePolicyAsync(adapter, space, new PartitionAccessPolicy { Comment = false }, ct);
+
+        await VisibleUntil(schema, carol,
+            paths => paths.Contains(siblingPath) && paths.Contains(hiddenPath),
+            "the policy write triggers the from-scratch rebuild (TRUNCATE shadow + swap), which " +
+            "purges the orphan deny — the drift heals through a normal event, no raw SQL, no reboot", ct);
+    }
+}


### PR DESCRIPTION
Fixes #603 — the denormalized permission projection (`user_effective_permissions`) could silently diverge from the live access check: a node stayed readable but vanished from all listings. Yesterday's Store lockout (#919) had exactly this as a step: policy written, listings still empty until out-of-band action.

## The event → projection matrix — four real gaps found and closed

| Event | Pre-fix | Fix |
|---|---|---|
| `AccessAssignment` writes (access satellite) | covered (existing trigger) | — |
| Group/GroupMembership | covered (auth-mirror recompute) | — |
| **`PartitionAccessPolicy` (`_Policy`) write via the node pipeline** | **GAP — the primary #603 event.** `_Policy` is a plain `mesh_nodes` row and `mesh_nodes` had NO projection trigger; the only rebuilding writer was a test-only convenience method. Every application writer (e.g. the plugin installer) left the projection stale until an unrelated `_Access` write or reboot. | New `trg_policy_or_role_changed()` + three WHEN-gated triggers on `mesh_nodes` |
| **Custom `Role` node write** | GAP — masks resolved only at rebuild time | same triggers (`'Role'` in WHEN) |
| **`PublicRead = true` (grant side)** | **GAP (state mapping)** — the live evaluator ORs PublicRead in for every viewer; the projection had *no allow-row shape at all* (the fold wrote only denies) → no `partition_access` row → the whole schema dropped from the fan-out: readable node-by-node, absent from every listing. This is the plugin-partition shape (#919). | PublicRead now projects `('Public'|'Anonymous', ns, 'Read', true)` rows in BOTH the full rebuild and the per-user rebuild (without the latter, a per-subject rebuild of `Public` would delete-then-lose the policy rows — a divergence the fix itself would have introduced). |
| **Partition provisioning** | GAP (minor) — a re-created partition inherited the previous life's stale rows | rebuild step in `ensure_partition_schema` |
| Deployed DBs (body drift) | needed a one-time V-migration | **boot-time self-heal** re-applies rebuild-function bodies + trigger topology per schema — deployed DBs converge on next restart, no migration |

Orphan purge falls out: full rebuilds are TRUNCATE-shadow + atomic swap, and a policy touch now triggers one — so an admin heals a drifted partition with an ordinary write.

## Reconciliation ordering — verified, not assumed

No direct-read surface consults `user_effective_permissions`: exact-path opens gate through the live `PermissionEvaluator` (`MeshNodeStreamCache:1355-1405`), and query results are re-validated live (`StorageAdapterMeshQueryProvider.ValidateRead` → `RlsNodeValidator`). All other references are the SQL listing filters. So a drifted projection can only **under-list** (fail-closed), never lock a user out of a readable node.

## Verification

`PermissionProjectionSyncTests` (5, Testcontainers, production write shape, listings asserted through the permission-gated cross-schema fan-out): grant/revoke sync; policy deny write/delete sync **without manual rebuild**; PublicRead policy makes the partition listable for a roleless user (and flips off); custom Role mask change re-projects; an injected orphan deny is purged by the next policy event.

**Fail-without** (unpatched src): **4 failed / 1 passed** — the four timed out exactly on the projection never converging. **Pass-with: 5/5.** Full `Hosting.PostgreSql.Test` **644 passed / 0 failed / 1 pre-existing skip** · `Security.Test` **345/345** · `NodeOperations.Test` **85/85**. Independently re-verified **11/11** (new class + `GroupMembershipRecomputeTests`) after merging current main. `-c Release -warnaserror` clean.

## Residual (documented)

- PublicRead-ancestor + *deeper* deny: the projected fold and the live evaluator differ on that combination; unused today (store gating denies under non-PublicRead roots), documented in the fold comment.
- `_Access`-node deletion still doesn't purge `access_control` convenience rows (test-scoped writers only) — flagged on the issue.
- A hub-serialized custom Role (string-enum) would already fail today's rebuild cast — pre-existing, noted on the issue.
- Policy/Role writes now run a full rebuild inside the write transaction — same profile as grant writes, serialized by the existing advisory lock, WHEN-gated off all other `mesh_nodes` traffic.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)
