### PR TITLE
The course index showed one branch, never the course

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Label.razor
+++ b/src/MeshWeaver.Blazor/Components/Label.razor
@@ -11,6 +11,7 @@
         Typo="@Typo"
         Weight="@Weight"
         Style="@Style"
+        title="@InternalTooltip"
         @onclick="OnClick">
         @InternalData
     </FluentLabel>
@@ -22,7 +23,8 @@ else
         Disabled="@Disabled"
         Typo="@Typo"
         Weight="@Weight"
-        Style="@Style">
+        Style="@Style"
+        title="@InternalTooltip">
         @InternalData
     </FluentLabel>
 }
@@ -30,6 +32,7 @@ else
 @code
 {
     private string? InternalData { get; set; }
+    private string? InternalTooltip { get; set; }
     private HorizontalAlignment? Alignment { get; set; }
     private bool Disabled { get; set; }
     private Typography Typo { get; set; } = Typography.Body;
@@ -39,6 +42,7 @@ else
     {
         base.BindData();
         DataBind(ViewModel.Data, x => x.InternalData );
+        DataBind(ViewModel.Tooltip, x => x.InternalTooltip);
         DataBind(ViewModel.Disabled, x => x.Disabled);
         DataBind(ViewModel.Alignment, x => x.Alignment);
         DataBind(ViewModel.Typo, x => x.Typo);

--- a/src/MeshWeaver.Courses/CourseNavigationProvider.cs
+++ b/src/MeshWeaver.Courses/CourseNavigationProvider.cs
@@ -1,0 +1,230 @@
+using System.Reactive.Linq;
+using MeshWeaver.Courses.Configuration;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Courses;
+
+/// <summary>
+/// Supplies the left-hand index for pages that sit inside a course: the WHOLE course, grouped by
+/// module, with the reader's position marked — not the branch they happen to be standing in.
+///
+/// <para>Core's default lists the current node's children, so a reader in lesson 2 sees lesson 2's
+/// sub-nodes and nothing else: they cannot tell how long the course is, what is coming, or that
+/// they are nearly done. Courses owns the semantics core must not learn — that a course root is a
+/// <c>Course</c> node, that its direct <c>Module</c> children are the chapters, and that lessons
+/// live in the modules' <c>Theory</c> / <c>Example</c> / <c>Exercise</c> sub-namespaces — so it
+/// hands core the finished index through <see cref="INodeNavigationProvider"/>.</para>
+///
+/// <para><b>Two shared queries, never a per-page probe.</b> Which course (if any) a page belongs to
+/// comes from ONE query per PARTITION, keyed <c>course-roots:{partition}</c> — every page in the
+/// partition subscribes to the same synced collection. The index itself is ONE
+/// <c>scope:descendants</c> query per COURSE, keyed <c>course-index:{course}</c> and likewise
+/// shared by every page of that course. A course with 200 lessons therefore costs two live
+/// queries, not two hundred.</para>
+///
+/// <para>Both are live: adding, renaming or re-ordering a lesson re-emits and the index re-renders
+/// under the reader without a reload.</para>
+/// </summary>
+public sealed class CourseNavigationProvider : INodeNavigationProvider
+{
+    /// <summary>
+    /// The module sub-namespaces that hold lessons, in the order the module page renders them —
+    /// theory, then worked examples, then exercises. The index reads top-to-bottom the way the
+    /// module does.
+    /// </summary>
+    private static readonly string[] LessonSections =
+    [
+        ModuleNodeType.TheorySubNamespace,
+        ModuleNodeType.ExampleSubNamespace,
+        ExerciseNodeType.ExerciseSubNamespace,
+    ];
+
+    /// <summary>
+    /// The whole-course index for the page <paramref name="host"/> renders, or <c>null</c> when the
+    /// path shape rules a course out before any query is opened (a satellite, or a bare partition
+    /// root — neither can sit under a course).
+    /// </summary>
+    /// <param name="host">The layout-area host; its hub address IS the page's path.</param>
+    public IObservable<NodeNavigation?>? GetNavigation(LayoutAreaHost host)
+    {
+        var currentPath = host.Hub.Address.ToString();
+        if (string.IsNullOrEmpty(currentPath))
+            return null;
+
+        var segments = currentPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        // A satellite (_Access, _Thread, _Comment, …) is never a course page, and a bare partition
+        // root has no course ABOVE it. Decline both here — cheap, and it opens no query.
+        if (segments.Length < 2 || segments.Any(s => s[0] == '_'))
+            return null;
+
+        var hub = host.Hub;
+        var partition = segments[0];
+
+        // ONE query per partition, shared by every page in it: where are this partition's courses?
+        var roots = hub.GetQuery(
+            $"course-roots:{partition}",
+            $"path:{partition} scope:descendants nodeType:{CourseNodeType.NodeType} select:path,id,name,icon");
+
+        return roots
+            .Select(candidates => EnclosingCourse(candidates, currentPath))
+            .DistinctUntilChanged(root => root?.Path ?? string.Empty)
+            .Select(root => root is null
+                ? Observable.Return<NodeNavigation?>(null)
+                // ONE subtree query per course, shared by every page of it.
+                : hub.GetQuery(
+                        $"course-index:{root.Path}",
+                        $"path:{root.Path} scope:descendants is:main select:path,id,name,order,nodeType,icon")
+                    .Select(nodes => BuildNavigation(root, nodes, currentPath)))
+            .Switch();
+    }
+
+    /// <summary>
+    /// The course <paramref name="currentPath"/> sits in: the DEEPEST candidate that is the path
+    /// itself or an ancestor of it, so a course nested inside another wins over the outer one.
+    /// <c>null</c> when the page is not in a course at all. Pure — testable without a mesh.
+    /// </summary>
+    /// <param name="candidates">The partition's <c>Course</c> nodes.</param>
+    /// <param name="currentPath">The page being read.</param>
+    public static MeshNode? EnclosingCourse(IEnumerable<MeshNode> candidates, string currentPath)
+        => candidates
+            .Where(c => !string.IsNullOrEmpty(c.Path) && Contains(c.Path, currentPath))
+            .OrderByDescending(c => c.Path.Length)
+            .FirstOrDefault();
+
+    private static bool Contains(string root, string path)
+        => string.Equals(root, path, StringComparison.Ordinal)
+           || path.StartsWith(root + "/", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Turns one course-subtree snapshot into the index: the course's <c>Module</c> children as
+    /// groups, each holding its lessons, everything ordered by <see cref="MeshNode.Order"/> then id.
+    ///
+    /// <para>Exclusions match core's: any node with a <c>_</c>-prefixed path segment (<c>_Access</c>,
+    /// <c>_Thread</c>, <c>_Comment</c>, …) is plumbing, never a lesson. So are an exercise's own
+    /// <c>Source</c> / <c>Test</c> / <c>Solution</c> code nodes — they are rendered INSIDE the
+    /// exercise, and listing them would bury the course structure they belong to.</para>
+    ///
+    /// <para>Position is stamped last, on exactly one entry: the entry whose path IS the page, or —
+    /// when the page is not itself an entry (a reader inside an exercise's starter code, say) — the
+    /// deepest entry that contains it. So a reader always has a position, at any depth.</para>
+    ///
+    /// <para>Pure, so the structure and ordering can be pinned without a renderer.</para>
+    /// </summary>
+    /// <param name="course">The course root node.</param>
+    /// <param name="descendants">The course's descendants (one <c>scope:descendants</c> result).</param>
+    /// <param name="currentPath">The page being read.</param>
+    public static NodeNavigation BuildNavigation(
+        MeshNode course, IEnumerable<MeshNode> descendants, string currentPath)
+    {
+        var prefix = course.Path + "/";
+        var pages = descendants
+            .Where(n => !string.IsNullOrEmpty(n.Path)
+                        && n.Path.StartsWith(prefix, StringComparison.Ordinal)
+                        && !n.Path[prefix.Length..].Split('/').Any(s => s.Length > 0 && s[0] == '_'))
+            .ToList();
+
+        var modules = Ordered(pages.Where(n => !n.Path[prefix.Length..].Contains('/')
+                                               && ModuleNodeType.NodeType.Equals(n.NodeType, StringComparison.Ordinal)));
+
+        var entries = modules
+            .Select(module => new NodeNavigationEntry(
+                module.Name ?? module.Id, module.Path, Icon: module.Icon)
+            {
+                Children = LessonsOf(module, pages),
+            })
+            .ToList();
+
+        return MarkCurrent(
+            new NodeNavigation(course.Name ?? course.Id, entries) { TitlePath = course.Path },
+            currentPath);
+    }
+
+    // A module's lessons: {module}/{section}/{id} for the known lesson sections, plus any direct
+    // child of the module that is not one of those section folders (a course that keeps a page
+    // straight under its module still shows up). Ordered by section, then Order, then id.
+    private static IReadOnlyList<NodeNavigationEntry> LessonsOf(
+        MeshNode module, IReadOnlyList<MeshNode> pages)
+    {
+        var modulePrefix = module.Path + "/";
+        return pages
+            .Where(n => n.Path.StartsWith(modulePrefix, StringComparison.Ordinal))
+            .Select(n => (Node: n, Rank: LessonRank(n.Path[modulePrefix.Length..].Split('/'))))
+            .Where(x => x.Rank >= 0)
+            .GroupBy(x => x.Rank)
+            .OrderBy(g => g.Key)
+            .SelectMany(g => Ordered(g.Select(x => x.Node)))
+            .Select(n => new NodeNavigationEntry(n.Name ?? n.Id, n.Path, Icon: n.Icon))
+            .ToList();
+    }
+
+    // Where a module-relative path sits in the reading order, or -1 when it is not a lesson at all.
+    // {section}/{id} ranks by section; a bare {id} that is not a section folder comes last; anything
+    // deeper (an exercise's Source/Test/Solution code) is exercise-internal and never listed.
+    private static int LessonRank(string[] segments)
+    {
+        if (segments.Length == 2)
+        {
+            var section = Array.FindIndex(LessonSections,
+                s => s.Equals(segments[0], StringComparison.Ordinal));
+            return section < 0 ? -1 : section;
+        }
+        if (segments.Length != 1)
+            return -1;
+        return LessonSections.Any(s => s.Equals(segments[0], StringComparison.Ordinal))
+            ? -1                                   // the section folder itself, not a lesson
+            : LessonSections.Length;               // a page kept straight under the module
+    }
+
+    // The canonical child ordering, shared with ModuleLayoutAreas: Order ascending (null last),
+    // then id — stable across re-renders.
+    private static List<MeshNode> Ordered(IEnumerable<MeshNode> nodes)
+        => nodes
+            .OrderBy(n => n.Order ?? int.MaxValue)
+            .ThenBy(n => n.Id, StringComparer.Ordinal)
+            .ToList();
+
+    // Stamps "you are here" onto exactly one entry AFTER the index is built, so the index itself is
+    // provably the same wherever the reader stands — navigating moves the marker, it never re-scopes
+    // or shrinks the list. An exact entry wins; otherwise the deepest entry containing the page does
+    // (a reader inside an exercise's starter code is marked on the exercise).
+    private static NodeNavigation MarkCurrent(NodeNavigation navigation, string currentPath)
+    {
+        var candidates = navigation.Entries
+            .SelectMany(e => new[] { e.Path }.Concat(e.Children.Select(c => c.Path)))
+            .Concat([navigation.TitlePath ?? string.Empty]);
+
+        string? current = null;
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrEmpty(candidate))
+                continue;
+            if (string.Equals(candidate, currentPath, StringComparison.Ordinal))
+            {
+                current = candidate;
+                break;
+            }
+            if (currentPath.StartsWith(candidate + "/", StringComparison.Ordinal)
+                && (current is null || candidate.Length > current.Length))
+                current = candidate;
+        }
+
+        if (current is null)
+            return navigation;
+
+        return navigation with
+        {
+            Entries = navigation.Entries
+                .Select(e => e with
+                {
+                    IsCurrent = string.Equals(e.Path, current, StringComparison.Ordinal),
+                    Children = e.Children
+                        .Select(c => c with { IsCurrent = string.Equals(c.Path, current, StringComparison.Ordinal) })
+                        .ToList(),
+                })
+                .ToList(),
+        };
+    }
+}

--- a/src/MeshWeaver.Courses/CoursesConfigurationExtensions.cs
+++ b/src/MeshWeaver.Courses/CoursesConfigurationExtensions.cs
@@ -1,6 +1,8 @@
 using MeshWeaver.Courses.Configuration;
 using MeshWeaver.Domain;
+using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Courses;
 
@@ -17,7 +19,9 @@ public static class CoursesConfigurationExtensions
     /// Registers the Courses facility on the mesh builder: the four node types
     /// and the courses content types on the mesh hub + every per-node hub (so
     /// course content round-trips through polymorphic JSON across routing,
-    /// mesh and per-node hubs — mirrors <c>AddAI</c>).
+    /// mesh and per-node hubs — mirrors <c>AddAI</c>), plus the
+    /// <see cref="CourseNavigationProvider"/> that gives every page inside a
+    /// course the WHOLE course as its left-hand index.
     /// </summary>
     public static TBuilder AddCourses<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
         => (TBuilder)builder
@@ -25,6 +29,9 @@ public static class CoursesConfigurationExtensions
             .AddModuleType()
             .AddExerciseType()
             .AddExerciseAttemptType()
+            // Mesh-scoped singleton — its lifetime IS the mesh's, and every per-node hub resolves
+            // it from the same container, so a course page anywhere in the mesh gets the index.
+            .ConfigureServices(services => services.AddSingleton<INodeNavigationProvider, CourseNavigationProvider>())
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddCoursesTypes();

--- a/src/MeshWeaver.Courses/ModuleLayoutAreas.cs
+++ b/src/MeshWeaver.Courses/ModuleLayoutAreas.cs
@@ -116,7 +116,7 @@ public static class ModuleLayoutAreas
             var section = Controls.Stack.WithWidth("100%");
             foreach (var block in orderedTheory)
                 section = section.WithView(
-                    new LayoutAreaControl(new Address(block.Path), new LayoutAreaReference("")),
+                    new LayoutAreaControl(new Address(block.Path), EmbedReference()),
                     Embed(block));
             stack = stack.WithView(section, TheorySection);
         }
@@ -130,7 +130,7 @@ public static class ModuleLayoutAreas
                 .WithView(Controls.H2(LocalizationCatalog.Get("ui.examples", locale)).WithStyle("margin: 16px 0 8px 0;"));
             foreach (var example in orderedExamples)
                 section = section.WithView(
-                    new LayoutAreaControl(new Address(example.Path), new LayoutAreaReference("")),
+                    new LayoutAreaControl(new Address(example.Path), EmbedReference()),
                     Embed(example));
             stack = stack.WithView(section, ExampleSection);
         }
@@ -197,4 +197,13 @@ public static class ModuleLayoutAreas
 
     /// <summary>Stable per-child embed area id (the child's node id).</summary>
     private static string Embed(MeshNode node) => $"Embed-{node.Id}";
+
+    /// <summary>
+    /// The child's DEFAULT area, referenced as an EMBED — the same
+    /// <c>showHeader=false</c> flag the <c>@@</c> markdown embed carries. The module page already
+    /// frames each block, so the embedded node must not bring its own page chrome with it: no node
+    /// header with Move/Copy/Delete, no inline comments, and no left-hand index (the course index
+    /// belongs to the page the reader opened, not to a block inside it).
+    /// </summary>
+    private static LayoutAreaReference EmbedReference() => new("") { Id = "?showHeader=false" };
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-whole-course-index.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-whole-course-index.md
@@ -1,0 +1,23 @@
+---
+Name: The course index now shows the whole course and marks where you are
+Category: What's New
+Description: The collapsible left-hand index on a course page lists every module and lesson of the course, with your current page marked instead of the list pruned to it.
+Icon: Sparkle
+---
+
+# The course index now shows the whole course and marks where you are
+
+The collapsible index on the left of a course page used to list only the current
+page's own sub-nodes. Standing in lesson 2 you saw lesson 2's children and
+nothing else — you could not tell how long the course was, what was coming, or
+that you were nearly done, so you navigated by the Next button and by guesswork.
+
+It now lists the **whole course**: every module as a collapsible group, every
+lesson inside it, ordered the way the course declares. The page you are reading
+is **marked** rather than the list pruned to it — with a ▸ glyph as well as an
+accent colour, so the marker still reads if you cannot distinguish the colour,
+and as plain text rather than a link, because a link to the page you are already
+on is a dead control.
+
+Nothing else changes: a doc or a space still gets its own children, and the index
+only widens on pages that actually sit inside a course.

