### PR TITLE
The AddSkillSource tombstone claimed no callers — one lived in the plugins repo

### DIFF
--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -271,11 +271,20 @@ public static class AiSettingsNodeType
     // AddSkillSource (the void, fire-and-forget skill-source installer) was DELETED here (#683):
     // it subscribed to its own write internally, so an install plan could report success before
     // the settings write landed — a prompt uninstall then raced it and the late write resurrected
-    // a source for a package whose nodes were gone. It had no callers left: install-time source
-    // registration goes through IPartitionInstallHook.OnPartitionInstalled (AiSourcesInstallHook),
-    // which returns IObservable<Unit> and is Concat-chained by PackageInstaller.RunInstallHooks,
-    // so the install result is not produced until the settings write has landed. Any future
-    // registration path must compose that hook chain — never a void method that self-subscribes.
+    // a source for a package whose nodes were gone. Install-time source registration goes through
+    // IPartitionInstallHook.OnPartitionInstalled (AiSourcesInstallHook), which returns
+    // IObservable<Unit> and is Concat-chained by PackageInstaller.RunInstallHooks, so the install
+    // result is not produced until the settings write has landed. Any future registration path must
+    // compose that hook chain — never a void method that self-subscribes.
+    //
+    // 🚨 The original tombstone claimed "it had no callers left". That was WRONG, and the way it was
+    // wrong is worth keeping: MeshWeaver.Plugins' Store/Plugin/Source/Localizer.cs called it, for
+    // PER-VIEWER (not install-time) registration at course-localization time. A repo-local grep
+    // cannot see that — plugin node source is Roslyn-compiled against this assembly from a DIFFERENT
+    // REPO, so deleting a public member here can only be proven safe by grepping MeshWeaver.Plugins
+    // too. The break is silent until mw-plugin-test:latest is rebuilt, at which point every Store
+    // node type fails to compile and, since most modules depend on Store, Plugins CI goes red
+    // repo-wide. Before deleting any public API in this assembly, grep the plugins repo.
 
     /// <summary>
     /// The LIVE resolved skill queries for a user + context — the reactive form the skill surfaces


### PR DESCRIPTION
Corrects a false claim in the `AddSkillSource` tombstone left by #683.

## What was wrong

The comment said the method "had no callers left" before it was deleted. It had one — in a **different repo**: `Store/Plugin/Source/Localizer.cs` in MeshWeaver.Plugins, calling it for **per-viewer** registration at course-localization time, not the install-time registration the tombstone points at (`IPartitionInstallHook.OnPartitionInstalled`).

## Why it slipped through, which is the part worth recording

Plugin node source is Roslyn-compiled against this assembly **from another repository**, so a repo-local grep cannot see those callers. Deleting a public member in `MeshWeaver.AI` is only provably safe after grepping MeshWeaver.Plugins as well.

The failure mode is silent and delayed: nothing breaks until `mw-plugin-test:latest` is next rebuilt, at which point every `Store` node type fails to compile — and because most modules depend on Store, Plugins CI goes red repo-wide, far from the change that caused it.

## Scope

Comment only — no behaviour change, and the deletion itself stays (its rationale was sound: the method was `void` and self-subscribing, so an install could report success before its settings write landed and a prompt uninstall would race it). The actual compile break is being fixed on the MeshWeaver.Plugins side.

No What's New entry: this is a pure-internal comment correction with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
