### PR TITLE
FormatTimeAgo tests exercise the shipping function — the drifted inline copy is deleted

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -911,17 +911,10 @@ public partial class CollaborativeMarkdownView
         _ => "Change"
     };
 
-    // The relative buckets are zone-independent; only the absolute >7d fallback is a wall
-    // clock, so that one renders in the viewer's zone.
+    // The formatting itself lives in the hub-free Collaboration project so its tests exercise
+    // the shipping function (#788); this wrapper only resolves the viewer's zone id.
     internal static string FormatTimeAgo(DateTimeOffset dateTime, string? zoneId = null)
-    {
-        var timeSpan = DateTimeOffset.UtcNow - dateTime;
-        if (timeSpan.TotalMinutes < 1) return "just now";
-        if (timeSpan.TotalMinutes < 60) return $"{(int)timeSpan.TotalMinutes}m ago";
-        if (timeSpan.TotalHours < 24) return $"{(int)timeSpan.TotalHours}h ago";
-        if (timeSpan.TotalDays < 7) return $"{(int)timeSpan.TotalDays}d ago";
-        return DisplayTimeExtensions.ToDisplayTime(dateTime, zoneId).ToString("MMM d, yyyy");
-    }
+        => TimeAgo.Format(dateTime, DisplayTimeExtensions.ResolveZone(zoneId));
 
     /// <summary>
     /// Disposes the JavaScript interop module, releases the <c>DotNetObjectReference</c>,

