### PR TITLE
Red-log ticketing: two defects the first deploy found

### DIFF
--- a/Dockerfile.logwatcher
+++ b/Dockerfile.logwatcher
@@ -5,8 +5,12 @@
 #   az acr build --registry meshweaver --image memex-log-watcher:1.0.0 \
 #     --file Dockerfile.logwatcher .
 #
-# Untracked on purpose: the sanctioned build path is `dotnet publish -t:PublishContainer`
-# (deploy/aks/DEPLOY-RUNBOOK.md § 6b). Keep this only if the ACR-side build becomes the norm.
+# NOT the sanctioned build path — that stays `dotnet publish -t:PublishContainer`
+# (deploy/aks/DEPLOY-RUNBOOK.md § 6b), which is what CI and the runbook use. This is tracked only
+# so the escape hatch exists when the local link to ACR cannot carry image layers: on 2026-08-08 the
+# SDK push wedged on repeated "Broken pipe" retries, and the deploy completed only by building
+# ACR-side from a source-only context. Build the context deliberately — a bare `.` from the repo
+# root sweeps in `.claude/worktrees/` (dozens of full checkouts) and the upload never finishes.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 

--- a/Dockerfile.logwatcher
+++ b/Dockerfile.logwatcher
@@ -1,0 +1,31 @@
+# Fallback build path for mw-log-watcher, used with `az acr build` when pushing image layers
+# from a laptop to ACR is unreliable (the SDK's PublishContainer pushes every layer over the local
+# link; this uploads SOURCE instead and lets ACR do the heavy work).
+#
+#   az acr build --registry meshweaver --image memex-log-watcher:1.0.0 \
+#     --file Dockerfile.logwatcher .
+#
+# Untracked on purpose: the sanctioned build path is `dotnet publish -t:PublishContainer`
+# (deploy/aks/DEPLOY-RUNBOOK.md § 6b). Keep this only if the ACR-side build becomes the norm.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Central package management + the props/targets every project inherits — copied first so a source
+# edit alone does not invalidate the restore layer.
+COPY Directory.Build.props Directory.Packages.props nuget.config ./
+
+# The watcher and the two framework projects it references (see MeshWeaver.LogWatcher.csproj).
+COPY src/ src/
+COPY tools/MeshWeaver.LogWatcher/ tools/MeshWeaver.LogWatcher/
+
+RUN dotnet publish tools/MeshWeaver.LogWatcher/MeshWeaver.LogWatcher.csproj \
+    -c Release -o /app --no-self-contained
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
+WORKDIR /app
+COPY --from=build /app .
+
+# Matches the Deployment's securityContext (runAsNonRoot) — the state volume is mounted at
+# /var/lib/mw-log-watcher and must be writable by this uid.
+USER $APP_UID
+ENTRYPOINT ["dotnet", "mw-log-watcher.dll"]

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -222,7 +222,8 @@ az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
 | `Log watcher is not configured` | Step 1 missed — `PortalUrl`/`IngestToken` unset. |
 | `Portal REJECTED report … with 401` | The two tokens differ — the watcher's secret and the portal's `LogWatch__IngestToken` must be the same string. |
 | `Portal REJECTED report … with 404` | The portal's `LogWatch__IngestToken` is unset, so `/api/log-incidents` is not mapped at all — step 1 was done on the watcher side only. |
-| `Loki: 0 red line(s)` forever | Nothing red in the watched namespaces, or `Namespaces` names the wrong ones. |
+| `Loki: 0 line(s)` forever | The namespace label is wrong, or Promtail is not shipping that namespace. |
+| `Could not persist watcher state … Access to the path … is denied` | The state PVC mounted root-owned. The pod needs `securityContext.fsGroup: 1654` (the shipped manifest sets it). The watcher still reports, but the cursor stops persisting, so a restart replays the lookback window. |
 | Incidents appear but stay `New` | Step 2 missed — no repository routed, so the control plane idles. |
 
 Then browse `Admin/_LogIncident` in the portal: every incident links to the ticket it opened and to

--- a/deploy/aks/manifests/observability/log-watcher.yaml
+++ b/deploy/aks/manifests/observability/log-watcher.yaml
@@ -55,6 +55,18 @@ spec:
       labels:
         app: mw-log-watcher
     spec:
