### PR TITLE
NodeType watchers ride SubscribeWithReEstablish — no more silent log-and-die control plane

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -173,7 +173,13 @@ internal static class NodeTypeCompilationHelpers
         // start / GetQuery wait inside the Subscribe callback (those can deadlock when
         // the callback fires on the workspace emission thread that coincides with the
         // ActionBlock). HandleDispatchCompile owns all the work on the hub's ActionBlock.
-        var watcherSub = ownStream
+        // #891: subscribed through SubscribeWithReEstablish — the old bare log-and-die OnError
+        // left the compile control plane permanently dead (no Pending flip ever dispatched
+        // again) while the hub kept running. Transient stream faults re-establish; poisoned
+        // own content (undeserializable NodeTypeDefinition) parks the type — the visible,
+        // bounded sink — and stops instead of looping on the replayed emission.
+        var watcherSub = ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+            () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition)
             .DistinctUntilChanged(node => ((NodeTypeDefinition)node!.Content!).CompilationStatus)
             .Where(node =>
@@ -189,8 +195,7 @@ internal static class NodeTypeCompilationHelpers
                         && string.IsNullOrWhiteSpace(def.Configuration)
                         && string.IsNullOrWhiteSpace(def.HubConfiguration)
                         && (def.Sources is null || def.Sources.Count == 0));
-            })
-            .Subscribe(
+            }),
                 pendingNode =>
                 {
                     // 🅿️ PARKED short-circuit. A prior compile of this NodeType reached a
@@ -271,8 +276,14 @@ internal static class NodeTypeCompilationHelpers
                             o => o.WithTarget(hub.Address));
                     }
                 },
-                ex => logger?.LogWarning(ex,
-                    "Compile watcher faulted for {HubPath}", hub.Address.Path));
+            hub.Address,
+            logger,
+            "Compile watcher",
+            onPoisonedContent: ex => parkRegistry?.OnCompileFailed(
+                hub, hubPath,
+                "The NodeType's own node content could not be deserialized — the compile control "
+                + "plane is parked until the content is repaired: " + ex.Message,
+                deterministic: true, recipientUserId: null, sources: null, logger));
 
         // 🚨 2026-05-21 (PM) — First-build-only kickoff (safer variant).
         //
@@ -569,7 +580,14 @@ internal static class NodeTypeCompilationHelpers
         // (`nodeType:Code namespace:{hubPath}/Source scope:subtree`) was
         // the dominant background traffic in prod (2026-05-21). Mirrors the
         // skip branch in InstallCompileWatcher's kickoff at line ~122.
-        return ownStream
+        // #891: SubscribeWithReEstablish, not a bare log-and-die Subscribe — a fault in the
+        // per-path source streams (a cross-hub delivery blip riding through Switch) used to
+        // kill source tracking permanently: IsDirty froze and the parked-type auto-retry
+        // never fired again. Transient faults re-establish (the DistinctUntilChanged resets
+        // and the current source set re-resolves — idempotent); poisoned own content stops
+        // loudly (the compile watcher's park is the visible sink for the same emission).
+        return ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+            () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && !IsStaticOnlyNodeType(node, def))
             .DistinctUntilChanged(node =>
@@ -624,8 +642,7 @@ internal static class NodeTypeCompilationHelpers
                     if (!string.IsNullOrEmpty(n.Path))
                         snap = snap.SetItem(n.Path!, n.LastModified.UtcTicks);
                 return (IReadOnlyDictionary<string, long>)snap;
-            })
-            .Subscribe(
+            }),
                 snapshot =>
                 {
                     // 🅿️ Auto-retry a PARKED (terminally-failed) type when its SOURCE snapshot has
@@ -692,8 +709,9 @@ internal static class NodeTypeCompilationHelpers
                             "SourcesWatcher: failed to write CurrentSourceVersions for {HubPath}",
                             hubPath));
                 },
-                ex => logger?.LogWarning(ex,
-                    "SourcesWatcher: per-path stream for {HubPath} faulted", hubPath));
+            hub.Address,
+            logger,
+            "Sources watcher");
     }
 
     /// <summary>
@@ -824,7 +842,14 @@ internal static class NodeTypeCompilationHelpers
         // post-settle emission stamps `LastReleaseRequestHandledAt`, so
         // subsequent emissions with the same trigger fail the `req > handled`
         // gate.
-        return ownStream
+        // #891: SubscribeWithReEstablish, not a bare log-and-die Subscribe — a dead release
+        // watcher means the user's Compile button silently does nothing forever. On a transient
+        // re-establish the high-water marks live OUTSIDE the factory, so an already-committed
+        // trigger replayed by the fresh subscription fails the IsPast gate — no double compile.
+        // Poisoned own content stops loudly (the compile watcher parks the type on the same
+        // emission — the visible sink).
+        return ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+            () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && def.RequestedReleaseAt is { } req
                 // Strictly past our process-local COMMIT high-water — a flapped-back
@@ -836,8 +861,7 @@ internal static class NodeTypeCompilationHelpers
                 && (def.LastReleaseRequestHandledAt is null
                     || req > def.LastReleaseRequestHandledAt.Value)
                 && def.CompilationStatus is not CompilationStatus.Pending
-                                          and not CompilationStatus.Compiling)
-            .Subscribe(
+                                          and not CompilationStatus.Compiling),
                 node =>
                 {
                     // 🚨 The trigger value OBSERVED by the Where for THIS emission.
@@ -905,8 +929,9 @@ internal static class NodeTypeCompilationHelpers
                         ex => logger?.LogWarning(ex,
                             "[ReleaseRequestWatcher] {HubPath}: failed to dispatch release", hubPath));
                 },
-                ex => logger?.LogWarning(ex,
-                    "[ReleaseRequestWatcher] {HubPath}: stream faulted", hubPath));
+            hub.Address,
+            logger,
+            "ReleaseRequestWatcher");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
@@ -181,18 +181,34 @@ public static class ActivityControlPlaneExtensions
     /// <summary>
     /// Subscribes to <paramref name="source"/> and keeps a control-plane / submission
     /// watcher alive across <b>transient</b> faults by re-establishing after a short
-    /// delay — but treats a <b>terminal</b> fault as terminal.
+    /// delay — but treats a <b>terminal</b> fault as terminal. This is THE subscription
+    /// primitive for any watcher whose death would leave a hub half-alive (its process
+    /// keeps running while its control plane is dead — the #891 wedges-to-zero violation);
+    /// never subscribe such a watcher with a bare log-and-die <c>OnError</c> handler.
     ///
-    /// <para>🚨 A <see cref="ErrorType.NotFound"/> <see cref="DeliveryFailureException"/>
-    /// on a hub's OWN node means the node this watcher exists to observe is gone /
-    /// unroutable. Re-establishing then just re-issues a doomed cross-hub
-    /// <c>SubscribeRequest</c> every second forever — the atioz compile-activity storm
-    /// of 2026-06-10 (4999 NotFound round-trips through the single RoutingGrain in 14
-    /// min, starving unrelated subscriptions). That is the exact "resubscribe to recover
-    /// from a state that shouldn't happen" pattern the deleted 2026-06-08 watchdog was.
-    /// On a terminal own-node-gone fault we STOP (the orphaned hub idle-disposes); we
-    /// re-establish ONLY for genuinely transient faults (a hub hiccup where the activity
-    /// is still alive and must not be left unobserved).</para>
+    /// <para>Three fault classes, in classification order:</para>
+    /// <list type="number">
+    ///   <item><description><b>Poisoned own content</b> — a
+    ///     <see cref="MeshNodeStreamException"/> with
+    ///     <see cref="MeshNodeErrorCode.Deserialization"/>: the watched node's own content
+    ///     cannot be materialized. TERMINAL for re-establish purposes: the faulted stream
+    ///     replays the same emission, so re-establishing is a 1 Hz poison loop, not a
+    ///     recovery. Logged CRITICAL and surfaced through
+    ///     <paramref name="onPoisonedContent"/> so the failure lands in a visible sink
+    ///     (e.g. the compile park registry) instead of a single log line.</description></item>
+    ///   <item><description><b>Own node gone</b> — a routing
+    ///     <see cref="ErrorType.NotFound"/> <see cref="DeliveryFailureException"/>: the node
+    ///     this watcher exists to observe is gone / unroutable. Re-establishing then just
+    ///     re-issues a doomed cross-hub <c>SubscribeRequest</c> every second forever — the
+    ///     atioz compile-activity storm of 2026-06-10 (4999 NotFound round-trips through the
+    ///     single RoutingGrain in 14 min, starving unrelated subscriptions). That is the
+    ///     exact "resubscribe to recover from a state that shouldn't happen" pattern the
+    ///     deleted 2026-06-08 watchdog was. STOP; the orphaned hub idle-disposes.</description></item>
+    ///   <item><description><b>Everything else</b> — a genuinely transient fault (hub
+    ///     hiccup, cross-hub delivery blip) where the node is still alive and must not be
+    ///     left unobserved: re-establish after a short delay with a fresh
+    ///     subscription.</description></item>
+    /// </list>
     /// </summary>
     /// <typeparam name="T">Element type produced by the observed source.</typeparam>
     /// <param name="source">Factory that (re-)creates the observable to watch; called once per
@@ -207,14 +223,18 @@ public static class ActivityControlPlaneExtensions
     /// <param name="scheduleReEstablish">Test seam for how a transient re-establish is
     /// scheduled. Production default is a 1 s <see cref="Observable.Timer(TimeSpan)"/>
     /// off the action block.</param>
-    internal static IDisposable SubscribeWithReEstablish<T>(
+    /// <param name="onPoisonedContent">Optional visible sink invoked (once, with the fault) when
+    /// the watcher stops on poisoned own content — route it somewhere a user/operator can see
+    /// (park registry, health surface), not just a log.</param>
+    public static IDisposable SubscribeWithReEstablish<T>(
         Func<IObservable<T>> source,
         Action<T> onNext,
         Address address,
         ILogger? logger,
         string faultLogContext,
         Action? onTransientFault = null,
-        Action<Action>? scheduleReEstablish = null)
+        Action<Action>? scheduleReEstablish = null,
+        Action<Exception>? onPoisonedContent = null)
     {
         var serial = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
@@ -228,6 +248,21 @@ public static class ActivityControlPlaneExtensions
                 onNext,
                 ex =>
                 {
+                    if (IsPoisonedContent(ex))
+                    {
+                        // Terminal: the watched node's own content cannot be deserialized, and
+                        // the stream replays it — a re-establish is a 1 Hz poison loop, not a
+                        // recovery. Stop, scream, and surface through the visible sink; the
+                        // cure is repairing the content (then recycling the hub re-activates
+                        // fresh watchers).
+                        logger?.LogCritical(ex,
+                            "{Context} on {Address} STOPPED: own-node content cannot be deserialized — " +
+                            "re-establishing would replay the same poisoned emission. The watcher stays " +
+                            "down until the content is repaired and the hub re-activates (#891).",
+                            faultLogContext, address);
+                        onPoisonedContent?.Invoke(ex);
+                        return;
+                    }
                     if (IsOwnNodeGone(ex))
                     {
                         // Terminal: the node this watcher observes is gone/unroutable.
@@ -250,6 +285,24 @@ public static class ActivityControlPlaneExtensions
             disposed = true;
             serial.Dispose();
         });
+    }
+
+    /// <summary>
+    /// True when <paramref name="ex"/> (or an inner exception) is a
+    /// <see cref="MeshNodeStreamException"/> with
+    /// <see cref="MeshNodeErrorCode.Deserialization"/> — the per-emission typing fault
+    /// <c>MeshNodeStreamHandle</c>'s content-typing boundary raises when a node's persisted
+    /// content cannot be materialized. Re-subscribing replays the same emission, so for a
+    /// watcher this is terminal-with-visibility, never re-establish.
+    /// </summary>
+    internal static bool IsPoisonedContent(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is MeshNodeStreamException { Error.Code: MeshNodeErrorCode.Deserialization })
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Test/ActivityControlPlaneResubscribeTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ActivityControlPlaneResubscribeTest.cs
@@ -72,6 +72,56 @@ public class ActivityControlPlaneResubscribeTest
     }
 
     [Fact]
