### PR TITLE
Activation seeds from durable truth — the write-loss family fixed at its root (#590 #648 #667)

### DIFF
--- a/src/MeshWeaver.Data.Contract/MeshNodeError.cs
+++ b/src/MeshWeaver.Data.Contract/MeshNodeError.cs
@@ -57,9 +57,21 @@ public enum MeshNodeErrorCode
     /// this code is the owner's explicit statement that the write is gone, so the
     /// mirror may safely re-enqueue the SAME update against the fresh activation:
     /// the re-enqueue re-diffs against the freshest state, making it idempotent and
-    /// ordering-safe. Every other NACK code stays terminal (never auto-retried).
+    /// ordering-safe. Together with <see cref="OwnerNotReady"/> these are the only
+    /// auto-retried NACK codes; every other code stays terminal.
     /// </summary>
-    OwnerDisposing = 7
+    OwnerDisposing = 7,
+    /// <summary>
+    /// The owning activation is up but has NOT finished loading its durable state
+    /// (activation seed in flight — a slow storage read, a NodeType assembly reload
+    /// window) — the patch was provably NEVER applied. 🚨 Deliberately distinct from
+    /// <see cref="NotFound"/>: answering "not found" for a node that exists poisons
+    /// every existence check built on the read (and the stream cache's negative
+    /// cache) — the #667 deploy-window write loss. Same retry contract as
+    /// <see cref="OwnerDisposing"/>: the write never happened, so the mirror may
+    /// safely re-enqueue the SAME update once the activation has loaded.
+    /// </summary>
+    OwnerNotReady = 8
 }
 
 /// <summary>

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -694,6 +694,32 @@ public static class DataExtensions
         IMessageHub hub, IMessageDelivery<PatchDataRequest> request)
     {
         var hubPath = hub.Address.ToString();
+
+        // 🚨 Single-writer activation invariant (#648): a SUPERSEDED activation must
+        // refuse-and-redirect, never merge-and-ack. A hub past Started is quiescing or
+        // disposing — its in-RAM state is about to die and its persistence writes are
+        // dropped by the teardown guards, so applying a patch here manufactures a
+        // Success-acked write whose state the fresh activation never sees (the stale-
+        // second-activation write loss of TwoSiloRecycleConvergence, run 30159928718).
+        // At handler entry the merge turn has provably NOT run, so OwnerDisposing is
+        // exact: the caller's re-enqueue machinery redirects the SAME update to the
+        // fresh activation, where it re-diffs against the freshest state.
+        if (hub.RunLevel > MessageHubRunLevel.Started)
+        {
+            var supersededErr = new MeshNodeError(
+                MeshNodeErrorCode.OwnerDisposing,
+                hubPath,
+                "superseded activation: this owner is quiescing/disposing — the patch was "
+                + "NOT applied; safe to retry against the fresh activation");
+            hub.Post(new PatchDataResponse(false, hub.Version)
+                {
+                    Error = supersededErr.Message,
+                    NodeError = supersededErr,
+                },
+                o => o.ResponseFor(request));
+            return request.Processed();
+        }
+
         try
         {
             var reference = request.Message.Reference;
@@ -881,8 +907,14 @@ public static class DataExtensions
     /// patch can never flap a field — string edits merge by splice, conflicting scalars are refused.
     /// Without base values (legacy / one-off senders) it falls back to the
     /// <see cref="DropStaleMonotonicTriggers"/> guard + plain <see cref="MergePatchRecursive"/>.
+    /// <returns>The number of REFUSED keys — fields whose conflicting write was dropped in favour of
+    /// the newer live value. 🚨 The caller MUST NOT ack a patch as Success when every intended change
+    /// was refused (refusals &gt; 0 and the node is unchanged): a refused write did not land, and
+    /// acking it Success is the silent acked-write-loss of #648. Monotonic-trigger DROPS are not
+    /// counted — a backward move of a strictly-increasing trigger is a legal merge outcome
+    /// (superseded by the newer instant), not a lost write.</returns>
     /// </summary>
-    internal static void ApplyMeshNodeMerge(
+    internal static int ApplyMeshNodeMerge(
         System.Text.Json.Nodes.JsonObject currentNode,
         System.Text.Json.Nodes.JsonObject patchNode,
         bool isMeshNode,
@@ -906,17 +938,23 @@ public static class DataExtensions
                 // request LOST (memex-cloud 2026-07-20 GitSync burst: every explicit Store/Plugin
                 // compile trigger was dropped while mirrors lagged the owner).
                 RebaseMonotonicTriggers(currentNode, patchNode, baseValues, jsonOpts, logger, hubPath);
+                var refused = 0;
                 Serialization.MeshNodePatchMerge.Apply(currentNode, patchNode, baseValues,
-                    onRefuse: key => logger?.LogWarning(
-                        "[MergeGuard] {HubPath}: refused stale/reordered cross-hub write to '{Key}' "
-                        + "(changed since the writer's base) — kept the newer live value.", hubPath, key));
-                return;
+                    onRefuse: key =>
+                    {
+                        refused++;
+                        logger?.LogWarning(
+                            "[MergeGuard] {HubPath}: refused stale/reordered cross-hub write to '{Key}' "
+                            + "(changed since the writer's base) — kept the newer live value.", hubPath, key);
+                    });
+                return refused;
             }
             // No base carried (MCP one-off / legacy sender): keep the monotonic-trigger guard so a bare
             // RequestedReleaseAt patch still can't flap, then merge last-write-wins.
             DropStaleMonotonicTriggers(currentNode, patchNode, jsonOpts, logger, hubPath);
         }
         MergePatchRecursive(currentNode, patchNode);
+        return 0;
     }
 
     /// <summary>
@@ -1139,7 +1177,7 @@ public static class DataExtensions
                     // request) so a reordered/stale write can't flap a field; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
                     var preMergeNode = currentNode.DeepClone().AsObject();