--- a/src/MeshWeaver.Graph/INodeNavigationProvider.cs
+++ b/src/MeshWeaver.Graph/INodeNavigationProvider.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using MeshWeaver.Mesh;
+using MeshWeaver.Layout.Composition;
 
 namespace MeshWeaver.Graph;
 
@@ -11,30 +11,69 @@ namespace MeshWeaver.Graph;
 /// children, which is right for a doc or a space and wrong for a course: a reader standing in
 /// lesson 2 sees lesson 2's sub-nodes and nothing else, so they cannot tell how long the course is,
 /// what is coming, or that they are nearly done. But core must not learn what a lesson is to fix
-/// that. The course semantics — the <c>module*100 + difficulty</c> Order convention, what counts as
-/// a chapter, which satellites to hide — already live in the Edu module, and re-deriving them here
-/// would put a copy in the wrong repo.</para>
+/// that. The course semantics — what counts as a module, which sub-namespaces hold lessons, which
+/// satellites to hide — already live in the courses module, and re-deriving them here would put a
+/// copy in the wrong project.</para>
 ///
 /// <para><b>The default stands.</b> A provider that does not claim a node returns null and core
 /// renders exactly what it renders today, so docs and spaces are untouched and a deployment without
 /// the module simply loses the richer menu rather than breaking.</para>
