### PR TITLE
Localize the no-usable-model round failure (follow-up to #938)

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -66,7 +66,7 @@ public class AgentChatClient : IAgentChat
     // keys in factory config, invisible to the credential resolver) — it becomes fatal only
     // when agent creation ALSO produced nothing, which is what latches noUsableModelError.
     private bool modelFallbackExhausted;
-    private string? noUsableModelError;
+    private bool noUsableModel;
     private string? persistentThreadId;
     private IReadOnlyList<string>? currentAttachments;
     private bool isPersistentFactory;
@@ -145,14 +145,30 @@ public class AgentChatClient : IAgentChat
     public string? SubstitutedFromModel => substitutedFromModel;
 
     /// <summary>
-    /// Speaking message describing why NO model can serve a round on this client: the selection has
-    /// no usable credential, the catalog offered no usable replacement, AND agent creation produced
-    /// nothing. Null in every other state — in particular a deployment whose keys live in factory
-    /// config (invisible to the credential resolver) still builds agents and keeps running.
-    /// <para><c>ThreadExecution</c> fails the round with this message instead of letting it proceed
-    /// onto a client that will only produce a raw provider error (#476).</para>
+    /// True when NO model can serve a round on this client: the selection has no usable credential,
+    /// the catalog offered no usable replacement, AND agent creation produced nothing. False in
+    /// every other state — in particular a deployment whose keys live in factory config (invisible
+    /// to the credential resolver) still builds agents and keeps running.
+    /// <para><c>ThreadExecution</c> fails such a round with a localized message naming the requested
+    /// model (<see cref="RequestedModelName"/>), instead of letting it proceed onto a client that
+    /// can only produce a raw provider error (#476). The English factory detail stays in
+    /// <see cref="NoUsableModelDetail"/> — logs and diagnostics only, never the user's cell.</para>
     /// </summary>
-    public string? NoUsableModelError => noUsableModelError;
+    public bool HasNoUsableModel => noUsableModel;
+
+    /// <summary>
+    /// The model the caller asked for, resolved to its wire id — the argument the localized
+    /// no-usable-model message names. Null when the round carried no selection.
+    /// </summary>
+    public string? RequestedModelName => requestedModelName;
+
+    /// <summary>
+    /// The raw (English) factory failure behind <see cref="HasNoUsableModel"/>, e.g.
+    /// <c>"ApiKey is missing for model 'X'"</c>. Diagnostic only — it is logged, never written to
+    /// the user's response cell, because a raw provider dump in the thread is exactly what #476
+    /// complained about.
+    /// </summary>
+    public string? NoUsableModelDetail => lastAgentCreationError;
 
     // Live subscription to the workspace-level synced agent collection. Disposed
     // and replaced on every Initialize() call so the current context's queries
@@ -1523,7 +1539,7 @@ public class AgentChatClient : IAgentChat
         requestedModelName = currentModelName;
         substitutedFromModel = null;
         modelFallbackExhausted = false;
-        noUsableModelError = null;
+        noUsableModel = false;
         lastLoadedContextPath = contextPath;
         // Default the NodeType-search namespace to the context node's NodeType when the
         // caller didn't supply one. AgentPickerProjection.BuildAgentQueries will only
@@ -1790,7 +1806,7 @@ public class AgentChatClient : IAgentChat
         // if the new attempt succeeds.
         lastAgentCreationError = null;
         modelFallbackExhausted = false;
-        noUsableModelError = null;
+        noUsableModel = false;
 
         // 🩹 Self-heal a stale / deleted pinned model. The composer can carry a model id that no
         // longer resolves to a live LanguageModel (catalog refactor, deleted provider) — building a
@@ -1901,20 +1917,20 @@ public class AgentChatClient : IAgentChat
         // 🛑 #476: the fallback is exhausted (no model in the catalog has a usable credential) AND
         // not a single agent could be built — i.e. every factory refused the unusable selection
         // ("ApiKey is missing for model 'X'"). Running the round now can only produce a raw provider
-        // dump on a model nobody can serve, so latch a SPEAKING failure that ThreadExecution turns
-        // into a terminal Error. Both conditions are required: exhausted-alone is normal for a
-        // deployment whose keys live in factory config (the resolver cannot see those, yet the
-        // agents build and the round runs fine), and empty-alone has other causes that keep their
-        // existing "surface the reason as chat output" behaviour.
-        noUsableModelError = modelFallbackExhausted && createdAgents.IsEmpty
-            ? $"No language model can serve this round: the selected model "
-              + $"'{(string.IsNullOrEmpty(requestedModelName) ? "(none selected)" : requestedModelName)}' "
-              + "has no usable credentials, and no other model in the catalog resolves one. "
-              + "Configure a provider key (Settings → Language Models) or pick a different model."
-              + (string.IsNullOrEmpty(lastAgentCreationError) ? "" : $" Details: {lastAgentCreationError}")
-            : null;
-        if (noUsableModelError is not null)
-            logger.LogWarning("[AgentChatClient] {Error}", noUsableModelError);
+        // dump on a model nobody can serve, so latch the condition; ThreadExecution turns it into a
+        // terminal Error carrying a LOCALIZED message (the prose belongs at the write, where the
+        // round's AccessContext gives the viewer's language — never hard-coded here). Both
+        // conditions are required: exhausted-alone is normal for a deployment whose keys live in
+        // factory config (the resolver cannot see those, yet the agents build and the round runs
+        // fine), and empty-alone has other causes that keep their existing "surface the reason as
+        // chat output" behaviour.
+        noUsableModel = modelFallbackExhausted && createdAgents.IsEmpty;
+        if (noUsableModel)
+            logger.LogWarning(
+                "[AgentChatClient] No usable model: selected '{Model}' has no resolvable key, the "
+                + "catalog offers no usable replacement, and no agent could be built. Detail: {Detail}",
+                string.IsNullOrEmpty(requestedModelName) ? "(none selected)" : requestedModelName,
+                lastAgentCreationError ?? "(none)");
 
         logger.LogDebug("[AgentChatClient] Created {Count} agents", agents.Count);
     }

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1756,11 +1756,24 @@ internal static class ThreadExecution
                 // message that names the situation. Deterministic terminal write, same shape as the
                 // NOTHING_TO_SEND branch below, plus the parent/notification signals the error path
                 // uses so a delegating parent never waits on a round that will not run.
