### PR TITLE
Record the model that actually answered; fail the round when none can (#476, code half)

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -51,6 +51,22 @@ public class AgentChatClient : IAgentChat
     private string? currentAgentPath;
     private AgentSession? sharedThread;
     private string? currentModelName;
+    // The model the CALLER asked for, resolved to its wire id but BEFORE the stale-model
+    // fallback ran — the "requested" half of the requested-vs-effective pair. Null when the
+    // round carried no selection (a delegation sub-thread, a generator/automation round).
+    private string? requestedModelName;
+    // Non-null ONLY when a NON-EMPTY requested model was swapped by ApplyStaleModelFallback:
+    // the id that was asked for while <see cref="currentModelName"/> is the one that answers.
+    // This is the machine-readable substitution marker ThreadExecution stamps onto the round's
+    // response cell (ThreadMessage.RequestedModelName) — an automation detects "I did not get
+    // the model I asked for" from the DATA, never from prose.
+    private string? substitutedFromModel;
+    // True when the selected model is unusable AND the catalog offered NO usable replacement,
+    // i.e. the fallback is exhausted. On its own that is not fatal (a deployment can keep its
+    // keys in factory config, invisible to the credential resolver) — it becomes fatal only
+    // when agent creation ALSO produced nothing, which is what latches noUsableModelError.
+    private bool modelFallbackExhausted;
+    private string? noUsableModelError;
     private string? persistentThreadId;
     private IReadOnlyList<string>? currentAttachments;
     private bool isPersistentFactory;
@@ -109,6 +125,34 @@ public class AgentChatClient : IAgentChat
     /// every <see cref="WhenInitialized"/> emission.
     /// </summary>
     public IReadOnlyList<ModelInfo> LoadedModels => loadedModels;
+
+    /// <summary>
+    /// The model that ACTUALLY serves rounds on this client — the caller's selection after
+    /// <c>ApplyStaleModelFallback</c> healed it (and, for a round that carried no selection at
+    /// all, the resolved deployment default). <c>ThreadExecution</c> records THIS on the round's
+    /// response cell and in token accounting, so the persisted record never claims a model that
+    /// did not answer (#476). Null only when no model is selected and none resolves.
+    /// </summary>
+    public string? EffectiveModelName => currentModelName;
+
+    /// <summary>
+    /// The model id the caller ASKED for when it differs from <see cref="EffectiveModelName"/> —
+    /// i.e. the round was silently moved onto another model — else <c>null</c>. Stamped onto the
+    /// response cell as <see cref="ThreadMessage.RequestedModelName"/> so a NON-INTERACTIVE round
+    /// (delegation sub-thread, generator, scheduled automation), which reads no chat transcript,
+    /// can still detect the substitution from the node data.
+    /// </summary>
+    public string? SubstitutedFromModel => substitutedFromModel;
+
+    /// <summary>
+    /// Speaking message describing why NO model can serve a round on this client: the selection has
+    /// no usable credential, the catalog offered no usable replacement, AND agent creation produced
+    /// nothing. Null in every other state — in particular a deployment whose keys live in factory
+    /// config (invisible to the credential resolver) still builds agents and keeps running.
+    /// <para><c>ThreadExecution</c> fails the round with this message instead of letting it proceed
+    /// onto a client that will only produce a raw provider error (#476).</para>
+    /// </summary>
+    public string? NoUsableModelError => noUsableModelError;
 
     // Live subscription to the workspace-level synced agent collection. Disposed
     // and replaced on every Initialize() call so the current context's queries
@@ -1473,6 +1517,13 @@ public class AgentChatClient : IAgentChat
         // last-ditch fallback when the resolver service is absent.
         currentModelName = hub.ServiceProvider.GetService<ChatClientCredentialResolver>()?.ResolveModelId(modelName)
                            ?? SelectionId.IdOf(modelName);
+        // Remember what was ASKED for, in the same wire form the fallback compares against, so a
+        // later swap can be reported as a requested→effective pair rather than silently overwriting
+        // the record (#476). Reset the swap markers: this Initialize starts a fresh resolution.
+        requestedModelName = currentModelName;
+        substitutedFromModel = null;
+        modelFallbackExhausted = false;
+        noUsableModelError = null;
         lastLoadedContextPath = contextPath;
         // Default the NodeType-search namespace to the context node's NodeType when the
         // caller didn't supply one. AgentPickerProjection.BuildAgentQueries will only
@@ -1738,6 +1789,8 @@ public class AgentChatClient : IAgentChat
         // Reset before this attempt — a previous failure shouldn't be surfaced
         // if the new attempt succeeds.
         lastAgentCreationError = null;
+        modelFallbackExhausted = false;
+        noUsableModelError = null;
 
         // 🩹 Self-heal a stale / deleted pinned model. The composer can carry a model id that no
         // longer resolves to a live LanguageModel (catalog refactor, deleted provider) — building a
@@ -1844,6 +1897,25 @@ public class AgentChatClient : IAgentChat
         // new full dict, never a half-built one.
         agents = createdAgents;
         agentsInitialized = true;
+
+        // 🛑 #476: the fallback is exhausted (no model in the catalog has a usable credential) AND
+        // not a single agent could be built — i.e. every factory refused the unusable selection
+        // ("ApiKey is missing for model 'X'"). Running the round now can only produce a raw provider
+        // dump on a model nobody can serve, so latch a SPEAKING failure that ThreadExecution turns
+        // into a terminal Error. Both conditions are required: exhausted-alone is normal for a
+        // deployment whose keys live in factory config (the resolver cannot see those, yet the
+        // agents build and the round runs fine), and empty-alone has other causes that keep their
+        // existing "surface the reason as chat output" behaviour.
+        noUsableModelError = modelFallbackExhausted && createdAgents.IsEmpty
+            ? $"No language model can serve this round: the selected model "
+              + $"'{(string.IsNullOrEmpty(requestedModelName) ? "(none selected)" : requestedModelName)}' "
+              + "has no usable credentials, and no other model in the catalog resolves one. "
+              + "Configure a provider key (Settings → Language Models) or pick a different model."
+              + (string.IsNullOrEmpty(lastAgentCreationError) ? "" : $" Details: {lastAgentCreationError}")
+            : null;
+        if (noUsableModelError is not null)
+            logger.LogWarning("[AgentChatClient] {Error}", noUsableModelError);
+
         logger.LogDebug("[AgentChatClient] Created {Count} agents", agents.Count);
     }
 