+///
+/// <para><b>Reactive by construction.</b> A whole-course index is a QUERY, and a query is an
+/// <see cref="IObservable{T}"/> — so the seam hands back a stream, never a materialised list. That
+/// is what lets a provider walk up to the course root and read its subtree without blocking the
+/// render (see AsynchronousCalls.md: nothing on a hub may await). The stream feeds straight into
+/// the area's <c>CombineLatest</c>, so an added, renamed or re-ordered lesson re-renders the index
+/// live.</para>
 /// </summary>
 public interface INodeNavigationProvider
 {
     /// <summary>
-    /// The entries to show for <paramref name="node"/>, or <c>null</c> to decline — core then falls
-    /// back to its default child list. Declining is the normal answer for nodes this module does
-    /// not own; it must be cheap and must never throw.
+    /// The navigation to show for the page <paramref name="host"/> renders, as a live stream, or
+    /// <c>null</c> to decline outright — core then falls back to its default child list. Declining
+    /// is the normal answer for nodes this module does not own; it must be cheap (a path shape
+    /// check, never a query) and must never throw.
+    ///
+    /// <para>A provider that can only decide by querying returns a stream and emits <c>null</c>
+    /// (or an empty <see cref="NodeNavigation.Entries"/>) for the pages it does not claim. The
+    /// stream MUST emit promptly — core combines it with the node and permission streams, so one
+    /// that stays silent would hold the whole page back.</para>
     /// </summary>
-    /// <param name="node">The page being rendered.</param>
-    /// <param name="children">The children core would have listed, so a provider that only wants to
-    /// re-order or re-label them need not query again.</param>
-    IReadOnlyList<NodeNavigationEntry>? GetNavigation(MeshNode? node, IReadOnlyList<MeshNode> children);
+    /// <param name="host">The layout-area host rendering the page; its hub address IS the node path.</param>
+    IObservable<NodeNavigation?>? GetNavigation(LayoutAreaHost host);
+}
+
+/// <summary>
+/// A supplied left-hand navigation: the heading plus the entries beneath it.
+/// </summary>
+/// <param name="Title">The menu heading — the thing being indexed (e.g. the course name), not the
+/// page being read.</param>
+/// <param name="Entries">The top-level entries, in render order.</param>
+public record NodeNavigation(string Title, IReadOnlyList<NodeNavigationEntry> Entries)
+{
+    /// <summary>
+    /// The node the heading links to (the root of the supplied index), or <c>null</c> for a plain
+    /// heading. Core drops the link when that root IS the page being read — a link to the page you
+    /// are on is a dead control.
+    /// </summary>
+    public string? TitlePath { get; init; }
 }
 
 /// <summary>
 /// One line of a supplied navigation. <paramref name="IsCurrent"/> marks where the reader is —
-/// core renders that entry as text rather than a link, because a link to the page you are on is a
-/// dead control that teaches the reader their position marker is broken.
+/// core renders that entry with a glyph AND an accent, and as text rather than a link, because a
+/// link to the page you are on is a dead control that teaches the reader their position marker is
+/// broken. The glyph carries the marker for a reader who cannot distinguish the accent.
 /// </summary>
-public record NodeNavigationEntry(string Label, string Path, bool IsCurrent = false, string? Icon = null);
+/// <param name="Label">The text shown for the entry.</param>
+/// <param name="Path">The mesh path the entry stands for (and links to).</param>
+/// <param name="IsCurrent">Whether this entry is where the reader stands.</param>
+/// <param name="Icon">Optional icon for the entry.</param>
+public record NodeNavigationEntry(string Label, string Path, bool IsCurrent = false, string? Icon = null)
+{
+    /// <summary>
+    /// Nested entries — core renders an entry that has them as a collapsible sub-group, which is how
+    /// a long index stays scannable (a course groups its lessons by module).
+    /// </summary>
+    public IReadOnlyList<NodeNavigationEntry> Children { get; init; } = [];
+}

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Layout.Composition;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph;
 
@@ -35,8 +36,16 @@ public static class MarkdownOverviewLayoutArea
         var hideHeader = host.Reference.HasParameter("showHeader")
             && string.Equals(host.Reference.GetParameterValue("showHeader"), "false", System.StringComparison.OrdinalIgnoreCase);
 
+        // A module that OWNS this page may supply its own menu (a course lists the WHOLE course, not
+        // the branch you are in). An @@ embed never gets a side menu, so its providers are not even
+        // asked — no query is opened for a page that cannot show the result.
+        var suppliedStream = hideHeader
+            ? Observable.Return<NodeNavigation?>(null)
+            : SuppliedNavigation(host);
+
         return host.Workspace.GetMeshNodeStream()
-            .CombineLatest(permissionsStream, host.ObserveChildren("is:main"), (node, perms, children) =>
+            .CombineLatest(permissionsStream, host.ObserveChildren("is:main"), suppliedStream,
+                (node, perms, children, supplied) =>
             {
                 var canComment = perms.HasFlag(Permission.Comment) || perms.HasFlag(Permission.Update);
                 var canEdit = perms.HasFlag(Permission.Update);
@@ -48,13 +57,11 @@ public static class MarkdownOverviewLayoutArea
                     return (UiControl?)content;
                 var subNodes = OrderSubNodes(
                     children.Where(c => !LastSegment(c.Path).StartsWith('_')));
-                // A module that OWNS this page may supply its own menu (a course lists the whole
-                // course, not the branch you are in). Nothing supplied → core's default child list,
-                // unchanged — which is why docs and spaces are untouched by this.
-                var supplied = SuppliedNavigation(host, node, subNodes);
-                return (UiControl?)(subNodes.Count == 0 && supplied is null
+                // Nothing supplied → core's default child list, unchanged — which is why docs and
+                // spaces are untouched by this.
+                return (UiControl?)(subNodes.Count == 0 && supplied is not { Entries.Count: > 0 }
                     ? content
-                    : BuildWithSubNodeNav(node, subNodes, content, supplied));
+                    : BuildWithSubNodeNav(host, node, subNodes, content, supplied));
             });
     }
 
@@ -74,59 +81,95 @@ public static class MarkdownOverviewLayoutArea
             .ToList();
 
     /// <summary>
-    /// Wraps the page content with a collapsible left-hand NavMenu listing the node's sub-nodes,
-    /// giving every markdown node with children a navigable side menu of them.
+    /// Area id of the collapsible left-hand navigation, so consumers and tests can address the menu
+    /// without walking anonymous auto-named slots.
     /// </summary>
-        /// <summary>
-    /// Asks each registered <see cref="INodeNavigationProvider"/> for this node's navigation, first
-    /// non-null wins. A provider that declines (or throws — a broken module must not take the page
-    /// down with it) leaves core's default child list in place.
+    public const string NavigationArea = "Navigation";
+
+    /// <summary>
+    /// The glyph that marks where the reader stands. Language-neutral by design (nothing to
+    /// translate) and carried IN ADDITION to the accent colour, so the position survives for a
+    /// reader who cannot distinguish the accent.
     /// </summary>
