### PR TITLE
A compile problem now says whether it is your code or a timeout — and links the log

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -3261,8 +3261,9 @@ public class MeshOperations
 
     /// <summary>
     /// True when the NodeType's <see cref="NodeTypeDefinition.CompilationStatus"/>
-    /// has reached a terminal state (<see cref="CompilationStatus.Ok"/> or
-    /// <see cref="CompilationStatus.Error"/>). Pending and Compiling are
+    /// has reached a terminal state (<see cref="CompilationStatus.Ok"/>,
+    /// <see cref="CompilationStatus.Error"/> or
+    /// <see cref="CompilationStatus.Unavailable"/>). Pending and Compiling are
     /// transient — readers should keep waiting for the watcher's settle
     /// write rather than report a half-baked state.
     /// </summary>
@@ -3277,7 +3278,11 @@ public class MeshOperations
     /// the compile-settle wait instead of hanging until the 5s timeout.
     /// </summary>
     private static bool IsSettled(CompilationStatus? status)
-        => status == CompilationStatus.Ok || status == CompilationStatus.Error;
+        => status is CompilationStatus.Ok
+                  or CompilationStatus.Error
+                  // Terminal too: a driver already gave up determining the state, so no
+                  // further write is coming and a waiter would hang out its whole budget.
+                  or CompilationStatus.Unavailable;
 
     private string FormatDiagnosticsFromDef(
         Graph.Configuration.NodeTypeDefinition def, string nodeTypePath)
@@ -3286,7 +3291,9 @@ public class MeshOperations
         return FormatDiagnostics(
             status,
             nodeTypePath,
-            error: status == CompilationStatus.Error ? def.CompilationError : null,
+            error: status is CompilationStatus.Error or CompilationStatus.Unavailable
+                ? def.CompilationError
+                : null,
             startedAt: status == CompilationStatus.Compiling ? def.LastCompileStartedAt : null,
             lastCompiledAt: status == CompilationStatus.Ok ? def.LastCompileSucceededAt : null,
             hub.JsonSerializerOptions);
@@ -3417,8 +3424,7 @@ public class MeshOperations
                         .Where(n =>
                         {
                             var status = ReadCompilationStatusFromNode(n);
-                            return (status == CompilationStatus.Ok || status == CompilationStatus.Error)
-                                && IsNewCompileRun(n, before);
+                            return IsSettled(status) && IsNewCompileRun(n, before);
                         })
                         .Take(1)
                         .Timeout(TimeSpan.FromSeconds(60))
@@ -3434,11 +3440,18 @@ public class MeshOperations
                                     path = resolvedPath,
                                     error,
                                     activityPath,
-                                    message = status == CompilationStatus.Ok
-                                        ? "Compile SUCCEEDED."
-                                        : "Compile FAILED — see `error` for Roslyn diagnostics. "
-                                          + "Full source-discovery + matched-Code-paths trace lives at "
-                                          + (activityPath ?? "(no activity log written)") + "."
+                                    message = status switch
+                                    {
+                                        CompilationStatus.Ok => "Compile SUCCEEDED.",
+                                        // NOT a failure — the run never reported an answer.
+                                        CompilationStatus.Unavailable =>
+                                            "Compile state could NOT BE DETERMINED (see `error`) — this is a "
+                                            + "timeout, NOT a compile failure. Nothing is known to be wrong "
+                                            + "with the source; trigger the compile again.",
+                                        _ => "Compile FAILED — see `error` for Roslyn diagnostics. "
+                                            + "Full source-discovery + matched-Code-paths trace lives at "
+                                            + (activityPath ?? "(no activity log written)") + "."
+                                    }
                                 },
                                 hub.JsonSerializerOptions);
                         })
@@ -3674,6 +3687,22 @@ public class MeshOperations
                         lastCompiledAt,
                         message = "Compile SUCCEEDED at " + lastCompiledAt?.ToString("u")
                             + ". The NodeType assembly was built without errors and is loaded."
+                    },
+                    options);
+            case CompilationStatus.Unavailable:
+                // 🚨 Must never read as a compile failure: `error` here describes why the
+                // state could not be DETERMINED, not what is wrong with the source. An
+                // agent that confuses the two starts "fixing" code that compiles fine.
+                return JsonSerializer.Serialize(
+                    new
+                    {
+                        status = "Unavailable",
+                        nodeTypePath,
+                        error,
+                        message = "The compile state could NOT BE DETERMINED (a settle wait or an "
+                            + "assembly lookup timed out) — this is NOT a compile failure and NOTHING "
+                            + "is known to be wrong with the source. See `error` for what timed out. "
+                            + "Trigger a fresh compile and re-call GetDiagnostics."
                     },
                     options);
             case CompilationStatus.Unknown:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-compile-error-clarity.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-compile-error-clarity.md
@@ -1,0 +1,31 @@
+---
+Name: A compile problem now tells you whether it is your code or a timeout
+Category: What's New
+Description: The "this page can't be displayed" overlay now says whether the compiler rejected your code or a lookup simply timed out — and links the full compile log.
+Icon: Sparkle
+---
+
+# A compile problem now tells you whether it is your code or a timeout
+
+When a page could not be built, it always said the same thing: *"There was a
+compilation error in this item's code… Please correct the code."* That was
+right only some of the time. A registration lookup that timed out after three
+seconds, a build that had not settled yet, an assembly the node could not fetch,
+and a type built by a previous platform version all produced that identical
+sentence — sending you to edit source the compiler had never even read.
+
+Those cases now say what actually happened, and lead with **"No code change is
+needed for this."** followed by what to do instead (usually: wait, or Recompile).
+A genuine compiler error is unchanged — it still shows the diagnostics and still
+asks you to correct the code, because there it is the right advice.
+
+Two more things came with it:
+
+- **The broken page links its compile log.** The "View full compile log →" link
+  used to exist only on the type's own page; now the item's page carries it too,
+  which matters most on a timeout — the log is the only record of how far the
+  build got.
+- **"Could not be determined" is now a state of its own.** A build whose state
+  never came back is no longer recorded as a failure, so nothing downstream —
+  the type's page, the status badge, the `GetDiagnostics` answer an agent reads —
+  reports a healthy type as broken.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -74,7 +74,7 @@ internal static class NodeTypeContractHandler
             .SelectMany(_ => workspace.GetMeshNodeStream()
                 .AwaitCompilationSettled()
                 .Take(1))
-            .Timeout(TimeSpan.FromSeconds(60))
+            .Timeout(SettleBudget)
             .SelectMany(node =>
             {
                 if (node.Content is not NodeTypeDefinition def)
@@ -85,7 +85,8 @@ internal static class NodeTypeContractHandler
                     return Observable.Return(new ResolvedResponse(Fail(
                         null,
                         $"Node at '{hubPath}' is not a valid NodeType definition "
-                        + $"(Content type: {node.Content?.GetType().Name ?? "null"})."), false));
+                        + $"(Content type: {node.Content?.GetType().Name ?? "null"})."), false,
+                        Unavailable: true));
                 }
 
                 // Pinned release: resolve the explicitly requested Release MeshNode
@@ -110,9 +111,13 @@ internal static class NodeTypeContractHandler
                                     "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} could not be resolved (releaseNode={ReleaseNode}).",
                                     hubPath, requestedReleasePath,
                                     releaseNode == null ? "null" : releaseNode.Content?.GetType().Name ?? "no-content");
+                                // A release that does not RESOLVE is a lookup miss, not a
+                                // compile failure — flagged Unavailable so the write-back
+                                // below never brands the source broken.
                                 return Observable.Return(new ResolvedResponse(Fail(
                                     null,
-                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' could not be resolved."), false));
+                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' could not be resolved."), false,
+                                    Unavailable: true));
                             }
                             // Use the persisted integer version the IAssemblyStore.Put
                             // used, not a parse of the display Version string.
@@ -127,7 +132,8 @@ internal static class NodeTypeContractHandler
                                             hubPath, requestedReleasePath, release.AssemblyCollection, releaseVersion);
                                         return Observable.Return(new ResolvedResponse(Fail(
                                             null,
-                                            $"Pinned release '{requestedReleasePath}' assembly not found in store."), false));
+                                            $"Pinned release '{requestedReleasePath}' assembly not found in store."), false,
+                                            Unavailable: true));
                                     }
                                     logger?.LogDebug(
                                         "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} → {LocalPath}.",
@@ -188,6 +194,23 @@ internal static class NodeTypeContractHandler
                     .Select(result => new ResolvedResponse(
                         BuildResponse(hubPath, node, result), true));
             })
+            // 🚨 A settle TIMEOUT (or any resolution abort) is NOT a compile failure.
+            // It used to fall straight to the Subscribe error sink as
+            // Fail("The operation has timed out.") — a message that names nothing and,
+            // once persisted, made every instance page of the type say "There was a
+            // compilation error… Please correct the code" for source that was never
+            // even read (#641). Fold it into the SAME write-back as every other
+            // outcome, flagged Unavailable, with a message that names the type, the
+            // budget, and (for a non-timeout abort) the exception TYPE — the
+            // "{TypeName}: {Message}" treatment RunCompile gives a non-Roslyn abort.
+            .Catch<ResolvedResponse, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "GetCompilationPathRequest at {HubPath}: compile state could not be determined ({ExceptionType}).",
+                    hubPath, ex.GetType().Name);
+                return Observable.Return(new ResolvedResponse(
+                    Fail(null, DescribeResolutionFailure(hubPath, ex)), false, Unavailable: true));
+            })
             .SelectMany(resolved =>
             {
                 var response = resolved.Response;
@@ -241,6 +264,26 @@ internal static class NodeTypeContractHandler
                                         : def.CompiledFrameworkVersion
                                 }
                             };
+                        // 🚨 "Could not determine" is not "failed". Unavailable is a
+                        // MARKER, so it may never overwrite a state another driver owns
+                        // (Pending / Compiling — a compile is in flight and writes its own
+                        // terminal state; clobbering it would strand the dispatch), a
+                        // strictly better one (Ok — a usable build), or a never-compiled
+                        // null (which the first-build kickoff gates on).
+                        if (resolved.Unavailable)
+                            return def.CompilationStatus is null
+                                    or CompilationStatus.Pending
+                                    or CompilationStatus.Compiling
+                                    or CompilationStatus.Ok
+                                ? curr
+                                : curr with
+                                {
+                                    Content = def with
+                                    {
+                                        CompilationStatus = CompilationStatus.Unavailable,
+                                        CompilationError = response.Error
+                                    }
+                                };
                         return curr with
                         {
                             Content = def with
@@ -282,13 +325,44 @@ internal static class NodeTypeContractHandler
     }
 
     /// <summary>
-    /// Branch result: the response to post plus whether it came from a FRESH
+    /// Wall-clock budget for the dispatched compile to settle. Elapsing means the
+    /// state is UNDETERMINED — never that the source is broken (see
+    /// <see cref="DescribeResolutionFailure"/>).
+    /// </summary>
+    private static readonly TimeSpan SettleBudget = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Branch result: the response to post, whether it came from a FRESH
     /// <see cref="IMeshNodeCompilationService.CompileAndGetConfigurations"/> run
     /// (drives the <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> stamp
     /// in the write-back) as opposed to a hydrate of an existing assembly (which
-    /// must never re-stamp — that would erase an ABI-staleness marker).
+    /// must never re-stamp — that would erase an ABI-staleness marker), and whether
+    /// a failure was an AVAILABILITY failure rather than a compile failure.
     /// </summary>
-    private sealed record ResolvedResponse(GetCompilationPathResponse? Response, bool FreshCompile);
+    /// <param name="Unavailable">
+    /// True when the branch could not DETERMINE the compile state — a settle
+    /// timeout, an unresolvable pinned release, assembly bytes the store does not
+    /// hold. Persisted as <see cref="CompilationStatus.Unavailable"/>, never
+    /// <see cref="CompilationStatus.Error"/>, so readers show "retry / wait" instead
+    /// of telling the author to correct code that was never in question.
+    /// </param>
+    private sealed record ResolvedResponse(
+        GetCompilationPathResponse? Response, bool FreshCompile, bool Unavailable = false);
+
+    /// <summary>
+    /// Human-readable cause for a resolution that never produced an answer. A bare
+    /// <see cref="TimeoutException"/> message ("The operation has timed out.") tells
+    /// the reader neither WHAT timed out nor that it was a timeout at all once it is
+    /// persisted onto the node — which is exactly how a 60 s settle wait ended up
+    /// rendered as a compile error (#641).
+    /// </summary>
+    private static string DescribeResolutionFailure(string hubPath, Exception ex)
+        => ex is TimeoutException
+            ? $"The compile state of '{hubPath}' could not be determined: it did not settle within "
+              + $"{SettleBudget.TotalSeconds:0}s. This is a TIMEOUT, not a compilation error — "
+              + "no code change is implied."
+            : $"The compile state of '{hubPath}' could not be determined — "
+              + $"{ex.GetType().Name}: {ex.Message}";
 
     /// <summary>
     /// 🚨 The single-compile-driver gate. Ensures a NEVER-COMPILED dynamic NodeType
@@ -300,9 +374,11 @@ internal static class NodeTypeContractHandler
     /// (<c>InstallCompileWatcher</c>'s <c>firstBuildKickoffSub</c>): both guard on
     /// <c>CompilationStatus is null</c>, and the per-NodeType hub's serialized action
     /// block makes exactly ONE of them transition the status, so exactly one compile
-    /// runs. Any non-null status returns unchanged — the status machine already owns
-    /// the compile lifecycle (Pending/Compiling hold the settled-wait; Ok/Error are
-    /// terminal and handled by the response branches).
+    /// runs. Any other non-null status returns unchanged — the status machine already
+    /// owns the compile lifecycle (Pending/Compiling hold the settled-wait; Ok/Error
+    /// are terminal and handled by the response branches). The one exception is
+    /// <see cref="CompilationStatus.Unavailable"/>: it records that a previous attempt
+    /// gave up WITHOUT an answer, so it is treated like "never determined".
     /// <para>Runs as System — dispatching a first build is infrastructure, same as the
     /// kickoff; the requester (often an instance activation) only needs READ rights and
     /// must not be denied for lacking Edit on the NodeType node.</para>
@@ -319,7 +395,12 @@ internal static class NodeTypeContractHandler
                 _ => workspace.GetMeshNodeStream().Update(curr =>
                 {
                     if (curr.Content is not NodeTypeDefinition def) return curr;
-                    if (def.CompilationStatus is not null) return curr;
+                    // Unavailable counts as "no compile has determined anything" — a
+                    // previous attempt gave up without an answer, so the next REQUEST
+                    // (never a timer) dispatches a fresh one instead of leaving the type
+                    // stuck on an undetermined state forever.
+                    if (def.CompilationStatus is not null and not CompilationStatus.Unavailable)
+                        return curr;
                     if (NodeTypeCompilationHelpers.HasUsableBuild(curr, def)) return curr;
                     if (NodeTypeCompilationHelpers.IsStaticOnlyNodeType(curr, def)) return curr;
                     return curr with

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -134,21 +134,23 @@ internal static class NodeTypeEnrichmentHelpers
                 .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
                 .Take(1)
                 .Timeout(NodeTypeProbeTimeout)
-                .Catch<QueryResultChange<MeshNode>, Exception>(ex =>
+                .Select(probe => probe.Items.Count > 0 ? ProbeOutcome.Registered : ProbeOutcome.Missing)
+                // 🚨 A FAULTED probe is NOT the same answer as an EMPTY one. Folding
+                // both into "missing" made a ~3s lookup timeout (busy mesh hub, slow
+                // storage, restart in progress) render the genuine-compile-failure
+                // overlay — "There was a compilation error… Please correct the code" —
+                // for a type whose source was never even read (#641). Keep the two
+                // apart and say which one happened.
+                .Catch<ProbeOutcome, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
-                        "EnrichWithNodeType probe for NodeType '{NodeType}' faulted ({ExceptionType}) — treating as missing",
+                        "EnrichWithNodeType probe for NodeType '{NodeType}' faulted ({ExceptionType}) — registration is INDETERMINATE, not missing",
                         nodeType, ex.GetType().Name);
-                    return Observable.Return(new QueryResultChange<MeshNode>
-                    {
-                        ChangeType = QueryChangeType.Initial,
-                        Items = []
-                    });
+                    return Observable.Return(ProbeOutcome.Indeterminate);
                 })