@@ -1938,16 +2010,31 @@ public class AgentChatClient : IAgentChat
         var declaredSize = loadedAgents
             .FirstOrDefault(a => string.Equals(a.Name, currentAgentName, StringComparison.OrdinalIgnoreCase))
             ?.AgentConfiguration?.ModelTier;
+        // 🩺 The fallback target is HEALTH-CHECKED, never assumed: ResolveModelIdForSize ranks the
+        // catalog through the SAME HasUsableCredential predicate the early return above uses (and
+        // that AgentPickerProjection.ObserveDefaultComposer uses for the composer default), so a
+        // swap can only ever land on a model whose credentials actually resolve.
         var fallback = resolver.ResolveModelIdForSize(declaredSize);
         if (string.IsNullOrEmpty(fallback)
             || string.Equals(fallback, currentModelName, StringComparison.OrdinalIgnoreCase))
+        {
+            // Nothing usable to swap TO. Not fatal on its own — a deployment can keep its keys in
+            // factory config where the resolver cannot see them — so the round still tries. The
+            // latch lets CreateAgentsSync turn "no usable model AND no agent could be built" into a
+            // speaking round failure instead of a raw provider error (#476).
+            modelFallbackExhausted = true;
             return;
+        }
         var stale = currentModelName;
         currentModelName = fallback;
-        // 🔇 SILENT correction (user directive 2026-07-13: "the user does not get such messages —
-        // silently correct this and take the first valid model"). We LOG the swap for operators but do
-        // NOT emit a user-facing notice: an unusable pinned model is a config/catalog problem the user
-        // can't act on mid-thread, and surfacing it read as noise. The round just runs on the default.
+        // 🔇 SILENT for the USER (directive 2026-07-13: "the user does not get such messages —
+        // silently correct this and take the first valid model"): no assistant chat message, because
+        // an unusable pinned model is a config/catalog problem the user cannot act on mid-thread.
+        // NEVER silent for an OPERATOR though — that was the #476 defect. Two durable signals:
+        // this Warning naming BOTH models, and `substitutedFromModel`, which ThreadExecution stamps
+        // onto the round's response cell so a non-interactive round (which reads no chat stream)
+        // still carries the fact in its data.
+        substitutedFromModel = string.IsNullOrEmpty(stale) ? null : stale;
         logger.LogWarning(
             "[AgentChatClient] Selected model '{Stale}' is not usable (no resolvable key); "
             + "silently falling back to default model '{Default}'.",

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -497,9 +497,25 @@ public record ThreadMessage
     public string? AgentName { get; init; }
 
     /// <summary>
-    /// The model used to generate this response (for AgentResponse messages).
+    /// The model that ACTUALLY generated this response (for AgentResponse messages) — the
+    /// effective model after the stale-model fallback, never merely the one that was asked for.
+    /// Pair it with <see cref="RequestedModelName"/> to see a substitution.
     /// </summary>
     public string? ModelName { get; init; }
+
+    /// <summary>
+    /// The model the caller ASKED for, stamped ONLY when it differs from <see cref="ModelName"/>
+    /// — i.e. the round was moved onto a different model because the requested one had no usable
+    /// credentials (<c>AgentChatClient.ApplyStaleModelFallback</c>).
+    ///
+    /// <para>This is the durable, machine-readable substitution marker (#476). The swap used to be
+    /// visible only as an assistant chat message, so a NON-INTERACTIVE round — a delegation
+    /// sub-thread, a generator agent, a scheduled automation — recorded the requested model while a
+    /// different one answered, and nothing on the node said so. A background job can now detect
+    /// "I did not get the model I asked for" as <c>RequestedModelName is not null</c>, without
+    /// parsing prose. Null on the normal path (no substitution).</para>
+    /// </summary>
+    public string? RequestedModelName { get; init; }
 
     /// <summary>
     /// The harness (<see cref="Harnesses"/>) this round ran under. Stamped onto

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1021,7 +1021,8 @@ internal static class ThreadExecution
             string? summary = null,
             string? harness = null,
             int? cacheReadTokens = null, int? cacheWriteTokens = null,
-            bool stampActivity = true)
+            bool stampActivity = true,
+            string? requestedModelName = null)
         {
             // Cell already latched dead (no initial state ever arrived) — skip the write entirely.
             // Never construct/subscribe a doomed cache.Update; that is the storm. Empty completes
@@ -1156,6 +1157,10 @@ internal static class ThreadExecution
                     // persisted/displayed cell author is the friendly short name (last segment).
                     AgentName = SelectionId.IdOf(agentName) ?? current.AgentName,
                     ModelName = modelName ?? current.ModelName,
+                    // 🪧 Substitution marker (#476) — sticky once stamped: every later push in the
+                    // round carries it, so the terminal cell (Completed / Cancelled / Error alike)
+                    // records BOTH the model that answered and the one that was asked for.
+                    RequestedModelName = requestedModelName ?? current.RequestedModelName,
                     Harness = harness ?? current.Harness,
                     InputTokens = inputTokens ?? current.InputTokens,
                     OutputTokens = outputTokens ?? current.OutputTokens,
@@ -1448,6 +1453,29 @@ internal static class ThreadExecution
                         "[ThreadExec] Harness '{Harness}' → {Client} (bypassing provider chain) for {ThreadPath}",
                         request.Harness, harnessClient.GetType().Name, threadPath);
 