--- a/src/MeshWeaver.Markdown.Collaboration/TimeAgo.cs
+++ b/src/MeshWeaver.Markdown.Collaboration/TimeAgo.cs
@@ -1,0 +1,32 @@
+namespace MeshWeaver.Markdown.Collaboration;
+
+/// <summary>
+/// The relative-time label shown next to comments and tracked changes ("just now", "5m ago",
+/// "3d ago", falling through to an absolute date after 7 days). This is THE shipping
+/// implementation — <c>CollaborativeMarkdownView.FormatTimeAgo</c> delegates here — and lives in
+/// this hub-free project so its tests exercise the real function instead of an inline copy
+/// (#788: the copy had grown a weeks bucket the product never had, and stayed green through
+/// every change to the real one).
+/// </summary>
+public static class TimeAgo
+{
+    /// <summary>
+    /// Formats how long ago <paramref name="dateTime"/> was, relative to now. The relative
+    /// buckets (&lt; 7 days) are zone-independent; only the absolute-date fallback is a wall
+    /// clock, so that one renders in <paramref name="displayZone"/> (null → UTC — the display is
+    /// never wrong, just un-localized). Callers with a viewer context resolve the zone via
+    /// <c>DisplayTimeExtensions.ResolveZone(accessService.ViewerZoneId())</c>.
+    /// </summary>
+    public static string Format(DateTimeOffset dateTime, TimeZoneInfo? displayZone = null)
+    {
+        var timeSpan = DateTimeOffset.UtcNow - dateTime;
+        if (timeSpan.TotalMinutes < 1) return "just now";
+        if (timeSpan.TotalMinutes < 60) return $"{(int)timeSpan.TotalMinutes}m ago";
+        if (timeSpan.TotalHours < 24) return $"{(int)timeSpan.TotalHours}h ago";
+        if (timeSpan.TotalDays < 7) return $"{(int)timeSpan.TotalDays}d ago";
+        var display = displayZone is null
+            ? dateTime.ToUniversalTime()
+            : TimeZoneInfo.ConvertTime(dateTime, displayZone);
+        return display.ToString("MMM d, yyyy");
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/DisplayTimeExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/DisplayTimeExtensions.cs
@@ -73,7 +73,12 @@ public static class DisplayTimeExtensions
         return accessService?.CircuitContext?.TimeZoneId;
     }
 
-    private static TimeZoneInfo? ResolveZone(string? timeZoneId)
+    /// <summary>
+    /// Resolves a named IANA zone id to its <see cref="TimeZoneInfo"/>; null, empty, unknown or
+    /// invalid ids resolve to null (callers fall back to UTC). Public for formatters that live in
+    /// hub-free projects (e.g. <c>TimeAgo</c>) and take the resolved zone as a parameter.
+    /// </summary>
+    public static TimeZoneInfo? ResolveZone(string? timeZoneId)
     {
         if (string.IsNullOrWhiteSpace(timeZoneId))
             return null;

--- a/test/MeshWeaver.Markdown.Collaboration.Test/CommentMeshNodeTests.cs
+++ b/test/MeshWeaver.Markdown.Collaboration.Test/CommentMeshNodeTests.cs
@@ -402,60 +402,67 @@ public class CommentMeshNodeTests
 
     #region Relative Time Formatting
 
-    // FormatTimeAgo is defined on CollaborativeMarkdownView (Blazor project).
-    // These tests use an inline copy for isolation.
-    private static string FormatTimeAgo(DateTimeOffset dateTime)
-    {
-        var timeSpan = DateTimeOffset.UtcNow - dateTime;
-        if (timeSpan.TotalMinutes < 1) return "just now";
-        if (timeSpan.TotalMinutes < 60) return $"{(int)timeSpan.TotalMinutes}m ago";
-        if (timeSpan.TotalHours < 24) return $"{(int)timeSpan.TotalHours}h ago";
-        if (timeSpan.TotalDays < 7) return $"{(int)timeSpan.TotalDays}d ago";
-        if (timeSpan.TotalDays < 30) return $"{(int)(timeSpan.TotalDays / 7)}w ago";
-        return dateTime.ToString("MMM d, yyyy");
-    }
+    // These exercise TimeAgo.Format — the SHIPPING implementation the Blazor comment/change
+    // timestamps render through (CollaborativeMarkdownView.FormatTimeAgo delegates to it).
+    // They used to run against an inline copy "for isolation"; the copy drifted (it grew a
+    // weeks bucket the product never had) and the suite stayed green while asserting behaviour
+    // that did not ship (#788).
 
     [Fact]
     public void FormatTimeAgo_RecentDate_ShowsJustNow()
     {
-        var result = FormatTimeAgo(DateTimeOffset.UtcNow);
+        var result = TimeAgo.Format(DateTimeOffset.UtcNow);
         result.Should().Be("just now");
     }
 
     [Fact]
     public void FormatTimeAgo_MinutesAgo_ShowsMinutes()
     {
-        var result = FormatTimeAgo(DateTimeOffset.UtcNow.AddMinutes(-5));
+        var result = TimeAgo.Format(DateTimeOffset.UtcNow.AddMinutes(-5));
         result.Should().Be("5m ago");
     }
 
     [Fact]
     public void FormatTimeAgo_HoursAgo_ShowsHours()
     {
-        var result = FormatTimeAgo(DateTimeOffset.UtcNow.AddHours(-2));
+        var result = TimeAgo.Format(DateTimeOffset.UtcNow.AddHours(-2));
         result.Should().Be("2h ago");
     }
 
     [Fact]
     public void FormatTimeAgo_DaysAgo_ShowsDays()
     {
-        var result = FormatTimeAgo(DateTimeOffset.UtcNow.AddDays(-3));
+        var result = TimeAgo.Format(DateTimeOffset.UtcNow.AddDays(-3));
         result.Should().Be("3d ago");
     }
 
     [Fact]
-    public void FormatTimeAgo_WeeksAgo_ShowsWeeks()
+    public void FormatTimeAgo_TwoWeeksAgo_FallsThroughToAbsoluteDate()
     {
-        var result = FormatTimeAgo(DateTimeOffset.UtcNow.AddDays(-14));
-        result.Should().Be("2w ago");
+        // There is deliberately NO weeks bucket: past 7 days the label is the absolute date.
+        // (The drifted inline copy asserted "2w ago" here — behaviour the product never had.)
+        var date = DateTimeOffset.UtcNow.AddDays(-14);
+        var result = TimeAgo.Format(date);
+        result.Should().Be(date.ToString("MMM d, yyyy"));
     }
 
     [Fact]
     public void FormatTimeAgo_OldDate_ShowsFormattedDate()
     {
         var date = new DateTimeOffset(2024, 3, 15, 0, 0, 0, TimeSpan.Zero);
-        var result = FormatTimeAgo(date);
+        var result = TimeAgo.Format(date);
         result.Should().Be("Mar 15, 2024");
+    }
+
+    [Fact]
+    public void FormatTimeAgo_AbsoluteDate_RendersInTheViewersZone()
+    {
+        // 23:30 UTC on Mar 15 is already Mar 16 in Auckland (UTC+13 in March) — the absolute
+        // branch converts to the viewer's zone (#785), the relative buckets never need to.
+        var date = new DateTimeOffset(2024, 3, 15, 23, 30, 0, TimeSpan.Zero);
+        var auckland = TimeZoneInfo.FindSystemTimeZoneById("Pacific/Auckland");
+        var result = TimeAgo.Format(date, auckland);
+        result.Should().Be("Mar 16, 2024");
     }
 
     #endregion


### PR DESCRIPTION
Fixes #788.

The six `FormatTimeAgo_*` tests ran against a private inline copy "for isolation" that had drifted — it grew a weeks bucket the shipping `CollaborativeMarkdownView.FormatTimeAgo` never had. `FormatTimeAgo_WeeksAgo_ShowsWeeks` was a green test asserting behaviour the product does not have, and the suite stayed green through #785's change to the real function.

Per the issue's preferred option, the formatting core moves to `TimeAgo.Format` in the hub-free `MeshWeaver.Markdown.Collaboration` project with an explicit `TimeZoneInfo?` parameter (no Hub dependency); `DisplayTimeExtensions.ResolveZone` becomes public so the Blazor wrapper is a one-line zone-id resolver delegating to it. One source of truth, testable where the tests live.

- Weeks assertion replaced by the honest one: 14 days → absolute-date fall-through.
- New case pins #785's viewer-zone conversion on the absolute branch (23:30 UTC Mar 15 → "Mar 16, 2024" in Pacific/Auckland).
- 7/7 green in Release; `-warnaserror` builds of `MeshWeaver.Blazor` + the test project clean.

No What's New entry — test hygiene + internal refactor, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)