+      # 🚨 POD-level securityContext, and it is what makes the state volume usable. The container
+      # runs non-root (below), but a freshly provisioned PVC mounts root-owned — so without fsGroup
+      # the watcher starts, reads Loki, delivers reports, and then fails EVERY state write with
+      # "Access to the path '/var/lib/mw-log-watcher/pending.json.tmp' is denied". It looks healthy;
+      # only the durability guarantee is gone (the cursor stops persisting, so a restart replays the
+      # lookback window and redelivers). Observed on the first deploy, 2026-08-08.
+      # 1654 is the .NET images' APP_UID and the uid the cluster's non-root workloads already use.
+      securityContext:
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: mw-log-watcher
           image: meshweaver.azurecr.io/memex-log-watcher:latest

--- a/src/MeshWeaver.Observability.Contract/LokiQuery.cs
+++ b/src/MeshWeaver.Observability.Contract/LokiQuery.cs
@@ -1,0 +1,30 @@
+namespace MeshWeaver.Observability;
+
+/// <summary>
+/// The LogQL the watcher reads with. It lives here, beside <see cref="LogLineParser"/> and
+/// <see cref="BurstAggregator"/>, because it is part of the same contract: those two reconstruct a
+/// burst from consecutive lines, and that only works if the query actually returns those lines.
+/// Keeping it in the watcher's own (executable) project put it out of reach of the tests — which is
+/// how the defect below shipped.
+/// </summary>
+public static class LokiQuery
+{
+    /// <summary>
+    /// Every line in a namespace — <b>deliberately unfiltered</b>.
+    ///
+    /// <para>🚨 This used to be <c>{namespace="x"} |~ `^(fail|crit):`</c>. A .NET console error is a
+    /// red HEADER plus indented continuation lines (message, then stack trace), which Loki stores as
+    /// separate entries; a line filter returns the header ALONE. The grouper then had nothing to
+    /// re-attach, so every incident lost its exception and top frame and every fault in a category
+    /// collapsed onto ONE fingerprint — tickets that named a component but not a defect. Found on
+    /// the first production deploy (2026-08-08); the aggregator's unit tests never caught it because
+    /// they feed it whole synthetic bursts, exercising a shape the real query could not produce.</para>
+    ///
+    /// <para>Red-detection therefore happens client-side in the grouper, where the burst is intact.
+    /// The trade is volume — bounded by the caller's limit, with the cursor advancing only as far as
+    /// was actually read, so an over-limit window is caught up rather than skipped.</para>
+    /// </summary>
+    /// <param name="ns">The Kubernetes namespace label to select.</param>
+    /// <returns>The LogQL stream selector.</returns>
+    public static string ForNamespace(string ns) => $"{{namespace=\"{ns}\"}}";
+}