+                // 🪙 #476 — TRUTHFUL MODEL RECORD. `request.ModelName` is what the caller ASKED for;
+                // the model that actually answers is the one AgentChatClient resolved after its
+                // stale-model fallback (a pinned model with no usable credential is swapped for the
+                // lowest-Order model that HAS one; a round carrying no selection at all — delegation
+                // sub-thread, generator, scheduled automation — resolves the deployment default).
+                // Recording the request meant the node claimed a model that never ran, and every
+                // downstream consumer (audit trail, per-model token roll-up, cost) inherited the lie.
+                // A CLI harness resolves its own model, so read the client's value only for the
+                // MeshWeaver path; `actualModel` (the id the provider itself reports mid-stream)
+                // still wins over both wherever it is known.
+                var effectiveModel = harnessClient == null ? client.EffectiveModelName : null;
+                var substitutedFrom = harnessClient == null ? client.SubstitutedFromModel : null;
+                // 🔊 NEVER SILENT. The user-facing chat notice is deliberately gone (directive
+                // 2026-07-13), but an operator must be able to see the swap after the fact on ANY
+                // round type — hence this Warning naming both models AND the durable marker stamped
+                // onto the response cell below (ThreadMessage.RequestedModelName).
+                if (!string.IsNullOrEmpty(substitutedFrom))
+                    logger.LogWarning(
+                        "[ThreadExec] MODEL_SUBSTITUTED threadPath={ThreadPath} responseId={ResponseId} "
+                        + "requested={Requested} answered={Effective} — the requested model has no usable "
+                        + "credentials; this round runs on the fallback",
+                        threadPath, responseMsgId, substitutedFrom, effectiveModel ?? "(none)");
+
                 // Set context from remote stream — must subscribe (Current is null on cold streams).
                 // When ContextPath is empty we just set null; otherwise wait for the first emission
                 // (with a short timeout fallback so a missing/inaccessible node doesn't stall execution)
@@ -1635,7 +1663,8 @@ internal static class ThreadExecution
                     // link while the sub-thread executes (streaming loop is blocked
                     // during tool execution; throttle block never runs).
                     PushToResponseMessage(textSnapshot, snapshotLog, snapshotNodes,
-                        request.AgentName, request.ModelName);
+                        request.AgentName, effectiveModel ?? request.ModelName,
+                        requestedModelName: substitutedFrom);
                         })
                     : null;
                 // Middleware-side ForwardToolCall: UPDATES the matching bare entry
@@ -1718,6 +1747,51 @@ internal static class ThreadExecution
                     : chatHistory.Add(new ChatMessage(ChatRole.User, request.UserMessageText));
                 logger.LogInformation("[ThreadExec] Sending {Count} messages to agent ({HistoryCount} history + 1 new): threadPath={ThreadPath}, agent={Agent}",
                     allMessages.Count, chatHistory.Count, threadPath, request.AgentName ?? "(default)");
+
+                // 🛑 #476 — NO MODEL CAN SERVE THIS ROUND. The selection has no usable credential,
+                // the catalog offered no usable replacement, and no agent could be built. Proceeding
+                // would call a client that can only answer with a raw provider error (the "ApiKey is
+                // missing" / 429 dump pasted into the thread summary), and the round would settle as
+                // COMPLETED — success, to any automation reading the node. Fail it instead, with a
+                // message that names the situation. Deterministic terminal write, same shape as the
+                // NOTHING_TO_SEND branch below, plus the parent/notification signals the error path
+                // uses so a delegating parent never waits on a round that will not run.
+                if (harnessClient == null && client.NoUsableModelError is { } noModelError)
+                {
+                    logger.LogError(
+                        "[ThreadExec] NO_USABLE_MODEL threadPath={ThreadPath} responseId={ResponseId}: {Error}",
+                        threadPath, responseMsgId, noModelError);
+                    var noModelDone = new System.Reactive.Subjects.AsyncSubject<System.Reactive.Unit>();
+                    PushToResponseMessage(
+                        $"*Error: {noModelError}*",
+                        ImmutableList<ToolCallEntry>.Empty, ImmutableList<NodeChangeEntry>.Empty,
+                        request.AgentName, effectiveModel ?? request.ModelName,
+                        completedAt: DateTime.UtcNow,
+                        status: ThreadMessageStatus.Error,
+                        summary: noModelError,
+                        harness: request.Harness,
+                        requestedModelName: substitutedFrom).Subscribe(
+                        _ => { },
+                        ex => execLogger?.LogWarning(ex,
+                            "PushToResponseMessage(NoUsableModel) failed for {ThreadPath}", threadPath));
+                    UpdateThreadExecution(t => t.ResetExecution() with { Summary = noModelError }).Subscribe(
+                        _ => { },
+                        ex =>
+                        {
+                            execLogger?.LogWarning(ex,
+                                "UpdateThreadExecution(NoUsableModel): stream.Update failed for {ThreadPath}", threadPath);
+                            noModelDone.OnError(ex);
+                        },
+                        () =>
+                        {
+                            noModelDone.OnNext(System.Reactive.Unit.Default);
+                            noModelDone.OnCompleted();
+                        });
+                    NotifyParentCompletion(parentHub, threadPath, noModelError, false,
+                        ImmutableList<NodeChangeEntry>.Empty);
+                    EmitCompletionNotification(parentHub, threadPath, noModelError, request.AgentName);
+                    return noModelDone;
+                }
 
                 // 🚫 Nothing to send: no current user turn AND no prior history. There is
                 // genuinely nothing for the agent to respond to — finish the round gracefully
@@ -1852,9 +1926,13 @@ internal static class ThreadExecution
                 // placeholder is NOT agent progress, so it must not set LastActivityAt
                 // (else first-token latency reads as a stall to the parent heartbeat).
                 PushToResponseMessage("Generating response...", ImmutableList<ToolCallEntry>.Empty,
-                    ImmutableList<NodeChangeEntry>.Empty, request.AgentName, request.ModelName,
+                    ImmutableList<NodeChangeEntry>.Empty, request.AgentName,
+                    effectiveModel ?? request.ModelName,
                     status: ThreadMessageStatus.Streaming, harness: request.Harness,
-                    stampActivity: false);
+                    stampActivity: false,
+                    // Stamp the substitution marker on the FIRST write of the round, so a live
+                    // reader (and any round that dies before the terminal write) already carries it.
+                    requestedModelName: substitutedFrom);
 
                 // 🚦 The streaming round is an async I/O leaf and MUST run on the bounded AI
                 // I/O pool — NEVER Task.Run, NEVER inline on the hub turn. The pool offloads onto
@@ -1954,8 +2032,9 @@ internal static class ThreadExecution
                         .Sample(StreamingSampleInterval)
                         .Subscribe(s => PushToResponseMessage(
                             StripSummaryBlock(s.Text), s.ToolCalls, s.NodeChanges,
-                            request.AgentName, request.ModelName,
-                            status: ThreadMessageStatus.Streaming));
+                            request.AgentName, actualModel ?? effectiveModel ?? request.ModelName,
+                            status: ThreadMessageStatus.Streaming,
+                            requestedModelName: substitutedFrom));
 
                     // 💓 #321 reasoning heartbeat. Derived from the SAME `snapshots` stream:
                     // every real emission (text chunk / tool call / result) restarts an idle
@@ -2290,12 +2369,13 @@ internal static class ThreadExecution
                     // Single push: writes Text=finalText, Summary=summaryText,
                     // Status=Completed atomically to the response cell.
                     PushToResponseMessage(finalText, finalToolCalls, aggregatedChanges,
-                        request.AgentName, actualModel ?? request.ModelName,
+                        request.AgentName, actualModel ?? effectiveModel ?? request.ModelName,
                         inputTokens: inputTokens, outputTokens: outputTokens,
                         totalTokens: totalTokens, completedAt: DateTime.UtcNow,
                         status: ThreadMessageStatus.Completed,
                         summary: summaryText, harness: request.Harness,
-                        cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens).Subscribe(
+                        cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens,
+                        requestedModelName: substitutedFrom).Subscribe(
                         _ => { },
                         ex => execLogger?.LogWarning(ex,
                             "PushToResponseMessage(Completed) failed for {ThreadPath}", threadPath));
@@ -2319,7 +2399,7 @@ internal static class ThreadExecution
                     // never touches the round on the no-usage path.
                     TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                         AgentPickerProjection.PartitionOf(threadPath),
