### PR TITLE
Bound the trace log's fault RATE, not its lifetime total — a spent budget silenced the wedge

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -39,6 +39,24 @@ It arrives inside the **`testResults-shard<N>`** artifact under `collected-logs/
 alongside `_meshweaver-test-trace.log` and `_meshweaver-memory-delta.log`. **Retention is 15 days** —
 pull it before it expires.
 
+### 🚨 Ask the trace log whether it is complete before you reason from it
+
+`_meshweaver-test-trace.log` carries `[FAULT]` records — exception type, message and stack for
+everything logged at `Warning` or above with an exception. Its fault records are **rate-bounded**
+(100 per 10 s per process), so a storming process has records missing, and reasoning from an
+absence in a truncated log is how you conclude the wrong thing. The log always says when that
+happened:
+
+```bash
+grep FAULT-BUDGET collected-logs/_meshweaver-test-trace.log
+```
+
+Nothing back ⇒ every fault this process logged is in the file. Otherwise each hit names the
+running count of suppressed records, and a `resuming fault records after suppressing N` line
+states exactly how many were lost in that gap. A **budget never silences a later fault** — the
+window refills, so the fault next to a wedge is written even if an earlier storm saturated the
+allowance (issue #982).
+
 ```bash
 # find the shard artifact (the crashing shard's is the big one — the others are ~0MB)
 gh api repos/Systemorph/MeshWeaver/actions/runs/<RUN_ID>/artifacts \

--- a/src/MeshWeaver.Fixture/FaultRecordBudget.cs
+++ b/src/MeshWeaver.Fixture/FaultRecordBudget.cs
@@ -1,0 +1,147 @@
+namespace MeshWeaver.Fixture;
+
+/// <summary>
+/// What <see cref="FaultRecordBudget.Claim"/> decided about one fault record.
+/// </summary>
+/// <param name="WriteRecord">
+/// <c>true</c> when the record itself may be written; <c>false</c> when it is suppressed.
+/// </param>
+/// <param name="Notice">
+/// A sink-level line to write when non-null — <em>before</em> the record when
+/// <paramref name="WriteRecord"/> is <c>true</c>, and <em>instead of</em> it when it is
+/// <c>false</c>. This is the only thing that keeps a suppressed stretch visible, so a caller
+/// must never drop it.
+/// </param>
+public readonly record struct FaultRecordVerdict(bool WriteRecord, string? Notice);
+
+/// <summary>
+/// The write budget for
+/// <see cref="TestTraceLog.AppendFault(string, Microsoft.Extensions.Logging.LogLevel, string, Exception)"/>
+/// — a refilling per-window
+/// allowance, not a lifetime cap.
+///
+/// <para><b>Why a rate and not a total (issue #982).</b> The hazard this bounds is a
+/// <em>storm</em>: a resubscribe loop logging a fault per iteration writes until the runner's
+/// disk fills (the 2026-07 colima ENOSPC failure mode). A storm is a property of the write
+/// RATE, so a rate is what has to be bounded. The previous design bounded the lifetime TOTAL
+/// (1000 records per process) instead, which is a different quantity and had a fatal
+/// consequence for the sink's actual job: once a busy process passed the total, EVERY later
+/// fault was dropped for the rest of the process — including the one that fires next to the
+/// wedge, which is the only record anyone ever wants. Two shard-3 processes hit that ceiling in
+/// every sampled run of #982's 17-run sample, so the sink was at its least useful exactly in
+/// the long, busy processes where a wedge is most likely.</para>
+///
+/// <para>A window budget refills, so an earlier storm can never permanently silence the sink:
+/// a fault arriving after a quiet stretch is always written. What it costs is fidelity
+/// <em>during</em> a storm — the 101st fault in a 10-second burst is dropped — and that is the
+/// right trade, because a storm's records are the same record repeated while the late,
+/// isolated fault is unique.</para>
+///
+/// <para><b>Why not keep first-N + last-N.</b> Retaining the tail means buffering it in memory
+/// and flushing at the end — but this sink exists precisely for the case where there IS no end:
+/// a shard killed by its wall-clock cap (<c>exit=124</c>) or a host dying on a signal never runs
+/// a flush. Anything not already on disk when the process dies is gone, so every record must be
+/// written eagerly, line by line. A ring buffer would trade the one property that makes this
+/// file the only diagnostic CI keeps.</para>
+///
+/// <para><b>Truncation is never silent.</b> Whenever suppression starts in a window the budget
+/// hands back a notice line carrying the running suppressed count, and the first record written
+/// after a suppressed stretch carries a second notice naming exactly how many were lost in the
+/// gap. Both are tagged <c>[FAULT-BUDGET]</c>, so <c>grep FAULT-BUDGET</c> over a collected log
+/// answers "is this file complete?" — and a process killed mid-storm leaves the entering notice
+/// as the last thing in the file rather than an unremarkable silence.</para>
+/// </summary>
+public sealed class FaultRecordBudget
+{
+    private readonly int recordsPerWindow;
+    private readonly TimeSpan window;
+    private readonly object gate = new();
+
+    private DateTime windowStart;
+    private int writtenInWindow;
+    private bool noticedInWindow;
+    private long suppressedSinceLastRecord;
+    private long suppressedTotal;
+
+    /// <summary>
+    /// Creates a budget allowing <paramref name="recordsPerWindow"/> fault records per
+    /// <paramref name="window"/>.
+    /// </summary>
+    /// <param name="recordsPerWindow">Records allowed per window; must be positive.</param>
+    /// <param name="window">The window length; must be positive.</param>
+    public FaultRecordBudget(int recordsPerWindow, TimeSpan window)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(recordsPerWindow);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(window, TimeSpan.Zero);
+        this.recordsPerWindow = recordsPerWindow;
+        this.window = window;
+    }
+
+    /// <summary>
+    /// Total fault records this budget has suppressed. Monotonic for the life of the instance.
+    /// </summary>
+    public long SuppressedTotal
+    {
+        get { lock (gate) return suppressedTotal; }
+    }
+
+    /// <summary>
+    /// Claims the right to write one fault record at <paramref name="now"/>.
+    /// </summary>
+    /// <param name="now">
+    /// The record's timestamp. Passed in rather than read from the clock so the window
+    /// behaviour is deterministically testable without sleeping.
+    /// </param>
+    /// <returns>The verdict; see <see cref="FaultRecordVerdict"/>.</returns>
+    public FaultRecordVerdict Claim(DateTime now)
+    {
+        // A plain lock, not an async gate: this is a synchronous file-sink leaf with no await
+        // inside it, called from ILogger.Log. It is on nobody's hub scheduler.
+        lock (gate)
+        {
+            var elapsed = now - windowStart;
+            // elapsed < 0 rolls too, so a clock stepping backwards cannot freeze the window
+            // open and starve the budget for the rest of the process.
+            if (elapsed >= window || elapsed < TimeSpan.Zero)
+            {
+                windowStart = now;
+                writtenInWindow = 0;
+                noticedInWindow = false;
+            }
+
+            if (writtenInWindow < recordsPerWindow)
+            {
+                writtenInWindow++;
+                if (suppressedSinceLastRecord == 0)
+                    return new FaultRecordVerdict(true, null);
+
+                var dropped = suppressedSinceLastRecord;
+                suppressedSinceLastRecord = 0;
+                return new FaultRecordVerdict(
+                    true,
+                    $"resuming fault records after suppressing {Plural(dropped)} "
+                    + $"({suppressedTotal} suppressed in this process so far) — "
+                    + "this log is NOT a complete record of faults");
+            }
+
+            suppressedSinceLastRecord++;
+            suppressedTotal++;
+            if (noticedInWindow)
+                return new FaultRecordVerdict(false, null);
+
+            // One notice per window, not one per dropped record: enough to keep the file
+            // honest while it is storming, cheap enough that the notice can never become the
+            // storm itself.
+            noticedInWindow = true;
+            return new FaultRecordVerdict(
+                false,
+                $"budget of {recordsPerWindow} fault records per {window.TotalSeconds:0.###}s "
+                + $"exhausted — suppressing further fault records until the window rolls "
+                + $"({suppressedTotal} suppressed in this process so far); "
+                + "this log is NOT a complete record of faults");
+        }
+    }
+
+    private static string Plural(long count) =>
+        count == 1 ? "1 fault record" : $"{count} fault records";
+}

--- a/src/MeshWeaver.Fixture/FaultRecordBudget.cs
+++ b/src/MeshWeaver.Fixture/FaultRecordBudget.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace MeshWeaver.Fixture;
 
 /// <summary>
@@ -135,7 +137,10 @@ public sealed class FaultRecordBudget
             noticedInWindow = true;
             return new FaultRecordVerdict(
                 false,
-                $"budget of {recordsPerWindow} fault records per {window.TotalSeconds:0.###}s "
+                // Invariant so the line reads identically whatever locale the runner is in —
+                // a diagnostic that changes shape by machine is a diagnostic you cannot grep.
+                $"budget of {Plural(recordsPerWindow)} per "
+                + $"{window.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture)}s "
                 + $"exhausted — suppressing further fault records until the window rolls "
                 + $"({suppressedTotal} suppressed in this process so far); "
                 + "this log is NOT a complete record of faults");

--- a/src/MeshWeaver.Fixture/TestTraceLog.cs
+++ b/src/MeshWeaver.Fixture/TestTraceLog.cs
@@ -136,11 +136,16 @@ public static class TestTraceLog
         // The notice is what stops a truncated log from reading like a complete one, so it is
         // written whether or not the record itself survives — and it is tagged so a reader can
         // answer "did this file lose anything?" with one grep.
-        if (verdict.Notice is not null)
-            Append($"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT-BUDGET] {verdict.Notice}");
+        var notice = verdict.Notice is null
+            ? null
+            : $"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT-BUDGET] {verdict.Notice}";
 
         if (!verdict.WriteRecord)
+        {
+            if (notice is not null)
+                Append(notice);
             return;
+        }
 
         var detail = exception.ToString();
         if (detail.Length > MaxExceptionChars)
@@ -149,7 +154,14 @@ public static class TestTraceLog
         // pid on the header line for the same reason the phase trace carries it: every
         // test project in a shard appends to this one file, and a core dump is named
         // dotnet-<pid>.dmp.
-        Append($"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT] "
-            + $"[{level}] [{category}] {message}{Environment.NewLine}{detail}");
+        var record = $"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT] "
+            + $"[{level}] [{category}] {message}{Environment.NewLine}{detail}";
+
+        // ONE Append, so the notice and the record it explains cannot be split. Append releases
+        // the file lock per call and every test host in the shard writes to this file, so two
+        // calls would let another writer land between them — and a "resuming after suppressing
+        // N" line stranded from the record that resumed reintroduces exactly the ambiguity this
+        // whole change exists to remove.
+        Append(notice is null ? record : notice + Environment.NewLine + record);
     }
 }

--- a/src/MeshWeaver.Fixture/TestTraceLog.cs
+++ b/src/MeshWeaver.Fixture/TestTraceLog.cs
@@ -97,6 +97,11 @@ public static class TestTraceLog
     /// active, which is exactly the wedge case. That is why the recurring compile abort
     /// of issue #890 was undiagnosable: the framework logged the exception object with
     /// its stack, and every sink that carried the stack was invisible to CI.</para>
+    ///
+    /// <para>Records are rate-bounded by <see cref="FaultRecordBudget"/>, so a storming process
+    /// has some suppressed — but never a late one, and never silently: each suppressed stretch
+    /// is announced in the file by a <c>[FAULT-BUDGET]</c> line carrying the count, so
+    /// <c>grep FAULT-BUDGET</c> answers "is this log complete?".</para>
     /// </summary>
     /// <param name="category">The logger category name.</param>
     /// <param name="level">The record's severity.</param>

--- a/src/MeshWeaver.Fixture/TestTraceLog.cs
+++ b/src/MeshWeaver.Fixture/TestTraceLog.cs
@@ -13,7 +13,8 @@ namespace MeshWeaver.Fixture;
 ///
 /// <para>Two writers share it, which is why the path and the lock live here rather than
 /// on either one: <c>MonolithMeshTestBase</c>'s per-test phase trace, and
-/// <see cref="AppendFault"/> below. A second writer holding its OWN lock would interleave
+/// <see cref="AppendFault(string, LogLevel, string, Exception)"/> below.
+/// A second writer holding its OWN lock would interleave
 /// mid-line with the first and corrupt both.</para>
 /// </summary>
 public static class TestTraceLog
@@ -54,17 +55,35 @@ public static class TestTraceLog
         try { File.AppendAllText(Path, string.Empty); } catch { /* best-effort */ }
     }
 
