### PR TITLE
Every round spoke English because System shadowed the submitter

### DIFF
--- a/src/MeshWeaver.AI/HubThreadExtensions.cs
+++ b/src/MeshWeaver.AI/HubThreadExtensions.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,25 +44,47 @@ public static class HubThreadExtensions
     /// one moment the originating user's identity is reliably on the AsyncLocal
     /// (<c>AccessService.Context</c>) or the per-circuit fallback (<c>CircuitContext</c>). The
     /// captured <c>(ObjectId, Name)</c> is stamped onto the pending <see cref="ThreadMessage"/>
-    /// (<see cref="ThreadMessage.SubmitterObjectId"/> / <see cref="ThreadMessage.SubmitterName"/>)
+    /// (<see cref="ThreadMessage.SubmitterObjectId"/> / <see cref="ThreadMessage.SubmitterName"/> /
+    /// <see cref="ThreadMessage.SubmitterLocale"/>)
     /// so the round-dispatch watcher can rebuild the identity AFTER every later async boundary
     /// (its own <c>.Subscribe</c> continuation + the AI streaming continuations) has wiped the
     /// AsyncLocal. This is "capture the identity when computing the submit patch" — the data
     /// carries the truth, not the (by-then-null) AsyncLocal.
     ///
-    /// <para>Returns <c>(null, null)</c> when no real user identity is live (e.g. a hub-shaped
-    /// principal, or no context at all) — the watcher then falls back to the thread owner derived
-    /// from the node, NEVER hub-self. A hub-shaped principal is explicitly rejected here so it can
-    /// never be persisted as a fake submitter (the <c>CreatedBy=sync/…</c> class of bug).</para>
+    /// <para>🌍 The snapshot includes the submitter's <see cref="AccessContext.Locale"/>: every
+    /// user-facing string a round emits is resolved off the round's context, so a rebuilt context
+    /// without the language renders English for a German user (#948). The language is part of the
+    /// identity, and this is the one place it is reliably live.</para>
+    ///
+    /// <para><b>The first REAL USER wins, not the first non-null context.</b> The request-scoped
+    /// <c>Context</c> frequently holds a NON-user principal at the submit boundary — a hub-shaped
+    /// address, or <c>system-security</c> from an enclosing <c>ImpersonateAsSystem</c> scope
+    /// (seeding, hydration, any infrastructure step the submit is nested in). Taking it merely
+    /// because it is non-null stamps THAT as the submitter and discards the real signed-in user
+    /// sitting right there on the circuit context — which cost both the identity AND the language
+    /// (#948: a German user's round rendered English because <c>system-security</c> shadowed
+    /// <c>Roland/de</c>). This is the same <c>IsRealUser</c> predicate the round-dispatch watcher
+    /// applies at the other end of the rider; the two ends now agree.</para>
+    ///
+    /// <para>Returns all-null when no real user identity is live at all — the watcher then falls
+    /// back to the thread owner derived from the node, NEVER hub-self and never System.</para>
     /// </summary>
-    private static (string? ObjectId, string? Name) CaptureSubmitter(this IMessageHub hub)
+    private static (string? ObjectId, string? Name, string? Locale) CaptureSubmitter(this IMessageHub hub)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var ctx = accessService?.Context ?? accessService?.CircuitContext;
-        if (ctx is null || string.IsNullOrEmpty(ctx.ObjectId)
-            || AccessService.LooksLikeHubPrincipal(ctx.ObjectId))
-            return (null, null);
-        return (ctx.ObjectId, string.IsNullOrEmpty(ctx.Name) ? ctx.ObjectId : ctx.Name);
+        var ctx = IsRealUser(accessService?.Context) ? accessService!.Context
+            : IsRealUser(accessService?.CircuitContext) ? accessService!.CircuitContext
+            : null;
+        if (ctx is null)
+            return (null, null, null);
+        return (ctx.ObjectId, string.IsNullOrEmpty(ctx.Name) ? ctx.ObjectId : ctx.Name, ctx.Locale);
+
+        // A submitter is a PERSON. Hub addresses (sync/, mesh/, node/, activity/, portal/) and the
+        // well-known System identity are infrastructure credentials — never a submitter.
+        static bool IsRealUser(AccessContext? candidate) =>
+            !string.IsNullOrEmpty(candidate?.ObjectId)
+            && !AccessService.LooksLikeHubPrincipal(candidate.ObjectId)
+            && !string.Equals(candidate.ObjectId, WellKnownUsers.System, StringComparison.Ordinal);
     }
 
     // ═════════════════════════════════════════════════════════════════════