-                        actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
+                        actualModel ?? effectiveModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
                         cacheReadTokens, cacheWriteTokens)
                     .Subscribe(
                         _ => { },
@@ -2385,13 +2465,17 @@ internal static class ThreadExecution
                         // OperationCanceledException — so the cell + thread reflect what
                         // the round actually cost.
                         totalTokens = NormalizeTotal(totalTokens, inputTokens, outputTokens);
+                        // 🪙 #476: the model that ACTUALLY ran, exactly as the Completed branch and
+                        // RecordUsage record it — a cancelled round's cell must not claim the
+                        // requested model either.
                         PushToResponseMessage(cancelText, cancelToolCalls, cancelNodeChanges,
-                            request.AgentName, request.ModelName,
+                            request.AgentName, actualModel ?? effectiveModel ?? request.ModelName,
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             totalTokens: totalTokens,
                             completedAt: DateTime.UtcNow,
                             status: ThreadMessageStatus.Cancelled,
-                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens).Subscribe(
+                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens,
+                            requestedModelName: substitutedFrom).Subscribe(
                             _ => { },
                             ex => execLogger?.LogWarning(ex,
                                 "PushToResponseMessage(Cancelled) failed for {ThreadPath}", threadPath));
@@ -2412,7 +2496,7 @@ internal static class ThreadExecution
                         // after the terminal Cancelled status). Fail-open + no-op on zero tokens.
                         TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                             AgentPickerProjection.PartitionOf(threadPath),
-                            actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
+                            actualModel ?? effectiveModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
                             cacheReadTokens, cacheWriteTokens)
                         .Subscribe(
                             _ => { },
@@ -2488,13 +2572,19 @@ internal static class ThreadExecution
                         // Record tokens consumed before the fault (same rationale as the
                         // Cancelled branch) so an errored round still reports its cost.
                         totalTokens = NormalizeTotal(totalTokens, inputTokens, outputTokens);
+                        // 🪙 #476 — THE issue's repro: a round asked for model X, ran on the fallback
+                        // Y, and died on Y's 429. The error cell stamped `request.ModelName` (X), so
+                        // the record blamed a model that never ran while the summary quoted Y's rate
+                        // limit. Stamp what actually answered — and carry the requested id alongside
+                        // it as RequestedModelName so the swap is visible on the failed round too.
                         var pushErrorObs = PushToResponseMessage(errorText, errorToolCalls, errorNodeChanges,
-                            request.AgentName, request.ModelName,
+                            request.AgentName, actualModel ?? effectiveModel ?? request.ModelName,
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             totalTokens: totalTokens,
                             completedAt: DateTime.UtcNow,
                             status: ThreadMessageStatus.Error,
-                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens)
+                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens,
+                            requestedModelName: substitutedFrom)
                             .Timeout(TimeSpan.FromSeconds(10));
                         var errorTextLocal = errorText;
                         var errorNodeChangesLocal = errorNodeChanges;
@@ -2520,7 +2610,7 @@ internal static class ThreadExecution
                                 // Fail-open + no-op on zero tokens.
                                 TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                                     AgentPickerProjection.PartitionOf(threadPath),