-                .Select(probe => probe.Items.Count > 0)
-                .SelectMany(found =>
+                .SelectMany(outcome =>
                 {
-                    if (!found)
+                    if (outcome == ProbeOutcome.Missing)
                     {
                         var msg =
                             $"NodeType '{nodeType}' is not registered (referenced by instance '{node.Path}'). " +
@@ -164,6 +166,22 @@ internal static class NodeTypeEnrichmentHelpers
                         return Observable.Return(
                             WithOverlaySelfHeal(
                                 WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration),
+                                meshHub, nodeType, typeVersionAtOverlay: null, logger));
+                    }
+                    if (outcome == ProbeOutcome.Indeterminate)
+                    {
+                        var msg =
+                            $"The registration lookup for NodeType '{nodeType}' did not complete within "
+                            + $"{NodeTypeProbeTimeout.TotalSeconds:0}s.\n"
+                            + $"Instance '{node.Path}' is rendering this fallback until the lookup succeeds.";
+                        var (intro, callToAction, guidance) = OverlayCopy(OverlayCause.LookupTimedOut);
+                        // NULL version gate for the same reason as the missing case:
+                        // no type node was ever read here, so the first usable
+                        // emission is genuine news.
+                        return Observable.Return(
+                            WithOverlaySelfHeal(
+                                WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration,
+                                    guidance: guidance, intro: intro, callToAction: callToAction),
                                 meshHub, nodeType, typeVersionAtOverlay: null, logger));
                     }
                     return BuildEnrichmentChain(meshHub, meshConfiguration, compilationService, node, nodeType, logger);
@@ -182,6 +200,25 @@ internal static class NodeTypeEnrichmentHelpers
     /// "missing" and emit the error overlay.
     /// </summary>
     private static readonly TimeSpan NodeTypeProbeTimeout = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// What the type-existence probe actually established. The three answers are
+    /// deliberately distinct: "the type is not registered" (the author's problem)
+    /// and "the lookup did not answer" (the platform's problem) call for opposite
+    /// remedies, and collapsing them is what made a lookup timeout read as a
+    /// compile failure.
+    /// </summary>
+    private enum ProbeOutcome
+    {
+        /// <summary>A node exists at the NodeType path — proceed with enrichment.</summary>
+        Registered,
+
+        /// <summary>The probe answered, and nothing is registered at that path.</summary>
+        Missing,
+
+        /// <summary>The probe timed out or faulted — registration is UNKNOWN, not absent.</summary>
+        Indeterminate
+    }
 
     private static IObservable<MeshNode> BuildEnrichmentChain(
         IMessageHub meshHub,
@@ -244,7 +281,12 @@ internal static class NodeTypeEnrichmentHelpers
                 var userMessage = timedOut
                     ? $"NodeType '{nodeType}' build did not settle within {SlowPathTimeout.TotalSeconds:0}s.\n"
                       + $"Instance '{node.Path}' is rendering this fallback until the type's build settles."
-                    : $"NodeType '{nodeType}' enrichment failed for instance '{node.Path}': {ex.Message}";
+                    // A non-timeout abort still isn't the author's code: name the
+                    // exception TYPE, exactly as RunCompile does for a non-Roslyn abort.
+                    : $"NodeType '{nodeType}' could not be prepared for instance '{node.Path}'\n"
+                      + $"{ex.GetType().Name}: {ex.Message}";
+                var (intro, callToAction, guidance) = OverlayCopy(
+                    timedOut ? OverlayCause.BuildNotSettled : OverlayCause.EnrichmentFaulted);
                 // Self-heal with a NULL version gate: no type node is in hand
                 // here, and a currently-usable state would have settled instead
                 // of timing out — so the first usable emission is genuine news
@@ -252,9 +294,7 @@ internal static class NodeTypeEnrichmentHelpers
                 return Observable.Return(
                     WithOverlaySelfHeal(
                         WithCompilationErrorOverlay(node, nodeType, userMessage, meshConfiguration,
-                            guidance: timedOut ? UnsettledBuildGuidance : null,
-                            intro: timedOut ? UnsettledBuildIntro : null,
-                            callToAction: timedOut ? UnsettledBuildCallToAction : null),
+                            guidance: guidance, intro: intro, callToAction: callToAction),
                         meshHub, nodeType, typeVersionAtOverlay: null, logger));
             });
     }
@@ -376,16 +416,20 @@ internal static class NodeTypeEnrichmentHelpers
                     && string.IsNullOrWhiteSpace(staticDef.Configuration)
                     && string.IsNullOrWhiteSpace(staticDef.HubConfiguration)
                     && (staticDef.Sources is null || staticDef.Sources.Count == 0))
-                // Settled compile — Ok with assembly fields, or Error. The
-                // kickoff has flipped Pending and the activity is driving the
+                // Settled compile — Ok with assembly fields, Error, or Unavailable.
+                // The kickoff has flipped Pending and the activity is driving the
                 // transition. Take(1) here would otherwise snap a pre-compile
                 // null/Unknown emission and bind every per-instance hub to
                 // default config before the assembly even exists.
+                // Unavailable is terminal too: it means a driver already gave up
+                // determining the state, so waiting the full no-progress budget
+                // would only delay the (correct, retry-flavoured) overlay.
                 || (typeNode.Content is NodeTypeDefinition def
                     && ((def.CompilationStatus == CompilationStatus.Ok
                             && !string.IsNullOrEmpty(def.LatestAssemblyCollection)
                             && !string.IsNullOrEmpty(def.LatestAssemblyPath))
-                        || def.CompilationStatus == CompilationStatus.Error))
+                        || def.CompilationStatus is CompilationStatus.Error
+                                                 or CompilationStatus.Unavailable))
                 || typeNode.Content is not NodeTypeDefinition)
             .Take(1);
 
@@ -550,11 +594,20 @@ internal static class NodeTypeEnrichmentHelpers
                         // LATEST build may already be usable while the pin is
                         // broken — without the gate the watcher would fire on
                         // the replayed current state and hot-loop the recycle.
+                        // 🚨 A release that doesn't RESOLVE is a lookup miss, not a
+                        // compile failure — the source was never in question. Say so,
+                        // instead of sending the author off to "correct the code".
+                        var (unresolvedIntro, unresolvedCta, unresolvedGuidance) =
+                            OverlayCopy(OverlayCause.AssemblyUnavailable);
                         return Observable.Return(
                             WithOverlaySelfHeal(
                                 WithCompilationErrorOverlay(node, nodeType,
                                     $"Pinned release '{requestedReleasePath}' for '{nodeType}' could not be resolved.",
-                                    meshConfiguration),
+                                    meshConfiguration,
+                                    guidance: unresolvedGuidance,
+                                    intro: unresolvedIntro,
+                                    callToAction: unresolvedCta,
+                                    activityPath: def.LastCompilationActivityPath),
                                 meshHub, nodeType, typeNode.Version, logger));
                     }
                     // Use the persisted integer version the IAssemblyStore.Put used,
@@ -586,11 +639,17 @@ internal static class NodeTypeEnrichmentHelpers
                                     // the unresolved-pin overlay above: the latest
                                     // build may satisfy HasUsableBuild right now,
                                     // so only a Version ADVANCE may recycle.
+                                    var (missIntro, missCta, missGuidance) =
+                                        OverlayCopy(OverlayCause.AssemblyUnavailable);
                                     return Observable.Return(
                                         WithOverlaySelfHeal(
                                             WithCompilationErrorOverlay(node, nodeType,
                                                 $"Pinned release '{requestedReleasePath}' assembly not found in store.",
-                                                meshConfiguration),
+                                                meshConfiguration,
+                                                guidance: missGuidance,
+                                                intro: missIntro,
+                                                callToAction: missCta,
+                                                activityPath: def.LastCompilationActivityPath),
                                             meshHub, nodeType, typeNode.Version, logger));
                                 }
                                 return TriggerRecompileAndRetry(
@@ -773,12 +832,16 @@ internal static class NodeTypeEnrichmentHelpers
                 // Version-gated self-heal: when the operator's recompile lands
                 // (a Version-advancing write with a framework-matching build),
                 // every instance stuck on this prompt recycles itself.
+                var (staleIntro, staleCta, staleGuidance) = OverlayCopy(OverlayCause.FrameworkStale);
                 return Observable.Return(
                     WithOverlaySelfHeal(
                         WithCompilationErrorOverlay(node, nodeType,
                             "Built against a previous framework version",
                             meshConfiguration,
-                            guidance: "This type's compiled assembly targets an older MeshWeaver build, so the current process can't load it. Click **Recompile** (or call `compile` via MCP) to rebuild it against the current framework — no source changes are needed."),
+                            guidance: staleGuidance,
+                            intro: staleIntro,
+                            callToAction: staleCta,
+                            activityPath: def.LastCompilationActivityPath),
                         meshHub, nodeType, typeNode.Version, logger));
             }
             return TriggerRecompileAndRetry(
@@ -788,15 +851,41 @@ internal static class NodeTypeEnrichmentHelpers
                 requireUsableBuild: true);
         }
 
+        // 🚨 The compile state could not be DETERMINED (a settle wait or an assembly
+        // lookup timed out and persisted CompilationStatus.Unavailable — see
+        // NodeTypeContractHandler). Nothing is known to be wrong with the source, so
+        // this page must NOT say "correct the code": it swaps in the same
+        // no-code-change-needed copy the slow-path timeout uses, and links the compile
+        // log so the operator can see how far the build got.
+        if (def.CompilationStatus == CompilationStatus.Unavailable)
+        {
+            var (undeterminedIntro, undeterminedCta, undeterminedGuidance) =
+                OverlayCopy(OverlayCause.StateUndetermined);
+            return Observable.Return(
+                WithOverlaySelfHeal(
+                    WithCompilationErrorOverlay(node, nodeType,
+                        def.CompilationError
+                            ?? $"The compile state of NodeType '{nodeType}' could not be determined.",
+                        meshConfiguration,
+                        guidance: undeterminedGuidance,
+                        intro: undeterminedIntro,
+                        callToAction: undeterminedCta,
+                        activityPath: def.LastCompilationActivityPath),
+                    meshHub, nodeType, typeNode.Version, logger));
+        }
+
         var error = def.CompilationError ?? "Compilation failed";
         // Genuine compile failure — the page wording stays as-is ("correct the
         // code"), but the instance still self-heals: once the author fixes the
         // source and a SUCCESSFUL compile writes back (Version advances +
         // HasUsableBuild turns true), every instance stuck on this overlay
-        // recycles itself instead of waiting for a manual Recycle.
+        // recycles itself instead of waiting for a manual Recycle. The compile
+        // log link rides along so the broken INSTANCE page reaches the same
+        // diagnostics the NodeType's own Overview offers.
         return Observable.Return(
             WithOverlaySelfHeal(
-                WithCompilationErrorOverlay(node, nodeType, error, meshConfiguration),
+                WithCompilationErrorOverlay(node, nodeType, error, meshConfiguration,
+                    activityPath: def.LastCompilationActivityPath),
                 meshHub, nodeType, typeNode.Version, logger));
     }
 
@@ -962,7 +1051,10 @@ internal static class NodeTypeEnrichmentHelpers
         if (staleVersion is { } stale && typeNode.Version <= stale)
             return false;
 