@@ -138,7 +161,7 @@ public static class HubThreadExtensions
         // Capture the submitter's identity NOW — synchronous, live AsyncLocal — and persist it on the
         // pending message (below) so the round-dispatch watcher can rebuild it AFTER the async boundary
         // wipes the AsyncLocal. See ThreadMessage.SubmitterObjectId / AccessContextPropagation.md.
-        var (submitterObjectId, submitterName) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
 
         // 🎯 The thread's COMPOSER is the single source of truth for the round's sticky
         // selection (agent / model / harness / context). Seed it from the supplied composer
@@ -180,7 +203,8 @@ public static class HubThreadExtensions
                         attachments: attachments,
                         harness: harness,
                         submitterObjectId: submitterObjectId,
-                        submitterName: submitterName))
+                        submitterName: submitterName,
+                        submitterLocale: submitterLocale))
             }
             : baseThread; // empty thread — no round
         threadNode = threadNode with { Content = seededThread };
@@ -311,7 +335,7 @@ public static class HubThreadExtensions
         if (string.IsNullOrWhiteSpace(userText))
             return;
 
-        var (submitterObjectId, submitterName) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
         var userMessage = ThreadInput.CreateUserMessage(
             userText ?? string.Empty,
             createdBy: createdBy,
@@ -322,7 +346,8 @@ public static class HubThreadExtensions
             attachments: attachments,
             harness: harness,
             submitterObjectId: submitterObjectId,
-            submitterName: submitterName);
+            submitterName: submitterName,
+            submitterLocale: submitterLocale);
         try
         {
             ThreadInput.AppendUserInput(hub.GetWorkspace(), threadPath, userMessage);
@@ -375,7 +400,7 @@ public static class HubThreadExtensions
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.AI.HubThreadExtensions");
         var msgId = Guid.NewGuid().ToString("N")[..8];
-        var (submitterObjectId, submitterName) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
 
         hub.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
         {
@@ -399,7 +424,8 @@ public static class HubThreadExtensions
                 attachments: attachments ?? c.Attachments,
                 harness: c.Harness,
                 submitterObjectId: submitterObjectId,
-                submitterName: submitterName);
+                submitterName: submitterName,
+                submitterLocale: submitterLocale);
 
             return node with
             {

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -558,7 +558,10 @@ public record ThreadMessage
     /// <summary>
     /// The submitter's <see cref="AccessContext.Locale"/> — their preferred UI language as a
     /// BCP-47 tag (<c>de</c>, <c>en</c>, …) — captured alongside <see cref="SubmitterObjectId"/>
-    /// at submit time. Null when the submitter has no language preference (→ English).
+    /// at submit time. Null OR EMPTY when the submitter has no language preference — the value is
+    /// copied verbatim from <see cref="AccessContext.Locale"/>, whose own contract is
+    /// null/empty/unsupported → English, so both absences reach here unchanged. Test it with
+    /// <see cref="string.IsNullOrEmpty(string)"/>, never a null check alone.
     ///
     /// <para><b>🌍 Why the LANGUAGE has to ride on the message too.</b> The round-dispatch watcher
     /// rebuilds the round's <see cref="AccessContext"/> from this rider, because its

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -556,6 +556,22 @@ public record ThreadMessage
     public string? SubmitterName { get; init; }
 
     /// <summary>
+    /// The submitter's <see cref="AccessContext.Locale"/> — their preferred UI language as a
+    /// BCP-47 tag (<c>de</c>, <c>en</c>, …) — captured alongside <see cref="SubmitterObjectId"/>
+    /// at submit time. Null when the submitter has no language preference (→ English).
+    ///
+    /// <para><b>🌍 Why the LANGUAGE has to ride on the message too.</b> The round-dispatch watcher
+    /// rebuilds the round's <see cref="AccessContext"/> from this rider, because its
+    /// Throttle/Subscribe continuation has no live identity. Every user-facing string a round
+    /// emits is resolved explicitly off <c>AccessContext.Locale</c> (never ambient
+    /// <c>CultureInfo</c> — a round hops schedulers), so a rebuilt context that carries only
+    /// <see cref="SubmitterObjectId"/> + <see cref="SubmitterName"/> renders the DEFAULT language
+    /// for every viewer regardless of theirs. The identity's own presentation preference is part
+    /// of the identity: carry it on the same rider (#948).</para>
+    /// </summary>
+    public string? SubmitterLocale { get; init; }
+
+    /// <summary>
     /// Completed tool calls from this message's execution.
     /// Populated when execution finishes, used for post-execution inspection.
     /// </summary>

--- a/src/MeshWeaver.AI/ThreadInput.cs
+++ b/src/MeshWeaver.AI/ThreadInput.cs
@@ -34,6 +34,10 @@ public static class ThreadInput
     /// <see cref="ThreadMessage.SubmitterObjectId"/>.</param>
     /// <param name="submitterName">The submitter's <see cref="AccessContext.Name"/>, captured
     /// alongside <paramref name="submitterObjectId"/>.</param>
+    /// <param name="submitterLocale">The submitter's <see cref="AccessContext.Locale"/>, captured
+    /// alongside <paramref name="submitterObjectId"/> so the rebuilt round context can render
+    /// user-facing text in the submitter's language. See
+    /// <see cref="ThreadMessage.SubmitterLocale"/>.</param>
     public static ThreadMessage CreateUserMessage(
         string text,
         string? createdBy = null,
@@ -44,7 +48,8 @@ public static class ThreadInput
         IReadOnlyList<string>? attachments = null,
         string? harness = null,
         string? submitterObjectId = null,
-        string? submitterName = null) =>
+        string? submitterName = null,
+        string? submitterLocale = null) =>
         new()
         {
             Role = "user",
@@ -58,6 +63,7 @@ public static class ThreadInput
             Attachments = attachments,
             SubmitterObjectId = submitterObjectId,
             SubmitterName = submitterName,
+            SubmitterLocale = submitterLocale,
             Timestamp = DateTime.UtcNow,
             Type = ThreadMessageType.ExecutedInput,
             // User cells don't have a streaming lifecycle — Submitted on creation.

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -811,8 +811,11 @@ internal static class ThreadSubmissionServer
             fellBackToCreatedBy,
             userCtx?.ObjectId ?? "(null)",
             // 🌍 The language the round will speak — the one thing that makes a "renders English
-            // for a German user" report diagnosable from the log alone (#948).
-            userCtx?.Locale ?? "(default)");
+            // for a German user" report diagnosable from the log alone (#948). IsNullOrEmpty, not
+            // ??: AccessContext.Locale's contract is null/empty/unsupported → English, so an empty
+            // string is a real "no preference" and must read as "(default)", not as a blank gap
+            // that looks like the trace itself failed.
+            string.IsNullOrEmpty(userCtx?.Locale) ? "(default)" : userCtx!.Locale);
 
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
 

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -752,14 +752,30 @@ internal static class ThreadSubmissionServer
         // — the authoritative identity that survives every async boundary. Prefer it over the
         // wrapping-node CreatedBy fallback so the round's cross-hub cell/state writes carry the real
         // user and never post a null context → fail closed → stuck cell / wedge. See AccessContextPropagation.md.
