### PR TITLE
Unload node ALCs at the END of teardown, not before the I/O drain (#613)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-clean-shutdown-for-compiled-node-types.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-08-clean-shutdown-for-compiled-node-types.md
@@ -1,0 +1,17 @@
+---
+Name: Shutting down no longer crashes when custom types are in use
+Category: What's New
+Description: A portal or test host that had compiled custom NodeTypes could abort instead of exiting cleanly; shutdown now waits for in-flight work before reclaiming those types.
+Icon: Sparkle
+---
+
+# Shutting down no longer crashes when custom types are in use
+
+When a mesh shut down, the memory for each dynamically compiled NodeType was reclaimed a moment too
+early — while background rendering work that used those very types could still be running. Most of
+the time nothing noticed, but under load the process could abort outright instead of exiting
+cleanly, which showed up as unexplained crashes at the end of a test run or a pod restart.
+
+The reclaim now happens at the true end of shutdown, after all in-flight work has been stopped and
+joined. Nothing is held any longer than before during normal operation: a single node going away
+while the mesh keeps running still releases its memory immediately.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -14,6 +14,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Services.LanguageServer;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -837,6 +838,54 @@ public static class MeshDataSourceExtensions
         return Observable.Return(Unit.Default);
     }
 
+    /// <summary>
+    /// Reclaims this node's collectible <c>NodeAssemblyLoadContext</c>(s) at the only point where no
+    /// thread can still be executing their compiled types. Which point that is depends on WHY the
+    /// node hub is disposing, so the callback picks between two:
+    ///
+    /// <list type="bullet">
+    /// <item><b>The mesh is alive</b> (prod steady state: the node was deleted, its hub evicted or
+    ///   recycled). Nothing else is going to tell us it is safe and the mesh may run for months, so
+    ///   unload NOW — deferring would leak this ALC for the process lifetime, which is exactly the
+    ///   late-project CI OOM / GC-stall this hook was added to fix. No mesh-wide teardown is in
+    ///   progress, so no <see cref="IoPoolRegistry.DrainAll"/> is pending behind us.</item>
+    /// <item><b>The mesh is tearing down.</b> This callback runs from <c>MessageHub.DisposeImpl</c>,
+    ///   i.e. STRICTLY BEFORE <see cref="IMessageHub.DisposalCompleted"/> — but the pooled
+    ///   layout-render leaves that execute this node's compiled types are cancelled and JOINED only
+    ///   by <see cref="IoPoolRegistry.DrainAll"/>, which every teardown orchestrator runs AFTER
+    ///   <c>DisposalCompleted</c> (<c>MeshTeardownExtensions.WaitForDisposalAndIoDrainAsync</c>,
+    ///   <c>MonolithMeshTestBase</c>, <c>HubTestBase</c>). Unloading here therefore frees the
+    ///   LoaderAllocator out from under a leaf still inside <c>IoPool.SubscribeThroughPool</c>, and
+    ///   its next read of a NodeType-compiled type's GC statics is an
+    ///   <c>AccessViolationException</c> → SIGABRT (issue #613). So we hand the unload to
+    ///   <see cref="MeshTeardownSignal"/>, which fires only after every drain phase — precisely the
+    ///   role its own documentation assigns it ("everything that must not run before teardown truly
+    ///   ends — disposing the service scope, unloading node ALCs — subscribes here").</item>
+    /// </list>
+    ///
+    /// <para>With no <see cref="MeshTeardownSignal"/> registered there is no terminal signal to wait
+    /// for, so we keep the immediate unload rather than leak: a never-reclaimed ALC is the
+    /// regression this hook exists to prevent.</para>
+    /// </summary>
+    private static void UnloadNodeAssemblyContexts(
+        ICompilationCacheService compilationCache,
+        string sanitizedNodeName,
+        IMessageHub meshHub,
+        MeshTeardownSignal? teardownSignal)
+    {
+        if (teardownSignal is null || !meshHub.IsDisposing)
+        {
+            compilationCache.UnloadNodeContexts(sanitizedNodeName);
+            return;
+        }
+
+        // ReplaySubject(1)-backed and completing, so this subscription releases itself as soon as
+        // the report arrives — and a subscriber that attaches after teardown already finished still
+        // gets it immediately (never a silently-skipped unload).
+        teardownSignal.Completed
+            .Subscribe(_ => compilationCache.UnloadNodeContexts(sanitizedNodeName));
+    }
+
     private static void SubscribeToOwnDeletion(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetService<OwnNodeCache>();
@@ -876,7 +925,15 @@ public static class MeshDataSourceExtensions
             if (compilationCache != null)
             {
                 var sanitizedNodeName = compilationCache.SanitizeNodeName(hub.Address.Path);
-                hub.RegisterForDisposal(_ => compilationCache.UnloadNodeContexts(sanitizedNodeName));
+                // Captured HERE, during buildup, while the parent scope is guaranteed alive.
+                // MessageHubConfiguration.ParentHub re-resolves from ParentServiceProvider, which is
+                // routinely already torn down by the time a disposal callback runs (see the
+                // parentAddress note in MessageHub.DisposeImpl) — so the mesh hub and the terminal
+                // signal must both be resolved now, not from inside the callback.
+                var meshHub = hub.GetMeshHub();
+                var teardownSignal = hub.ServiceProvider.GetService<MeshTeardownSignal>();
+                hub.RegisterForDisposal(_ =>
+                    UnloadNodeAssemblyContexts(compilationCache, sanitizedNodeName, meshHub, teardownSignal));
             }
 
             // 🚨 Memory: same per-node reclaim for the LSP workspace cache. The language service is a

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeAlcUnloadTeardownOrderingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeAlcUnloadTeardownOrderingTest.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Ordered record of the teardown milestones this test pins. Instance state on a mesh-scoped
+/// singleton — never static (NoStaticState): it dies with the mesh, so nothing bleeds into the
+/// next test class and no <c>Clear()</c> is needed.
+/// </summary>
+internal sealed class TeardownOrderLog
+{
+    private readonly object gate = new();
+    private ImmutableList<string> marks = ImmutableList<string>.Empty;
+
+    public void Mark(string mark)
+    {
+        lock (gate)
+            marks = marks.Add(mark);
+    }
+
+    public ImmutableList<string> Marks
+    {
+        get
+        {
+            lock (gate)
+                return marks;
+        }
+    }
+}
+
+/// <summary>
+/// Records WHEN <see cref="ICompilationCacheService.UnloadNodeContexts"/> is invoked, then forwards
+/// to the real implementation. Re-declaring <see cref="ICompilationCacheService"/> in the base list
+/// re-maps interface dispatch onto this class, so the explicit implementation below wins for every
+/// caller that goes through the interface (which is what <c>MeshDataSource.SubscribeToOwnDeletion</c>
+/// does) — no 30-member forwarding decorator needed.
+/// </summary>
+internal sealed class OrderRecordingCompilationCacheService(
+    IOptions<CompilationCacheOptions> options,
+    ILogger<CompilationCacheService> logger,
+    TeardownOrderLog orderLog)
+    : CompilationCacheService(options, logger), ICompilationCacheService
+{
+    /// <summary>Marker prefix; the suffix is the sanitized node name being unloaded.</summary>
+    public const string UnloadMarkPrefix = "unload:";
+
+    void ICompilationCacheService.UnloadNodeContexts(string nodeName)
+    {
+        orderLog.Mark(UnloadMarkPrefix + nodeName);
+        base.UnloadNodeContexts(nodeName);
+    }
+}
+
+/// <summary>
+/// 🚨 Teardown PHASE-ORDERING guard for collectible node <c>AssemblyLoadContext</c>s (issue #613).
+///
+/// <para>A node's ALC must not be unloaded while a pooled I/O leaf can still be executing that
+/// ALC's compiled types. The join that guarantees nobody is — <see cref="IoPoolRegistry.DrainAll"/>
+/// — runs AFTER <see cref="IMessageHub.DisposalCompleted"/> in every teardown orchestrator
+/// (<c>MeshTeardownExtensions.WaitForDisposalAndIoDrainAsync</c>, <c>MonolithMeshTestBase</c>).
+/// A hub-disposal callback runs in <c>MessageHub.DisposeImpl</c>, i.e. strictly BEFORE
+/// <c>DisposalCompleted</c> — so unloading from there frees the LoaderAllocator out from under a
+/// layout-render leaf still inside <c>IoPool.SubscribeThroughPool</c>. The observed crash was
+/// <c>AccessViolationException</c> in <c>StaticsHelpers.GetGCThreadStaticBase</c> under
+/// <c>Enumerable.ToArray</c> (Workspace's <c>.Cast&lt;T&gt;().ToArray()</c> over a NodeType-compiled
+/// <c>T</c>) → SIGABRT, exit 134.</para>
+///
+/// <para>This test needs no crash: it records the invocation ORDER directly. The
+/// <c>ICompilationCacheService</c> is decorated to stamp each <c>UnloadNodeContexts</c> call, a real
+/// pooled leaf stamps from INSIDE <see cref="IoPoolRegistry.DrainAll"/> (its cancellation callback
+/// runs on <c>IoPool.Drain</c>'s <c>_poolCts.Cancel()</c>), and the test drives the exact phase
+/// sequence <c>MeshTeardownExtensions</c> does. Before the fix the unload lands first and this test
+/// is RED; the contract it asserts is the one <see cref="MeshTeardownSignal"/>'s own XML doc states
+/// — "everything that must not run before teardown truly ends — disposing the service scope,
+/// unloading node ALCs … subscribes here".</para>
+/// </summary>
+public class NodeAlcUnloadTeardownOrderingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Stamped from inside <c>IoPool.Drain</c> — the pool token's cancellation callback.</summary>
+    private const string DrainAllStartedMark = "drain-all:started";
+
+    /// <summary>Stamped on the calling thread the instant <see cref="IoPoolRegistry.DrainAll"/> returns.</summary>
+    private const string DrainAllReturnedMark = "drain-all:returned";
+
+    /// <summary>
+    /// Dedicated pool for the probe leaf so an infinitely-parked slot can never starve Layout / PG /
+    /// Compile. Unknown names get <c>IoPoolOptions.Default</c> (= ProcessorCount) slots.
+    /// </summary>
+    private const string ProbePoolName = "teardown-order-probe";
+
+    private const string ProbeNodeTypeId = "AlcUnloadOrderProbeStory";
+
+    /// <summary>Separate id so the live-mesh case never shares a cache entry with the teardown case.</summary>
+    private const string LiveProbeNodeTypeId = "AlcUnloadLiveProbeStory";
+
+    private static readonly TimeSpan TeardownBudget = TimeSpan.FromSeconds(30);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            // AFTER AddGraph: MeshBuilder.ConfigureServices applies its delegate immediately to the
+            // live IServiceCollection, so this replaces the registration AddGraph just made.
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<TeardownOrderLog>();
+                services.RemoveAll<ICompilationCacheService>();
+                services.AddSingleton<ICompilationCacheService>(sp =>
+                    new OrderRecordingCompilationCacheService(
+                        sp.GetRequiredService<IOptions<CompilationCacheOptions>>(),
+                        sp.GetRequiredService<ILogger<CompilationCacheService>>(),
+                        sp.GetRequiredService<TeardownOrderLog>()));
+                return services;
+            });
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>
+    /// Compiles a real NodeType so at least one recorded unload frees an actual collectible
+    /// <c>DynamicNode_*</c> LoaderAllocator — the thing whose premature release is the crash.
+    /// Mirrors <c>NodeTypeAssemblyLeakTest</c>: create the NodeType + its Source node, then observe
+    /// the terminal <c>CompilationStatus</c> the per-node hub writes back onto its own MeshNode via
+    /// <c>stream.Update</c> (no verb-shaped compile request — that response can simply never arrive).
+    /// </summary>
+    private async Task CompileProbeNodeTypeAsync(string nodeTypeId)
+    {
+        var nodeTypePath = $"type/{nodeTypeId}";
+        var typeNode = MeshNode.FromPath(nodeTypePath) with
+        {
+            Name = nodeTypeId,
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = $"config => config.WithContentType<{nodeTypeId}>()"
+            },
+            State = MeshNodeState.Active,
+        };
+
+        await MeshService.CreateNode(typeNode)
+            .SelectMany(_ => MeshService.CreateNode(new MeshNode("code", $"{nodeTypePath}/Source")
+            {
+                NodeType = "Code",
+                Name = "code",
+                Content = new CodeConfiguration
+                {
+                    Code = $"public record {nodeTypeId} {{ public string Id {{ get; init; }} = string.Empty; }}",
+                    Language = "csharp",
+                },
+                State = MeshNodeState.Active,
+            }))
+            .Should().Within(30.Seconds()).Emit();
+
+        var compiledNode = await Mesh.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(60.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition def
+                        && def.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error);
+
+        var compiledDef = (NodeTypeDefinition)compiledNode.Content!;
+        compiledDef.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            $"the probe NodeType must compile; error: {compiledDef.CompilationError}");
+    }
+
+    /// <summary>
+    /// A genuine pooled I/O leaf that parks until the pool token is cancelled. Registering on that
+    /// token means the stamp is written by <c>IoPool.Drain</c>'s own <c>_poolCts.Cancel()</c> — the
+    /// mark is produced INSIDE <see cref="IoPoolRegistry.DrainAll"/>, not by test bookkeeping. It
+    /// also recreates the hazard's precondition: a leaf in flight across the
+    /// <c>DisposalCompleted</c> → <c>DrainAll</c> window. It unwinds on cancellation, so the drain
+    /// joins it and the teardown report stays clean.
+    /// </summary>
+    private static async Task<Unit> ParkUntilDrainedAsync(CancellationToken ct, TeardownOrderLog orderLog)
+    {
+        await using var registration = ct.Register(() => orderLog.Mark(DrainAllStartedMark));
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: DrainAll cancelled us. Unwind promptly so the join is real.
+        }
+
+        return Unit.Default;
+    }
+
+    /// <summary>
+    /// The OTHER half of the gate, and the one that must never regress into a leak: when only the
+    /// NODE hub disposes and the mesh keeps running (prod steady state — node deleted, hub evicted or
+    /// recycled), the ALC must be reclaimed IMMEDIATELY. Deferring it to
+    /// <see cref="MeshTeardownSignal"/> there would hold the collectible context for the whole
+    /// process lifetime, which is exactly the late-project CI OOM / GC-stall that put this unload
+    /// hook in <c>MeshDataSource.SubscribeToOwnDeletion</c> in the first place. No
+    /// <c>DrainAll</c> is pending in this case, so there is nothing to order behind.
+    /// </summary>
+    [Fact]
+    public async Task NodeAssemblyContexts_AreUnloaded_Immediately_WhenTheMeshKeepsRunning()
+    {
+        var orderLog = Mesh.ServiceProvider.GetRequiredService<TeardownOrderLog>();
+
+        await CompileProbeNodeTypeAsync(LiveProbeNodeTypeId);
+
+        var nodeTypePath = $"type/{LiveProbeNodeTypeId}";
+        var expectedMark = OrderRecordingCompilationCacheService.UnloadMarkPrefix
+                           + Mesh.ServiceProvider.GetRequiredService<ICompilationCacheService>()
+                               .SanitizeNodeName(nodeTypePath);
+
+        orderLog.Marks.Should().NotContain(expectedMark,
+            "the NodeType's ALC must still be loaded while its hub is alive");
+
+        var nodeHub = Mesh.GetHostedHub(Mesh.GetAddress(nodeTypePath), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull("compiling the NodeType activates its per-node hub");
+
+        // Dispose ONLY the node hub. The mesh stays up, so the gate must take the immediate branch.
+        nodeHub!.Dispose();
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(20))
+            .StartWith(-1L)
+            .Where(_ => orderLog.Marks.Contains(expectedMark))
+            .FirstAsync()
+            .Timeout(TeardownBudget)
+            .ToTask();
+
+        Mesh.IsDisposing.Should().BeFalse(
+            "the reclaim must happen while the mesh is still running — if it only arrived because " +
+            "the mesh started tearing down, the live-mesh branch is not being exercised and a " +
+            "long-lived process would leak this ALC (the CI OOM this hook exists to prevent)");
+
+        Output.WriteLine($"[diag] live-mesh marks: {string.Join(" | ", orderLog.Marks)}");
+    }
+
+    [Fact]
+    public async Task NodeAssemblyContexts_AreUnloaded_OnlyAfterTheIoPoolsAreDrained()
+    {
+        var orderLog = Mesh.ServiceProvider.GetRequiredService<TeardownOrderLog>();
+        var ioPools = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>();
+        var asyncDisposeQueue = Mesh.ServiceProvider.GetService<AsyncDisposeQueue>();
+        var teardownSignal = Mesh.ServiceProvider.GetRequiredService<MeshTeardownSignal>();
+
+        await CompileProbeNodeTypeAsync(ProbeNodeTypeId);
+
+        // Park a real leaf on its own pool and wait until it actually holds a slot, so DrainAll has
+        // something to cancel + join (and something to stamp with).
+        var probePool = ioPools.Get(ProbePoolName);
+        using var probe = probePool
+            .Invoke(ct => ParkUntilDrainedAsync(ct, orderLog))
+            .Subscribe(_ => { }, _ => { });
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(20))
+            .StartWith(-1L)
+            .Where(_ => probePool.CurrentInFlight > 0)
+            .FirstAsync()
+            .Timeout(10.Seconds())
+            .ToTask();
+
+        // The production teardown sequence, inlined from
+        // MeshTeardownExtensions.WaitForDisposalAndIoDrainAsync so the DrainAll boundary can be
+        // stamped between phases. Nothing is skipped and the report is the genuine one.
+        Mesh.Dispose();
+        await Mesh.DisposalCompleted
+            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+            .FirstOrDefaultAsync()
+            .Timeout(TeardownBudget)
+            .ToTask();
+
+        var leakedIoLeaves = ioPools.DrainAll();
+        orderLog.Mark(DrainAllReturnedMark);
+
+        var asyncDisposeClean = asyncDisposeQueue is null
+                                || await asyncDisposeQueue.DrainAsync(TeardownBudget);
+
+        teardownSignal.SignalCompleted(new TeardownReport(leakedIoLeaves, asyncDisposeClean));
+
+        var marks = orderLog.Marks;
+        Output.WriteLine($"[diag] teardown marks: {string.Join(" | ", marks)}");
+
+        leakedIoLeaves.Should().Be(0,
+            "the probe leaf observes its cancellation token, so DrainAll's join must be real");
+        marks.Should().Contain(DrainAllStartedMark,
+            "the parked probe leaf must have been cancelled from inside IoPoolRegistry.DrainAll");
+
+        var drainAllReturnedAt = marks.IndexOf(DrainAllReturnedMark);
+        var unloadMarks = marks
+            .Select((mark, index) => (mark, index))
+            .Where(m => m.mark.StartsWith(OrderRecordingCompilationCacheService.UnloadMarkPrefix,
+                StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        unloadMarks.Should().NotBeEmpty(
+            "every per-node hub reclaims its collectible ALC on disposal, so teardown must call " +
+            "UnloadNodeContexts at least once");
+
+        var premature = unloadMarks.Where(m => m.index < drainAllReturnedAt).Select(m => m.mark).ToArray();
+        premature.Should().BeEmpty(
+            "a node's collectible AssemblyLoadContext may only be unloaded once IoPoolRegistry.DrainAll() " +
+            "has cancelled and JOINED every pooled leaf. Unloading earlier — from the hub-disposal " +
+            "callback, which MessageHub.DisposeImpl runs before DisposalCompleted — frees the " +
+            "LoaderAllocator under a layout-render leaf still inside IoPool.SubscribeThroughPool, and " +
+            "its next access to a NodeType-compiled type's statics is an AccessViolation (issue #613). " +
+            $"Unloaded too early: {string.Join(", ", premature)}");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
@@ -11,6 +11,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -160,12 +161,25 @@ public class NodeTypeAssemblyLeakTest(ITestOutputHelper output) : MonolithMeshTe
 
         // Tear the mesh down: every hosted per-node hub disposes, firing the
         // SubscribeToOwnDeletion → UnloadNodeContexts hook that drops its ALC.
-        Mesh.Dispose();
-        await Mesh.DisposalCompleted
-            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-            .FirstOrDefaultAsync()
+        //
+        // 🚨 Wait on the TERMINAL teardown signal, NOT on DisposalCompleted. During mesh teardown
+        // the ALC unload is deliberately deferred past IoPoolRegistry.DrainAll() — a pooled
+        // layout-render leaf can still be executing this ALC's compiled types when
+        // DisposalCompleted fires, and unloading under it frees the LoaderAllocator beneath a live
+        // thread (issue #613: AccessViolation → SIGABRT). MeshTeardownSignal is the point where
+        // every drain phase has finished AND the unload has run; waiting on DisposalCompleted here
+        // would pin the pre-#613 ordering as the contract. What this test ASSERTS is unchanged —
+        // zero surviving DynamicNode_* contexts — only WHEN it checks moved.
+        var teardownSignal = Mesh.ServiceProvider.GetRequiredService<MeshTeardownSignal>();
+        var terminal = teardownSignal.Completed
+            .FirstAsync()
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask();
+        var report = await Mesh.TeardownAsync(TimeSpan.FromSeconds(30));
+        await terminal;
+
+        report.Clean.Should().BeTrue(
+            $"a dirty teardown means live work survived into the ALC unload — {report}");
 
         await ForceCollectAsync(weakRefs);
 


### PR DESCRIPTION
Fixes the teardown SIGSEGV/SIGABRT in `MeshWeaver.FutuRe.Test` (#613).

## The bug: a teardown phase inversion

Node hubs unloaded their collectible `NodeAssemblyLoadContext` from a **synchronous hub-disposal
callback** (`MeshDataSource.cs:879`, inside `SubscribeToOwnDeletion`), which `MessageHub.DisposeImpl`
runs **strictly before** `SignalDisposalCompleted()`. But the pooled layout-render leaves that
execute those compiled types are cancelled and joined only by `IoPoolRegistry.DrainAll()`, which
every teardown orchestrator runs **after** `DisposalCompleted`
(`MeshTeardownExtensions.WaitForDisposalAndIoDrainAsync`, `MonolithMeshTestBase`, `HubTestBase`).

In that window a leaf still inside `IoPool.SubscribeThroughPool` ran `Workspace`'s
`.Cast<T>().ToArray()` over a NodeType-compiled `T` and read its GC thread-static base out of the
just-freed LoaderAllocator → `AccessViolationException` → SIGABRT (exit 134).

This violated the framework's own written contract: `MeshTeardownSignal`'s XML doc already names
*"unloading node ALCs"* as one of the things that subscribes to the terminal signal.

## The proof — deterministic, no crash needed

**This is the durable artifact of the PR.** The SIGSEGV is CI/load-dependent and did not reproduce
locally (3/3 clean runs on `main`), so the bug is pinned as an **ordering** test instead:

`NodeAlcUnloadTeardownOrderingTest` decorates `ICompilationCacheService` to stamp every
`UnloadNodeContexts` call, parks a **real pooled leaf** whose cancellation callback stamps from
*inside* `DrainAll` (`IoPool.Drain` → `_poolCts.Cancel()`), compiles a real NodeType so a genuine
collectible ALC exists, and drives the production teardown phases.

**Red on unmodified `main`** — all seven unloads land before the drain even starts:

```
unload:AccessAssignment | unload:PartitionAccessPolicy | unload:Admin_Partition_type |
unload:type_AlcUnloadOrderProbeStory_Activity_compile-… | unload:type_AlcUnloadOrderProbeStory_Activity_compile-state |
unload:type_AlcUnloadOrderProbeStory | unload:mesh_XFa24gY4G0CdS8xlYb6yew |
drain-all:started | drain-all:returned
```

**Green with this change** — the same seven unloads, none skipped, all after the drain returned:

```
drain-all:started | drain-all:returned |
unload:PartitionAccessPolicy | unload:AccessAssignment | unload:Admin_Partition_type |
unload:type_AlcUnloadOrderProbeStory_Activity_compile-state | unload:type_AlcUnloadOrderProbeStory_Activity_compile-… |
unload:type_AlcUnloadOrderProbeStory | unload:mesh_LogkIA6t9EO_sL0bjG27bQ
```

The assertion is "no unload may precede `DrainAll` returning", so it fails on the ordering itself,
not on a timing threshold.

## The fix, and why the deferral is CONDITIONAL

"Defer the unload past `DrainAll`" is right at mesh teardown but **cannot be unconditional**: in prod
the mesh never tears down, so a node hub disposing on its own (node deleted, hub evicted, recycled)
must still unload immediately — otherwise the ALC leaks for the whole process lifetime, which is
precisely the late-project **CI OOM / GC-stall** that `MeshDataSource.cs:879` was added to fix.

**Gated on `IMessageHub.IsDisposing` of the MESH hub** (`hub.GetMeshHub()`), captured at buildup —
the existing idiom from `MonolithRoutingService.cs:73`. Capture-at-construction is required because
`MessageHubConfiguration.ParentHub` re-resolves from a `ParentServiceProvider` that is routinely
already torn down by the time a disposal callback runs.

| Situation | Behaviour |
|---|---|
| Mesh alive (node hub disposes alone) | unload **immediately** — unchanged from today |
| Mesh tearing down | unload on `MeshTeardownSignal`, which fires only after `DrainAll` + the async-dispose quiesce |
| No `MeshTeardownSignal` registered | unload immediately — never leak because no one will signal |

A second test, `NodeAssemblyContexts_AreUnloaded_Immediately_WhenTheMeshKeepsRunning`, pins that
first row. It is not decorative: making the deferral unconditional makes it **time out** (verified by
temporarily mutating the gate), so the leak-preventing half of the branch cannot silently regress.

`NodeTypeAssemblyLeakTest` was *pinning the buggy ordering* — it waited on `DisposalCompleted` and
asserted zero surviving ALCs, i.e. it required the unload to have happened before `DrainAll`. Its
wait moves to the terminal teardown signal. **What it asserts is unchanged** — still zero surviving
`DynamicNode_*` ALCs, plus a new `report.Clean` check; only *when* it checks moved.

## Verification

All on a tree merged with current `main` (`b65c831b9`), built with CI's flags
(`dotnet build -c Release -warnaserror`, clean for `MeshWeaver.Graph`,
`MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.FutuRe.Test`, `MeshWeaver.Hosting.Test`,
`MeshWeaver.Graph.Test`):

| Suite | Result |
|---|---|
| `NodeAlcUnloadTeardownOrderingTest` + `NodeTypeAssemblyLeakTest` | 3/3 pass (red on `main` before the fix) |
| `MeshWeaver.FutuRe.Test` (the project #613 was filed against) | 59/59 pass, **exit 0** |
| `MeshWeaver.Hosting.Test` (teardown-ordering guards) | 129/129 pass |
| `MeshWeaver.Graph.Test` ALC-leak + compilation-cache | 21/21 pass |
| Monolith teardown/compile/ALC subset (`CompileFinishAndDispose`, `ClrMdDacUnloadCrash`, `DisposalPendingSaveFlush`, `CodeEditRecompile`, `DynamicTypePreWarmer`, …) | 20 pass, 1 pre-existing skip |

Regression history checked and not re-broken: #635, #715, #774 (the `CloseCreation` / re-entrant-hub
work) — `FutuRe.Test` is green with a zero exit code, which is the signal those fixes are measured on.

**One caveat, stated honestly:** a full `MeshWeaver.Hosting.Monolith.Test` run was 492 passed / 1
failed — `MeshNodeLanguageServiceTest.CheckSpeculative_AddsNuGetReferenceDirective_ResolvesAndCompiles`
hung on resolving `nuget:Humanizer 2.14.1`. That is network, not this change: the test's own comment
notes it relies on the package being warm in the NuGet cache, this worktree is fresh, and the network
on this machine was badly degraded at the time (a 149 MB build-time download was running at ~50 KB/s).
Its teardown reported **clean**, and it fails inside the test body, nowhere near the disposal path
this PR touches. CI, with a warm cache, is the real check.

**Not proven:** that the original SIGABRT is gone in CI. It never reproduced locally, so the evidence
here is the ordering contract, not the absence of the crash. If #613 recurs after this merges, the
phase inversion is no longer the explanation.

## #618 — related, but needs its own fix

Assessed as asked; **this PR does not fix #618** and does not claim to. #618 is a corrupt/evicted
`DynamicNode_*` assembly poisoning Orleans' `ReferencedAssemblyProvider` at `TestCluster.DeployAsync`.
Reasoning:

- This change alters only **when** `UnloadNodeContexts` runs during **mesh teardown**. The live-mesh
  path (node deleted / hub evicted) is deliberately unchanged, and `MessageHubGrain.OnDeactivateAsync`
  — which does its own `loadContext.Unload()` and already carries a documented KNOWN GAP for exactly
  this — is untouched.
- #618's mechanism is **enumerability after unload**, which no ordering change removes:
  `AssemblyLoadContext.Unload()` is asynchronous by contract, so the `Assembly` stays reachable from
  `AppDomain.CurrentDomain.GetAssemblies()` until the LoaderAllocator is actually collected — and
  Orleans' scan calls `assembly.IsDefined(...)` on it with no pin.
- The `NodeAssemblyLoadContext.Pin()` drain already in `Dispose()` was added for this exact error
  string (`TypeLoadException … format is invalid`) and does **not** cover Orleans' scan, because that
  scan takes no pin. That gap is what #618 needs — either refuse to load a truncated image, or keep
  dying assemblies out of the provider's enumerable set. Neither is an ordering fix.

Refs #613