-        if (d.CompilationStatus == CompilationStatus.Error)
+        // Error is terminal — and so is Unavailable: a driver has already given up
+        // determining the state, so no further emission is coming and waiting out the
+        // no-progress budget would only delay the overlay.
+        if (d.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable)
             return true;
 
         return (typeNode.HubConfiguration != null
@@ -1266,6 +1358,12 @@ internal static class NodeTypeEnrichmentHelpers
     /// </summary>
     private static readonly TimeSpan SelfHealGrace = TimeSpan.FromSeconds(45);
 
+    /// <param name="activityPath">
+    /// The NodeType's <see cref="NodeTypeDefinition.LastCompilationActivityPath"/>, when
+    /// the caller has the type node in hand. Renders the same "View full compile log →"
+    /// anchor the NodeType's OWN Overview offers — the broken INSTANCE page used to be the
+    /// one place with no route to the diagnostics (#641). Null simply omits the link.
+    /// </param>
     public static MeshNode WithCompilationErrorOverlay(
         MeshNode node,
         string nodeType,
@@ -1273,7 +1371,8 @@ internal static class NodeTypeEnrichmentHelpers
         MeshConfiguration meshConfiguration,
         string? guidance = null,
         string? intro = null,
-        string? callToAction = null)
+        string? callToAction = null,
+        string? activityPath = null)
     {
         var baseConfig = string.IsNullOrEmpty(error)
             ? (node.HubConfiguration ?? meshConfiguration.DefaultNodeHubConfiguration)
@@ -1282,7 +1381,7 @@ internal static class NodeTypeEnrichmentHelpers
         if (string.IsNullOrEmpty(error))
             return node with { HubConfiguration = baseConfig };
 
-        var overlay = CreateCompilationErrorConfiguration(error, guidance, intro, callToAction);
+        var overlay = CreateCompilationErrorConfiguration(error, guidance, intro, callToAction, activityPath);
         // Fallback-hub contract: the overlay hub serves what its default config CAN
         // (the error Overview layout, node data binding, Ping) — but everything else,
         // notably typed requests the broken assembly would have registered (which
@@ -1315,7 +1414,12 @@ internal static class NodeTypeEnrichmentHelpers
     // WithOverlaySelfHeal watcher) with manual Recycle only as fallback.
     private const string UnsettledBuildIntro =
         "This item's type has not finished **compilation** yet, so its page couldn't be built.";
-    private const string UnsettledBuildCallToAction =
+    /// <summary>
+    /// Shared lead-in for EVERY overlay whose cause is an availability problem — a
+    /// lookup timeout, a settle timeout, an assembly the store can't hand over. The
+    /// one sentence that has to be there: this is not the author's code.
+    /// </summary>
+    private const string NoCodeChangeNeeded =
         "**No code change is needed for this.** ";
     private const string UnsettledBuildGuidance =
         "This usually happens while a mesh restart or a bulk recompile is still in progress. "
@@ -1323,18 +1427,152 @@ internal static class NodeTypeEnrichmentHelpers
         + "itself and shows the real page on the next load. If it stays stuck, use the **Recycle** "
         + "menu to refresh it manually.";
 
+    // Overlay copy for a REGISTRATION LOOKUP that never answered (the probe timeout).
+    // Nothing about the type's source was read, so a "correct the code" page is a
+    // straight falsehood.
+    private const string LookupUnavailableIntro =
+        "This item's type could not be looked up in time, so its page couldn't be built. "
+        + "This is a lookup timeout — not a **compilation** error.";
+    private const string LookupUnavailableGuidance =
+        "The mesh did not answer the type-registration lookup within its budget — typically a "
+        + "restart in progress, a slow storage backend, or a busy mesh hub. The page recovers "
+        + "automatically once the lookup succeeds; use the **Recycle** menu to retry immediately.";
+
+    // Overlay copy for "the build exists but its ASSEMBLY cannot be handed over here"
+    // (pinned release unresolved, bytes missing from the store on this pod).
+    private const string AssemblyUnavailableIntro =
+        "This item's type has a build, but its compiled assembly could not be loaded on this node, "
+        + "so its page couldn't be built. This is not a **compilation** error in the source.";
+    private const string AssemblyUnavailableGuidance =
+        "The assembly store reachable from here does not hold the bytes this build points at — a "
+        + "fresh pod, a cold cache, or a release whose artifact was removed. Click **Recompile** "
+        + "(or call `compile` via MCP) to republish them; clearing the pinned release also resolves it.";
+
+    // Overlay copy for a persisted CompilationStatus.Unavailable — a driver already
+    // gave up determining the state (see NodeTypeContractHandler's settle timeout).
+    private const string UndeterminedBuildIntro =
+        "This item's type did not report its **compilation** state in time, so its page couldn't be built.";
+    private const string UndeterminedBuildGuidance =
+        "The last attempt to determine this type's build state timed out — a mesh restart, a queued "
+        + "bulk recompile, or a busy per-type hub. Nothing is known to be wrong with the code. The "
+        + "page recovers automatically once the build settles; **Recompile** forces a fresh attempt.";
+
+    // Overlay copy for an enrichment chain that FAULTED outright (a hub unreachable,
+    // a stream errored) — the build was never even consulted.
+    private const string EnrichmentFaultedIntro =
+        "This item's type could not be prepared, so its page couldn't be built. "
+        + "This is a platform fault — not a **compilation** error in the source.";
+    private const string EnrichmentFaultedGuidance =
+        "Preparing this type for the instance failed before its build was consulted; the summary "
+        + "above names the fault, and the full stack is in the platform log. Use the **Recycle** "
+        + "menu to retry — the page also recovers on its own once the type resolves again.";
+
+    private const string FrameworkStaleIntro =
+        "This item's type was built by a previous MeshWeaver version, so the **compilation** output "
+        + "this process needs can't be loaded.";
+    private const string FrameworkStaleGuidance =
+        "This type's compiled assembly targets an older MeshWeaver build, so the current process "
+        + "can't load it. Click **Recompile** (or call `compile` via MCP) to rebuild it against the "
+        + "current framework — no source changes are needed.";
+
+    /// <summary>
+    /// Default label of the compile-log anchor. The rendered overlay localizes it
+    /// through <c>host.Localize("ui.viewCompileLog")</c> at render time; this literal
+    /// is the fallback for the pure builder (and its unit tests).
+    /// </summary>
+    internal const string ViewCompileLogLabel = "View full compile log →";
+
+    /// <summary>
+    /// WHY an instance is showing the emergency page — and therefore whether that page
+    /// may tell the author to change code.
+    ///
+    /// <para>🚨 This exists because the answer used to be implicit: every overlay call
+    /// site that passed no <c>guidance</c> silently inherited "There was a
+    /// <b>compilation error</b>… <b>Please correct the code.</b>", so a 3 s registration
+    /// lookup timeout, a 60 s settle timeout, an assembly the store couldn't hand over,
+    /// and an ABI-stale DLL all told the author to fix source that Roslyn had never
+    /// rejected (#641). Naming the cause makes the wording a DECISION, and
+    /// <see cref="ImpliesCodeFix"/> pins which causes may make it.</para>
+    /// </summary>
+    internal enum OverlayCause
+    {
+        /// <summary>Roslyn rejected the source. A code fix IS the remedy.</summary>
+        CompileFailed,
+
+        /// <summary>Nothing is registered at the NodeType path — an authoring mistake.</summary>
+        TypeNotRegistered,
+
+        /// <summary>The registration lookup timed out: registration is UNKNOWN, not absent.</summary>
+        LookupTimedOut,
+
+        /// <summary>The type's build did not settle within its budget.</summary>
+        BuildNotSettled,
+
+        /// <summary>A driver recorded <see cref="CompilationStatus.Unavailable"/> — state undetermined.</summary>
+        StateUndetermined,
+
+        /// <summary>A build exists, but its assembly could not be resolved on this node.</summary>
+        AssemblyUnavailable,
+
+        /// <summary>The assembly was built against a previous framework version.</summary>
+        FrameworkStale,
+
+        /// <summary>The enrichment chain itself faulted before any build was consulted.</summary>
+        EnrichmentFaulted
+    }
+
+    /// <summary>
+    /// The single mapping from <see cref="OverlayCause"/> to the overlay's reason line,
+    /// lead-in and guidance. <c>null</c> keeps the genuine-error wording byte-for-byte.
+    /// </summary>
+    internal static (string? Intro, string? CallToAction, string? Guidance) OverlayCopy(OverlayCause cause)
+        => cause switch
+        {
+            OverlayCause.LookupTimedOut =>
+                (LookupUnavailableIntro, NoCodeChangeNeeded, LookupUnavailableGuidance),
+            OverlayCause.BuildNotSettled =>
+                (UnsettledBuildIntro, NoCodeChangeNeeded, UnsettledBuildGuidance),
+            OverlayCause.StateUndetermined =>
+                (UndeterminedBuildIntro, NoCodeChangeNeeded, UndeterminedBuildGuidance),
+            OverlayCause.AssemblyUnavailable =>
+                (AssemblyUnavailableIntro, NoCodeChangeNeeded, AssemblyUnavailableGuidance),
+            OverlayCause.EnrichmentFaulted =>
+                (EnrichmentFaultedIntro, NoCodeChangeNeeded, EnrichmentFaultedGuidance),
+            // The assembly is ABI-stale, not wrong: the guidance already said "no source
+            // changes are needed" while the lead-in said "Please correct the code."
+            // Contradictory copy is how an operator ends up editing working source.
+            OverlayCause.FrameworkStale =>
+                (FrameworkStaleIntro, NoCodeChangeNeeded, FrameworkStaleGuidance),
+            // CompileFailed / TypeNotRegistered — a code or registration fix IS the
+            // remedy, so the genuine-error wording stands.
+            _ => (null, null, null)
+        };
+
+    /// <summary>
+    /// True only for the causes whose remedy really is an edit by the author. Every other
+    /// cause is an availability problem the page must present as "retry / wait".
+    /// </summary>
+    internal static bool ImpliesCodeFix(OverlayCause cause)
+        => cause is OverlayCause.CompileFailed or OverlayCause.TypeNotRegistered;
+
     private static Func<MessageHubConfiguration, MessageHubConfiguration>
         CreateCompilationErrorConfiguration(
-            string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
+            string errorMessage, string? guidance, string? intro = null,
+            string? callToAction = null, string? activityPath = null)
     {
+        // The markdown is assembled at RENDER time, so the compile-log anchor can be
+        // localized off the viewing user's AccessContext (host.Localize) rather than
+        // baked in English at enrichment time.
         return config => config.AddLayout(layout =>
             layout.WithView(MeshNodeLayoutAreas.OverviewArea, (host, ctx) =>
                 Observable.Return<UiControl?>(
-                    BuildCompilationErrorMarkdown(errorMessage, guidance, intro, callToAction))));
+                    BuildCompilationErrorMarkdown(errorMessage, guidance, intro, callToAction,
+                        activityPath, host.Localize("ui.viewCompileLog")))));
     }
 
     private static UiControl BuildCompilationErrorMarkdown(
-        string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
+        string errorMessage, string? guidance, string? intro = null, string? callToAction = null,
+        string? activityPath = null, string? activityLinkLabel = null)
         => Controls.Stack
             // Card-style emergency page: an error accent, a comfortable reading
             // width and generous padding so a broken instance gets a real
@@ -1345,7 +1583,8 @@ internal static class NodeTypeEnrichmentHelpers
                 "border: 1px solid var(--error, #d13438); border-left: 4px solid var(--error, #d13438); " +
                 "border-radius: 8px; background: var(--neutral-layer-2);")
             .WithView(Controls.Markdown(
-                BuildCompilationErrorMarkdownText(errorMessage, guidance, intro, callToAction)));
+                BuildCompilationErrorMarkdownText(
+                    errorMessage, guidance, intro, callToAction, activityPath, activityLinkLabel)));
 
     /// <summary>
     /// Builds the markdown body of the emergency compile-error page: a friendly
@@ -1356,11 +1595,16 @@ internal static class NodeTypeEnrichmentHelpers
     /// <c>CompileErrorOverviewTest</c> asserts — keep them.
     /// <para><paramref name="intro"/> / <paramref name="callToAction"/> override the
     /// genuine-error reason line and the "Please correct the code." lead-in for
-    /// call sites where a code fix is NOT the remedy (the unsettled-build timeout
+    /// call sites where a code fix is NOT the remedy (every timeout / lookup-miss
     /// overlay). Null keeps the genuine-Error wording byte-for-byte.</para>
+    /// <para><paramref name="activityPath"/> appends the "View full compile log →"
+    /// anchor pointing at the NodeType's last compile activity — the same route the
+    /// NodeType's own Overview offers, which the broken INSTANCE page previously
+    /// lacked entirely.</para>
     /// </summary>
     internal static string BuildCompilationErrorMarkdownText(
-        string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
+        string errorMessage, string? guidance, string? intro = null, string? callToAction = null,
+        string? activityPath = null, string? activityLinkLabel = null)
     {
         var newlineIdx = errorMessage.IndexOf('\n');
         var header = newlineIdx >= 0 ? errorMessage[..newlineIdx].TrimEnd(':') : errorMessage;
@@ -1380,6 +1624,12 @@ internal static class NodeTypeEnrichmentHelpers
         sb.Append("\n---\n\n");
         sb.Append(callToAction ?? "**Please correct the code.** ")
             .Append(guidance ?? DefaultCompilationErrorGuidance).Append('\n');
+        // The route to the diagnostics. A markdown link, never an embedded
+        // LayoutAreaControl: the activity is history and may be unaddressable, and
+        // subscribing to an inexistent address is the resubscribe storm.
+        if (!string.IsNullOrEmpty(activityPath))
+            sb.Append("\n[").Append(activityLinkLabel ?? ViewCompileLogLabel)
+                .Append("](/").Append(activityPath).Append(")\n");
         return sb.ToString();
     }
 }

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -182,6 +182,16 @@ public static class NodeTypeLayoutAreas
                             return Task.CompletedTask;
                         }));
                 }
+                else if (def.CompilationStatus == CompilationStatus.Unavailable)
+                {
+                    // The state could not be DETERMINED — no Roslyn diagnostics exist to
+                    // mark up, and no code fix is implied. Offer the one thing that helps:
+                    // a LINK (never an embedded area — the activity is history and may be
+                    // unaddressable) to whatever the last compile did manage to log.
+                    if (!string.IsNullOrEmpty(def.LastCompilationActivityPath))
+                        stack = stack.WithView(Controls.Markdown(
+                            $"[{host.Localize("ui.viewCompileLog")}](/{def.LastCompilationActivityPath})"));
+                }
                 else if (!string.IsNullOrEmpty(def.LastCompilationActivityPath))
                 {
                     // Live activity log = the "show details" of an IN-FLIGHT compile
@@ -304,6 +314,13 @@ public static class NodeTypeLayoutAreas
                 string.IsNullOrEmpty(def.CompilationError)
                     ? "The last compile failed — no diagnostic captured. Click **Recycle** on the parent NodeType to retry."
                     : $"```text\n{def.CompilationError}\n```"),
+            // 🚨 NOT a failure: the last attempt could not DETERMINE the state (a settle
+            // or lookup timeout). Never phrase this as broken code.
+            CompilationStatus.Unavailable => ("❔", "Compile state unknown",
+                (string.IsNullOrEmpty(def.CompilationError)
+                    ? "The last attempt to determine this type's build state did not complete."
+                    : $"```text\n{def.CompilationError}\n```")
+                + "\n\nNothing is known to be wrong with the code — click **Recompile** to try again."),
             // null / Unknown — split on whether there's anything to compile at all.
             _ => hasSource
                 ? ("…", "Waiting for compile to start",
@@ -1032,6 +1049,7 @@ public static class NodeTypeLayoutAreas
                 CompilationStatus.Pending => "Compiling…",
                 CompilationStatus.Compiling => "Compiling…",
                 CompilationStatus.Error => "Last compile: Error",
+                CompilationStatus.Unavailable => host.Localize("ui.compileStateUnknown"),
                 _ => ""
             }).WithStyle("color: var(--neutral-foreground-hint); font-size: 13px;"));
 
@@ -1248,6 +1266,7 @@ public static class NodeTypeLayoutAreas
                 CompilationStatus.Compiling => "Compiling…",
                 CompilationStatus.Ok => "Last compile: Ok",
                 CompilationStatus.Error => "Last compile: Error",
+                CompilationStatus.Unavailable => host.Localize("ui.compileStateUnknown"),
                 _ => ""
             }).WithStyle("color: var(--neutral-foreground-hint); font-size: 13px;"));
 
@@ -1762,7 +1781,10 @@ public static class NodeTypeLayoutAreas
             && !string.IsNullOrEmpty(def.LatestAssemblyPath);
         var neverCompiled = !hasBuild
             && status != CompilationStatus.Compiling
-            && status != CompilationStatus.Error;
+            && status != CompilationStatus.Error
+            // "Could not determine" is not "never compiled" — claiming the latter
+            // hides the real (retryable) cause behind a wrong first build.
+            && status != CompilationStatus.Unavailable;
 
         var panel = Controls.Stack
             .WithOrientation(Orientation.Horizontal)
@@ -1785,6 +1807,15 @@ public static class NodeTypeLayoutAreas
             chip = Controls.Body(host.Localize("ui.compilationFailed")).WithStyle("font-weight: 600; color: var(--error-foreground);");
             compileButtonLabel = "Retry compile";
             panelStyleSuffix = "background: var(--error-fill-rest); border-color: var(--error-stroke-rest);";
+        }
+        else if (status == CompilationStatus.Unavailable)
+        {
+            // Undetermined, not failed: warning tint (something needs attention) rather
+            // than the error tint that reads as "your code is broken".
+            chip = Controls.Body(host.Localize("ui.compileStateUnknown"))
+                .WithStyle("font-weight: 600; color: var(--warning-foreground);");
+            compileButtonLabel = "Retry compile";
+            panelStyleSuffix = "background: var(--warning-fill-rest); border-color: var(--warning-stroke-rest);";
         }
         else if (neverCompiled)
         {
@@ -1903,6 +1934,17 @@ public static class NodeTypeLayoutAreas
                 .WithView(Controls.Html(
                     $"<pre style=\"white-space: pre-wrap; font-family: monospace; font-size: 12px; color: var(--error); margin: 0;\">{System.Net.WebUtility.HtmlEncode(def.CompilationError)}</pre>"));
         }