-        if (userCtx is null)
-        {
-            var submitter = dispatch.UserMessageIds
-                .Select(mid => thread.PendingUserMessages.TryGetValue(mid, out var m) ? m : null)
-                .LastOrDefault(m => !string.IsNullOrEmpty(m?.SubmitterObjectId));
-            if (submitter?.SubmitterObjectId is { } sid)
-                userCtx = new AccessContext { ObjectId = sid, Name = submitter.SubmitterName ?? sid };
-        }
+        var submitter = dispatch.UserMessageIds
+            .Select(mid => thread.PendingUserMessages.TryGetValue(mid, out var m) ? m : null)
+            .LastOrDefault(m => !string.IsNullOrEmpty(m?.SubmitterObjectId));
+        if (userCtx is null && submitter?.SubmitterObjectId is { } sid)
+            userCtx = new AccessContext
+            {
+                ObjectId = sid,
+                Name = submitter.SubmitterName ?? sid,
+                // 🌍 The submitter's LANGUAGE rides on the same rider as their identity. Every
+                // user-facing string this round emits is resolved off AccessContext.Locale, so a
+                // context rebuilt without it renders English for every viewer (#948).
+                Locale = submitter.SubmitterLocale
+            };
+        // 🌍 …and when the identity came from an AMBIENT context above, that context is
+        // locale-less BY CONSTRUCTION: the thread hub's OWNER-INJECTION (ThreadExecution) stamps
+        // the owner as {ObjectId, Name} only — no presentation preferences — onto the shared
+        // AccessService, and it is that injected context the watcher usually observes here. The
+        // per-round rider is the only carrier of the submitter's language, so take it from there
+        // whichever branch supplied the identity. Without this the round speaks English to a
+        // German submitter even though the rider knew better (#948).
+        else if (userCtx is not null
+                 && string.IsNullOrEmpty(userCtx.Locale)
+                 && !string.IsNullOrEmpty(submitter?.SubmitterLocale))
+            userCtx = userCtx with { Locale = submitter.SubmitterLocale };
 
         var fellBackToCreatedBy = false;
         // Resolution: thread content's CreatedBy → wrapping node's CreatedBy → null.
