### PR TITLE
An empty TERMINAL activity log says so — never "Running…" beside "✓ Done"

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-activity-log-no-output.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-activity-log-no-output.md
@@ -1,0 +1,17 @@
+---
+Name: Finished runs with no output now say so
+Category: What's New
+Description: An activity that finishes without producing log output now states that explicitly instead of showing a stale "Running…" row.
+Icon: Sparkle
+---
+
+# Finished runs with no output now say so
+
+When a script run finished without writing anything to its log — common for code
+cells whose result is a rendered control rather than log lines — the activity
+panel showed "✓ Done" next to a row that still read "Running…", leaving you to
+guess whether the run had worked.
+
+The log panel now checks the run's actual status: a running activity still shows
+"Running…", and a finished one with an empty log states "This run produced no
+output." — in your language.

--- a/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
@@ -250,10 +250,14 @@ public static class ActivityLayoutAreas
     /// <summary>
     /// The activity log — one row per <see cref="LogMessage"/>: a fixed-width
     /// level tag (INFO / WARN / ERROR / DBG, coloured by severity) beside the
-    /// message text. An empty log on a running activity renders a single
-    /// "Running…" row. Control-based (a vertical <see cref="StackControl"/> of
-    /// horizontal rows) — replaces the former hand-rolled messages HTML and is
-    /// unit-testable without a layout host.
+    /// message text. An empty log on a RUNNING activity renders a single
+    /// "Running…" row; an empty log on a TERMINAL activity says explicitly that
+    /// the run produced no output (#915 — a script whose result is a control
+    /// logs nothing, and "Running…" beside a "✓ Done" header read as a
+    /// contradiction the reader had to decode as failure). Control-based
+    /// (a vertical <see cref="StackControl"/> of horizontal rows) — replaces
+    /// the former hand-rolled messages HTML and is unit-testable without a
+    /// layout host.
     /// </summary>
     public static StackControl BuildLog(ActivityLog log, string? locale = null)
     {
@@ -263,10 +267,7 @@ public static class ActivityLayoutAreas
                 + "font-size: .85rem; gap: 2px; max-height: 320px; overflow: auto;");
 
         if (log.Messages.Count == 0)
-        {
-            return stack.WithView(Controls.Label(LocalizationCatalog.Get("ui.running", locale))
-                .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);"));
-        }
+            return stack.WithView(BuildEmptyLogLabel(log, locale));
 
         foreach (var msg in log.Messages)
         {
@@ -282,6 +283,19 @@ public static class ActivityLayoutAreas
 
         return stack;
     }
+
+    /// <summary>
+    /// The single row an EMPTY log renders: "Running…" while the activity is still
+    /// <see cref="ActivityStatus.Running"/>, and an explicit "this run produced no output"
+    /// statement once it is terminal — never a running label on a finished activity
+    /// (#915: a code cell whose result is a control logs nothing, so "✓ Done" sat beside
+    /// "Running…" and read as a failure). Public pure builder like its siblings so the
+    /// status dependence is unit-testable without a layout host.
+    /// </summary>
+    public static LabelControl BuildEmptyLogLabel(ActivityLog log, string? locale = null) =>
+        Controls.Label(LocalizationCatalog.Get(
+                log.Status == ActivityStatus.Running ? "ui.running" : "ui.activityNoOutput", locale))
+            .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);");
 
     private static string StatusColor(ActivityStatus status) => status switch
     {

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -347,6 +347,7 @@
   "ui.sourceChanged": "Quelle geändert — muss kompiliert werden",
   "ui.upToDate": "Aktuell",
   "ui.notYetRun": "Noch nicht ausgeführt.",
+  "ui.activityNoOutput": "Dieser Lauf hat keine Ausgabe erzeugt.",
   "ui.running": "Wird ausgeführt…",
   "ui.noActivityData": "Keine Aktivitätsdaten.",
   "ui.noActivityYet": "Noch keine Aktivität.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -347,6 +347,7 @@
   "ui.sourceChanged": "Source changed — needs compile",
   "ui.upToDate": "Up to date",
   "ui.notYetRun": "Not yet run.",
+  "ui.activityNoOutput": "This run produced no output.",
   "ui.running": "Running…",
   "ui.noActivityData": "No activity data.",
   "ui.noActivityYet": "No activity yet.",

--- a/test/MeshWeaver.Graph.Test/ActivityProgressViewTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityProgressViewTest.cs
@@ -105,6 +105,26 @@ public class ActivityProgressViewTest
         var logStack = ActivityLayoutAreas.BuildLog(Running());
 
         logStack.Areas.Should().HaveCount(1, "an empty running log shows a single 'Running…' row");
+        ActivityLayoutAreas.BuildEmptyLogLabel(Running()).Data!.ToString()
+            .Should().Be("Running…");
+    }
+
+    [Theory]
+    [InlineData(ActivityStatus.Succeeded)]
+    [InlineData(ActivityStatus.Failed)]
+    [InlineData(ActivityStatus.Warning)]
+    [InlineData(ActivityStatus.Cancelled)]
+    public void Log_EmptyTerminal_SaysNoOutput_NeverRunning(ActivityStatus status)
+    {
+        // #915: a script whose result is a control logs nothing, so a terminal activity with an
+        // empty log is a normal outcome — it must say so explicitly. The old branch rendered
+        // "Running…" without consulting Status, so the reader saw "✓ Done" beside "Running…"
+        // and had to decode the contradiction as failure.
+        var log = new ActivityLog("test") { Status = status, End = DateTime.UtcNow };
+
+        ActivityLayoutAreas.BuildLog(log).Areas.Should().HaveCount(1);
+        ActivityLayoutAreas.BuildEmptyLogLabel(log).Data!.ToString()
+            .Should().Be("This run produced no output.");
     }
 
     [Fact]


### PR DESCRIPTION
Addresses #915 — direction 3 ("say so"), the only direction that needs no product decision. Deliberately does NOT close #915: directions 1/2 (render into the cell / hide Run where it cannot show anything) change what Run means for embedded cells and stay open for a product call.

## The defect

`ActivityLayoutAreas.BuildLog`'s empty-log branch rendered "Running…" without consulting `log.Status`, though its own doc comment says *"an empty log on a **running** activity"*. Empty terminal logs became a normal outcome after #876/#861 (control results are no longer written to the activity log), so a reader running a rendering cell saw **"✓ Done" beside "Running…"** and had to decode the contradiction as failure.

## The fix

- Empty row consults `Status`: Running keeps "Running…"; any terminal status renders an explicit localized **"This run produced no output."**
- New `ui.activityNoOutput` key in both `strings.en.json` and `strings.de.json` (LocalizationTest enforces parity — 33/33 green).
- Label extracted as the public pure builder `BuildEmptyLogLabel`, matching the file's unit-testable-builder pattern.

## Tests

`ActivityProgressViewTest` 11/11 — 4 new terminal-status theory cases assert the exact rendered text; the running row is now asserted by text too. Release `-warnaserror` builds clean.

What's New entry included (user-visible copy change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)