### PR TITLE
Cleanup asked Postgres for 12,000 locks from a 6,400-slot table

### DIFF
--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CleanupLockFootprintTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CleanupLockFootprintTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Measures what <see cref="PostgreSqlFixture.CleanDataAsync"/> costs the Postgres LOCK TABLE, and
+/// pins that the cost does not grow with the number of partition schemas the run has accumulated
+/// (issue #977).
+///
+/// <para><b>The defect this measures.</b> Cleanup emptied every <c>(schema, table)</c> pair in the
+/// container from ONE command. Npgsql sends a multi-statement command as a single implicit
+/// transaction, so every targeted table AND every one of its indexes was locked simultaneously
+/// (<c>mesh_nodes</c> alone carries 11 indexes). PostgreSQL's lock table is a fixed shared-memory
+/// array — <c>max_locks_per_transaction × (max_connections + max_prepared_transactions)</c>, 6400
+/// slots at this container's defaults — and nothing ever dropped a partition schema, so the price
+/// every later test paid only ever went up, until a test tipped it over into
+/// <c>Npgsql.PostgresException 53200: out of shared memory</c>. The victim was whichever test ran at
+/// the tipping point, which is why it read as an unrelated regression in that test's own class.</para>
+///
+/// <para><b>Why a measurement and not an integration run.</b> The failure is CI-only BY
+/// CONSTRUCTION: a local container is short-lived and never accumulates ~50 partition schemas, so a
+/// green suite proves nothing about it. What proves the fix is the SHAPE of the cost — this test
+/// accumulates partitions itself and reads the lock count straight out of <c>pg_locks</c> from
+/// inside the very transaction that holds them, so the number is exact and never races.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class CleanupLockFootprintTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+{
+    /// <summary>Partitions accumulated for the first measurement.</summary>
+    private const int SmallAccumulation = 4;
+
+    /// <summary>Partitions accumulated for the second measurement — 5× the first.</summary>
+    private const int LargeAccumulation = 20;
+
+    /// <summary>
+    /// The lock footprint of the cleanup must be a function of the BATCH BOUND, not of how many
+    /// partition schemas the container has accumulated.
+    ///
+    /// <para>Both shapes are produced by the shipping <see cref="PostgreSqlFixture.BuildCleanupBatches"/>
+    /// — the pre-fix shape is simply the same call with the bound set to "everything", so this
+    /// compares the real code against its own unbounded predecessor rather than a re-implementation
+    /// of it.</para>
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public async Task CleanupLockFootprint_StaysBounded_WhileUnchunkedGrowsWithAccumulatedPartitions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var prefix = "zzlock" + Guid.NewGuid().ToString("N")[..8];
+        try
+        {
+            // ── Accumulate a handful of partitions, and measure. ──────────────────────────────
+            await AccumulatePartitionsAsync(prefix, 0, SmallAccumulation, ct);
+            var smallTargets = await CleanupTargetsAsync(prefix, ct);
+            var smallUnchunked = await PeakRelationLocksAsync(Unchunked(smallTargets), ct);
+            var smallChunked = await PeakRelationLocksAsync(
+                PostgreSqlFixture.BuildCleanupBatches(smallTargets), ct);
+
+            // ── Accumulate 5× as many, and measure the same two shapes again. ─────────────────
+            await AccumulatePartitionsAsync(prefix, SmallAccumulation, LargeAccumulation, ct);
+            var largeTargets = await CleanupTargetsAsync(prefix, ct);
+            var largeUnchunked = await PeakRelationLocksAsync(Unchunked(largeTargets), ct);
+            var largeChunked = await PeakRelationLocksAsync(
+                PostgreSqlFixture.BuildCleanupBatches(largeTargets), ct);
+
+            output.WriteLine(string.Create(CultureInfo.InvariantCulture,
+                $"""
+                 partitions={SmallAccumulation}  pairs={smallTargets.Count}  unchunked={smallUnchunked} locks  chunked={smallChunked} locks
+                 partitions={LargeAccumulation}  pairs={largeTargets.Count}  unchunked={largeUnchunked} locks  chunked={largeChunked} locks
+                 """));
+
+            // The premise: the work itself IS proportional to accumulated partitions. 5× the
+            // partitions, 5× the (schema, table) pairs to empty. That is inherent and fine — what
+            // must not be proportional is how many of those locks are held AT ONCE.
+            largeTargets.Count.Should().Be(
+                smallTargets.Count * LargeAccumulation / SmallAccumulation,
+                "each accumulated partition adds the same fixed set of tables to clean");
+
+            // 🚨 The defect, reproduced: as a single transaction, the lock footprint tracks the
+            // pair count — 5× the partitions, ~5× the locks held simultaneously. Extrapolated to a
+            // full suite's worth of accumulated schemas, that is what reaches 53200.
+            largeUnchunked.Should().BeGreaterThan(
+                smallUnchunked * 4,
+                "unchunked, every accumulated partition's tables and indexes are locked at once");
+
+            // 🚨 The fix: chunked, the peak is set by MaxTablesPerCleanupBatch alone. Accumulating
+            // 5× the partitions does not raise it at all.
+            largeChunked.Should().Be(
+                smallChunked,
+                "the chunk bound, not the accumulated schema count, decides the lock footprint");
+
+            // And the bound is a real reduction, not a rounding: cleaning 20 partitions chunked
+            // holds fewer locks at once than cleaning 4 partitions in one transaction did.
+            largeChunked.Should().BeLessThan(
+                smallUnchunked,
+                "the bounded footprint is below the unbounded one at a fifth of the load");
+
+            // No batch may exceed the bound — the property the lock count follows from.
+            foreach (var batch in PostgreSqlFixture.BuildCleanupBatches(largeTargets))
+                CountDeletes(batch).Should().BeLessThanOrEqualTo(PostgreSqlFixture.MaxTablesPerCleanupBatch);
+        }
+        finally
+        {
+            // The fixture created these schemas, so the fixture drops them — the same call
+            // CleanDataAsync makes. Nothing is left behind for the next test to pay for.
+            await fixture.DropTrackedSchemasAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// The source-side half of #977: a schema the fixture created is GONE after a clean, together
+    /// with its <c>public.searchable_schemas</c> registration — so accumulation stops at zero
+    /// instead of growing for the container's lifetime.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CleanData_DropsTheSchemasTheFixtureCreated_AndDeregistersThem()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var schema = "zzdrop" + Guid.NewGuid().ToString("N")[..8];
+
+        await fixture.CreateSchemaAdapterAsync(schema, StandardPartition(schema), ct);
+        // Register it the way a provisioned partition registers itself, so the de-registration is
+        // actually exercised rather than trivially true.
+        await using (var register = fixture.DataSource.CreateCommand(
+            "INSERT INTO public.searchable_schemas (schema_name) VALUES ($1) ON CONFLICT DO NOTHING"))
+        {
+            register.Parameters.AddWithValue(schema);
+            await register.ExecuteNonQueryAsync(ct);
+        }
+
+        (await SchemaCountAsync(schema, ct)).Should().Be(1L, "the fixture just created it");
+        (await CleanupTargetsAsync(schema, ct)).Count.Should()
+            .BeGreaterThan(0, "its tables are cleanup targets while it exists");
+
+        await fixture.CleanDataAsync(ct);
+
+        (await SchemaCountAsync(schema, ct)).Should().Be(0L, "CleanData drops what the fixture created");
+        (await CleanupTargetsAsync(schema, ct)).Count.Should()
+            .Be(0, "a dropped schema costs later tests nothing");
+        (await RegisteredCountAsync(schema, ct)).Should()
+            .Be(0L, "a searchable_schemas row naming a dropped schema would break the cross-schema union");
+    }
+
+    /// <summary>
+    /// A framework schema <see cref="PostgreSqlFixture.InitializeAsync"/> provisions once per
+    /// container survives a clean even when a test built an adapter over it — dropping it would
+    /// take the container's framework state (the V27 access-object mirror) with it.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CleanData_NeverDropsAFrameworkSchema_EvenWhenATestAdaptsIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await fixture.CreateSchemaAdapterAsync("auth", null, ct);
+        await fixture.CleanDataAsync(ct);
+
+        (await SchemaCountAsync("auth", ct)).Should().Be(1L, "auth is framework state, not test data");
+        (await SchemaCountAsync("system_access", ct)).Should().Be(1L, "so is system_access");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The pre-#977 shape: ONE batch holding every DELETE, i.e. the same builder with the bound
+    /// lifted to the whole target list.
+    /// </summary>
+    private static IReadOnlyList<string> Unchunked(IReadOnlyList<(string Schema, string Table)> targets)
+        => PostgreSqlFixture.BuildCleanupBatches(targets, Math.Max(targets.Count, 1));
+
+    /// <summary>A standard content partition — the satellite layout a real Space/User carries.</summary>
+    private static PartitionDefinition StandardPartition(string schema) => new()
+    {
+        Namespace = schema,
+        Schema = schema,
+        TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+        NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+    };
+
+    /// <summary>
+    /// Provisions partitions <paramref name="from"/>..<paramref name="to"/> through the fixture's
+    /// own <see cref="PostgreSqlFixture.CreateSchemaAdapterAsync"/> — real schemas with the real
+    /// table and index layout, so the lock counts measured are the ones production cleanup incurs.
+    /// The per-schema data sources are released immediately (each holds a physical connection).
+    /// </summary>
+    private async Task AccumulatePartitionsAsync(string prefix, int from, int to, CancellationToken ct)
+    {
+        for (var i = from; i < to; i++)
+        {
+            var schema = prefix + i.ToString(CultureInfo.InvariantCulture);
+            await fixture.CreateSchemaAdapterAsync(schema, StandardPartition(schema), ct);
+        }
+        await fixture.DisposeTrackedSchemaDataSourcesAsync();
+    }
+
+    /// <summary>
+    /// The cleanup targets the fixture itself would resolve, narrowed to the schemas this test
+    /// accumulated so the measurement is unaffected by whatever else the collection left behind.
+    /// </summary>
+    private async Task<IReadOnlyList<(string Schema, string Table)>> CleanupTargetsAsync(
+        string prefix, CancellationToken ct)
+        => (await fixture.DiscoverPerSchemaCleanupTargetsAsync(ct))
+            .Where(t => t.Schema.StartsWith(prefix, StringComparison.Ordinal))
+            .ToArray();
+
+    /// <summary>
+    /// Executes each batch in its own transaction and reads, FROM INSIDE that transaction, how many
+    /// relation locks it holds — <c>pg_locks</c> filtered to this backend is the exact set of locks
+    /// the batch put in the shared lock table, so there is nothing to sample and nothing to race.
+    /// Every transaction is rolled back: this measures the cost, it does not perform the cleanup.
+    /// </summary>
+    private async Task<int> PeakRelationLocksAsync(IReadOnlyList<string> batches, CancellationToken ct)
+    {
+        await using var connection = await fixture.DataSource.OpenConnectionAsync(ct);
+        var peak = 0;
+        foreach (var batch in batches)
+        {
+            await using var tx = await connection.BeginTransactionAsync(ct);
+            await using (var cmd = new NpgsqlCommand(batch, connection, tx))
+                await cmd.ExecuteNonQueryAsync(ct);
+            await using (var probe = new NpgsqlCommand(
+                "SELECT count(*) FROM pg_locks WHERE pid = pg_backend_pid() AND locktype = 'relation'",
+                connection, tx))
+                peak = Math.Max(peak, (int)(long)(await probe.ExecuteScalarAsync(ct))!);
+            await tx.RollbackAsync(ct);
+        }
+        return peak;
+    }
+
+    private async Task<long> SchemaCountAsync(string schema, CancellationToken ct)
+    {
+        await using var cmd = fixture.DataSource.CreateCommand(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = $1");
+        cmd.Parameters.AddWithValue(schema);
+        return (long)(await cmd.ExecuteScalarAsync(ct))!;
+    }
+
+    private async Task<long> RegisteredCountAsync(string schema, CancellationToken ct)
+    {
+        await using var cmd = fixture.DataSource.CreateCommand(
+            "SELECT COUNT(*) FROM public.searchable_schemas WHERE schema_name = $1");
+        cmd.Parameters.AddWithValue(schema);
+        return (long)(await cmd.ExecuteScalarAsync(ct))!;
+    }
+
+    private static int CountDeletes(string batch)
+        => batch.Split("DELETE FROM", StringSplitOptions.None).Length - 1;
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CleanupLockFootprintTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CleanupLockFootprintTests.cs
@@ -149,6 +149,49 @@ public class CleanupLockFootprintTests(PostgreSqlFixture fixture, ITestOutputHel
     }
 
     /// <summary>
+    /// 🚨 A schema the fixture did NOT create survives a clean, even when a test builds an adapter
+    /// over it. Ownership means "we created it", never "we have seen the name".
+    ///
+    /// <para><b>Why this is the sharpest edge of the drop.</b> <c>CREATE SCHEMA IF NOT EXISTS</c>
+    /// succeeds silently on a schema somebody else made, so tracking every adapted name would make
+    /// CleanData drop a partition the mesh provisioned — destructively, silently, and only once some
+    /// future test adapts a pre-existing partition. The blast radius is another test's data, which
+    /// surfaces as cross-test bleed that looks like an unrelated defect: exactly the confusion #977
+    /// cost time on in the first place.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CleanData_LeavesAPreExistingSchemaStanding_WhenATestOnlyAdaptsIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var schema = "zzpre" + Guid.NewGuid().ToString("N")[..8];
+
+        // Provisioned by somebody else — the mesh's own partition DDL, exactly how a real partition
+        // arrives in the container.
+        await using (var provision = fixture.DataSource.CreateCommand(
+            "SELECT public.ensure_partition_schema($1)"))
+        {
+            provision.Parameters.AddWithValue(schema);
+            await provision.ExecuteNonQueryAsync(ct);
+        }
+        try
+        {
+            // A test now adapts it. The CREATE inside raises 42P06 — not ours.
+            await fixture.CreateSchemaAdapterAsync(schema, StandardPartition(schema), ct);
+
+            await fixture.CleanDataAsync(ct);
+
+            (await SchemaCountAsync(schema, ct)).Should()
+                .Be(1L, "the fixture did not create this schema, so it is not the fixture's to drop");
+        }
+        finally
+        {
+            await using var drop = fixture.DataSource.CreateCommand(
+                $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+            await drop.ExecuteNonQueryAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
     /// A framework schema <see cref="PostgreSqlFixture.InitializeAsync"/> provisions once per
     /// container survives a clean even when a test built an adapter over it — dropping it would
     /// take the container's framework state (the V27 access-object mirror) with it.

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlFixture.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlFixture.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading;
@@ -32,6 +34,52 @@ public class PostgreSqlFixture : IAsyncLifetime
     // batches pushed past max_connections=100 even with MaxPoolSize=1.
     private readonly System.Collections.Concurrent.ConcurrentBag<NpgsqlDataSource>
         _trackedSchemaDataSources = new();
+
+    // Names of the partition schemas CreateSchemaAdapterAsync created. Dropped by
+    // CleanDataAsync together with their data sources (#977): nothing else ever removed
+    // them, so every partition a test left behind stayed in the container for the rest of
+    // the run and every LATER test paid for it — see MaxTablesPerCleanupBatch.
+    private readonly System.Collections.Concurrent.ConcurrentBag<string> _trackedSchemas = new();
+
+    /// <summary>
+    /// Schemas <see cref="InitializeAsync"/> provisions once per container (mirroring the prod
+    /// migration) plus the catalog schemas. A test may legitimately build an adapter over one of
+    /// them; dropping it would take the whole container's framework state with it, so they are
+    /// never dropped even when tracked.
+    /// </summary>
+    private static readonly System.Collections.Immutable.ImmutableHashSet<string> UndroppableSchemas =
+        System.Collections.Immutable.ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "public", "auth", "system_access", "information_schema");
+
+    /// <summary>
+    /// Upper bound on the number of <c>(schema, table)</c> DELETEs <see cref="CleanDataAsync"/>
+    /// puts into ONE transaction — the fix for #977.
+    ///
+    /// <para>Npgsql sends a multi-statement command as a single implicit transaction, so the old
+    /// "one batched DELETE over every pair in the container" held a lock on every targeted table
+    /// AND every one of its indexes simultaneously (<c>mesh_nodes</c> alone carries 11 indexes →
+    /// ~12 locks per pair). PostgreSQL's lock table is a fixed shared-memory array of
+    /// <c>max_locks_per_transaction × (max_connections + max_prepared_transactions)</c> slots —
+    /// 6400 at the container's defaults — so the cost of cleanup grew with every partition schema
+    /// any earlier test left behind until it tipped over into
+    /// <c>Npgsql.PostgresException 53200: out of shared memory</c>. The victim was whichever test
+    /// happened to run at the tipping point (observed: the four NodeAuthorshipPersistenceTests),
+    /// which is why it read as an unrelated regression, and it only ever reproduced on CI because
+    /// only a full-suite container accumulates that many schemas.</para>
+    ///
+    /// <para>Chunking makes the lock footprint per transaction a CONSTANT (~20 pairs × ~12 locks)
+    /// instead of a function of accumulated schemas. Raising the Postgres bound instead would only
+    /// move the tipping point.</para>
+    /// </summary>
+    public const int MaxTablesPerCleanupBatch = 20;
+
+    /// <summary>
+    /// Upper bound on schemas dropped per transaction. <c>DROP SCHEMA … CASCADE</c> takes an
+    /// ACCESS EXCLUSIVE lock on every object it removes (~90 per partition schema: 10 tables plus
+    /// their indexes), so the drop is chunked for exactly the reason the DELETEs are.
+    /// </summary>
+    public const int MaxSchemasPerDropBatch = 4;
 
     public async ValueTask InitializeAsync()
     {
@@ -98,9 +146,10 @@ public class PostgreSqlFixture : IAsyncLifetime
     public async Task<(NpgsqlDataSource SchemaDataSource, PostgreSqlStorageAdapter Adapter)>
         CreateSchemaAdapterAsync(string schemaName, PartitionDefinition? partitionDef = null, CancellationToken ct = default)
     {
-        // Create schema
-        await using (var cmd = DataSource.CreateCommand($"CREATE SCHEMA IF NOT EXISTS \"{schemaName}\""))
+        // Create schema — and remember it, so CleanDataAsync can drop it again (#977).
+        await using (var cmd = DataSource.CreateCommand($"CREATE SCHEMA IF NOT EXISTS \"{Quote(schemaName)}\""))
             await cmd.ExecuteNonQueryAsync(ct);
+        _trackedSchemas.Add(schemaName);
 
         // Create per-schema data source with a SINGLE-connection pool. Default
         // MaxPoolSize=100 multiplied across ~30 per-test schema activations
@@ -192,18 +241,25 @@ public class PostgreSqlFixture : IAsyncLifetime
     /// (low-level PG ops) stay async inside.
     /// </summary>
     public IObservable<Unit> CleanData()
-        => IoPool.Unbounded.Invoke(async _ => { await CleanDataAsync(); return Unit.Default; });
+        => IoPool.Unbounded.Invoke(async ct => { await CleanDataAsync(ct); return Unit.Default; });
 
     /// <summary>
     /// Cleans all data tables for test isolation.
     /// </summary>
-    public async Task CleanDataAsync()
+    public async Task CleanDataAsync(CancellationToken ct = default)
     {
         // Release per-schema pool connections first so the DELETE statements
         // don't compete with leaked schema adapters. Async-dispose so the physical
         // connections actually return to the server (sync Dispose can leave them
         // pending → 53300: too many clients under the sharded run).
         await DisposeTrackedSchemaDataSourcesAsync();
+
+        // …and drop the schemas those data sources belonged to. The fixture created them, so
+        // the fixture removes them: this is where the #977 accumulation is stopped AT THE SOURCE
+        // rather than paid for by every later test. It is safe at exactly this point because
+        // DisposeTrackedSchemaDataSourcesAsync has already made every adapter handed out for
+        // those schemas unusable — no test can be holding a live one across a CleanData.
+        await DropTrackedSchemasAsync(ct);
 
         // 7 DELETEs in one round-trip. TRUNCATE looks tempting but is ~3× slower
         // here: tests use tiny tables (a handful of rows each), so DELETE's
@@ -221,7 +277,7 @@ public class PostgreSqlFixture : IAsyncLifetime
             DELETE FROM group_members;
             DELETE FROM node_type_permissions;
             """);
-        await cmd.ExecuteNonQueryAsync();
+        await cmd.ExecuteNonQueryAsync(ct);
 
         // Per-partition schemas (orga, orgb, testorg, …) carry their own mesh_nodes +
         // satellite tables that survive prior tests in the same collection (threads in
@@ -232,39 +288,118 @@ public class PostgreSqlFixture : IAsyncLifetime
         // and every test got slower as the suite progressed — QuerySyntaxTests measured
         // 0.12s/test early vs 2.5s/test late (20×), which is most of the full suite's
         // wall-clock. Instead: ONE catalog query resolves all (schema, data-table) pairs,
-        // then a single batched DELETE. Same tables, same isolation, O(1) catalog probing.
+        // then a batched DELETE. Same tables, same isolation, O(1) catalog probing.
         // DELETE on the tiny/empty tables is ~free — the per-schema probing was the cost.
-        var perSchemaTables = new[]
+        //
+        // 🚨 #977: the batch is CHUNKED. One command per chunk = one implicit transaction per
+        // chunk, so PostgreSQL releases the relation + index locks between chunks and the lock
+        // footprint stops being a function of how many schemas the run has accumulated. See
+        // MaxTablesPerCleanupBatch; CleanupLockFootprintTests measures both shapes.
+        var targets = await DiscoverPerSchemaCleanupTargetsAsync(ct);
+        foreach (var batch in BuildCleanupBatches(targets))
         {
-            "mesh_nodes", "threads", "activities", "user_activities", "access",
-            "annotations", "notifications", "code", "partition_objects",
-            "user_effective_permissions"
-        };
+            await using var del = DataSource.CreateCommand(batch);
+            await del.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    /// <summary>The per-partition data tables <see cref="CleanDataAsync"/> empties between tests.</summary>
+    private static readonly System.Collections.Immutable.ImmutableArray<string> PerSchemaTables =
+    [
+        "mesh_nodes", "threads", "activities", "user_activities", "access",
+        "annotations", "notifications", "code", "partition_objects",
+        "user_effective_permissions"
+    ];
+
+    /// <summary>
+    /// ONE catalog query resolving every <c>(schema, table)</c> pair the per-schema cleanup has to
+    /// empty. Ordered so the batching in <see cref="BuildCleanupBatches"/> — and therefore the lock
+    /// footprint it produces — is deterministic and measurable.
+    /// </summary>
+    public async Task<IReadOnlyList<(string Schema, string Table)>> DiscoverPerSchemaCleanupTargetsAsync(
+        CancellationToken ct = default)
+    {
         var targets = new List<(string Schema, string Table)>();
-        await using (var listTables = DataSource.CreateCommand(
+        await using var listTables = DataSource.CreateCommand(
             """
             SELECT table_schema, table_name
             FROM information_schema.tables
             WHERE table_name = ANY($1)
               AND table_schema NOT IN ('public', 'pg_catalog', 'information_schema', 'pg_toast')
               AND table_schema NOT LIKE 'pg\_%'
-            """))
+            ORDER BY table_schema, table_name
+            """);
+        listTables.Parameters.AddWithValue(PerSchemaTables.ToArray());
+        await using var rdr = await listTables.ExecuteReaderAsync(ct);
+        while (await rdr.ReadAsync(ct))
+            targets.Add((rdr.GetString(0), rdr.GetString(1)));
+        return targets;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="targets"/> into DELETE batches of at most
+    /// <paramref name="maxTablesPerBatch"/> tables each. Each returned string is executed as its
+    /// OWN command — i.e. its own implicit transaction — which is what bounds the lock count
+    /// (#977). Pure and deterministic so a test can measure the footprint it produces.
+    /// </summary>
+    public static IReadOnlyList<string> BuildCleanupBatches(
+        IReadOnlyList<(string Schema, string Table)> targets,
+        int maxTablesPerBatch = MaxTablesPerCleanupBatch)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxTablesPerBatch, 1);
+        var batches = new List<string>((targets.Count + maxTablesPerBatch - 1) / maxTablesPerBatch);
+        for (var offset = 0; offset < targets.Count; offset += maxTablesPerBatch)
         {
-            listTables.Parameters.AddWithValue(perSchemaTables);
-            await using var rdr = await listTables.ExecuteReaderAsync();
-            while (await rdr.ReadAsync())
-                targets.Add((rdr.GetString(0), rdr.GetString(1)));
+            var end = Math.Min(offset + maxTablesPerBatch, targets.Count);
+            var sb = new System.Text.StringBuilder((end - offset) * 48);
+            for (var i = offset; i < end; i++)
+                sb.Append("DELETE FROM \"").Append(Quote(targets[i].Schema))
+                  .Append("\".\"").Append(Quote(targets[i].Table)).Append("\";\n");
+            batches.Add(sb.ToString());
         }
-        if (targets.Count > 0)
+        return batches;
+    }
+
+    /// <summary>
+    /// Drops every schema <see cref="CreateSchemaAdapterAsync"/> created since the last call, and
+    /// de-registers it from <c>public.searchable_schemas</c> so no cross-schema fan-out is left
+    /// pointing at a schema that no longer exists.
+    ///
+    /// <para>This is the source-side half of the #977 fix: without it the container ends a full
+    /// suite carrying every partition schema every test ever asked for, which is what made the
+    /// cleanup cost — and the cross-schema UNION fan-outs — grow all run long.</para>
+    /// </summary>
+    public async Task DropTrackedSchemasAsync(CancellationToken ct = default)
+    {
+        var schemas = new SortedSet<string>(StringComparer.Ordinal);
+        while (_trackedSchemas.TryTake(out var schema))
+            if (!UndroppableSchemas.Contains(schema))
+                schemas.Add(schema);
+        if (schemas.Count == 0)
+            return;
+
+        // De-register FIRST: a searchable_schemas row naming a dropped schema would send the
+        // cross-schema UNION into a missing relation. One tiny statement, one table, unbounded
+        // only in parameter count.
+        await using (var deregister = DataSource.CreateCommand(
+            "DELETE FROM public.searchable_schemas WHERE schema_name = ANY($1)"))
         {
-            var sb = new System.Text.StringBuilder(targets.Count * 48);
-            foreach (var (schema, table) in targets)
-                sb.Append("DELETE FROM \"").Append(schema.Replace("\"", "\"\""))
-                  .Append("\".\"").Append(table.Replace("\"", "\"\"")).Append("\";\n");
-            await using var del = DataSource.CreateCommand(sb.ToString());
-            await del.ExecuteNonQueryAsync();
+            deregister.Parameters.AddWithValue(schemas.ToArray());
+            await deregister.ExecuteNonQueryAsync(ct);
+        }
+
+        foreach (var chunk in schemas.Chunk(MaxSchemasPerDropBatch))
+        {
+            var sb = new System.Text.StringBuilder(chunk.Length * 48);
+            foreach (var schema in chunk)
+                sb.Append("DROP SCHEMA IF EXISTS \"").Append(Quote(schema)).Append("\" CASCADE;\n");
+            await using var drop = DataSource.CreateCommand(sb.ToString());
+            await drop.ExecuteNonQueryAsync(ct);
         }
     }
+
+    /// <summary>Escapes a SQL identifier for use inside double quotes.</summary>
+    private static string Quote(string identifier) => identifier.Replace("\"", "\"\"");
 }
 
 /// <summary>

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlFixture.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlFixture.cs
@@ -42,10 +42,14 @@ public class PostgreSqlFixture : IAsyncLifetime
     private readonly System.Collections.Concurrent.ConcurrentBag<string> _trackedSchemas = new();
 
     /// <summary>
-    /// Schemas <see cref="InitializeAsync"/> provisions once per container (mirroring the prod
-    /// migration) plus the catalog schemas. A test may legitimately build an adapter over one of
-    /// them; dropping it would take the whole container's framework state with it, so they are
-    /// never dropped even when tracked.
+    /// Backstop never-drop list: the schemas <see cref="InitializeAsync"/> provisions once per
+    /// container (mirroring the prod migration) plus the catalog schemas. Dropping one would take
+    /// the container's framework state with it.
+    ///
+    /// <para>Ownership tracking should already keep these safe — <see cref="CreateSchemaAdapterAsync"/>
+    /// only records a schema it actually CREATED, and these exist before any test runs. This list is
+    /// the second line of defence, not the first, because it can only ever cover names someone
+    /// thought of.</para>
     /// </summary>
     private static readonly System.Collections.Immutable.ImmutableHashSet<string> UndroppableSchemas =
         System.Collections.Immutable.ImmutableHashSet.Create(
@@ -146,10 +150,28 @@ public class PostgreSqlFixture : IAsyncLifetime
     public async Task<(NpgsqlDataSource SchemaDataSource, PostgreSqlStorageAdapter Adapter)>
         CreateSchemaAdapterAsync(string schemaName, PartitionDefinition? partitionDef = null, CancellationToken ct = default)
     {
-        // Create schema — and remember it, so CleanDataAsync can drop it again (#977).
-        await using (var cmd = DataSource.CreateCommand($"CREATE SCHEMA IF NOT EXISTS \"{Quote(schemaName)}\""))
+        // Create the schema, and take ownership ONLY if this call is what created it (#977).
+        //
+        // 🚨 Deliberately NOT `CREATE SCHEMA IF NOT EXISTS`. That form succeeds silently on a schema
+        // somebody else made — a partition the mesh provisioned, or one an earlier step in the same
+        // test set up — and tracking it would make CleanDataAsync DROP another owner's schema. The
+        // damage would be silent, destructive, and would only ever trigger once a test adapts a
+        // pre-existing partition, surfacing as cross-test bleed that looks like an unrelated defect.
+        // The bare CREATE is atomic: it either creates the schema (ours to drop) or raises 42P06
+        // duplicate_schema (someone else's — adapt it, never own it). The error is read as an
+        // ANSWER to "did I create this?", not swallowed: nothing else about it is suppressed.
+        var createdByUs = true;
+        try
+        {
+            await using var cmd = DataSource.CreateCommand($"CREATE SCHEMA \"{Quote(schemaName)}\"");
             await cmd.ExecuteNonQueryAsync(ct);
-        _trackedSchemas.Add(schemaName);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.DuplicateSchema)
+        {
+            createdByUs = false;
+        }
+        if (createdByUs)
+            _trackedSchemas.Add(schemaName);
 
         // Create per-schema data source with a SINGLE-connection pool. Default
         // MaxPoolSize=100 multiplied across ~30 per-test schema activations


### PR DESCRIPTION
Fixes #977.

## The defect

`PostgreSqlFixture.CleanDataAsync` emptied **every `(schema, table)` pair in the container from ONE command**. Npgsql sends a multi-statement command as a single implicit transaction, so every targeted table *and every one of its indexes* was locked simultaneously (`mesh_nodes` alone carries 11 indexes). Nothing ever dropped a partition schema, so the price every later test paid only ever went up — until it tipped into `Npgsql.PostgresException 53200: out of shared memory` on whichever test happened to be running at that moment.

The arithmetic, on the actual test image (`pgvector/pgvector:pg17`, verified — not inferred):

| | |
|---|---|
| Lock table | `max_locks_per_transaction=64` × (`max_connections=100` + `max_prepared_transactions=0`) = **6,400 slots**, shared across all backends |
| Peak pairs one cleanup discovered across the full suite | **1,493** |
| Locks per pair (measured) | **8.1** |
| ⇒ demanded in ONE transaction at peak | **~12,100** |

Twice the lock table, from a test fixture. It only ever showed up on CI because only a full-suite container accumulates that many schemas; a local container is short-lived and never gets there. (6,400 is the guaranteed floor, not a hard wall — the lock hash can spill into spare shared memory, which is why the failure is a threshold effect rather than a clean cliff.)

Not done here, deliberately: raising `max_locks_per_transaction`, giving the container more memory, or retrying the cleanup. Each only moves the tipping point.

## The fix — both halves

**1. Chunk the DELETEs** (`MaxTablesPerCleanupBatch = 20`). One command per chunk = one implicit transaction per chunk, so Postgres releases the relation and index locks between them. The footprint is now decided by the chunk bound, not by accumulated schemas.

**2. Drop the schemas the fixture created**, in the same `CleanData` step that already disposes their data sources — so no test can be holding a live adapter across it — and de-register them from `public.searchable_schemas` so no cross-schema fan-out is left pointing at a missing relation.

### 🚨 Ownership means "we created it", never "we saw the name"

The first cut of half 2 tracked every `schemaName` handed to `CreateSchemaAdapterAsync`, including when `CREATE SCHEMA IF NOT EXISTS` found the schema already there — so adapting a **pre-existing** partition would have made `CleanData` drop somebody else's schema. Silent, destructive, and dormant until such a test lands. Caught in review; fixed in ca5a22a6e.

`IF NOT EXISTS` is gone. A bare `CREATE SCHEMA` is atomic and answers the question directly:

- creates the schema → **ours**: tracked, dropped at the next `CleanData`
- raises `42P06 duplicate_schema` → **somebody else's**: adapted, never owned, never dropped

No probe, so no create/probe race. The 42P06 is read as an *answer*, not swallowed. The `public`/`auth`/`system_access` never-drop list stays but is documented as a **backstop** — it can only ever cover names someone thought of, so it is the second line of defence, not the mechanism.

Most of the container's accumulation comes from mesh-provisioned partitions the fixture does not own (`EnsurePartitionProvisioned`), so half 2 removes a minority of it: peak pairs **1,493 → 1,143** (−23%). Chunking is what makes cleanup safe regardless; the drop stops the fixture's own contribution and bounds the cross-schema UNION fan-out too.

## Measurement, not a green run

The failure is CI-only *by construction*, so a passing suite proves very little. `CleanupLockFootprintTests` accumulates real partitions and reads `pg_locks` **from inside the transaction that holds them** — exact, nothing sampled, nothing raced. Both shapes come from the shipping `BuildCleanupBatches`; the pre-fix shape is that same call with the bound lifted to "everything", so this compares the real code against its own predecessor rather than a re-implementation.

```
 4 partitions →  40 pairs → unchunked  325 locks | chunked 163 locks
20 partitions → 200 pairs → unchunked 1621 locks | chunked 163 locks
```

**5× the partitions → 5× the unchunked footprint → the chunked footprint does not move at all.** That is the property, stated as an assertion rather than a hope.

## A/B: the guard tests are load-bearing

Disabling only the drop (leaving chunking in place) and re-running the full suite fails exactly one test, the one guarding it:

```
FAILED CleanupLockFootprintTests.CleanData_DropsTheSchemasTheFixtureCreated_AndDeregistersThem
  Expected value to be 0 because CleanData drops what the fixture created, but found 1.
```

Fails with the fix off, passes with it on — not a vacuous assertion. `CleanData_LeavesAPreExistingSchemaStanding_WhenATestOnlyAdaptsIt` likewise fails against the `IF NOT EXISTS` version.

## Cleanup semantics unchanged

This fixture underpins the whole suite, and a subtle change here surfaces as cross-test bleed that looks like something else entirely. Same tables, same discovery query, same relative order — only the transaction boundaries move.

Full `MeshWeaver.Hosting.PostgreSql.Test` suite, Release: **672 passed, 1 skipped, 0 failed** (673 total). Release `-warnaserror`: 0 warnings.

## Not verified

- The extrapolated 12,100 figure combines the measured suite peak (1,493 pairs) with the 8.1 locks/pair measured on fixture-created schemas carrying the standard satellite layout. Real suite schemas have that shape, but it is an extrapolation, not a direct reading of a 53200 failure.
- The original CI failure is not reproduced here — nothing local accumulates enough. What is shown is that the cost no longer grows.

No What's New entry: test-infrastructure only, no user-visible change.