### PR TITLE
Delete the racy fire-and-forget AddSkillSource — the sequenced install hook is the only path

### DIFF
--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -199,38 +199,14 @@ public static class AiSettingsNodeType
             MergeAgentSource(settings, partition),
             $"{partition}/{AgentPickerProjection.SkillSubNamespace}");
 
-    /// <summary>
-    /// Installs a SKILL PACKAGE for <paramref name="user"/>: appends the package's skill folder (e.g.
-    /// <c>Office/Skill</c>) to the user's <see cref="AiSettings.SkillQueries"/> sources — idempotent,
-    /// fire-and-forget, same keyed-query read discipline as <see cref="EnsureExists"/> (never a
-    /// point-read of a possibly-absent node).
-    /// </summary>
-    public static void AddSkillSource(
-        IMessageHub hub, IServiceProvider services, string user, string sourceNamespace)
-    {
-        var meshService = services.GetService<IMeshService>();
-        if (meshService is null || string.IsNullOrEmpty(user) || string.IsNullOrEmpty(sourceNamespace))
-            return;
-        var path = PathFor(user);
-        hub.GetWorkspace()
-            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType} select:path,id,name,nodeType,content")
-            .Take(1)
-            .SelectMany(nodes =>
-            {
-                var node = nodes.FirstOrDefault(n =>
-                    string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase));
-                var current = Effective(node, BuildDefaults(services), hub.JsonSerializerOptions);
-                var merged = MergeSkillSource(current, sourceNamespace);
-                var target = node ?? MeshNode.FromPath(path) with { NodeType = NodeType, Name = "AI Settings" };
-                return meshService.CreateOrUpdateNode(target with { Content = merged });
-            })
-            .Subscribe(
-                _ => { },
-                ex => services.GetService<ILoggerFactory>()
-                    ?.CreateLogger(typeof(AiSettingsNodeType))
-                    .LogWarning(ex, "AddSkillSource: appending {Source} for {Path} failed",
-                        sourceNamespace, path));
-    }
+    // AddSkillSource (the void, fire-and-forget skill-source installer) was DELETED here (#683):
+    // it subscribed to its own write internally, so an install plan could report success before
+    // the settings write landed — a prompt uninstall then raced it and the late write resurrected
+    // a source for a package whose nodes were gone. It had no callers left: install-time source
+    // registration goes through IPartitionInstallHook.OnPartitionInstalled (AiSourcesInstallHook),
+    // which returns IObservable<Unit> and is Concat-chained by PackageInstaller.RunInstallHooks,
+    // so the install result is not produced until the settings write has landed. Any future
+    // registration path must compose that hook chain — never a void method that self-subscribes.
 
     /// <summary>
     /// The LIVE resolved skill queries for a user + context — the reactive form the skill surfaces

--- a/src/MeshWeaver.AI/AiSourcesInstallHook.cs
+++ b/src/MeshWeaver.AI/AiSourcesInstallHook.cs
@@ -19,7 +19,8 @@ namespace MeshWeaver.AI;
 /// <c>AiSettings.AgentQueries</c>, which is written ONCE and never revisited. A user whose settings
 /// predate the install therefore asks for <c>namespace:{user}/Agent|{space}/Agent|Agent</c> forever —
 /// none of which match — and gets an empty picker with no error in any log. Skills had the identical
-/// latent hole: <c>AddSkillSource</c> existed but nothing ever called it.</para>
+/// latent hole: a fire-and-forget <c>AddSkillSource</c> existed but nothing ever called it
+/// (deleted with #683 — this hook's sequenced chain is the only registration path).</para>
 ///
 /// <para><b>Every user, not just the installer.</b> A package is installed once, by an admin, for the
 /// whole instance — so the sources belong on every account, including accounts created before the


### PR DESCRIPTION
Fixes #683.

`AiSettingsNodeType.AddSkillSource` returned `void` and `.Subscribe`d its own write internally — the install plan could report success before the settings write landed, and a prompt uninstall raced it (the late write resurrects a skill source for a package whose nodes are gone).

Verification against current main shows the method is **dead code**: zero callers anywhere in `src/`, `test/`, `memex/`. Install-time source registration goes through `IPartitionInstallHook.OnPartitionInstalled` (`AiSourcesInstallHook`), which returns `IObservable<Unit>` and is `Concat`-chained by `PackageInstaller.RunInstallHooks` — the install result is not produced until the settings write has landed. That IS the sequencing #683 asked for; the remaining hazard was the racy entry point sitting next to the correct hook, waiting to be picked up again.

Deleted with a tombstone comment naming the required pattern (compose the hook chain, never a self-subscribing void). The two prose references to its history are updated.

`PackageSourceRegistrationTest` 8/8 green in Release; `-warnaserror` build clean. No What's New — internal dead-code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)