### PR TITLE
The export shipped without the right to run it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -651,6 +651,44 @@ securityService.HasPermission("Anonymous", Permission.Read)
     .Subscribe(allowed => /* ... */);
 ```
 
+## 🧩 Library-seeded nodes need a library-seeded grant — the `Templates` partition
+
+**A partition whose nodes are seeded by library code must have its access grant seeded the same
+way, in the same call.** Otherwise the nodes exist on every mesh and are usable on none of them
+except where an admin happened to grant the right by hand.
+
+The `Templates` partition is the worked example. It holds the built-in "operations as scripts"
+Code nodes — `Templates/Export/{Pdf,Docx}` (seeded by `AddMarkdownExport()`) and
+`Templates/Import/{NodeCopy,Mirror}` (seeded by `AddGraph()`). Running one posts an
+`ExecuteScriptRequest` at the template, which is gated by
+`[RequiresPermission(Permission.Execute)]` **on the template's own path**. The templates shipped
+with no grant at all, so every non-admin's export died at the click with
+`"Access denied: user 'x' lacks Execute permission on 'Templates/Export/Pdf'"` (issue #423). The
+gate was correct — the missing grant was the bug.
+
+`ScriptTemplates.PublicExecuteGrant()` is that grant, seeded via
+`builder.AddMeshNodesIfAbsent(...)` from both call sites (either alone must land it; both together
+must land it once). Three properties make it the *minimum*, not a widening:
+
+| Choice | Why |
+|---|---|
+| `Public`, **not** `Anonymous` | A run writes its `Activity` into the caller's home (`ActivityParentPath = "{viewer}"`), which a signed-out visitor does not have. Granting Anonymous would buy nothing. |
+| `Viewer` (Read + Execute + Api) | Execute is what the gate checks; Read resolves the node. Viewer is the narrowest built-in role carrying Execute and grants **no** Create/Update/Delete — a user may run a template, never change one. |
+| `MainNode = "Templates"` | Scoped to the partition, per the scope invariant above. An empty `MainNode` here would be a **root** grant for every authenticated user. |
+
+> ### 🚨 Why this is seeded alongside the nodes and NOT as a migration
+> `Doc`'s equivalent Public/Anonymous grant is seeded **both** ways — statically in
+> `AddDocumentation()` *and* as PG rows by `DocumentationBackfill`. That second half exists because
+> doc pages are backfilled into the `doc` schema, so the SQL fold and `partition_access` need real
+> rows.
+>
+> `Templates` has no such half. Its nodes are `AddMeshNodes` statics served in-memory by
+> `StaticNodeQueryProvider`; **they never reach Postgres**, on a fresh mesh or a long-lived one. A
+> migration therefore could not cover them — it would write grant rows into a `templates` schema
+> that does not exist and that nothing reads. Seeding the grant where the nodes live is the only
+> placement that covers a fresh mesh and an existing deployment identically: both get it from the
+> next image, with no backfill.
+
 ---
 
 # Type-declared subtree gates (`NodeTypeGate`)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-export-works-without-being-an-admin.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-export-works-without-being-an-admin.md
@@ -1,0 +1,34 @@
+---
+Name: Exporting a page or deck no longer requires being an admin
+Category: What's New
+Description: Export to PDF, Export to DOCX and Copy node tree now run for any signed-in user — they previously failed with an access-denied error unless you happened to be an administrator.
+Icon: Sparkle
+---
+
+# Exporting a page or deck no longer requires being an admin
+
+Choosing **Export to PDF** on a page or a slide deck used to fail for most
+people with a message like:
+
+```
+Export failed: Templates/Export/Pdf: Access denied:
+user 'sglauser' lacks Execute permission on 'Templates/Export/Pdf'
+```
+
+The export itself was never broken. What was missing was permission to **run**
+it. Exports are built as small scripts that ship with the platform, and running
+one requires the Execute right on that script — but the scripts shipped without
+anyone being granted that right. Administrators had it by virtue of being
+administrators and so never saw the failure; everybody else was refused at the
+moment they clicked the button.
+
+Every signed-in user may now run the built-in scripts, so **Export to PDF**,
+**Export to DOCX**, **Send to contacts** and **Copy node tree** all work from an
+ordinary account.
+
+This does not open anything up beyond that. The permission granted is
+*read and run*, on the built-in scripts only — nobody gains the ability to add,
+edit or delete a script, and it confers nothing anywhere else in the mesh.
+An export still runs **as you**: it can only include content you were already
+allowed to read, and it still writes its result into your own home. Signed-out
+visitors are not included, since an export needs a home to write into.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -161,6 +161,15 @@ public static class GraphConfigurationExtensions
             // Doc/Architecture/AsynchronousCalls.md → "Static handlers compose".
             builder.AddMeshNodes(GraphImportTemplates.GetStaticNodes());
 
+            // …and the access grant that lets an ordinary (non-admin) user actually RUN them.
+            // ExecuteScriptRequest is gated on Permission.Execute on the template's own path, so
+            // without this every non-admin's node copy failed "lacks Execute permission on
+            // Templates/Import/NodeCopy" (issue #423). Seeded here, next to the nodes it guards,
+            // because those nodes are in-memory statics that never reach Postgres — so a
+            // migration could not cover them. IfAbsent: AddMarkdownExport() seeds the same
+            // partition-level grant, and either call alone must land it exactly once.
+            builder.AddMeshNodesIfAbsent(ScriptTemplates.PublicExecuteGrant());
+
             // Register services that don't need hub-level dependencies at the mesh level
             builder.ConfigureServices(services =>
             {

--- a/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
+++ b/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
@@ -101,6 +101,15 @@ public static class MarkdownExportExtensions
         // → "Operations as scripts". Stateless static helper, no DI provider.
         builder.AddMeshNodes(MarkdownExportTemplates.GetStaticNodes());
 
+        // …and the access grant that lets an ordinary (non-admin) user actually RUN them.
+        // ExecuteScriptRequest is gated on Permission.Execute on the template's own path, so
+        // without this every non-admin's export failed "lacks Execute permission on
+        // Templates/Export/Pdf" (issue #423 — the reopen reason). Seeded here, next to the nodes
+        // it guards, because those nodes are in-memory statics that never reach Postgres — so a
+        // migration could not cover them. IfAbsent: AddGraph() seeds the same partition-level
+        // grant, and either call alone must land it exactly once.
+        builder.AddMeshNodesIfAbsent(ScriptTemplates.PublicExecuteGrant());
+
         // Menu items, layout views, and the export request handler must live on the
         // node hubs (one per Markdown node) — that's where layout rendering runs and where
         // the user's click navigates. Registering on the mesh hub via ConfigureHub would

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -256,6 +256,33 @@ public record MeshBuilder
     }
 
     /// <summary>
+    /// Adds each node whose <see cref="MeshNode.Path"/> is not already seeded on this builder.
+    ///
+    /// <para>For PARTITION-LEVEL GOVERNANCE that several independent modules must each be able to
+    /// guarantee on their own. The motivating case is the <c>Templates</c> partition's access
+    /// grant (<see cref="ScriptTemplates.PublicExecuteGrant"/>): <c>AddGraph()</c> seeds
+    /// <c>Templates/Import/*</c> and <c>AddMarkdownExport()</c> seeds <c>Templates/Export/*</c>,
+    /// and either call ALONE must land the grant while both together must land it ONCE. Plain
+    /// <see cref="AddMeshNodes"/> appends unconditionally, so the two would seed a duplicate.</para>
+    ///
+    /// <para>State lives on this builder instance only — no static registry, nothing process-wide
+    /// (AGENTS.md → "No static collections").</para>
+    /// </summary>
+    /// <param name="nodes">The mesh nodes to add if their path is not already present.</param>
+    /// <returns>The builder for method chaining.</returns>
+    public MeshBuilder AddMeshNodesIfAbsent(params IEnumerable<MeshNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            if (MeshNodes.Any(existing =>
+                    string.Equals(existing.Path, node.Path, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            MeshNodes.Add(node);
+        }
+        return this;
+    }
+
+    /// <summary>
     /// Registers a type on the mesh-level TypeRegistry for cross-hub serialization.
     /// Use this to register content types that need to be serialized across hub boundaries.
     /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/ScriptTemplates.cs
+++ b/src/MeshWeaver.Mesh.Contract/ScriptTemplates.cs
@@ -1,0 +1,86 @@
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The <c>Templates</c> partition — the mesh-wide home of the built-in
+/// "operations as scripts" Code templates that library code seeds via
+/// <c>AddMeshNodes</c>: <c>Templates/Export/{Pdf,Docx}</c> (MeshWeaver.Markdown.Export)
+/// and <c>Templates/Import/{NodeCopy,Mirror}</c> (MeshWeaver.Graph).
+///
+/// <para>Every one of those templates runs by posting an <see cref="ExecuteScriptRequest"/>
+/// at the template node, and that request is gated by
+/// <c>[RequiresPermission(Permission.Execute)]</c> on the template's own path — so a caller
+/// with no grant on <c>Templates</c> is refused with
+/// <c>"Access denied: user 'x' lacks Execute permission on 'Templates/Export/Pdf'"</c>.
+/// The templates shipped without any accompanying grant, so only users who happened to
+/// already hold Execute there could export a deck or copy a node tree (issue #423).
+/// <b>The gate is correct — the missing grant was the bug.</b></para>
+///
+/// <para><see cref="PublicExecuteGrant"/> is that grant, and it is deliberately the
+/// SMALLEST one that makes an ordinary user's export work:</para>
+/// <list type="bullet">
+///   <item><b><see cref="WellKnownUsers.Public"/>, not <see cref="WellKnownUsers.Anonymous"/></b> —
+///     signed-in users only. A run writes its <c>Activity</c> into the caller's home
+///     (<c>ActivityParentPath = "{viewer}"</c>), which an unauthenticated visitor does not have,
+///     so granting Anonymous would buy nothing and widen the surface for free.</item>
+///   <item><b><see cref="Role.Viewer"/></b> (Read + Execute + Api) — Execute is the permission the
+///     gate checks, and Read is needed to resolve the template node at all. Viewer is the
+///     narrowest built-in role carrying Execute; it grants <b>no</b> Create / Update / Delete /
+///     Export, so an ordinary user still cannot add, edit or remove a template.</item>
+///   <item><b>Scoped to <see cref="Partition"/></b> via <c>MainNode</c> — NOT a root grant, and
+///     NOT public read on anything else. It confers nothing outside <c>Templates</c>, which holds
+///     only library-seeded static Code nodes. Running a template still executes under the
+///     CALLER's identity, so a script can only read what the caller could already read and only
+///     write where the caller could already write.</item>
+/// </list>
+///
+/// <para>See <c>Doc/Architecture/AccessControl.md</c> → "The scope invariant".</para>
+/// </summary>
+public static class ScriptTemplates
+{
+    /// <summary>
+    /// Partition (and access scope) the built-in script templates live under: <c>Templates</c>.
+    /// </summary>
+    public const string Partition = "Templates";
+
+    /// <summary>Namespace holding the partition's <c>AccessAssignment</c> satellites.</summary>
+    public const string AccessNamespace = $"{Partition}/_Access";
+
+    /// <summary>Path of the grant returned by <see cref="PublicExecuteGrant"/>.</summary>
+    public static readonly string PublicExecuteGrantPath =
+        $"{AccessNamespace}/{WellKnownUsers.Public}_Access";
+
+    /// <summary>
+    /// The <c>AccessAssignment</c> that lets every authenticated user RUN the built-in script
+    /// templates: <see cref="WellKnownUsers.Public"/> → <see cref="Role.Viewer"/>, scoped to
+    /// <see cref="Partition"/>.
+    ///
+    /// <para>Seeded via <c>AddMeshNodes</c> alongside the templates themselves (from both
+    /// <c>AddGraph()</c> and <c>AddMarkdownExport()</c>), which is what makes it land on a fresh
+    /// mesh AND on every existing deployment with no migration: the template nodes it guards are
+    /// themselves in-memory statics served by <c>StaticNodeQueryProvider</c> and are never
+    /// persisted to Postgres, so the grant has to live in exactly the same place they do.</para>
+    /// </summary>
+    /// <returns>The Public/Viewer grant node for the <c>Templates</c> partition.</returns>
+    public static MeshNode PublicExecuteGrant() =>
+        new($"{WellKnownUsers.Public}_Access", AccessNamespace)
+        {
+            NodeType = SecurityCollections.AccessAssignmentNodeType,
+            Name = $"{WellKnownUsers.Public} Access",
+            Description =
+                "Lets every authenticated user run the built-in script templates "
+                + "(export, node copy, mirror). Read + Execute only — no write.",
+            State = MeshNodeState.Active,
+            // 🔒 The scope invariant: MainNode MUST name the scope the path encodes. An empty
+            // MainNode here would be a ROOT grant merely filed under Templates/ — i.e. a data
+            // superuser grant for every authenticated user. See AccessControl.md.
+            MainNode = Partition,
+            Content = new AccessAssignment
+            {
+                AccessObject = WellKnownUsers.Public,
+                DisplayName = "All authenticated users",
+                Roles = [new RoleAssignment { Role = Role.Viewer.Id }]
+            }
+        };
+}

--- a/test/MeshWeaver.Security.Test/ScriptTemplateExecuteAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/ScriptTemplateExecuteAccessTest.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Markdown.Export;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Messaging;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Regression guard for issue <b>#423</b> (the reopen): an ORDINARY, NON-ADMIN user must be able to
+/// run the built-in script templates — <c>Templates/Export/{Pdf,Docx}</c> and
+/// <c>Templates/Import/{NodeCopy,Mirror}</c>.
+///
+/// <para>The defect: those templates are seeded by library code via <c>AddMeshNodes</c> with <b>no
+/// accompanying access grant</b>, while <see cref="ExecuteScriptRequest"/> is gated by
+/// <c>[RequiresPermission(Permission.Execute)]</c> on the template's own path. So every non-admin's
+/// export died with <c>"Access denied: user 'sglauser' lacks Execute permission on
+/// 'Templates/Export/Pdf'"</c>. The gate is correct; the missing grant was the bug, and the fix is
+/// <see cref="ScriptTemplates.PublicExecuteGrant"/>.</para>
+///
+/// <para>🚨 <b>Why the existing coverage could not catch this, and what this fixture does
+/// differently.</b> <c>DeckExportScriptRelayTest</c> / <c>ExportDocumentScriptRelayTest</c> derive
+/// from <see cref="MonolithMeshTestBase"/> and run as the auto-logged-in DevLogin ADMIN, whose root
+/// grant carries Execute everywhere — structurally unable to fail. This fixture therefore does two
+/// things they don't:</para>
+/// <list type="number">
+///   <item>calls <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> instead of
+///     <c>base.ConfigureMesh</c>, to OPT OUT of <c>TestUsers.PublicAdminAccess()</c> — that default
+///     grants <see cref="WellKnownUsers.Public"/> the <b>Admin</b> role at ROOT, which would hand
+///     every user Execute on everything and mask the defect completely;</item>
+///   <item>drives the export as <see cref="OrdinaryUser"/>, who is granted
+///     <see cref="Role.Editor"/> on the space being exported FROM and <b>deliberately nothing at
+///     all on <c>Templates</c></b> — exactly a real signed-in user's shape.</item>
+/// </list>
+/// </summary>
+public class ScriptTemplateExecuteAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A plain signed-in user — no admin anywhere. Named after the issue's reporter.</summary>
+    private const string OrdinaryUser = "sglauser";
+
+    private const string SpaceNs = "ExportSpace";
+    private const string SourceId = "Report";
+    private const string SourcePath = $"{SpaceNs}/{SourceId}";
+
+    private static readonly string ExportPdfTemplate =
+        $"{MarkdownExportTemplates.TemplatesNamespace}/{MarkdownExportTemplates.ExportPdfId}";
+    private static readonly string ExportDocxTemplate =
+        $"{MarkdownExportTemplates.TemplatesNamespace}/{MarkdownExportTemplates.ExportDocxId}";
+    private static readonly string ImportNodeCopyTemplate =
+        $"{GraphImportTemplates.TemplatesNamespace}/{GraphImportTemplates.NodeCopyId}";
+    private static readonly string ImportMirrorTemplate =
+        $"{GraphImportTemplates.TemplatesNamespace}/{GraphImportTemplates.MirrorId}";
+
+    // 🚨 ConfigureMeshBase, NOT base.ConfigureMesh — see the class remarks: the default adds
+    // TestUsers.PublicAdminAccess() (Public → Admin at ROOT), under which this test can never fail.
+    // AddGraph() (from the base) seeds Templates/Import/*; AddMarkdownExport() seeds
+    // Templates/Export/*. Both also seed the SAME partition-level grant, so this fixture doubles as
+    // the idempotency check on AddMeshNodesIfAbsent — a duplicate would show up as two grant nodes.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMarkdownExport()
+            .AddMeshNodes(
+                // The space the user exports FROM, plus the document itself.
+                new MeshNode(SpaceNs) { Name = "Export Space", NodeType = MarkdownNodeType.NodeType },
+                new MeshNode(SourceId, SpaceNs)
+                {
+                    Name = "Sample Document",
+                    NodeType = MarkdownNodeType.NodeType,
+                    Content = MarkdownContent.Parse(
+                        "# Sample\n\nA NONADMINTOKEN paragraph that must reach the rendered PDF.",
+                        "", SourcePath)
+                },
+                // The user's own home partition — the shape onboarding writes. A script run lands
+                // its Activity here (ActivityParentPath = "{viewer}"); every user is implicitly
+                // Admin of the scope equal to their own id, so no explicit home grant is needed.
+                new MeshNode(OrdinaryUser) { Name = "S Glauser", NodeType = "User" },
+                // The ONLY grant this user gets: Editor on the space being exported.
+                // Nothing whatsoever on Templates — that is the point of the test.
+                AssignmentNodeFactory.UserRole(OrdinaryUser, Role.Editor.Id, SpaceNs));
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private void SignInAsOrdinaryUser()
+    {
+        var ctx = new AccessContext { ObjectId = OrdinaryUser, Name = "S Glauser" };
+        Access.SetContext(ctx);
+        Access.SetCircuitContext(ctx);
+    }
+
+    private void SignOut()
+    {
+        Access.SetContext(null);
+        Access.SetCircuitContext(null);
+    }
+
+    private Task<Permission> EffectivePermissions(string path)
+        => Mesh.GetEffectivePermissions(path, OrdinaryUser)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+    /// <summary>
+    /// The precise pin: a non-admin holds <see cref="Permission.Execute"/> on every built-in script
+    /// template — and still holds NO write there. Covers Import as well as Export, because
+    /// <c>Templates/Import/NodeCopy</c> shipped with the identical exposure and is dispatched
+    /// through the same gate by <c>NodeCopyDispatchHandler</c>.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task OrdinaryUser_CanExecuteBuiltInScriptTemplates_ButCannotWriteThem()
+    {
+        foreach (var template in new[]
+                 {
+                     ExportPdfTemplate, ExportDocxTemplate,
+                     ImportNodeCopyTemplate, ImportMirrorTemplate
+                 })
+        {
+            var effective = await EffectivePermissions(template);
+            Output.WriteLine($"{OrdinaryUser} on {template}: {effective}");
+
+            effective.Should().HaveFlag(Permission.Execute,
+                $"an ordinary signed-in user must be able to RUN {template} — " +
+                "ExecuteScriptRequest is gated on Execute on this exact path (issue #423)");
+            effective.Should().HaveFlag(Permission.Read,
+                $"{template} must be resolvable by the caller for the dispatch to find it");
+
+            // Minimum grant: Viewer, never Editor/Admin. A user may run a template, never change it.
+            effective.Should().NotHaveFlag(Permission.Create,
+                $"the Templates grant must not confer Create on {template}");
+            effective.Should().NotHaveFlag(Permission.Update,
+                $"the Templates grant must not confer Update on {template}");
+            effective.Should().NotHaveFlag(Permission.Delete,
+                $"the Templates grant must not confer Delete on {template}");
+        }
+    }
+
+    /// <summary>
+    /// The grant is scoped to <c>Templates</c> and must not leak anywhere else — it is emphatically
+    /// NOT a root grant filed under <c>Templates/</c> (AccessControl.md → "The scope invariant").
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TemplatesGrant_DoesNotLeakOutsideTheTemplatesPartition()
+    {
+        var atRoot = await EffectivePermissions("");
+        atRoot.Should().NotHaveFlag(Permission.Execute,
+            "the Templates grant is scoped to Templates — it must confer nothing at ROOT");
+
+        // A partition the user has no business in stays closed.
+        var elsewhere = await EffectivePermissions(MonolithMeshTestBase.TestPartition);
+        elsewhere.Should().NotHaveFlag(Permission.Read,
+            "an ungranted partition must stay unreadable — the Templates grant must not widen it");
+    }
+
+    /// <summary>
+    /// The user-visible acceptance criterion from #423: a NON-ADMIN clicks "Export to PDF" and gets
+    /// a PDF. Before the fix this failed at dispatch with
+    /// <c>"Templates/Export/Pdf: Access denied: … lacks Execute permission"</c> on
+    /// <see cref="ExportDocumentResponse.Error"/>.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task OrdinaryUser_ExportsDocumentToPdf_EndToEnd()
+    {
+        SignInAsOrdinaryUser();
+        try
+        {
+            var request = new ExportDocumentRequest(SourcePath, new DocumentExportOptions
+            {
+                Format = ExportFormat.Pdf,
+                Title = "Sample Document",
+                CoverPage = false,
+                TableOfContents = false
+            });
+
+            var dispatch = await Mesh
+                .Observe<ExportDocumentResponse>(request, o => o.WithTarget(new Address(SourcePath)))
+                .Should().Within(60.Seconds()).Emit();
+
+            // THE regression assertion — this is the exact string the issue reports.
+            dispatch.Message.Error.Should().BeNullOrEmpty(
+                "a non-admin's export must dispatch, not be refused for lack of Execute on " +
+                $"{ExportPdfTemplate} (issue #423)");
+            dispatch.Message.ActivityPath.Should().NotBeNullOrEmpty(
+                "the response should carry the running activity's path");
+
+            var workspace = GetClient(c => c.AddData()).GetWorkspace();
+            var terminal = await workspace
+                .GetMeshNodeStream(dispatch.Message.ActivityPath)
+                .Select(node => node?.Content as ActivityLog)
+                .Should().Within(2.Minutes())
+                .Match(log => log is not null && log.Status != ActivityStatus.Running);
+
+            terminal!.Status.Should().Be(ActivityStatus.Succeeded,
+                because: "the non-admin's export should render without errors. Messages:\n  "
+                         + string.Join("\n  ",
+                             terminal.Messages.Select(m => $"[{m.LogLevel}] {m.Message}")));
+
+            terminal.ReturnValue.Should().NotBeNull("the script should record its rendered output");
+            var rendered = terminal.ReturnValue!.Value
+                .Deserialize<RenderedDocument>(Mesh.JsonSerializerOptions);
+            rendered.Should().NotBeNull();
+            rendered!.Format.Should().Be(ExportFormat.Pdf);
+            rendered.MimeType.Should().Be("application/pdf");
+            rendered.Content.Should().NotBeNull().And.NotBeEmpty();
+            rendered.Content.Length.Should().BeGreaterThan(100,
+                "a real PDF is at least a few hundred bytes");
+        }
+        finally
+        {
+            SignOut();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #423 (the reopen — the access defect, not the feature).

## The defect

Every non-admin who clicked **Export to PDF** was refused, exactly as @sierragolflima reported:

```
Templates/Export/Pdf: Access denied: user 'sglauser'
lacks Execute permission on 'Templates/Export/Pdf'
```

The export feature itself is complete and correct. What was missing was **one access grant**:

- The built-in "operations as scripts" templates are seeded by library code via `AddMeshNodes` — `Templates/Export/{Pdf,Docx}` by `AddMarkdownExport()`, `Templates/Import/{NodeCopy,Mirror}` by `AddGraph()`.
- Running one posts an `ExecuteScriptRequest`, gated by `[RequiresPermission(Permission.Execute)]` **on the template's own path** (`ExecuteScriptRequest.cs:18`).
- Nothing ever granted that right (zero occurrences of `Templates/_Access` in the tree), and nothing in the export path impersonates System — the script genuinely runs as the caller, which is the intended design.

Admins held Execute by being admins and never saw the failure. Everyone else was refused at the click.

**The gate is correct; the missing grant was the bug.** So the fix is the grant — `[RequiresPermission(Permission.Execute)]` is untouched.

## Scope — Import had the identical exposure

`Templates/Import/NodeCopy` is seeded the same way and dispatched through the same gate by `NodeCopyDispatchHandler.cs:43`. The grant is therefore scoped to the **`Templates` partition**, fixing both at once rather than leaving the twin to be rediscovered from the other direction.

## The design choice: alongside the nodes, not a migration — and it is forced, not preferred

`Doc`'s equivalent Public/Anonymous grant is seeded **both** ways: statically in `AddDocumentation()` *and* as PG rows by `DocumentationBackfill.cs:203`. That second half exists because doc pages are backfilled into the `doc` schema, so the SQL fold and `partition_access` need real rows.

**`Templates` has no such half.** Its nodes are `AddMeshNodes` statics served in-memory by `StaticNodeQueryProvider`; they never reach Postgres, on a fresh mesh or a long-lived one. A migration could not cover them — it would write grant rows into a `templates` schema that does not exist and that nothing reads.

So seeding the grant where the nodes live is the only placement that covers both cases identically:

| | How it is covered |
|---|---|
| **Fresh mesh** | `AddGraph()` / `AddMarkdownExport()` seed the grant in the same call that seeds the templates. Nothing else to run. |
| **Existing deployment** (memex, atioz, …) | Same code path — the grant is in-memory alongside the in-memory templates, so it arrives with the next image. **No backfill, no migration, no manual grant.** |

This also answers the open verification question from the issue: the cloud portals were affected (there is no grant in source), and they are fixed by the next roll rather than by an operator applying something by hand.

## The grant is the minimum, not a widening

`ScriptTemplates.PublicExecuteGrant()` — and each choice is deliberate:

| Choice | Why |
|---|---|
| `Public`, **not** `Anonymous` | A run writes its `Activity` into the caller's home (`ActivityParentPath = "{viewer}"`), which a signed-out visitor has not got. Granting Anonymous would buy nothing and widen the surface for free. |
| `Viewer` (Read + Execute + Api) | Execute is what the gate checks; Read resolves the node. Viewer is the **narrowest built-in role carrying Execute**, and grants no Create/Update/Delete — you may run a template, never change one. |
| `MainNode = "Templates"` | Scoped to the partition, per AccessControl.md's scope invariant. An empty `MainNode` here would be a **root** grant for every authenticated user. |

Not public read on anything else: `Templates` holds only library-seeded static Code nodes, and running a template still executes **as the caller** — it can only read what the caller could already read and only write where they could already write.

`AddMeshNodesIfAbsent` is new because both `AddGraph()` and `AddMarkdownExport()` must each be able to land the partition-level grant **alone**, while the two together land it **once**; plain `AddMeshNodes` appends unconditionally. Builder instance state only — no static registry.

## The regression test fails against current main

The two existing e2e export tests structurally could not catch this: both derive from `MonolithMeshTestBase`, which **auto-logs in as Admin**.

`ScriptTemplateExecuteAccessTest` does two things differently:

1. calls `ConfigureMeshBase` to **opt out of `TestUsers.PublicAdminAccess()`** — that default grants `Public` the **Admin** role at ROOT, which would hand every user Execute on everything and mask the defect completely;
2. drives the export as `sglauser`, granted `Editor` on the source space and **deliberately nothing on `Templates`**.

Verified by reverting only the two seeding lines (i.e. reproducing main exactly):

```
[FAIL] OrdinaryUser_ExportsDocumentToPdf_EndToEnd
  Expected value to be null or empty …, but found
  "Templates/Export/Pdf: Access denied: user 'sglauser'
   lacks Execute permission on 'Templates/Export/Pdf'"