@@ -768,6 +784,11 @@ internal static class ThreadSubmissionServer
             : threadNode.CreatedBy;
         if (userCtx is null && !string.IsNullOrEmpty(resolvedCreatedBy))
         {
+            // 🌍 No Locale on this path, deliberately: CreatedBy is a bare user id stamped on the
+            // node — it carries no presentation preferences, and this branch runs when there is no
+            // submitter rider at all (a resumed / orphaned round). The round therefore speaks the
+            // DEFAULT language, which is the honest answer when nothing on the data says otherwise;
+            // inventing one (e.g. reading the ambient culture) would be worse (#948).
             userCtx = new AccessContext { ObjectId = resolvedCreatedBy, Name = resolvedCreatedBy };
             fellBackToCreatedBy = true;
         }
@@ -779,7 +800,8 @@ internal static class ThreadSubmissionServer
         logger?.LogInformation(
             "[ThreadSubmission] DispatchRound identity thread={ThreadPath} responseId={ResponseId} " +
             "asyncLocal={AsyncLocal} hubAsUserMatch={HubAsUser} circuit={Circuit} threadCreatedBy={ThreadCreatedBy} " +
-            "nodeCreatedBy={NodeCreatedBy} fallbackToCreatedBy={FallbackToCreatedBy} effective={Effective}",
+            "nodeCreatedBy={NodeCreatedBy} fallbackToCreatedBy={FallbackToCreatedBy} effective={Effective} "
+            + "locale={Locale}",
             threadPath, responseMsgId,
             asyncLocalCtx?.ObjectId ?? "(null)",
             hubAsUserMatch,
@@ -787,7 +809,10 @@ internal static class ThreadSubmissionServer
             thread.CreatedBy ?? "(null)",
             threadNode.CreatedBy ?? "(null)",
             fellBackToCreatedBy,
-            userCtx?.ObjectId ?? "(null)");
+            userCtx?.ObjectId ?? "(null)",
+            // 🌍 The language the round will speak — the one thing that makes a "renders English
+            // for a German user" report diagnosable from the log alone (#948).
+            userCtx?.Locale ?? "(default)");
 
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-round-messages-in-your-language.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-round-messages-in-your-language.md
@@ -1,0 +1,18 @@
+---
+Name: Chat rounds speak your language
+Category: What's New
+Description: Messages a chat round writes back — like "no language model can serve this round" — now appear in the language you picked, not always English.
+Icon: Sparkle
+---
+
+# Chat rounds speak your language
+
+When a chat round has something to tell you — for example that no language model can currently
+serve it — that message is now shown in the language you selected, not always in English.
+
+Until now those messages were written by a background step that had lost track of who submitted
+the message, and with it your language preference. Your name and account were carried across, but
+your language was not, so the text fell back to English for everyone.
+
+Your language now travels with your message all the way to the round that answers it. This applies
+to every message a round writes back, including ones added in future.

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -134,6 +134,12 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
     /// (c): NOTHING resolves — the requested model is unusable and the catalog offers no usable
     /// replacement, so no agent can be built. The round must FAIL with a message that names the
     /// situation, not settle as a success carrying a raw provider error.
