### PR TITLE
One defect, reported once per target, became 66 incidents

### DIFF
--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -132,7 +132,8 @@ public static partial class LogLineParser
 
     /// <summary>
     /// Masks the volatile parts of a message so two occurrences of the same fault normalize to the
-    /// same text: guids, hex blobs, timestamps, quoted literals, paths, and bare numbers.
+    /// same text: guids, hex blobs, timestamps, quoted literals, paths, labelled identifiers, and
+    /// bare numbers.
     /// This is what keeps "node 7a2f… not found" and "node 91bc… not found" one incident.
     ///
     /// <para>Order matters. Guids and timestamps are masked FIRST so the path rule can then swallow
@@ -147,6 +148,7 @@ public static partial class LogLineParser
         masked = Path().Replace(masked, "{path}");
         masked = Quoted().Replace(masked, "'{value}'");
         masked = HexBlob().Replace(masked, "{hex}");
+        masked = LabelledIdentifier().Replace(masked, "${label}: {id}");
         masked = Number().Replace(masked, "{n}");
         return WhitespaceRun().Replace(masked, " ").Trim();
     }
@@ -205,6 +207,15 @@ public static partial class LogLineParser
 
     [GeneratedRegex(@"\b(?:0x)?[0-9a-fA-F]{16,}\b", RegexOptions.CultureInvariant)]
     private static partial Regex HexBlob();
+
+    // A bare identifier introduced by a known label — `target: Claims`, `sender: Edu`, `for: Foo`.
+    // These are the SUBJECT of a message, not the fault in it: one defect reported once per target
+    // produced one incident per target name until this masked them (66 incidents for ~3 real bugs,
+    // 2026-08-08). Only single tokens are masked, and only after these labels, so a genuine message
+    // like "Sequence contains no elements" is untouched.
+    [GeneratedRegex(@"\b(?<label>target|sender|for|from|to|node|hub|partition|user|area|space|type)\s*:\s*(?![{'""])[A-Za-z0-9_.\-/]+",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+    private static partial Regex LabelledIdentifier();
 
     [GeneratedRegex(@"(?<![A-Za-z_])\d+(?:\.\d+)?", RegexOptions.CultureInvariant)]
     private static partial Regex Number();

--- a/test/MeshWeaver.Observability.Test/LogLineParserTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogLineParserTest.cs
@@ -130,4 +130,49 @@ public class LogLineParserTest
         normalized.Should().Contain("{time}");
         normalized.Should().Contain("'{value}'");
     }
+
+    /// <summary>
+    /// A message that names WHO it is about must not fork the fingerprint per subject. Production
+    /// 2026-08-08: one ROUTER_TRAFFIC defect, reported once per target hub, produced ~50 incidents —
+    /// and would have produced ~50 tickets — because `target: Claims`, `target: Edu`, `target: X`
+    /// each normalized differently. `sender:` was already masked (it held a mesh path); `target:`
+    /// held a bare word and survived.
+    /// </summary>
+    [Fact]
+    public void Fingerprint_DoesNotForkOnTheSubjectOfTheMessage()
+    {
+        const string template =
+            "ROUTER_TRAFFIC: RawJson has the mesh hub as sender (sender: mesh/N-u6rl0oAUuc, target: {0}). "
+            + "The mesh hub is the ROUTER and must not execute work.";
+
+        var a = LogLineParser.Normalize(string.Format(template, "Claims"));
+        var b = LogLineParser.Normalize(string.Format(template, "Edu"));
+        var c = LogLineParser.Normalize(string.Format(template, "X"));
+
+        b.Should().Be(a);
+        c.Should().Be(a);
+        a.Should().Contain("target: {id}");
+    }
+
+    [Fact]
+    public void Normalize_LeavesOrdinaryProseAlone()
+    {
+        // The masking is keyed on a known label + a SINGLE token, so a real message keeps its words —
+        // over-masking would collapse genuinely different faults onto one fingerprint, which is the
+        // failure this system started with.
+        var normalized = LogLineParser.Normalize("Sequence contains no elements");
+
+        normalized.Should().Be("Sequence contains no elements");
+    }
+
+    [Fact]
+    public void Normalize_DoesNotDoubleMaskAnAlreadyMaskedValue()
+    {
+        // `sender:` is followed by a path that the path rule already turned into {path}; the
+        // identifier rule must not then rewrite it to {id} and undo the distinction.
+        var normalized = LogLineParser.Normalize("delivery (sender: rbuergi/Foo/Bar, target: Edu)");
+
+        normalized.Should().Contain("{path}");
+        normalized.Should().Contain("target: {id}");
+    }
 }


### PR DESCRIPTION
The first fully working sweep on `memex.systemorph.com` produced **66 incidents**. About fifty were the same ROUTER_TRAFFIC defect, split by who it was about:

```
... has the mesh hub as sender (sender: {path}, target: Claims)
                                                target: Edu
                                                target: X          ← ~50 of these
```

`sender:` was already masked — it held a mesh path, and the path rule caught it. **`target:` held a bare word**, which is not a guid, number, path or quoted literal, so it survived normalization and forked the fingerprint per subject. Left running, that was ~50 GitHub issues for ~3 real bugs.

## The fix

Normalization masks a single-token value after a known label (`target`, `sender`, `for`, `from`, `to`, `node`, `hub`, `partition`, `user`, `area`, `space`, `type`).

Deliberately narrow on **both** axes — only these labels, and only a lone token — because the opposite mistake is the one this system shipped with two days ago, where over-collapsing produced one fingerprint per *category* and tickets that named a component but not a defect. A value already rewritten to `{path}`/`{guid}` is skipped so the two rules don't fight.

Three tests: the same defect with different subjects is one fingerprint, ordinary prose is untouched, and an already-masked value is not re-masked.

## How it was found

By deploying, and reading the 66 nodes **before** they became tickets. The incidents were deleted and the watcher paused; nothing was filed. This is the third defect the deploy caught that the tests could not — the first two were in #965.

## Open question, deliberately not settled here

Whether `ROUTER_TRAFFIC` should be ticketed **at all**. It is a diagnostic that logs at `fail:` and fires once per target. If it shouldn't be, the answer is `IgnoreCategories` or an agent `Suppress` — not finer masking. That's a judgement about what deserves a ticket, not a defect, so it belongs with the maintainer rather than in this PR.

58 tests pass; full solution builds clean with CI's flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK