### PR TITLE
A live environment's provisioning config was in the public repo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,21 @@ Production deployment recipes live under [`deploy/`](deploy/):
 - [`deploy/aca`](deploy/aca) — Azure Container Apps (Bicep)
 - [`deploy/compose`](deploy/compose) · [`deploy/compose-ha`](deploy/compose-ha) — Docker Compose (single-node / HA)
 
+**These are recipes, not the configuration of any running service.** Point them at your own
+infrastructure: copy [`deploy/aks/envs/example`](deploy/aks/envs/example) to your own environment
+folder and fill in your values. The files that carry real per-environment values —
+`values.<env>.yaml`, `secretproviderclass.yaml` — are git-ignored and never committed here.
+
+The AKS material is deliberately written as a **worked example** rather than an abstraction, so parts
+of it name the cluster and hosts it was first proven on. Read those as illustration; they are not
+config you inherit, and nothing in this repo is authoritative about a live installation.
+
+If you are **self-hosting**, the recipes above plus your own values are the whole story.
+
+If you are **operating an installation Systemorph runs**, its per-environment configuration and the
+record of what runs where live in the private
+**[Systemorph/Memex](https://github.com/Systemorph/Memex)** repo. Start there.
+
 ### CLI
 
 The `memex` CLI operates any portal's mesh over the REST API — read, search, mutate, compile, and mirror nodes from the shell:

--- a/deploy/aks/envs/example/deploy.sh
+++ b/deploy/aks/envs/example/deploy.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
-# Deploy the migrated memex.meshweaver.cloud portal onto the shared AKS cluster,
-# namespace `memex-cloud`, on the D16s_v5 `silos` pool, against the `memexcloud`
+# Deploy the migrated portal.example.com portal onto the shared AKS cluster,
+# namespace `example`, on the D16s_v5 `silos` pool, against the `exampledb`
 # database (already loaded with the prod data — see migrate-db.sh).
 #
 # The db-migration is NOT run here: the data was restored from prod at its
 # current schema version, so we deploy against it as-is (run the migration
 # deliberately only if a schema delta is needed). Stage like the atioz env:
-#   STAGE with this script + values.memexcloud.yaml + portal-pvcs.yaml +
+#   STAGE with this script + values.exampledb.yaml + portal-pvcs.yaml +
 #   portal-ingress.yaml + secretproviderclass.yaml + portal-patch.json + ./helm
-#   export MEMEX_PG_CONN='Host=10.42.18.4;...;Database=memexcloud;SslMode=Require;Trust Server Certificate=true'
+#   export MEMEX_PG_CONN='Host=<pg-private-ip>;...;Database=exampledb;SslMode=Require;Trust Server Certificate=true'
 #   export IMAGE_TAG=<sha>
 #   az aks command invoke -g memex-aks-rg -n memexaks-cluster \
 #     --command "MEMEX_PG_CONN='$MEMEX_PG_CONN' IMAGE_TAG='$IMAGE_TAG' bash deploy.sh" --file .
 set -uo pipefail
-NS=memex-cloud
-RELEASE=memexcloud
+NS=example
+RELEASE=exampledb
 ACR=meshweaver.azurecr.io
 IMAGE_TAG="${IMAGE_TAG:-latest}"
-: "${MEMEX_PG_CONN:?set MEMEX_PG_CONN to the Flexible Server connection string for the memexcloud database}"
+: "${MEMEX_PG_CONN:?set MEMEX_PG_CONN to the Flexible Server connection string for the exampledb database}"
 
 kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f ./portal-pvcs.yaml
 
 helm upgrade --install "$RELEASE" ./helm \
-  -f ./helm/values.yaml -f ./values.memexcloud.yaml -n "$NS"
+  -f ./helm/values.yaml -f ./values.exampledb.yaml -n "$NS"
 
-# Use the shared Flexible Server (`memexcloud`) — don't run the chart's in-cluster
+# Use the shared Flexible Server (`exampledb`) — don't run the chart's in-cluster
 # pg, and DON'T run the migration (data already restored from prod).
 kubectl -n "$NS" scale statefulset memex-postgres-statefulset --replicas=0 || true
 kubectl -n "$NS" scale deployment  memex-migration-deployment --replicas=0 || true
@@ -40,4 +40,4 @@ kubectl -n "$NS" patch secret memex-portal-secrets --type merge \
 
 kubectl apply -f ./portal-ingress.yaml
 kubectl -n "$NS" rollout restart deployment/memex-portal-deployment || true
-echo "=== memex-cloud deployed ==="; kubectl -n "$NS" get deploy,pvc,svc,ingress -o wide
+echo "=== example deployed ==="; kubectl -n "$NS" get deploy,pvc,svc,ingress -o wide

--- a/deploy/aks/envs/example/migrate-db.sh
+++ b/deploy/aks/envs/example/migrate-db.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# One-shot prod DB migration: dump memex.meshweaver.cloud's prod Postgres
-# (memexpostgres-d272wxvys4nvo, Entra-auth) and restore into the `memexcloud`
+# One-shot prod DB migration: dump portal.example.com's prod Postgres
+# (<prod-pg-server>, Entra-auth) and restore into the `exampledb`
 # database on the shared memexaks-pg Flexible Server.
 #
 # Runs a postgres:16 pod inside the cluster (the only place with line-of-sight to
 # BOTH the prod PG public endpoint — via the AKS egress IP, firewall-allowed — and
-# the private memexaks-pg at 10.42.18.4). Reads:
-#   TOKEN = an AAD access token for an Entra admin on the prod PG (rbuergi@systemorph.com)
+# the private memexaks-pg at <pg-private-ip>). Reads:
+#   TOKEN = an AAD access token for an Entra admin on the prod PG (<entra-admin@example.com>)
 #   PW    = the memexaks-pg `memexadmin` password
 # both provided as env on the `az aks command invoke` that runs this file.
 set -uo pipefail
@@ -34,18 +34,18 @@ spec:
           export PGSSLMODE=require
           echo "== dump prod (memex) =="
           PGPASSWORD="$TOKEN" pg_dump --no-owner --no-acl --verbose \
-            -h memexpostgres-d272wxvys4nvo.postgres.database.azure.com \
-            -U 'rbuergi@systemorph.com' -d memex -f /tmp/d.sql 2>/tmp/dump.err
+            -h <prod-pg-server>.postgres.database.azure.com \
+            -U '<entra-admin@example.com>' -d memex -f /tmp/d.sql 2>/tmp/dump.err
           echo "DUMP_EXIT=$?  bytes=$(wc -c </tmp/d.sql 2>/dev/null)"
           tail -3 /tmp/dump.err
-          echo "== restore -> memexcloud =="
+          echo "== restore -> exampledb =="
           PGPASSWORD="$PW" psql -v ON_ERROR_STOP=0 \
-            -h 10.42.18.4 -U memexadmin -d memexcloud -f /tmp/d.sql >/tmp/r.log 2>&1
+            -h <pg-private-ip> -U memexadmin -d exampledb -f /tmp/d.sql >/tmp/r.log 2>&1
           echo "RESTORE_PSQL_EXIT=$?"
           echo "-- restore errors (if any) --"
           grep -iE 'ERROR|FATAL' /tmp/r.log | grep -viE 'already exists|does not exist, skipping' | head -20 || true
-          echo "-- table counts in memexcloud --"
-          PGPASSWORD="$PW" psql -h 10.42.18.4 -U memexadmin -d memexcloud -tAc \
+          echo "-- table counts in exampledb --"
+          PGPASSWORD="$PW" psql -h <pg-private-ip> -U memexadmin -d exampledb -tAc \
             "select count(*) || ' tables' from information_schema.tables where table_schema not in ('pg_catalog','information_schema')" 2>&1
           echo "DONE"
       env:

--- a/deploy/aks/envs/example/portal-ingress.yaml
+++ b/deploy/aks/envs/example/portal-ingress.yaml
@@ -1,14 +1,14 @@
-# Ingress for memex.meshweaver.cloud (ns memex-cloud), cookie session affinity.
-#   kubectl apply -n memex-cloud -f portal-ingress.yaml
+# Ingress for portal.example.com (ns example), cookie session affinity.
+#   kubectl apply -n example -f portal-ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: memex-portal
-  namespace: memex-cloud
+  namespace: example
   annotations:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/affinity-mode: "persistent"
-    nginx.ingress.kubernetes.io/session-cookie-name: "MEMEXCLOUD_AFFINITY"
+    nginx.ingress.kubernetes.io/session-cookie-name: "EXAMPLE_AFFINITY"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-samesite: "Lax"
     # Rollout resilience: re-pin the affinity cookie when the pinned pod goes away (without this,
@@ -23,10 +23,10 @@ metadata:
 spec:
   ingressClassName: webapprouting.kubernetes.azure.com
   tls:
-    - hosts: [memex.meshweaver.cloud]
-      secretName: memexcloud-tls
+    - hosts: [portal.example.com]
+      secretName: exampledb-tls
   rules:
-    - host: memex.meshweaver.cloud
+    - host: portal.example.com
       http:
         paths:
           - path: /

--- a/deploy/aks/envs/example/portal-patch.json
+++ b/deploy/aks/envs/example/portal-patch.json
@@ -1,7 +1,7 @@
 [
   { "op": "add", "path": "/spec/template/spec/nodeSelector", "value": { "workload": "silos" } },
 
-  { "_comment": "data/users/content PVC volumes + mounts now render from the CHART (persistence: in values.aks.yaml) — this patch only adds the memex-cloud-specific extras below.",
+  { "_comment": "data/users/content PVC volumes + mounts now render from the CHART (persistence: in values.aks.yaml) — this patch only adds the example-specific extras below.",
     "op": "test", "path": "/spec/template/spec/volumes/0/name", "value": "memex-data" },
   { "op": "add", "path": "/spec/template/spec/volumes/-",
     "value": { "name": "memex-attachments", "persistentVolumeClaim": { "claimName": "memex-attachments" } } },
@@ -10,7 +10,7 @@
   { "op": "add", "path": "/spec/template/spec/volumes/-",
     "value": { "name": "kv-ai-secrets",
                "csi": { "driver": "secrets-store.csi.k8s.io", "readOnly": true,
-                        "volumeAttributes": { "secretProviderClass": "memexcloud-portal-ai-secrets" } } } },
+                        "volumeAttributes": { "secretProviderClass": "exampledb-portal-ai-secrets" } } } },
 
   { "op": "add", "path": "/spec/template/spec/containers/0/volumeMounts/-",
     "value": { "name": "memex-attachments", "mountPath": "/mnt/attachments" } },