--- a/src/MeshWeaver.Observability/LogIncidentControlPlane.cs
+++ b/src/MeshWeaver.Observability/LogIncidentControlPlane.cs
@@ -206,8 +206,14 @@ public sealed class LogIncidentControlPlane : BackgroundService
             Error = null,
         }).Select(_ =>
         {
+            // 🚨 The thread hangs off the INCIDENT node, not the satellite namespace. Passing
+            // `Admin/_LogIncident` here failed every triage in production with "No node found at
+            // 'Admin/_LogIncident'. Closest ancestor is 'Admin'" — that path is a namespace, not a
+            // node, and StartThread needs a real owner to anchor under (satellites never sit at top
+            // level). The incident IS the owner, so its thread lands at {incidentPath}/_Thread/{id}
+            // and stays reachable from the ticket.
             hub.StartThread(
-                namespacePath: LogIncidentNodeType.IncidentNamespace,
+                namespacePath: work.Path,
                 userText: Prompt(work.Incident),
                 agentName: options.TriageAgent,
                 contextPath: work.Path,

--- a/test/MeshWeaver.Observability.Test/LokiQueryShapeTest.cs
+++ b/test/MeshWeaver.Observability.Test/LokiQueryShapeTest.cs
@@ -1,0 +1,65 @@
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// Pins the one property of the Loki query that the aggregator tests cannot see, and that a
+/// production deploy caught on day one: <b>the query must not filter to red header lines</b>.
+///
+/// <para>A .NET console error is a header (<c>fail: Category[0]</c>) plus indented continuation
+/// lines — the message, then the stack trace — stored by Loki as separate entries. With a
+/// <c>|~ "^(fail|crit):"</c> line filter only the header comes back, so
+/// <see cref="BurstAggregator"/> never receives the lines it exists to re-attach: no exception, no
+/// top frame, and every fault in a category collapsing to ONE fingerprint. The aggregator's own
+/// tests kept passing because they feed it synthetic multi-line input — a path the real query never
+/// produced. This test closes that gap from the query side.</para>
+/// </summary>
+public class LokiQueryShapeTest
+{
+    [Fact]
+    public void NamespaceQuery_SelectsTheNamespace()
+        => LokiQuery.ForNamespace("memex").Should().Be("{namespace=\"memex\"}");
+
+    [Fact]
+    public void NamespaceQuery_CarriesNoLineFilter()
+    {
+        var query = LokiQuery.ForNamespace("memex");
+
+        // `|~` / `|=` would drop the continuation lines the grouper needs. If someone re-adds a
+        // filter "to cut volume", this fails and the comment above says what it costs.
+        query.Should().NotContain("|~");
+        query.Should().NotContain("|=");
+    }
+
+    [Fact]
+    public void AggregatorFindsTheFault_OnlyWhenContinuationLinesSurvive()
+    {
+        var t0 = new DateTimeOffset(2026, 8, 8, 20, 0, 0, TimeSpan.Zero);
+        LogLine L(string line) => new(t0, "memex", "pod-a", line);
+
+        // What Loki returns with NO line filter — the whole burst.
+        var whole = new[]
+        {
+            L("fail: MeshWeaver.Data.MeshDataSource[0]"),
+            L("      Update failed for node rbuergi/Foo/7a2f1c4e-9b3d-4a21-8f65-0c1d2e3f4a5b"),
+            L("      System.InvalidOperationException: Sequence contains no elements"),
+            L("         at MeshWeaver.Data.MeshDataSource.Apply(MeshNode node)"),
+        };
+        // What the OLD filtered query returned — headers only.
+        var headersOnly = new[] { whole[0] };
+
+        var fromWhole = BurstAggregator.Aggregate(whole, maxSamples: 5, maxSampleLength: 2000)[0];
+        var fromHeaders = BurstAggregator.Aggregate(headersOnly, maxSamples: 5, maxSampleLength: 2000)[0];
+
+        // With the burst intact the incident identifies the actual defect…
+        fromWhole.ExceptionType.Should().Be("System.InvalidOperationException");
+        fromWhole.TopFrame.Should().Be("MeshWeaver.Data.MeshDataSource.Apply(MeshNode node)");
+
+        // …and with headers alone it cannot: no exception, no frame, and the "message" degrades to
+        // the category itself — which is why every fault in a category shared one fingerprint.
+        fromHeaders.ExceptionType.Should().BeNull();
+        fromHeaders.TopFrame.Should().BeNull();
+        fromHeaders.Fingerprint.Should().NotBe(fromWhole.Fingerprint);
+    }
+}

--- a/tools/MeshWeaver.LogWatcher/LogWatcherOptions.cs
+++ b/tools/MeshWeaver.LogWatcher/LogWatcherOptions.cs
@@ -59,8 +59,13 @@ public sealed record LogWatcherOptions
     /// </summary>
     public TimeSpan IngestLag { get; init; } = TimeSpan.FromSeconds(30);
 
-    /// <summary>Max entries Loki may return per query.</summary>
-    public int QueryLimit { get; init; } = 1000;
+    /// <summary>
+    /// Max entries Loki may return per query. The query is deliberately UNFILTERED (the grouper
+    /// needs each red header's continuation lines), so this bounds every line in the window, not
+    /// just the red ones — hence the headroom. Hitting it is safe: the worker advances the cursor
+    /// only to the last line actually read and catches up on the next poll, logging that it did.
+    /// </summary>
+    public int QueryLimit { get; init; } = 5000;
 
     /// <summary>Evidence lines sent per report.</summary>
     public int MaxSamplesPerReport { get; init; } = 5;

--- a/tools/MeshWeaver.LogWatcher/LokiClient.cs
+++ b/tools/MeshWeaver.LogWatcher/LokiClient.cs
@@ -27,21 +27,15 @@ public sealed class LokiClient(HttpClient http, IIoPool pool, ILogger<LokiClient
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// The LogQL selector for red lines in one namespace. <c>|~</c> is a line filter, so Loki does
-    /// the matching server-side and only red lines cross the wire — the whole point of filtering
-    /// here rather than shipping every INFO line to the watcher.
-    /// </summary>
-    public static string RedLineQuery(string ns) =>
-        $"{{namespace=\"{ns}\"}} |~ `^(fail|crit):`";
-
-    /// <summary>
-    /// Reads red lines in <c>[start, end)</c> for one namespace, oldest first. Emits the batch.
+    /// Reads the lines in <c>[start, end)</c> for one namespace, oldest first. Emits the batch —
+    /// ALL lines, not just red ones: the grouper needs each red header's continuation lines to
+    /// reconstruct the burst (see <see cref="LokiQuery.ForNamespace"/>).
     /// </summary>
     public IObservable<ImmutableList<LogLine>> Query(
         string ns, DateTimeOffset start, DateTimeOffset end, int limit)
     {
         var url = "/loki/api/v1/query_range"
-                  + $"?query={Uri.EscapeDataString(RedLineQuery(ns))}"
+                  + $"?query={Uri.EscapeDataString(LokiQuery.ForNamespace(ns))}"
                   + $"&start={Nanos(start)}&end={Nanos(end)}"
                   + $"&limit={limit.ToString(CultureInfo.InvariantCulture)}"
                   + "&direction=forward";
@@ -52,7 +46,7 @@ public sealed class LokiClient(HttpClient http, IIoPool pool, ILogger<LokiClient
                 var entries = Flatten(response).ToImmutableList();
                 if (entries.Count > 0)
                     logger?.LogInformation(
-                        "Loki: {Count} red line(s) in {Namespace} for [{Start:HH:mm:ss}, {End:HH:mm:ss})",
+                        "Loki: {Count} line(s) in {Namespace} for [{Start:HH:mm:ss}, {End:HH:mm:ss})",
                         entries.Count, ns, start.UtcDateTime, end.UtcDateTime);
                 return entries;
             });


### PR DESCRIPTION
Deployed red-log ticketing to memex.systemorph.com today. Reports delivered end to end on the first try — then stopped, twice, in ways the unit tests had no way of catching.

## 1. Triage never ran

The incident node recorded the cause exactly:

```
"status": "Failed",
"error":  "Thread creation failed: No node found at 'Admin/_LogIncident'.
           Closest ancestor is 'Admin' (remainder='_LogIncident')."
```

`StartThread` was handed the satellite **namespace** as its host, but a thread needs a real owning node to anchor under. The incident itself is that owner — the thread now lands at `{incidentPath}/_Thread/{id}`, which also keeps the agent's reasoning reachable from the ticket it produced.

## 2. Every incident was missing its exception and stack frame

The Loki query carried `|~ "^(fail|crit):"`. A .NET console error is a red **header** plus indented continuation lines (message, then stack trace), stored by Loki as separate entries — so a line filter returned the header **alone**. `BurstAggregator`, whose entire job is re-attaching those lines, was fed headers and nothing else.

Live evidence from the first sweep:

```json
"normalizedMessage": "MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[{n}]",
"samples": [{ "line": "crit: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]" }]
```

No `exceptionType`, no `topFrame`, and the message degraded to the category — so **every fault in a category shared one fingerprint**. Tickets that name a component but not a defect.

**The aggregator's tests passed throughout**, because they feed it whole synthetic bursts — a shape the real query could never produce. The tests covered the grouper's logic and not the contract between the grouper and its input. That's the part worth remembering.

## The fix

- Query is now unfiltered; red-detection happens client-side where the burst is intact.
- `QueryLimit` 1000 → 5000 for the extra volume. Safe: the truncation guard already advances the cursor only as far as it actually read, so an over-limit window is caught up, never skipped.
- The LogQL moved into `Observability.Contract` beside the parser and grouper. It belongs with them — and leaving it in the watcher's **executable** project is exactly what put it out of the tests' reach (the test project can't reference an Exe; that hijacks the test host's entry point).
- `LokiQueryShapeTest` pins both halves: the query carries no line filter, and the aggregator demonstrably cannot identify a fault from headers alone.

## Also

`Dockerfile.logwatcher` — pushing image layers from a laptop to ACR failed repeatedly (broken pipe, wedged retries), so the image was built with `az acr build` from a source-only context. Documented as the fallback it is; the sanctioned path stays `dotnet publish -t:PublishContainer`.

53 tests pass; full solution builds clean with CI's flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK