### PR TITLE
Bind the plugin paywall to its NodeType instead of materialising _Policy + per-child denies

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -653,6 +653,76 @@ securityService.HasPermission("Anonymous", Permission.Read)
 
 ---
 
+# Type-declared subtree gates (`NodeTypeGate`)
+
+A node type that owns an entitlement-gated subtree — a storefront plugin, a paid course —
+declares its access shape **once, on the type**, instead of materialising it per instance:
+
+```csharp
+builder.ConfigureNodeTypeAccess(access => access.WithGate(new NodeTypeGate("Store/Plugin")
+{
+    PublicSurfaces = [NodeTypeGate.Self, "Overview", "Subscribe"],
+    RedirectOnDenied = "Subscribe",
+}));
+```
+
+Read as: *every* node of type `Store/Plugin` keeps its cover (`Self`), its marketing page and its
+checkout surface readable by everyone — anonymous visitors included — and a reader denied anywhere
+beneath it is sent to `{plugin}/Subscribe`. Nothing else is written. No `_Policy` node, no
+per-child deny, no root grant.
+
+**The rest of the model falls out of what the framework already does:**
+
+| Requirement | Mechanism |
+|---|---|
+| Everything except the declared surfaces is closed | The framework's deny-by-default — no grant, no Read |
+| Purchase / coupon opens the whole subtree | ONE `Viewer` `AccessAssignment` at the plugin root; grants inherit downward |
+| Denied reader is redirected | `NodeTypeGate.RedirectOnDenied`, resolved relative to the gated node |
+
+## Two properties worth relying on
+
+**A gate only ever GRANTS.** It never denies, never caps, and never removes a permission a role or
+an entitlement confers. A declaration that can only widen a short, explicitly listed set of paths
+cannot lock anyone out and cannot regress an existing deployment — which is why an actual `_Policy`
+node still wins over the type-declared redirect, and why the older allow-then-deny gate keeps
+working unchanged next to it.
+
+**`Self` opens the node and nothing beneath it.** That asymmetry is the reason the gate must live
+on the type at all: an `AccessAssignment` at the plugin root inherits strictly downward, so opening
+the cover that way opens the whole subtree — which is exactly why the materialised shape had to
+write a deny for every non-public child to claw it back.
+
+## Why not materialise it per instance
+
+Measured on memex, 2026-07-28 (issue #701), the per-instance shape failed three separate ways:
+
+- **Churn.** The reconcile pass rewrote `_Policy` until its version counter reached six figures
+  (`AgenticEngineering` 254,760), every write by `system-security`, as pure bookkeeping.
+- **Writer/reader drift.** The written policies carried only `redirectOnDenied`, while the reader
+  additionally required `publicRead: false` — the gate read as *not gated* in production.
+- **Silent non-application.** Gating keyed off a `price` field, so two plugins that shipped
+  `price: null` were completely ungated: every page anonymously readable.
+
+A declaration on the type has no version counter to churn, no second condition to drift from, and
+cannot be "not run" for an instance. A plugin that declares no price is gated for the same reason
+every other one is — its type.
+
+## Cost, and the evaluators
+
+`PermissionEvaluator` resolves a target path's **nearest gated ancestor-or-self** from one
+process-wide cached query per gated node type (`$security-gated:{type}`) — bounded by the number of
+gated *nodes*, not their children, and seeded with the static providers so a statically declared
+plugin resolves on the first emission. A mesh that declares no gate subscribes nothing and runs the
+exact fold it ran before.
+
+> ⚠️ **The SQL fold does not yet know about gates.** Postgres RLS decides *query listing*; the
+> evaluator above decides *exact reads and every UI gate*. Until the gate lands in the SQL
+> predicate, a declared public surface is readable by path but will not appear in an anonymous
+> `search`. The asymmetry is strictly in the safe direction — SQL is stricter, never looser, so it
+> cannot become a bypass — but it is a real gap, not a design choice.
+
+---
+
 # Hierarchical access pattern
 
 ```mermaid

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-type-declared-plugin-gate.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-type-declared-plugin-gate.md
@@ -1,0 +1,28 @@
+---
+Name: A plugin's paywall is now part of its type
+Category: What's New
+Description: Gated plugins declare their public cover, marketing page and checkout once on the node type instead of having a policy and a deny row written for every child.
+Icon: LockClosed
+---
+
+# A plugin's paywall is now part of its type
+
+A plugin that sells something has always needed the same shape: the cover, the marketing page and
+the checkout stay open to everyone, everything else waits for a purchase. Until now that shape was
+written out per plugin — an access policy node plus a deny row for each protected child, re-derived
+every time the plugin synced.
+
+That bookkeeping had a habit of going wrong quietly. The policy nodes were rewritten so often their
+version counters reached six figures; what the gate wrote and what it later read back had drifted
+apart; and because the gating keyed off a price field, two plugins that shipped without one were
+left completely open — every page readable by anyone who guessed the address.
+
+A plugin now declares its public surfaces and its "no access, go here" target **once, on its type**.
+Nothing is written per plugin, so there is nothing to churn, nothing to drift, and no pass that can
+fail to run for one plugin and not another. A plugin with no price is protected for the same reason
+every other one is.
+
+Buying still works exactly as before, and is now the only thing that opens the content: one
+entitlement record on the plugin, and the whole plugin opens. Existing gated content keeps its
+current setup untouched — the new declaration only ever opens the surfaces it names, so it cannot
+close anything that is open today.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -160,7 +160,8 @@ public record MeshBuilder
                     autocompleteExcludedNodeTypes: excludedTypes.Count > 0 ? excludedTypes : null,
                     nodeTypePermissions: accessConfig.Build(),
                     queryRoutingRules: routingRules,
-                    streamRoutedAddressTypes: streamRoutedTypes);
+                    streamRoutedAddressTypes: streamRoutedTypes,
+                    nodeTypeGates: accessConfig.BuildGates());
             })
             // Static nodes registered via AddMeshNodes(...) flow as an
             // IStaticNodeProvider. Application code reads them via

--- a/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
@@ -20,7 +20,8 @@ public class MeshConfiguration(
     IReadOnlySet<string>? autocompleteExcludedNodeTypes = null,
     IReadOnlyList<NodeTypePermission>? nodeTypePermissions = null,
     IReadOnlyList<QueryRoutingRule>? queryRoutingRules = null,
-    IReadOnlySet<string>? streamRoutedAddressTypes = null)
+    IReadOnlySet<string>? streamRoutedAddressTypes = null,
+    IReadOnlyList<NodeTypeGate>? nodeTypeGates = null)
 {
     /// <summary>
     /// Address-type prefixes that route via the cluster-wide Orleans memory
@@ -106,6 +107,14 @@ public class MeshConfiguration(
     /// Read by the persistence layer to sync to the database.
     /// </summary>
     public IReadOnlyList<NodeTypePermission> NodeTypePermissions { get; } = nodeTypePermissions ?? [];
+
+    /// <summary>
+    /// Type-declared subtree gates configured via
+    /// <c>ConfigureNodeTypeAccess(a => a.WithGate(...))</c> — see <see cref="NodeTypeGate"/>.
+    /// Read by <c>PermissionEvaluator</c>; EMPTY on every mesh that declares none, which is the
+    /// condition under which the evaluator skips the gate machinery entirely.
+    /// </summary>
+    public IReadOnlyList<NodeTypeGate> NodeTypeGates { get; } = nodeTypeGates ?? [];
 
     /// <summary>
     /// Query routing rules that resolve partition and table hints from ParsedQuery.

--- a/src/MeshWeaver.Mesh.Contract/Security/NodeTypeAccessBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/NodeTypeAccessBuilder.cs
@@ -7,6 +7,7 @@ namespace MeshWeaver.Mesh.Security;
 public class NodeTypeAccessBuilder
 {
     private readonly HashSet<string> _publicReadTypes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, NodeTypeGate> _gates = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Marks a node type as publicly readable by all authenticated users.
@@ -18,8 +19,38 @@ public class NodeTypeAccessBuilder
     }
 
     /// <summary>
+    /// Declares that every node of <paramref name="nodeType"/> gates its own subtree, opening
+    /// exactly <paramref name="publicSurfaces"/> to everyone — anonymous visitors included — and
+    /// nothing else. Use <see cref="NodeTypeGate.Self"/> (the empty string) for the gated node
+    /// itself (the cover); any other entry is a path relative to it, subtree included.
+    ///
+    /// <para>Last declaration per node type wins, so a deployment can re-declare a type's gate
+    /// without the two accumulating into a union nobody wrote.</para>
+    /// </summary>
+    public NodeTypeAccessBuilder WithGate(string nodeType, params string[] publicSurfaces)
+        => WithGate(new NodeTypeGate(nodeType) { PublicSurfaces = publicSurfaces });
+
+    /// <summary>
+    /// Declares a full <see cref="NodeTypeGate"/> — public surfaces plus the type-declared
+    /// <see cref="NodeTypeGate.RedirectOnDenied"/> target. Last declaration per node type wins.
+    /// </summary>
+    public NodeTypeAccessBuilder WithGate(NodeTypeGate gate)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        if (!string.IsNullOrWhiteSpace(gate.NodeType))
+            _gates[gate.NodeType] = gate;
+        return this;
+    }
+
+    /// <summary>
     /// Gets all node type permissions configured via this builder.
     /// </summary>
     public IReadOnlyList<NodeTypePermission> Build()
         => _publicReadTypes.Select(t => new NodeTypePermission(t, PublicRead: true)).ToList();
+
+    /// <summary>
+    /// Gets the type-declared subtree gates configured via <see cref="WithGate(NodeTypeGate)"/>.
+    /// Empty by default — a mesh that declares none pays nothing and behaves exactly as before.
+    /// </summary>
+    public IReadOnlyList<NodeTypeGate> BuildGates() => _gates.Values.ToList();
 }

--- a/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGate.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGate.cs
@@ -1,0 +1,65 @@
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// TYPE-DECLARED gating for a node type that owns an entitlement-gated subtree — the shape a
+/// storefront plugin (<c>Store/Plugin</c>) needs, declared ONCE on the TYPE instead of
+/// materialised per instance as a <c>_Policy</c> node plus a deny row for every non-public child.
+///
+/// <para><b>The model.</b> A node of a gated type is <i>deny-by-default</i>: the framework's
+/// baseline already refuses Read to anyone holding no grant, so the subtree needs no denies to be
+/// closed. What a gate adds is the small set of DECLARED exceptions that must stay open to a
+/// signed-OUT visitor — the cover, the marketing page, the checkout surface — plus where to send
+/// a reader who is denied. Purchase (or a coupon) writes ONE entitlement grant at the gated node,
+/// and downward inheritance opens the whole subtree. Nothing else is written, ever.</para>
+///
+/// <para><b>Why the type and not the instance.</b> Materialising the same shape per plugin has
+/// three measured failure modes (issue #701, memex 2026-07-28): the reconcile pass rewrote
+/// <c>_Policy</c> until its version counter reached six figures (<c>AgenticEngineering</c> 254,760,
+/// every write by <c>system-security</c>); the written policy carried only
+/// <see cref="PartitionAccessPolicy.RedirectOnDenied"/> while the reader additionally required
+/// <c>publicRead: false</c>, so writer and reader disagreed in production; and gating keyed off a
+/// <c>price</c> field, leaving two plugins that shipped <c>price: null</c> completely ungated —
+/// every page anonymously readable. A declaration on the type has no version counter to churn, no
+/// second condition to drift from, and cannot be "not run" for an instance.</para>
+///
+/// <para><b>A gate only ever GRANTS.</b> It never denies, never caps, and never removes a
+/// permission a role or an entitlement legitimately confers. That is deliberate: a declaration
+/// that can only widen a narrow, explicitly listed set of paths cannot lock anyone out of anything
+/// and cannot regress an existing deployment. "Everything else is closed" is the framework's
+/// pre-existing default, not something this record asserts.</para>
+///
+/// <para>Declared via <c>builder.ConfigureNodeTypeAccess(a =&gt; a.WithGate("Store/Plugin", …))</c>
+/// and honoured by <c>PermissionEvaluator</c> — see <see cref="NodeTypeGateEvaluator"/> for the
+/// pure path arithmetic.</para>
+/// </summary>
+/// <param name="NodeType">The gated node type (e.g. <c>"Store/Plugin"</c>).</param>
+public record NodeTypeGate(string NodeType)
+{
+    /// <summary>
+    /// The surface value meaning "the gated node ITSELF" — the cover. Listing it opens the gated
+    /// node and NOTHING below it, which is the one shape an <c>AccessAssignment</c> cannot express
+    /// (grants inherit strictly downward, which is exactly why the materialised shape needed a deny
+    /// on every child to claw the subtree back).
+    /// </summary>
+    public const string Self = "";
+
+    /// <summary>
+    /// Paths RELATIVE to a node of this type that are readable by EVERYONE — anonymous visitors
+    /// included — together with their subtrees. <see cref="Self"/> (the empty string) means the
+    /// gated node itself; any other entry is a relative path such as <c>"Overview"</c>,
+    /// <c>"Subscribe"</c> or <c>"Public/Docs"</c>. Blank-after-trim entries collapse to
+    /// <see cref="Self"/>; traversals (<c>..</c>) are refused by
+    /// <see cref="NodeTypeGateEvaluator.NormalizeSurface"/>.
+    /// </summary>
+    public IReadOnlyList<string> PublicSurfaces { get; init; } = [];
+
+    /// <summary>
+    /// Where to send a reader denied Read anywhere in the gated subtree, RELATIVE to the gated node
+    /// (e.g. <c>"Subscribe"</c> resolves to <c>{plugin}/Subscribe</c>). An entry starting with
+    /// <c>'/'</c> is taken as an absolute mesh path. This is the type-declared replacement for
+    /// writing <see cref="PartitionAccessPolicy.RedirectOnDenied"/> into a per-instance
+    /// <c>_Policy</c> node; an actual <c>_Policy</c> still WINS where one exists, so a deployment
+    /// that already carries hand-tuned policies keeps them during migration.
+    /// </summary>
+    public string? RedirectOnDenied { get; init; }
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGateEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGateEvaluator.cs
@@ -76,11 +76,22 @@ public static class NodeTypeGateEvaluator
         if (string.IsNullOrWhiteSpace(gate.RedirectOnDenied) || string.IsNullOrEmpty(gatedPath))
             return null;
 
-        var declared = gate.RedirectOnDenied!;
+        var declared = gate.RedirectOnDenied!.Trim();
         if (declared.StartsWith('/'))
         {
-            var absolute = declared.TrimStart('/');
-            return absolute.Length == 0 ? null : absolute;
+            // 🚨 An ABSOLUTE redirect gets the same scrutiny as a relative one. It skipped both the
+            // trim and the `..` refusal, so a declaration with stray whitespace produced a path
+            // nothing resolves, and one containing a traversal segment was handed back verbatim —
+            // a redirect target is a PATH we send a denied caller to, so it must never be able to
+            // climb out of what was declared. (NormalizeSurface maps ""/"." to Self, which is
+            // meaningless for an absolute target: an empty absolute redirect stays null.)
+            var absolute = declared.TrimStart('/').Trim();
+            if (absolute.Length == 0)
+                return null;
+            foreach (var segment in absolute.Split('/', StringSplitOptions.RemoveEmptyEntries))
+                if (segment == "..")
+                    return null;
+            return absolute;
         }
 
         var relative = NormalizeSurface(declared);

--- a/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGateEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/NodeTypeGateEvaluator.cs
@@ -1,0 +1,153 @@
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// The pure path arithmetic behind <see cref="NodeTypeGate"/> — no hub, no streams, no I/O, so the
+/// rule that decides "is this path one of the gate's declared public surfaces" is unit-testable on
+/// its own and reads identically wherever it is applied.
+///
+/// <para>Both entry points take the gated NODES as a <c>path → nodeType</c> map (the instances of
+/// the gated types that currently exist) and resolve the NEAREST gated ancestor-or-self of the
+/// target — longest matching path wins, so a plugin nested inside another plugin is decided by the
+/// inner one.</para>
+/// </summary>
+public static class NodeTypeGateEvaluator
+{
+    /// <summary>
+    /// Canonicalizes a declared surface: trims whitespace and slashes, collapses blank to
+    /// <see cref="NodeTypeGate.Self"/>, and REFUSES anything containing a <c>..</c> traversal
+    /// segment (returns <c>null</c>) — a gate must never be able to open a path outside the node
+    /// it is anchored on.
+    /// </summary>
+    public static string? NormalizeSurface(string? surface)
+    {
+        var trimmed = (surface ?? string.Empty).Trim().Trim('/');
+        if (trimmed.Length == 0 || trimmed == ".")
+            return NodeTypeGate.Self;
+        foreach (var segment in trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            if (segment == "..")
+                return null;
+        return trimmed;
+    }
+
+    /// <summary>
+    /// True when <paramref name="targetPath"/> is one of <paramref name="gate"/>'s declared public
+    /// surfaces relative to <paramref name="gatedPath"/> — the surface node itself or anything
+    /// beneath it. <see cref="NodeTypeGate.Self"/> matches ONLY <paramref name="gatedPath"/>
+    /// exactly, never a descendant.
+    /// </summary>
+    public static bool IsPublicSurface(NodeTypeGate gate, string gatedPath, string targetPath)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        if (string.IsNullOrEmpty(gatedPath) || string.IsNullOrEmpty(targetPath))
+            return false;
+
+        foreach (var declared in gate.PublicSurfaces)
+        {
+            var surface = NormalizeSurface(declared);
+            if (surface is null)
+                continue;
+            if (surface.Length == 0)
+            {
+                // The cover: the gated node itself, and deliberately nothing below it.
+                if (string.Equals(targetPath, gatedPath, StringComparison.OrdinalIgnoreCase))
+                    return true;
+                continue;
+            }
+
+            var surfacePath = gatedPath + "/" + surface;
+            if (string.Equals(targetPath, surfacePath, StringComparison.OrdinalIgnoreCase)
+                || targetPath.StartsWith(surfacePath + "/", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="gate"/>'s <see cref="NodeTypeGate.RedirectOnDenied"/> against the
+    /// gated node's path — relative by default, absolute when the declaration starts with
+    /// <c>'/'</c>. <c>null</c> when the gate declares none, or when the declaration is a traversal.
+    /// The result carries no leading <c>'/'</c>, matching
+    /// <c>PermissionEvaluator.GetRedirectOnDenied</c>'s contract.
+    /// </summary>
+    public static string? ResolveRedirect(NodeTypeGate gate, string gatedPath)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        if (string.IsNullOrWhiteSpace(gate.RedirectOnDenied) || string.IsNullOrEmpty(gatedPath))
+            return null;
+
+        var declared = gate.RedirectOnDenied!;
+        if (declared.StartsWith('/'))
+        {
+            var absolute = declared.TrimStart('/');
+            return absolute.Length == 0 ? null : absolute;
+        }
+
+        var relative = NormalizeSurface(declared);
+        if (relative is null)
+            return null;
+        return relative.Length == 0 ? gatedPath : gatedPath + "/" + relative;
+    }
+
+    /// <summary>
+    /// True when <paramref name="targetPath"/> sits on a declared public surface of the nearest
+    /// gated ancestor-or-self — i.e. the framework must grant Read to EVERY reader, anonymous
+    /// included. False whenever no gated ancestor exists, so a mesh that declares no gate is
+    /// completely unaffected.
+    /// </summary>
+    public static bool IsAnonymouslyReadable(
+        IReadOnlyList<NodeTypeGate> gates,
+        IReadOnlyDictionary<string, string> gatedNodes,
+        string targetPath)
+        => Resolve(gates, gatedNodes, targetPath) is { } hit
+           && IsPublicSurface(hit.Gate, hit.GatedPath, targetPath);
+
+    /// <summary>
+    /// The type-declared redirect target for <paramref name="targetPath"/> — the nearest gated
+    /// ancestor-or-self's <see cref="NodeTypeGate.RedirectOnDenied"/>, resolved against that
+    /// node's path. <c>null</c> when nothing applies.
+    /// </summary>
+    public static string? ResolveRedirect(
+        IReadOnlyList<NodeTypeGate> gates,
+        IReadOnlyDictionary<string, string> gatedNodes,
+        string targetPath)
+        => Resolve(gates, gatedNodes, targetPath) is { } hit
+            ? ResolveRedirect(hit.Gate, hit.GatedPath)
+            : null;
+
+    /// <summary>
+    /// The nearest gated ancestor-or-self of <paramref name="targetPath"/>: the LONGEST gated node
+    /// path that the target equals or sits beneath, paired with its gate declaration.
+    /// </summary>
+    private static (NodeTypeGate Gate, string GatedPath)? Resolve(
+        IReadOnlyList<NodeTypeGate> gates,
+        IReadOnlyDictionary<string, string> gatedNodes,
+        string targetPath)
+    {
+        if (gates is not { Count: > 0 } || gatedNodes is not { Count: > 0 }
+            || string.IsNullOrEmpty(targetPath))
+            return null;
+
+        (NodeTypeGate Gate, string GatedPath)? best = null;
+        foreach (var (gatedPath, nodeType) in gatedNodes)
+        {
+            if (string.IsNullOrEmpty(gatedPath))
+                continue;
+            if (!string.Equals(targetPath, gatedPath, StringComparison.OrdinalIgnoreCase)
+                && !targetPath.StartsWith(gatedPath + "/", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (best is { } current && current.GatedPath.Length >= gatedPath.Length)
+                continue;   // a nearer (longer) gate already won
+
+            foreach (var gate in gates)
+            {
+                if (!string.Equals(gate.NodeType, nodeType, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                best = (gate, gatedPath);
+                break;
+            }
+        }
+
+        return best;
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -80,6 +80,10 @@ internal static class PermissionEvaluator
     private const string GroupMembershipNodeType = "GroupMembership";
     private const string MembershipQueryId = "$security-memberships";
 
+    // Per-gated-type cached query key prefix — one shared upstream subscription per gated node
+    // type, process-wide, like every other $security-* query.
+    private const string GatedQueryPrefix = "$security-gated:";
+
     #region Public surface
 
     public static IObservable<bool> HasPermission(IMessageHub hub, string nodePath, Permission permission)
@@ -126,6 +130,12 @@ internal static class PermissionEvaluator
         var staticNodes = CollectStaticAccessAssignments(hub);
         var staticPolicies = CollectStaticPolicies(hub);
 
+        // Type-declared subtree gates (issue #701). EMPTY on every mesh that declares none, and
+        // every branch below short-circuits on that — a deployment without gates runs the exact
+        // fold it ran before, subscribes no extra query and pays nothing.
+        var gates = CollectGates(hub);
+        var staticGatedNodes = CollectStaticGatedNodes(hub, gates);
+
         // 🚨 Capture AccessContext on the CALLER'S thread before any Rx
         // scheduler hop. AsyncLocal does NOT flow through SubscribeOn/
         // ObserveOn — when the .Select lambdas below land on TaskPool
@@ -156,12 +166,18 @@ internal static class PermissionEvaluator
         var staticOnlyScopeRoles = ComputeStaticOnlyScopeRoles(staticNodes, userId, hub.JsonSerializerOptions);
         var staticOnlyDeniedScopeRoles = ComputeStaticOnlyDeniedScopeRoles(staticNodes, userId, hub.JsonSerializerOptions);
         var fast = ComputeRoleState(staticOnlyScopeRoles, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, staticOnlyDeniedScopeRoles);
+        // A gate declared over a STATIC node resolves synchronously — the declared public surface
+        // is readable on the first emission, with no wait on the synced queries (same reasoning as
+        // the static PublicRead policy seeded below).
+        fast = (fast.RoleIds, fast.PermissionCap,
+            fast.PublicGrant | GateGrant(gates, staticGatedNodes, nodePath));
 
         var enriched = Observable.CombineLatest(
                 ObserveEffectiveAssignments(hub, cache, nodePath, staticNodes),
                 ObserveScopePolicies(hub, cache, nodePath, staticPolicies),
                 ObserveAllMembershipNodes(hub),
-                (nodes, policies, memberships) =>
+                ObserveGatedNodes(hub, cache, gates, staticGatedNodes),
+                (nodes, policies, memberships, gatedNodes) =>
                 {
                     // Match grants to the viewer OR any group they belong to (transitively). A group
                     // grant's subject is the group path, and memberships live UNDER the group node —
@@ -170,9 +186,17 @@ internal static class PermissionEvaluator
                     // matches on. Consistent with the Postgres rebuild's global group expansion.
                     var subjects = ResolveUserGroups(userId, memberships, hub.JsonSerializerOptions).Add(userId);
                     var (granted, denied) = ComputeScopeRoles(subjects, nodes, staticNodes, hub.JsonSerializerOptions);
-                    return (Granted: granted, Denied: denied, RuntimePolicies: policies);
+                    return (Granted: granted, Denied: denied, RuntimePolicies: policies, GatedNodes: gatedNodes);
                 })
-            .Select(snap => ComputeRoleState(snap.Granted, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, snap.Denied, snap.RuntimePolicies));
+            .Select(snap =>
+            {
+                var state = ComputeRoleState(snap.Granted, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, snap.Denied, snap.RuntimePolicies);
+                // The gate contributes to the PUBLIC grant — ORed in after (roles ∩ cap), exactly
+                // like PartitionAccessPolicy.PublicRead — so a declared public surface needs no
+                // role and no AccessAssignment row of any kind. It only ever ADDS Read.
+                return (state.RoleIds, state.PermissionCap,
+                    state.PublicGrant | GateGrant(gates, snap.GatedNodes, nodePath));
+            });
 
         // Emit the synchronous static snapshot whenever it carries ANY signal —
         // roles OR a static public-read grant. The public grant is computed from
@@ -307,7 +331,7 @@ internal static class PermissionEvaluator
         var ns = targetNamespace ?? "";
         var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
         var staticPolicies = CollectStaticPolicies(hub);
-        return ObserveScopePolicies(hub, cache, ns, staticPolicies)
+        var fromPolicy = ObserveScopePolicies(hub, cache, ns, staticPolicies)
             .Select(policies =>
             {
                 // Nearest scope (self first) with a RedirectOnDenied wins; walk to root.
@@ -318,7 +342,22 @@ internal static class PermissionEvaluator
                     if (string.IsNullOrEmpty(s)) break;
                 }
                 return (string?)null;
-            })
+            });
+
+        // Type-declared fallback (issue #701): a NodeTypeGate supplies the redirect its instances
+        // would otherwise each have to materialise into a `_Policy` node. An actual `_Policy` STILL
+        // WINS — a deployment mid-migration keeps every hand-tuned policy it already carries, and
+        // this only fills the gap where none exists.
+        var gates = CollectGates(hub);
+        if (gates.Count == 0)
+            return fromPolicy.DistinctUntilChanged();
+
+        var staticGatedNodes = CollectStaticGatedNodes(hub, gates);
+        return Observable.CombineLatest(
+                fromPolicy,
+                ObserveGatedNodes(hub, cache, gates, staticGatedNodes),
+                (policyRedirect, gatedNodes) => policyRedirect
+                    ?? NodeTypeGateEvaluator.ResolveRedirect(gates, gatedNodes, ns))
             .DistinctUntilChanged();
     }
 
@@ -340,6 +379,55 @@ internal static class PermissionEvaluator
         }
         return result;
     }
+
+    /// <summary>
+    /// The mesh's type-declared subtree gates (<see cref="NodeTypeGate"/>), or an empty list when
+    /// none is configured — which is the default and the fast path everywhere it is consulted.
+    /// </summary>
+    private static IReadOnlyList<NodeTypeGate> CollectGates(IMessageHub hub)
+        => hub.ServiceProvider.GetService<MeshConfiguration>()?.NodeTypeGates ?? [];
+
+    /// <summary>
+    /// The STATIC nodes whose type carries a gate, as <c>path → nodeType</c>. Static providers are
+    /// read synchronously, so a gate anchored on a statically declared node applies on the very
+    /// first emission with no synced-query cold start.
+    /// </summary>
+    private static ImmutableDictionary<string, string> CollectStaticGatedNodes(
+        IMessageHub hub, IReadOnlyList<NodeTypeGate> gates)
+    {
+        if (gates.Count == 0)
+            return ImmutableDictionary<string, string>.Empty;
+
+        var gatedTypes = new HashSet<string>(
+            gates.Select(g => g.NodeType), StringComparer.OrdinalIgnoreCase);
+        var result = ImmutableDictionary<string, string>.Empty;
+        foreach (var provider in hub.ServiceProvider.GetServices<IStaticNodeProvider>())
+        {
+            foreach (var node in provider.GetStaticNodes())
+            {
+                if (string.IsNullOrEmpty(node.NodeType) || string.IsNullOrEmpty(node.Path))
+                    continue;
+                if (gatedTypes.Contains(node.NodeType))
+                    result = result.SetItem(node.Path, node.NodeType);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// <see cref="Permission.Read"/> when <paramref name="nodePath"/> sits on a declared public
+    /// surface of its nearest gated ancestor-or-self; otherwise <see cref="Permission.None"/>.
+    /// A gate NEVER subtracts — "everything else is closed" is the framework's pre-existing
+    /// deny-by-default, not something the gate asserts.
+    /// </summary>
+    private static Permission GateGrant(
+        IReadOnlyList<NodeTypeGate> gates,
+        IReadOnlyDictionary<string, string> gatedNodes,
+        string nodePath)
+        => gates.Count > 0
+           && NodeTypeGateEvaluator.IsAnonymouslyReadable(gates, gatedNodes, nodePath)
+            ? Permission.Read
+            : Permission.None;
 
     private static IReadOnlyDictionary<string, PartitionAccessPolicy> CollectStaticPolicies(IMessageHub hub)
     {
@@ -681,6 +769,50 @@ internal static class PermissionEvaluator
                 return dict;
             })
             .DistinctUntilChanged();
+    }
+
+    /// <summary>
+    /// The instances of every gated node type, as <c>path → nodeType</c> — the set a target path is
+    /// matched against to find its nearest gated ancestor. One process-wide cached query PER GATED
+    /// TYPE (there is normally one), the same global shape <see cref="ObserveAllMembershipNodes"/>
+    /// already uses, and bounded by the number of gated nodes rather than by their children.
+    ///
+    /// <para>🚨 Each per-type query is <c>StartWith</c>-seeded with the statics. This observable
+    /// feeds a <c>CombineLatest</c> that gates EVERY permission check, and CombineLatest emits
+    /// nothing until every source has: a gated-type query that is slow (or that never matches
+    /// because no such node exists yet) would otherwise stall the whole fold and hang every read.
+    /// Seeding also starts STRICTER — no gated nodes known ⇒ no public surface ⇒ deny — so the
+    /// pre-load window can only be more restrictive, never a bypass.</para>
+    /// </summary>
+    private static IObservable<ImmutableDictionary<string, string>> ObserveGatedNodes(
+        IMessageHub hub, IMeshNodeStreamCache cache, IReadOnlyList<NodeTypeGate> gates,
+        ImmutableDictionary<string, string> staticGatedNodes)
+    {
+        if (gates.Count == 0)
+            return Observable.Return(staticGatedNodes);
+
+        var options = hub.JsonSerializerOptions;
+        var perType = gates
+            .Select(gate => cache
+                .GetQuery($"{GatedQueryPrefix}{gate.NodeType}", options,
+                    $"nodeType:{gate.NodeType} scope:subtree select:path,id,namespace,name,nodeType")
+                .StartWith(Array.Empty<MeshNode>()))
+            .ToArray();
+
+        return Observable.CombineLatest(perType)
+            .Select(lists =>
+            {
+                var map = staticGatedNodes;
+                foreach (var list in lists)
+                {
+                    foreach (var node in list)
+                    {
+                        if (!string.IsNullOrEmpty(node.Path) && !string.IsNullOrEmpty(node.NodeType))
+                            map = map.SetItem(node.Path, node.NodeType);
+                    }
+                }
+                return map;
+            });
     }
 
     private static IObservable<MeshNode[]> ObserveAllRoleNodes(IMessageHub hub)

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -777,12 +777,14 @@ internal static class PermissionEvaluator
     /// TYPE (there is normally one), the same global shape <see cref="ObserveAllMembershipNodes"/>
     /// already uses, and bounded by the number of gated nodes rather than by their children.
     ///
-    /// <para>🚨 Each per-type query is <c>StartWith</c>-seeded with the statics. This observable
-    /// feeds a <c>CombineLatest</c> that gates EVERY permission check, and CombineLatest emits
-    /// nothing until every source has: a gated-type query that is slow (or that never matches
-    /// because no such node exists yet) would otherwise stall the whole fold and hang every read.
-    /// Seeding also starts STRICTER — no gated nodes known ⇒ no public surface ⇒ deny — so the
-    /// pre-load window can only be more restrictive, never a bypass.</para>
+    /// <para>🚨 Each per-type query is <c>StartWith</c>-seeded with an EMPTY list, and the fold
+    /// below then starts from <paramref name="staticGatedNodes"/>. This observable feeds a
+    /// <c>CombineLatest</c> that gates EVERY permission check, and CombineLatest emits nothing
+    /// until every source has: a gated-type query that is slow (or that never matches because no
+    /// such node exists yet) would otherwise stall the whole fold and hang every read. The empty
+    /// seed also starts STRICTER — before a query answers, only the statically-known gated nodes
+    /// are in the map, so an as-yet-unseen gated node has no public surface and is denied — which
+    /// makes the pre-load window more restrictive, never a bypass.</para>
     /// </summary>
     private static IObservable<ImmutableDictionary<string, string>> ObserveGatedNodes(
         IMessageHub hub, IMeshNodeStreamCache cache, IReadOnlyList<NodeTypeGate> gates,

--- a/test/MeshWeaver.Security.Test/NodeTypeGateEvaluatorTests.cs
+++ b/test/MeshWeaver.Security.Test/NodeTypeGateEvaluatorTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// The PURE path arithmetic of <see cref="NodeTypeGateEvaluator"/> — no hub, no mesh, no streams.
+/// The integration behaviour rides on <c>NodeTypeGateTests</c>; this class pins the rule itself so a
+/// failure names the exact path relation that broke instead of surfacing as a permission timeout.
+/// </summary>
+public class NodeTypeGateEvaluatorTests
+{
+    private const string PluginType = "Store/Plugin";
+
+    private static readonly NodeTypeGate Gate = new(PluginType)
+    {
+        PublicSurfaces = [NodeTypeGate.Self, "Overview", "Subscribe"],
+        RedirectOnDenied = "Subscribe",
+    };
+
+    private static readonly IReadOnlyList<NodeTypeGate> Gates = [Gate];
+
+    private static readonly IReadOnlyDictionary<string, string> GatedNodes =
+        new Dictionary<string, string> { ["Storefront"] = PluginType };
+
+    [Theory]
+    [InlineData("Storefront", true)]                     // the cover — the Self surface
+    [InlineData("Storefront/Overview", true)]            // the marketing page
+    [InlineData("Storefront/Overview/Detail", true)]     // …and its subtree
+    [InlineData("Storefront/Subscribe", true)]           // checkout
+    [InlineData("Storefront/PaidLesson", false)]         // gated: entitlement only
+    [InlineData("Storefront/Overviewer", false)]         // prefix collision is NOT a surface
+    [InlineData("Elsewhere/Overview", false)]            // outside every gated node
+    public void PublicSurfaces_AreExactlyWhatTheTypeDeclares(string path, bool expected)
+        => Assert.Equal(expected,
+            NodeTypeGateEvaluator.IsAnonymouslyReadable(Gates, GatedNodes, path));
+
+    /// <summary>
+    /// 🚨 The Self surface opens the gated node and NOTHING beneath it. That asymmetry is the whole
+    /// reason the gate must live on the TYPE: an <c>AccessAssignment</c> grant at the plugin root
+    /// inherits strictly downward, which is precisely why the materialised shape had to write a
+    /// deny for every non-public child to claw the subtree back.
+    /// </summary>
+    [Fact]
+    public void SelfSurface_OpensTheNodeOnly_NeverItsSubtree()
+    {
+        var coverOnly = new NodeTypeGate(PluginType) { PublicSurfaces = [NodeTypeGate.Self] };
+        Assert.True(NodeTypeGateEvaluator.IsPublicSurface(coverOnly, "Storefront", "Storefront"));
+        Assert.False(NodeTypeGateEvaluator.IsPublicSurface(coverOnly, "Storefront", "Storefront/Any"));
+    }
+
+    [Fact]
+    public void Redirect_ResolvesRelativeToTheGatedNode()
+        => Assert.Equal("Storefront/Subscribe",
+            NodeTypeGateEvaluator.ResolveRedirect(Gates, GatedNodes, "Storefront/PaidLesson"));
+
+    [Fact]
+    public void Redirect_IsNull_OutsideEveryGatedNode()
+        => Assert.Null(
+            NodeTypeGateEvaluator.ResolveRedirect(Gates, GatedNodes, "Elsewhere/Node"));
+
+    [Fact]
+    public void Redirect_HonoursAnAbsoluteDeclaration()
+    {
+        var gate = new NodeTypeGate(PluginType) { RedirectOnDenied = "/Store/Catalog" };
+        Assert.Equal("Store/Catalog", NodeTypeGateEvaluator.ResolveRedirect(gate, "Storefront"));
+    }
+
+    /// <summary>A gate must never be able to open a path outside the node it is anchored on.</summary>
+    [Theory]
+    [InlineData("../Sibling")]
+    [InlineData("Public/../../Escape")]
+    public void Traversals_AreRefused(string surface)
+    {
+        Assert.Null(NodeTypeGateEvaluator.NormalizeSurface(surface));
+        var gate = new NodeTypeGate(PluginType) { PublicSurfaces = [surface] };
+        Assert.False(NodeTypeGateEvaluator.IsPublicSurface(gate, "Storefront", "Sibling"));
+        Assert.False(NodeTypeGateEvaluator.IsPublicSurface(gate, "Storefront", "Escape"));
+    }
+
+    /// <summary>
+    /// The NEAREST gated ancestor decides — a plugin nested inside another plugin is governed by
+    /// the inner one, so a surface declared by the outer gate does not leak into the inner subtree.
+    /// </summary>
+    [Fact]
+    public void NearestGatedAncestorWins()
+    {
+        var nodes = new Dictionary<string, string>
+        {
+            ["Storefront"] = PluginType,
+            ["Storefront/Inner"] = PluginType,
+        };
+        // "Storefront/Inner/Subscribe" is a surface of the INNER gate (Subscribe is declared).
+        Assert.True(NodeTypeGateEvaluator.IsAnonymouslyReadable(
+            Gates, nodes, "Storefront/Inner/Subscribe"));
+        // The inner node itself is a cover (Self) — of the inner gate.
+        Assert.True(NodeTypeGateEvaluator.IsAnonymouslyReadable(Gates, nodes, "Storefront/Inner"));
+        // A gated page under the inner plugin stays closed.
+        Assert.False(NodeTypeGateEvaluator.IsAnonymouslyReadable(
+            Gates, nodes, "Storefront/Inner/PaidLesson"));
+        Assert.Equal("Storefront/Inner/Subscribe", NodeTypeGateEvaluator.ResolveRedirect(
+            Gates, nodes, "Storefront/Inner/PaidLesson"));
+    }
+
+    /// <summary>
+    /// A mesh that declares NO gate is completely unaffected — the condition every call site
+    /// short-circuits on, so the feature costs an unconfigured deployment nothing at all.
+    /// </summary>
+    [Fact]
+    public void NoGateDeclared_MatchesNothing()
+    {
+        Assert.False(NodeTypeGateEvaluator.IsAnonymouslyReadable([], GatedNodes, "Storefront"));
+        Assert.Null(NodeTypeGateEvaluator.ResolveRedirect([], GatedNodes, "Storefront/PaidLesson"));
+    }
+
+    /// <summary>
+    /// A gate whose type has no instances yet matches nothing — the declaration alone never opens
+    /// a path, so the pre-load window of the gated-node query can only be stricter.
+    /// </summary>
+    [Fact]
+    public void GateWithoutInstances_MatchesNothing()
+        => Assert.False(NodeTypeGateEvaluator.IsAnonymouslyReadable(
+            Gates, new Dictionary<string, string>(), "Storefront"));
+}

--- a/test/MeshWeaver.Security.Test/NodeTypeGateEvaluatorTests.cs
+++ b/test/MeshWeaver.Security.Test/NodeTypeGateEvaluatorTests.cs
@@ -67,6 +67,23 @@ public class NodeTypeGateEvaluatorTests
         Assert.Equal("Store/Catalog", NodeTypeGateEvaluator.ResolveRedirect(gate, "Storefront"));
     }
 
+    /// <summary>
+    /// An ABSOLUTE redirect gets the same scrutiny as a relative one. It previously skipped both
+    /// the trim and the `..` refusal, so a declaration with stray whitespace produced a path that
+    /// resolves to nothing, and one carrying a traversal was handed back verbatim — a redirect is
+    /// where a DENIED caller is sent, so it must never climb out of what was declared.
+    /// </summary>
+    [Theory]
+    [InlineData("/Store/../Escape", null)]
+    [InlineData("/../Escape", null)]
+    [InlineData("/", null)]
+    [InlineData("  /Store/Catalog  ", "Store/Catalog")]
+    public void AbsoluteRedirect_IsTrimmedAndRefusesTraversal(string declared, string? expected)
+    {
+        var gate = new NodeTypeGate(PluginType) { RedirectOnDenied = declared };
+        Assert.Equal(expected, NodeTypeGateEvaluator.ResolveRedirect(gate, "Storefront"));
+    }
+
     /// <summary>A gate must never be able to open a path outside the node it is anchored on.</summary>
     [Theory]
     [InlineData("../Sibling")]

--- a/test/MeshWeaver.Security.Test/NodeTypeGateTests.cs
+++ b/test/MeshWeaver.Security.Test/NodeTypeGateTests.cs
@@ -1,0 +1,169 @@
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// The TYPE-DECLARED plugin gate (issue #701) against the REAL <see cref="PermissionEvaluator"/>.
+///
+/// <para><b>What the whole class is worth reading for: the mesh below writes exactly ONE node for
+/// the gate</b> — the plugin itself — plus one entitlement grant for the buyer. There is no
+/// <c>_Policy</c> node, no root Public/Anonymous grant, and not a single per-child deny. Everything
+/// the paywall needs is read off the node's TYPE:</para>
+/// <list type="bullet">
+///   <item>the cover, the marketing page and the checkout surface are anonymously readable,</item>
+///   <item>every other page is closed to an anonymous visitor,</item>
+///   <item>one root Viewer grant (what a purchase or a coupon writes) opens the whole subtree,</item>
+///   <item>a denied reader's redirect target comes from the type, not from a written policy.</item>
+/// </list>
+///
+/// <para>This inverts the materialised shape pinned by <c>PaywallRealGateShapeTests</c> (root
+/// Public+Anonymous Viewer grants, then a Public+Anonymous DENY on every non-public child —
+/// allow-then-deny, O(children) rows re-derived on every sync). Both shapes are honoured: the gate
+/// only ever GRANTS on its declared surfaces, so it cannot weaken the deny-based gate that existing
+/// deployments still carry.</para>
+///
+/// <para>🚨 There is nothing here that a gating pass can fail to run for a given plugin, and no
+/// second condition (the production <c>_Policy</c> nodes carried <c>redirectOnDenied</c> while the
+/// reader additionally demanded <c>publicRead: false</c>) for writer and reader to drift apart on.
+/// A plugin that declares no price is gated for the same reason every other one is — its TYPE.</para>
+/// </summary>
+public class NodeTypeGateTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PluginType = "Store/Plugin";
+    private const string Plugin = "Storefront";
+    private const string Buyer = "gate_buyer";
+    private const string Visitor = "gate_visitor";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .ConfigureNodeTypeAccess(access => access.WithGate(new NodeTypeGate(PluginType)
+            {
+                // The cover, the marketing page and the checkout surface — nothing else.
+                PublicSurfaces = [NodeTypeGate.Self, "Overview", "Subscribe"],
+                RedirectOnDenied = "Subscribe",
+            }))
+            .AddMeshNodes(
+                // The ONE node the gate needs: the plugin. Its TYPE carries the policy.
+                MeshNode.FromPath(Plugin) with { NodeType = PluginType, Name = "Storefront" },
+                // The entitlement: a single Viewer grant at the plugin root — what a purchase or a
+                // coupon writes. Nothing else is needed to open the subtree.
+                AssignmentNodeFactory.UserRole(Buyer, "Viewer", Plugin));
+
+    // Security tests need granular permissions — skip the PublicAdmin seed.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact(Timeout = 30000)]
+    public async Task Cover_IsAnonymouslyReadable_FromTheTypeAlone()
+        => await Mesh.GetEffectivePermissions(Plugin, WellKnownUsers.Anonymous)
+            .Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read),
+                "the plugin's own node is a declared public surface of its type — no grant, no " +
+                "policy and no row of any kind is written for it");
+
+    [Theory(Timeout = 30000)]
+    [InlineData("Overview")]
+    [InlineData("Subscribe")]
+    public async Task MarketingAndCheckout_AreAnonymouslyReadable(string surface)
+        => await Mesh.GetEffectivePermissions($"{Plugin}/{surface}", WellKnownUsers.Anonymous)
+            .Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read),
+                $"'{surface}' is declared anonymous on the type — a visitor must be able to see " +
+                "the offer and start a purchase without signing in");
+
+    /// <summary>
+    /// The gated page is closed to an anonymous visitor — with NO deny row anywhere in the mesh.
+    ///
+    /// <para>🚨 The positive wait comes FIRST and is load-bearing. A deny-shaped assertion
+    /// (<c>!HasFlag(Read)</c>) is satisfied by the very first emission of a cold fold —
+    /// <see cref="Permission.None"/> before anything has loaded — so on its own it certifies
+    /// nothing and passes vacuously. Establishing that the cover IS readable proves the gate has
+    /// folded on THIS mesh, which is what makes the denial below evidence rather than a race.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GatedChild_IsClosedToAnonymous_WithNoDenyRows()
+    {
+        await Mesh.GetEffectivePermissions(Plugin, WellKnownUsers.Anonymous)
+            .Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read),
+                "barrier: the gate must be folded before a denial means anything");
+
+        await Mesh.GetEffectivePermissions($"{Plugin}/PaidLesson", WellKnownUsers.Anonymous)
+            .Should().Within(20.Seconds()).Match(p => !p.HasFlag(Permission.Read),
+                "a page that is not a declared surface stays closed by the framework's " +
+                "deny-by-default — the gate never had to write a deny to achieve it");
+    }
+
+    /// <summary>The signed-in visitor who bought nothing is in exactly the same position.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task AuthenticatedButNotEntitled_IsDenied()
+    {
+        await Mesh.GetEffectivePermissions(Plugin, Visitor)
+            .Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read),
+                "barrier: the public cover proves the gate folded for this identity too");
+
+        await Mesh.GetEffectivePermissions($"{Plugin}/PaidLesson", Visitor)
+            .Should().Within(20.Seconds()).Match(p => !p.HasFlag(Permission.Read),
+                "signing in is not an entitlement");
+    }
+
+    /// <summary>
+    /// The entitlement — ONE Viewer grant at the plugin root — opens the ENTIRE subtree, with no
+    /// second grant and nothing per-child. This is the case that catches an over-strict gate: a
+    /// declaration that denied instead of merely granting would strip the buyer here.
+    /// </summary>
+    [Theory(Timeout = 30000)]
+    [InlineData("PaidLesson")]
+    [InlineData("Module/Deep/Lesson")]
+    public async Task Entitlement_OpensTheWholeSubtree(string page)
+        => await Mesh.GetEffectivePermissions($"{Plugin}/{page}", Buyer)
+            .Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read),
+                "the entitlement record is the single switch that opens the subtree");
+
+    /// <summary>
+    /// The redirect target comes from the TYPE. No <c>_Policy</c> node exists in this mesh — the
+    /// churn source measured on memex (version counters in the hundreds of thousands, every write
+    /// by <c>system-security</c>) simply has nothing to rewrite.
+    /// </summary>
+    [Theory(Timeout = 30000)]
+    [InlineData(Plugin)]
+    [InlineData(Plugin + "/PaidLesson")]
+    [InlineData(Plugin + "/Module/Deep/Lesson")]
+    public async Task RedirectOnDenied_IsTypeDeclared_WithNoPolicyNode(string path)
+        => await Mesh.GetRedirectOnDenied(path)
+            .Should().Within(20.Seconds()).Match(r => r == $"{Plugin}/Subscribe");
+
+    /// <summary>
+    /// Nothing outside a gated node's subtree is touched — the gate is anchored on its instances,
+    /// so a mesh's other partitions evaluate exactly as they did before.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task OutsideTheGatedNode_NothingChanges()
+    {
+        await Mesh.GetEffectivePermissions("SomeOtherPartition/Node", WellKnownUsers.Anonymous)
+            .Should().Within(20.Seconds()).Match(p => !p.HasFlag(Permission.Read));
+        await Mesh.GetRedirectOnDenied("SomeOtherPartition/Node")
+            .Should().Within(20.Seconds()).Match(r => r == null);
+    }
+
+    /// <summary>
+    /// The signed-OUT navigation decision — the surface a real visitor hits first. The cover and
+    /// checkout load; the gated page goes to /login (from where the authenticated-but-denied
+    /// visitor is redirected to the type-declared paywall by <c>NamedAreaView</c>).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AnonymousGate_LoadsThePublicSurfaces_AndStopsAtTheGatedOne()
+    {
+        await AnonymousGate.AllowAnonymous(Mesh, Plugin)
+            .Should().Within(20.Seconds()).Match(allowed => allowed);
+        await AnonymousGate.AllowAnonymous(Mesh, $"{Plugin}/Subscribe")
+            .Should().Within(20.Seconds()).Match(allowed => allowed);
+        await AnonymousGate.AllowAnonymous(Mesh, $"{Plugin}/PaidLesson")
+            .Should().Within(20.Seconds()).Match(allowed => !allowed);
+    }
+}


### PR DESCRIPTION
Addresses #701.

Binds a gated plugin's access shape to its **NodeType** instead of materialising a `_Policy` node
plus a deny row per child. This is the MeshWeaver-side framework half; the Store plugin in
`Systemorph/MeshWeaver.Plugins` has to adopt it (see **What the Plugins repo must do** below), so
this does not close the issue on its own.

## The model implemented

```csharp
builder.ConfigureNodeTypeAccess(access => access.WithGate(new NodeTypeGate("Store/Plugin")
{
    PublicSurfaces = [NodeTypeGate.Self, "Overview", "Subscribe"],
    RedirectOnDenied = "Subscribe",
}));
```

Every node of the declared type keeps its cover (`Self`), its marketing page and its checkout
surface readable by **everyone including anonymous visitors**; a reader denied anywhere beneath it
is sent to `{plugin}/Subscribe`. Nothing is written per plugin — no `_Policy`, no root grant, no
per-child deny.

The other three requirements fall out of machinery that already exists:

| Requirement | Mechanism |
|---|---|
| Everything except the declared surfaces is closed | The framework's deny-by-default — no grant, no Read |
| Purchase / coupon opens the whole subtree | ONE `Viewer` `AccessAssignment` at the plugin root; grants inherit downward |
| Gated even with `price: null` | The gate is on the TYPE — there is no price in the rule at all |

### Two properties this leans on

**A gate only ever GRANTS.** It never denies, never caps, never removes a permission a role or an
entitlement confers. A declaration that can only widen a short, explicitly listed set of paths
cannot lock anyone out and cannot regress an existing deployment — which is why the older
allow-then-deny gate keeps working unchanged beside it, and why an actual `_Policy` still WINS over
the type-declared redirect (a deployment mid-migration keeps every hand-tuned policy it carries).

**`Self` opens the node and nothing beneath it.** That asymmetry is *why* this has to be on the
type: an `AccessAssignment` at the plugin root inherits strictly downward, so opening the cover
that way opens the whole subtree — precisely why the materialised shape needed a deny on every
non-public child to claw it back.

### Cost

`PermissionEvaluator` resolves a path's nearest gated ancestor-or-self from one process-wide cached
query **per gated node type** (`$security-gated:{type}`) — bounded by the number of gated *nodes*,
not their children — seeded from the static providers so a statically declared plugin resolves on
the first emission. **A mesh that declares no gate subscribes nothing and runs the exact fold it
ran before**; every call site short-circuits on `gates.Count == 0`. That is also what makes this
safe to merge ahead of the Plugins-repo half: with no declaration anywhere, behaviour is unchanged.

The per-type query is `StartWith`-seeded because it feeds the `CombineLatest` gating every
permission check — an unseeded source that never matched (no such node yet) would stall the fold
and hang every read. Seeding also starts *stricter* (no gated nodes known ⇒ no public surface ⇒
deny), so the pre-load window can only be more restrictive, never a bypass.

## Two landmines found while mapping this — reported, deliberately not tripped

**1. `NodeTypePermission` never reaches the database.** The issue cites
`node_type_permissions` / `ConfigureNodeTypeAccess(a => a.WithPublicRead(...))` as a hook that is
"already first-class in both evaluators". It is not. The only DI→DB bridge,
`PostgreSqlExtensions.InitializePostgreSqlSchemaAsync`, has **zero callers** across `src/`,
`memex/` and `tools/` — every `SyncNodeTypePermissionsAsync` call in the repo is from a test. So the
`public_read` clause in all three RLS predicates evaluates against an empty table in production.
The in-memory `PermissionEvaluator` doesn't consult `NodeTypePermission` either (0 references).
The hook is inert on **both** sides.

**2. …and wiring it up would open paid content.** ~25 node types declare `WithPublicRead`,
including `Course`, `Module`, `Exercise`, `Thread`, `Skill` and `Agent`. Populating the table today
would grant public read on all of them at once to every authenticated user with partition access —
i.e. it would unlock exactly the paid course content this issue is trying to protect. That is why
this PR builds a **separate, purely additive** declaration rather than extending `PublicRead`, and
why the dead bridge is left dead pending a decision on each of those 25 types.

## Deliberate gap: the SQL fold does not know about gates

Postgres RLS decides *query listing*; `PermissionEvaluator` decides *exact reads and every UI gate*
(`AnonymousGate`, `RlsNodeValidator`, `MeshOperations.Get`, `NamedAreaView`, layout areas). Only the
latter is implemented here.

Consequence: a declared public surface is readable by path but will not appear in an anonymous
`search`. **The asymmetry is strictly in the safe direction — SQL is stricter, never looser — so it
cannot become a paywall bypass**, but it is a real gap and it is the one acceptance criterion of
#701 not met. Closing it needs a new per-schema table + migration + the clause in three SQL sites
(`PostgreSqlSqlGenerator.GenerateAccessControlClause`, `BuildPerSchemaAccessClause`, and the
`search_across_schemas` stored proc); it cannot reuse `node_type_permissions` for landmine 2 above.
Documented inline in `AccessControl.md` rather than left to be discovered.

## What the Plugins repo must do (`Systemorph/MeshWeaver.Plugins`)

`PluginGate` lives at `Store/Plugin/Source/PluginGate` and is not visible from this repo. To take
this up:

1. **Declare the gate** on the `Store/Plugin` NodeType configuration — `PublicSurfaces` from
   `MarketingPath` + the subscribe surface + `publicSegments`, `RedirectOnDenied = "Subscribe"`.
2. **Delete the materialisation**: stop writing `{plugin}/_Policy` and stop writing the
   Public/Anonymous Viewer `denied: true` rows per child. This is what takes the measured churn
   (`AgenticEngineering` `_Policy` at version 254,760, every write by `system-security`) to zero.
3. **Stop writing the root Public/Anonymous Viewer GRANT.** It is what makes the per-child denies
   necessary; without it the subtree is closed by default and the cover is opened by the type.
4. **Delete `IsGatedPolicy`.** Its two-condition read (`publicReadOff && paywall`) against policies
   that only ever carried `redirectOnDenied` is the writer/reader disagreement measured in
   production — there is no policy to interrogate any more, so the predicate has nothing to drift
   from. This is the "fix the read/write agreement explicitly" item: it is fixed by removing the
   second condition's subject entirely, not by relaxing the check.
5. **Keep `Enroll` exactly as it is** — one root `Viewer` grant is still the entitlement, and it
   still opens the whole subtree.

Until step 1 lands, this PR changes nothing at runtime (no gate declared anywhere).

## Tests

New:
- `test/MeshWeaver.Security.Test/NodeTypeGateEvaluatorTests.cs` — 16 pure path-arithmetic tests:
  surface matching, `Self` opening the node but never its subtree, prefix collisions
  (`Overviewer` is not `Overview`), `..` traversal refusal, nearest-gated-ancestor-wins for nested
  plugins, and the no-gate / no-instances short-circuits.
- `test/MeshWeaver.Security.Test/NodeTypeGateTests.cs` — 12 integration tests against the REAL
  `PermissionEvaluator`, on a mesh whose entire gate is **one plugin node plus one entitlement
  grant**: cover + marketing + checkout anonymously readable; gated child closed to anonymous *and*
  to a signed-in non-buyer with no deny row anywhere; the single root grant opening `PaidLesson`
  and `Module/Deep/Lesson`; the redirect resolving from the type with no `_Policy` node; nothing
  outside the gated subtree affected; and the signed-out `AnonymousGate` decision.

Every deny-shaped assertion is preceded by a **positive** wait on the same mesh. A `!HasFlag(Read)`
assertion is satisfied by the first emission of a cold fold (`Permission.None` before anything has
loaded), so on its own it passes vacuously — establishing that the cover IS readable is what makes
the denial evidence rather than a race.

Results (local, Release):
- `MeshWeaver.Security.Test` — **373/373 passed** (the full suite, incl. `AnonymousGateTests`,
  `RedirectOnDeniedTests`, `UserPublicReadTest`, `AdminPartitionAdminTests`, `SecurityServiceTests`)
- `MeshWeaver.slnx` — `-c Release -warnaserror`: **0 warnings, 0 errors**
- `MeshWeaver.Hosting.PostgreSql.Test` (Docker-backed) — **18/18 passed**:
  `PaywallRealGateShapeTests`, `PaywallIdentityMatrixTests`, `GatedNodeExactPathReadTests`,
  `PerSubjectAccessFoldTests`. These exercise `PermissionEvaluator` against the REAL materialised
  gate shape and are the surface most at risk from the changed fold, since this PR adds a fourth
  source to the `CombineLatest` in the hot path.
- `MeshWeaver.Graph.Test` — **48/48 passed** (`AccessAssignmentGuardTest`,
  `UserNodeTypePermissionTest`)
- `MeshWeaver.Documentation.Test` link integrity — **passed** (`AccessControl.md` + the new
  What's New page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
