### PR TITLE
The agent picker reads AiSettings.AgentQueries — plugin agents surface everywhere

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -345,10 +345,30 @@ public static class AgentPickerProjection
     /// </summary>
     public static IObservable<IReadOnlyList<AgentDisplayInfo>> ObserveAgents(
         IMessageHub hub, string? userPath = null, string? spacePath = null)
-        => ObserveSnapshot(hub.GetWorkspace(), hub,
-                $"{AgentsQueryId}|u={userPath ?? ""}|s={spacePath ?? ""}",
-                BuildAgentQuery(userPath, spacePath))
+    {
+        // #901: the pipeline is settings-aware — the user's AiSettings.AgentQueries rows (written
+        // by AiSourcesInstallHook on package install) extend the canonical base query, so
+        // plugin-shipped agents surface in EVERY consumer of this pipe (combobox, default
+        // composer, AgentChatClient's execution-side resolution) without per-surface wiring.
+        // The query id carries a fingerprint of the resolved set: hub.GetQuery caches the shared
+        // upstream by id, so a settings change MUST mint a new id or the old subscription serves
+        // stale queries forever.
+        var workspace = hub.GetWorkspace();
+        return AiSettingsNodeType.ObserveAgentQueries(workspace, hub, hub.ServiceProvider, userPath, spacePath)
+            .Select(queries => ObserveSnapshot(workspace, hub,
+                $"{AgentsQueryId}|u={userPath ?? ""}|s={spacePath ?? ""}|q={Fingerprint(queries)}",
+                queries))
+            .Switch()
             .Select(snapshot => ProjectAgents(snapshot, hub.JsonSerializerOptions));
+    }
+
+    /// <summary>Deterministic short fingerprint of a resolved query set, for cache-keying the
+    /// shared synced-query subscription per distinct set (SHA-256 prefix — stable across
+    /// processes, unlike string.GetHashCode).</summary>
+    private static string Fingerprint(IReadOnlyList<string> queries)
+        => Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(string.Join("\n", queries))))[..12];
 
     /// <summary>
     /// 🚨 The EXACT pipeline the chat model combobox is bound to. The view subscribes to this; tests

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -200,6 +200,75 @@ public static class AiSettingsNodeType
             $"{partition}/{AgentPickerProjection.SkillSubNamespace}");
 
     /// <summary>
+    /// Resolves the user's AGENT sources for a context — the read side of
+    /// <see cref="MergeAgentSource"/>, whose absence was #901: packages dutifully wrote their
+    /// <c>{partition}/Agent</c> rows into <see cref="AiSettings.AgentQueries"/> and nothing ever
+    /// read them, so plugin-shipped agents stayed invisible in every picker.
+    ///
+    /// <para>The canonical base query (<see cref="AgentPickerProjection.BuildAgentQuery"/> —
+    /// platform + user + space namespaces) is ALWAYS first: it is the only row guaranteed to
+    /// resolve, mirroring the skills rule that the platform row leads. The settings rows follow
+    /// (token-substituted; the fused default template dedupes against the base when its tokens
+    /// resolve, and drops harmlessly when the context is empty — the base already covers those
+    /// layers). Reserved/rogue partitions are nulled so a poisoned context can't break the query.</para>
+    /// </summary>
+    public static string[] ResolveAgentQueries(
+        AiSettings? settings, string? contextPath, string? userPath)
+    {
+        string? Partition(string? path)
+            => AgentPickerProjection.IsReservedPartition(path) ? null : AgentPickerProjection.PartitionOf(path);
+        var spacePartition = Partition(contextPath);
+        var baseQuery = AgentPickerProjection.BuildAgentQuery(userPath, spacePartition);
+        var templates = settings is { AgentQueries.IsDefaultOrEmpty: false }
+            ? settings.AgentQueries.AsEnumerable()
+            : DefaultAgentQueryTemplates;
+        return new[] { baseQuery }
+            .Concat(ResolveQueries(templates, spacePartition, null, userPath))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// The LIVE resolved agent queries for a user + context — the reactive form
+    /// <see cref="AgentPickerProjection.ObserveAgents"/> consumes (mirrors
+    /// <see cref="ObserveSkillQueries"/>): observes the user's <see cref="AiSettings"/>
+    /// (defaults when there is no signed-in user) and re-resolves the source rows on change.
+    /// </summary>
+    public static IObservable<string[]> ObserveAgentQueries(
+        IWorkspace workspace, IMessageHub hub, IServiceProvider services,
+        string? user, string? contextPath)
+        => string.IsNullOrEmpty(user)
+            ? Observable.Return(ResolveAgentQueries(null, contextPath, user))
+            : Observe(workspace, hub, services, user!)
+                .Select(settings => ResolveAgentQueries(settings, contextPath, user))
+                .DistinctUntilChanged(qs => string.Join("\n", qs));
+
+    /// <summary>
+    /// One-shot form of <see cref="ObserveAgentQueries"/> for click-time surfaces (the
+    /// <c>/agent</c> picker dialog): resolves against the FIRST live settings snapshot — not
+    /// <see cref="Observe"/>'s immediate defaults emission, which would miss package rows — and
+    /// degrades to the defaults-resolved base after <paramref name="timeout"/> so the picker can
+    /// never hang on a slow settings read.
+    /// </summary>
+    public static IObservable<string[]> ResolveAgentQueriesOnce(
+        IWorkspace workspace, IMessageHub hub, IServiceProvider services,
+        string? user, string? contextPath, TimeSpan? timeout = null)
+    {
+        if (string.IsNullOrEmpty(user))
+            return Observable.Return(ResolveAgentQueries(null, contextPath, user));
+        var defaults = BuildDefaults(services);
+        return workspace
+            .GetQuery($"{NodeType}|{user}", $"path:{PathFor(user!)} nodeType:{NodeType} select:path,id,name,nodeType,content")
+            .Take(1)
+            .Select(nodes => Effective(
+                nodes.FirstOrDefault(n => string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase)),
+                defaults, hub.JsonSerializerOptions))
+            .Timeout(timeout ?? TimeSpan.FromSeconds(2))
+            .Catch<AiSettings, Exception>(_ => Observable.Return(defaults))
+            .Select(settings => ResolveAgentQueries(settings, contextPath, user));
+    }
+
+    /// <summary>
     /// Installs a SKILL PACKAGE for <paramref name="user"/>: appends the package's skill folder (e.g.
     /// <c>Office/Skill</c>) to the user's <see cref="AiSettings.SkillQueries"/> sources — idempotent,
     /// fire-and-forget, same keyed-query read discipline as <see cref="EnsureExists"/> (never a

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2195,14 +2195,23 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             .Catch<AgentPickerProjection.PickerContext, Exception>(_ =>
                 System.Reactive.Linq.Observable.Return(
                     AgentPickerProjection.DerivePickerContext(null, initialContext)))
-            .Subscribe(pc => InvokeAsync(() =>
+            // #901: the agent picker resolves the user's AiSettings.AgentQueries (package-installed
+            // agent sources) on top of the canonical base union — the same settings-aware set
+            // ObserveAgents feeds the combobox and AgentChatClient, so /agent offers exactly what
+            // execution resolves. One-shot with a bounded settings read (degrades to the base
+            // union, never hangs the picker).
+            .SelectMany(pc => (isAgent
+                    ? AiSettingsNodeType.ResolveAgentQueriesOnce(
+                        workspace, Hub, Hub.ServiceProvider, _userHome,
+                        AgentPickerProjection.PartitionOf(pc.ContextPath))
+                    : System.Reactive.Linq.Observable.Return(
+                        AgentPickerProjection.BuildModelQueries(pc.ContextPath, pc.NodeTypePath, userPath: _userHome)))
+                .Select(queries => (Context: pc, Queries: queries)))
+            .Subscribe(t => InvokeAsync(() =>
             {
                 if (_isDisposed) return;
-                var queries = isAgent
-                    ? AgentPickerProjection.BuildAgentQueries(_userHome, AgentPickerProjection.PartitionOf(pc.ContextPath))
-                    : AgentPickerProjection.BuildModelQueries(pc.ContextPath, pc.NodeTypePath, userPath: _userHome);
-                var cacheKey = $"picker|{field}|{pc.ContextPath}|{pc.NodeTypePath}|{string.Join("|", queries)}";
-                RunPicker(workspace, picker, queries, cacheKey, accessService, pickerUser);
+                var cacheKey = $"picker|{field}|{t.Context.ContextPath}|{t.Context.NodeTypePath}|{string.Join("|", t.Queries)}";
+                RunPicker(workspace, picker, t.Queries, cacheKey, accessService, pickerUser);
             }));
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-plugin-agents-in-picker.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-plugin-agents-in-picker.md
@@ -1,0 +1,17 @@
+---
+Name: Plugin-shipped agents now appear in the agent picker
+Category: What's New
+Description: Agents installed by a package are now offered in the chat's agent picker and combobox, wherever you are chatting.
+Icon: Sparkle
+---
+
+# Plugin-shipped agents now appear in the agent picker
+
+Installing a package that ships its own AI agents registered those agents in your
+settings — but the chat's agent picker never read that registration, so the agents
+stayed invisible unless you happened to chat inside the package's own space.
+
+The picker, the agent combobox and the chat engine now resolve your registered
+agent sources everywhere: a package's agents are offered right next to the built-in
+and your own agents, in any space, and the selection validates against the same
+list the chat actually executes with.

--- a/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
@@ -424,6 +424,50 @@ public class AgentPickerQueriesTest
                 "namespace:Office/Skill nodeType:Skill");
     }
 
+    // ─── ResolveAgentQueries: the READ side of AgentQueries (#901) ───
+    // Packages write their {partition}/Agent rows into AiSettings.AgentQueries; these pin that the
+    // picker pipeline actually RESOLVES them — the missing half that left plugin agents invisible.
+
+    [Fact]
+    public void ResolveAgentQueries_Defaults_IsExactlyTheCanonicalBase()
+    {
+        // Null settings ⇒ the fused default template resolves to the canonical base union and
+        // dedupes against it — pre-#901 behavior preserved bit-for-bit for users with no packages.
+        AiSettingsNodeType.ResolveAgentQueries(null, "AgenticPension/Foo/_Thread/x", "rbuergi")
+            .Should().Equal("namespace:rbuergi/Agent|AgenticPension/Agent|Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void ResolveAgentQueries_PackageRow_AppendsAfterBase()
+    {
+        var settings = AiSettingsNodeType.MergePackageSources(new AiSettings(), "Essentials");
+        AiSettingsNodeType.ResolveAgentQueries(settings, "AgenticPension", "rbuergi")
+            .Should().Equal(
+                "namespace:rbuergi/Agent|AgenticPension/Agent|Agent nodeType:Agent" + Proj,
+                "namespace:Essentials/Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void ResolveAgentQueries_NullContext_KeepsPlatformAndUserViaBase()
+    {
+        // The fused default template references {currentPath} and DROPS with a null context — the
+        // always-first canonical base is what keeps platform + user agents present regardless.
+        var settings = AiSettingsNodeType.MergePackageSources(new AiSettings(), "Essentials");
+        AiSettingsNodeType.ResolveAgentQueries(settings, contextPath: null, userPath: "rbuergi")
+            .Should().Equal(
+                "namespace:rbuergi/Agent|Agent nodeType:Agent" + Proj,
+                "namespace:Essentials/Agent nodeType:Agent" + Proj);
+    }
+
+    [Fact]
+    public void ResolveAgentQueries_ReservedContext_IsNulled()
+    {
+        // A rogue route partition (login, settings, …) must never reach the query — it would fail
+        // the whole union with a permission error on the policy-less reserved partition.
+        AiSettingsNodeType.ResolveAgentQueries(null, "login/whatever", "rbuergi")
+            .Should().Equal("namespace:rbuergi/Agent|Agent nodeType:Agent" + Proj);
+    }
+
     [Fact]
     public void MergeSkillSource_EmptyList_SeedsDefaultsThenAppends()
     {

--- a/test/MeshWeaver.Hosting.Monolith.Test/AgentPickerProjectionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/AgentPickerProjectionTest.cs
@@ -212,6 +212,44 @@ public class AgentPickerProjectionTest : MonolithMeshTestBase
     }
 
     /// <summary>
+    /// 🚨 #901 end-to-end: a PACKAGE-shipped agent surfaces through the settings-aware pipeline.
+    /// The install hook writes <c>namespace:{pkg}/Agent</c> into the user's
+    /// <see cref="AiSettings.AgentQueries"/> (the write side that landed with #858); this pins the
+    /// READ side — <see cref="AgentPickerProjection.ObserveAgents"/> resolves those rows, so the
+    /// package's agent appears in the picker even though the chat runs OUTSIDE the package's own
+    /// partition. Pre-fix, the pipeline issued only the fixed base union and the seeded package
+    /// agent below never surfaced.
+    /// </summary>
+    [Fact]
+    public async Task ObserveAgents_PackageSourceInSettings_SurfacesPackageAgent()
+    {
+        const string user = "rbuergi";
+        const string packageAgentPath = "PickerPkg/Agent/PackageAgent";
+
+        await SeedAgent(packageAgentPath, "Package Agent", "package-agent");
+        // The exact write AiSourcesInstallHook performs per user at install time.
+        await SeedTopLevel(MeshNode.FromPath(AiSettingsNodeType.PathFor(user)) with
+        {
+            NodeType = AiSettingsNodeType.NodeType,
+            Name = "AI Settings",
+            Content = AiSettingsNodeType.MergePackageSources(new AiSettings(), "PickerPkg"),
+        });
+
+        // Chat context is a DIFFERENT space (ACME) — pre-#901 the fixed union
+        // (rbuergi/Agent|ACME/Agent|Agent) could never see PickerPkg/Agent.
+        var agents = await AgentPickerProjection
+            .ObserveAgents(Hub, userPath: user, spacePath: "ACME")
+            .Should().Within(15.Seconds())
+            .Match(a => a.Any(x => x.Path == packageAgentPath));
+
+        agents.Select(a => a.Path).Should().Contain(packageAgentPath,
+            "the package's AgentQueries row must be RESOLVED by the picker pipeline — writing it "
+            + "into settings while never reading it is exactly #901.");
+        agents.Select(a => a.Name).Should().Contain("Assistant",
+            "the canonical base union stays first — package rows extend it, never replace it.");
+    }
+
+    /// <summary>
     /// Seeds an Agent MeshNode at <paramref name="path"/> as System (bypasses the partition
     /// write guard for the ad-hoc ACME fixture partition — same shape as
     /// <see cref="MonolithMeshTestBase.SeedTopLevel"/>, reused for nested fixtures here).


### PR DESCRIPTION
Fixes #901.

## The defect

#858 wired the **write** side (install hook registers `{partition}/Agent` into every user's `AiSettings.AgentQueries`) and the **skills** read side — but nothing ever read `AgentQueries`. Every picker surface issued the fixed `namespace:{user}/Agent|{space}/Agent|Agent` union, so plugin-shipped agents stayed invisible (empty picker, "the agent catalog is empty" on selection) unless the chat ran inside the plugin's own partition.

## The fix — mirror the skills read side, one pipeline

- `ResolveAgentQueries`: canonical base union **always first** (the only row guaranteed to resolve — the skills platform-row rule), settings rows follow token-substituted and deduped. The fused default template dedupes into the base when its tokens resolve and drops harmlessly on a null context — package rows can never displace platform/user agents.
- `ObserveAgentQueries` (live) + `ResolveAgentQueriesOnce` (click-time one-shot against the first **live** settings snapshot, 2 s bound → degrades to the base, never hangs the picker).
- `AgentPickerProjection.ObserveAgents` is now settings-aware (`ObserveAgentQueries` + `Switch`) — **one change fixes every consumer**: combobox/@-detection, `ObserveDefaultComposer`, and `AgentChatClient`'s execution-side resolution, so the picker offers exactly what execution resolves. The synced-query id carries a SHA-256 fingerprint of the resolved set (the shared upstream is cached by id — a settings change must mint a new id).
- `OpenPicker`'s `/agent` branch resolves through `ResolveAgentQueriesOnce` in its existing timing-safe chain.

## Verification

- `AgentPickerQueriesTest` 40/40 — 4 new `ResolveAgentQueries` cases: defaults ≡ canonical base bit-for-bit (pre-fix behavior preserved for users with no packages), package row appends after base, null context keeps platform+user via the base, reserved context nulled.
- `AgentPickerProjectionTest` 6/6 — new end-to-end: a package agent seeded under `PickerPkg/Agent` + the exact settings write the install hook performs surfaces through `ObserveAgents` while chatting in a **different** space.
- Release `-warnaserror` builds clean (MeshWeaver.AI, MeshWeaver.Blazor.Portal, both test projects).

What's New entry included (user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)