-    // Bound on the number of fault records this process may append. A test process that
-    // storms (a resubscribe loop logging a warning per iteration) would otherwise write
-    // the artifact until the runner's disk fills — the 2026-07 colima ENOSPC failure mode.
-    // This bounds the ARTIFACT, not the diagnosis: the first faults in a cascade are the
-    // ones that name the cause; the thousandth repeat adds nothing.
-    // Sized against measurement, not a guess: one deliberately-failing compile test
-    // (CodeEditRecompileTest.FailedCompile_…) emits 15 fault records, so a per-shard budget
-    // has to be in the thousands to still be holding the record that names a LATE fault.
-    private const int MaxFaultRecords = 1000;
+    // ── Fault-record budget ────────────────────────────────────────────────────────────
+    // Bounds the write RATE, because a storm (a resubscribe loop logging a warning per
+    // iteration filling the runner's disk — the 2026-07 colima ENOSPC failure mode) IS a
+    // rate. It deliberately does NOT bound the lifetime total: a total, once spent, silences
+    // the sink for the rest of the process and takes the late fault next to the wedge with
+    // it, which is the only record anyone ever reads (issue #982). See FaultRecordBudget for
+    // the full argument, including why keeping the tail in a ring buffer is not an option
+    // here (a process killed by `timeout` never flushes one).
+    //
+    // Sized against the #982 measurement, not a guess: a healthy shard process emits ~1500
+    // fault records across a ≤20-minute shard — order 1.3/s. 100 per 10s is ~7x that, so a
+    // healthy run never suppresses, while a genuine storm (thousands/s) is clamped to 10/s.
+    // The artifact cost is then bounded by WALL CLOCK rather than by an arbitrary total:
+    // 10 records/s x ~3 KB ≈ 1.8 MB/min, and a shard's own 20-minute cap (its projects run
+    // sequentially in one loop) puts the ceiling near 36 MB uncompressed — a few MB in the
+    // artifact at the workflow's compression-level 9.
+    private const int FaultRecordsPerWindow = 100;
+    private static readonly TimeSpan FaultWindow = TimeSpan.FromSeconds(10);
+
+    // Process-wide, and deliberately so, despite the no-static-state rule: this sink IS a
+    // per-process artifact (CI collects one file per runner) and its writers — fixture
+    // construction, teardown, and reactive continuations on background schedulers — belong to
+    // no mesh and outlive every mesh in the process. A mesh-scoped budget would reset on each
+    // test class and so would not bound a storm that spans classes, which is the hazard. It
+    // needs no Clear()-for-test-isolation hook either: the policy is exercised in tests
+    // through its own instances (FaultRecordBudget), never through this one.
+    private static readonly FaultRecordBudget FaultBudget = new(FaultRecordsPerWindow, FaultWindow);
+
     private const int MaxExceptionChars = 2500;
-    private static int _faultRecordsWritten;
 
     /// <summary>
     /// Appends one fault record — level, category, message and the exception's full
@@ -84,15 +103,39 @@ public static class TestTraceLog
     /// <param name="message">The formatted log message.</param>
     /// <param name="exception">The exception whose type and stack to record.</param>
     public static void AppendFault(string category, LogLevel level, string message, Exception exception)
+        => AppendFault(FaultBudget, DateTime.UtcNow, category, level, message, exception);
+
+    /// <summary>
+    /// The <see cref="AppendFault(string, LogLevel, string, Exception)"/> body with its budget
+    /// and clock supplied — the seam tests use to exercise suppression deterministically
+    /// against their OWN <see cref="FaultRecordBudget"/>, without sleeping and without
+    /// spending the process's real budget (which would suppress a genuine fault logged later
+    /// in the same run).
+    /// </summary>
+    /// <param name="budget">The budget to claim from.</param>
+    /// <param name="now">The record's timestamp.</param>
+    /// <param name="category">The logger category name.</param>
+    /// <param name="level">The record's severity.</param>
+    /// <param name="message">The formatted log message.</param>
+    /// <param name="exception">The exception whose type and stack to record.</param>
+    public static void AppendFault(
+        FaultRecordBudget budget,
+        DateTime now,
+        string category,
+        LogLevel level,
+        string message,
+        Exception exception)
     {
-        var written = Interlocked.Increment(ref _faultRecordsWritten);
-        if (written > MaxFaultRecords)
-        {
-            if (written == MaxFaultRecords + 1)
-                Append($"{DateTime.UtcNow:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT] "
-                    + $"further fault records suppressed after {MaxFaultRecords} in this process");
+        var verdict = budget.Claim(now);
+
+        // The notice is what stops a truncated log from reading like a complete one, so it is
+        // written whether or not the record itself survives — and it is tagged so a reader can
+        // answer "did this file lose anything?" with one grep.
+        if (verdict.Notice is not null)
+            Append($"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT-BUDGET] {verdict.Notice}");
+
+        if (!verdict.WriteRecord)
             return;
-        }
 
         var detail = exception.ToString();
         if (detail.Length > MaxExceptionChars)
@@ -101,7 +144,7 @@ public static class TestTraceLog
         // pid on the header line for the same reason the phase trace carries it: every
         // test project in a shard appends to this one file, and a core dump is named
         // dotnet-<pid>.dmp.
-        Append($"{DateTime.UtcNow:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT] "
+        Append($"{now:HH:mm:ss.fff} pid={Environment.ProcessId} [FAULT] "
             + $"[{level}] [{category}] {message}{Environment.NewLine}{detail}");
     }
 }