+        else if (def.CompilationStatus == CompilationStatus.Unavailable)
+        {
+            // Availability problem, not a compile failure — hint colour, and the text is
+            // the "could not determine" message, never Roslyn diagnostics.
+            panel = panel
+                .WithView(Controls.Body(LocalizationCatalog.Get("ui.compileStateUnknown", locale))
+                    .WithStyle("color: var(--warning-foreground); font-weight: 600;"));
+            if (!string.IsNullOrEmpty(def.CompilationError))
+                panel = panel.WithView(Controls.Body(def.CompilationError!)
+                    .WithStyle("color: var(--neutral-foreground-hint); font-size: 12px;"));
+        }
         else if (def.CompilationStatus == CompilationStatus.Ok
                  && !string.IsNullOrEmpty(def.LatestReleasePath))
         {
@@ -1918,7 +1960,7 @@ public static class NodeTypeLayoutAreas
         {
             var activityHref = "/" + def.LastCompilationActivityPath;
             panel = panel.WithView(Controls.Html(
-                $"<a href=\"{System.Net.WebUtility.HtmlEncode(activityHref)}\" style=\"font-size: 12px; color: var(--neutral-foreground-hint);\">View full compile log →</a>"));
+                $"<a href=\"{System.Net.WebUtility.HtmlEncode(activityHref)}\" style=\"font-size: 12px; color: var(--neutral-foreground-hint);\">{System.Net.WebUtility.HtmlEncode(LocalizationCatalog.Get("ui.viewCompileLog", locale))}</a>"));
         }
 
         return panel;

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -1958,9 +1958,13 @@ public static class NodeTypeLayoutAreas
 
         if (!string.IsNullOrEmpty(def.LastCompilationActivityPath))
         {
-            var activityHref = "/" + def.LastCompilationActivityPath;
-            panel = panel.WithView(Controls.Html(
-                $"<a href=\"{System.Net.WebUtility.HtmlEncode(activityHref)}\" style=\"font-size: 12px; color: var(--neutral-foreground-hint);\">{System.Net.WebUtility.HtmlEncode(LocalizationCatalog.Get("ui.viewCompileLog", locale))}</a>"));
+            // 🚨 A LINK is a control, not a string of HTML. Hand-built markup is banned
+            // (AGENTS.md: never emit HTML strings — use the framework's controls), and it also
+            // forced manual HtmlEncode of both the href and the label. Markdown renders the same
+            // anchor, escapes for us, and keeps the styling on the control.
+            panel = panel.WithView(Controls
+                .Markdown($"[{LocalizationCatalog.Get("ui.viewCompileLog", locale)}](/{def.LastCompilationActivityPath})")
+                .WithStyle("font-size: 12px; color: var(--neutral-foreground-hint);"));
         }
 
         return panel;

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -476,7 +476,8 @@ public static class DynamicTypePreWarmer
 
                             var settled = stream
                                 .Where(n => n?.Content is NodeTypeDefinition d
-                                    && (d.CompilationStatus == CompilationStatus.Error
+                                    && (d.CompilationStatus is CompilationStatus.Error
+                                                            or CompilationStatus.Unavailable
                                         || (d.CompilationStatus == CompilationStatus.Ok
                                             && IsFreshSuccess(d.LastCompileSucceededAt, baseline))))
                                 .Take(1)
@@ -484,9 +485,17 @@ public static class DynamicTypePreWarmer
                                 .Select(n =>
                                 {
                                     var d = (NodeTypeDefinition)n!.Content!;
-                                    return d.CompilationStatus == CompilationStatus.Error
-                                        ? new PreWarmOutcome(typePath, PreWarmStatus.CompileError, d.CompilationError)
-                                        : new PreWarmOutcome(typePath, PreWarmStatus.Compiled, "rebuilt after store miss");
+                                    return d.CompilationStatus switch
+                                    {
+                                        CompilationStatus.Error => new PreWarmOutcome(
+                                            typePath, PreWarmStatus.CompileError, d.CompilationError),
+                                        // The rebuild never reported an answer — not a
+                                        // compile failure, so never labelled one.
+                                        CompilationStatus.Unavailable => new PreWarmOutcome(
+                                            typePath, PreWarmStatus.TimedOut, d.CompilationError),
+                                        _ => new PreWarmOutcome(
+                                            typePath, PreWarmStatus.Compiled, "rebuilt after store miss")
+                                    };
                                 });
 
                             // Never emits — it exists only for its write side effect, and it is
@@ -547,17 +556,28 @@ public static class DynamicTypePreWarmer
         => Observable.Using(
                 () => AccessContextScope.AsSystem(accessService),
                 _ => workspace.GetMeshNodeStream(typePath)
+                    // Unavailable is terminal too — a driver already gave up determining
+                    // the state, so waiting out the rest of the budget for a write that
+                    // is not coming only slows the sweep down.
                     .Where(n => n?.Content is NodeTypeDefinition d
                         && (NodeTypeCompilationHelpers.HasUsableBuild(n, d)
-                            || d.CompilationStatus == CompilationStatus.Error))
+                            || d.CompilationStatus is CompilationStatus.Error
+                                                   or CompilationStatus.Unavailable))
                     .Take(1)
                     .Timeout(budget)
                     .Select(n =>
                     {
                         var d = (NodeTypeDefinition)n!.Content!;
-                        return d.CompilationStatus == CompilationStatus.Error
-                            ? new PreWarmOutcome(typePath, PreWarmStatus.CompileError, d.CompilationError)
-                            : new PreWarmOutcome(typePath, PreWarmStatus.Compiled);
+                        return d.CompilationStatus switch
+                        {
+                            CompilationStatus.Error => new PreWarmOutcome(
+                                typePath, PreWarmStatus.CompileError, d.CompilationError),
+                            // TimedOut, never CompileError: the type is not broken, its
+                            // state simply never came back.
+                            CompilationStatus.Unavailable => new PreWarmOutcome(
+                                typePath, PreWarmStatus.TimedOut, d.CompilationError),
+                            _ => new PreWarmOutcome(typePath, PreWarmStatus.Compiled)
+                        };
                     }))
             .Catch<PreWarmOutcome, Exception>(ex => Observable.Return(
                 ex is TimeoutException

--- a/src/MeshWeaver.Mesh.Contract/Services/CompilationStatus.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/CompilationStatus.cs
@@ -28,5 +28,29 @@ public enum CompilationStatus
     Ok,
 
     /// <summary>The most recent compile failed; <c>CompilationError</c> on the NodeTypeDefinition has the text.</summary>
-    Error
+    Error,
+
+    /// <summary>
+    /// The compile state could NOT BE DETERMINED: a settle wait or a registration
+    /// lookup timed out, or a recorded assembly could not be resolved from the
+    /// store. <b>Nothing is known to be wrong with the source</b> — this is an
+    /// availability problem, and the remedy is to retry / wait, never "correct the
+    /// code".
+    ///
+    /// <para>Kept distinct from <see cref="Error"/> precisely because a reader that
+    /// cannot tell the two apart tells the author to fix code that compiles fine:
+    /// a 60 s settle timeout used to be persisted as <c>Error</c> with the message
+    /// "The operation has timed out.", and every instance page of that type then
+    /// rendered the "There was a compilation error… Please correct the code"
+    /// overlay (issue #641).</para>
+    ///
+    /// <para>🚨 Writers must treat this as a MARKER, never an answer: it may never
+    /// overwrite a state another driver owns (<see cref="Pending"/> /
+    /// <see cref="Compiling"/> — a compile is in flight and will write its own
+    /// terminal state), a strictly better one (<see cref="Ok"/> — a usable build),
+    /// or a never-compiled <c>null</c> (which the first-build kickoff needs).
+    /// Appended LAST so the persisted ordinal of every existing member is
+    /// unchanged.</para>
+    /// </summary>
+    Unavailable
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -340,6 +340,8 @@
   "ui.compileFailed": "Kompilieren fehlgeschlagen",
   "ui.compiling": "Wird kompiliert…",
   "ui.neverCompiled": "Noch nie kompiliert — zum Erstellen auf Kompilieren klicken",
+  "ui.compileStateUnknown": "Letzte Kompilierung: Status konnte nicht ermittelt werden",
+  "ui.viewCompileLog": "Vollständiges Kompilierungsprotokoll anzeigen →",
   "ui.noConfiguration": "Keine Konfiguration definiert.",
   "ui.noConfigLambda": "Kein Konfigurations-Lambda definiert.",
   "ui.noneConfigured": "Nichts konfiguriert.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -340,6 +340,8 @@
   "ui.compileFailed": "Compile failed",
   "ui.compiling": "Compiling…",
   "ui.neverCompiled": "Never compiled — click Compile to build",
+  "ui.compileStateUnknown": "Last compile: state could not be determined",
+  "ui.viewCompileLog": "View full compile log →",
   "ui.noConfiguration": "No Configuration defined.",
   "ui.noConfigLambda": "No configuration lambda defined.",
   "ui.noneConfigured": "None configured.",

--- a/test/MeshWeaver.Content.Test/CompileErrorOverviewTest.cs
+++ b/test/MeshWeaver.Content.Test/CompileErrorOverviewTest.cs
@@ -124,6 +124,124 @@ public class CompileErrorOverviewTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     [Fact(Timeout = 120_000)]
+    public async Task TimedOutNodeType_InstanceOverview_ReadsAsRetry_AndLinksTheCompileLog()
+    {
+        // 🚨 #641: a LOOKUP/SETTLE TIMEOUT is not a compile failure. A NodeType whose state
+        // could not be determined persists CompilationStatus.Unavailable (written by
+        // NodeTypeContractHandler when its settle wait elapses), and every instance of it
+        // must render the retry copy — never "There was a compilation error… Please correct
+        // the code" for source that was never even read. It must also LINK the compile log:
+        // on a timeout that log is the only evidence of how far the build actually got.
+        const string typeId = "TimedOutOverviewType";
+        const string typePath = $"{Partition}/{typeId}";
+        const string activityPath = $"{typePath}/_Activity/compile-timeout";
+        const string instanceId = "timed-out-overview-instance";
+
+        var workspace = Mesh.GetWorkspace();
+
+        await NodeFactory.CreateNode(new MeshNode(typeId, Partition)
+        {
+            Name = "Timed Out Overview Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "A type whose compile state could not be determined.",
+                // No Configuration / Sources: nothing here is broken, and nothing will
+                // recompile it — the state is simply UNDETERMINED.
+                CompilationStatus = CompilationStatus.Unavailable,
+                CompilationError =
+                    "The compile state of 'TimedOutOverviewType' could not be determined: "
+                    + "it did not settle within 60s. This is a TIMEOUT, not a compilation error.",
+                LastCompilationActivityPath = activityPath
+            }
+        }).Should().Emit();
+
+        // The seeded state must survive as written — no watcher may reinterpret an
+        // undetermined state as a compile (the kickoff gates on CompilationStatus == null).
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Unavailable);
+        Output.WriteLine("NodeType is parked at Unavailable.");
+
+        await NodeFactory.CreateNode(new MeshNode(instanceId, Partition)
+        {
+            Name = "Timed Out Overview Instance",
+            NodeType = typePath,
+            State = MeshNodeState.Active
+        }).Should().Emit();
+
+        var client = GetClient();
+        var overviewRef = new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea);
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address($"{Partition}/{instanceId}"), overviewRef);
+
+        // Same non-hang contract as the broken-type test: the overlay hub activates and the
+        // Overview comes back — but with the RETRY story, not the code-fix one.
+        await stream.GetControlStream($"{overviewRef.Area}/1")
+            .Should().Within(60.Seconds())
+            .Match(c => c is MarkdownControl md
+                && (md.Markdown?.ToString() ?? string.Empty) is var t
+                && t.Contains("No code change is needed", StringComparison.OrdinalIgnoreCase)
+                && !t.Contains("Please correct the code", StringComparison.OrdinalIgnoreCase)
+                && t.Contains($"](/{activityPath})", StringComparison.Ordinal));
+        Output.WriteLine("Instance Overview reads as a timeout, links the compile log, and never says 'correct the code'.");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task BrokenNodeType_InstanceOverview_StillAsksForACodeFix_AndLinksTheCompileLog()
+    {
+        // The counterpart guarantee: distinguishing timeouts must not soften a REAL compile
+        // failure. A genuine Roslyn error still shows the diagnostics AND asks for a code fix
+        // — and now also links the compile activity from the INSTANCE page.
+        const string typeId = "BrokenLinkedType";
+        const string typePath = $"{Partition}/{typeId}";
+        const string instanceId = "broken-linked-instance";
+
+        var workspace = Mesh.GetWorkspace();
+
+        await NodeFactory.CreateNode(new MeshNode(typeId, Partition)
+        {
+            Name = "Broken Linked Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Deliberately non-compiling — the genuine-failure counterpart.",
+                Configuration = "config => still not valid C# (((["
+            }
+        }).Should().Emit();
+
+        // Wait for the REAL compile to fail AND stamp the activity it wrote its log to.
+        var failed = await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error
+                && !string.IsNullOrEmpty(d.LastCompilationActivityPath));
+        var activityPath = ((NodeTypeDefinition)failed.Content!).LastCompilationActivityPath!;
+        Output.WriteLine($"Compile settled at Error with activity {activityPath}.");
+
+        await NodeFactory.CreateNode(new MeshNode(instanceId, Partition)
+        {
+            Name = "Broken Linked Instance",
+            NodeType = typePath,
+            State = MeshNodeState.Active
+        }).Should().Emit();
+
+        var client = GetClient();
+        var overviewRef = new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea);
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address($"{Partition}/{instanceId}"), overviewRef);
+
+        await stream.GetControlStream($"{overviewRef.Area}/1")
+            .Should().Within(60.Seconds())
+            .Match(c => c is MarkdownControl md
+                && (md.Markdown?.ToString() ?? string.Empty) is var t
+                && t.Contains("Please correct the code", StringComparison.OrdinalIgnoreCase)
+                && t.Contains($"](/{activityPath})", StringComparison.Ordinal));
+        Output.WriteLine("Genuine failure still asks for a code fix — and now links its compile log.");
+    }
+
+    [Fact(Timeout = 120_000)]
     public async Task OneBrokenNodeType_DoesNotBreak_OtherNodes()
     {
         // 🚨 Isolation contract: a single non-compiling NodeType must NOT take down the rest of the

--- a/test/MeshWeaver.Graph.Test/CompileErrorPageTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileErrorPageTest.cs
@@ -170,4 +170,124 @@ public class CompileErrorPageTest
         md.Should().Contain("Edit the source and recompile.",
             "caller-supplied guidance is used when provided");
     }