-    private static IReadOnlyList<NodeNavigationEntry>? SuppliedNavigation(
-        LayoutAreaHost host, MeshNode? node, IReadOnlyList<MeshNode> children)
+    public const string CurrentMarker = "▸";
+
+    /// <summary>
+    /// Asks each registered <see cref="INodeNavigationProvider"/> for this page's navigation, first
+    /// one that claims it wins. A provider that declines — synchronously by returning null, or
+    /// reactively by emitting null / no entries — leaves core's default child list in place, and one
+    /// that throws is logged and skipped: a module's navigation is a nicety, the page is not.
+    /// </summary>
+    private static IObservable<NodeNavigation?> SuppliedNavigation(LayoutAreaHost host)
     {
-        var providers = host.Hub.ServiceProvider
-            .GetServices<INodeNavigationProvider>();
-        foreach (var provider in providers)
+        var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.NodeNavigation");
+        var streams = new List<IObservable<NodeNavigation?>>();
+        foreach (var provider in host.Hub.ServiceProvider.GetServices<INodeNavigationProvider>())
         {
+            IObservable<NodeNavigation?>? stream;
             try
             {
-                if (provider.GetNavigation(node, children) is { Count: > 0 } entries)
-                    return entries;
+                stream = provider.GetNavigation(host);
             }
-            catch
+            catch (Exception ex)
             {
-                // A module's navigation is a nicety; the page is not. Fall through to the default.
+                logger?.LogWarning(ex, "Navigation provider {Provider} threw for {Path} — using the default child list",
+                    provider.GetType().Name, host.Hub.Address);
+                continue;
             }
+            if (stream is null)
+                continue;
+            var declined = provider.GetType().Name;
+            streams.Add(stream
+                // Always emit, immediately: the stream is CombineLatest'd with the node and
+                // permission streams, so one that stayed silent would hold the whole page back.
+                .StartWith((NodeNavigation?)null)
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex, "Navigation provider {Provider} faulted for {Path} — using the default child list",
+                        declined, host.Hub.Address);
+                    return Observable.Return<NodeNavigation?>(null);
+                }));
         }
-        return null;
+
+        return streams.Count switch
+        {
+            0 => Observable.Return<NodeNavigation?>(null),
+            1 => streams[0],
+            _ => Observable.CombineLatest(streams)
+                .Select(supplied => supplied.FirstOrDefault(n => n is { Entries.Count: > 0 })),
+        };
     }
 
-private static UiControl BuildWithSubNodeNav(
-        MeshNode? node, IReadOnlyList<MeshNode> subNodes, UiControl content,
-        IReadOnlyList<NodeNavigationEntry>? supplied = null)
+    /// <summary>
+    /// Wraps the page content with the collapsible left-hand NavMenu: the navigation a module
+    /// supplied for this page when there is one, otherwise core's default list of the node's own
+    /// sub-nodes.
+    /// </summary>
+    private static UiControl BuildWithSubNodeNav(
+        LayoutAreaHost host, MeshNode? node, IReadOnlyList<MeshNode> subNodes, UiControl content,
+        NodeNavigation? supplied = null)
     {
-        var group = new NavGroupControl(node?.Name ?? "Contents").WithSkin(s => s.WithExpanded(true));
-        if (supplied is { Count: > 0 })
-        {
-            // A module OWNS these pages and knows more about them than core does — a course knows
-            // its whole chapter list and which one the reader is standing in. The current entry is
-            // rendered as TEXT, not a link: a link to the page you are on is a dead control that
-            // teaches the reader their position marker is broken.
-            foreach (var entry in supplied)
-                group = entry.IsCurrent
-                    ? group.WithView(Controls.Body($"▸ {entry.Label}")
-                        .WithStyle("display:block;padding:4px 12px;font-weight:600;"))
-                    : group.WithView(new NavLinkControl(entry.Label, entry.Icon, $"/{entry.Path}"));
-            var suppliedNav = Controls.NavMenu
-                .WithSkin(s => s.WithWidth(240).WithCollapsible(true)).WithNavGroup(group);
-            return Controls.Stack
-                .WithOrientation(Orientation.Horizontal).WithWidth("100%")
-                .WithStyle("gap: 24px; align-items: flex-start;")
-                .WithView(suppliedNav)
-                .WithView(Controls.Stack.WithStyle("flex: 1; min-width: 0;").WithView(content));
-        }
+        var group = supplied is { Entries.Count: > 0 }
+            ? BuildSuppliedGroup(host, supplied)
+            : BuildChildrenGroup(host, node, subNodes);
 
+        var nav = Controls.NavMenu.WithSkin(s => s.WithWidth(240).WithCollapsible(true)).WithNavGroup(group);
+
+        return Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithWidth("100%")
+            .WithStyle("gap: 24px; align-items: flex-start;")
+            .WithView(nav, NavigationArea)
+            .WithView(Controls.Stack.WithStyle("flex: 1; min-width: 0;").WithView(content));
+    }
+
+    // Core's default: the node's own children, one flat list.
+    private static NavGroupControl BuildChildrenGroup(
+        LayoutAreaHost host, MeshNode? node, IReadOnlyList<MeshNode> subNodes)
+    {
+        var group = new NavGroupControl(node?.Name ?? host.Localize("nav.contents"))
+            .WithSkin(s => s.WithExpanded(true));
         foreach (var child in subNodes)
         {
             var href = $"/{child.Path}";
@@ -135,16 +178,57 @@ private static UiControl BuildWithSubNodeNav(
                 ? group.WithView(new NavLinkControl(child.Name ?? child.Id, null, href))
                 : group.WithView(new NavLinkControl(child.Name ?? child.Id, icon, href));
         }
-
-        var nav = Controls.NavMenu.WithSkin(s => s.WithWidth(240).WithCollapsible(true)).WithNavGroup(group);
-
-        return Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithWidth("100%")
-            .WithStyle("gap: 24px; align-items: flex-start;")
-            .WithView(nav)
-            .WithView(Controls.Stack.WithStyle("flex: 1; min-width: 0;").WithView(content));
+        return group;
     }
+
+    // A module OWNS these pages and knows more about them than core does — a course knows its whole
+    // module list and which lesson the reader is standing in. The heading names what is indexed (the
+    // course), NOT the page being read, and links to it unless that root IS the page being read.
+    private static NavGroupControl BuildSuppliedGroup(LayoutAreaHost host, NodeNavigation supplied)
+    {
+        var currentPath = host.Hub.Address.ToString();
+        var titleIsCurrent = supplied.TitlePath is { } titlePath
+            && string.Equals(titlePath, currentPath, System.StringComparison.Ordinal);
+
+        var group = new NavGroupControl(Marked(supplied.Title, titleIsCurrent))
+            .WithSkin(s => s.WithExpanded(true));
+        if (supplied.TitlePath is { } path && !titleIsCurrent)
+            group = group.WithUrl($"/{path}");
+
+        foreach (var entry in supplied.Entries)
+            group = AppendEntry(host, group, entry);
+        return group;
+    }
+
+    // One supplied entry: a nested collapsible group when it has children (a course's module),
+    // a link otherwise — or, when it is where the reader stands, MARKED TEXT rather than a link.
+    private static NavGroupControl AppendEntry(
+        LayoutAreaHost host, NavGroupControl group, NodeNavigationEntry entry)
+    {
+        if (entry.Children.Count > 0)
+        {
+            var sub = new NavGroupControl(Marked(entry.Label, entry.IsCurrent))
+                .WithSkin(s => s.WithExpanded(true));
+            if (!entry.IsCurrent)
+                sub = sub.WithUrl($"/{entry.Path}");
+            if (entry.Icon is { } icon)
+                sub = sub.WithIcon(icon);
+            foreach (var child in entry.Children)
+                sub = AppendEntry(host, sub, child);
+            return group.WithGroup(sub);
+        }
+
+        return entry.IsCurrent
+            // TEXT, not a link: a link to the page you are on is a dead control that teaches the
+            // reader their position marker is broken. Glyph AND accent — see CurrentMarker.
+            ? group.WithView(Controls.Body(Marked(entry.Label, true))
+                .WithTooltip(host.Localize("nav.youAreHere"))
+                .WithStyle("display:block;padding:4px 12px;font-weight:600;color:var(--accent-fill-rest);"))
+            : group.WithView(new NavLinkControl(entry.Label, entry.Icon, $"/{entry.Path}"));
+    }
+
+    private static string Marked(string label, bool isCurrent)
+        => isCurrent ? $"{CurrentMarker} {label}" : label;
 
     private static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, bool canComment, bool canEdit, bool hideHeader)
     {

--- a/src/MeshWeaver.Layout/LabelControl.cs
+++ b/src/MeshWeaver.Layout/LabelControl.cs
@@ -32,6 +32,12 @@ public record LabelControl(object Data)
     /// </summary>
     public object? Weight { get; init; }
     /// <summary>
+    /// Gets or initializes the hover / assistive text of the label, rendered as the element's
+    /// <c>title</c>. Use it to say in words what a glyph says visually — the text is user-facing,
+    /// so pass a localized string.
+    /// </summary>
+    public object? Tooltip { get; init; }
+    /// <summary>
     /// Sets the alignment of the label.
     /// </summary>
     /// <param name="alignment">The alignment to set.</param>
@@ -61,6 +67,12 @@ public record LabelControl(object Data)
     /// <param name="weight">The weight to set.</param>
     /// <returns>A new <see cref="LabelControl"/> instance with the specified weight.</returns>
     public LabelControl WithWeight(object weight) => this with {Weight = weight};
+    /// <summary>
+    /// Sets the hover / assistive text of the label.
+    /// </summary>
+    /// <param name="tooltip">The localized text to show as the element's <c>title</c>.</param>
+    /// <returns>A new <see cref="LabelControl"/> instance with the specified tooltip.</returns>
+    public LabelControl WithTooltip(object tooltip) => this with {Tooltip = tooltip};
 }
 /// <summary>
 /// Represents the typography options for a label.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -74,6 +74,8 @@
   "menu.breadcrumb": "Navigationspfad",
   "menu.mainMenu": "Hauptmenü",
   "menu.expandCollapse": "Menü ein-/ausklappen",
+  "nav.contents": "Inhalt",
+  "nav.youAreHere": "Sie sind hier",
   "menu.edit": "Bearbeiten",
   "menu.pin": "Anheften",
   "menu.move": "Verschieben",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -74,6 +74,8 @@
   "menu.breadcrumb": "Breadcrumb",
   "menu.mainMenu": "Main menu",
   "menu.expandCollapse": "Menu expand/collapse toggle",
+  "nav.contents": "Contents",
+  "nav.youAreHere": "You are here",
   "menu.edit": "Edit",
   "menu.pin": "Pin",
   "menu.move": "Move",

--- a/test/MeshWeaver.Courses.Test/CourseIndexNavigationTest.cs
+++ b/test/MeshWeaver.Courses.Test/CourseIndexNavigationTest.cs
@@ -1,0 +1,215 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Courses.Configuration;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Courses.Test;
+
+/// <summary>
+/// The left-hand index on a course page is the WHOLE course, not the branch the reader happens to
+/// stand in (#770). A reader in a lesson of module 1 must see module 2's lessons too — that is the
+/// thing "the current node's children" can never produce — with their position MARKED rather than
+/// the list pruned to it.
+///
+/// <para>Pinned twice: on <see cref="CourseNavigationProvider.BuildNavigation"/> (pure — structure,
+/// ordering, exclusions, and that the index does not change as you go deeper), and end-to-end
+/// through the real Overview area as the browser receives it.</para>
+/// </summary>
+public class CourseIndexNavigationTest(ITestOutputHelper output) : CoursesTestBase(output)
+{
+    private const string CourseId = "Algebra";
+    private const string CoursePath = $"{CoursePartition}/{CourseId}";
+    private const string ModuleOne = $"{CoursePath}/M1";
+    private const string ModuleTwo = $"{CoursePath}/M2";
+    private const string DeepLesson = $"{ModuleOne}/{ModuleNodeType.TheorySubNamespace}/T2";
+
+    private static MeshNode Course => new(CourseId, CoursePartition)
+    {
+        Name = "Algebra", NodeType = CourseNodeType.NodeType
+    };
+
+    /// <summary>
+    /// A course whose modules are declared OUT of Order order, with lessons in two different
+    /// modules, an exercise with its own internal Source node, and satellites at two levels.
+    /// </summary>
+    private static IReadOnlyList<MeshNode> CourseSubtree() =>
+    [
+        // Modules declared 2-then-1 so the assertion pins Order, not declaration order.
+        new("M2", CoursePath) { Name = "Second module", NodeType = ModuleNodeType.NodeType, Order = 2 },
+        new("M1", CoursePath) { Name = "First module", NodeType = ModuleNodeType.NodeType, Order = 1 },
+
+        new("T2", $"{ModuleOne}/{ModuleNodeType.TheorySubNamespace}")
+            { Name = "Lesson two", NodeType = MarkdownNodeType.NodeType, Order = 2 },
+        new("T1", $"{ModuleOne}/{ModuleNodeType.TheorySubNamespace}")
+            { Name = "Lesson one", NodeType = MarkdownNodeType.NodeType, Order = 1 },
+        new("E1", $"{ModuleOne}/{ExerciseNodeType.ExerciseSubNamespace}")
+            { Name = "Drill", NodeType = ExerciseNodeType.NodeType, Order = 1 },
+        // Exercise internals — rendered INSIDE the exercise, never a line of the course index.
+        new(ExerciseNodeType.StarterNodeId,
+            $"{ModuleOne}/{ExerciseNodeType.ExerciseSubNamespace}/E1/{ExerciseNodeType.SourceSubNamespace}")
+            { Name = "Starter", NodeType = CodeNodeType.NodeType },
+
+        new("T3", $"{ModuleTwo}/{ModuleNodeType.TheorySubNamespace}")
+            { Name = "Lesson three", NodeType = MarkdownNodeType.NodeType, Order = 1 },
+
+        // Satellites at course level and under a lesson — plumbing, never learner-facing pages.
+        new("c1", $"{CoursePath}/_Comment") { Name = "A comment" },
+        new("a1", $"{ModuleOne}/{ModuleNodeType.TheorySubNamespace}/T1/_Access") { Name = "An assignment" },
+    ];
+
+    private static IEnumerable<string> PathsOf(NodeNavigation nav)
+        => nav.Entries.SelectMany(e => new[] { e.Path }.Concat(e.Children.Select(c => c.Path)));
+
+    [Fact]
+    public void FromADeepLesson_TheIndexListsTheWholeCourse_GroupedByModule_OrderedByOrder()
+    {
+        var nav = CourseNavigationProvider.BuildNavigation(Course, CourseSubtree(), DeepLesson);
+
+        nav.Title.Should().Be("Algebra", "the heading names what is indexed — the course, not the lesson");
+        nav.TitlePath.Should().Be(CoursePath);
+
+        // Grouped by module, ordered by Order (M1 declared second, listed first).
+        nav.Entries.Select(e => e.Path).Should().Equal(ModuleOne, ModuleTwo);
+        nav.Entries.Select(e => e.Label).Should().Equal("First module", "Second module");
+
+        // Module 1: theory before exercises, each ordered by Order.
+        nav.Entries[0].Children.Select(c => c.Path).Should().Equal(
+            $"{ModuleOne}/{ModuleNodeType.TheorySubNamespace}/T1",
+            DeepLesson,
+            $"{ModuleOne}/{ExerciseNodeType.ExerciseSubNamespace}/E1");
+
+        // THE point of #770: the OTHER module's lesson is listed too. Children-of-the-current-node
+        // could never surface this — the reader is three levels away from it.
+        nav.Entries[1].Children.Select(c => c.Path).Should().Equal(
+            $"{ModuleTwo}/{ModuleNodeType.TheorySubNamespace}/T3");
+    }
+
+    [Fact]
+    public void TheCurrentLessonIsTheOnlyMarkedEntry()
+    {
+        var nav = CourseNavigationProvider.BuildNavigation(Course, CourseSubtree(), DeepLesson);
+
+        var marked = nav.Entries
+            .SelectMany(e => new[] { e }.Concat(e.Children))
+            .Where(e => e.IsCurrent)
+            .ToList();
+
+        marked.Should().ContainSingle("exactly one entry can be where the reader stands")
+            .Which.Path.Should().Be(DeepLesson);
+    }
+
+    [Fact]
+    public void APageBelowTheIndexMarksTheDeepestEntryThatContainsIt()
+    {
+        // Reading an exercise's starter code: the starter is not a line of the index, so the
+        // EXERCISE carries the marker. A reader always has a position, at any depth.
+        var inside = $"{ModuleOne}/{ExerciseNodeType.ExerciseSubNamespace}/E1/"
+                     + $"{ExerciseNodeType.SourceSubNamespace}/{ExerciseNodeType.StarterNodeId}";
+        var nav = CourseNavigationProvider.BuildNavigation(Course, CourseSubtree(), inside);
+
+        nav.Entries.SelectMany(e => e.Children).Single(c => c.IsCurrent)
+            .Path.Should().Be($"{ModuleOne}/{ExerciseNodeType.ExerciseSubNamespace}/E1");
+    }
+
+    [Fact]
+    public void SatellitesAndExerciseInternalsAreExcluded()
+    {
+        var paths = PathsOf(CourseNavigationProvider.BuildNavigation(Course, CourseSubtree(), DeepLesson))
+            .ToList();
+
+        paths.Should().NotContain(p => p.Contains("/_"), "_-prefixed satellites are plumbing, not pages");
+        paths.Should().NotContain(p => p.Contains($"/{ExerciseNodeType.SourceSubNamespace}/"),
+            "an exercise's own code nodes render inside the exercise, not in the course index");
+    }
+
+    [Fact]
+    public void TheIndexIsIdenticalAtEveryDepth_OnlyTheMarkerMoves()
+    {
+        var subtree = CourseSubtree();
+        var atRoot = CourseNavigationProvider.BuildNavigation(Course, subtree, CoursePath);
+
+        foreach (var depth in new[] { ModuleOne, DeepLesson, $"{ModuleTwo}/{ModuleNodeType.TheorySubNamespace}/T3" })
+        {
+            var here = CourseNavigationProvider.BuildNavigation(Course, subtree, depth);
+            PathsOf(here).Should().Equal(PathsOf(atRoot),
+                $"navigating to '{depth}' must move the marker, never re-scope or shrink the index");
+        }
+    }
+
+    [Fact]
+    public void APageOutsideAnyCourseGetsNoSuppliedIndex()
+        => CourseNavigationProvider
+            .EnclosingCourse([Course], $"{CoursePartition}/SomethingElse/Page")
+            .Should().BeNull("core's default child list must stand for docs and spaces");
+
+    [Fact(Timeout = 120_000)]
+    public async Task Overview_OnADeepLesson_RendersTheWholeCourseIndex()
+    {
+        await SeedCourse();
+
+        var (stream, reference) = OpenArea(DeepLesson, MarkdownLayoutAreas.OverviewArea);
+
+        // The page is the nav column + the content column; the nav is addressable by its area id.
+        var menu = (NavMenuControl)(await stream
+            .GetControlStream($"{reference.Area}/{MarkdownOverviewLayoutArea.NavigationArea}")
+            .Should().Within(60.Seconds()).Match(c => c is NavMenuControl { Areas.Count: 1 }))!;
+
+        // The heading is the COURSE, and it holds one group per module — both of them, from a lesson
+        // three levels down. Live index: wait for the emission that has the whole course.
+        var courseGroup = (NavGroupControl)(await stream
+            .GetControlStream(menu.Areas[0].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is NavGroupControl { Areas.Count: 2 }))!;
+        courseGroup.Title.ToString().Should().Be("Algebra");
+
+        // Module 1 — the reader's own module: two theory lessons then the exercise. The current
+        // lesson is MARKED and NOT a link; its sibling still is.
+        var currentModule = (NavGroupControl)(await stream
+            .GetControlStream(courseGroup.Areas[0].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is NavGroupControl { Areas.Count: 3 }))!;
+
+        var here = await stream.GetControlStream(currentModule.Areas[1].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is LabelControl);
+        here.Should().BeOfType<LabelControl>(
+                "a link to the page you are on is a dead control — the current entry is marked text")
+            .Which.Data.ToString().Should()
+            .StartWith(MarkdownOverviewLayoutArea.CurrentMarker,
+                "the marker is a glyph as well as an accent, so it survives for a reader who cannot see the colour");
+
+        var sibling = await stream.GetControlStream(currentModule.Areas[0].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is NavLinkControl);
+        sibling.Should().BeOfType<NavLinkControl>().Which.Url?.ToString().Should()
+            .Be($"/{ModuleOne}/{ModuleNodeType.TheorySubNamespace}/T1");
+
+        // Module 2 — a module the reader is NOT in still lists its lesson. This is the whole point:
+        // the index is the course, not the branch.
+        var otherModule = (NavGroupControl)(await stream
+            .GetControlStream(courseGroup.Areas[1].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is NavGroupControl { Areas.Count: 1 }))!;
+
+        var otherLesson = await stream.GetControlStream(otherModule.Areas[0].Area!.ToString()!)
+            .Should().Within(60.Seconds()).Match(c => c is NavLinkControl);
+        otherLesson.Should().BeOfType<NavLinkControl>().Which.Url?.ToString().Should()
+            .Be($"/{ModuleTwo}/{ModuleNodeType.TheorySubNamespace}/T3");
+    }
+
+    /// <summary>
+    /// Seeds the course of <see cref="CourseSubtree"/> into the mesh: two modules with one theory
+    /// lesson each, plus a second lesson in module 1 (the page the render test opens).
+    /// </summary>
+    private async Task SeedCourse()
+    {
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await mesh.CreateNode(Course).Should().Within(30.Seconds()).Emit();
+        foreach (var node in CourseSubtree().Where(n => !n.Path.Contains("/_")))
+            await mesh.CreateNode(node).Should().Within(30.Seconds()).Emit();
+    }
+}


### PR DESCRIPTION
Fixes #770.

The collapsible index on the left of a course page listed the current node's children, so a reader standing in lesson 2 saw lesson 2's sub-nodes and nothing else. They could not tell how long the course was, what was coming, or that they were nearly done, and they navigated by the Next button and by guesswork.

## The seam could not do its job

The core half of this landed in `3eb28c3c5` as `INodeNavigationProvider` — a seam that lets a module supply the menu for pages it OWNS, leaving docs and spaces on core's default. But it was declared **synchronous**, handing the provider only the child list core had already fetched. A whole-course index is a QUERY, and nothing on a hub may block on one (AsynchronousCalls.md), so as written the seam could only re-order or re-label the very children that ARE the bug. It had zero implementations.

So it becomes reactive:

- `GetNavigation(LayoutAreaHost)` returns `IObservable<NodeNavigation?>` — `null` declines synchronously (cheap, opens no query), and a provider that can only decide by querying emits `null` for pages it does not claim. Core `CombineLatest`s it with the node and permission streams, so the index follows adds, renames and re-orders live.
- Entries nest (`NodeNavigationEntry.Children`), so a long course groups its lessons by module instead of listing two hundred flat.
- `@@` embeds never get a side menu, so their providers are not asked at all — no query is opened for a page that cannot show the result.

## Courses supplies it

`CourseNavigationProvider` owns the semantics core must not learn: a course root is a `Course` node, its direct `Module` children are the chapters, and lessons live in the modules' `Theory` / `Example` / `Exercise` sub-namespaces.

**Two shared queries, never a probe per page.** ONE query per PARTITION (`course-roots:{partition}`) resolves which course, if any, a page sits under; ONE `scope:descendants` query per COURSE (`course-index:{course}`) IS the index. Both are keyed so every page of the partition and every page of the course subscribe to the same synced collection — a course with 200 lessons costs two live queries, not two hundred. Satellites (`_`-prefixed segments) and an exercise's own `Source`/`Test`/`Solution` code nodes are filtered the way core filters them.

**Position is stamped last**, onto exactly one entry, so the index is provably the same wherever the reader stands — navigating moves the marker, it never re-scopes or shrinks the list. A page below the index (an exercise's starter code) marks the deepest entry that contains it, so a reader always has a position. The current entry renders as marked TEXT rather than a link — a link to the page you are on is a dead control — with a `▸` glyph **as well as** an accent colour, so the marker survives for a reader who cannot distinguish the colour.

## Two fixes that fall out of making this render

- The module page embedded its theory and example children WITHOUT the `showHeader=false` the `@@` embed carries, so each block brought a full node header (Move/Copy/Delete) and its own inline comments into a page that already framed it — and would now have brought a second course index too. They are embeds; they say so.
- `LabelControl` grew a `Tooltip`, rendered as the element's `title`, so a glyph can say in words what it says visually.

## Internationalization

The glyph is language-neutral. Its `nav.youAreHere` tooltip and the `nav.contents` heading (which replaces a hard-coded English `"Contents"` that was there before) are in **both** `strings.en.json` and `strings.de.json`; `LocalizationTest` passes.

## Tests

`test/MeshWeaver.Courses.Test/CourseIndexNavigationTest.cs` — pinned twice, on the pure builder and end-to-end through the real Overview area as the browser receives it:

- from a DEEP lesson the index lists the WHOLE course, grouped by module, ordered by `Order` (modules seeded out of order to prove it) — **including the other module's lesson**, which children-of-the-current-node can never surface;
- exactly one entry is marked, and a page below the index marks the deepest entry containing it;
- `_`-satellites and exercise internals are excluded;
- the index is byte-identical at every depth — only the marker moves;
- a page outside any course gets no supplied index, so core's default stands;
- end-to-end: the nav renders as a `NavMenu` → course group → one group per module, the current lesson a `LabelControl` starting with `▸` (not a link), its sibling and the other module's lesson still `NavLinkControl`s.

**Local results** (Release, `-warnaserror`):

| Suite | Result |
|---|---|
| `MeshWeaver.Courses.Test` (incl. 7 new) | 24/24 pass |
| `MeshWeaver.Graph.Test` | 824/824 pass |
| `MeshWeaver.Layout.Test` | 343/343 pass |
| `LocalizationTest` | 33/33 pass |
| `DocumentationLinkIntegrityTest`, `MarkdownEmbedAnnotationsTest` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)