[FAIL] OrdinaryUser_CanExecuteBuiltInScriptTemplates_ButCannotWriteThem
  Expected None to have flag Execute …
  (stdout: sglauser on Templates/Export/Pdf: None)
```

— the reported string, verbatim. With the fix restored: **3/3 pass**.

The third test (`TemplatesGrant_DoesNotLeakOutsideTheTemplatesPartition`) passes both ways by design — it is the over-granting guard, pinning that the grant confers nothing at ROOT and does not widen an ungranted partition.

## Verification

Release + `-warnaserror`, clean:

| Suite | Result |
|---|---|
| `MeshWeaver.Security.Test` (full) | **384/384** |
| `MeshWeaver.Documentation.Test` (incl. link integrity) | **19/19** |
| The 4 pre-existing export e2e tests (`DeckExportScriptRelay`, `ExportDocumentScriptRelay`, `SendDocumentToContacts`) | **4/4** |
| `ScriptTemplateExecuteAccessTest` | **3/3** (2 fail without the fix) |

## Out of scope

**Pixel-faithful slide rendering** (gradient backgrounds / raw-HTML slides, needing headless Chromium in the portal image) remains deliberately deferred — the QuestPDF route is content-faithful by design. It is unrelated to this access defect and should be tracked separately rather than keeping #423 open by implication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)