+    public void PoisonedContent_DoesNotResubscribe_AndReachesTheVisibleSink()
+    {
+        // #891: a MeshNodeStreamException(Deserialization) is the per-emission typing fault the
+        // stream handle raises for undeserializable node content. The faulted stream REPLAYS the
+        // same emission, so a re-establish is a 1 Hz poison loop — the watcher must stop after
+        // exactly one subscription AND surface the fault through the visible sink (the compile
+        // watchers park the NodeType there), never die on a single log line.
+        var poison = new MeshNodeStreamException(new MeshNodeError(
+            MeshNodeErrorCode.Deserialization, "mesh/1", "cannot materialize NodeTypeDefinition"));
+        var subscriptions = 0;
+        var reEstablishes = 0;
+        Exception? sunk = null;
+        var sinkCalls = 0;
+
+        using var _ = ActivityControlPlaneExtensions.SubscribeWithReEstablish<int>(
+            () => Observable.Defer(() => { subscriptions++; return Observable.Throw<int>(poison); }),
+            _ => { },
+            new Address("mesh", "1"),
+            logger: null,
+            faultLogContext: "test",
+            scheduleReEstablish: reEstablish => { if (reEstablishes++ < 5) reEstablish(); },
+            onPoisonedContent: ex => { sinkCalls++; sunk = ex; });
+
+        subscriptions.Should().Be(1,
+            "poisoned content replays on every resubscribe — re-establishing is a poison loop");
+        sinkCalls.Should().Be(1, "the fault must land in the visible sink exactly once");
+        sunk.Should().BeSameAs(poison);
+    }
+
+    [Fact]
+    public void IsPoisonedContent_ClassifiesOnlyDeserializationFaults()
+    {
+        var poison = new MeshNodeStreamException(new MeshNodeError(
+            MeshNodeErrorCode.Deserialization, "mesh/1", "bad content"));
+        ActivityControlPlaneExtensions.IsPoisonedContent(poison).Should().BeTrue();
+
+        // Wrapped one level down — still detected.
+        ActivityControlPlaneExtensions.IsPoisonedContent(
+            new InvalidOperationException("outer", poison)).Should().BeTrue();
+
+        // Other MeshNode error codes are NOT poison — a NotFound goes through the
+        // own-node-gone classification, a Conflict is transient.
+        ActivityControlPlaneExtensions.IsPoisonedContent(
+            new MeshNodeStreamException(new MeshNodeError(
+                MeshNodeErrorCode.Conflict, "mesh/1", "version conflict"))).Should().BeFalse();
+        ActivityControlPlaneExtensions.IsPoisonedContent(
+            new InvalidOperationException("hub hiccup")).Should().BeFalse();
+    }
+
+    [Fact]
     public void IsOwnNodeGone_TypedNotFound_And_RewrappedMessage_BothDetected()
     {
         // Typed path (Failure.ErrorType == NotFound).


### PR DESCRIPTION
Fixes #891.

## The hazard

The three NodeType control-plane watchers (`InstallCompileWatcher`, `InstallSourcesWatcher`, `InstallReleaseRequestWatcher`) subscribed the own stream with `Subscribe(onNext, ex => log)`. One fault terminated the subscription permanently and silently: compiles stopped dispatching, source tracking froze (`IsDirty` dead, parked-type auto-retry dead), and the Compile button did nothing forever — a hub running half-alive, the wedges-to-zero violation.

## Why option 1 (prove no OnError) is off the table

`SynchronizationStream.OnError` terminally faults the ReplaySubject on legitimate paths (unauthorized, delivery failure, write-path failure), and `MeshNodeStreamHandle`'s content-typing boundary raises per-emission `MeshNodeStreamException(Deserialization)` faults by design (the GUI renders a typed error card off them).

## The fix

All three watchers now subscribe through the canonical `SubscribeWithReEstablish` — the reviewed post-storm primitive `WatchControlPlane`/`WatchSubmission` already use (fault-driven re-establish with terminal discrimination; **not** a timer/poller watchdog — it reacts only to an actual `OnError` and stops on terminal classes). Extended with a third fault class:

| Fault | Behavior |
|---|---|
| Poisoned own content (`Deserialization`) | **Stop** (replay would poison-loop at 1 Hz), log CRITICAL, surface via `onPoisonedContent` — the compile watcher parks the type via `OnCompileFailed(deterministic: true)`, so the failure is user-visible (park notification, diagnostics serve the cached error) instead of one warning line |
| Own node gone (routing NotFound) | Stop, as before (2026-06-10 storm guard) |
| Anything else | Transient — re-establish (1 s), fresh subscription |

Replay safety on re-establish: compile dispatch is status-guarded (Pending→Compiling atomic), the sources snapshot write is idempotent (`DictEquals`), and the release watcher's high-water marks live outside the re-subscribed factory so committed triggers fail the `IsPast` gate — no double compile.

`SubscribeWithReEstablish` becomes public (it is the watcher primitive), with the fault classes documented.

## Verification

- New contract tests: `PoisonedContent_DoesNotResubscribe_AndReachesTheVisibleSink`, `IsPoisonedContent_ClassifiesOnlyDeserializationFaults` — 5/5 in `ActivityControlPlaneResubscribeTest`.
- Existing watcher semantics pinned by `ReleaseRequestWatcherHighWaterTest` + `CodeEditRecompileTest` — 12/12 unchanged.
- Release `-warnaserror` builds clean.
- Known coverage gap, stated honestly: no end-to-end test poisons a real persisted NodeTypeDefinition (requires corrupt JSON on an FS-backed mesh); the classification + stop/park semantics are pinned at the helper level and the wiring is exercised by the existing compile-cycle tests.

No What's New entry — latent-hazard resilience fix, no observed user-facing behavior change on healthy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)