+
+    // ── A TIMEOUT is not a compile failure (#641) ──
+    // Every overlay used to inherit "There was a compilation error… Please correct the
+    // code" whenever the call site passed no guidance, so a 3s registration-lookup
+    // timeout, a 60s settle timeout, an assembly the store couldn't hand over and an
+    // ABI-stale DLL all told the author to fix source Roslyn had never rejected.
+    // NodeTypeEnrichmentHelpers.OverlayCopy is now the SINGLE place that decides the
+    // wording, and ImpliesCodeFix pins which causes may claim a code fix.
+
+    [Fact]
+    public void EveryOverlayCause_SaysCorrectTheCode_OnlyWhenACodeFixIsActuallyTheRemedy()
+    {
+        // Enumerated, not listed: a NEW cause added later is covered automatically and
+        // cannot quietly inherit the genuine-error wording.
+        foreach (var cause in Enum.GetValues<NodeTypeEnrichmentHelpers.OverlayCause>())
+        {
+            var (intro, callToAction, guidance) = NodeTypeEnrichmentHelpers.OverlayCopy(cause);
+            var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+                "NodeType 'Acme/Widget' build did not settle within 60s.\n"
+                + "Instance 'Acme/widget-1' is rendering this fallback until the type's build settles.",
+                guidance, intro, callToAction);
+
+            md.Should().Contain("⚠", $"{cause}: every overlay keeps the emergency-page headline");
+            md.Should().Contain("compilation",
+                $"{cause}: the overlay contract CompileErrorOverviewTest asserts on the word 'compilation'");
+
+            if (NodeTypeEnrichmentHelpers.ImpliesCodeFix(cause))
+            {
+                md.Should().Contain("Please correct the code",
+                    $"{cause} genuinely IS the author's to fix");
+            }
+            else
+            {
+                md.Should().NotContain("Please correct the code",
+                    $"{cause} is an availability problem — telling the author to edit working source is the #641 bug");
+                md.Should().Contain("No code change is needed",
+                    $"{cause} must say so explicitly, not merely omit the code-fix line");
+            }
+        }
+    }
+
+    [Fact]
+    public void SettleTimeoutOverlay_ReadsAsRetry_AndStillNamesWhatTimedOut()
+    {
+        var (intro, callToAction, guidance) =
+            NodeTypeEnrichmentHelpers.OverlayCopy(NodeTypeEnrichmentHelpers.OverlayCause.BuildNotSettled);
+
+        var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+            "NodeType 'Acme/Widget' build did not settle within 60s.\n"
+            + "Instance 'Acme/widget-1' is rendering this fallback until the type's build settles.",
+            guidance, intro, callToAction);
+
+        md.Should().NotContain("Please correct the code");
+        md.Should().Contain("No code change is needed");
+        md.Should().Contain("Acme/Widget", "the page still names the type that didn't settle");
+        md.Should().Contain("60s", "and the budget that elapsed — a bare 'timed out' is unactionable");
+        md.Should().Contain("Recycle", "with a concrete way to retry");
+    }
+
+    [Fact]
+    public void GenuineRoslynFailure_StillShowsTheCompilerOutput_AndAsksForACodeFix()
+    {
+        // The counterpart guarantee: distinguishing timeouts must not soften a REAL failure.
+        var (intro, callToAction, guidance) =
+            NodeTypeEnrichmentHelpers.OverlayCopy(NodeTypeEnrichmentHelpers.OverlayCause.CompileFailed);
+
+        var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+            "Compilation failed for 'Acme/Widget'\n"
+            + "CS0103 error (line 9): 'Chart' does not exist in the current context",
+            guidance, intro, callToAction);
+
+        md.Should().Contain("Please correct the code");
+        md.Should().Contain("CS0103", "the actual compiler diagnostics are still shown");
+        md.Should().Contain("```text", "still in a code block, not prose");
+        md.Should().NotContain("No code change is needed");
+    }
+
+    [Fact]
+    public void InstanceOverlayPage_LinksTheCompileLog_WhenAnActivityPathIsKnown()
+    {
+        // 🚨 The broken INSTANCE page used to be the one surface with no route to the
+        // diagnostics — only the NodeType's own Overview carried "View full compile log →".
+        const string activityPath = "Acme/Widget/_Activity/compile-42";
+
+        var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+            "Compilation failed for 'Acme/Widget'\nCS0103 error (line 9): 'Chart' does not exist",
+            guidance: null, intro: null, callToAction: null, activityPath: activityPath);
+
+        md.Should().Contain($"](/{activityPath})",
+            "the overlay links straight to the compile activity so the user reaches the full log");
+        md.Should().Contain(NodeTypeEnrichmentHelpers.ViewCompileLogLabel);
+    }
+
+    [Fact]
+    public void InstanceOverlayPage_TimeoutWithActivity_CarriesBothTheRetryCopyAndTheLogLink()
+    {
+        const string activityPath = "Acme/Widget/_Activity/compile-43";
+        var (intro, callToAction, guidance) =
+            NodeTypeEnrichmentHelpers.OverlayCopy(NodeTypeEnrichmentHelpers.OverlayCause.StateUndetermined);
+
+        var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+            "The compile state of 'Acme/Widget' could not be determined: it did not settle within 60s.",
+            guidance, intro, callToAction, activityPath);
+
+        md.Should().NotContain("Please correct the code");
+        md.Should().Contain($"](/{activityPath})",
+            "a timeout page needs the log MORE than a failure page — it's the only evidence of how far the build got");
+    }
+
+    [Fact]
+    public void InstanceOverlayPage_OmitsTheCompileLogLink_WhenNoActivityWasEverRecorded()
+    {
+        // No phantom links: an activity path that was never written must not become a
+        // dead route (a subscription to an inexistent address is the resubscribe storm).
+        var md = NodeTypeEnrichmentHelpers.BuildCompilationErrorMarkdownText(
+            "Compilation failed", guidance: null);
+
+        md.Should().NotContain("](/");
+        md.Should().NotContain(NodeTypeEnrichmentHelpers.ViewCompileLogLabel);
+    }
 }

