### PR TITLE
ScopeDescendants asserts the shape, not an exact emission count (#946)

### DIFF
--- a/test/MeshWeaver.Query.Test/ObservableQueryIntegrationTests.cs
+++ b/test/MeshWeaver.Query.Test/ObservableQueryIntegrationTests.cs
@@ -134,19 +134,32 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
         await NodeFactory.CreateNode(MeshNode.FromPath($"{p}/Project/Task") with { Name = "Task", NodeType = "Code" }).Should().Emit();
         await NodeFactory.CreateNode(MeshNode.FromPath($"{p}/Project/Task/Subtask") with { Name = "Subtask", NodeType = "Code" }).Should().Emit();
 
-        var changes = await accumulated.Should(WaitTimeout).Match(acc => acc.Skip(initialCount)
+        // 🚨 Assert the SHAPE (the three paths we created each produced an Added), never a COUNT.
+        // `scope:descendants` legitimately matches anything created under {p} — a satellite the
+        // framework writes for the new nodes lands in the same window under load — so an
+        // exactly-3 assertion fails whenever one extra descendant shows up, which is what made
+        // this the top flake of 2026-08-08 (four unrelated PRs: #927, #940, #942, #947). Counting
+        // emissions on a change feed that races the initial snapshot is called out in AGENTS.md
+        // precisely because of this failure mode.
+        var expected = new[] { $"{p}/Project", $"{p}/Project/Task", $"{p}/Project/Task/Subtask" };
+        var changes = await accumulated.Should(WaitTimeout).Match(acc =>
+        {
+            var added = acc.Skip(initialCount)
+                .Where(c => c.ChangeType == QueryChangeType.Added)
+                .SelectMany(c => c.Items)
+                .Select(n => n.Path)
+                .ToHashSet();
+            return expected.All(added.Contains);
+        });
+
+        var addedPaths = changes.Skip(initialCount)
             .Where(c => c.ChangeType == QueryChangeType.Added)
             .SelectMany(c => c.Items)
             .Select(n => n.Path)
-            .Distinct()
-            .Count() >= 3);
-
-        var addedItems = changes.Skip(initialCount)
-            .Where(c => c.ChangeType == QueryChangeType.Added)
-            .SelectMany(c => c.Items)
-            .DistinctBy(n => n.Path)
-            .ToList();
-        addedItems.Should().HaveCount(3, "Each created descendant should emit an Added change");
+            .ToHashSet();
+        addedPaths.Should().Contain(expected,
+            "each created descendant must emit an Added change — extra descendants are allowed, "
+            + "the scope matches everything under the root");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #946.

## The flake, and why it was the pipeline's top blocker today

`ScopeDescendants_NotifiesOnAllDescendantChanges` waited for `>= 3` distinct `Added` paths, then asserted **`HaveCount(3)` exactly**. `scope:descendants` matches *anything* created under the root — so one extra descendant landing inside that window (a satellite the framework writes for the new nodes, timing-dependent under load) turns a correct system into a red build.

It hit **four unrelated PRs today** — #927, #940, #942, #947 — always shard 1, always passing locally. Each occurrence blocked a green PR and burned a CI cycle.

## Why this is the test's bug, not the product's

AGENTS.md already forbids this exact shape:

> Never assert "exactly N change events" on a stream backed by pg_notify or any change feed that can race the initial-snapshot path. Filter on the emission shape, not the count.

The test now asserts what it means: **each of the three created descendants emitted an `Added` change**. Extra descendants are explicitly allowed, because the scope legitimately matches them.

## Deliberately not changed

Sibling assertions in the same class count emissions to prove a **negative** ("sibling create must not emit for ancestors scope") — there a bound *is* the assertion, and none of them has flaked. Changing passing tests without evidence is its own risk; the commit notes the pattern so it's visible if one of them starts.

`ObservableQueryIntegrationTests` 9/9 locally. No What's New — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)