### PR TITLE
A fresh replica's first write to a path was guarded by nothing — the invariant moves into the store

### DIFF
--- a/src/MeshWeaver.Data.Contract/ActivityCategory.cs
+++ b/src/MeshWeaver.Data.Contract/ActivityCategory.cs
@@ -19,6 +19,15 @@ public static class ActivityCategory
     /// </summary>
     public const string Compilation = nameof(Compilation);
     /// <summary>
+    /// Activity recording that a write lost a version race against the durable row and was merged
+    /// into it rather than refused. Raised by the write-integrity chain
+    /// (<c>MonotonicWriteGuardStorageAdapter</c>) so a latest-wins resolution that DROPPED a value is
+    /// visible instead of silent — the failure mode of record was an acked write that rolled a row
+    /// back with no error anywhere.
+    /// </summary>
+    public const string WriteConflict = nameof(WriteConflict);
+
+    /// <summary>
     /// Activity whose category is unknown or unclassified.
     /// </summary>
     public const string Unknown = nameof(Unknown);

--- a/src/MeshWeaver.Data/Serialization/MeshNodePatchMerge.cs
+++ b/src/MeshWeaver.Data/Serialization/MeshNodePatchMerge.cs
@@ -110,6 +110,149 @@ public static class MeshNodePatchMerge
     }
 
     /// <summary>
+    /// TWO-WAY sibling of <see cref="Apply"/>, for the one caller that has no base to rebase against: a
+    /// write that lost a version race AT THE STORE. There the write-integrity chain holds only the two
+    /// full objects — the durable row and the refused write — and no common ancestor, because the losing
+    /// writer never shipped one (issue #971).
+    ///
+    /// <para><b>Why the three-way <see cref="Apply"/> cannot serve this.</b> Its whole classification
+    /// turns on <c>live == base</c>. Handed <c>baseValues: null</c> it takes the "no conflict signal"
+    /// branch and applies the patch WHOLESALE — i.e. the stale snapshot would overwrite the newer row,
+    /// which is exactly the defect. There is no argument shape that makes <see cref="Apply"/> behave
+    /// two-way, so the entry point is separate; the SEMANTICS are shared (same recursion, same
+    /// <see cref="StringDelta"/>, same array-identity merge) so the two can never drift on the parts that
+    /// are genuinely common.</para>
+    ///
+    /// <para><b>Resolution order</b> (the project's stated conflict policy): equal → nothing; nested
+    /// object → recurse; array → UNION by element identity (<see cref="MergeArray"/> with an empty base,
+    /// so no element is ever dropped — RFC&#160;7396's replace-the-array is what silently loses them);
+    /// string where one side is a single-splice SUPERSET of the other → keep the superset, both writers'
+    /// text survives; everything else (numbers, bools, dates, shape changes, and strings that diverged on
+    /// both sides) → LATEST wins and <paramref name="onOverwritten"/> is called. That callback is the
+    /// load-bearing half: latest-wins is acceptable, latest-wins invisibly is the bug.</para>
+    ///
+    /// <para>🚨 A key ABSENT from <paramref name="latest"/> is never adopted from <paramref name="stale"/>.
+    /// The serializer suppresses defaults, so absence is ambiguous between "the newer writer removed it"
+    /// and "its value is the default" — and under both readings the newer state is the one to keep.</para>
+    /// </summary>
+    /// <param name="latest">The durable object. Mutated IN PLACE into the merged result.</param>
+    /// <param name="stale">The losing write's object.</param>
+    /// <param name="prefix">Dotted member prefix used when reporting (e.g. <c>Content</c>).</param>
+    /// <param name="onMerged">Called with the member path for each leaf where BOTH writers' content survived.</param>
+    /// <param name="onOverwritten">Called with the member path for each leaf that was NOT auto-resolvable.</param>
+    public static void ApplyTwoWay(
+        JsonObject latest,
+        JsonObject stale,
+        string prefix,
+        Action<string>? onMerged = null,
+        Action<string>? onOverwritten = null)
+    {
+        foreach (var (key, staleVal) in stale.ToArray())
+        {
+            // Absent on the newer side → the newer state stands (see the default-suppression note).
+            if (!latest.TryGetPropertyValue(key, out var liveVal))
+                continue;
+            if (JsonNode.DeepEquals(liveVal, staleVal))
+                continue;
+
+            var member = string.IsNullOrEmpty(prefix) ? key : $"{prefix}.{key}";
+
+            if (liveVal is JsonObject liveObj && staleVal is JsonObject staleObj)
+            {
+                ApplyTwoWay(liveObj, staleObj, member, onMerged, onOverwritten);
+                continue;
+            }
+
+            if (liveVal is JsonArray liveArr && staleVal is JsonArray staleArr)
+            {
+                // Union by element identity — MergeArray with an EMPTY base, which is precisely
+                // "neither side can be shown to have removed anything, so keep every element".
+                var union = MergeArray(liveArr, staleArr, []);
+                if (!JsonNode.DeepEquals(union, liveVal))
+                {
+                    latest[key] = union;
+                    onMerged?.Invoke(member);
+                }
+                continue;
+            }
+
+            if (TryGetString(liveVal, out var liveStr) && TryGetString(staleVal, out var staleStr))
+            {
+                if (TryMergeTwoWay(liveStr, staleStr, out var resolved))
+                {
+                    if (!string.Equals(resolved, liveStr, StringComparison.Ordinal))
+                    {
+                        latest[key] = JsonValue.Create(resolved);
+                        onMerged?.Invoke(member);
+                    }
+                }
+                else
+                {
+                    onOverwritten?.Invoke(member);
+                }
+                continue;
+            }
+
+            if (liveVal is null)
+            {
+                // An explicit JSON null on the newer side carries no content the stale writer could
+                // have destroyed, so adopting its value keeps strictly more data.
+                latest[key] = staleVal?.DeepClone();
+                onMerged?.Invoke(member);
+                continue;
+            }
+
+            onOverwritten?.Invoke(member);
+        }
+    }
+
+    /// <summary>
+    /// The base-less string rule, shared by <see cref="ApplyTwoWay"/> and the MeshNode-level members it
+    /// cannot see (Name, Description, …). Returns <c>true</c> when the two strings auto-resolved, with
+    /// <paramref name="resolved"/> set to the value to keep; <c>false</c> when they diverged on BOTH
+    /// sides and the caller must apply latest-wins plus a warning.
+    ///
+    /// <para><see cref="StringDelta.Compute"/> reduces the pair to ONE splice (common prefix + common
+    /// suffix stripped). A splice that only INSERTS means <paramref name="stale"/> contains
+    /// <paramref name="latest"/> in full — take the superset and nothing is lost. A splice that only
+    /// REMOVES means the reverse — keep latest, again nothing is lost. A splice that does both is a
+    /// genuine divergence: with no common ancestor there is no way to tell an insertion by one writer
+    /// from a deletion by the other, so it is not auto-resolvable.</para>
+    ///
+    /// <para>The superset case can resurrect text the newer writer deleted. That is accepted
+    /// deliberately: the alternative silently destroys text an acked write added, which is the failure
+    /// mode of record. Resurrection is visible in the content and reported; destruction is not.</para>
+    /// </summary>
+    public static bool TryMergeTwoWay(string? latest, string? stale, out string? resolved)
+    {
+        if (string.Equals(latest, stale, StringComparison.Ordinal) || string.IsNullOrEmpty(stale))
+        {
+            resolved = latest;
+            return true;
+        }
+        if (string.IsNullOrEmpty(latest))
+        {
+            resolved = stale;               // latest carries nothing here — adopting loses nothing
+            return true;
+        }
+
+        var delta = StringDelta.Compute(latest, stale);
+        if (delta.Inserted.Length == 0)
+        {
+            resolved = latest;              // latest ⊃ stale
+            return true;
+        }
+        if (delta.RemovedLength == 0)
+        {
+            resolved = stale;               // stale ⊃ latest — take the union
+            return true;
+        }
+
+        resolved = latest;                  // diverged on both sides — caller warns
+        return false;
+    }
+
+    /// <summary>
     /// Three-way array merge by whole-element value identity:
     /// <c>result = live − (base∖patch) + (patch∖base)</c> — keep every LIVE element the writer did NOT
     /// remove (in live order), then append the writer's additions (in patch order); de-duplicated. Lands

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-write-conflicts-merge-not-vanish.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-write-conflicts-merge-not-vanish.md
@@ -1,0 +1,21 @@
+---
+Name: A node can no longer quietly revert to an older version
+Category: What's New
+Description: Concurrent edits from different servers are merged instead of overwriting each other, and anything that could not be merged is recorded in the activity log.
+Icon: Sparkle
+---
+
+# A node can no longer quietly revert to an older version
+
+When more than one server was handling your portal — during an update, after a restart, or when
+extra capacity was added automatically — a save that had been sitting on an out-of-date copy of a
+node could overwrite a newer one. The overwrite reported success, so the only sign anything had gone
+wrong was a page that had mysteriously reverted to older content.
+
+Saves are now checked against the stored node itself rather than against each server's own memory,
+so an out-of-date save can no longer replace newer content. Instead of being rejected, it is merged
+into what is already stored: text that only one side had is kept, and where the two genuinely
+disagree the newer value wins.
+
+Anything that could not be merged automatically is written to the node's activity log, naming
+exactly which field was affected. Nothing is discarded silently any more.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -435,7 +435,23 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
         => _ioPool.Invoke<MeshNode?>(async ct =>
         {
-            await WriteAsyncCore(node, options, ct).ConfigureAwait(false);
+            var applied = await WriteAsyncCore(node, options, ct).ConfigureAwait(false);
+            if (!applied)
+            {
+                // The version-conditional upsert left the row alone: it already carries a HIGHER
+                // MeshNode.Version (#971). Emit the STORED row — that is what the write-integrity
+                // chain merges the losing write into — and publish NOTHING, because nothing changed
+                // and a notification carrying the losing node would hand every subscriber the stale
+                // state the store just rejected.
+                var stored = await ReadAsyncCore(node.Path, options, ct).ConfigureAwait(false);
+                _logger?.LogWarning(
+                    "[PostgreSqlStorageAdapter] write to {Path} at Version={IncomingVersion} was REFUSED by the "
+                    + "version condition; the durable row is at Version={StoredVersion}. MeshNode.Version is the "
+                    + "owner's monotonic persistence clock, so the losing write is a stale snapshot — it is merged "
+                    + "into durable truth by the write-integrity chain, never applied over it.",
+                    node.Path, node.Version, stored?.Version);
+                return stored ?? node;
+            }
             // Fire the in-process Changes feed so same-process synced-query
             // subscribers re-emit without waiting for the PG NOTIFY round-trip.
             // PostgreSqlChangeListener still publishes for cross-process; the
@@ -495,12 +511,18 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             // there, every per-node hub and synced-query subscriber still believes it is not, and
             // nothing forces a refresh. So the committed set is ANNOUNCED on both paths.
             var committed = new HashSet<string>(StringComparer.Ordinal);
+            // Paths whose version-conditional upsert was REFUSED (#971) — the durable row already
+            // carries a higher MeshNode.Version. They are neither committed nor a failure: the batch
+            // succeeded, this node's write simply did not apply, so it must not be announced on the
+            // change feed and the caller must be handed the DURABLE row rather than the loser.
+            var refused = new List<MeshNode>();
             try
             {
                 foreach (var window in built.GroupBy(b => b.Table, StringComparer.Ordinal))
                 {
                     await using var batch = _dataSource.CreateBatch();
-                    foreach (var item in window)
+                    var items = window.ToList();
+                    foreach (var item in items)
                     {
                         var command = new NpgsqlBatchCommand(item.Sql);
                         foreach (var value in item.Parameters)
@@ -508,8 +530,13 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                         batch.BatchCommands.Add(command);
                     }
                     await batch.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                    foreach (var item in window)
-                        committed.Add(item.Node.Path);
+                    for (var i = 0; i < items.Count; i++)
+                    {
+                        if (batch.BatchCommands[i].Rows > 0)
+                            committed.Add(items[i].Node.Path);
+                        else
+                            refused.Add(items[i].Node);
+                    }
                 }
             }
             catch
@@ -519,7 +546,21 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             }
 
             PublishChanges(ordered, committed);
-            return ordered;
+            if (refused.Count == 0)
+                return ordered;
+
+            _logger?.LogWarning(
+                "[PostgreSqlStorageAdapter] {Count} node(s) in a batch write were REFUSED by the version "
+                + "condition — the durable rows are newer: {Paths}. The stored rows are returned so the "
+                + "write-integrity chain merges into durable truth instead of overwriting it.",
+                refused.Count, string.Join(", ", refused.Select(n => $"{n.Path}@v{n.Version}")));
+
+            // Hand back durable truth for the refused paths, in the caller's original order.
+            var stored = new Dictionary<string, MeshNode>(StringComparer.Ordinal);
+            await foreach (var durable in ReadManyAsyncCore(
+                               [.. refused.Select(n => n.Path)], options, ct).ConfigureAwait(false))
+                stored[durable.Path] = durable;
+            return [.. ordered.Select(n => stored.TryGetValue(n.Path, out var d) ? d : n)];
         });
     }
 
@@ -540,13 +581,18 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         }
     }
 
-    private async Task WriteAsyncCore(MeshNode node, JsonSerializerOptions options, CancellationToken ct)
+    /// <summary>
+    /// Runs the one-node upsert and reports whether it APPLIED. The upsert is version-conditional
+    /// (see <see cref="BuildUpsertAsync"/>), so a row count of zero is not an error — it is the store
+    /// refusing a write whose <see cref="MeshNode.Version"/> is below the durable row's (#971).
+    /// </summary>
+    private async Task<bool> WriteAsyncCore(MeshNode node, JsonSerializerOptions options, CancellationToken ct)
     {
         var (sql, parameters) = await BuildUpsertAsync(node, options).ConfigureAwait(false);
         await using var cmd = _dataSource.CreateCommand(sql);
         foreach (var value in parameters)
             cmd.Parameters.AddWithValue(value);
-        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        return await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false) > 0;
     }
 
     /// <summary>
@@ -588,9 +634,19 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         var excludeInsertCol = writeSync ? ", exclude_from_context" : "";
         var excludeInsertVal = writeSync ? ", $20" : "";
         var excludeUpdate = writeSync ? ",\n                exclude_from_context = EXCLUDED.exclude_from_context" : "";
+        // 🚨 `AS target` + the trailing WHERE make this a version-CONDITIONAL upsert (#971): the row is
+        // left untouched when it already carries a HIGHER MeshNode.Version than the incoming node.
+        // MeshNode.Version is the owner's forward-only revision counter, so a regressing write is a
+        // stale snapshot about to destroy acknowledged data — and this predicate is the ONLY thing that
+        // stops it cross-replica. The in-process high-water filter in MonotonicWriteGuardStorageAdapter
+        // is empty on a freshly started pod, so that pod's FIRST write to a path used to be guarded by
+        // nothing at all: not the empty mark, not the (previously unconditional) UPDATE. Equal versions
+        // still apply — re-persisting an unchanged node is a legitimate, common shape. The alias is
+        // required: inside ON CONFLICT DO UPDATE the target row is referenced by its range-table name,
+        // and `{table}` is schema-qualified.
         var sql =
             $"""
-            INSERT INTO {table} (namespace, id, name, description, node_type, category, icon, display_order,
+            INSERT INTO {table} AS target (namespace, id, name, description, node_type, category, icon, display_order,
                                     last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol}{excludeInsertCol})
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal}{excludeInsertVal})
             ON CONFLICT (namespace, id) DO UPDATE SET
@@ -607,6 +663,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 desired_id = EXCLUDED.desired_id,
                 embedding = EXCLUDED.embedding,
                 main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}{excludeUpdate}
+            WHERE target.version <= EXCLUDED.version
             """;
 
         var parameters = new List<object>(20)

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
@@ -464,7 +464,16 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
     public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
         => _ioPool.Invoke<MeshNode?>(async ct =>
         {
-            await WriteAsyncCore(node, options, ct).ConfigureAwait(false);
+            var applied = await WriteAsyncCore(node, options, ct).ConfigureAwait(false);
+            if (!applied)
+            {
+                // Refused by the version condition (#971): emit the STORED row — that is what the
+                // write-integrity chain merges the losing write into — and publish NOTHING, because
+                // nothing changed and a notification carrying the losing node would hand every
+                // subscriber the stale state the store just rejected.
+                var stored = await ReadAsyncCore(node.Path, options, ct).ConfigureAwait(false);
+                return stored ?? node;
+            }
             // Fire the in-process Changes feed so same-process synced-query subscribers re-emit
             // without waiting for the change-feed poller round-trip. The poller's origin-id
             // filter drops this silo's own event-log echoes, so there is no double-fire.
@@ -484,7 +493,11 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
     /// try/catch-guarded: a projection/mirror failure logs a warning but never fails the node
     /// write (mirroring PG's fail-safe trigger guards).
     /// </summary>
-    private async Task WriteAsyncCore(MeshNode node, JsonSerializerOptions options, CancellationToken ct)
+    /// <returns>
+    /// <c>true</c> when the row was written; <c>false</c> when the version-conditional upsert kept a
+    /// NEWER durable row and left everything (including the trigger-replacement steps) untouched.
+    /// </returns>
+    private async Task<bool> WriteAsyncCore(MeshNode node, JsonSerializerOptions options, CancellationToken ct)
     {
         var ns = node.Namespace ?? "";
 
@@ -569,9 +582,30 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
             SnowflakeConnectionSource.AddParam(cmd, "id", node.Id, DbType.String);
         }
 
+        void BindNodeKeyAndVersion(DbCommand cmd)
+        {
+            BindNodeKey(cmd);
+            SnowflakeConnectionSource.AddParam(cmd, "version", node.Version, DbType.Int64);
+        }
+
         await using var connection = await _source.OpenAsync(ct).ConfigureAwait(false);
-        await UpsertAsync(connection, table, columns, BindNodeParams, BindNodeKey, capabilities, ct)
+        var applied = await UpsertAsync(
+                connection, table, columns, BindNodeParams, BindNodeKey, capabilities, ct,
+                versionConditional: true, bindKeyAndVersion: BindNodeKeyAndVersion)
             .ConfigureAwait(false);
+        if (!applied)
+        {
+            // The version condition refused the write: the durable row is newer (#971). Nothing was
+            // mutated, so none of the trigger-replacement steps below may run either — they all derive
+            // from a row that was NOT written. The caller reads durable truth back and merges into it.
+            _logger?.LogWarning(
+                "[SnowflakeStorageAdapter] write to {Path} at Version={IncomingVersion} was REFUSED by the version "
+                + "condition — the durable row is newer. MeshNode.Version is the owner's monotonic persistence "
+                + "clock, so the losing write is a stale snapshot; it is merged into durable truth by the "
+                + "write-integrity chain, never applied over it.",
+                path, node.Version);
+            return false;
+        }
 
         // ── Trigger replacement ────────────────────────────────────────────────────────────
         // PG performs the next three steps in DB triggers on mesh_nodes / access. Snowflake has
@@ -630,6 +664,8 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
         {
             await RebuildProjectionGuardedAsync(connection, path, ct).ConfigureAwait(false);
         }
+
+        return true;
     }
 
     /// <summary>
@@ -645,14 +681,31 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
     /// <param name="bindKey">Binds ONLY the <c>:ns</c>/<c>:id</c> key parameters — the fallback DELETE references nothing else, and unused binds must not be sent.</param>
     /// <param name="capabilities">The capabilities snapshot for this operation.</param>
     /// <param name="ct">Cancellation token.</param>
-    private static async Task UpsertAsync(
+    /// <param name="versionConditional">
+    /// When true the upsert is CONDITIONAL on <c>version</c>: an existing row whose <c>version</c> is
+    /// strictly HIGHER than the incoming one is left untouched, and the method returns <c>false</c>
+    /// (#971). This is Snowflake's half of the cross-replica "a node's durable state never moves
+    /// backward" invariant — the in-process high-water filter in
+    /// <c>MonotonicWriteGuardStorageAdapter</c> is empty on a freshly started replica, so it cannot be
+    /// the guarantee. Passed <c>false</c> by the auth MIRROR, which is a derived projection of a row
+    /// that has already passed the gate on the way in; gating it again would strand the mirror behind
+    /// its source whenever the two carry different version lineages.
+    /// </param>
+    /// <param name="bindKeyAndVersion">
+    /// Binds <c>:ns</c>/<c>:id</c>/<c>:version</c> — the parameters the conditional fallback DELETE
+    /// references. Required when <paramref name="versionConditional"/> is true.
+    /// </param>
+    /// <returns><c>true</c> when the row was written; <c>false</c> when a newer row was kept.</returns>
+    private static async Task<bool> UpsertAsync(
         DbConnection connection,
         string table,
         IReadOnlyList<(string Column, string Expr)> columns,
         Action<DbCommand> bind,
         Action<DbCommand> bindKey,
         SnowflakeCapabilities capabilities,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool versionConditional = false,
+        Action<DbCommand>? bindKeyAndVersion = null)
     {
         if (capabilities.SupportsMerge)
         {
@@ -663,33 +716,48 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
                     .Select(c => $"{SnowflakeIdentifiers.Quote(c.Column)} = s.{SnowflakeIdentifiers.Quote(c.Column)}"));
             var insertColumns = string.Join(", ", columns.Select(c => SnowflakeIdentifiers.Quote(c.Column)));
             var insertValues = string.Join(", ", columns.Select(c => $"s.{SnowflakeIdentifiers.Quote(c.Column)}"));
+            // The version gate rides the MATCHED branch, so a newer row simply does not match and the
+            // MERGE reports zero affected rows — the Snowflake spelling of Postgres's
+            // `ON CONFLICT … DO UPDATE … WHERE target.version <= EXCLUDED.version`.
+            var matched = versionConditional
+                ? "WHEN MATCHED AND t.\"version\" <= s.\"version\" THEN UPDATE SET "
+                : "WHEN MATCHED THEN UPDATE SET ";
 
             await using var merge = connection.CreateCommand();
             merge.CommandText = $"""
                 MERGE INTO {table} AS t
                 USING (SELECT {sourceSelect}) AS s
                 ON t."namespace" = s."namespace" AND t."id" = s."id"
-                WHEN MATCHED THEN UPDATE SET {updateSet}
+                {matched}{updateSet}
                 WHEN NOT MATCHED THEN INSERT ({insertColumns}) VALUES ({insertValues})
                 """;
             bind(merge);
-            await merge.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-            return;
+            return await merge.ExecuteNonQueryAsync(ct).ConfigureAwait(false) > 0;
         }
 
+        // Emulator fallback: DELETE + INSERT on the same connection (same cap-1 write-pool slot, so
+        // the pair is effectively atomic within this silo). The version gate becomes a conditional
+        // DELETE plus a NOT-EXISTS guard on the INSERT: a newer row survives the DELETE and then
+        // blocks the INSERT, so the pair leaves durable state untouched and reports zero rows.
         await using (var delete = connection.CreateCommand())
         {
-            delete.CommandText = $"DELETE FROM {table} WHERE \"namespace\" = :ns AND \"id\" = :id";
-            bindKey(delete);
+            delete.CommandText = versionConditional
+                ? $"DELETE FROM {table} WHERE \"namespace\" = :ns AND \"id\" = :id AND \"version\" <= :version"
+                : $"DELETE FROM {table} WHERE \"namespace\" = :ns AND \"id\" = :id";
+            (versionConditional ? bindKeyAndVersion ?? bindKey : bindKey)(delete);
             await delete.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
         await using var insert = connection.CreateCommand();
-        insert.CommandText =
+        var insertSelect =
             $"INSERT INTO {table} ({string.Join(", ", columns.Select(c => SnowflakeIdentifiers.Quote(c.Column)))}) " +
             $"SELECT {string.Join(", ", columns.Select(c => c.Expr))}";
+        insert.CommandText = versionConditional
+            ? insertSelect
+              + $" WHERE NOT EXISTS (SELECT 1 FROM {table} WHERE \"namespace\" = :ns AND \"id\" = :id)"
+            : insertSelect;
         bind(insert);
-        await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        return await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false) > 0;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -85,14 +85,35 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
             // makes the in-memory adapter behave exactly like every serializing backend.
             if (node.HubConfiguration is not null)
                 node = node with { HubConfiguration = null };
-            if (!string.IsNullOrEmpty(node.Path))
+            if (string.IsNullOrEmpty(node.Path))
+                return Observable.Return<MeshNode?>(node);
+
+            // 🚨 VERSION-CONDITIONAL upsert — the in-memory twin of the Postgres
+            // `ON CONFLICT … WHERE target.version <= EXCLUDED.version` gate (#971). A single
+            // AddOrUpdate keeps whichever row carries the higher MeshNode.Version, so the decision is
+            // atomic against every concurrent writer of the same path — no read-then-write window for
+            // one to slip through. The dictionary IS the store of record here, so this is where the
+            // "a node's durable state never moves backward" invariant has to live; the in-process
+            // high-water filter above it is empty on a fresh replica and cannot be the guarantee.
+            var winner = _nodes.AddOrUpdate(
+                Norm(node.Path), node,
+                (_, existing) => existing.Version > node.Version ? existing : node);
+            if (!ReferenceEquals(winner, node))
             {
-                _nodes[Norm(node.Path)] = node;
-                _logger?.LogDebug("[InMemoryAdapter#{Id:X}] Write {Path} (count={Count})",
-                    GetHashCode(), Norm(node.Path), _nodes.Count);
-                try { _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node)); } catch { /* never throw */ }
+                // Refused: the stored row is newer. Emit it (never the loser) so the write-integrity
+                // chain can merge into durable truth, and publish NOTHING — nothing changed, and a
+                // notification carrying the losing node would hand every subscriber the stale state
+                // the store just rejected.
+                _logger?.LogDebug(
+                    "[InMemoryAdapter#{Id:X}] Write {Path} REFUSED — incoming v{Incoming} is below stored v{Stored}",
+                    GetHashCode(), Norm(node.Path), node.Version, winner.Version);
+                return Observable.Return<MeshNode?>(winner);
             }
-            return Observable.Return(node);
+
+            _logger?.LogDebug("[InMemoryAdapter#{Id:X}] Write {Path} (count={Count})",
+                GetHashCode(), Norm(node.Path), _nodes.Count);
+            try { _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node)); } catch { /* never throw */ }
+            return Observable.Return<MeshNode?>(node);
         });
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Data;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.Logging;
@@ -54,11 +56,32 @@ namespace MeshWeaver.Hosting.Persistence;
 /// <c>MonotonicWriteGuardWindowTest</c>. A claim left high by a write that then fails is
 /// harmless by the paragraph above — a too-high mark only costs one verification read.</para>
 ///
-/// <para><b>Refuse, loudly — never throw.</b> A refusal logs at <c>Error</c> with both
-/// versions and the path, and emits the STORED (winning) node so the caller's "what is
-/// durable now" contract still holds. Throwing would turn a data-integrity save into a
-/// faulted create/flush chain on paths that are not written to handle it (the create
-/// pipeline, the dispose-time flush) — trading silent loss for a different outage.</para>
+/// <para>🚨 <b>The in-process mark is a FILTER, never the durable guarantee (#971).</b> A second
+/// replica starts with an empty mark table, so its FIRST write to a path has nothing to compare
+/// against and takes the fast path unverified. The durable half of the invariant therefore lives in
+/// the STORE: every backend that can express the condition makes its upsert conditional on
+/// <see cref="MeshNode.Version"/> (Postgres <c>ON CONFLICT … DO UPDATE … WHERE
+/// target.version &lt;= EXCLUDED.version</c>, Snowflake's <c>WHEN MATCHED AND …</c>, the in-memory
+/// store's version-keeping <c>AddOrUpdate</c>) and reports a refusal by emitting the STORED node
+/// instead of the written one. This decorator treats that emission exactly like its own verification
+/// read: as a confirmed conflict to resolve. Without it, monotonicity on a fresh replica's first
+/// write was enforced by nothing at all — not the empty mark, not the unconditional upsert.</para>
+///
+/// <para><b>Resolve by merging — never refuse the caller (#971).</b> A confirmed conflict is NOT
+/// bounced back to the writer: callers of <c>stream.Update</c> do not write conflict-retry loops and
+/// must not have to. The durable row is re-read and the losing write is reconciled into it by
+/// <see cref="MeshNodeConflictMerge"/> — non-strings latest-wins, strings merged where one side is a
+/// superset, anything not auto-resolvable latest-wins. Nothing throws: turning a data-integrity save
+/// into a faulted create/flush chain on paths not written to handle it (the create pipeline, the
+/// dispose-time flush) would trade silent loss for a different outage.</para>
+///
+/// <para>🚨 <b>Latest-wins is acceptable; latest-wins INVISIBLY is the bug.</b> Every member the
+/// merge could not auto-resolve is logged at <c>Warning</c> AND recorded as an <c>ActivityLog</c>
+/// MeshNode satellite at <c>{path}/_Activity/write-conflict-{stale}-{latest}</c>. The defect this
+/// component was built for (#826) was an acked write that rolled a row back with no error anywhere —
+/// so a resolution that drops a value must leave a durable, user-visible trace. The satellite id is
+/// derived from the two versions, so re-presenting the SAME stale snapshot collapses onto one record
+/// instead of accumulating.</para>
 ///
 /// <para><b>Equal versions pass.</b> The guard rejects STRICT regressions only. A re-write at
 /// the same version is a legitimate, common shape: static/never-mutated nodes sit at their
@@ -143,19 +166,123 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
                         return WriteAndRecord(node, options);
                     }
 
-                    // Confirmed backward write against live durable state. Refuse.
+                    // Confirmed backward write against live durable state.
                     ResetMark(path, stored.Version);
-                    logger?.LogError(
-                        "[MonotonicWriteGuard] REFUSED a backward write to {Path}: incoming Version={IncomingVersion} "
-                        + "is BELOW the stored Version={StoredVersion}. MeshNode.Version is the owner's monotonic "
-                        + "persistence clock (MeshNode.NextVersion floors every mint at current+1), so a regressing "
-                        + "write is a STALE snapshot about to destroy acknowledged data — not a newer state. The "
-                        + "stored node is kept. Find the writer that adopted a stale own-node snapshot; do not relax "
-                        + "this guard.",
-                        path, node.Version, stored.Version);
-                    return Observable.Return<MeshNode?>(stored);
+                    return ResolveConflict(node, stored, options);
                 });
         });
+    }
+
+    /// <summary>
+    /// Reconciles a write that lost the version race, and returns what is durable afterwards.
+    ///
+    /// <para>Reached from BOTH conflict detectors — this decorator's own verification read, and a
+    /// store whose version-conditional upsert refused the write and handed back the row it kept.
+    /// They are the same event, so they resolve the same way (#971).</para>
+    ///
+    /// <para>🚨 <b>One attempt, never a retry loop.</b> The merged node is written once. If the row
+    /// moved again in between, the second refusal is LOGGED and the newer row is returned — a
+    /// re-merge loop here would be an unbounded spin against a hot path, and the write it is spinning
+    /// for is by construction older than what is already durable.</para>
+    /// </summary>
+    private IObservable<MeshNode?> ResolveConflict(MeshNode stale, MeshNode latest, JsonSerializerOptions options)
+    {
+        var path = latest.Path;
+        var resolution = MeshNodeConflictMerge.Merge(latest, stale, options);
+
+        logger?.LogWarning(
+            "[MonotonicWriteGuard] CONFLICT on {Path}: a write at Version={IncomingVersion} lost the race against "
+            + "the durable Version={StoredVersion}. MeshNode.Version is the owner's monotonic persistence clock "
+            + "(MeshNode.NextVersion floors every mint at current+1), so the losing write is a STALE snapshot, not a "
+            + "newer state. Resolved by merging into the durable row: merged={MergedMembers}; "
+            + "latest-wins (stale values DROPPED)={OverwrittenMembers}. Find the writer that adopted a stale "
+            + "own-node snapshot; do not relax this guard.",
+            path, stale.Version, latest.Version,
+            Describe(resolution.MergedMembers), Describe(resolution.OverwrittenMembers));
+
+        RecordConflictActivity(path, stale.Version, latest.Version, resolution, options);
+
+        if (resolution.IsLatestUnchanged)
+            return Observable.Return<MeshNode?>(latest);   // nothing salvageable — the durable row already IS the answer
+
+        Observe(resolution.Node);
+        return inner.Write(resolution.Node, options)
+            .Select(written =>
+            {
+                if (written is not null && written.Version > resolution.Node.Version)
+                {
+                    logger?.LogWarning(
+                        "[MonotonicWriteGuard] the merged resolution for {Path} was itself refused — the row advanced "
+                        + "to Version={StoredVersion} while the merge ran. Keeping the newer row; NOT re-merging (a "
+                        + "retry loop here spins against a hot path for a write that is older than durable truth).",
+                        path, written.Version);
+                    return written;
+                }
+                return written ?? resolution.Node;
+            });
+    }
+
+    private static string Describe(System.Collections.Immutable.ImmutableList<string> members)
+        => members.IsEmpty ? "(none)" : string.Join(", ", members);
+
+    /// <summary>
+    /// Writes the durable, user-visible trace of a resolved conflict: an <c>ActivityLog</c> MeshNode
+    /// satellite at <c>{path}/_Activity/write-conflict-{staleVersion}-{latestVersion}</c>, carrying one
+    /// <see cref="LogLevel.Warning"/> message per member whose value was dropped (and an informational
+    /// line for what was merged).
+    ///
+    /// <para>Best effort by contract — a failure to record the trace must never fail the resolution it
+    /// describes, so it is logged rather than propagated. It is also skipped for paths already inside an
+    /// <c>_Activity</c> namespace, so a conflict on a trace can never write a trace about a trace.</para>
+    /// </summary>
+    private void RecordConflictActivity(
+        string path, long staleVersion, long latestVersion,
+        MeshNodeConflictResolution resolution, JsonSerializerOptions options)
+    {
+        if (string.IsNullOrEmpty(path)
+            || path.Contains("/_Activity/", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var messages = ImmutableList<LogMessage>.Empty
+            .Add(new LogMessage(
+                $"A write at Version={staleVersion} lost the race against the durable Version={latestVersion} "
+                + $"on '{path}' and was merged into it.",
+                LogLevel.Information));
+        messages = resolution.OverwrittenMembers.Aggregate(messages, (acc, member) => acc.Add(
+            new LogMessage(
+                $"'{member}' was not auto-resolvable — the newer value was kept and the losing write's value dropped.",
+                LogLevel.Warning)));
+        messages = resolution.MergedMembers.Aggregate(messages, (acc, member) => acc.Add(
+            new LogMessage($"'{member}' was merged — both writes' content survives.", LogLevel.Information)));
+
+        var activityNamespace = $"{path}/_Activity";
+        var id = $"write-conflict-{staleVersion}-{latestVersion}";
+        var activity = new MeshNode(id, activityNamespace)
+        {
+            Name = $"Write conflict on {path}",
+            NodeType = "ActivityLog",
+            MainNode = path,
+            State = MeshNodeState.Active,
+            Version = 1,
+            LastModified = DateTimeOffset.UtcNow,
+            Content = new ActivityLog(ActivityCategory.WriteConflict)
+            {
+                Id = id,
+                HubPath = path,
+                AffectedPaths = [path],
+                End = DateTime.UtcNow,
+                Status = resolution.OverwrittenMembers.IsEmpty
+                    ? ActivityStatus.Succeeded
+                    : ActivityStatus.Warning,
+                Messages = messages
+            }
+        };
+
+        inner.Write(activity, options).Subscribe(
+            _ => { },
+            ex => logger?.LogWarning(ex,
+                "[MonotonicWriteGuard] could not record the write-conflict activity for {Path}; the conflict itself "
+                + "was resolved and is reported in the preceding warning.", path));
     }
 
     /// <summary>
@@ -164,14 +291,23 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
     /// before the row is mutated" note on the class. Observing only the completed write left the
     /// mark trailing the row for the whole duration of that write (including the change-feed
     /// fan-out it performs from inside itself), and a stale writer landing in that window skipped
-    /// verification and rolled the store back. The trailing <c>Do(Observe)</c> is retained: the
-    /// backend may return a node whose version differs from the one we handed it (a partition
-    /// adapter, a conditional upsert), and the mark must track what is actually durable.</para>
+    /// verification and rolled the store back.</para>
+    ///
+    /// <para>🚨 A backend emission carrying a version ABOVE the one we handed it is the store
+    /// reporting that its version-conditional upsert REFUSED the write and kept the row it already
+    /// had (#971) — the cross-replica half of the invariant, and the only thing standing between a
+    /// fresh replica's first write and a silent rollback. It is a confirmed conflict, so it resolves
+    /// through exactly the same merge as the verification-read branch. The trailing
+    /// <c>Do(Observe)</c> then tracks whatever is actually durable.</para>
     /// </summary>
     private IObservable<MeshNode?> WriteAndRecord(MeshNode node, JsonSerializerOptions options)
     {
         Observe(node);
-        return inner.Write(node, options).Do(Observe);
+        return inner.Write(node, options)
+            .SelectMany(written => written is not null && written.Version > node.Version
+                ? ResolveConflict(node, written, options)
+                : Observable.Return(written))
+            .Do(Observe);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -255,8 +255,15 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
         messages = resolution.MergedMembers.Aggregate(messages, (acc, member) => acc.Add(
             new LogMessage($"'{member}' was merged — both writes' content survives.", LogLevel.Information)));
 
+        // 🚨 The id is keyed on the DURABLE version alone, never on the losing writer's. One record
+        // per durable revision is the right granularity ("this revision had a conflict") AND it is
+        // what bounds the litter: a wedged owner mints an INCREASING version on every retry
+        // (834, 835, 836 … against a stuck 2423 — the #725/#872 fork shape), so a stale-version-keyed
+        // id would accumulate one satellite per retry, forever. Re-recording overwrites the same node
+        // at Version = 1, which the store's equal-version rule accepts, so this can never conflict
+        // with itself. Which losing version lost is in the message text.
         var activityNamespace = $"{path}/_Activity";
-        var id = $"write-conflict-{staleVersion}-{latestVersion}";
+        var id = $"write-conflict-{latestVersion}";
         var activity = new MeshNode(id, activityNamespace)
         {
             Name = $"Write conflict on {path}",

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -77,11 +77,11 @@ namespace MeshWeaver.Hosting.Persistence;
 ///
 /// <para>🚨 <b>Latest-wins is acceptable; latest-wins INVISIBLY is the bug.</b> Every member the
 /// merge could not auto-resolve is logged at <c>Warning</c> AND recorded as an <c>ActivityLog</c>
-/// MeshNode satellite at <c>{path}/_Activity/write-conflict-{stale}-{latest}</c>. The defect this
+/// MeshNode satellite at <c>{path}/_Activity/write-conflict-{latestVersion}</c>. The defect this
 /// component was built for (#826) was an acked write that rolled a row back with no error anywhere —
-/// so a resolution that drops a value must leave a durable, user-visible trace. The satellite id is
-/// derived from the two versions, so re-presenting the SAME stale snapshot collapses onto one record
-/// instead of accumulating.</para>
+/// so a resolution that drops a value must leave a durable, user-visible trace. The id is keyed on the
+/// DURABLE version alone, which bounds the record to one per revision no matter how many losing
+/// attempts land against it (see <see cref="RecordConflictActivity"/>).</para>
 ///
 /// <para><b>Equal versions pass.</b> The guard rejects STRICT regressions only. A re-write at
 /// the same version is a legitimate, common shape: static/never-mutated nodes sit at their
@@ -227,7 +227,7 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
 
     /// <summary>
     /// Writes the durable, user-visible trace of a resolved conflict: an <c>ActivityLog</c> MeshNode
-    /// satellite at <c>{path}/_Activity/write-conflict-{staleVersion}-{latestVersion}</c>, carrying one
+    /// satellite at <c>{path}/_Activity/write-conflict-{latestVersion}</c>, carrying one
     /// <see cref="LogLevel.Warning"/> message per member whose value was dropped (and an informational
     /// line for what was merged).
     ///

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
@@ -1,0 +1,202 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Data.Serialization;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The outcome of <see cref="MeshNodeConflictMerge.Merge"/>: the node to persist plus exactly which
+/// members were reconciled and which had the losing writer's value dropped.
+/// </summary>
+/// <param name="Node">The merged node — always carries the LATEST row's identity and bookkeeping.</param>
+/// <param name="MergedMembers">
+/// Members where BOTH writers' content survived (a string the stale writer extended, an array element
+/// only it carried). Reported, not warned: nothing was lost.
+/// </param>
+/// <param name="OverwrittenMembers">
+/// Members that were NOT auto-resolvable — two divergent values with no common ancestor to rebase
+/// against. Latest won and the stale writer's value was DROPPED. This is the set that must reach the
+/// activity log: dropping a value silently is the whole defect this merge exists to stop.
+/// </param>
+public sealed record MeshNodeConflictResolution(
+    MeshNode Node,
+    ImmutableList<string> MergedMembers,
+    ImmutableList<string> OverwrittenMembers)
+{
+    /// <summary>
+    /// True when the stale writer contributed nothing that survived — the durable row already IS the
+    /// answer, so the resolution needs no write of its own.
+    /// </summary>
+    public bool IsLatestUnchanged => MergedMembers.IsEmpty;
+}
+
+/// <summary>
+/// Maps a <see cref="MeshNode"/> onto the base-less conflict policy implemented by
+/// <see cref="MeshNodePatchMerge.ApplyTwoWay"/> — the resolution for a write that lost a version race
+/// AT THE STORE (issue #971).
+///
+/// <para><b>Where the conflict comes from.</b> The write-integrity chain sees an incoming node whose
+/// <see cref="MeshNode.Version"/> is strictly BELOW the durable row's — either this process's
+/// high-water mark said so and the verification read confirmed it, or the store itself refused the
+/// write with a version-conditional upsert and handed back the row it kept. Both are the same event:
+/// a writer holding an older snapshot.</para>
+///
+/// <para><b>This class owns only the MEMBER MAPPING.</b> Every merge decision — the string rule, the
+/// array-identity union, the recursion, what counts as unresolvable — lives in
+/// <see cref="MeshNodePatchMerge"/>, alongside the three-way merge that cross-hub patches use, so the
+/// two can never drift into disagreeing about the same JSON. What is specific here is which
+/// <see cref="MeshNode"/> members are user data (merge them), which are the store's own bookkeeping
+/// (latest always wins, never reported), and how <see cref="MeshNode.Content"/> is projected to JSON
+/// and materialised back into its CLR type.</para>
+///
+/// <para>🚨 <b>Identity and bookkeeping always come from LATEST, never reported.</b>
+/// <see cref="MeshNode.Id"/>, <see cref="MeshNode.Namespace"/>, <see cref="MeshNode.MainNode"/>,
+/// <see cref="MeshNode.Version"/>, <see cref="MeshNode.LastModified"/>,
+/// <see cref="MeshNode.LastModifiedBy"/>, <see cref="MeshNode.CreatedBy"/> and
+/// <see cref="MeshNode.CreatedDate"/> are the store's clock and authorship, not user data. They differ
+/// on essentially every conflict, so folding them into the report would bury the members that actually
+/// matter. The merged node keeps the latest row's version specifically so re-persisting it cannot
+/// itself be read as a rollback.</para>
+///
+/// <para>🚨 <b><see cref="MeshNode.HubConfiguration"/> and
+/// <see cref="MeshNode.GlobalServiceConfigurations"/> are delegates</b> — they cannot round-trip
+/// through JSON, which is why the node as a whole is never serialized here. Only
+/// <see cref="MeshNode.Content"/> takes that path, and it is materialised back into the LATEST
+/// content's own type so a merge can never degrade typed content into a bare
+/// <see cref="JsonElement"/>.</para>
+/// </summary>
+public static class MeshNodeConflictMerge
+{
+    /// <summary>
+    /// Reconciles <paramref name="stale"/> (the write that lost the version race) into
+    /// <paramref name="latest"/> (the durable row) under the policy documented on
+    /// <see cref="MeshNodePatchMerge.ApplyTwoWay"/>.
+    /// </summary>
+    /// <param name="latest">The durable row — the higher <see cref="MeshNode.Version"/>. Wins every tie.</param>
+    /// <param name="stale">The refused write.</param>
+    /// <param name="options">Serializer options used to project <see cref="MeshNode.Content"/> to JSON and back.</param>
+    /// <returns>The merged node plus the merged / overwritten member reports.</returns>
+    public static MeshNodeConflictResolution Merge(
+        MeshNode latest, MeshNode stale, JsonSerializerOptions options)
+    {
+        var merged = new List<string>();
+        var overwritten = new List<string>();
+
+        var result = latest with
+        {
+            Name = MergeText(nameof(MeshNode.Name), latest.Name, stale.Name, merged, overwritten),
+            Description = MergeText(nameof(MeshNode.Description), latest.Description, stale.Description, merged, overwritten),
+            NodeType = MergeText(nameof(MeshNode.NodeType), latest.NodeType, stale.NodeType, merged, overwritten),
+            Category = MergeText(nameof(MeshNode.Category), latest.Category, stale.Category, merged, overwritten),
+            Icon = MergeText(nameof(MeshNode.Icon), latest.Icon, stale.Icon, merged, overwritten),
+            DesiredId = MergeText(nameof(MeshNode.DesiredId), latest.DesiredId, stale.DesiredId, merged, overwritten),
+            PreRenderedHtml = MergeText(nameof(MeshNode.PreRenderedHtml), latest.PreRenderedHtml, stale.PreRenderedHtml, merged, overwritten),
+        };
+
+        // Non-string members: latest wins, reported when the stale writer held something else.
+        ReportIfDifferent(nameof(MeshNode.Order), latest.Order, stale.Order, overwritten);
+        ReportIfDifferent(nameof(MeshNode.State), latest.State, stale.State, overwritten);
+        ReportIfDifferent(nameof(MeshNode.SyncBehavior), latest.SyncBehavior, stale.SyncBehavior, overwritten);
+        ReportIfDifferent(nameof(MeshNode.IsDefinitionOnly), latest.IsDefinitionOnly, stale.IsDefinitionOnly, overwritten);
+        ReportIfDifferent(nameof(MeshNode.IsSatelliteType), latest.IsSatelliteType, stale.IsSatelliteType, overwritten);
+        if (!SameExclusions(latest.ExcludeFromContext, stale.ExcludeFromContext))
+            overwritten.Add(nameof(MeshNode.ExcludeFromContext));
+
+        result = result with { Content = MergeContent(latest.Content, stale.Content, options, merged, overwritten) };
+
+        return new MeshNodeConflictResolution(result, [.. merged], [.. overwritten]);
+    }
+
+    /// <summary>
+    /// A MeshNode-level string member, resolved by the SAME rule
+    /// (<see cref="MeshNodePatchMerge.TryMergeTwoWay"/>) that <see cref="MeshNodePatchMerge.ApplyTwoWay"/>
+    /// applies to string leaves inside <see cref="MeshNode.Content"/>.
+    /// </summary>
+    private static string? MergeText(
+        string member, string? latest, string? stale, List<string> merged, List<string> overwritten)
+    {
+        if (MeshNodePatchMerge.TryMergeTwoWay(latest, stale, out var resolved))
+        {
+            if (!string.Equals(resolved, latest, StringComparison.Ordinal))
+                merged.Add(member);
+            return resolved;
+        }
+        overwritten.Add(member);
+        return latest;
+    }
+
+    private static void ReportIfDifferent<T>(string member, T latest, T stale, List<string> overwritten)
+    {
+        if (!EqualityComparer<T>.Default.Equals(latest, stale))
+            overwritten.Add(member);
+    }
+
+    private static bool SameExclusions(IReadOnlyCollection<string>? latest, IReadOnlyCollection<string>? stale)
+    {
+        if (latest is null || latest.Count == 0)
+            return stale is null || stale.Count == 0;
+        if (stale is null || stale.Count != latest.Count)
+            return false;
+        return latest.SequenceEqual(stale, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Projects both contents to JSON, merges through <see cref="MeshNodePatchMerge.ApplyTwoWay"/>, and
+    /// materialises the result back into the LATEST content's CLR type. A content whose two sides are
+    /// not both JSON objects (a shape change, a scalar content) is not mergeable: latest wins and the
+    /// member is reported rather than silently dropped.
+    /// </summary>
+    private static object? MergeContent(
+        object? latest, object? stale, JsonSerializerOptions options,
+        List<string> merged, List<string> overwritten)
+    {
+        if (stale is null)
+            return latest;
+        if (latest is null)
+        {
+            merged.Add(nameof(MeshNode.Content));
+            return stale;
+        }
+
+        JsonObject? latestJson, staleJson;
+        try
+        {
+            latestJson = JsonSerializer.SerializeToNode(latest, latest.GetType(), options) as JsonObject;
+            staleJson = JsonSerializer.SerializeToNode(stale, stale.GetType(), options) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            // Not hidden: unserializable content is REPORTED as an overwritten member so the
+            // activity-log entry names it, and the newer row is kept intact.
+            overwritten.Add(nameof(MeshNode.Content));
+            return latest;
+        }
+
+        if (latestJson is null || staleJson is null)
+        {
+            overwritten.Add(nameof(MeshNode.Content));
+            return latest;
+        }
+
+        // Only entries added to `merged` correspond to an actual mutation of `latestJson`; an
+        // overwritten member leaves the live value in place by definition. So an unchanged `merged`
+        // means there is nothing to re-materialise — keep the live instance rather than paying a
+        // round-trip through JSON for no gain.
+        var mutationsBefore = merged.Count;
+        MeshNodePatchMerge.ApplyTwoWay(
+            latestJson, staleJson, nameof(MeshNode.Content), merged.Add, overwritten.Add);
+        if (merged.Count == mutationsBefore)
+            return latest;
+
+        try
+        {
+            return latestJson.Deserialize(latest.GetType(), options) ?? latest;
+        }
+        catch (JsonException)
+        {
+            overwritten.Add(nameof(MeshNode.Content));
+            return latest;
+        }
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
@@ -186,10 +186,10 @@ public static class MeshNodeConflictMerge
             latestJson = JsonSerializer.SerializeToNode(latest, latest.GetType(), options) as JsonObject;
             staleJson = JsonSerializer.SerializeToNode(stale, stale.GetType(), options) as JsonObject;
         }
-        catch (JsonException)
+        catch (Exception ex) when (IsSerializationFailure(ex))
         {
-            // Not hidden: unserializable content is REPORTED as an overwritten member so the
-            // activity-log entry names it, and the newer row is kept intact.
+            // Not hidden: content this serializer cannot project is REPORTED as an overwritten
+            // member, so the activity-log entry names it and the newer row is kept intact.
             overwritten.Add(nameof(MeshNode.Content));
             return latest;
         }
@@ -214,10 +214,27 @@ public static class MeshNodeConflictMerge
         {
             return latestJson.Deserialize(latest.GetType(), options) ?? latest;
         }
-        catch (JsonException)
+        catch (Exception ex) when (IsSerializationFailure(ex))
         {
             overwritten.Add(nameof(MeshNode.Content));
             return latest;
         }
     }
+
+    /// <summary>
+    /// The serialization failures that are an EXPECTED input condition here — content whose CLR type
+    /// this serializer cannot project to JSON and back. <see cref="JsonSerializer"/> documents both:
+    /// <see cref="NotSupportedException"/> when no compatible converter exists for the type or one of
+    /// its members, and <see cref="JsonException"/> for malformed/cyclic JSON. Both mean the same
+    /// thing for a merge — the content is not mergeable — so both are reported as an overwritten
+    /// member and the newer row is kept.
+    ///
+    /// <para>🚨 Deliberately NOT a blanket catch. Anything else — a custom converter throwing an
+    /// arbitrary exception — is a genuine fault, not an unmergeable input, and it must propagate.
+    /// Swallowing it would hide a defect behind a plausible-looking "latest wins", which is the exact
+    /// shape this whole change exists to eliminate. A loud failure is an acceptable outcome; a silent
+    /// wrong one is not.</para>
+    /// </summary>
+    private static bool IsSerializationFailure(Exception ex)
+        => ex is JsonException or NotSupportedException;
 }

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeConflictMerge.cs
@@ -50,6 +50,16 @@ public sealed record MeshNodeConflictResolution(
 /// (latest always wins, never reported), and how <see cref="MeshNode.Content"/> is projected to JSON
 /// and materialised back into its CLR type.</para>
 ///
+/// <para><b>Which members take the string merge.</b> Only <see cref="MeshNode.Name"/> and
+/// <see cref="MeshNode.Description"/> — the prose. <see cref="MeshNode.NodeType"/>,
+/// <see cref="MeshNode.Category"/>, <see cref="MeshNode.Icon"/> and <see cref="MeshNode.DesiredId"/>
+/// are wire identifiers, not text: splicing them could retype a node (<c>"Code"</c> + <c>"CodeCell"</c>),
+/// which drives routing and hub activation. <see cref="MeshNode.PreRenderedHtml"/> is derived from
+/// <see cref="MeshNode.Content"/>, so it follows the merged content rather than being spliced. All of
+/// those take latest-wins-and-REPORT, so the policy's fallback still covers them and nothing is
+/// dropped silently. The user data that actually benefits from merging lives in
+/// <see cref="MeshNode.Content"/>, which is merged leaf by leaf.</para>
+///
 /// <para>🚨 <b>Identity and bookkeeping always come from LATEST, never reported.</b>
 /// <see cref="MeshNode.Id"/>, <see cref="MeshNode.Namespace"/>, <see cref="MeshNode.MainNode"/>,
 /// <see cref="MeshNode.Version"/>, <see cref="MeshNode.LastModified"/>,
@@ -83,16 +93,27 @@ public static class MeshNodeConflictMerge
         var merged = new List<string>();
         var overwritten = new List<string>();
 
+        // PROSE members take the string merge. Only these two: they are text a human wrote, which is
+        // what a splice-level merge is meaningful on.
         var result = latest with
         {
             Name = MergeText(nameof(MeshNode.Name), latest.Name, stale.Name, merged, overwritten),
             Description = MergeText(nameof(MeshNode.Description), latest.Description, stale.Description, merged, overwritten),
-            NodeType = MergeText(nameof(MeshNode.NodeType), latest.NodeType, stale.NodeType, merged, overwritten),
-            Category = MergeText(nameof(MeshNode.Category), latest.Category, stale.Category, merged, overwritten),
-            Icon = MergeText(nameof(MeshNode.Icon), latest.Icon, stale.Icon, merged, overwritten),
-            DesiredId = MergeText(nameof(MeshNode.DesiredId), latest.DesiredId, stale.DesiredId, merged, overwritten),
-            PreRenderedHtml = MergeText(nameof(MeshNode.PreRenderedHtml), latest.PreRenderedHtml, stale.PreRenderedHtml, merged, overwritten),
         };
+
+        // 🚨 IDENTIFIER-shaped strings are NOT prose and are deliberately excluded from the string
+        // rule: NodeType, Category, Icon and DesiredId are wire discriminators that drive routing and
+        // per-node hub activation. The superset rule would happily splice "Code" and "CodeCell" into
+        // one of them and silently retype the node — an outsized consequence next to a merged
+        // sentence. They take the same latest-wins-and-REPORT path as the true non-strings, so the
+        // policy's fallback still applies and nothing is dropped silently. PreRenderedHtml joins them
+        // because it is DERIVED from Content: the correct value follows from the merged content, and
+        // splicing two renderings could only produce broken markup.
+        ReportIfDifferent(nameof(MeshNode.NodeType), latest.NodeType, stale.NodeType, overwritten);
+        ReportIfDifferent(nameof(MeshNode.Category), latest.Category, stale.Category, overwritten);
+        ReportIfDifferent(nameof(MeshNode.Icon), latest.Icon, stale.Icon, overwritten);
+        ReportIfDifferent(nameof(MeshNode.DesiredId), latest.DesiredId, stale.DesiredId, overwritten);
+        ReportIfDifferent(nameof(MeshNode.PreRenderedHtml), latest.PreRenderedHtml, stale.PreRenderedHtml, overwritten);
 
         // Non-string members: latest wins, reported when the stale writer held something else.
         ReportIfDifferent(nameof(MeshNode.Order), latest.Order, stale.Order, overwritten);

--- a/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
@@ -57,6 +57,31 @@ public interface IStorageAdapter
     /// accepted the path; emits <c>null</c> when the path isn't owned here
     /// so the try-then-claim chain in <c>PersistenceService.Write</c> moves
     /// on to the next writable provider.
+    ///
+    /// <para>🚨 <b>The write is CONDITIONAL on <see cref="MeshNode.Version"/> wherever the backend can
+    /// express the condition (#971).</b> <c>MeshNode.Version</c> is the node's forward-only revision
+    /// counter — every mint goes through <see cref="MeshNode.NextVersion"/> (<c>current + 1</c>) and an
+    /// unchanged node is re-persisted at the version it already carries — so a correctly-produced write
+    /// is ALWAYS at or above the version already stored. A backend that can compare therefore MUST
+    /// leave the row untouched when <c>node.Version</c> is strictly BELOW the durable row's, and MUST
+    /// report that by emitting the STORED (winning) node instead of the one it was handed. Equal
+    /// versions still apply: re-persisting an unchanged node is a legitimate, common shape.</para>
+    ///
+    /// <para>Why this belongs in the store and not only in a decorator: the in-process high-water
+    /// filter in <c>MonotonicWriteGuardStorageAdapter</c> is empty on a freshly started replica, so
+    /// that replica's FIRST write to any path has nothing to compare against. Monotonicity is a
+    /// property of the ROW, and only the store can enforce it across replicas — a rollout briefly
+    /// running two pods, a KEDA scale-out, a restarted replica. The emitted stored node is what lets
+    /// the decorator turn the refusal into a MERGE (see <c>MeshNodeConflictMerge</c>) rather than
+    /// bouncing a conflict back at a caller that has no retry loop.</para>
+    ///
+    /// <para>A backend that CANNOT express the condition (single-process file system, a store with no
+    /// conditional upsert) simply emits the written node as before; the in-process guard remains its
+    /// only protection, which is sound because such backends are not multi-replica.</para>
+    ///
+    /// <para>A refused write must NOT publish <see cref="Changes"/> — nothing changed, and a
+    /// notification carrying the losing node would hand every subscriber the stale state the store
+    /// just rejected.</para>
     /// </summary>
     IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options);
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/StoreLevelWriteConflictTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StoreLevelWriteConflictTest.cs
@@ -151,7 +151,9 @@ public class StoreLevelWriteConflictTest(ITestOutputHelper output) : MonolithMes
         // 🚨 The load-bearing half. Latest-wins is acceptable; latest-wins INVISIBLY is the defect
         // (#968 was an acked write that rolled a row back with no error anywhere). The dropped member
         // must leave a durable, user-visible trace.
-        var activityPath = $"{path}/_Activity/write-conflict-{staleVersion}-{durableVersion}";
+        // Keyed on the DURABLE version alone — one record per durable revision, so a wedged writer
+        // retrying at an ever-increasing version cannot litter one satellite per attempt.
+        var activityPath = $"{path}/_Activity/write-conflict-{durableVersion}";
         var activity = await ReadDurable(activityPath).Should().Within(30.Seconds()).Emit();
         activity.Should().NotBeNull(
             "a conflict whose resolution DROPPED a value must record it in the activity log — a "

--- a/test/MeshWeaver.Hosting.Monolith.Test/StoreLevelWriteConflictTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StoreLevelWriteConflictTest.cs
@@ -1,0 +1,169 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the STORE-level half of "a node's durable state never moves backward" (issue #971) — the half
+/// <see cref="MonotonicWriteGuardWindowTest"/> deliberately does not cover.
+///
+/// <para><b>The gap.</b> <c>MonotonicWriteGuardStorageAdapter</c>'s high-water mark is per-PROCESS. A
+/// second replica starts with an EMPTY mark table, so its first write to a given path finds no mark,
+/// takes the unverified fast path, and lands unchecked. Nothing below it objected either: the Postgres
+/// upsert carried no version condition and the in-memory store was a plain
+/// <c>_nodes[path] = node</c>. So on a fresh replica's first write to a path, monotonicity was enforced
+/// by NOTHING — not the empty mark, not the store. Invisible in single-process tests, live in any
+/// rollout, KEDA scale-out or restart, and silent when it fires: the stale write is ACKED and the next
+/// write is minted one above the rolled-back row, so the wrong lineage persists.</para>
+///
+/// <para><b>How the property is constructed rather than raced.</b> "A second writer with no prior
+/// mark" is built directly — a fresh <c>MonotonicWriteGuardStorageAdapter</c> instance over the SAME
+/// underlying store, which is exactly what a newly started replica holds. No load, no sleeps, no
+/// timing budget: the empty mark is the initial state of a new instance.</para>
+///
+/// <para><b>Fail-without</b> (verified against current <c>main</c>): the fresh guard finds no mark,
+/// hands the stale node straight to a store with no version condition, and the durable row becomes the
+/// v1 snapshot — both the emission assertion and the durable-read assertion fail.
+/// <b>Pass-with:</b> the store itself refuses the regressing write, hands back the row it kept, and the
+/// guard merges the loser into durable truth instead of bouncing a conflict at a caller that has no
+/// retry loop.</para>
+/// </summary>
+public class StoreLevelWriteConflictTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+    private JsonSerializerOptions JsonOptions => Mesh.JsonSerializerOptions;
+
+    /// <summary>Reads the node straight out of durable storage — no hub, no stream, no cache.</summary>
+    private IObservable<MeshNode?> ReadDurable(string path) => Storage.Read(path, JsonOptions);
+
+    /// <summary>
+    /// A SIMULATED SECOND REPLICA: a fresh write-integrity guard over the same store this process
+    /// already holds. Its high-water table is empty — precisely the state a newly started pod is in
+    /// for every path it has not yet touched — so it exercises the case where the in-process filter
+    /// cannot help and only the store can.
+    /// </summary>
+    private IStorageAdapter FreshReplicaGuard()
+        => new MonotonicWriteGuardStorageAdapter(
+            Mesh.ServiceProvider.GetRequiredKeyedService<IStorageAdapter>("inner"),
+            Mesh.ServiceProvider.GetService<ILogger<MonotonicWriteGuardStorageAdapter>>());
+
+    [Fact(Timeout = 55_000)]
+    public async Task AWriterWithNoHighWaterMark_CannotRollTheDurableRowBack()
+    {
+        var id = $"store-cas-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+
+        var created = await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+        created!.Version.Should().Be(1, "the create is revision 1 — the stale snapshot below rides that version");
+
+        const long durableVersion = 7000L;
+        await Storage.Write(created with { Name = "durable-advance", Version = durableVersion }, JsonOptions)
+            .Should().Within(30.Seconds()).Emit();
+
+        // The stale snapshot a lagging replica still holds: the create-time node, unchanged Version.
+        // Presented through a guard that has NEVER seen this path, so its mark table is empty and the
+        // only thing that can stop it is the store.
+        var replica = FreshReplicaGuard();
+        var emitted = await replica.Write(created with { Name = "stale-snapshot" }, JsonOptions)
+            .Should().Within(30.Seconds()).Emit();
+        Output.WriteLine($"[replica write] emitted={(emitted is null ? "null" : $"v{emitted.Version}/{emitted.Name}")}");
+
+        emitted.Should().NotBeNull();
+        emitted!.Version.Should().BeGreaterThanOrEqualTo(durableVersion,
+            "a refused write must emit the STORED (winning) row — that is the 'what is durable now' "
+            + "contract the write-integrity chain merges into, and the signal an owner rebases on");
+
+        var durable = await ReadDurable(path).Should().Within(30.Seconds()).Emit();
+        durable.Should().NotBeNull();
+        durable!.Version.Should().BeGreaterThanOrEqualTo(durableVersion,
+            "MeshNode.Version is the node's forward-only revision counter, so a write below the durable "
+            + "row is a stale snapshot — and on a replica whose in-process high-water mark is empty the "
+            + "STORE is the only thing left to enforce that");
+        durable.Name.Should().Be("durable-advance",
+            "the newer row's content must survive a losing write, not be overwritten by it");
+    }
+
+    [Fact(Timeout = 55_000)]
+    public async Task AConflictIsMerged_NotRefused_AndTheDroppedValueReachesTheActivityLog()
+    {
+        var id = $"store-merge-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active,
+            Description = "alpha beta"
+        }).Should().Within(30.Seconds()).Emit();
+
+        var created = await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+        var staleVersion = created!.Version;
+
+        const long durableVersion = 9000L;
+        await Storage.Write(
+                created with { Name = "durable-advance", Description = "alpha beta", Version = durableVersion },
+                JsonOptions)
+            .Should().Within(30.Seconds()).Emit();
+
+        // The losing write. Two members diverge in DIFFERENT ways on purpose:
+        //   Name        — "durable-advance" vs "stale-name": the splice both removes and inserts, so
+        //                 with no common ancestor it is NOT auto-resolvable → latest wins, and the drop
+        //                 must be reported.
+        //   Description — "alpha beta" vs "alpha beta gamma": a pure insertion, so the stale text is a
+        //                 superset → both writers' content survives.
+        var emitted = await Storage.Write(
+                created with { Name = "stale-name", Description = "alpha beta gamma", Version = staleVersion },
+                JsonOptions)
+            .Should().Within(30.Seconds()).Emit();
+        Output.WriteLine($"[conflicting write] emitted={(emitted is null ? "null" : $"v{emitted.Version}/{emitted.Name}")}");
+
+        var durable = await ReadDurable(path).Should().Within(30.Seconds()).Emit();
+        durable.Should().NotBeNull();
+        Output.WriteLine($"[durable] v{durable!.Version} name={durable.Name} description={durable.Description}");
+
+        durable.Version.Should().BeGreaterThanOrEqualTo(durableVersion,
+            "resolving a conflict by merging must never move the row backward — the merge keeps the "
+            + "LATEST row's version precisely so re-persisting it cannot itself read as a rollback");
+        durable.Name.Should().Be("durable-advance",
+            "two divergent strings with no common ancestor are not auto-resolvable — latest wins");
+        durable.Description.Should().Be("alpha beta gamma",
+            "the losing write's text was a pure insertion, so both writers' content survives — this is "
+            + "the 'merge both objects together' half of the policy, and refusing the write outright "
+            + "would have destroyed it");
+
+        // 🚨 The load-bearing half. Latest-wins is acceptable; latest-wins INVISIBLY is the defect
+        // (#968 was an acked write that rolled a row back with no error anywhere). The dropped member
+        // must leave a durable, user-visible trace.
+        var activityPath = $"{path}/_Activity/write-conflict-{staleVersion}-{durableVersion}";
+        var activity = await ReadDurable(activityPath).Should().Within(30.Seconds()).Emit();
+        activity.Should().NotBeNull(
+            "a conflict whose resolution DROPPED a value must record it in the activity log — a "
+            + "resolution nobody can see is the failure mode this whole mechanism exists to stop");
+        activity!.NodeType.Should().Be("ActivityLog");
+
+        var log = activity.Content.Should().BeOfType<ActivityLog>().Subject;
+        log.Category.Should().Be(ActivityCategory.WriteConflict);
+        log.Status.Should().Be(ActivityStatus.Warning,
+            "a resolution that dropped a value is a warning, not a clean success");
+        log.Messages.Where(m => m.LogLevel == LogLevel.Warning)
+            .Should().Contain(m => m.Message.Contains(nameof(MeshNode.Name), StringComparison.Ordinal),
+                "the entry must NAME the member whose value was dropped, not merely say a conflict happened");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MonotonicWriteGuardTests.cs
+++ b/test/MeshWeaver.Hosting.Test/MonotonicWriteGuardTests.cs
@@ -148,15 +148,25 @@ public class MonotonicWriteGuardTests
     [Fact]
     public async Task StaleHighWaterMark_DoesNotRefuse_WhenTheStoreMovedOutOfBand()
     {
-        // The in-process high-water mark is a cheap FILTER, never the verdict. Another
-        // replica deleting + recreating the node (or an out-of-band store restore) leaves
-        // this process holding a mark ABOVE the real durable row; the guard must verify
-        // against the store and let the write through, not refuse on a stale suspicion.
+        // The in-process high-water mark is a cheap FILTER, never the verdict. Another replica
+        // deleting + recreating the node leaves this process holding a mark ABOVE the real durable
+        // row; the guard must verify against the store and let the write through, not refuse on a
+        // stale suspicion.
         var (store, leaf) = BuildStore();
 
         await store.Write(Node("v50", 50), JsonOptions).Should().Emit();
 
-        // Out-of-band rewind straight on the leaf — this process never sees it.
+        // The out-of-band rewind, straight on the leaf — this process never sees it.
+        //
+        // 🚨 It is a DELETE + recreate, not a bare write of v1 over v50 (#971). The leaf itself is
+        // now version-conditional, so an in-place rewind through IStorageAdapter is refused by the
+        // STORE — that is the whole point of the store-level compare-and-set, and it is what makes a
+        // fresh replica's first write safe. Delete-then-recreate is how a legitimate rewind has
+        // always been expressed (see the guard's "Legitimate rewinds" note and the
+        // RecreateAfterDelete cases above): the row is gone, so the recreate at version 1 faces
+        // nothing to regress against. What this test pins is unchanged and orthogonal — that a mark
+        // left stale by that sequence cannot by itself refuse the next legitimate write.
+        await leaf.Delete(Path).Should().Emit();
         await leaf.Write(Node("recreated-elsewhere", 1), JsonOptions).Should().Emit();
 
         await store.Write(Node("v2-legitimate", 2), JsonOptions).Should().Emit();


### PR DESCRIPTION
Fixes #971.

## Verdict up front

**On a fresh replica's first write to a path, "the store never moves backward" was enforced by nothing at all.** Not by the in-process guard — its high-water table is empty on a new process, so the write took the unverified fast path. Not by the database — the Postgres upsert carried no version condition, and the in-memory store was a plain `_nodes[path] = node`. #968 closed the *in-process* window; this closes the *cross-process* one it explicitly recorded as residual.

The failure is silent by construction: the stale write is **acked**, and the next write is minted one above the rolled-back row and accepted for a perfectly good reason — so the wrong lineage persists with no error anywhere.

## The fix, in two halves

### 1. The invariant moves into the store

`MeshNode.Version` is the node's forward-only revision counter, so a correctly-produced write is always at or above what is stored. Every backend that can express that now refuses a strictly-regressing write **at the row** and reports it by emitting the STORED node instead of the one it was handed:

| backend | condition |
|---|---|
| Postgres | `INSERT … AS target … ON CONFLICT (namespace, id) DO UPDATE SET … WHERE target.version <= EXCLUDED.version` — row count 0 ⇒ refused |
| in-memory | one `AddOrUpdate` keeping the higher `Version` — atomic against every concurrent writer, no read-then-write window |
| Snowflake | `WHEN MATCHED AND t."version" <= s."version" THEN UPDATE SET …`; the no-MERGE emulator fallback gets a conditional `DELETE … AND "version" <= :version` plus a `WHERE NOT EXISTS` guard on the `INSERT` |

Equal versions still apply — re-persisting an unchanged node is a legitimate, common shape. A refused write publishes **no** change notification (nothing changed, and a notification carrying the loser would hand every subscriber the state the store just rejected), and on Snowflake none of the trigger-replacement steps run either, since they all derive from a row that was not written. `WriteMany` reads per-command `NpgsqlBatchCommand.Rows`, so a refused node in a batch is neither announced nor reported as committed, and the caller gets durable truth back in its original order.

The contract is written into `IStorageAdapter.Write`'s doc, including the explicit licence for backends that cannot express it to behave as before.

### 2. The conflict resolves by MERGING, never by refusing

Per the maintainer's policy on the issue. Callers of `stream.Update` do not write conflict-retry loops and must not have to, so `MonotonicWriteGuardStorageAdapter` now funnels **both** conflict detectors — its own verification read, and a store that refused the write — into one resolution: re-read, merge the loser into durable truth, write once. Deliberately **one attempt, never a retry loop**: if the row moved again during the merge, the second refusal is logged and the newer row is kept.

The merged node carries the **latest** row's version, specifically so re-persisting it cannot itself read as a rollback. That also preserves the `saved.Version > written.Version` signal `RefusedWriteOwnerRebaseTest` pins, so the owner-rebase path is unchanged.

## How each policy rule maps onto the shared merge

You asked me not to write a second merge. I did not — but one rule genuinely could not be expressed through the existing entry point, and I want to be plain about which.

**`MeshNodePatchMerge.Apply` (three-way) cannot serve this at all.** Its whole classification turns on `live == base`, and handed `baseValues: null` it takes the "no conflict signal" branch and applies the patch **wholesale** — i.e. the stale snapshot overwrites the newer row, which *is* the defect. There is no argument shape that makes it behave two-way. So the addition is a second **entry point on the same class** (`ApplyTwoWay`), sharing the recursion, `StringDelta`, and `MergeArray`, rather than a second merge implementation that could drift. `MeshNodeConflictMerge` on top of it owns only the MeshNode member mapping (which members are user data, which are the store's own bookkeeping, and how `Content` is projected to JSON and materialised back into its CLR type — the node as a whole is never serialized, because `HubConfiguration`/`GlobalServiceConfigurations` are delegates).

| rule | how it lands | shared with the three-way merge? |
|---|---|---|
| **non-strings → latest wins** | every non-string, non-object, non-array leaf keeps `live` and reports the member | **identical** — `Apply` already refuses conflicting scalars and keeps live |
| **strings → try to merge** | `StringDelta.Compute(latest, stale)` reduces the pair to one splice; a pure **insertion** means stale ⊃ latest (take the superset), a pure **removal** means latest ⊃ stale (keep latest); a splice that both removes and inserts is a genuine divergence ⇒ not auto-resolvable | **new rule, shared primitive.** `Apply`'s string merge rebases the writer's splice over the intervening edit — that needs a base. With none, only the superset case is decidable. |
| **arrays → element identity, not RFC 7396 replace** | calls the **same `MergeArray`** with an empty base, which is exactly "neither side can be shown to have removed anything, so keep every element" — union by whole-element value equality | **same code path** |
| **unresolvable → latest wins + a warning in the activity log** | `onOverwritten` → `OverwrittenMembers` → a `LogWarning` **and** a durable `ActivityLog` MeshNode | **new** — `Apply`'s `onRefuse` has no durable sink today |

**Which MeshNode members take the string merge:** only `Name` and `Description` — the prose. `NodeType`, `Category`, `Icon` and `DesiredId` are wire identifiers, not text; the superset rule would happily splice `"Code"` and `"CodeCell"` into one of them and silently **retype** the node, which drives routing and per-node hub activation. `PreRenderedHtml` is derived from `Content`, so it follows the merged content rather than being spliced into broken markup. All five take latest-wins-**and-report**, so the policy's fallback still covers them and nothing is dropped silently. The user data that actually benefits from merging lives in `Content`, which is merged leaf by leaf.

Two ambiguities the base-less merge cannot resolve, decided deliberately and documented at the call site rather than hidden:

- **A superset string, and a union array, can resurrect content the newer writer deleted.** Without a common ancestor, "the stale writer inserted this" and "the newer writer deleted it" are literally the same observation. The alternative silently destroys content an acked write added, which is the failure mode of record — so the policy resolves toward keeping content. Resurrection is visible in the content and reported; destruction is not.
- **A key absent from the latest object is never adopted from the stale one.** The serializer suppresses defaults, so absence is ambiguous between "removed" and "is the default" — and under both readings the newer state is the one to keep. Adopting there would let an older snapshot re-assert a field the newer write had just defaulted.

## The warning is the load-bearing half

Latest-wins is acceptable; latest-wins **invisibly** is the #968 defect — an acked write that rolled a row back with no error anywhere. So every member the merge could not resolve produces both:

- a structured `LogWarning` naming the path, both versions, and the merged / dropped member lists; and
- a durable `ActivityLog` MeshNode at `{path}/_Activity/write-conflict-{latestVersion}`, category `WriteConflict`, `ActivityStatus.Warning`, with one `LogLevel.Warning` message **per dropped member, naming it**.

The id is keyed on the **durable** version alone, never the loser's. That is the right granularity ("this revision had a conflict") and it is what bounds the litter: a wedged owner mints an *increasing* version on every retry — the #725/#872 fork shape, 834, 835, 836 … against a stuck 2423 — so keying on the losing version would accumulate one satellite per attempt, forever. Re-recording overwrites the same node at `Version = 1`, which the store's equal-version rule accepts, so the record can never conflict with itself. It is best-effort by contract (a failed trace must not fail the resolution it describes) and skipped for paths already inside an `_Activity` namespace, so a conflict on a trace can never write a trace about a trace.

## Snowflake

**Fixed, not deferred — but unverified against a live endpoint.** `SnowflakePartitionStorageProvider` has **no write path of its own** (grep for `INSERT`/`MERGE`/`UPDATE`/`Write(` in it returns nothing): it exposes `SnowflakePathRoutingAdapter`, whose `Write` delegates straight to the per-schema `SnowflakeStorageAdapter.Write`. That is the path now made version-conditional, so the provider's gap closes with it.

Its *other* per-process dictionaries (`_registeredPartitions`, `_schemasInitialized`, `_provisioned`) are **not** the same defect and are deliberately untouched: they are idempotent provisioning promise-caches, not an authority on durable state. A second replica starting with an empty `_provisioned` just re-runs an idempotent `CREATE SCHEMA IF NOT EXISTS`; nothing is lost.

I could not execute this against Snowflake or its emulator — that backend has no CI coverage here. The change is compile-clean and shape-identical to the Postgres one, and that is the whole of my evidence for it.

## Not covered, and why

FileSystem, Caching, Sqlite, Cosmos and AzureBlob adapters keep their previous behaviour, which the interface doc now explicitly sanctions. FileSystem/Caching/Sqlite are single-process dev and test hosts — there is no second replica, and a file-level read-then-write "CAS" would be racy anyway. Cosmos has ETag optimistic concurrency but no `version <=` predicate: it would need a read plus `IfMatch` on every write, i.e. an extra round-trip on the hot path, against a backend that is emulator-unverified with a known contract gap. In every one of these the in-process guard remains the protection it always was, which is sound precisely because they are not multi-replica.

## Verification

**Fail-without, run against current `main`** (the two behaviour-bearing files reverted to `origin/main`, rebuilt, re-run) — both new tests fail, and the output names the defect exactly:

- `AWriterWithNoHighWaterMark_CannotRollTheDurableRowBack` → `[replica write] emitted=v1/stale-snapshot`, `Expected 1 to be greater than or equal to 7000`. On main the fresh replica's write **landed**: the v1 snapshot went straight over the v7000 row. That is the issue's silent rollback, reproduced.
- `AConflictIsMerged_NotRefused_AndTheDroppedValueReachesTheActivityLog` → `[durable] v9000 name=durable-advance description=alpha beta`, `Expected "alpha beta gamma" … but found "alpha beta"`. On main the conflict was **refused**, so the losing write's text was destroyed rather than merged, and no activity-log record existed.

**Pass-with:** 2/2. The property is **constructed, not raced** — "a second writer with no prior mark" is a fresh `MonotonicWriteGuardStorageAdapter` instance over the same store, which is exactly a newly started replica's state. No load, no sleeps, no timing budget.

**Regression**, biased toward everything that writes an explicit `MeshNode.Version` (found by grepping the test tree for `Version = ` alongside a `.Write(`):

| scope | result |
|---|---|
| `MeshWeaver.Hosting.Test` (whole project) | **129 / 129** |
| write-integrity pins: `MonotonicWriteGuardWindowTest`, `RefusedWriteOwnerRebaseTest`, `StaleActivationSeedRollbackTest`, `StaleActivationDurableFirstSeedTest` + the 2 new | **8 / 8** |
| Monolith `Version|Storage|Persist|Recycle|NodeOps` subset | **33 / 33** |
| `PartitionRootBootstrapTest`, `OwnerlessPartitionRepairTest` | **12 / 12** |
| `GhostPartitionRootRecoveryTest`, `BulkSaveInstallTest` | **6 / 6** |

One existing test needed a **setup** change, and it is worth reading rather than skimming. `MonotonicWriteGuardTests.StaleHighWaterMark_DoesNotRefuse_WhenTheStoreMovedOutOfBand` simulated "another replica deleted + recreated the node" by writing v1 straight over v50 on the leaf, with no delete. The leaf is now version-conditional, so the **store** refuses that in-place rewind — which is precisely the behaviour this PR exists to add, so the setup, not the guard, was what broke. It now does what its own comment says: `Delete` then recreate at v1, which is how a legitimate rewind has always been expressed (the `RecreateAfterDelete*` cases beside it, and the guard's "Legitimate rewinds" note — the row is gone, so the recreate faces nothing to regress against). The property it pins is untouched and still fails if the guard ever trusts its mark over a verification read. **An in-place rewind through `IStorageAdapter` is no longer possible on a conditional backend** — that is a deliberate, load-bearing consequence, not a side effect: an out-of-band restore is done with database tooling, not through this interface.

**The Postgres SQL was executed against real Postgres**, not merely compiled — the aliased-target + conditional-`ON CONFLICT` shape on a scratch temp table: create `INSERT 0 1`, advance to 7000 `INSERT 0 1`, regressing write at v1 **`INSERT 0 0` with the row untouched**, equal-version rewrite `INSERT 0 1`. That zero row count is exactly what `WriteAsyncCore` now reads to report the refusal.

`dotnet build -c Release -warnaserror` clean on `MeshWeaver.Hosting`, `MeshWeaver.Hosting.PostgreSql`, `MeshWeaver.Hosting.Snowflake` and `MeshWeaver.Hosting.Monolith.Test`, after merging current main.

**What I could not verify locally:** the Postgres and Snowflake test suites. The PG suite needs its container fixture and this machine was already carrying heavy contention; the Snowflake one has no CI coverage at all. The SQL probe above is the strongest evidence I could get for the PG statement short of that suite — CI is the check for the rest, and the PG change touches every write, so it is the thing to watch on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
