### PR TITLE
MCP: name the bad argument instead of "An error occurred"

### DIFF
--- a/src/MeshWeaver.Mcp/McpArgumentValidation.cs
+++ b/src/MeshWeaver.Mcp/McpArgumentValidation.cs
@@ -1,0 +1,232 @@
+using System.Globalization;
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace MeshWeaver.Mcp;
+
+/// <summary>
+/// Names the argument a <c>tools/call</c> got wrong — instead of letting the caller see the SDK's
+/// opaque <c>"An error occurred invoking '&lt;tool&gt;'."</c>.
+///
+/// <para><b>The bug this closes (#639).</b> Tool schemas change between images —
+/// <c>create nodes</c> became <c>create node</c>, <c>delete path</c> became <c>delete paths</c>.
+/// A caller still speaking the older dialect gets two failure modes today, both of them useless:</para>
+/// <list type="number">
+///   <item><b>The unknown argument is SILENTLY DROPPED.</b> <c>McpJsonUtilities.DefaultOptions</c>
+///     leaves <c>UnmappedMemberHandling</c> at its default (<c>Skip</c>), so
+///     <c>AIFunctionFactory</c>'s unexpected-key check never fires. When the renamed parameter has a
+///     default (e.g. <c>edit_content replaceAll</c>), the call RUNS with the default — a half-executed
+///     step that reports success. That is the "half-executed sequences" of the 2026-07-24
+///     plugin-install retrospective.</item>
+///   <item><b>Otherwise the binder throws and the message is swallowed.</b>
+///     <c>AIFunctionFactory</c> throws <c>ArgumentException("The arguments dictionary is missing a
+///     value for the required parameter 'node'.")</c>, and <c>McpServerImpl</c>'s <c>tools/call</c>
+///     wrapper turns any non-<c>McpException</c> into the fixed text
+///     <c>"An error occurred invoking 'create'."</c> — the argument name never reaches the caller.</item>
+/// </list>
+///
+/// <para><b>The seam.</b> <see cref="CallToolFilter"/> is a single <c>CallToolFilter</c> registered
+/// once in <see cref="McpExtensions.AddMeshMcp"/>, so EVERY tool — present and future — is covered
+/// with no per-tool duplication. It runs inside the SDK's outermost <c>tools/call</c> wrapper (which
+/// has already resolved <see cref="RequestContext{TParams}.MatchedPrimitive"/>) but BEFORE the
+/// argument binder, and short-circuits with a normal <c>IsError</c> result carrying the real message.
+/// Validation is driven entirely by the tool's own published <see cref="Tool.InputSchema"/>, so it can
+/// never drift from what <c>tools/list</c> advertises.</para>
+///
+/// <para><b>Conservative by construction.</b> The check must never reject something the binder would
+/// have accepted, so: JSON <c>null</c> always passes through (the tool's own required-field check
+/// gives a better answer), numeric strings are accepted for <c>integer</c>/<c>number</c> parameters
+/// (<c>McpJsonUtilities.DefaultOptions</c> sets <c>NumberHandling = AllowReadingFromString</c>), and a
+/// parameter whose schema declares no <c>type</c> (<c>anyOf</c>/<c>$ref</c>) is not judged at all.</para>
+///
+/// <para>🚨 These strings are MODEL-FACING, not user-facing: they are read by the calling agent, never
+/// rendered in the portal. Per AGENTS.md they stay English and are deliberately NOT localized — the
+/// same rule that keeps LLM tool-parameter <c>[Description]</c>s untranslated.</para>
+/// </summary>
+public static class McpArgumentValidation
+{
+    /// <summary>
+    /// The <c>tools/call</c> filter: validates the raw arguments against the matched tool's published
+    /// input schema and answers with a naming error instead of delegating to the binder.
+    /// </summary>
+    /// <param name="next">The next handler in the <c>tools/call</c> pipeline.</param>
+    /// <returns><paramref name="next"/> wrapped with argument validation.</returns>
+    public static McpRequestHandler<CallToolRequestParams, CallToolResult> CallToolFilter(
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next) =>
+        (request, cancellationToken) =>
+            request.MatchedPrimitive is McpServerTool tool
+            && Validate(tool.ProtocolTool, request.Params?.Arguments) is { } error
+                ? new ValueTask<CallToolResult>(new CallToolResult
+                {
+                    IsError = true,
+                    Content = [new TextContentBlock { Text = error }]
+                })
+                : next(request, cancellationToken);
+
+    /// <summary>
+    /// Checks a call's arguments against a tool's published input schema.
+    /// </summary>
+    /// <param name="tool">The tool being called (its <see cref="Tool.InputSchema"/> IS the contract).</param>
+    /// <param name="arguments">The raw arguments as received on the wire; may be null or empty.</param>
+    /// <returns>
+    /// <c>null</c> when the call binds — otherwise an <c>Error: …</c> message naming the offending
+    /// argument, in the same shape the tools already use for their own failures.
+    /// </returns>
+    public static string? Validate(Tool tool, IDictionary<string, JsonElement>? arguments)
+    {
+        var schema = tool.InputSchema;
+        if (schema.ValueKind != JsonValueKind.Object
+            || !schema.TryGetProperty("properties", out var properties)
+            || properties.ValueKind != JsonValueKind.Object)
+            return null;   // no declared shape — nothing to check against
+
+        // Declaration order, which is also the order the parameters appear in the tool's signature.
+        var expected = properties.EnumerateObject().Select(p => p.Name).ToArray();
+        var supplied = arguments as IEnumerable<KeyValuePair<string, JsonElement>> ?? [];
+
+        // 1. Unknown argument — the rename tell, and the one the binder drops on the floor.
+        foreach (var argument in supplied)
+            if (!properties.TryGetProperty(argument.Key, out _))
+                return $"Error: unknown argument '{argument.Key}' for tool '{tool.Name}' — expected one of: "
+                     + $"{string.Join(", ", expected)}."
+                     + (ClosestMatch(argument.Key, expected) is { } suggestion ? $" Did you mean '{suggestion}'?" : string.Empty)
+                     + " (Tool schemas change between releases — call tools/list for the current shape.)";
+
+        // 2. Missing required argument.
+        if (schema.TryGetProperty("required", out var required) && required.ValueKind == JsonValueKind.Array)
+        {
+            var requiredNames = required.EnumerateArray()
+                .Where(r => r.ValueKind == JsonValueKind.String)
+                .Select(r => r.GetString()!)
+                .ToArray();
+            foreach (var name in requiredNames)
+                if (arguments is null || !arguments.ContainsKey(name))
+                    return $"Error: missing required argument '{name}' for tool '{tool.Name}' — "
+                         + $"required: {string.Join(", ", requiredNames)}.";
+        }
+
+        // 3. Wrong type.
+        foreach (var argument in supplied)
+            if (properties.TryGetProperty(argument.Key, out var parameterSchema)
+                && Mismatch(parameterSchema, argument.Value) is { } declaredType)
+                return $"Error: argument '{argument.Key}' for tool '{tool.Name}' expects {declaredType}, "
+                     + $"got {Describe(argument.Value)}.";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the declared type name when <paramref name="value"/> cannot bind to
+    /// <paramref name="parameterSchema"/>, or <c>null</c> when it can (or when the schema declares no
+    /// judgeable type).
+    /// </summary>
+    private static string? Mismatch(JsonElement parameterSchema, JsonElement value)
+    {
+        if (parameterSchema.ValueKind != JsonValueKind.Object
+            || !parameterSchema.TryGetProperty("type", out var declaredType))
+            return null;   // anyOf / $ref / untyped — not ours to judge
+
+        var declared = declaredType.ValueKind switch
+        {
+            JsonValueKind.String => [declaredType.GetString()!],
+            JsonValueKind.Array => declaredType.EnumerateArray()
+                .Where(t => t.ValueKind == JsonValueKind.String)
+                .Select(t => t.GetString()!)
+                .ToArray(),
+            _ => Array.Empty<string>()
+        };
+
+        // JSON null always passes through: the binder maps it to null and the tool's own
+        // "'path' is required" answer is more useful than a type complaint.
+        if (declared.Length == 0 || value.ValueKind == JsonValueKind.Null || declared.Any(t => Accepts(t, value)))
+            return null;
+
+        var judgeable = declared.Where(t => t != "null").ToArray();
+        return judgeable.Length == 0 ? null : string.Join(" or ", judgeable);
+    }
+
+    private static bool Accepts(string declaredType, JsonElement value) => declaredType switch
+    {
+        "string" => value.ValueKind == JsonValueKind.String,
+        // NumberHandling = AllowReadingFromString, so a numeric STRING binds — but only when it
+        // really parses as one; "abc" for an int would still throw inside the binder.
+        "integer" => value.ValueKind == JsonValueKind.Number
+                     || (value.ValueKind == JsonValueKind.String
+                         && long.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out _)),
+        "number" => value.ValueKind == JsonValueKind.Number
+                    || (value.ValueKind == JsonValueKind.String
+                        && double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out _)),
+        "boolean" => value.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        "array" => value.ValueKind == JsonValueKind.Array,
+        "object" => value.ValueKind == JsonValueKind.Object,
+        "null" => value.ValueKind == JsonValueKind.Null,
+        _ => true   // unknown type keyword — don't guess
+    };
+
+    /// <summary>Renders a received value as "&lt;kind&gt; (&lt;raw json, truncated&gt;)".</summary>
+    private static string Describe(JsonElement value)
+    {
+        var kind = value.ValueKind switch
+        {
+            JsonValueKind.String => "string",
+            JsonValueKind.Number => "number",
+            JsonValueKind.True or JsonValueKind.False => "boolean",
+            JsonValueKind.Array => "array",
+            JsonValueKind.Object => "object",
+            JsonValueKind.Null => "null",
+            _ => "nothing"
+        };
+        var raw = value.GetRawText().ReplaceLineEndings(" ");
+        return raw.Length <= 60 ? $"{kind} ({raw})" : $"{kind} ({raw[..59]}…)";
+    }
+
+    /// <summary>
+    /// The likeliest intended parameter for an unknown argument name — a rename is a small edit
+    /// (<c>nodes</c>→<c>node</c>, <c>path</c>→<c>paths</c>, <c>replace_all</c>→<c>replaceAll</c>).
+    /// Returns null when nothing is close enough to name with confidence.
+    /// </summary>
+    private static string? ClosestMatch(string supplied, IReadOnlyList<string> expected)
+    {
+        var normalized = Normalize(supplied);
+        string? best = null;
+        var bestDistance = int.MaxValue;
+        foreach (var candidate in expected)
+        {
+            var distance = Distance(normalized, Normalize(candidate));
+            if (distance >= bestDistance)
+                continue;
+            bestDistance = distance;
+            best = candidate;
+        }
+        return best is not null && bestDistance <= Math.Max(2, Normalize(best).Length / 3) ? best : null;
+    }
+
+    /// <summary>Case- and underscore-insensitive, so <c>replace_all</c> matches <c>replaceAll</c>.</summary>
+    private static string Normalize(string name) => name.Replace("_", string.Empty).ToLowerInvariant();
+
+    /// <summary>Levenshtein edit distance over two normalized names (two-row DP).</summary>
+    private static int Distance(string left, string right)
+    {
+        if (left.Length == 0)
+            return right.Length;
+        if (right.Length == 0)
+            return left.Length;
+
+        var previous = new int[right.Length + 1];
+        var current = new int[right.Length + 1];
+        for (var j = 0; j <= right.Length; j++)
+            previous[j] = j;
+
+        for (var i = 1; i <= left.Length; i++)
+        {
+            current[0] = i;
+            for (var j = 1; j <= right.Length; j++)
+                current[j] = Math.Min(
+                    Math.Min(current[j - 1] + 1, previous[j] + 1),
+                    previous[j - 1] + (left[i - 1] == right[j - 1] ? 0 : 1));
+            (previous, current) = (current, previous);
+        }
+        return previous[right.Length];
+    }
+}

--- a/src/MeshWeaver.Mcp/McpArgumentValidation.cs
+++ b/src/MeshWeaver.Mcp/McpArgumentValidation.cs
@@ -34,10 +34,18 @@ namespace MeshWeaver.Mcp;
 /// Validation is driven entirely by the tool's own published <see cref="Tool.InputSchema"/>, so it can
 /// never drift from what <c>tools/list</c> advertises.</para>
 ///
-/// <para><b>Conservative by construction.</b> The check must never reject something the binder would
-/// have accepted, so: JSON <c>null</c> always passes through (the tool's own required-field check
-/// gives a better answer), numeric strings are accepted for <c>integer</c>/<c>number</c> parameters
-/// (<c>McpJsonUtilities.DefaultOptions</c> sets <c>NumberHandling = AllowReadingFromString</c>), and a
+/// <para><b>One deliberate rejection, otherwise conservative.</b> Unknown argument NAMES are rejected
+/// ON PURPOSE, and that is the point of this class: the binder currently ACCEPTS them —
+/// <c>McpJsonUtilities.DefaultOptions</c> leaves <c>UnmappedMemberHandling</c> at <c>Skip</c> — so a
+/// caller using an older tool dialect has its argument silently dropped and, when the renamed
+/// parameter carries a default, gets a SUCCESS for a call that ignored what it asked for (#639's
+/// half-executed sequences). 🚨 Do NOT "restore conservatism" by loosening this check; a silent drop
+/// is the defect.</para>
+///
+/// <para>Everywhere ELSE the check stays strictly weaker than the binder — it must never reject a
+/// VALUE the binder would have accepted, so: JSON <c>null</c> always passes through (the tool's own
+/// required-field check gives a better answer), numeric strings are accepted for
+/// <c>integer</c>/<c>number</c> parameters (<c>NumberHandling = AllowReadingFromString</c>), and a
 /// parameter whose schema declares no <c>type</c> (<c>anyOf</c>/<c>$ref</c>) is not judged at all.</para>
 ///
 /// <para>🚨 These strings are MODEL-FACING, not user-facing: they are read by the calling agent, never

--- a/src/MeshWeaver.Mcp/McpExtensions.cs
+++ b/src/MeshWeaver.Mcp/McpExtensions.cs
@@ -73,7 +73,16 @@ public static class McpExtensions
             // and clients poll with `get`.
             .WithHttpTransport(options => options.Stateless = true)
             .WithToolsFromAssembly(typeof(McpMeshPlugin).Assembly)
-            .WithResourcesFromAssembly(typeof(McpResources).Assembly);
+            .WithResourcesFromAssembly(typeof(McpResources).Assembly)
+            // 🚨 One shared seam for argument validation (#639). Without it a call in an older
+            // schema dialect (create `nodes` before it became `node`, delete `path` before
+            // `paths`) either has the stale argument SILENTLY DROPPED — the binder's
+            // unmapped-member check is off, so a renamed parameter with a default runs with that
+            // default and reports success — or dies as the SDK's fixed
+            // "An error occurred invoking 'create'.", which names nothing. The filter runs before
+            // the binder and answers with the offending argument name; see
+            // McpArgumentValidation for the full mechanism.
+            .WithRequestFilters(filters => filters.AddCallToolFilter(McpArgumentValidation.CallToolFilter));
 
         // BindConfiguration resolves IConfiguration from DI at options
         // construction — works wherever the standard ASP.NET host is running,