-                    ApplyMeshNodeMerge(currentNode, patchNode,
+                    var refusedKeys = ApplyMeshNodeMerge(currentNode, patchNode,
                         typeof(T).FullName == "MeshWeaver.Mesh.MeshNode",
                         request.Message, jsonOpts,
                         hub.ServiceProvider.GetService<ILoggerFactory>()
@@ -1151,10 +1189,19 @@ public static class DataExtensions
                     // commit — the version bump below would otherwise MANUFACTURE the difference
                     // that makes it look like a change. On THIS deferred path a no-op commit also
                     // never emits, so the post-commit subscription would time out and NACK a write
-                    // that in fact succeeded. Ack success up front against the untouched state.
+                    // that in fact succeeded. Ack success up front against the untouched state —
+                    // 🚨 UNLESS the merge REFUSED keys and nothing landed: then the caller's write
+                    // provably did not happen, and acking Success is the #648 acked-write-loss.
+                    // NACK with Conflict so the caller re-reads and re-applies.
                     if (System.Text.Json.Nodes.JsonNode.DeepEquals(preMergeNode, currentNode))
                     {
-                        AckOnce(true);
+                        if (refusedKeys > 0)
+                            AckOnce(false, new MeshNodeError(
+                                MeshNodeErrorCode.Conflict, hubPath,
+                                $"cross-hub write refused: {refusedKeys} field(s) changed on the owner "
+                                + "since the writer's base and nothing was applied — re-read and re-apply"));
+                        else
+                            AckOnce(true);
                         return;
                     }
 
@@ -1441,10 +1488,18 @@ public static class DataExtensions
                                 .Timeout(TimeSpan.FromSeconds(10))
                                 .Subscribe(
                                     _ => RunMergeTurn(deferred: true),
+                                    // 🚨 NOT NotFound (#667): the store never initialized within the
+                                    // bound — that is an activation that has not LOADED, not an owner
+                                    // answering "no such node". A NotFound here is a false negative
+                                    // for a node that exists (it poisons existence checks and the
+                                    // stream cache's negative cache); OwnerNotReady states the truth
+                                    // — the patch was provably never applied — and is auto-retried
+                                    // by the caller against the loaded activation.
                                     _ => AckOnce(false, new MeshNodeError(
-                                        MeshNodeErrorCode.NotFound, hubPath,
-                                        "Target MeshNode not found for patch apply "
-                                        + "(store did not initialize within the bound)")));
+                                        MeshNodeErrorCode.OwnerNotReady, hubPath,
+                                        "owner activation has not loaded its state within the bound — "
+                                        + "the patch was NOT applied; safe to retry once the "
+                                        + "activation has loaded")));
                             hub.RegisterForDisposal(deferSub);
                             return null; // no write this turn — the deferred attempt commits
                         }
@@ -1465,18 +1520,27 @@ public static class DataExtensions
                     // reordered/stale cross-hub patch merge instead of flapping; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
                     var preMergeNode = currentNode.DeepClone().AsObject();