--- a/test/MeshWeaver.Observability.Test/FaultRecordBudgetTest.cs
+++ b/test/MeshWeaver.Observability.Test/FaultRecordBudgetTest.cs
@@ -1,0 +1,177 @@
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// Pins the two properties issue #982 is about, on the policy that decides whether a fault
+/// record reaches <c>/tmp/meshweaver-test-trace.log</c> — the only diagnostic that survives a
+/// CI wedge.
+///
+/// <list type="number">
+/// <item>A late fault is never lost to an earlier storm. The old lifetime cap dropped every
+/// record after the 1000th for the rest of the process, so in exactly the long, busy
+/// processes where a wedge is likely, the fault next to the wedge was already discarded.</item>
+/// <item>Truncation is never silent. Whatever is dropped, the file says so, in a greppable
+/// line that carries the count.</item>
+/// </list>
+///
+/// <para>Every test uses its OWN budget instance, so there is no shared state to reset and no
+/// ordering dependency between tests.</para>
+/// </summary>
+public class FaultRecordBudgetTest
+{
+    private static readonly DateTime T0 = new(2026, 8, 9, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public void WithinTheWindowBudget_EveryRecordIsWrittenAndNothingIsAnnounced()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 3, Window);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var verdict = budget.Claim(T0);
+            Assert.True(verdict.WriteRecord);
+            // A healthy run must stay free of sink chatter, or the notice loses its meaning.
+            Assert.Null(verdict.Notice);
+        }
+
+        Assert.Equal(0, budget.SuppressedTotal);
+    }
+
+    [Fact]
+    public void OverflowingTheWindow_SuppressesButAnnouncesItWithACount()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 2, Window);
+        budget.Claim(T0);
+        budget.Claim(T0);
+
+        var first = budget.Claim(T0);
+        Assert.False(first.WriteRecord);
+        Assert.NotNull(first.Notice);
+        // The words a reader needs to see to know the file is partial.
+        Assert.Contains("suppressing", first.Notice, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("NOT a complete record", first.Notice, StringComparison.Ordinal);
+        Assert.Contains("1 suppressed in this process so far", first.Notice, StringComparison.Ordinal);
+        // And the bound it hit, so the reader can tell a storm from a bug in the sink.
+        Assert.Contains("2 fault records per 10s", first.Notice, StringComparison.Ordinal);
+
+        Assert.Equal(1, budget.SuppressedTotal);
+    }
+
+    [Fact]
+    public void AStormEmitsOneNoticePerWindow_NotOnePerDroppedRecord()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, Window);
+        budget.Claim(T0);
+
+        var announced = 0;
+        for (var i = 0; i < 500; i++)
+        {
+            var verdict = budget.Claim(T0);
+            Assert.False(verdict.WriteRecord);
+            if (verdict.Notice is not null)
+                announced++;
+        }
+
+        // Otherwise the notice becomes the storm it is reporting.
+        Assert.Equal(1, announced);
+        Assert.Equal(500, budget.SuppressedTotal);
+    }
+
+    /// <summary>
+    /// THE regression for #982: a storm early in a long process must not silence the sink for
+    /// the rest of it. Under the old lifetime cap this record was dropped; under a refilling
+    /// window it is written.
+    /// </summary>
+    [Fact]
+    public void ALateFaultAfterAnEarlierStorm_IsStillWritten()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, Window);
+        budget.Claim(T0);
+        for (var i = 0; i < 10_000; i++)
+            budget.Claim(T0);
+
+        // Ten minutes later — the wedge — a single fault fires.
+        var late = budget.Claim(T0 + TimeSpan.FromMinutes(10));
+
+        Assert.True(late.WriteRecord);
+        Assert.Equal(10_000, budget.SuppressedTotal);
+    }
+
+    [Fact]
+    public void ResumingAfterSuppression_StatesExactlyHowManyRecordsWereLostInTheGap()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, Window);
+        budget.Claim(T0);
+        budget.Claim(T0);
+        budget.Claim(T0);
+        budget.Claim(T0);
+
+        var resumed = budget.Claim(T0 + Window);
+
+        Assert.True(resumed.WriteRecord);
+        Assert.NotNull(resumed.Notice);
+        Assert.Contains("resuming fault records after suppressing 3 fault records",
+            resumed.Notice, StringComparison.Ordinal);
+        Assert.Contains("NOT a complete record", resumed.Notice, StringComparison.Ordinal);
+
+        // The gap counter resets, so the next resume reports ITS gap, not a running total.
+        budget.Claim(T0 + Window + Window);
+        var afterQuiet = budget.Claim(T0 + Window + Window + Window);
+        Assert.True(afterQuiet.WriteRecord);
+        Assert.Null(afterQuiet.Notice);
+    }
+
+    [Fact]
+    public void ASustainedStorm_KeepsAnnouncingSoTheTailIsNeverSilent()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, Window);
+        var suppressionNotices = new List<string>();
+        var resumeNotices = new List<string>();
+
+        // Three back-to-back saturated windows, as a wedged process would produce.
+        for (var w = 0; w < 3; w++)
+        {
+            var at = T0 + w * Window;
+            for (var i = 0; i < 50; i++)
+            {
+                var verdict = budget.Claim(at);
+                if (verdict.Notice is null)
+                    continue;
+                (verdict.WriteRecord ? resumeNotices : suppressionNotices).Add(verdict.Notice);
+            }
+        }
+
+        // One suppression notice per window — a process killed at any point during the storm
+        // leaves one within a window's worth of records of the tail, never a bare silence.
+        Assert.Equal(3, suppressionNotices.Count);
+        // Plus one per window the storm carried into, naming that gap exactly.
+        Assert.Equal(2, resumeNotices.Count);
+        Assert.All(resumeNotices, n =>
+            Assert.Contains("after suppressing 49 fault records", n, StringComparison.Ordinal));
+
+        // Each notice carries the running total, so the LAST one is a live lower bound on the
+        // loss without the reader having to scroll back to where the storm began.
+        Assert.Contains("1 suppressed in this process so far",
+            suppressionNotices[0], StringComparison.Ordinal);
+        Assert.Contains("99 suppressed in this process so far",
+            suppressionNotices[^1], StringComparison.Ordinal);
+        Assert.Equal(147, budget.SuppressedTotal);
+    }
+
+    /// <summary>
+    /// A backwards clock step (NTP) must roll the window rather than freeze it open, which
+    /// would starve the budget for the rest of the process — the very failure being fixed.
+    /// </summary>
+    [Fact]
+    public void AClockStepBackwards_RollsTheWindowInsteadOfStarvingIt()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, Window);
+        budget.Claim(T0);
+        Assert.False(budget.Claim(T0).WriteRecord);
+
+        Assert.True(budget.Claim(T0 - TimeSpan.FromMinutes(1)).WriteRecord);
+    }
+}