--- a/src/MeshWeaver.Mcp/README.md
+++ b/src/MeshWeaver.Mcp/README.md
@@ -13,6 +13,18 @@ This is the transport-layer MCP module — **independent of Blazor** (it was pre
 - API-token authentication via `RequireAuthorization("McpAuth")`
 - Configurable base URL for generating NavigateTo links to the MeshWeaver UI
 
+## Argument validation
+
+Tool schemas change between releases (`create nodes` became `create node`, `delete path` became `delete paths`). A caller still speaking the older dialect used to get nothing useful: the SDK leaves `UnmappedMemberHandling` at `Skip`, so an unknown argument was **silently dropped** — and when the renamed parameter had a default, the call *ran* with that default and reported success. Anything the binder did throw on was flattened by the SDK into the fixed text `An error occurred invoking 'create'.`, which names nothing.
+
+`McpArgumentValidation` closes that. It registers **one** `CallToolFilter` in `AddMeshMcp`, so every tool — present and future — is checked against its own published `InputSchema` before the binder runs, and the call is answered with the offending argument named:
+
+- `Error: unknown argument 'nodes' for tool 'create' — expected one of: node. Did you mean 'node'? (Tool schemas change between releases — call tools/list for the current shape.)`
+- `Error: missing required argument 'node' for tool 'create' — required: node.`
+- `Error: argument 'limit' for tool 'search' expects integer, got string ("twenty").`
+
+The check is deliberately conservative — it must never reject a call the binder would have accepted: JSON `null` passes through, numeric strings bind to `integer`/`number` (`NumberHandling = AllowReadingFromString`), and a parameter whose schema declares no `type` is not judged. The messages are model-facing and stay English by design (AGENTS.md: LLM-facing tool text is not localized).
+
 ## The `GitHubSync` tool
 
 `github_sync` triggers a Space's GitHub sync headlessly — the same one-click Commit / Update / Check the browser's `GitHubAction` layout area runs. Each op runs as a mesh **Activity** (progress / cancel / persisted log) via `MeshWeaver.GitSync.GitHubActivityExtensions`; the tool fires the activity under the caller's identity and returns the activity handle immediately (it never blocks the MCP handler on the long-running GitHub I/O). Requires the Space's `_GitSync` config to exist.

--- a/test/MeshWeaver.AI.Test/McpArgumentValidationTest.cs
+++ b/test/MeshWeaver.AI.Test/McpArgumentValidationTest.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using MeshWeaver.Mcp;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Issue #639 — a schema-mismatch call must NAME the bad argument.
+///
+/// <para>Tool schemas change between images (<c>create nodes</c>→<c>node</c>,
+/// <c>delete path</c>→<c>paths</c>). Before this validation a caller on the older dialect got one of
+/// two useless answers: the stale argument was <b>silently dropped</b> (the SDK leaves
+/// <c>UnmappedMemberHandling</c> at <c>Skip</c>, so a renamed parameter with a default just RAN with
+/// that default — the half-executed sequences of the 2026-07-24 plugin-install retrospective), or the
+/// binder threw and <c>McpServerImpl</c> flattened it to the fixed text
+/// <c>"An error occurred invoking 'create'."</c>, which names nothing.</para>
+///
+/// <para><b>These tests drive the REAL production tool declarations.</b> Each case builds the tool
+/// through the very <c>McpServerTool.Create</c> path <c>WithToolsFromAssembly</c> uses in
+/// <see cref="McpExtensions.AddMeshMcp"/>, so the schema under test IS the shipped schema — rename a
+/// parameter on <see cref="McpMeshPlugin"/> and these expectations move with it.</para>
+///
+/// <para>The tool INSTANCE is never materialised: <c>McpServerTool.Create</c> stores the target
+/// factory and only calls it at invoke time, so a schema-only test needs no mesh, no hub and no
+/// session — it is a pure check of the contract the caller sees.</para>
+///
+/// <para>What is NOT covered here: the <c>CallToolFilter</c> wrapper itself. Short-circuiting it
+/// end-to-end needs a <c>RequestContext&lt;CallToolRequestParams&gt;</c>, which requires a live
+/// <c>McpServer</c> (transport + initialize handshake). The filter is a three-line adapter over
+/// <see cref="McpArgumentValidation.Validate"/> — the decision logic all lives in the validated
+/// method.</para>
+/// </summary>
+public class McpArgumentValidationTest
+{
+    /// <summary>
+    /// The production tool declaration for a <see cref="McpMeshPlugin"/> method — same
+    /// <c>McpServerTool.Create</c> path the server registration uses, so the input schema, the tool
+    /// name (<c>EditContent</c> → <c>edit_content</c>) and the required-set are the shipped ones.
+    /// </summary>
+    private static Tool ToolFor(string methodName) =>
+        McpServerTool.Create(
+                typeof(McpMeshPlugin).GetMethod(methodName)!,
+                _ => throw new InvalidOperationException("schema-only: the tool is never invoked"),
+                new McpServerToolCreateOptions())
+            .ProtocolTool;
+
+    private static Dictionary<string, JsonElement> Args(params (string Name, string Json)[] arguments) =>
+        arguments.ToDictionary(a => a.Name, a => JsonDocument.Parse(a.Json).RootElement);
+
+    // ── The schemas the tests stand on (guards the validator against becoming a silent no-op) ──
+
+    [Fact]
+    public void RealToolSchemas_DeclareTheirParameters()
+    {
+        var create = ToolFor(nameof(McpMeshPlugin.Create));
+        Assert.Equal("create", create.Name);
+        var properties = create.InputSchema.GetProperty("properties");
+        Assert.True(properties.TryGetProperty("node", out _), "create's parameter is 'node' (singular)");
+        Assert.False(properties.TryGetProperty("nodes", out _), "'nodes' is update's parameter, not create's");
+    }
+
+    // ── Unknown argument: name it, list the expected ones, and point at the likely rename ──
+
+    [Fact]
+    public void UnknownArgument_NamesIt_AndListsTheExpectedNames()
+    {
+        // The exact retrospective case: an older dialect calling `create` with `nodes`.
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Create)),
+            Args(("nodes", "\"[{\\\"id\\\":\\\"A\\\"}]\"")));
+
+        Assert.NotNull(error);
+        Assert.StartsWith("Error:", error);
+        Assert.Contains("unknown argument 'nodes'", error);
+        Assert.Contains("expected one of: node", error);
+        Assert.Contains("Did you mean 'node'?", error);
+        Assert.DoesNotContain("An error occurred", error);
+    }
+
+    [Fact]
+    public void UnknownArgument_OnDelete_PointsAtTheRenamedPlural()
+    {
+        // The other half of the retrospective: `delete path` before it became `delete paths`.
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Delete)),
+            Args(("path", "\"ACME/Old\"")));
+
+        Assert.NotNull(error);
+        Assert.Contains("unknown argument 'path'", error);
+        Assert.Contains("expected one of: paths", error);
+        Assert.Contains("Did you mean 'paths'?", error);
+    }
+
+    [Fact]
+    public void UnknownArgument_WithADefaultedTwin_IsRefused_NotSilentlyDropped()
+    {
+        // The dangerous shape: `replaceAll` has a default, so before this check the binder dropped
+        // the misspelled `replace_all` and RAN the edit with replaceAll=false — a half-executed step
+        // reported as success.
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.EditContent)),
+            Args(
+                ("path", "\"ACME/Doc\""),
+                ("oldText", "\"a\""),
+                ("newText", "\"b\""),
+                ("replace_all", "true")));
+
+        Assert.NotNull(error);
+        Assert.Contains("unknown argument 'replace_all'", error);
+        Assert.Contains("Did you mean 'replaceAll'?", error);
+    }
+
+    [Fact]
+    public void UnknownArgument_WithNoCloseMatch_StillListsTheExpectedNames()
+    {
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Move)),
+            Args(("frobnicate", "\"x\"")));
+
+        Assert.NotNull(error);
+        Assert.Contains("unknown argument 'frobnicate'", error);
+        Assert.Contains("sourcePath", error);
+        Assert.Contains("targetPath", error);
+        Assert.DoesNotContain("Did you mean", error);
+    }
+
+    // ── Missing required argument ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MissingRequiredArgument_NamesIt()
+    {
+        var error = McpArgumentValidation.Validate(ToolFor(nameof(McpMeshPlugin.Create)), Args());
+
+        Assert.NotNull(error);
+        Assert.StartsWith("Error:", error);
+        Assert.Contains("missing required argument 'node'", error);
+        Assert.DoesNotContain("An error occurred", error);
+    }
+
+    [Fact]
+    public void MissingOneOfSeveralRequired_NamesTheMissingOne()
+    {
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Move)),
+            Args(("sourcePath", "\"OrgA/Child\"")));
+
+        Assert.NotNull(error);
+        Assert.Contains("missing required argument 'targetPath'", error);
+    }
+
+    // ── Wrong type ─────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WrongTypedArgument_NamesTheArgument_TheExpectedType_AndWhatArrived()
+    {
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Search)),
+            Args(("query", "\"nodeType:Agent\""), ("limit", "\"twenty\"")));
+
+        Assert.NotNull(error);
+        Assert.Contains("argument 'limit'", error);
+        Assert.Contains("expects integer", error);
+        Assert.Contains("got string (\"twenty\")", error);
+    }
+
+    [Fact]
+    public void ObjectSentForAStringArgument_IsNamed()
+    {
+        // `create` takes the node as a JSON *string*; sending the object itself throws inside the
+        // binder today (JsonException → "An error occurred invoking 'create'.").
+        var error = McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Create)),
+            Args(("node", "{\"id\":\"A\"}")));
+
+        Assert.NotNull(error);
+        Assert.Contains("argument 'node'", error);
+        Assert.Contains("expects string", error);
+        Assert.Contains("got object", error);
+    }
+
+    // ── Calls that DO bind must pass untouched (the check may never reject a working call) ─────
+
+    [Fact]
+    public void WellFormedCall_Passes()
+    {
+        Assert.Null(McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Get)),
+            Args(("path", "\"ACME/Project\""))));
+    }
+
+    [Fact]
+    public void OmittedOptionalArguments_Pass()
+    {
+        // search(query, basePath = null, limit = 50) — only the required one supplied.
+        Assert.Null(McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Search)),
+            Args(("query", "\"nodeType:Agent\""))));
+    }
+
+    [Fact]
+    public void NumericStringForAnIntegerArgument_Passes()
+    {
+        // McpJsonUtilities.DefaultOptions sets NumberHandling = AllowReadingFromString, so "20"
+        // binds to int — the check must not be stricter than the binder.
+        Assert.Null(McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Search)),
+            Args(("query", "\"laptop\""), ("limit", "\"20\""))));
+    }
+
+    [Fact]
+    public void NullForAnOptionalArgument_Passes()
+    {
+        // JSON null binds to null; the tool's own required-field answer beats a type complaint.
+        Assert.Null(McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.Search)),
+            Args(("query", "\"laptop\""), ("basePath", "null"))));
+    }
+
+    [Fact]
+    public void BooleanFlagSuppliedCorrectly_Passes()
+    {
+        Assert.Null(McpArgumentValidation.Validate(
+            ToolFor(nameof(McpMeshPlugin.EditContent)),
+            Args(
+                ("path", "\"ACME/Doc\""),
+                ("oldText", "\"a\""),
+                ("newText", "\"b\""),
+                ("replaceAll", "true"))));
+    }
+
+    // ── Why the validation has to exist: the binder's own behaviour, pinned ─────────────────────
+    //
+    // These drive Microsoft.Extensions.AI's binder — the component that owns the failure — under
+    // McpJsonUtilities.DefaultOptions, the exact serializer options the MCP server builds its tools
+    // with. They document what a caller got BEFORE the filter, and they fail loudly if an SDK bump
+    // ever changes those semantics (at which point the filter's rationale needs re-reading).
+
+    private static string SampleCreate(string node) => $"created:{node}";
+
+    private static string SampleEditContent(string path, bool replaceAll = false) => $"{path}:{replaceAll}";
+
+    private static AIFunction Bind(Delegate method) =>
+        AIFunctionFactory.Create(method, new AIFunctionFactoryOptions { SerializerOptions = McpJsonUtilities.DefaultOptions });
+
+    [Fact]
+    public async Task Binder_SilentlyDropsAnUnknownArgument_AndRunsAnyway()
+    {
+        // The dangerous half of #639: `replace_all` is not a parameter, so the binder ignores it and
+        // the call RUNS with replaceAll=false. No error, no warning — a half-executed step reported
+        // as success. Nothing but a pre-binder check can catch this.
+        var result = await Bind(SampleEditContent).InvokeAsync(new AIFunctionArguments
+        {
+            ["path"] = JsonDocument.Parse("\"ACME/Doc\"").RootElement,
+            ["replace_all"] = JsonDocument.Parse("true").RootElement
+        });
+
+        Assert.Equal("ACME/Doc:False", result?.ToString());
+    }
+
+    [Fact]
+    public async Task Binder_MissingRequiredArgument_ThrowsAMessageTheSdkThenDiscards()
+    {
+        // The binder DOES name the parameter — but McpServerImpl's tools/call wrapper turns any
+        // non-McpException into the fixed "An error occurred invoking '<tool>'.", so this text never
+        // reaches the caller. Our filter answers before the binder is ever asked.
+        var error = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await Bind(SampleCreate).InvokeAsync(new AIFunctionArguments
+            {
+                ["nodes"] = JsonDocument.Parse("\"[]\"").RootElement   // the old dialect's name
+            }));
+
+        Assert.Contains("node", error.Message);
+    }
+
+    [Fact]
+    public async Task Binder_WrongTypedArgument_ThrowsAJsonExceptionNamingNoParameter()
+    {
+        // An object where a JSON string is expected: the failure is a raw JsonException about the
+        // JSON shape — it does not name the argument at all, and the SDK discards it too.
+        var error = await Assert.ThrowsAnyAsync<Exception>(async () =>
+            await Bind(SampleCreate).InvokeAsync(new AIFunctionArguments
+            {
+                ["node"] = JsonDocument.Parse("{\"id\":\"A\"}").RootElement
+            }));
+
+        Assert.IsType<JsonException>(error);
+    }
+}

--- a/test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj
+++ b/test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj
@@ -12,6 +12,10 @@
     <ProjectReference Include="..\..\src\MeshWeaver.AI.ClaudeCode\MeshWeaver.AI.ClaudeCode.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.AzureFoundry\MeshWeaver.AI.AzureFoundry.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
+    <!-- McpArgumentValidationTest drives the REAL MCP tool declarations (McpMeshPlugin +
+         McpArgumentValidation). Available transitively via Memex.Portal.Shared; referenced
+         explicitly so the dependency is visible where it is used. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Mcp\MeshWeaver.Mcp.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />


### PR DESCRIPTION
Fixes #639.

## What a caller gets today

Tool schemas change between images — `create nodes` became `create node`, `delete path` became `delete paths`. A caller still speaking the older dialect gets one of two useless answers. I pinned both empirically (three tests in this PR drive Microsoft.Extensions.AI's binder under `McpJsonUtilities.DefaultOptions`, the exact options the MCP server builds its tools with):

| Case | Today |
|---|---|
| **Unknown / extra argument** | **Silently dropped.** `McpJsonUtilities.DefaultOptions` leaves `UnmappedMemberHandling` at its default `Skip`, so `AIFunctionFactory`'s unexpected-key check never fires. When the renamed parameter carries a default (e.g. `edit_content replaceAll`), the call **runs with that default and reports success** — the half-executed sequences of the 2026-07-24 plugin-install retrospective. Verified: `edit_content` with `replace_all: true` returns `ACME/Doc:False`. |
| **Missing required argument** | `AIFunctionFactory` throws `ArgumentException("The arguments dictionary is missing a value for the required parameter 'node'.")` — a good message that **never reaches the caller**: `McpServerImpl`'s `tools/call` wrapper turns every non-`McpException` into the fixed text **`An error occurred invoking 'create'.`** |
| **Wrong-typed argument** | `JsonException` from the deserializer, naming no parameter at all — flattened to the same **`An error occurred invoking 'create'.`** |

## What a caller gets after

```
Error: unknown argument 'nodes' for tool 'create' — expected one of: node. Did you mean 'node'?
       (Tool schemas change between releases — call tools/list for the current shape.)
Error: missing required argument 'node' for tool 'create' — required: node.
Error: argument 'limit' for tool 'search' expects integer, got string ("twenty").
```

Same `Error: …` shape the tools already use for their own failures (`Error: invalid base64 content: …`, `Error: 'space' is required`), delivered as a normal `IsError` result.

## The shared seam

**One** `CallToolFilter` — `McpArgumentValidation.CallToolFilter`, registered once in `McpExtensions.AddMeshMcp` via `WithRequestFilters(f => f.AddCallToolFilter(...))`. Every tool, present and future, is covered with no per-tool duplication.

It runs **inside** the SDK's outermost `tools/call` wrapper (so `RequestContext.MatchedPrimitive` is already resolved) but **before** the argument binder, and validates purely against the matched tool's own published `Tool.InputSchema` — so the check can never drift from what `tools/list` advertises.

**Conservative by construction** — it must never reject a call the binder would have accepted:
- JSON `null` always passes through (the tool's own `'path' is required` answer beats a type complaint).
- Numeric **strings** bind to `integer`/`number` — `McpJsonUtilities.DefaultOptions` sets `NumberHandling = AllowReadingFromString`, so `limit: "20"` is accepted and only `limit: "twenty"` is refused.
- A parameter whose schema declares no `type` (`anyOf`/`$ref`) is not judged at all.

The "did you mean" suggestion is Levenshtein over underscore- and case-normalized names, so `replace_all` → `replaceAll` and `nodes` → `node` are named, while an unrelated key gets the expected-name list without a misleading guess.

## Tests

`test/MeshWeaver.AI.Test/McpArgumentValidationTest.cs` — 17 tests, all green (58 ms, no mesh needed).

They drive the **REAL production tool declarations**: each case builds the tool through the very `McpServerTool.Create` path `WithToolsFromAssembly` uses, so the schema under test IS the shipped schema — rename a parameter on `McpMeshPlugin` and these expectations move with it. `McpServerTool.Create` stores the target factory and only calls it at invoke time, so a schema-only test needs no hub or session.

Coverage: unknown argument named + expected list + suggestion (`create nodes`, `delete path`, `edit_content replace_all`, and a no-close-match case); missing required named (`create`, `move`); wrong type named with expected type and what arrived; and the calls that **must keep passing** (well-formed, omitted optionals, numeric string for an int, null for an optional, correct boolean flag). Three further tests pin the binder's own pre-fix behaviour so an SDK bump that changes those semantics fails loudly instead of leaving this filter's rationale stale.

**Honest gap:** the `CallToolFilter` wrapper itself is not exercised end-to-end. Short-circuiting it needs a `RequestContext<CallToolRequestParams>`, which requires a live `McpServer` (transport + `initialize` handshake) — impractical in a unit test. Per the task's instruction, the decision logic therefore lives entirely in our own dispatch path (`McpArgumentValidation.Validate`), which the tests drive directly; the filter is a three-line adapter over it.

**Also not covered:** the in-portal agent tool surface (`MeshPlugin` in `MeshWeaver.AI`) binds through Microsoft.Extensions.AI directly rather than through the MCP `tools/call` pipeline, so it does not go through this filter. #639 is scoped to MCP; if the same opaque-error class shows up for in-portal agents it wants its own seam.

## Notes

- **No What's New entry** — this is agent/tool-facing diagnostics (MCP clients read these strings), not end-user portal UI.
- **Not localized, deliberately.** Per AGENTS.md, LLM-facing text stays English — translating it degrades tool-calling, the same rule that keeps tool-parameter `[Description]`s untranslated. Called out in the source doc comment so nobody "fixes" it later.
- Release + `-warnaserror` clean for both touched projects (`MeshWeaver.Mcp`, `MeshWeaver.AI.Test`); branch is synced with current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