--- a/test/MeshWeaver.Graph.Test/RecompileSettlePredicateTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecompileSettlePredicateTest.cs
@@ -116,6 +116,23 @@ public class RecompileSettlePredicateTest
     }
 
     [Fact]
+    public void Unavailable_IsTerminal_SoTheWaitCannotBurnItsWholeBudget()
+    {
+        // CompilationStatus.Unavailable records that a driver already GAVE UP determining
+        // the state (a settle or lookup timeout). No further write is coming, so treating
+        // it as unsettled would hold the activation for the whole no-progress budget and
+        // then surface the same overlay anyway.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Unavailable, version: 21), staleVersion: 20, requireUsableBuild: false)
+            .Should().BeTrue("nothing further will be written for an undetermined state");
+
+        // …but it is still not a USABLE build, so the framework-stale heal keeps waiting.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Unavailable, version: 99), staleVersion: null, requireUsableBuild: true)
+            .Should().BeFalse("requireUsableBuild accepts only a genuinely loadable build");
+    }
+
+    [Fact]
     public void NonNodeTypeDefinitionContent_IsSettled_SoTheWaitCannotHang()
     {
         // Nothing left to wait on: the path is not a NodeTypeDefinition at all.


### PR DESCRIPTION
Fixes #641.

## Already on main (not redone here)

The audit on the issue established that the compiler output itself is already
surfaced: `BuildCompilationErrorMarkdownText`'s diagnostics fence plus the
per-source Monaco with Roslyn markers (`NodeTypeLayoutAreas`), the
`CompileProgressIndicator`, the `{TypeName}: {Message}` treatment for a
non-Roslyn abort in `RunCompile`, and ONE timeout path that already reads
correctly — the enrichment settle timeout ("has not finished compilation yet…
no code change is needed"). None of that is touched.

## What this PR adds

### 1. The broken INSTANCE page never linked the compile activity

`WithCompilationErrorOverlay` never received `LastCompilationActivityPath`, so
the "View full compile log →" anchor existed only on the NodeType's own
Overview — the *instance* page, the one a user actually lands on, had no route
to the diagnostics at all. The path is now threaded through to the markdown
builder and rendered as a markdown link (never an embedded `LayoutAreaControl`:
the activity is history and may be unaddressable — subscribing to an inexistent
address is the resubscribe storm). It rides along on every overlay that has a
type node in hand, and it matters most on a timeout, where the log is the only
evidence of how far the build got.

### 2. Timeouts and lookup misses no longer render as compile failures

Every overlay call site that passed no `guidance` silently inherited *"There was
a **compilation error** in this item's code… **Please correct the code.**"*
Four causes reached it that way, none of them the author's code:

- the **type-registration probe** (~3 s) folded a FAULT into "type is not
  registered", so an indeterminate lookup and a genuinely missing type produced
  identical copy. Split into `Registered` / `Missing` / `Indeterminate`;
- **pinned-release / assembly-store misses** — an assembly this node cannot
  fetch is a lookup miss, not broken source;
- **framework-stale** — whose guidance already said "no source changes are
  needed" *under* a lead-in demanding a code fix;
- an **enrichment chain that faulted** outright, before any build was consulted
  (it now also names the exception TYPE, like `RunCompile` does).

The wording is no longer implicit: `NodeTypeEnrichmentHelpers.OverlayCause` +
`OverlayCopy` are the single place that decides it, and `ImpliesCodeFix` pins
which causes may ask for an edit. Every availability cause leads with **"No code
change is needed for this."**

The contract handler's 60 s settle timeout fell straight to the Subscribe error
sink as `Fail("The operation has timed out.")` — naming neither what timed out
nor that it *was* a timeout — and once that reached the write-back it persisted
`CompilationStatus = Error`. It now folds into the same write-back with a
message that names the type and the budget.

### 3. Structural: `CompilationStatus.Unavailable`

The enum had no way to say "could not determine", so a timeout could only be
persisted as `Error`. `Unavailable` is appended **last** (every existing
persisted ordinal unchanged) and is a MARKER, never an answer: the write-back
refuses to let it overwrite a state another driver owns (`Pending`/`Compiling` —
that compile writes its own terminal state; clobbering it would strand the
dispatch), a strictly better one (`Ok`), or a never-compiled `null` the
first-build kickoff gates on. `EnsureCompileDispatched` treats it as "never
determined", so the next **request** — never a timer — dispatches a fresh
compile rather than leaving the type parked.

Every reader was checked (`grep CompilationStatus`) so the new member cannot be
mistaken for a failure or hang a waiter:

| Reader | Handling |
|---|---|
| enrichment `settled` predicate, `IsRecompileSettled` | terminal — waiting would burn the whole no-progress budget for a write that is not coming |
| `ApplyStreamResult` | dedicated branch: retry copy + compile-log link |
| MCP `GetDiagnostics` / `compile` (`MeshOperations`) | settled, and reported as "NOT a compile failure" instead of hanging or blaming the source |
| NodeType progress page / status badges / compile panel (`NodeTypeLayoutAreas`) | own undetermined state (warning tint, "Retry compile"), never the error tint |
| `DynamicTypePreWarmer` | terminal; reported `TimedOut`, never `CompileError` |
| `NodeTypeBakeStatus` | deliberately unchanged — `Unavailable` is not `PreviouslyBroken` and stays probeable |
| `AwaitCompilationSettled` (`MeshDataSource`) | already correct (only Pending/Compiling are in-flight) |

## Tests

- `CompileErrorPageTest` — the copy invariant is **enumerated over
  `OverlayCause`**, so a cause added later cannot quietly inherit the code-fix
  wording; plus the settle-timeout page, the genuine-failure page, and the
  compile-log link (present / absent).
- `RecompileSettlePredicateTest` — `Unavailable` is terminal, but never
  satisfies `requireUsableBuild`.
- `CompileErrorOverviewTest` — end to end: an `Unavailable` type's instance
  Overview reads as retry and links the log and never says "correct the code";
  a genuine Roslyn failure still shows its diagnostics, still asks for the fix,
  and now links its log too.

Local runs (Release): Graph.Test 831 passed · Content.Test/CompileErrorOverview
4 passed · Messaging.Hub.Test Localization 33 passed ·
Documentation link integrity passed · Monolith CompileSingleDriverConsistency +
MeshNodeCompilationIntegration passed. All touched projects build clean with
`-c Release -warnaserror`.

## Known gap

The overlay's prose (headline, guidance paragraphs) remains English-only, as it
was before this PR — localizing it means deferring the whole copy to render time
and migrating the pre-existing constants, which is a separate change. The two
NEW discrete strings this PR adds (`ui.viewCompileLog`,
`ui.compileStateUnknown`) are in both `strings.en.json` and `strings.de.json`,
and the previously hard-coded "View full compile log →" on the NodeType page now
reads from the catalog. `CompileProgressIndicator` (the global banner) still
surfaces only in-flight compiles and hard failures — an `Unavailable` type shows
nothing there rather than an error-styled banner, which the page overlay covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