-                if (harnessClient == null && client.NoUsableModelError is { } noModelError)
+                if (harnessClient == null && client.HasNoUsableModel)
                 {
+                    // 🌍 The message the USER reads is localized off the round's own AccessContext —
+                    // explicit locale, never ambient CultureInfo (a round hops schedulers). The raw
+                    // English factory detail ("ApiKey is missing for model 'X'") goes to the LOG
+                    // only: a raw provider dump in the thread is precisely what #476 complained of.
+                    var noModelError = LocalizationCatalog.Get(
+                        string.IsNullOrEmpty(client.RequestedModelName)
+                            ? "chat.noUsableModelNoSelection"
+                            : "chat.noUsableModel",
+                        userAccessContext?.Locale,
+                        client.RequestedModelName);
                     logger.LogError(
-                        "[ThreadExec] NO_USABLE_MODEL threadPath={ThreadPath} responseId={ResponseId}: {Error}",
-                        threadPath, responseMsgId, noModelError);
+                        "[ThreadExec] NO_USABLE_MODEL threadPath={ThreadPath} responseId={ResponseId} "
+                        + "requested={Requested}: {Detail}",
+                        threadPath, responseMsgId,
+                        client.RequestedModelName ?? "(none selected)",
+                        client.NoUsableModelDetail ?? "(none)");
                     var noModelDone = new System.Reactive.Subjects.AsyncSubject<System.Reactive.Unit>();
                     PushToResponseMessage(
                         $"*Error: {noModelError}*",

--- a/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
@@ -138,8 +138,10 @@ model so the thread keeps running. Three rules make that swap honest:
   — an unusable pin is a configuration problem the user cannot act on mid-round.
 - **Nothing usable ⇒ the round FAILS.** If the selection is unusable and the catalog offers no
   usable replacement *and* no agent could be built, the round terminates with
-  `ThreadMessageStatus.Error` and a message naming the situation. It does not proceed to produce a
-  raw provider error under a `Completed` status, which any automation would read as success.
+  `ThreadMessageStatus.Error` and a localized message naming the situation (`chat.noUsableModel`,
+  resolved off the round's own `AccessContext.Locale`); the raw factory error stays in the log. It
+  does not proceed to produce a raw provider error under a `Completed` status, which any automation
+  would read as success.
   (Exhausted-fallback alone is not fatal: a deployment whose keys live in factory config is
   invisible to the credential resolver yet builds agents and runs normally.)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-model-substitution-visible.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-model-substitution-visible.md
@@ -25,6 +25,6 @@ served the round.
 
 And when *no* model can serve a round at all — the pinned one has no credentials
 and nothing else in the catalogue does either — the round now **fails**, with a
-message naming the situation and pointing at Settings → Language Models. Before,
-it ended as a success carrying a raw provider error, which anything reading the
-result had no way to tell apart from a real answer.
+message in your language naming the situation and pointing at Settings → Language
+Models. Before, it ended as a success carrying a raw provider error, which anything
+reading the result had no way to tell apart from a real answer.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -169,6 +169,8 @@
   "chat.nothingToPick": "Nichts zur Auswahl.",
   "chat.noModelsAvailable": "Keine Modelle zur Auswahl verfügbar.",
   "chat.noLanguageModel": "Kein Sprachmodell verfügbar. Unter Einstellungen → Sprachmodelle ein Modell hinzufügen (oder die Modelle eines Providers für diese Installation konfigurieren), um den Chat zu nutzen.",
+  "chat.noUsableModel": "Kein Sprachmodell kann diese Runde bedienen: Das ausgewählte Modell „{0}“ hat keine nutzbaren Zugangsdaten, und kein anderes Modell im Katalog löst welche auf. Unter Einstellungen → Sprachmodelle einen Provider-Schlüssel hinterlegen oder ein anderes Modell wählen.",
+  "chat.noUsableModelNoSelection": "Kein Sprachmodell kann diese Runde bedienen: Kein Modell im Katalog hat nutzbare Zugangsdaten. Unter Einstellungen → Sprachmodelle einen Provider-Schlüssel hinterlegen.",
   "chat.errorBoundary": "Im Chat ist ein Fehler aufgetreten — er bleibt hier isoliert, der Rest der Anwendung funktioniert weiter.",
   "chat.reloadChat": "Chat neu laden",
   "chat.sendFailed": "Nachricht konnte nicht gesendet werden: {0}",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -169,6 +169,8 @@
   "chat.nothingToPick": "Nothing to pick.",
   "chat.noModelsAvailable": "No models available to select.",
   "chat.noLanguageModel": "No language model is available. Add one in Settings → Language Models (or configure a provider's models for this deployment) to start chatting.",
+  "chat.noUsableModel": "No language model can serve this round: the selected model '{0}' has no usable credentials, and no other model in the catalogue resolves one. Add a provider key in Settings → Language Models, or pick a different model.",
+  "chat.noUsableModelNoSelection": "No language model can serve this round: no model in the catalogue has usable credentials. Add a provider key in Settings → Language Models.",
   "chat.errorBoundary": "The chat hit an error — contained here so the rest of the app keeps working.",
   "chat.reloadChat": "Reload chat",
   "chat.sendFailed": "Couldn't send your message: {0}",

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -166,9 +166,14 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         cell.Status.Should().Be(ThreadMessageStatus.Error,
             "a round that no model can serve must FAIL — settling as Completed reads as success to "
             + "every automation that checks the node (#476)");
-        cell.Summary.Should().Contain("No language model can serve this round",
-            "the failure must speak: name the situation instead of pasting a raw provider error");
+        // The failure must SPEAK — and speak the viewer's language: it comes from the localization
+        // catalog, not a hard-coded English literal, and it names the requested model.
+        cell.Summary.Should().Be(
+            LocalizationCatalog.Get("chat.noUsableModel", locale: null, StaleModel),
+            "the round's failure text must be the localized catalog message for this situation");
         cell.Summary.Should().Contain(StaleModel, "the message must name the model that was requested");
+        cell.Summary.Should().NotContain("ApiKey",
+            "the raw provider/factory error belongs in the log, never pasted into the thread (#476)");
         thread.Status.Should().Be(ThreadExecutionStatus.Idle, "the round must settle, never park");
     }
 


### PR DESCRIPTION
Addresses #476 (code half), follow-up to #938 — which was merged before this fix could land on it. The ops half of the issue (a deployment with real model quota) still stays with the maintainer.

## What #938 got wrong

The Copilot review on #938 was right: `noUsableModelError` was composed as a **hard-coded English sentence** inside `AgentChatClient.CreateAgentsSync` and written verbatim to the response cell's `Text` + `Summary`. That is a user-visible string, so it renders English for a German viewer — the i18n rule in AGENTS.md. It also carried the raw factory error (`"ApiKey is missing for model 'X'"`) into the thread, which is exactly the raw provider dump #476 complains about.

## The fix — split the CONDITION from its PRESENTATION

- `AgentChatClient` now latches only the condition and its inputs: `HasNoUsableModel`, `RequestedModelName`, and `NoUsableModelDetail` (the English factory error, **log-only**).
- `ThreadExecution` builds the prose at write time, where the round's own `AccessContext` supplies the viewer's language:
  `LocalizationCatalog.Get("chat.noUsableModel" | "chat.noUsableModelNoSelection", userAccessContext?.Locale, requested)` — an **explicit** locale, never ambient `CultureInfo` (a round hops schedulers, so an AsyncLocal culture would render one user's failure in another user's language).
- The raw factory detail moves to the `NO_USABLE_MODEL` log line only — it never reaches the thread.
- Keys added to **both** `strings.en.json` and `strings.de.json` (`LocalizationTest` gates the pair).

`ModelSubstitutionTest.NoUsableModelAnywhere_FailsRoundWithSpeakingError` now asserts the cell's `Summary` **is** the catalog message for the requested model, and that no `ApiKey` text reaches the thread — so the localization wiring itself is pinned, not just the English words.

Local (Release, `-warnaserror`): `MeshWeaver.AI` + `MeshWeaver.AI.Test` build clean; ModelSubstitution / ThreadTokenUsage / RoundFaultTerminalState 9/9; `MeshWeaver.Messaging.Hub.Test` localization 33/33. On the pre-cherry-pick branch the same change ran the full `MeshWeaver.AI.Test` (1053 passed), `MeshWeaver.Threading.Test` (128), `MeshWeaver.Hosting.Orleans.Test` (136).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