-                                    actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
+                                    actualModel ?? effectiveModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
                                     cacheReadTokens, cacheWriteTokens)
                                 .Subscribe(
                                     _ => { },

--- a/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
@@ -117,6 +117,34 @@ Which model a conversation actually runs on resolves in this order (see `ChatCli
 
 ---
 
+## When a Selected Model Is Unusable — the Fallback Is Honest, Never Silent
+
+A pinned model can stop resolving (its provider node lost its key, the catalog was refactored,
+the model was deleted). `AgentChatClient.ApplyStaleModelFallback` then swaps it for a working
+model so the thread keeps running. Three rules make that swap honest:
+
+- **The substitute is health-checked.** The fallback ranks the catalog through
+  `ChatClientCredentialResolver.HasUsableCredential` — a NON-EMPTY ApiKey, not merely a
+  non-`Missing` resolution — the same predicate `AgentPickerProjection` uses for the composer
+  default. A keyless, endpoint-only entry is skipped even when it sorts first by `Order`, so the
+  round never lands on a model every factory refuses with "ApiKey is missing".
+- **The round records what ACTUALLY answered.** `ThreadMessage.ModelName` carries the effective
+  model on every terminal path (Completed, Cancelled **and** Error), and the per-model
+  `TokenUsage` satellite is keyed by it — so cost is attributed to the model that ran. When the
+  effective model differs from the pick, `ThreadMessage.RequestedModelName` carries the requested
+  id alongside it. That pair is the substitution marker: an automation detects "I did not get the
+  model I asked for" from the node, without reading the chat text. An operator additionally gets a
+  `MODEL_SUBSTITUTED` warning naming both models. There is deliberately no user-facing chat notice
+  — an unusable pin is a configuration problem the user cannot act on mid-round.
+- **Nothing usable ⇒ the round FAILS.** If the selection is unusable and the catalog offers no
+  usable replacement *and* no agent could be built, the round terminates with
+  `ThreadMessageStatus.Error` and a message naming the situation. It does not proceed to produce a
+  raw provider error under a `Completed` status, which any automation would read as success.
+  (Exhausted-fallback alone is not fatal: a deployment whose keys live in factory config is
+  invisible to the credential resolver yet builds agents and runs normally.)
+
+---
+
 ## How the Model Picker Is Populated
 
 The picker is **node-based**, not factory-based. `AgentPickerProjection` runs `nodeType:LanguageModel|ModelProvider` queries over the platform `Provider` catalog, the context's `{path}/Provider` subtrees, and the user's own `{user}/_Memex` namespace, and shows the resulting `LanguageModel` nodes, grouped by provider. Those nodes come from two places: the system catalog `BuiltInLanguageModelProvider` materialises from each `{Section}:Models` config list (imported into the `Provider` partition on boot and served from the DB), and space/user `ModelProvider` nodes authored in the mesh.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-model-substitution-visible.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-model-substitution-visible.md
@@ -1,0 +1,30 @@
+---
+Name: You are told when a different model answered your round
+Category: What's New
+Description: A round that gets moved onto a fallback model now records the model that actually answered, keeps the requested one alongside it, and fails outright when no model can serve.
+Icon: Sparkle
+---
+
+# You are told when a different model answered your round
+
+When the model pinned on a thread has no usable credentials, the round is quietly
+moved onto another one so your work keeps running. That part is unchanged — but
+until now the record lied about it: the thread stored the model you *asked for*
+while a different model did the answering. A failing round then blamed a model
+that never ran, and the tokens were booked against it too.
+
+Every round now records the model that **actually answered**. When that is not the
+model you picked, the response also carries the requested one alongside it, so the
+swap is visible on the thread itself — not only in the chat text. That matters for
+rounds nobody is watching: a delegation sub-thread, a generator agent, a scheduled
+run. Their result now carries the fact, and an operator sees a warning naming both
+models in the log.
+
+Token usage and cost follow the same truth: they are booked against the model that
+served the round.
+
+And when *no* model can serve a round at all — the pinned one has no credentials
+and nothing else in the catalogue does either — the round now **fails**, with a
+message naming the situation and pointing at Settings → Language Models. Before,
+it ended as a success carrying a raw provider error, which anything reading the
+result had no way to tell apart from a real answer.

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -1,0 +1,304 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the HONESTY of the stale-model fallback (GitHub issue #476).
+///
+/// <para>A round whose pinned model has no usable credential is silently moved onto another model
+/// (<c>AgentChatClient.ApplyStaleModelFallback</c>). Three things went wrong with that:</para>
+/// <list type="number">
+/// <item>The round RECORDED the model that was asked for — <c>request.ModelName</c> was stamped onto
+/// the response cell on the streaming, Cancelled and Error paths — while a DIFFERENT model answered.
+/// The node then claimed a model that never ran (and the failing round's summary quoted the OTHER
+/// model's 429).</item>
+/// <item>The swap was surfaced ONLY as an assistant chat message, so a non-interactive round
+/// (delegation sub-thread, generator agent, scheduled automation) — which nobody reads — recorded
+/// nothing at all.</item>
+/// <item>Nothing failed when NO model was usable: the round dead-ended on a factory error and still
+/// settled as <c>Completed</c>, i.e. success to any automation reading the node.</item>
+/// </list>
+///
+/// <para>The tests below drive real rounds through <c>ThreadExecution</c> with a scripted chat client
+/// (the seam every AI test uses — no mocking of framework interfaces) over a real seeded model
+/// catalog: one keyed provider and one KEYLESS provider whose model sorts at a LOWER Order, so a
+/// fallback that skipped the health check would prefer it.</para>
+/// </summary>
+public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output)
+{
+    private const string TestUser = "rbuergi@systemorph.com";
+
+    private const string KeyedProviderName = "SubstKeyedProvider";
+    private const string KeylessProviderName = "SubstKeylessProvider";
+    private const string KeyedProviderPath = $"{ModelProviderNodeType.RootNamespace}/{KeyedProviderName}";
+    private const string KeylessProviderPath = $"{ModelProviderNodeType.RootNamespace}/{KeylessProviderName}";
+
+    /// <summary>The healthy model: a provider node WITH an ApiKey → <c>HasUsableCredential</c> true.</summary>
+    private const string HealthyModel = "subst-healthy-model";
+    /// <summary>TokenUsage sanitises non-alphanumerics to '_' when keying the per-model satellite.</summary>
+    private const string HealthyUsageKey = "subst_healthy_model";
+    /// <summary>
+    /// The requested-but-unusable model. Its provider carries NO key, and it deliberately sorts at a
+    /// LOWER Order than <see cref="HealthyModel"/> — a fallback ranking on Order alone would pick it.
+    /// </summary>
+    private const string StaleModel = "subst-stale-model";
+
+    private const int InTokens = 61;
+    private const int OutTokens = 29;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory, SubstitutionChatClientFactory>();
+                return services;
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    /// <summary>
+    /// (a) + (b): the requested model is unusable, the fallback answers — and the round records the
+    /// model that ACTUALLY answered plus a machine-readable marker naming the one that was asked
+    /// for; the substitute is a model with a usable credential, never the lower-Order keyless one.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task UnusableRequestedModel_RoundRecordsAnsweringModel_AndCarriesRequestedMarker()
+    {
+        await SeedProvider(KeyedProviderName, apiKey: "sk-subst-476");
+        await SeedProvider(KeylessProviderName, apiKey: null);
+        await SeedModel(HealthyModel, KeyedProviderPath, KeyedProviderName, order: -1000);
+        // Lower Order than the healthy one: if the fallback ranked on Order WITHOUT the usability
+        // predicate it would land here — on a model every factory refuses for want of a key.
+        await SeedModel(StaleModel, KeylessProviderPath, KeylessProviderName, order: -2000);
+
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+        resolver.EnsureSubscription();
+        // Warm the resolver's snapshot until the catalog is visible to it. The DEFAULT it computes is
+        // the health-checked one — the keyless model outranks it on Order and is still skipped.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => resolver.ResolveDefaultModelId())
+            .Should().Within(30.Seconds()).Match(id => id == HealthyModel);
+
+        resolver.HasUsableCredential(StaleModel).Should().BeFalse(
+            "the requested model's provider carries no ApiKey — every factory throws 'ApiKey is missing' for it");
+        resolver.HasUsableCredential(HealthyModel).Should().BeTrue();
+
+        var threadPath = await SeedThread();
+        var client = GetClient();
+        client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
+
+        var thread = await WaitForThread(threadPath,
+            t => t.Status == ThreadExecutionStatus.Idle && t.Messages.Count >= 2, 60_000);
+
+        var cell = await WaitForCell(threadPath, thread.Messages[^1],
+            m => m.Status == ThreadMessageStatus.Completed, 30_000);
+
+        cell.ModelName.Should().Be(HealthyModel,
+            "the round must record the model that ACTUALLY answered, not the one that was requested (#476)");
+        cell.RequestedModelName.Should().Be(StaleModel,
+            "the substitution must leave a durable, machine-readable marker on the round — a "
+            + "non-interactive caller reads the node, never the chat transcript");
+        resolver.HasUsableCredential(cell.ModelName).Should().BeTrue(
+            "the fallback must only ever select a model whose credentials actually resolve");
+
+        // …and the same truth flows into token accounting: the per-model satellite is keyed by the
+        // model that answered, so its cost is attributed to the right model.
+        var usage = await WaitForUsage(threadPath, HealthyUsageKey,
+            u => u.InputTokens == InTokens && u.OutputTokens == OutTokens, 30_000);
+        usage.Model.Should().Be(HealthyModel);
+    }
+
+    /// <summary>
+    /// (c): NOTHING resolves — the requested model is unusable and the catalog offers no usable
+    /// replacement, so no agent can be built. The round must FAIL with a message that names the
+    /// situation, not settle as a success carrying a raw provider error.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task NoUsableModelAnywhere_FailsRoundWithSpeakingError()
+    {
+        // ONLY the keyless provider + its model: nothing in the catalog can serve a round.
+        await SeedProvider(KeylessProviderName, apiKey: null);
+        await SeedModel(StaleModel, KeylessProviderPath, KeylessProviderName, order: -2000);
+
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+        resolver.EnsureSubscription();
+        // Warm on the CANDIDATE list (the model is in the snapshot) rather than on the default, which
+        // is null both before and after warm-up and would prove nothing.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => resolver.ReadSizeCandidates())
+            .Should().Within(30.Seconds())
+            .Match(c => c.Any(m => m.Id == StaleModel));
+        resolver.ResolveDefaultModelId().Should().BeNull(
+            "the precondition for this test is that NO model in the catalog has a usable credential");
+
+        var threadPath = await SeedThread();
+        var client = GetClient();
+        client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
+
+        var thread = await WaitForThread(threadPath,
+            t => t.Status == ThreadExecutionStatus.Idle && t.Messages.Count >= 2, 60_000);
+
+        var cell = await WaitForCell(threadPath, thread.Messages[^1],
+            m => m.Status is ThreadMessageStatus.Completed or ThreadMessageStatus.Error, 30_000);
+
+        cell.Status.Should().Be(ThreadMessageStatus.Error,
+            "a round that no model can serve must FAIL — settling as Completed reads as success to "
+            + "every automation that checks the node (#476)");
+        cell.Summary.Should().Contain("No language model can serve this round",
+            "the failure must speak: name the situation instead of pasting a raw provider error");
+        cell.Summary.Should().Contain(StaleModel, "the message must name the model that was requested");
+        thread.Status.Should().Be(ThreadExecutionStatus.Idle, "the round must settle, never park");
+    }
+
+    // ─── Seeding ───
+
+    private async Task SeedProvider(string name, string? apiKey) =>
+        await NodeFactory.CreateNode(new MeshNode(name, ModelProviderNodeType.RootNamespace)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = name,
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = name,
+                ApiKey = apiKey,
+                Endpoint = "https://example.invalid/v1",
+                Label = name,
+                CreatedAt = DateTimeOffset.UtcNow
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+    private async Task SeedModel(string id, string providerPath, string providerName, int order) =>
+        await NodeFactory.CreateNode(new MeshNode(id, providerPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = id,
+            State = MeshNodeState.Active,
+            Order = order,
+            Content = new ModelDefinition
+            {
+                Id = id,
+                Provider = providerName,
+                ProviderRef = providerPath,
+                Order = order
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+    private async Task<string> SeedThread()
+    {
+        var threadId = Guid.NewGuid().AsString();
+        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
+        {
+            Name = $"Model Substitution Thread {threadId}",
+            NodeType = ThreadNodeType.NodeType,
+            MainNode = MonolithMeshTestBase.TestPartition,
+            Content = new MeshThread { CreatedBy = TestUser }
+        }).Should().Within(30.Seconds()).Emit();
+        return threadPath;
+    }
+
+    // ─── Waits ───
+
+    private async Task<MeshThread> WaitForThread(string threadPath, Func<MeshThread, bool> predicate, int timeoutMs)
+        => (await Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => n?.Content as MeshThread)
+            .Where(t => t is not null)
+            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
+            .Match(t => predicate(t!)))!;
+
+    private async Task<ThreadMessage> WaitForCell(string threadPath, string cellId, Func<ThreadMessage, bool> predicate, int timeoutMs)
+        => (await Mesh.GetWorkspace().GetMeshNodeStream($"{threadPath}/{cellId}")
+            .Select(n => n?.Content as ThreadMessage)
+            .Where(m => m is not null)
+            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
+            .Match(m => predicate(m!)))!;
+
+    private async Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
+        => (await Mesh.GetWorkspace()
+            .GetMeshNodeStream($"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}")
+            .Select(n => n?.Content as TokenUsage)
+            .Where(u => u is not null)
+            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
+            .Match(u => predicate(u!)))!;
+
+    // ─── Scripted chat client ───
+
+    /// <summary>
+    /// Streams one text chunk plus a usage report. It sets NO <c>ModelId</c> — the production
+    /// condition — so the model on the record can only come from what the client resolved.
+    /// </summary>
+    private sealed class EchoChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ack")));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "ack");
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, new AIContent[]
+            {
+                new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = InTokens,
+                    OutputTokenCount = OutTokens,
+                    TotalTokenCount = InTokens + OutTokens
+                })
+            });
+            await Task.Yield();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Serves both catalog ids, and — like every real factory — REFUSES a model whose credentials
+    /// don't resolve ("ApiKey is missing for model 'X'"). That refusal is what makes an unusable
+    /// selection produce zero agents, which is the state the round-failure path keys on.
+    /// </summary>
+    private sealed class SubstitutionChatClientFactory(IMessageHub hub) : ChatClientAgentFactory(hub)
+    {
+        public override string Name => "SubstitutionFactory";
+        public override IReadOnlyList<string> Models => [HealthyModel, StaleModel];
+        public override int Order => 0;
+
+        protected override IChatClient CreateChatClient(AgentConfiguration agentConfig)
+        {
+            var resolver = Hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
+            if (resolver is not null && !resolver.HasUsableCredential(CurrentModelName))
+                throw new InvalidOperationException(
+                    $"ApiKey is missing for model '{CurrentModelName ?? "(none selected)"}'");
+            return new EchoChatClient();
+        }
+    }
+}


### PR DESCRIPTION
Addresses #476. **This lands the CODE half (part 2) only** — part 1 ("no language model on `memex.systemorph.com` has usable quota") is an operational/credential matter and stays with the maintainer; nothing here touches deployment config, and the issue stays open for it.

## The mechanism

`memex.systemorph.com` reports `DeepSeek-V4-Flash … 429 RateLimitReached` while the same thread's composer records `modelName: glm-5.2`. Both come from ONE round: `AgentChatClient.ApplyStaleModelFallback` (`src/MeshWeaver.AI/AgentChatClient.cs:2010`) swaps a pinned model with no usable credential for the lowest-`Order` model that has one — and the write side only told half the story.

1. **The record named the request, not the answer.** `ThreadExecution` stamped `request.ModelName` on the streaming pushes and on BOTH non-happy terminal paths (Cancelled `ThreadExecution.cs:2468`, Error `:2578`); only Completed used `actualModel ?? request.ModelName`. The issue's exact round — one that FAILS on the substitute's 429 — therefore persisted the requested model and blamed a model that never ran.
2. **`actualModel` can't cover it.** It is scraped from `update.ModelId` mid-stream, so a round that dies before its first update (429 on the first call) has no model at all. Nothing carried the effective model out of the client.
3. **Nothing failed when nothing resolved.** Agent creation threw per agent, the client yielded prose, and the round settled `Completed` — success, to any automation reading the node.

## The fix

- **Truthful recording.** `AgentChatClient` exposes `EffectiveModelName` (post-fallback) and `SubstitutedFromModel` (non-null only when a NON-EMPTY pick was swapped). `ThreadExecution` reads them once per round (`ThreadExecution.cs:1456`) and stamps `actualModel ?? effectiveModel ?? request.ModelName` on every push and on all three `RecordUsage` calls — so token accounting and cost follow the same truth.
- **Never silent.** Still silent for the *user* (directive 2026-07-13: an unusable pin is not actionable mid-round, so no assistant chat message and no new user-visible string ⇒ no i18n surface). Never silent for an *operator*: a `MODEL_SUBSTITUTED` warning naming both models, plus a durable marker on the round — `ThreadMessage.RequestedModelName` (`Thread.cs:508`), stamped from the round's first write and sticky through the terminal one. A non-interactive round (delegation sub-thread, generator agent, scheduled automation) reads no transcript; it can now detect "I did not get the model I asked for" from the node data. Written through the existing round/cell update surface — no new request/response types.
- **Health-checked target + speaking failure.** The substitute was already gated on `HasUsableCredential` (a non-empty ApiKey — the same predicate `ObserveDefaultComposer` uses); the missing half was the exhausted case. `ApplyStaleModelFallback` latches `modelFallbackExhausted`, `CreateAgentsSync` turns *exhausted + zero agents built* into a speaking `NoUsableModelError` (`AgentChatClient.cs:1901`), and `ThreadExecution` fails such a round with `Status=Error` + that message (`ThreadExecution.cs:1751`), notifying the parent so a delegation never waits on a round that cannot run. **Both** conditions are required — exhausted alone is normal for a deployment whose keys live in factory config, invisible to the resolver, and those rounds keep running unchanged.

No retries, no timers, no quota polling — resolution plus honest reporting only.

## Tests

`test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs` drives real rounds through `ThreadExecution` with the scripted-chat-client seam the AI tests already own (no new mocking), over a seeded catalog holding a keyed provider and a KEYLESS one whose model sorts at a **lower** `Order` — a fallback ranking on `Order` alone would pick the unusable one:

- the round records the **answering** model, carries `RequestedModelName` = the requested one, and the `_Usage` satellite is keyed by the answering model;
- the substitute always has a usable credential;
- with nothing usable anywhere the round ends **Error** with a message naming the situation, not `Completed`.

Local (Release): new tests 2/2 · `MeshWeaver.AI.Test` round/model classes 24/24 · `MeshWeaver.Threading.Test` round classes 20/20 · `AgentChatClientNoSuitableAgentTest` 1/1 (the "surface the reason as chat output" contract is untouched) · `DocumentationLinkIntegrityTest` 1/1. `MeshWeaver.AI`, `MeshWeaver.Documentation`, `MeshWeaver.Blazor.Portal` build clean with `-c Release -warnaserror`.

Docs: What's New entry + a "the fallback is honest, never silent" section in `Doc/AI/ProviderConfiguration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)