### PR TITLE
What's New: admins can enroll a user in one step

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-admin-enroll-action.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-admin-enroll-action.md
@@ -1,0 +1,22 @@
+---
+Name: Admins can enroll a user in one step
+Category: What's New
+Description: Giving somebody access to a package is now a single action — it writes the entitlement record and the access grant together, so nobody ends up "purchased but locked out".
+Icon: PersonAdd
+---
+
+# Admins can enroll a user in one step
+
+Granting somebody access to a Store package used to take two writes that had to agree: the
+entitlement record that marks them an owner, and the access grant that actually opens the gated
+pages. Buying a package did both. Doing it by hand did not — so an admin who added the record saw
+the package listed as owned while every lesson inside stayed locked, with nothing on screen
+explaining the contradiction.
+
+Enrollment is now one action. A platform admin opens **Enroll** on the package, names the person,
+and clicks once; both records are written together, exactly as a purchase writes them. Automation
+gets the same door — a scripted enrollment runs the same code path, so an onboarding script and a
+checkout can no longer drift apart.
+
+Only platform admins can enroll. Re-enrolling somebody who already has access is safe: it refreshes
+their grant in place rather than duplicating anything, and entitlements never expire.


### PR DESCRIPTION
Fixes #642.

The implementation lands in **[MeshWeaver.Plugins#370](https://github.com/Systemorph/MeshWeaver.Plugins/pull/370)** — the enroll primitive it exposes (`PluginGate.Enroll`, wrapped by `Entitlements.GrantEntitlement`) lives in the Store plugin's Roslyn-compiled node source, not in this repo, so this PR carries only the user-facing release note.

## What the issue was

A purchase is two writes — the eternal entitlement record at `{plugin}/_Entitlements/{viewer}` **and** the `_Access` Viewer grant at `{plugin}/_Access/{viewer}_Access`. Coupon redemption and paid orders run both. Admins and automation had no such path, so enrolling by hand meant creating the record and stopping: the store counts that viewer as an owner while the permission fold still denies every gated page.

## What shipped there

`AdminEnrollment.Run(hub, pluginPath, viewer, via)` — validate → gate on `hub.IsGlobalAdmin(userId)` → call the existing `Entitlements.GrantEntitlement`. It re-implements nothing, so a third write added to a purchase tomorrow lands there for free. Two surfaces sit on it: the `/{plugin}/Enroll` admin panel and a `Store/Enrollment` control-plane node an agent creates over MCP (the same shape as `Store/Provision`). 21 in-node tests, green; the plugin compile gate is clean.

## Why the note lives here

`Store` is a Platform package installed on every mesh, so this is a portal-visible change and What's New is where portal users read about it. Strings on the new panel are localized (en + de) in the plugin's own `StoreTexts` catalog, which is that repo's translation mechanism.

Release build with CI's flags: `dotnet build src/MeshWeaver.Documentation -c Release -warnaserror` → 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