--- a/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
+++ b/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
@@ -60,6 +60,80 @@ public class TestTraceLogFaultTest
         Assert.Contains("MeshNodeCompilationService", contents, StringComparison.Ordinal);
     }
 
+    private static string ReadTraceLog()
+    {
+        // Read with FileShare.ReadWrite: this file is append-only and shared by every test
+        // host in a shard, so another writer may hold it open.
+        using var stream = new FileStream(
+            TestTraceLog.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Issue #982: a fault the budget drops must leave the file SAYING so. The file is the only
+    /// diagnostic that survives a wedge, so a reader who cannot tell a truncated log from a
+    /// complete one draws the wrong conclusion from a silence that is really a discard.
+    ///
+    /// <para>Uses its own tiny <see cref="FaultRecordBudget"/> rather than the process-wide one:
+    /// exhausting the real budget here would suppress a genuine fault logged later in this same
+    /// test host — the test would create the defect it is pinning.</para>
+    /// </summary>
+    [Fact]
+    public void ASuppressedFault_IsAnnouncedInTheCollectedTraceFile()
+    {
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, TimeSpan.FromMinutes(5));
+        var now = DateTime.UtcNow;
+        var kept = $"fault-kept-{Guid.NewGuid():N}";
+        var dropped = $"fault-dropped-{Guid.NewGuid():N}";
+
+        TestTraceLog.AppendFault(budget, now, "Probe", LogLevel.Warning, kept, Thrown(kept));
+        TestTraceLog.AppendFault(budget, now, "Probe", LogLevel.Warning, dropped, Thrown(dropped));
+
+        var contents = ReadTraceLog();
+
+        Assert.Contains(kept, contents, StringComparison.Ordinal);
+        // Really dropped — otherwise this test would pass on a sink that never suppresses.
+        Assert.DoesNotContain(dropped, contents, StringComparison.Ordinal);
+
+        // …and the drop is stated, in a line a reader can find with one grep. Asserted on the
+        // slice AFTER our own kept record so a notice written by another test in this shared
+        // file cannot stand in for the one this test is about.
+        var tail = contents[(contents.IndexOf(kept, StringComparison.Ordinal) + kept.Length)..];
+        Assert.Contains("[FAULT-BUDGET]", tail, StringComparison.Ordinal);
+        Assert.Contains("this log is NOT a complete record of faults",
+            tail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other half of #982: the budget refills, so the fault that fires next to the wedge —
+    /// long after an earlier storm spent the allowance — still reaches the file. Under the
+    /// lifetime cap this record was dropped for the rest of the process.
+    /// </summary>
+    [Fact]
+    public void AFaultAfterAnEarlierStorm_StillReachesTheCollectedTraceFile()
+    {
+        var window = TimeSpan.FromSeconds(10);
+        var budget = new FaultRecordBudget(recordsPerWindow: 1, window);
+        var now = DateTime.UtcNow;
+        var late = $"fault-late-{Guid.NewGuid():N}";
+
+        TestTraceLog.AppendFault(budget, now, "Probe", LogLevel.Warning, "burst", Thrown("burst"));
+        for (var i = 0; i < 50; i++)
+            TestTraceLog.AppendFault(budget, now, "Probe", LogLevel.Warning, "burst", Thrown("burst"));
+
+        // The wedge, ten minutes later.
+        TestTraceLog.AppendFault(
+            budget, now + TimeSpan.FromMinutes(10), "Probe", LogLevel.Warning, late, Thrown(late));
+
+        var contents = ReadTraceLog();
+
+        Assert.Contains(late, contents, StringComparison.Ordinal);
+        // And the record that survived says how much of the burst was lost before it.
+        Assert.Contains("resuming fault records after suppressing 50 fault records",
+            contents, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// The file the assertion above reads is the one the CI workflow copies into
     /// <c>collected-logs/</c>; if the path ever drifts from that contract the artifact silently

--- a/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
+++ b/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
@@ -104,6 +104,9 @@ public class TestTraceLogFaultTest
         Assert.Contains("[FAULT-BUDGET]", tail, StringComparison.Ordinal);
         Assert.Contains("this log is NOT a complete record of faults",
             tail, StringComparison.Ordinal);
+        // Tied to THIS test's budget by its distinctive bound, so a suppression notice from any
+        // other writer in this shared file cannot satisfy the assertion in its place.
+        Assert.Contains("budget of 1 fault record per 300s", tail, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
+++ b/test/MeshWeaver.Observability.Test/TestTraceLogFaultTest.cs
@@ -13,7 +13,8 @@ namespace MeshWeaver.Observability.Test;
 /// <c>ILogger.LogWarning(exception, …)</c> reached only xUnit's <c>ITestOutputHelper</c>
 /// (which the trx logger does not persist) and an opt-in per-method file that is off in CI.
 /// So a recurrence reported <c>Object reference not set to an instance of an object.</c> and
-/// nothing else. <see cref="TestTraceLog.AppendFault"/> is the sink that closes that gap.</para>
+/// nothing else. <see cref="TestTraceLog.AppendFault(string, LogLevel, string, Exception)"/>
+/// is the sink that closes that gap.</para>
 /// </summary>
 public class TestTraceLogFaultTest
 {


### PR DESCRIPTION
Fixes #982

## The defect

`/tmp/meshweaver-test-trace.log` is the **only** diagnostic that reaches CI after a wedge — no `.trx` is written when a shard is killed at its wall-clock cap, ActivityLog nodes are not artifacts, and nothing captures `ILogger`. That sink capped fault records at **1000 per process**. Two shard-3 processes hit the ceiling in every sampled run of #982's 17-run sample, and past it every later fault was dropped for the rest of the process.

So the sink was at its least useful exactly where a wedge is most likely: in a long, busy process, the fault firing *next to* the wedge had already been discarded before the wedge happened.

## Why the cap was the wrong shape, not merely the wrong number

The hazard the cap exists for is a **storm** — a resubscribe loop logging a fault per iteration, writing until the runner's disk fills (the 2026-07 colima ENOSPC failure mode). A storm is a property of the write **rate**. The cap bounded the lifetime **total**, which is a different quantity, and bought the disk protection by permanently silencing the sink. Raising 1000 to 10000 would have moved the ceiling without changing that; it would still be a lifetime total, still spent, still silent afterwards.

## The new bound, and what it costs

`FaultRecordBudget` — **100 fault records per 10-second window**, refilling.

Sized from the #982 measurement rather than guessed: a healthy shard process emits ~1500 fault records across a ≤20-minute shard, order **1.3/s**. The budget is 10/s, ~7× that, so **a healthy run never suppresses anything**. A genuine storm (thousands/s) is clamped to 10/s.

**What is still dropped:** the 101st and later fault within any single 10-second window. In practice that means a storm loses repeats of the record it is already storming with — and only for as long as it storms.

**What it never drops:** a fault after a quiet stretch. The window refills, so an earlier storm cannot silence a later record. That is the #982 property.

**Artifact cost is now bounded by wall clock instead of an arbitrary total:** 10 records/s × ~3 KB ≈ 1.8 MB/min, and a shard's own 20-minute cap (its projects run sequentially in one loop) puts the ceiling near **36 MB uncompressed** — a few MB in the artifact at the workflow's `compression-level: 9`. The old cap's ceiling was ~2.5 MB, so this trades a few MB of artifact for never losing the tail.

## A truncated log can no longer be mistaken for a complete one

Two `[FAULT-BUDGET]` lines, both in the same file, written through the same `Append`:

```
10:31:13.055 pid=57603 [FAULT-BUDGET] budget of 1 fault record per 10s exhausted — suppressing
  further fault records until the window rolls (1 suppressed in this process so far); this log is
  NOT a complete record of faults
10:41:13.055 pid=57603 [FAULT-BUDGET] resuming fault records after suppressing 50 fault records
  (50 suppressed in this process so far) — this log is NOT a complete record of faults
```

- **Entering suppression** emits one notice per window (not per dropped record — the notice must never become the storm), carrying the running suppressed count. A process killed mid-storm therefore leaves a notice within a window's worth of records of the tail, rather than an unremarkable silence.
- **Resuming** names exactly how many were lost in that gap.
- Both are greppable: `grep FAULT-BUDGET collected-logs/_meshweaver-test-trace.log`. Nothing back ⇒ the file is complete.

`DebuggingNativeCrashes.md` — what a triager reads before opening a collected shard artifact — now leads with that grep. It previously named the trace log without saying it could be partial.

## Why not first-N + last-N

Keeping the tail means buffering it in memory and flushing at the end, and this sink exists precisely for the case where there **is** no end: a host killed by `timeout` (`exit=124`) or dying on a signal never runs a flush. Anything not already on disk is gone. A ring buffer would trade away the one property that makes this file the only diagnostic CI keeps.

## Static state

The budget is process-static, deliberately, against the no-static-state rule. This sink **is** a per-process artifact (CI collects one file per runner), and its writers — fixture construction, teardown, and reactive continuations on background schedulers — belong to no mesh and outlive every mesh in the process. A mesh-scoped budget would reset on each test class and so would not bound a storm spanning classes, which is the hazard. It needs no `Clear()`-for-isolation hook: tests drive the policy through their own `FaultRecordBudget` instances via the `AppendFault(budget, now, …)` seam, never through the process one. No static collection is introduced — the state is scalar counters on one instance.

## Verification

The CI collection step (`dotnet-test.yml:588-589`) is a plain whole-file `cp` into `collected-logs/_meshweaver-test-trace.log`, uploaded `if: always()` — no trimming, no line limits — so the marker rides the exact same path as `[FAULT]` records, which #982 already verified empirically (102/102 shard artifacts carried it).

The pins were checked against **both** old behaviours by mutation, not assumed:

| Mutation | Result |
|---|---|
| Window never rolls (i.e. the old lifetime cap) | 5 failures, incl. `ALateFaultAfterAnEarlierStorm_IsStillWritten` and the end-to-end `AFaultAfterAnEarlierStorm_StillReachesTheCollectedTraceFile` |
| Suppression notice dropped (silent truncation) | 4 failures, incl. `ASuppressedFault_IsAnnouncedInTheCollectedTraceFile` |

`MeshWeaver.Observability.Test`: 67/67 green. `src/MeshWeaver.Fixture` and the test project both build clean under `-c Release -p:CIRun=true -warnaserror`.

## No What's New entry

Test/CI diagnostic infrastructure with no user-visible effect — skipped deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