+    ///
+    /// <para>🌍 The round submits under a GERMAN submitter (#948) and asserts the GERMAN catalog
+    /// text. Asserting the English entry (<c>locale: null</c>) would pass equally against a
+    /// hard-coded English literal AND against a round that lost the submitter's locale — which is
+    /// exactly the defect this pins: the submission watcher rebuilds the round's identity from the
+    /// submitter rider on the pending message, so the locale has to ride there too.</para>
     /// </summary>
     [Fact(Timeout = 120_000)]
     public async Task NoUsableModelAnywhere_FailsRoundWithSpeakingError()
@@ -153,9 +159,31 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         resolver.ResolveDefaultModelId().Should().BeNull(
             "the precondition for this test is that NO model in the catalog has a usable credential");
 
+        // 🌍 The assertion below only bites if EN and DE actually differ for this key — otherwise
+        // "renders German" and "renders English" are the same string and the test goes vacuous.
+        var germanText = LocalizationCatalog.Get("chat.noUsableModel", "de", StaleModel);
+        var englishText = LocalizationCatalog.Get("chat.noUsableModel", locale: null, StaleModel);
+        germanText.Should().NotBe(englishText,
+            "the German and English catalog entries must differ, or asserting the German text "
+            + "would pass against an English round and prove nothing (#948)");
+
         var threadPath = await SeedThread();
         var client = GetClient();
-        client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
+
+        // Submit as a GERMAN-speaking user. The submitter's identity — locale included — is
+        // captured at the submit boundary and rides on the pending message, because the submission
+        // watcher's Throttle/Subscribe continuation has no live AccessContext (#948).
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var previousContext = access.CircuitContext;
+        access.SetCircuitContext((previousContext ?? TestUsers.Admin) with { Locale = "de" });
+        try
+        {
+            client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
+        }
+        finally
+        {
+            access.SetCircuitContext(previousContext);
+        }
 
         var thread = await WaitForThread(threadPath,
             t => t.Status == ThreadExecutionStatus.Idle && t.Messages.Count >= 2, 60_000);
@@ -166,11 +194,20 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         cell.Status.Should().Be(ThreadMessageStatus.Error,
             "a round that no model can serve must FAIL — settling as Completed reads as success to "
             + "every automation that checks the node (#476)");
-        // The failure must SPEAK — and speak the viewer's language: it comes from the localization
-        // catalog, not a hard-coded English literal, and it names the requested model.
-        cell.Summary.Should().Be(
-            LocalizationCatalog.Get("chat.noUsableModel", locale: null, StaleModel),
-            "the round's failure text must be the localized catalog message for this situation");
+
+        // The mechanism, pinned: the submitter's language rides on the user message next to their
+        // identity. That rider is what the round-dispatch watcher rebuilds the round's
+        // AccessContext from, so if it loses the locale every round speaks English (#948).
+        var userCell = await WaitForCell(threadPath, thread.Messages[0], _ => true, 30_000);
+        userCell.SubmitterLocale.Should().Be("de",
+            "the submit boundary must capture the submitter's language onto the message — it is the "
+            + "only carrier that survives the watcher's Throttle/Subscribe hop (#948)");
+        // The failure must SPEAK — and speak the SUBMITTER's language: it comes from the
+        // localization catalog resolved off the round's own AccessContext.Locale, not a hard-coded
+        // English literal, and it names the requested model.
+        cell.Summary.Should().Be(germanText,
+            "the round's failure text must be the catalog message in the submitter's language — "
+            + "the round's AccessContext must carry the submitter's Locale (#948)");
         cell.Summary.Should().Contain(StaleModel, "the message must name the model that was requested");
         cell.Summary.Should().NotContain("ApiKey",
             "the raw provider/factory error belongs in the log, never pasted into the thread (#476)");