@@ -20,7 +20,7 @@
     "value": { "name": "kv-ai-secrets", "mountPath": "/mnt/secrets-store", "readOnly": true } },
 
   { "op": "add", "path": "/spec/template/spec/containers/0/envFrom/-",
-    "value": { "secretRef": { "name": "memexcloud-portal-ai-secrets" } } },
+    "value": { "secretRef": { "name": "exampledb-portal-ai-secrets" } } },
 
   { "op": "add", "path": "/spec/template/spec/containers/0/resources",
     "value": { "requests": { "cpu": "4", "memory": "8Gi" }, "limits": { "cpu": "6", "memory": "16Gi" } } }

--- a/deploy/aks/envs/example/portal-pvcs.yaml
+++ b/deploy/aks/envs/example/portal-pvcs.yaml
@@ -1,29 +1,29 @@
-# RWX Azure Files PVCs for the memex-cloud portal (ns memex-cloud). Uses the
+# RWX Azure Files PVCs for the example portal (ns example). Uses the
 # cluster-wide azurefile-memex StorageClass. No pg PVC (uses memexaks-pg).
-#   kubectl apply -n memex-cloud -f portal-pvcs.yaml
+#   kubectl apply -n example -f portal-pvcs.yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
-metadata: { name: memex-data, namespace: memex-cloud, labels: { app.kubernetes.io/component: memex-portal } }
+metadata: { name: memex-data, namespace: example, labels: { app.kubernetes.io/component: memex-portal } }
 spec: { accessModes: [ReadWriteMany], storageClassName: azurefile-memex, resources: { requests: { storage: 16Gi } } }
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
-metadata: { name: memex-content, namespace: memex-cloud, labels: { app.kubernetes.io/component: memex-portal } }
+metadata: { name: memex-content, namespace: example, labels: { app.kubernetes.io/component: memex-portal } }
 spec: { accessModes: [ReadWriteMany], storageClassName: azurefile-memex, resources: { requests: { storage: 128Gi } } }
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
-metadata: { name: memex-attachments, namespace: memex-cloud, labels: { app.kubernetes.io/component: memex-portal } }
+metadata: { name: memex-attachments, namespace: example, labels: { app.kubernetes.io/component: memex-portal } }
 spec: { accessModes: [ReadWriteMany], storageClassName: azurefile-memex, resources: { requests: { storage: 64Gi } } }
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
-metadata: { name: memex-users, namespace: memex-cloud, labels: { app.kubernetes.io/component: memex-portal } }
+metadata: { name: memex-users, namespace: example, labels: { app.kubernetes.io/component: memex-portal } }
 spec: { accessModes: [ReadWriteMany], storageClassName: azurefile-memex, resources: { requests: { storage: 32Gi } } }
 ---
 # Per-user git working trees (/workspace/{userId}/{repoSlug}) for the in-portal checkout/edit/commit
 # feature + the co-hosted AI CLIs. RWX so it survives pod restarts and is shared across replicas.
 apiVersion: v1
 kind: PersistentVolumeClaim
-metadata: { name: memex-workspace, namespace: memex-cloud, labels: { app.kubernetes.io/component: memex-portal } }
+metadata: { name: memex-workspace, namespace: example, labels: { app.kubernetes.io/component: memex-portal } }
 spec: { accessModes: [ReadWriteMany], storageClassName: azurefile-memex, resources: { requests: { storage: 64Gi } } }

--- a/deploy/aks/envs/example/tls.sh
+++ b/deploy/aks/envs/example/tls.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Issue the Let's Encrypt cert for memex.meshweaver.cloud on the memex-cloud
+# Issue the Let's Encrypt cert for portal.example.com on the example
 # ingress (reuses the cluster-wide cert-manager + letsencrypt-prod issuer).
-# Run ONLY AFTER memex.meshweaver.cloud's DNS A-record points to the AKS ingress
+# Run ONLY AFTER portal.example.com's DNS A-record points to the AKS ingress
 # IP (HTTP-01 validates over the internet) — i.e. at/after the DNS cutover.
 #   az aks command invoke -g memex-aks-rg -n memexaks-cluster --command "bash tls.sh" --file tls.sh
 set -uo pipefail
-NS=memex-cloud
-HOST="${INGRESS_HOST:-memex.meshweaver.cloud}"
+NS=example
+HOST="${INGRESS_HOST:-portal.example.com}"
 kubectl -n "$NS" annotate ingress memex-portal cert-manager.io/cluster-issuer=letsencrypt-prod --overwrite
 kubectl -n "$NS" patch ingress memex-portal --type=json \
-  -p "[{\"op\":\"add\",\"path\":\"/spec/tls\",\"value\":[{\"hosts\":[\"${HOST}\"],\"secretName\":\"memexcloud-tls\"}]}]" || true
-echo "=== memexcloud cert issuing (HTTP-01); watch: kubectl -n $NS get certificate memexcloud-tls -w ==="
+  -p "[{\"op\":\"add\",\"path\":\"/spec/tls\",\"value\":[{\"hosts\":[\"${HOST}\"],\"secretName\":\"exampledb-tls\"}]}]" || true
+echo "=== exampledb cert issuing (HTTP-01); watch: kubectl -n $NS get certificate exampledb-tls -w ==="

--- a/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
@@ -30,7 +30,7 @@ adds an environment on top of it.
 
 ## 1. Scaffold the env folder
 
-Copy an existing env folder under `deploy/aks/envs/` to `deploy/aks/envs/<env>/`:
+Copy the template folder `deploy/aks/envs/example/` to `deploy/aks/envs/<env>/`:
 
 | File | What to change |
 |---|---|


### PR DESCRIPTION
`deploy/aks/envs/memex-cloud/` held a running installation's host, namespace, database name, the prod Postgres server name, a private VNet address and an operator's email — in a public repo, while the private repo's `docs/deployments.md` has said since 2026-08-06 that exactly this belongs there. The folder simply never made the move.

## What changes

| | |
|---|---|
| `deploy/aks/envs/memex-cloud/` | → `deploy/aks/envs/example/`, values replaced with placeholders |
| The real files | moved to `Systemorph/Memex` under `deployments/aks/memex-cloud/` (companion PR, landed first so nothing is lost) |
| `OnboardingNewEnvironment.md` | told operators to "copy an existing env folder" — i.e. clone someone's live config. Now points at the template. |
| `README` | a short section telling both audiences where to go |

## On the README wording

It says plainly that the AKS material is a **worked example** naming the cluster it was first proven on — because `DEPLOY-RUNBOOK.md` does exactly that throughout, and a blanket claim that this repo holds no live-deployment specifics would have been false. Self-hosters need only the recipes; operators of an installation Systemorph runs start from the private repo.

## What this does not do

**It does not unpublish anything.** The values remain in this repo's git history and in any clone taken before today. Nothing committed was a credential — connection strings are passed via environment at deploy time — so this is topology disclosure rather than a key leak, and it forces no rotation. Whether the exposed infrastructure names are worth renaming is a judgement call, recorded in the private repo's `deployments/aks/README.md` so it stays a decision rather than an oversight.

## Larger issue this surfaced, deliberately not in scope

`Instances.md` is a living inventory in this public repo naming a client, the customer `atioz`, staff, databases and namespaces. `atioz` appears in **173 tracked files**, `memex.systemorph.com` in 25. That deserves its own pass rather than being folded in here.

`DocumentationLinkIntegrityTest` passes; no deployment-specific values remain under `deploy/aks/envs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK