### PR TITLE
Chat: first "@" autocomplete now shows the results for what you typed (#542)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoCompletionSession.cs
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoCompletionSession.cs
@@ -1,0 +1,116 @@
+namespace MeshWeaver.Blazor.Components.Monaco;
+
+/// <summary>
+/// Per-editor state machine behind the Monaco async-completion glue
+/// (<c>MonacoEditorView.GetAsyncCompletions</c>). One instance lives per editor; each distinct
+/// query opens exactly one subscription to the consumer's completion observable, and every
+/// snapshot that subscription emits is pushed to JS <b>stamped with the query it answers</b>.
+///
+/// <para>That stamp is the contract issue #542 hangs on: the JS provider buffers pushed
+/// snapshots (<c>state._pendingCompletionItems</c> in MonacoEditorView.razor.js) and, on the
+/// re-triggered suggest request, consumes the buffer <i>instead of fetching</i>. When the push
+/// was unkeyed, a buffer produced for an earlier trigger token (e.g. <c>@</c>) was served as
+/// the answer for the now-current one (e.g. <c>@Zebra</c>) — wrong first results — while the
+/// fetch for the real query was skipped, so only a manual re-trigger recovered. The stamp lets
+/// the provider consume a buffered snapshot only when it answers the query currently being
+/// completed, and discard-and-fetch otherwise.</para>
+/// </summary>
+/// <param name="subscribe">Opens the completion stream for a query (the component's
+/// <c>CompletionCallback</c>). Evaluated per query change, so a swapped-in callback is picked
+/// up on the next query.</param>
+/// <param name="push">Delivers a snapshot to the suggest widget, keyed by the query the
+/// snapshot answers. Invoked synchronously from the subscription's OnNext.</param>
+/// <param name="onError">Receives the failing query and the error from the stream or from a
+/// synchronously-throwing subscribe.</param>
+public sealed class MonacoCompletionSession(
+    Func<string, IObservable<IReadOnlyList<CompletionItem>>> subscribe,
+    Action<string, CompletionItem[]> push,
+    Action<string, Exception> onError) : IDisposable
+{
+    private readonly object gate = new();
+    private CompletionItem[] currentCompletions = [];
+    private string? currentQuery;
+    private IDisposable? activeSubscription;
+
+    /// <summary>
+    /// Returns the latest snapshot for <paramref name="query"/> synchronously. A query change
+    /// disposes the previous subscription, resets the snapshot to empty, and subscribes the
+    /// stream for the new query — whose emissions arrive via <c>push</c>, each stamped with
+    /// this query. A repeated query returns the live snapshot without resubscribing (the
+    /// existing subscription keeps pushing). An emission from a superseded subscription that
+    /// is still in flight when the query changes is dropped here (never clobbers the new
+    /// query's snapshot) — and its query stamp would not match the current trigger anyway.
+    /// </summary>
+    public CompletionItem[] GetCompletions(string query)
+    {
+        IObservable<IReadOnlyList<CompletionItem>>? stream = null;
+        lock (gate)
+        {
+            if (string.Equals(currentQuery, query, StringComparison.Ordinal))
+                return currentCompletions;
+
+            currentQuery = query;
+            activeSubscription?.Dispose();
+            activeSubscription = null;
+            currentCompletions = [];
+        }
+
+        try
+        {
+            stream = subscribe(query);
+        }
+        catch (Exception ex)
+        {
+            onError(query, ex);
+        }
+
+        if (stream is null)
+            return [];
+
+        IDisposable? subscription = null;
+        try
+        {
+            subscription = stream.Subscribe(
+                snapshot =>
+                {
+                    var arr = snapshot as CompletionItem[] ?? snapshot.ToArray();
+                    lock (gate)
+                    {
+                        // Superseded mid-flight: a newer query owns the session now.
+                        if (!string.Equals(currentQuery, query, StringComparison.Ordinal))
+                            return;
+                        currentCompletions = arr;
+                    }
+                    push(query, arr);
+                },
+                ex => onError(query, ex));
+        }
+        catch (Exception ex)
+        {
+            onError(query, ex);
+        }
+
+        lock (gate)
+        {
+            if (string.Equals(currentQuery, query, StringComparison.Ordinal))
+            {
+                activeSubscription = subscription;
+                return currentCompletions;
+            }
+        }
+
+        // The query moved on while we were subscribing — this subscription lost the session.
+        subscription?.Dispose();
+        return [];
+    }
+
+    /// <summary>Disposes the active completion subscription, if any.</summary>
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            activeSubscription?.Dispose();
+            activeSubscription = null;
+        }
+    }
+}

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
@@ -429,17 +429,19 @@
             await OnCompletionAccepted.InvokeAsync(path);
     }
 
-    // Latest snapshot from the active completion observable. Updated by the Subscribe
-    // handler in GetAsyncCompletions; returned synchronously to JS on subsequent invokes.
-    private CompletionItem[] _currentCompletions = [];
-    private string _currentCompletionsQuery = "";
-    private IDisposable? _activeCompletionSub;
+    // Per-editor completion state machine: one subscription per query, every pushed snapshot
+    // stamped with the query it answers (the key the JS pending-buffer consume matches on —
+    // issue #542). Created lazily on the first suggest request; the lambdas re-read
+    // CompletionCallback / jsModule at invoke time so parameter/lifecycle updates flow.
+    private MonacoCompletionSession? _completionSession;
 
     /// <summary>
     /// JSInvokable method called from JavaScript to get async completions.
     /// Subscribes to the configured observable callback; returns the current snapshot
     /// synchronously and pushes subsequent snapshots via <see cref="PushCompletionUpdateAsync"/>
-    /// so the suggest widget streams in results as they arrive.
+    /// so the suggest widget streams in results as they arrive. Every push carries the query
+    /// the snapshot answers so the JS provider consumes it only for the matching trigger token
+    /// (see <see cref="MonacoCompletionSession"/>).
     /// </summary>
     [JSInvokable]
     public Task<object[]> GetAsyncCompletions(string query)
@@ -447,33 +449,18 @@
         if (CompletionCallback == null)
             return Task.FromResult(Array.Empty<object>());
 
-        if (!string.Equals(_currentCompletionsQuery, query, StringComparison.Ordinal))
-        {
-            _currentCompletionsQuery = query;
-            _activeCompletionSub?.Dispose();
-            _currentCompletions = [];
-
-            try
+        _completionSession ??= new MonacoCompletionSession(
+            q => CompletionCallback!(q),
+            (q, items) =>
             {
-                _activeCompletionSub = CompletionCallback(query).Subscribe(
-                    snapshot =>
-                    {
-                        var arr = snapshot is CompletionItem[] a ? a : snapshot.ToArray();
-                        _currentCompletions = arr;
-                        // Fire-and-forget: order is preserved by JS event loop. We can't
-                        // await here — Subscribe handlers must stay synchronous.
-                        if (jsModule != null)
-                            _ = PushCompletionUpdateAsync(arr);
-                    },
-                    ex => Logger.LogError(ex, "Error getting async completions for query: {Query}", query));
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error subscribing to async completions for query: {Query}", query);
-            }
-        }
+                // Fire-and-forget: order is preserved by JS event loop. We can't
+                // await here — Subscribe handlers must stay synchronous.
+                if (jsModule != null)
+                    _ = PushCompletionUpdateAsync(q, items);
+            },
+            (q, ex) => Logger.LogError(ex, "Error getting async completions for query: {Query}", q));
 
-        return Task.FromResult(MapCompletionsToJs(_currentCompletions));
+        return Task.FromResult(MapCompletionsToJs(_completionSession.GetCompletions(query)));
     }
 
     /// <summary>
@@ -598,8 +585,10 @@
     /// <summary>
     /// Pushes updated completion items to the editor and re-triggers the suggest widget.
     /// Used for progressive streaming: fast local results first, remote results merge in later.
+    /// <paramref name="query"/> is the query the items answer; the JS side keys its pending
+    /// buffer on it so a snapshot is never served for a different trigger token (issue #542).
     /// </summary>
-    public async Task PushCompletionUpdateAsync(CompletionItem[] items)
+    public async Task PushCompletionUpdateAsync(string query, CompletionItem[] items)
     {
         if (jsModule == null)
             return;
@@ -616,7 +605,7 @@
             sortKey = i.SortKey ?? ""
         }).ToArray<object>();
 
-        await jsModule.InvokeVoidAsync("pushCompletionUpdate", EditorId, mapped);
+        await jsModule.InvokeVoidAsync("pushCompletionUpdate", EditorId, query, mapped);
     }
 
     public async ValueTask<string> GetValueAsync()
@@ -939,7 +928,7 @@
     public async ValueTask DisposeAsync()
     {
         _activeDiagnosticsSub?.Dispose();
-        _activeCompletionSub?.Dispose();
+        _completionSession?.Dispose();
         if (jsModule != null)
         {
             try

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -728,11 +728,24 @@ export function registerCompletionProvider(editorId, config) {
 
             let currentItems;
 
-            if (isAsync && currentState._pendingCompletionItems) {
-                // Progressive update: use pre-fetched items pushed via pushCompletionUpdate
-                currentItems = currentState._pendingCompletionItems;
+            const pending = isAsync ? currentState._pendingCompletionItems : null;
+            if (pending && pending.query === fullQuery) {
+                // Progressive update: use pre-fetched items pushed via pushCompletionUpdate —
+                // but ONLY when they answer the query currently being completed. The buffer is
+                // keyed by the query the .NET subscription computed the snapshot for.
+                currentItems = pending.items;
                 currentState._pendingCompletionItems = null;
             } else if (isAsync) {
+                // Any pending buffer here answers a DIFFERENT (stale) query: a push for an
+                // earlier trigger token landing after the user typed on, or a leftover from a
+                // previous suggest session (a push that arrived while no @-token was active is
+                // never consumed — the early `!triggerMatch` return above skips the buffer).
+                // Consuming it unkeyed served the stale items as the FIRST result for the new
+                // trigger AND skipped the fetch for the real query — issue #542 ("first @
+                // autocomplete shows wrong results; only re-triggering shows the right list").
+                // Discard it and fetch for the current query; the resulting .NET subscription
+                // re-pushes snapshots keyed to this query, which the branch above then serves.
+                currentState._pendingCompletionItems = null;
                 // Async mode: fetch from server with debounce (send full query including trigger char)
                 currentItems = await debouncedFetch(fullQuery);
             } else {
@@ -949,11 +962,15 @@ export function triggerSuggest(editorId) {
 
 // Push updated completion items into the editor's pending state and re-trigger suggestions.
 // Used for progressive streaming: fast local results arrive first, remote results merge in later.
-export function pushCompletionUpdate(editorId, items) {
+// `query` is the query these items answer — the completion provider consumes the buffer ONLY
+// when it still matches the trigger token being completed, and discards-and-fetches otherwise
+// (issue #542: an unkeyed buffer served a previous query's items as the first result while
+// suppressing the fetch for the current one).
+export function pushCompletionUpdate(editorId, query, items) {
     const state = editorState.get(editorId);
     if (state) {
-        // Store updated items — the completion provider's debouncedFetch will use these on re-trigger
-        state._pendingCompletionItems = items;
+        // Store updated items keyed by query — consumed by the provider on the re-trigger below
+        state._pendingCompletionItems = { query, items };
         const editorInstance = state.editorInstance;
         if (editorInstance) {
             editorInstance.trigger('', 'editor.action.triggerSuggest', {});

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-first-autocomplete-results.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-first-autocomplete-results.md
@@ -1,0 +1,19 @@
+---
+Name: First "@" suggestions are now correct
+Category: What's New
+Description: The first autocomplete popup after typing "@" in the chat composer now shows the results for what you actually typed — no more re-triggering to get the right list.
+Icon: Sparkle
+---
+
+# First "@" suggestions are now correct
+
+Typing `@` in the chat composer to reference a mesh node sometimes showed the
+wrong suggestions on the very first popup — typically the results for a previous
+search, or for the bare `@` before you had finished typing the name. Only
+deleting and retyping the reference (or otherwise re-triggering the popup)
+brought up the right list.
+
+The composer now tags every batch of streamed-in suggestions with the search
+text it answers, and the suggestion widget only shows a batch that matches what
+you are currently typing — anything stale is discarded and the correct search
+runs instead. The first popup reflects your actual input, every time.

--- a/test/MeshWeaver.Autocomplete.Test/MonacoCompletionSessionTest.cs
+++ b/test/MeshWeaver.Autocomplete.Test/MonacoCompletionSessionTest.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Blazor.Components.Monaco;
+using Xunit;
+
+namespace MeshWeaver.Autocomplete.Test;
+
+/// <summary>
+/// Pins the C# half of the issue-#542 fix: <see cref="MonacoCompletionSession"/> (the state
+/// machine behind <c>MonacoEditorView.GetAsyncCompletions</c>) must stamp every snapshot it
+/// pushes to the Monaco suggest widget with the query the snapshot answers. The JS provider
+/// (MonacoEditorView.razor.js) buffers pushed snapshots and consumes the buffer instead of
+/// fetching — keyed by exactly this stamp. An unkeyed push let a snapshot computed for an
+/// earlier trigger token (e.g. <c>@</c>) be served as the first result for the current one
+/// (e.g. <c>@Zebra</c>) while suppressing the fetch for the real query, so only a manual
+/// re-trigger showed the right list. The JS consumption itself is not covered here (no JS
+/// harness in this suite); these tests pin the contract the JS keying relies on.
+/// </summary>
+public class MonacoCompletionSessionTest
+{
+    private static CompletionItem Item(string label) => new() { Label = label };
+
+    private sealed record Push(string Query, CompletionItem[] Items);
+
+    [Fact]
+    public void FirstQuery_SubscribesOnce_PushesSnapshotsKeyedByQuery()
+    {
+        var subject = new Subject<IReadOnlyList<CompletionItem>>();
+        var subscribed = new List<string>();
+        var pushes = new List<Push>();
+        var session = new MonacoCompletionSession(
+            q => { subscribed.Add(q); return subject; },
+            (q, items) => pushes.Add(new(q, items)),
+            (_, ex) => throw ex);
+
+        // First invoke for a fresh query: no snapshot yet — returns empty synchronously.
+        session.GetCompletions("@").Should().BeEmpty();
+        subscribed.Should().Equal("@");
+
+        var snapshot = new[] { Item("Alpha"), Item("Beta") };
+        subject.OnNext(snapshot);
+
+        // The push carries the query the snapshot answers — the JS pending-buffer key.
+        pushes.Should().HaveCount(1);
+        pushes[0].Query.Should().Be("@");
+        pushes[0].Items.Should().Equal(snapshot);
+
+        // Same query again: serves the live snapshot without opening a second subscription.
+        session.GetCompletions("@").Should().Equal(snapshot);
+        subscribed.Should().Equal("@");
+    }
+
+    [Fact]
+    public void SupersededQuery_SnapshotIsNeverServedForTheNewTrigger()
+    {
+        var subjects = new Dictionary<string, Subject<IReadOnlyList<CompletionItem>>>();
+        var pushes = new List<Push>();
+        var session = new MonacoCompletionSession(
+            q => subjects[q] = new(),
+            (q, items) => pushes.Add(new(q, items)),
+            (_, ex) => throw ex);
+
+        // The #542 sequence: Monaco's first provider request fires with the bare trigger…
+        session.GetCompletions("@");
+        var staleItems = new[] { Item("Alpha") };
+        subjects["@"].OnNext(staleItems); // …and its snapshot lands while the user typed on.
+        pushes.Should().HaveCount(1);
+        pushes[0].Query.Should().Be("@");
+
+        // The next provider request carries the full token. The "@" snapshot must not leak
+        // into it: the old subscription is disposed and the new query starts empty.
+        session.GetCompletions("@Zebra").Should().BeEmpty();
+        subjects["@"].HasObservers.Should().BeFalse();
+
+        var zebraItems = new[] { Item("Zebra Fund") };
+        subjects["@Zebra"].OnNext(zebraItems);
+
+        // Every push is stamped with the query of the subscription that produced it,
+        // so the JS side can discard the "@" buffer when completing "@Zebra".
+        pushes.Should().HaveCount(2);
+        pushes[1].Query.Should().Be("@Zebra");
+        pushes[1].Items.Should().Equal(zebraItems);
+        session.GetCompletions("@Zebra").Should().Equal(zebraItems);
+    }
+
+    [Fact]
+    public void SynchronousEmissionOnSubscribe_IsReturnedByTheFirstCall()
+    {
+        var items = new[] { Item("Alpha") };
+        var pushes = new List<Push>();
+        var session = new MonacoCompletionSession(
+            _ => Observable.Return<IReadOnlyList<CompletionItem>>(items),
+            (q, arr) => pushes.Add(new(q, arr)),
+            (_, ex) => throw ex);
+
+        // A source that emits synchronously on Subscribe: the first snapshot for the trigger
+        // reflects that trigger's query — returned by the very first call, and pushed keyed.
+        session.GetCompletions("@").Should().Equal(items);
+        pushes.Should().HaveCount(1);
+        pushes[0].Query.Should().Be("@");
+        pushes[0].Items.Should().Equal(items);
+    }
+
+    [Fact]
+    public void StreamError_ReportsTheFailingQuery()
+    {
+        var failures = new List<(string Query, Exception Error)>();
+        var boom = new InvalidOperationException("boom");
+        var session = new MonacoCompletionSession(
+            _ => Observable.Throw<IReadOnlyList<CompletionItem>>(boom),
+            (_, _) => { },
+            (q, ex) => failures.Add((q, ex)));
+
+        session.GetCompletions("@x").Should().BeEmpty();
+        failures.Should().HaveCount(1);
+        failures[0].Query.Should().Be("@x");
+        failures[0].Error.Should().BeSameAs(boom);
+    }
+
+    [Fact]
+    public void Dispose_ClosesTheActiveSubscription()
+    {
+        var subject = new Subject<IReadOnlyList<CompletionItem>>();
+        var session = new MonacoCompletionSession(
+            _ => subject,
+            (_, _) => { },
+            (_, ex) => throw ex);
+
+        session.GetCompletions("@");
+        subject.HasObservers.Should().BeTrue();
+
+        session.Dispose();
+        subject.HasObservers.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes #542.

## Symptom

The first `@` autocomplete in the chat composer showed wrong results — typically a previous search's items or the results for the bare `@` — and only re-triggering the popup brought up the right list.

## Mechanism (verified in code, not assumed)

The Monaco glue streams completion snapshots from .NET and buffers them for the suggest widget — but the buffer was **not keyed by the query the snapshot answers**:

- `pushCompletionUpdate` (`src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js`, pre-fix line 952-962) stored each pushed snapshot unkeyed in `state._pendingCompletionItems` and re-triggered suggest.
- The provider's next request (pre-fix line 731-734) consumed that buffer **instead of fetching** whenever it was non-null — regardless of which query the items were computed for.

Two concrete stale-serve paths, both killed by keying:

1. **Fast typing** — typing `@Zebra` quickly: Monaco's first provider request fires with `@` only; its snapshot lands after the user typed on; the re-triggered provider consumes the `@` items as the answer for `@Zebra` **and skips the fetch** — `.NET` never sees `@Zebra`, the items don't match "Zebra", and the widget dead-ends until a manual re-trigger.
2. **Leftover buffer** — a push landing while no `@`-token is active is never consumed (the provider early-returns at the `!triggerMatch` check, razor.js line 710-712), so the buffer survives to the **next** suggest session, whose first request serves the previous session's items and skips the fetch — the "first @ shows wrong results" report verbatim.

`BlazorAutocompleteService.GetCompletions`/`GetReferenceCompletions` and `ThreadChatView.GetCompletions` were inspected too: stateless per query, `RunUnderCircuitUser` handles the access context — no defect there.

## Fix (root cause, no delays / no re-fetch timers)

Stamp every push with the query the snapshot answers; consume only on exact match:

- **`MonacoCompletionSession.cs`** (new): the per-editor completion state machine previously inline in `MonacoEditorView.GetAsyncCompletions` — one subscription per query, synchronous snapshot return. Each pushed snapshot now carries the query of the subscription that produced it (closure-captured, so an in-flight emission from a superseded query keeps its own stamp), and a superseded emission can no longer clobber the new query's snapshot.
- **`MonacoEditorView.razor`**: `GetAsyncCompletions` delegates to the session; `PushCompletionUpdateAsync(query, items)` forwards the stamp to JS.
- **`MonacoEditorView.razor.js`**: the buffer is `{ query, items }`; the provider consumes it only when `pending.query === fullQuery`, otherwise discards it and fetches for the current query — whose subscription re-pushes correctly keyed snapshots that the matching branch then serves.

Known adjacent hygiene issue, deliberately untouched here: the JS `debounce()` helper never resolves superseded callers' promises (they leak pending). It does not produce wrong results — Monaco cancels superseded sessions — and is not part of this mechanism.

## Tests

- `MonacoCompletionSessionTest` (test/MeshWeaver.Autocomplete.Test, 5 tests, green) pins the C# contract the JS keying relies on: pushes stamped with the producing query; a superseded query's snapshot never leaks into the new trigger; a synchronously-emitting source is returned by the very first call; stream errors report the failing query; dispose closes the subscription.
- Honest gap: the JS consume/discard branch has no harness in this suite and is untested; E2E coverage is `ChatAtAutocompleteTest` (Playwright, e2e portal).
- Builds green with CI flags (`-c Release -warnaserror`): MeshWeaver.Blazor, MeshWeaver.Blazor.Portal, MeshWeaver.Documentation, MeshWeaver.Autocomplete.Test.

## What's New

`src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-first-autocomplete-results.md` — first `@` suggestions now reflect what you actually typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)