### PR DESCRIPTION
Fixes #948.

## The defect

A round resolves its user-facing text explicitly off `AccessContext.Locale` (never ambient culture — a round hops schedulers). But the round-dispatch watcher **rebuilds** that context from the submitter rider on the pending message, and the rider carried only `ObjectId` + `Name`. The language was dropped, so **every user-facing string a round emits rendered English for every viewer**, whatever their language.

## What tracing turned up (one level up from where the issue predicted)

The issue expected the locale to be available at the capture site and simply not carried. It was worse: `CaptureSubmitter` took the first **non-null** access context, and at the submit boundary the request-scoped context is frequently a *non-user* principal — a hub address, or `system-security` from an enclosing `ImpersonateAsSystem` scope. A diagnostic printed exactly that:

```
same=True  ctx=system-security/-  circuit=Roland/de
```

So the rider was stamped `system-security` while the real signed-in German user sat on the circuit context. It lost the language *and* mis-stamped the identity — and note the watcher's own `IsRealUser` predicate **rejects** `system-security`, so the rider was smuggling a principal straight past a gate that exists to stop it.

## The fix — both ends of the rider now agree

- **`CaptureSubmitter` picks the first REAL USER context**, not the first non-null one, applying the same predicate the watcher applies (no hub-shaped principals, no System).
- **The rider carries the locale** next to the identity (`ThreadMessage.SubmitterLocale`), stamped by `StartThread` / `SubmitMessage` / `SubmitComposer`.
- **`DispatchRound` consumes it in BOTH branches.** The ambient branch needs it too: the thread hub's OWNER-INJECTION stamps the owner as `{ObjectId, Name}` only, so an identity taken from there is locale-less by construction.
- **The `CreatedBy` fallback deliberately stays default**, with a comment saying so — a bare user id on the node carries no presentation preference, and inventing one (e.g. reading ambient culture) would be worse.
- **The dispatch identity trace now prints the language**, so "renders English for a German user" is diagnosable from the log alone.

## The un-vacuumed test

`ModelSubstitutionTest.NoUsableModelAnywhere_FailsRoundWithSpeakingError` asserted the round's summary against the **English** catalog entry (`locale: null`) — which passes equally against a hard-coded English literal. It now submits as a German user and asserts the **German** text, with a sanity assertion that the EN and DE entries differ so it cannot go vacuous again, plus a direct assertion on the rider so a regression names its own cause.

**Before this change** (verified on the branch with only the test edit applied):

```
Expected value to be "Kein Sprachmodell kann diese Runde bedienen: …",
but found "No language model can serve this round: …".
```

**After**: `Passed! - Failed: 0, Passed: 2` (Release).

## Verification

- `ModelSubstitutionTest` (both cases): **2/2 passed**, Release, on the tree merged with current main.
- Wider regression for the changed `CaptureSubmitter` semantics — `MeshWeaver.AI.Test --filter ~Thread`: **94/94 passed**, Release.
- `dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.AI`, `MeshWeaver.Documentation`, `MeshWeaver.AI.Test` — all **0 warnings, 0 errors**.
- Branch merged with `origin/main` before pushing.
- No new user-visible strings were introduced (the existing `chat.noUsableModel*` catalog keys are reused), so no `strings.{en,de}.json` changes are needed; no `CultureInfo.CurrentUICulture` resolution anywhere in the diff.

## Sweep

`chat.noUsableModel` / `chat.noUsableModelNoSelection` are currently the only round-emitted strings resolved from `userAccessContext?.Locale`; both now render in the submitter's language. The fix is generic — any future round-emitted localized string inherits it.

What's New: included (user-visible — round messages now appear in your language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)