-                    ApplyMeshNodeMerge(currentNode, patchNode, isMeshNode: true,
+                    var refusedKeys = ApplyMeshNodeMerge(currentNode, patchNode, isMeshNode: true,
                         request.Message, jsonOpts, mergeGuardLogger, hubPath);
                     // 🚨 Owner-side no-change backstop: a patch whose every value already matches
-                    // the live node (an MCP patch re-asserting current state, a refused three-way
-                    // merge, an importer re-writing unchanged content) must NOT bump the Version,
-                    // persist a history row or tick the change feed. Gate BEFORE the bump — the
-                    // bump itself would otherwise manufacture the difference. Ack success with the
-                    // untouched state; the no-emission path is already handled (AckOnce latches,
-                    // postSub timeout dedupes) exactly like the NotFound no-op above.
+                    // the live node (an MCP patch re-asserting current state, an importer
+                    // re-writing unchanged content) must NOT bump the Version, persist a history
+                    // row or tick the change feed. Gate BEFORE the bump — the bump itself would
+                    // otherwise manufacture the difference. Ack success with the untouched state;
+                    // the no-emission path is already handled (AckOnce latches, postSub timeout
+                    // dedupes) exactly like the NotFound no-op above.
+                    // 🚨 #648 invariant: a merge that REFUSED keys and changed nothing must NOT
+                    // ack Success — the caller's write provably did not land. NACK with Conflict
+                    // so the caller re-reads and re-applies instead of believing the lie.
                     if (System.Text.Json.Nodes.JsonNode.DeepEquals(preMergeNode, currentNode))
                     {
-                        AckOnce(true);
+                        if (refusedKeys > 0)
+                            AckOnce(false, new MeshNodeError(
+                                MeshNodeErrorCode.Conflict, hubPath,
+                                $"cross-hub write refused: {refusedKeys} field(s) changed on the owner "
+                                + "since the writer's base and nothing was applied — re-read and re-apply"));
+                        else
+                            AckOnce(true);
                         return null;
                     }
                     // The OWNER bumps the Version on apply (same rule as the deferred path).

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -104,6 +104,18 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     // resurrect the row via the activation-save below. See RecentlyDeletedRegistry.
     private readonly RecentlyDeletedRegistry? _recentlyDeletedRegistry;
 
+    // Latest node the ROUTING-supplied own-node stream has delivered — captured by a
+    // ctor-time subscription so the durable-first activation seed can GRAFT the routing
+    // node's NON-PERSISTABLE enrichment (the in-process HubConfiguration delegate) onto
+    // the raw durable row. The routing node is ENRICHED by ResolveHubConfiguration; the
+    // durable row can never carry the delegate (it does not serialize). Without the graft,
+    // every HubConfiguration-reading consumer of the workspace's own node — the compile
+    // watcher's truly-static exclusion, the first-build kickoff, NodeTypeDataModelAreas —
+    // sees null on a durable-first seed and misclassifies a static NodeType as "needs a
+    // first build" (the spurious activation compile that rewrote ContentNarrowing's
+    // persisted bytes). See GraftRoutingEnrichment.
+    private MeshNode? _latestRoutingNode;
+
     internal MeshNodeTypeSource(
         IWorkspace workspace,
         object dataSource,
@@ -125,6 +137,19 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         _ownNodeStream = ownNodeStream?
             .DistinctUntilChanged()
             .Replay(1).RefCount();
+        // Capture the latest routing emission for the enrichment graft (see
+        // _latestRoutingNode). Subscribed at construction so the snapshot is in hand
+        // BEFORE Initialize's durable-first seed emits: on Monolith the routing leg is
+        // Observable.Return(enriched) (synchronous), on Orleans it replays the node the
+        // grain activation already resolved. Subscribing this stream touches no hub or
+        // workspace construction — it is the routing layer's already-materialized value.
+        if (_ownNodeStream is not null)
+        {
+            var enrichmentCaptureSub = _ownNodeStream.Subscribe(
+                n => Volatile.Write(ref _latestRoutingNode, n),
+                _ => { });
+            workspace.Hub.RegisterForDisposal(enrichmentCaptureSub);
+        }
         _logger = workspace.Hub.ServiceProvider.GetService<ILogger<MeshNodeTypeSource>>();
         _ownNodeCache = workspace.Hub.ServiceProvider
             .GetService<MeshDataSourceExtensions.OwnNodeCache>();
@@ -696,12 +721,27 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     /// </para>
     /// <para>
     /// So the seed is the durable row (<c>Doc/Architecture/MeshNodeVersioning.md</c>: "the node
-    /// loads its persisted Version verbatim on activation"), MERGED with — not replaced by —
-    /// the routing stream, and every emission passes <see cref="AcceptOwnNodeEmission"/>, which
-    /// drops any node whose <see cref="MeshNode.Version"/> regresses below the highest already
-    /// held. Merge (rather than Concat) is deliberate: a slow or faulted storage read can never
-    /// delay or block activation — the routing stream still seeds, exactly as before — while a
-    /// stale routing emission loses to the durable one on version.
+    /// loads its persisted Version verbatim on activation"), and the routing stream FOLLOWS it,
+    /// with every emission passing <see cref="AcceptOwnNodeEmission"/>, which drops any node
+    /// whose <see cref="MeshNode.Version"/> regresses below the highest already held.
+    /// </para>
+    /// <para>
+    /// 🚨 <b>Concat (durable settles FIRST), not Merge — the #648/#590/#667 activation family.</b>
+    /// The previous <c>Observable.Merge</c> raced the two legs and the framework's initial-store
+    /// build (<c>GetInitialValueAsync</c>) takes the FIRST accepted emission and then DISPOSES
+    /// the subscription — so on any asynchronous backend (Postgres, blob) the synchronously-
+    /// replaying routing cache reliably beat the durable read, the hub seeded an arbitrarily
+    /// stale snapshot as live state, and the late durable emission was never even observed.
+    /// Every write then minted below the durable row, the MonotonicWriteGuard refused it, and
+    /// the <c>AdoptDurableTruth</c> rebase clobbered the acked write in RAM (the #590 "updates
+    /// stop persisting" / #648 acked-write-loss shape). Concat subscribes the routing leg only
+    /// after the durable read has SETTLED (emitted its row-or-null and completed, or degraded to
+    /// Empty on a fault), so when a durable row exists it is by construction the activation
+    /// seed. Activation therefore HOLDS for the duration of one storage read — #667's "wait,
+    /// don't Not-found": messages queue against the initializing stream instead of being
+    /// answered from absent/stale state. A FAULTED read still falls back to the routing leg
+    /// (see <see cref="DurableSeed"/>), with the storage-level MonotonicWriteGuard as the
+    /// backstop against a rollback from that degraded seed.
     /// </para>
     /// <para>
     /// When no stream is supplied (fixtures that bypass routing), falls back
@@ -714,13 +754,23 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         CancellationToken cancellationToken)
     {
         if (_ownNodeStream is not null)
-            // Tag the source and filter DOWNSTREAM of the merge: Observable.Merge serialises
-            // notifications through its gate, so the version bookkeeping and
+            // Tag the source and filter DOWNSTREAM of the concatenation: Concat subscribes the
+            // legs strictly one after the other, so the version bookkeeping and
             // BuildInstanceCollection stay single-threaded — a Where placed on each leg
-            // instead would run on that leg's own thread, outside the gate.
-            return Observable.Merge(
-                    DurableSeed().Select(n => (Node: n, Durable: true)),
-                    _ownNodeStream.Select(n => (Node: n, Durable: false)))
+            // instead would run on that leg's own thread, outside the sequential chain.
+            //
+            // 🚨 Concat, NOT Merge: the durable read must SETTLE before the cache-backed
+            // routing leg may seed — see the contract in this method's doc. The framework's
+            // initial-store build takes the FIRST accepted emission and disposes the
+            // subscription, so under Merge a stale routing replay that won the race became
+            // the activation seed and the late durable row was discarded unobserved.
+            //
+            // The durable row is grafted with the routing node's non-persistable enrichment
+            // (GraftRoutingEnrichment) so a durable-first seed never strips the in-process
+            // HubConfiguration delegate that the compile watcher / first-build kickoff /
+            // data-model areas read off the workspace's own node.
+            return DurableSeed().Select(n => (Node: GraftRoutingEnrichment(n), Durable: true))
+                .Concat(_ownNodeStream.Select(n => (Node: n, Durable: false)))
                 .Where(e => AcceptOwnNodeEmission(e.Node, e.Durable))
                 .Select(e => BuildInstanceCollection(e.Node));
 
@@ -734,6 +784,29 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // queued CreateNodeRequest / GetDataResponse traffic isn't held forever.
         _workspace.Hub.OpenGate(MeshNodeExtensions.MeshNodeInitGateName);
         return Observable.Return(_lastSaved);
+    }
+
+    /// <summary>
+    /// Grafts the ROUTING node's non-persistable enrichment onto the durable activation
+    /// seed: the in-process <see cref="MeshNode.HubConfiguration"/> delegate that
+    /// <c>ResolveHubConfiguration</c> computed cannot survive a round-trip through storage,
+    /// so a durable row read straight from the store never carries it. The durable row stays
+    /// authoritative for VERSION and CONTENT (the write-loss family's invariant); only the
+    /// delegate rides over — and only when the routing snapshot describes the SAME path.
+    /// Consumers of the workspace's own node that key on the delegate (the compile watcher's
+    /// truly-static exclusion, the first-build kickoff, <c>NodeTypeDataModelAreas</c>) then
+    /// behave identically whether the seed came from the durable read or the routing replay.
+    /// Fail-open: no routing snapshot (or no delegate on it) leaves the row untouched.
+    /// </summary>
+    private MeshNode? GraftRoutingEnrichment(MeshNode? durableRow)
+    {
+        if (durableRow is null || durableRow.HubConfiguration is not null)
+            return durableRow;
+        var routing = Volatile.Read(ref _latestRoutingNode);
+        if (routing?.HubConfiguration is null
+            || !string.Equals(routing.Path, durableRow.Path, StringComparison.OrdinalIgnoreCase))
+            return durableRow;
+        return durableRow with { HubConfiguration = routing.HubConfiguration };
     }
 
     /// <summary>
@@ -758,15 +831,18 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     /// logged at Warning with the exception and then dropped. Either way the routing stream
     /// still seeds and the hub comes up exactly as it did before this change.</para>
     ///
-    /// <para><b>No wall-clock bound, on purpose.</b> The merge (not concat) in
-    /// <c>Initialize</c> already makes a stalled read harmless: it cannot delay or block
-    /// activation, it just never contributes. A <c>Timeout</c> would therefore change nothing
-    /// about liveness — it would only be able to make things worse, because a cold-partition
-    /// read under a boot storm legitimately takes tens of seconds and a budget short enough to
-    /// be a useful signal would start SKIPPING the seed on exactly the slow activations that
-    /// need it most. The stall does not go unguarded: <c>MonotonicWriteGuardStorageAdapter</c>
-    /// is the independent backstop — a hub that never got its seed and adopts a stale snapshot
-    /// still cannot roll the store back. That is why the fix is two changes and not one.</para>
+    /// <para><b>No wall-clock bound, on purpose.</b> <c>Initialize</c> concatenates this read
+    /// AHEAD of the routing leg, so a slow read now HOLDS activation for its duration — that is
+    /// the design (#667's "wait, don't Not-found"): a cold-partition read under a boot storm
+    /// legitimately takes tens of seconds, and answering messages from absent/stale state in
+    /// that window is precisely the write-loss family this seed exists to kill. A
+    /// <c>Timeout</c> here would re-open that hole on exactly the slow activations that need
+    /// the durable seed most — the read either settles truthfully (row, null, or a FAULT that
+    /// degrades to the routing leg via the Catch below) or the storage adapter is defective,
+    /// and a defective adapter must surface as held callers' bounded errors, not as a silent
+    /// stale seed. <c>MonotonicWriteGuardStorageAdapter</c> stays the independent backstop —
+    /// a hub whose seed degraded to the cache-backed routing leg still cannot roll the store
+    /// back.</para>
     /// </summary>
     private IObservable<MeshNode?> DurableSeed()
     {

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -74,6 +74,17 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
     public override IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
         => Observable.Defer(() =>
         {
+            // 🚨 A durable store cannot hold an in-process delegate. FileSystem/Postgres strip
+            // MeshNode.HubConfiguration naturally at the serialization boundary; this adapter
+            // stores the INSTANCE, so without this strip a workspace node that carries the
+            // routing-grafted enrichment (or a compilation-error overlay wrapper) would be
+            // retained in the store-of-record, later served back by reads/path-resolution, and
+            // latch EnrichWithNodeType's "already enriched" short-circuit onto a STALE config —
+            // an instance then re-binds an obsolete overlay on every re-activation instead of
+            // re-enriching (the OverlaySelfHealInstanceRecycleTest probe loop). Stripping here
+            // makes the in-memory adapter behave exactly like every serializing backend.
+            if (node.HubConfiguration is not null)
+                node = node with { HubConfiguration = null };
             if (!string.IsNullOrEmpty(node.Path))
             {
                 _nodes[Norm(node.Path)] = node;

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1076,7 +1076,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                 var lateErr = resp.NodeError ?? new MeshNodeError(
                                     MeshNodeErrorCode.Unknown, _path!,
                                     resp.Error ?? "Update rejected by owner");
-                                if (lateErr.Code == MeshNodeErrorCode.OwnerDisposing
+                                // OwnerNotReady carries the same provably-never-applied contract
+                                // as OwnerDisposing (activation had not loaded its state — #667),
+                                // so the same idempotent re-enqueue applies.
+                                if (lateErr.Code is MeshNodeErrorCode.OwnerDisposing
+                                        or MeshNodeErrorCode.OwnerNotReady
                                     && attempt < MaxOwnerDisposingReenqueues)
                                 {
                                     diagLogger?.LogWarning(
@@ -1143,6 +1147,31 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                             var err = resp.NodeError ?? new MeshNodeError(
                                                 MeshNodeErrorCode.Unknown, _path!,
                                                 resp.Error ?? "Update rejected by owner");
+                                            // 🚨 Refuse-and-REDIRECT (#648): OwnerDisposing /
+                                            // OwnerNotReady are the owner's explicit statement
+                                            // that the patch was provably NEVER applied — a
+                                            // superseded activation quiescing, or an activation
+                                            // whose durable seed had not loaded. Re-enqueue the
+                                            // SAME update against the fresh/loaded activation
+                                            // (the re-diff against the freshest state makes it
+                                            // idempotent), chaining its outcome to THIS caller.
+                                            // Every other code stays a fail-fast terminal.
+                                            if (err.Code is MeshNodeErrorCode.OwnerDisposing
+                                                    or MeshNodeErrorCode.OwnerNotReady
+                                                && attempt < MaxOwnerDisposingReenqueues)
+                                            {
+                                                diagLogger?.LogWarning(
+                                                    "[UpdateRemote] OWNER_NACK_REENQUEUE hub={Hub} target={Path} code={Code} attempt={Attempt} — the patch was never applied; re-enqueueing against the fresh activation",
+                                                    _workspace.Hub.Address, _path, err.Code, attempt + 1);
+                                                using (accessServiceAtEntry is not null && capturedContextAtEntry is not null
+                                                    ? accessServiceAtEntry.SwitchAccessContext(capturedContextAtEntry)
+                                                    : null)
+                                                {
+                                                    composite.Add(UpdateRemote(update, attempt + 1)
+                                                        .Subscribe(observer.OnNext, observer.OnError, observer.OnCompleted));
+                                                }
+                                                return;
+                                            }
                                             diagLogger?.LogWarning(
                                                 "[UpdateRemote] OWNER_REJECTED hub={Hub} target={Path} code={Code} msg={Msg}",
                                                 _workspace.Hub.Address, _path, err.Code, err.Message);

--- a/test/MeshWeaver.Hosting.Monolith.Test/GatedReadStorageAdapter.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GatedReadStorageAdapter.cs
@@ -1,0 +1,137 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Test-only innermost <see cref="IStorageAdapter"/> decorator that makes <see cref="Read"/>
+/// GENUINELY ASYNCHRONOUS for designated paths — the deterministic stand-in for a Postgres/blob
+/// backend whose activation-seed read lags the synchronously-replaying routing caches. This is
+/// what turns the per-node-hub activation races (#590/#648/#667 — stale seed, superseded
+/// activation, deploy-window write loss) from CI-load flakes into deterministic repros: hold the
+/// path's reads, drive the scenario, observe that the read was reached, release.
+///
+/// <para>Register it BEFORE the test base's <c>AddInMemoryPersistence</c> (whose
+/// <c>TryAddSingleton</c> then no-ops) so the framework's write-integrity chain
+/// (SubtreeDeletionGuard → MonotonicWriteGuard → VersionWriting) decorates THIS adapter —
+/// the gate then sits exactly where a slow backend sits, underneath every guard.</para>
+///
+/// <para>Instance state only (mesh-scoped singleton, dies with the test mesh) — no statics.</para>
+/// </summary>
+internal sealed class GatedReadStorageAdapter(IStorageAdapter inner) : IStorageAdapter
+{
+    private readonly ConcurrentDictionary<string, AsyncSubject<Unit>> _gates =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ReplaySubject<Unit>> _heldReadObserved =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, int> _writeCounts =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Holds every subsequent <see cref="Read"/> of <paramref name="path"/> until
+    /// <see cref="Release"/>. Idempotent per path.</summary>
+    public void HoldReads(string path)
+        => _gates.GetOrAdd(path, _ => new AsyncSubject<Unit>());
+
+    /// <summary>Opens the gate: held (and future) reads of <paramref name="path"/> proceed.</summary>
+    public void Release(string path)
+    {
+        if (_gates.TryRemove(path, out var gate))
+        {
+            gate.OnNext(Unit.Default);
+            gate.OnCompleted();
+        }
+    }
+
+    /// <summary>
+    /// Emits once a <see cref="Read"/> for <paramref name="path"/> has ARRIVED at a closed gate —
+    /// the positive "the activation/consumer reached its durable read and is held" signal tests
+    /// sequence on instead of sleeping. Replayed, so subscribing after the arrival still fires.
+    /// </summary>
+    public IObservable<Unit> WaitForHeldRead(string path)
+        => _heldReadObserved.GetOrAdd(path, _ => new ReplaySubject<Unit>(1)).Take(1);
+
+    /// <summary>Number of storage writes that REACHED this (innermost) adapter for
+    /// <paramref name="path"/> — refused writes never arrive here.</summary>
+    public int WriteCount(string path) => _writeCounts.GetValueOrDefault(path);
+
+    public IObservable<DataChangeNotification> Changes => inner.Changes;
+
+    public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            if (_gates.TryGetValue(path, out var gate))
+            {
+                _heldReadObserved.GetOrAdd(path, _ => new ReplaySubject<Unit>(1))
+                    .OnNext(Unit.Default);
+                return gate.SelectMany(_ => inner.Read(path, options));
+            }
+            return inner.Read(path, options);
+        });
+
+    public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+        => paths.Select(p => Read(p, options).Where(n => n is not null).Select(n => n!)).Merge();
+
+    public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            if (!string.IsNullOrEmpty(node.Path))
+                _writeCounts.AddOrUpdate(node.Path, 1, (_, c) => c + 1);
+            return inner.Write(node, options);
+        });
+
+    public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+        IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            foreach (var node in nodes)
+                if (!string.IsNullOrEmpty(node.Path))
+                    _writeCounts.AddOrUpdate(node.Path, 1, (_, c) => c + 1);
+            return inner.WriteMany(nodes, options);
+        });
+
+    public IObservable<string> Delete(string path) => inner.Delete(path);
+
+    public IObservable<bool> DeleteIfExists(string path) => inner.DeleteIfExists(path);
+
+    public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath)
+        => inner.ListChildPaths(parentPath);
+
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
+    public IObservable<bool> Exists(string path) => inner.Exists(path);
+
+    public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
+        string fullPath, JsonSerializerOptions options)
+        => inner.FindBestPrefixMatch(fullPath, options);
+
+    public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
+        string fullPath, JsonSerializerOptions options)
+        => inner.ResolvePath(fullPath, options);
+
+    public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
+        => inner.ListPartitionSubPaths(nodePath);
+
+    public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
+        => inner.GetPartitionObjects(nodePath, subPath, options);
+
+    public IObservable<Unit> SavePartitionObjects(
+        string nodePath, string? subPath,
+        IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+        => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+    public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+        => inner.DeletePartitionObjects(nodePath, subPath);
+
+    public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+        => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationDurableFirstSeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationDurableFirstSeedTest.cs
@@ -1,0 +1,228 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// DETERMINISTIC pins of the per-node-hub activation-seed family (#590 / #648 / #667) on an
+/// ASYNC storage backend, modelled by <see cref="GatedReadStorageAdapter"/>: the durable
+/// activation-seed read is held (exactly what a Postgres read under load looks like) while the
+/// cache-backed routing legs (path-resolution memo, mesh-node stream replay) answer instantly.
+///
+/// <para><b>The mechanism under test.</b> <c>MeshNodeTypeSource.Initialize</c> feeds the
+/// framework's initial-store build, which takes the FIRST accepted emission and disposes the
+/// subscription. Before the fix the durable read and the routing replay were Merge-raced, so on
+/// any async backend the STALE routing snapshot reliably won the seed and the late durable row
+/// was discarded unobserved. The reactivated hub then applied writes onto the stale snapshot,
+/// minted below the durable row, had every save refused by the MonotonicWriteGuard, and the
+/// AdoptDurableTruth rebase clobbered the acked write in RAM — the exact production shapes of
+/// #590 ("updates stop persisting after re-activation") and #667 ("in-flight writes are
+/// silently discarded during a deploy window"). The fix concatenates the legs: the durable read
+/// SETTLES first, the activation holds for its duration (#667's "wait, don't Not-found"), and a
+/// held write applies onto durable truth once the read completes.</para>
+///
+/// <para>The load-dependent twin of these pins is <c>StaleActivationSeedRollbackTest</c> (same
+/// state built via the synchronous in-memory adapter); the gate here removes the timing.</para>
+/// </summary>
+public class StaleActivationDurableFirstSeedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private GatedReadStorageAdapter Gated
+        => Mesh.ServiceProvider.GetRequiredService<GatedReadStorageAdapter>();
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+    private JsonSerializerOptions JsonOptions => Mesh.JsonSerializerOptions;
+
+    /// <summary>
+    /// Register the gate-wrapped in-memory adapter BEFORE the base's
+    /// <c>AddInMemoryPersistence</c> (whose TryAddSingleton then no-ops), so the framework's
+    /// write-integrity decorators wrap THIS adapter — the gate sits exactly where a slow
+    /// backend sits.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton(sp => new GatedReadStorageAdapter(
+                new InMemoryStorageAdapter(sp.GetService<ILogger<InMemoryStorageAdapter>>())));
+            services.AddSingleton<IStorageAdapter>(sp =>
+                sp.GetRequiredService<GatedReadStorageAdapter>());
+            return services;
+        });
+        return base.ConfigureMesh(builder);
+    }
+
+    /// <summary>Reads the node straight out of durable storage — bypassing every hub, stream and
+    /// cache — so an assertion about DURABILITY cannot be satisfied by an in-RAM snapshot.</summary>
+    private IObservable<MeshNode?> ReadDurable(string path) => Storage.Read(path, JsonOptions);
+
+    /// <summary>Disposes the per-node hub owning <paramref name="path"/> — the idle-recycle.</summary>
+    private async Task RecycleOwner(string path)
+    {
+        var resolution = await PathResolver.ResolvePath(path).Should().Within(30.Seconds()).Emit();
+        resolution.Should().NotBeNull($"'{path}' must resolve to an owning hub");
+        var owner = Mesh.GetHostedHub(new Address(resolution!.Prefix.ToString()!), HostedHubCreation.Never);
+        owner.Should().NotBeNull("the owner hub must be live after the warm read");
+        owner!.Dispose();
+        Output.WriteLine($"[recycle] disposed owner hub for {path}");
+    }
+
+    /// <summary>
+    /// #590 / #648 / #667: a post-recycle write issued while the reactivating hub's durable
+    /// seed read is IN FLIGHT must be HELD and then applied onto durable truth — never applied
+    /// onto the stale routing-cache snapshot (where its mint lands below the durable row, the
+    /// guard refuses every save, and the rebase clobbers the acked write), and never NACKed
+    /// NotFound for a node that exists.
+    /// <para><b>Fail-without:</b> with the Merge-raced seed the routing cache seeds the store
+    /// the moment the hub activates (the durable read is held), the write applies onto it and
+    /// is destroyed by the refusal→rebase cycle: "post-recycle" never becomes durable and the
+    /// final poll times out. <b>Pass-with:</b> activation holds until the gate opens, the seed
+    /// is the durable row, and the write lands strictly above it.</para>
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task PostRecycleWrite_WhenDurableSeedLagsTheRoutingCache_LandsAboveDurableTruth()
+    {
+        var id = $"gated-seed-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+
+        var created = await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+        Output.WriteLine($"[created] version={created!.Version}");
+
+        // Recycle the owner. The routing caches survive — that is the whole point.
+        await RecycleOwner(path);
+
+        // Durable state advances OUT OF BAND (the acked writes the recycled owner would not
+        // know about). Straight through IStorageAdapter: no IMeshChangeFeed publish, so the
+        // path-resolution cache keeps serving the pre-recycle node.
+        const long durableVersion = 9000L;
+        await Storage.Write(created with
+        {
+            Name = "durable-advance", Version = durableVersion
+        }, JsonOptions).Should().Within(30.Seconds()).Emit();
+        (await ReadDurable(path).Should().Within(30.Seconds()).Emit())!
+            .Version.Should().Be(durableVersion, "the out-of-band advance must be durable before we reactivate");
+
+        // Close the gate: from here, every durable read of the path (the reactivation's
+        // activation seed, the cache hydration, the guard's verification read) is held —
+        // the async-backend shape where the routing caches answer first.
+        var heldRead = Gated.WaitForHeldRead(path);
+        Gated.HoldReads(path);
+
+        var writeErrors = new List<Exception>();
+        var client = GetClient(c => c.AddData());
+        client.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "post-recycle" })
+            .Subscribe(
+                _ => { },
+                ex =>
+                {
+                    lock (writeErrors) writeErrors.Add(ex);
+                    Output.WriteLine($"[write error] {ex.Message}");
+                });
+
+        // Positive signal: a consumer of the durable row has reached the held read — the
+        // reactivation is in its activation window. Give the (un-fixed) stale-seed pipeline a
+        // short beat to do its damage inside the window, then open the gate. The beat only
+        // widens the demonstrated defect window on pre-fix code; with the fix the outcome is
+        // independent of it (activation simply holds until the release).
+        await heldRead.Should().Within(20.Seconds()).Emit();
+        await Observable.Timer(TimeSpan.FromMilliseconds(500)).Should().Within(10.Seconds()).Emit();
+        Gated.Release(path);
+        Output.WriteLine("[gate] released");
+
+        // The write must land durably, ABOVE the durable version: the activation seed was the
+        // durable row, and the write applied onto it.
+        var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .SelectMany(_ => ReadDurable(path))
+            .Should().Within(30.Seconds()).Match(n => n is { Name: "post-recycle" },
+                "a write held by a reactivating hub must apply onto the durable seed once the "
+                + "read settles — a hub seeded from the stale routing cache destroys it in the "
+                + "refusal→rebase cycle and the name never becomes durable");
+
+        Output.WriteLine($"[persisted] name={persisted!.Name} version={persisted.Version}");
+        persisted.Version.Should().BeGreaterThan(durableVersion,
+            "the write applied onto the durable seed, so its mint is strictly above the durable row "
+            + "— landing below it means the hub reactivated on the stale cache snapshot");
+
+        // #667: the held write must never have surfaced as a discard (NotFound / abort) —
+        // held-then-applied, or NACKed-retryable-and-retried, never silently dropped.
+        lock (writeErrors)
+            writeErrors.Should().BeEmpty(
+                "a write during the activation-hold window is held and applied — it must not "
+                + "error while the node provably exists");
+    }
+
+    /// <summary>
+    /// #590 invariant pin — activation is a READ: reactivating a per-node hub (via a plain
+    /// read) must serve durable truth and must not write ANYTHING back to storage. The #590
+    /// rollback was an activation-time write-back persisting hydrated stale state over newer
+    /// durable data; with the durable-first seed plus the initial-load echo suppression
+    /// (<c>OwnNodeCache.PersistedSnapshot</c>) a pure reactivation leaves the store untouched.
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task ReactivationViaRead_ServesDurableTruth_AndWritesNothingBack()
+    {
+        var id = $"read-reactivation-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+
+        await RecycleOwner(path);
+
+        // Advance durable truth out of band so the routing memo is provably stale.
+        const long durableVersion = 7000L;
+        var durable = (await ReadDurable(path).Should().Within(30.Seconds()).Emit())!;
+        await Storage.Write(durable with
+        {
+            Name = "durable-advance", Version = durableVersion
+        }, JsonOptions).Should().Within(30.Seconds()).Emit();
+
+        var writesBefore = Gated.WriteCount(path);
+
+        // Reactivate via READ — the same surface the GUI binds to.
+        var client = GetClient(c => c.AddData());
+        var served = await client.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .Should().Within(20.Seconds())
+            .Match(n => n.Name == "durable-advance",
+                "a reactivating hub must seed from (and serve) the durable row, not the stale "
+                + "routing-cache snapshot");
+        served.Version.Should().BeGreaterThanOrEqualTo(durableVersion);
+
+        // Negative window: give the debounce flush and the persistence sampler several of their
+        // 200 ms windows to write anything at all, then assert nothing reached the store.
+        await Observable.Timer(TimeSpan.FromSeconds(2)).Should().Within(20.Seconds()).Emit();
+
+        Gated.WriteCount(path).Should().Be(writesBefore,
+            "activation is a READ — persisting the just-loaded state back is the #590 "
+            + "activation write-back (v979: stale content re-persisted by system-security "
+            + "during activation)");
+        var after = await ReadDurable(path).Should().Within(20.Seconds()).Emit();
+        after!.Version.Should().Be(durableVersion, "the durable row must be untouched by the reactivation");
+        after.Name.Should().Be("durable-advance");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SupersededActivationPatchNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SupersededActivationPatchNackTest.cs
@@ -1,0 +1,178 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// DETERMINISTIC pins of the two #648 owner-side ack invariants:
+/// <list type="number">
+///   <item><b>All-keys-refused ⇒ never Success.</b> A cross-hub three-way merge that refuses
+///   EVERY intended change (the writer's base is stale and the live value is newer) used to
+///   fall into the no-change backstop and ack SUCCESS — the caller's resilient machinery
+///   stopped retrying and the write was lost while reported applied. The owner must NACK
+///   (Conflict) so the caller re-reads and re-applies.</item>
+///   <item><b>A superseded activation refuses-and-redirects, never merge-and-acks.</b> A patch
+///   delivered to a QUIESCING/DISPOSING activation used to be merged into state that dies with
+///   the hub and acked Success. The single-writer activation invariant: only the CURRENT
+///   activation applies patches; a superseded one NACKs retryable (OwnerDisposing) so the
+///   caller's re-enqueue lands the same update on the fresh activation.</item>
+/// </list>
+/// Both pins drive the REAL owner pipeline over the wire (PatchDataRequest — the exact message
+/// <c>UpdateRemote</c> posts), because the defect is the owner's ACK SEMANTICS.
+/// </summary>
+public class SupersededActivationPatchNackTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+    private JsonSerializerOptions JsonOptions => Mesh.JsonSerializerOptions;
+
+    private IObservable<MeshNode?> ReadDurable(string path) => Storage.Read(path, JsonOptions);
+
+    private string NameKey => JsonOptions.PropertyNamingPolicy?.ConvertName(nameof(MeshNode.Name))
+        ?? nameof(MeshNode.Name);
+
+    private async Task<Address> ResolveOwner(string path)
+    {
+        var resolution = await PathResolver.ResolvePath(path).Should().Within(30.Seconds()).Emit();
+        resolution.Should().NotBeNull($"'{path}' must resolve to an owning hub");
+        return new Address(resolution!.Prefix.ToString()!);
+    }
+
+    /// <summary>
+    /// Creates a node, advances its live Name to <c>live-truth</c> through the owner, and
+    /// returns the crafted stale-mirror patch: Name → <c>stale-mirror-write</c> diffed against
+    /// the pre-advance base <c>created</c>. The owner's three-way merge must refuse the key
+    /// (whole-string rewrites on both sides overlap), leaving the node unchanged.
+    /// </summary>
+    private async Task<(string Path, Address Owner, PatchDataRequest Patch)> ArrangeRefusedPatch()
+    {
+        var id = $"refused-nack-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+
+        var client = GetClient(c => c.AddData());
+        await client.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "live-truth" })
+            .Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "live-truth" });
+
+        var owner = await ResolveOwner(path);
+        var patch = new PatchDataRequest(
+            new MeshNodeReference(),
+            new RawJson($"{{\"{NameKey}\":\"stale-mirror-write\"}}"))
+        {
+            BaseValues = new RawJson($"{{\"{NameKey}\":\"created\"}}")
+        };
+        return (path, owner, patch);
+    }
+
+    /// <summary>
+    /// #648 pin 1 — fail-without: the no-change backstop acked the all-refused patch
+    /// SUCCESS; pass-with: the owner NACKs Conflict and keeps the live value.
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task AllKeysRefusedThreeWayMerge_IsNackedConflict_NeverAckedSuccess()
+    {
+        var (path, owner, patch) = await ArrangeRefusedPatch();
+
+        var response = await AwaitResponseAsync(patch, o => o.WithTarget(owner));
+        var patchResponse = response.Message;
+
+        Output.WriteLine(
+            $"[response] success={patchResponse.Success} code={patchResponse.NodeError?.Code} "
+            + $"error={patchResponse.Error}");
+        patchResponse.Success.Should().BeFalse(
+            "a merge that refused EVERY intended change did not apply the caller's write — "
+            + "acking it Success is the #648 acked-write-loss (the resilient caller stops "
+            + "retrying a write that never landed)");
+        patchResponse.NodeError.Should().NotBeNull();
+        patchResponse.NodeError!.Code.Should().Be(MeshNodeErrorCode.Conflict,
+            "the caller must be told to re-read and re-apply — a terminal typed conflict, "
+            + "not a silent success and not a retry storm");
+
+        // And the owner kept the newer live value — the refusal is the merge's verdict.
+        (await ReadNode(path).Should().Within(30.Seconds()).Emit())!
+            .Name.Should().Be("live-truth");
+    }
+
+    /// <summary>
+    /// #648 pin 2 — single-writer activation invariant. The patch is posted right after the
+    /// owner's <c>Dispose()</c>: the DisposeRequest is queued ahead of it in the same inbox,
+    /// so the handler sees a hub past Started. Fail-without: the quiescing activation merges
+    /// into dying state and acks Success (for this all-refused patch, the no-change backstop's
+    /// Success lie). Pass-with: the owner refuses at handler entry with the retryable
+    /// OwnerDisposing — or, when the window has already closed, the delivery fails typed —
+    /// and under NO outcome is the patch acked Success.
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task PatchDeliveredToDisposingActivation_IsNackedRetryable_NeverMergeAndAck()
+    {
+        var (path, ownerAddress, patch) = await ArrangeRefusedPatch();
+
+        var owner = Mesh.GetHostedHub(ownerAddress, HostedHubCreation.Never);
+        owner.Should().NotBeNull("the owner hub must be live after the warm read");
+        owner!.Dispose();
+        Output.WriteLine($"[dispose] posted for {ownerAddress}");
+
+        // Sequence on the OBSERVED lifecycle, not on hope: post the patch only once the owner
+        // is provably past Started (Quiescing or later) — the superseded-activation window the
+        // invariant is about. Routing may still hand the patch to a FRESH activation when the
+        // old one has already left the routing table; both branches are asserted below.
+        await Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Select(_ => owner.RunLevel)
+            .Should().Within(20.Seconds()).Match(level => level > MessageHubRunLevel.Started);
+        Output.WriteLine($"[runlevel] owner at {owner.RunLevel}");
+
+        try
+        {
+            var response = await AwaitResponseAsync(patch, o => o.WithTarget(ownerAddress));
+            var patchResponse = response.Message;
+            Output.WriteLine(
+                $"[response] success={patchResponse.Success} code={patchResponse.NodeError?.Code} "
+                + $"error={patchResponse.Error}");
+
+            patchResponse.Success.Should().BeFalse(
+                "a superseded (quiescing/disposing) activation must refuse-and-redirect — "
+                + "merging into state that dies with the hub and acking Success is the #648 "
+                + "acked-write-loss");
+            patchResponse.NodeError.Should().NotBeNull();
+            patchResponse.NodeError!.Code.Should().BeOneOf(
+                [MeshNodeErrorCode.OwnerDisposing, MeshNodeErrorCode.Conflict],
+                "the disposing activation NACKs OwnerDisposing (retryable — the caller "
+                + "re-enqueues against the fresh activation); if routing already reached a "
+                + "FRESH activation instead, the stale-base patch is refused as Conflict — "
+                + "either way, never Success");
+        }
+        catch (Exception ex) when (ex is DeliveryFailureException or TimeoutException or TaskCanceledException)
+        {
+            // The disposal window closed before the patch was handled — the delivery fails
+            // typed (shutting-down NACK / hub torn down). A refusal, not a lie: acceptable.
+            Output.WriteLine($"[nack-shape-2] {ex.GetType().Name}: {ex.Message}");
+        }
+
+        // Whatever the NACK shape, the write must not have half-landed anywhere durable.
+        var final = await Observable.Timer(TimeSpan.FromSeconds(1))
+            .SelectMany(_ => ReadDurable(path))
+            .Should().Within(20.Seconds()).Emit();
+        final!.Name.Should().NotBe("stale-mirror-write",
+            "a refused/NACKed patch must leave no durable trace");
+    }
+}


### PR DESCRIPTION
Fixes #590, #648, #667 — one mechanism behind all three, plus the live prod sighting recorded on #919.

## Root cause — the activation seed raced durable truth and lost

`MeshNodeTypeSource.Initialize` merged the durable storage read with the cache-backed routing legs (`Observable.Merge`), and `GetInitialValueAsync` takes the **first** accepted emission then disposes the subscription. On any async backend (PG — the prod portals) the synchronously-replaying stale routing snapshot reliably won the seed and the late durable row was **discarded unobserved**. Every subsequent write minted below durable truth → `MonotonicWriteGuard` refused each save → `AdoptDurableTruth` rebased the owner and **clobbered the acked write in RAM**. That is #590 (updates stop persisting after re-activation), #648 (acked-success loss on a stale second activation) and #667/#919 (deploy-window discards) — and why it never reproduced on in-memory (synchronous reads).

## Fixes

- **Seed ordering**: `Merge` → **`Concat`** — the durable read settles first (row / null / fault-degrade), the routing leg follows; activation *holds* for one storage read (#667's "wait, don't Not-found"); version floor unchanged.
- **Enrichment graft**: the durable row (authoritative for version/content) is grafted with the routing node's non-persistable `HubConfiguration` delegate — without it, durable-first seeding stripped the delegate and fired spurious activation compiles (caught as 2 suite regressions, both healed).
- **InMemory delegate strip**: a durable store cannot hold an in-process delegate (FS/PG strip via serialization; InMemory retained the instance and latched stale overlay configs forever — deterministically reproduced and fixed via `OverlaySelfHealInstanceRecycleTest`).
- **#648 invariant 1**: an all-keys-refused three-way merge NACKs **`Conflict`** — never acks Success.
- **#648 invariant 2**: a disposing activation NACKs retryable (`OwnerDisposing`) at handler entry; direct-path NACKs now re-enqueue like the late path.
- **#667**: new wire code **`OwnerNotReady`** — a cold store's defer-timeout is retryable and provably-not-applied, never a false `NotFound` (which also poisoned the stream cache's negative cache).

## Verification

- Acceptance (unmodified): `StaleActivationSeedRollbackTest` **15/15 consecutive** on the final build. Honest note: the claimed 8/15 red on pristine main did **not** reproduce on this machine (in-memory is structurally green) — the deterministic pin below covers the mechanism instead.
- New deterministic repros with a gated-read adapter (async-backend stand-in): `StaleActivationDurableFirstSeedTest` — **fail-without confirmed** (the acked write demonstrably destroyed by the refusal→rebase cycle), pass-with green; `SupersededActivationPatchNackTest` (never-Success across all reachable NACK shapes); an all-keys-refused ⇒ Conflict pin; an activation-is-a-read pin.
- Suites: Hosting.Monolith **×3 consecutive 482/0** · Data 303 · NodeOperations 85 · Graph 820 · Query 361 · Orleans `TwoSiloRecycleConvergenceTest` 1/1. Independently re-verified **7/7** across the new + acceptance + overlay classes after merging current main. `-c Release -warnaserror` clean per project.

## Residual (documented)

Quiescing-NACK branch not directly red/greened locally (Monolith passes Quiescing in <20 ms; matters most on Orleans). Activation now holds for the durable read — on PG a boot storm serializes on the `pg:{adapter}` pool; that is the requested trade. `Take(1)` seed semantics otherwise unchanged.

Closes #590
Closes #648
Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
