### PR TITLE
A zero budget is not an unmeetable one — the identity-read timeout test raced its own query

### DIFF
--- a/test/MeshWeaver.Auth.Test/IdentityUnavailableNotDeniedTests.cs
+++ b/test/MeshWeaver.Auth.Test/IdentityUnavailableNotDeniedTests.cs
@@ -245,15 +245,25 @@ public class ApiTokenRoleResolutionUnavailableTests(ITestOutputHelper output) : 
     }
 
     /// <summary>
-    /// The seam the handler branches on, exercised against the real workspace: a budget the read
-    /// cannot possibly meet must classify Unavailable rather than hand back an empty role set.
+    /// The seam the handler branches on: a read that reaches no verdict inside its budget must
+    /// classify Unavailable rather than hand back an empty role set.
+    ///
+    /// <para>🚨 Driven with a source that CANNOT emit (<see cref="Observable.Never{T}()"/>) rather
+    /// than a zero budget over the real query. A zero budget is not unmeetable: <c>Bounded</c>
+    /// applies <c>.Timeout(budget, …)</c>, whose timer is scheduled, while a warm cached query
+    /// emits SYNCHRONOUSLY during Subscribe — so the value beats the timer and the read resolves.
+    /// That made the original form pass on a warm cache and fail on a cold one; it went green
+    /// pre-merge and red on main. "Never emits" removes the race instead of widening the bound.</para>
     /// </summary>
     [Fact]
-    public async Task LoadDbRoles_WithUnmeetableBudget_IsUnavailable_NotEmptyRoles()
+    public async Task ReadThatReachesNoVerdict_IsUnavailable_NotEmptyRoles()
     {
-        var services = new ServiceCollection().AddSingleton<IMessageHub>(Mesh).BuildServiceProvider();
-
-        var outcome = await UserRoleResolver.LoadDbRolesAsync(services, "someuser", TimeSpan.Zero);
+        var outcome = await IdentityRead.Bounded(
+                Observable.Never<IReadOnlyCollection<string>>(),
+                TimeSpan.FromMilliseconds(50),
+                "LoadUserRoles(someuser)",
+                logger: null)
+            .FirstAsync();
 
         outcome.IsUnavailable.Should().BeTrue(
             "a read that could not complete says nothing about the user's grants — an empty set here "


### PR DESCRIPTION
Fixes a race in a test I merged an hour ago as part of #970.

## What happened

`LoadDbRoles_WithUnmeetableBudget_IsUnavailable_NotEmptyRoles` went **green on its own PR** and then **red on main** (`b96d20aca`, shard 2) — and green again on the next commit. Classic timing, not a regression.

## Why the budget was not unmeetable

`IdentityRead.Bounded` classifies via `.Timeout(budget, …)`. That timer is **scheduled**; a warm cached synced query emits **synchronously during Subscribe**. So with `TimeSpan.Zero`:

- warm cache → the value wins the race → `Resolved` → assertion fails
- cold cache → the timer wins → `Unavailable` → assertion passes

Same test, same product code, opposite outcomes depending on cache state. "Zero" bounds the *wait*, it does not prevent the *answer*.

## The fix

Drive the seam with `Observable.Never<T>()` — a source that **cannot** emit, so no verdict is reachable by construction and the classification under test is the only possible outcome.

This removes the race rather than widening a bound. No sleep, no retry, no relaxed assertion: the assertion text and its reasoning are byte-identical, and the 50 ms budget is now arbitrary because nothing can beat it.

Renamed to `ReadThatReachesNoVerdict_IsUnavailable_NotEmptyRoles` — the budget was never the interesting part.

## What is deliberately not changed

The product code. `Bounded`'s behaviour is correct: a read that answers inside its budget *should* resolve. The defect was in how the test tried to reach the unavailable branch.

The end-to-end companion (`LoadDbRoles_WithRealBudget_ResolvesEmptyForUserWithNoGrants`) keeps exercising the real workspace for the resolved path, so coverage of the live seam is not lost — only the branch that cannot be reached deterministically through a budget moved to the seam that can.

## Verification

`MeshWeaver.Auth.Test` **143/143** in Release, `-c Release -warnaserror` clean.

Note the trap generalizes: a zero or near-zero `.Timeout(...)` is never a reliable way to force the timeout branch when the source can complete synchronously. Force it with a source that cannot produce a value.
