### PR TITLE
TypeSource.Update is honestly side-effect-only — the phantom transform contract is gone

### DIFF
--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -93,7 +93,13 @@ public record DataChangeResponse(long Version, ActivityLog Log)
 /// </summary>
 public enum DataChangeStatus
 {
-    /// <summary>The change was committed (possibly with warnings).</summary>
+    /// <summary>
+    /// The change was applied to the in-memory store (possibly with warnings) and is visible to
+    /// every subscriber. NOT a durability guarantee: persistence is dispatched to the
+    /// System-identity persistence hub AFTER this status is reported, so a crash in that window
+    /// can lose an acknowledged change. Callers that need durable-write semantics must observe
+    /// the storage backend, not this status.
+    /// </summary>
     Committed,
     /// <summary>The change failed and was not committed.</summary>
     Failed

--- a/src/MeshWeaver.Data/ITypeSource.cs
+++ b/src/MeshWeaver.Data/ITypeSource.cs
@@ -67,11 +67,15 @@ public interface ITypeSource
     );
 
     /// <summary>
-    /// Applies a store change to this type's collection and returns the resulting collection.
+    /// Applies a store change to this type's collection. Side-effect-only by contract: the
+    /// implementation reacts to the change (persists it, forwards it to a backend, records a
+    /// snapshot) — it cannot transform what gets stored. The store content is already fixed by
+    /// the time this is called; every caller (<c>Synchronize</c> in the data sources) invokes it
+    /// per registered type source purely for its effects. This used to return the collection,
+    /// which read as a transform hook while every call site discarded it (#886).
     /// </summary>
     /// <param name="changeItem">The store change to apply.</param>
-    /// <returns>The updated instance collection for this type.</returns>
-    InstanceCollection Update(ChangeItem<EntityStore> changeItem);
+    void Update(ChangeItem<EntityStore> changeItem);
 
     /// <summary>
     /// The collection name under which instances of this type are stored.

--- a/src/MeshWeaver.Data/TypeSource.cs
+++ b/src/MeshWeaver.Data/TypeSource.cs
@@ -40,30 +40,30 @@ public abstract record TypeSource<TTypeSource> : ITypeSource
     protected TTypeSource This => (TTypeSource)this;
 
     /// <summary>
-    /// Extracts this type's collection from the incoming store change and applies the source's update logic.
+    /// Extracts this type's collection from the incoming store change and applies the source's
+    /// update side effects (see <see cref="ITypeSource.Update"/> — side-effect-only by contract).
     /// </summary>
     /// <param name="changeItem">The store change to apply; its value must not be null.</param>
-    /// <returns>The updated instance collection for this type.</returns>
-    public virtual InstanceCollection Update(ChangeItem<EntityStore> changeItem)
+    public virtual void Update(ChangeItem<EntityStore> changeItem)
     {
         if(changeItem.Value is null)
             throw new ArgumentNullException(nameof(changeItem), "Change item value cannot be null.");
 
         var myCollection = changeItem.Value.Reduce(new CollectionReference(TypeDefinition.CollectionName));
 
-        return UpdateImpl(myCollection);
+        UpdateImpl(myCollection);
     }
 
     private IDisposable? workspaceSubscription;
 
     /// <summary>
-    /// Override hook applied to this type's collection during update; the base implementation
-    /// returns the collection unchanged.
+    /// Override hook invoked with this type's collection on every update — for side effects only
+    /// (persist, forward, snapshot); the base implementation does nothing.
     /// </summary>
     /// <param name="myCollection">The collection extracted for this type.</param>
-    /// <returns>The transformed collection.</returns>
-    protected virtual InstanceCollection UpdateImpl(InstanceCollection myCollection) =>
-        myCollection;
+    protected virtual void UpdateImpl(InstanceCollection myCollection)
+    {
+    }
 
     ITypeSource ITypeSource.WithInitialData(
         Func<

--- a/src/MeshWeaver.Data/TypeSource.cs
+++ b/src/MeshWeaver.Data/TypeSource.cs
@@ -46,6 +46,7 @@ public abstract record TypeSource<TTypeSource> : ITypeSource
     /// <param name="changeItem">The store change to apply; its value must not be null.</param>
     public virtual void Update(ChangeItem<EntityStore> changeItem)
     {
+        ArgumentNullException.ThrowIfNull(changeItem);
         if(changeItem.Value is null)
             throw new ArgumentNullException(nameof(changeItem), "Change item value cannot be null.");
 

--- a/src/MeshWeaver.Data/TypeSourceWithType.cs
+++ b/src/MeshWeaver.Data/TypeSourceWithType.cs
@@ -38,24 +38,26 @@ public record TypeSourceWithType<T>(IWorkspace Workspace, object DataSource)
     : TypeSourceWithType<T, TypeSourceWithType<T>>(Workspace, DataSource)
 {
     /// <summary>
-    /// Applies the configured update action to the incoming collection before it is stored.
+    /// Invokes the configured update action with the incoming collection.
     /// </summary>
-    /// <param name="instances">The collection to transform.</param>
-    /// <returns>The transformed collection.</returns>
-    protected override InstanceCollection UpdateImpl(InstanceCollection instances) =>
+    /// <param name="instances">This type's collection after the change was applied.</param>
+    protected override void UpdateImpl(InstanceCollection instances) =>
         UpdateAction.Invoke(instances);
 
     /// <summary>
-    /// Transformation applied to each incoming collection during update; defaults to the identity function.
+    /// Side effect invoked with each incoming collection during update; defaults to a no-op.
     /// </summary>
-    protected Func<InstanceCollection, InstanceCollection> UpdateAction { get; init; } = i => i;
+    protected Action<InstanceCollection> UpdateAction { get; init; } = _ => { };
 
     /// <summary>
-    /// Returns a copy of this type source with the given update transformation applied on each update.
+    /// Returns a copy of this type source that invokes the given side effect on each update —
+    /// e.g. persisting the collection to an external backend. The action observes the updated
+    /// collection; it cannot transform what gets stored (the store content is already fixed
+    /// when it runs — see <see cref="ITypeSource.Update"/>).
     /// </summary>
-    /// <param name="update">Function that transforms the instance collection.</param>
+    /// <param name="update">Side effect receiving this type's updated instance collection.</param>
     /// <returns>An updated type source.</returns>
-    public TypeSourceWithType<T> WithUpdate(Func<InstanceCollection, InstanceCollection> update) =>
+    public TypeSourceWithType<T> WithUpdate(Action<InstanceCollection> update) =>
         This with
         {
             UpdateAction = update

--- a/src/MeshWeaver.Data/TypeSourceWithTypeWithDataStorage.cs
+++ b/src/MeshWeaver.Data/TypeSourceWithTypeWithDataStorage.cs
@@ -34,11 +34,10 @@ public record TypeSourceWithTypeWithDataStorage<T>
 
     /// <summary>
     /// Diffs the incoming collection against the last saved snapshot and persists the resulting
-    /// adds, updates, and deletes to storage.
+    /// adds, updates, and deletes to storage; the collection becomes the new snapshot.
     /// </summary>
     /// <param name="instances">The current collection to persist.</param>
-    /// <returns>The same collection, now recorded as the last saved snapshot.</returns>
-    protected override InstanceCollection UpdateImpl(InstanceCollection instances)
+    protected override void UpdateImpl(InstanceCollection instances)
     {
         var adds = instances
             .Instances.Where(x => !LastSaved.Instances.ContainsKey(x.Key))
@@ -52,7 +51,7 @@ public record TypeSourceWithTypeWithDataStorage<T>
             .Select(x => x.Value)
             .ToArray();
         var deletes = LastSaved
-            .Instances.Where(x => instances.Instances.ContainsKey(x))
+            .Instances.Where(x => !instances.Instances.ContainsKey(x.Key))
             .Select(x => x.Value)
             .ToArray();
 
@@ -61,7 +60,6 @@ public record TypeSourceWithTypeWithDataStorage<T>
         Storage.Delete(deletes);
 
         LastSaved = instances;
-        return instances;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -238,13 +238,12 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     /// <summary>
     /// Diffs the incoming instance collection against the last-saved snapshot and
     /// dispatches the resulting persistence work: creates and deletes are queued onto
-    /// the debounce flush, updates are version-stamped and re-emitted (the workspace's
-    /// own-node persistence sampler saves them). Also opens the MeshNode init gate when
-    /// the own node becomes Active/Transient. Returns the (possibly re-stamped) collection.
+    /// the debounce flush, updates are version-stamped into the snapshot the diff
+    /// bookkeeping keeps (the workspace's own-node persistence sampler saves them).
+    /// Also opens the MeshNode init gate when the own node becomes Active/Transient.
     /// </summary>
     /// <param name="instances">The instance collection to persist/update.</param>
-    /// <returns>The instance collection to store as the new authoritative snapshot.</returns>
-    protected override InstanceCollection UpdateImpl(InstanceCollection instances)
+    protected override void UpdateImpl(InstanceCollection instances)
     {
         instances = MergePartialUpdates(instances);
 
@@ -259,7 +258,7 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         {
             _logger?.LogDebug("MeshNodeTypeSource.UpdateImpl: no-op empty change for {HubPath} (preserving {Count} loaded entries)",
                 _hubPath, _lastSaved.Instances.Count);
-            return _lastSaved;
+            return;
         }
 
         // Open MeshNode init gate when node becomes Active or Transient
@@ -368,13 +367,14 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         foreach (var node in stampedAdds)
             _pendingSaves[node.Path] = node;
 
-        // 🚨 The stamped version goes into the LIVE collection too, not just the save queue.
-        // Otherwise the in-RAM node and the durable row disagree: a created node persists at
-        // Version 1 while the owner's collection keeps the incoming 0, and the next write —
-        // which counts from the LIVE node — mints 1 again, landing a second, different payload
-        // on the version-history row {Id}_1 and silently overwriting the create snapshot
-        // (VersionHistoryTest). Same for a re-added durable node lifted to _ownNodeVersionFloor:
-        // the live node must carry the version the store is about to hold.
+        // 🚨 The stamped version goes into the SNAPSHOT this diff bookkeeping keeps
+        // (_lastSaved, below), not just the save queue. Otherwise the snapshot and the durable
+        // row disagree: a created node persists at Version 1 while the snapshot keeps the
+        // incoming 0, and the next diff — which compares against the snapshot — mints 1 again,
+        // landing a second, different payload on the version-history row {Id}_1 and silently
+        // overwriting the create snapshot (VersionHistoryTest). Same for a re-added durable node
+        // lifted to _ownNodeVersionFloor: the snapshot must carry the version the store is about
+        // to hold.
         if (stampedAdds.Length > 0)
             instances = instances with
             {
@@ -460,7 +460,6 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             }
 
         _lastSaved = instances;
-        return instances;
     }
 
     /// <summary>Records that this hub now holds own-node state at <paramref name="version"/>:

--- a/src/MeshWeaver.Graph/PartitionTypeSource.cs
+++ b/src/MeshWeaver.Graph/PartitionTypeSource.cs
@@ -57,12 +57,11 @@ public record PartitionTypeSource<T> : TypeSourceWithType<T, PartitionTypeSource
 
     /// <summary>
     /// Diffs the incoming instance collection against the last-saved snapshot and syncs
-    /// adds and updates back to the persistence partition (deletes are not yet supported).
-    /// Returns the supplied collection as the new authoritative snapshot.
+    /// adds and updates back to the persistence partition (deletes are not yet supported);
+    /// the supplied collection becomes the new snapshot.
     /// </summary>
     /// <param name="instances">The instance collection to persist/update.</param>
-    /// <returns>The instance collection to store as the new authoritative snapshot.</returns>
-    protected override InstanceCollection UpdateImpl(InstanceCollection instances)
+    protected override void UpdateImpl(InstanceCollection instances)
     {
         _logger?.LogDebug("PartitionTypeSource<{Type}>.UpdateImpl: Called with {Count} instances",
             typeof(T).Name, instances.Instances.Count);
@@ -107,7 +106,6 @@ public record PartitionTypeSource<T> : TypeSourceWithType<T, PartitionTypeSource
         // If needed, we could add DeletePartitionObjectAsync to IStorageAdapter
 
         _lastSaved = instances;
-        return instances;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/DataTest.cs
+++ b/test/MeshWeaver.Data.Test/DataTest.cs
@@ -258,7 +258,6 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
     /// Saves updated MyData instances to storage
     /// </summary>
     /// <param name="instanceCollection">The collection of instances to save</param>
-    /// <returns>The saved instance collection</returns>
     private void SaveMyData(InstanceCollection instanceCollection)
     {
         storage.OnNext(instanceCollection.Instances);

--- a/test/MeshWeaver.Data.Test/DataTest.cs
+++ b/test/MeshWeaver.Data.Test/DataTest.cs
@@ -259,10 +259,9 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
     /// </summary>
     /// <param name="instanceCollection">The collection of instances to save</param>
     /// <returns>The saved instance collection</returns>
-    private InstanceCollection SaveMyData(InstanceCollection instanceCollection)
+    private void SaveMyData(InstanceCollection instanceCollection)
     {
         storage.OnNext(instanceCollection.Instances);
-        return instanceCollection;
     }
     /// <summary>
     /// Tests validation failure scenarios and error handling


### PR DESCRIPTION
Fixes #886.

## Part 1 — the dead transform contract

`ITypeSource.Update` returned an `InstanceCollection` and `WithUpdate` documented *"applies the configured update action to the incoming collection before it is stored"* — but every call site (both `Synchronize` twins in `GenericUnpartitionedDataSource` and `UnpartitionedDataSourceWithStorage.UpdateAsync`) discarded the return. Every working consumer operates by side effect; a user writing a pure "normalize before store" transform got a silent no-op.

Per the issue's recommendation, the signature now tells the truth end-to-end: `Update`/`UpdateImpl` return `void`, `UpdateAction` is `Action<InstanceCollection>`, and `WithUpdate` takes the side effect it always was — a transform-shaped lambda no longer compiles into a silent no-op.

## Found while converting the method

`TypeSourceWithTypeWithDataStorage`'s delete diff was doubly broken: `LastSaved.Instances.Where(x => instances.Instances.ContainsKey(x))` passed the whole `KeyValuePair` as the key (never matches) **and** the condition was inverted — storage deletes never fired. Fixed to `!instances.Instances.ContainsKey(x.Key)`, matching the documented diff semantics. The type has zero in-repo consumers (kept as public framework API).

## Part 2 — `DataChangeStatus.Committed` over-promises

Documented the real semantics on the enum member: applied to the in-memory store and visible to subscribers, **not** durable — persistence dispatches afterwards on the System persistence hub. Renaming the member would be a wire-format break, so the docs carry the truth.

## Verification

`MeshWeaver.Data.Test` 303/303 green in Release; `-warnaserror` build clean.

No What's New entry — internal API contract change, no user-visible behavior on any shipped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)