### PR TITLE
A pending Rx timer kept disposed hubs alive — in four watchers, three of them on the live thread path

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -188,6 +188,11 @@ internal static class ThreadExecution
         // round never dispatches (Status stuck at StartingExecution, IsExecuting
         // forever): the live-path "observer dies" deadlock. On fault, re-establish.
         IDisposable? sub = null;
+        // 🚨 #991 — hold the PENDING re-establish so teardown cancels it. An uncancelled
+        // `Observable.Timer` sits on the process-wide TimerQueue (a strong GC root) and
+        // roots `Establish` → this closure → the hub for the whole delay, so a stream that
+        // faults as the hub tears down keeps the hub alive past disposal.
+        var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
         // 🚨 Observe the PARENT thread hub's AUTHORITATIVE own MeshNode stream —
         // NOT the cross-hub IMeshNodeStreamCache. The cache opens a remote
@@ -273,12 +278,18 @@ internal static class ThreadExecution
                     logger?.LogWarning(ex,
                         "[ExecRoundWatcher] stream errored for {ThreadPath} — re-establishing", threadPath);
                     if (!disposed)
-                        System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                            .Subscribe(_ => Establish());
+                        pendingReEstablish.Disposable =
+                            System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
+                                .Subscribe(_ => Establish());
                 });
 
         Establish();
-        execHub.RegisterForDisposal(_ => { disposed = true; sub?.Dispose(); });
+        execHub.RegisterForDisposal(_ =>
+        {
+            disposed = true;
+            pendingReEstablish.Dispose();
+            sub?.Dispose();
+        });
     }
 
     /// <summary>
@@ -422,6 +433,11 @@ internal static class ThreadExecution
         // SIGABRT). The re-establish must stop when the hub is gone AND must hop off
         // the synchronous stack.
         var disposed = false;
+        // 🚨 #991 — hold the PENDING re-establish so teardown cancels it. An uncancelled
+        // `Observable.Timer` sits on the process-wide TimerQueue (a strong GC root) and
+        // roots `Establish` → this closure → the hub for the whole delay, so a stream that
+        // faults as the hub tears down keeps the hub alive past disposal.
+        var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         // Idempotency for the resume path: re-launch an interrupted round AT MOST
         // once per ActiveMessageId. The observation is self-healing (re-establishes
         // on fault), so without this a re-read of the same Executing state would
@@ -591,8 +607,9 @@ internal static class ThreadExecution
                     logger?.LogWarning(ex,
                         "[ThreadExec] Init observation faulted for {ThreadPath} — re-establishing recovery",
                         threadPath);
-                    System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                        .Subscribe(_ => { if (!disposed) Establish(); });
+                    pendingReEstablish.Disposable =
+                        System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
+                            .Subscribe(_ => { if (!disposed) Establish(); });
                 });
 
         Establish();
@@ -705,7 +722,13 @@ internal static class ThreadExecution
                 ex => logger?.LogWarning(ex,
                     "[ThreadExec] Init watchdog stream faulted for {ThreadPath}", threadPath));
 
-        hub.RegisterForDisposal(_ => { disposed = true; sub?.Dispose(); watchdog.Dispose(); });
+        hub.RegisterForDisposal(_ =>
+        {
+            disposed = true;
+            pendingReEstablish.Dispose();
+            sub?.Dispose();
+            watchdog.Dispose();
+        });
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -280,6 +280,11 @@ internal static class ThreadSubmissionServer
         // short delay. Mirrors ThreadExecution.InitializeThreadLifecycle and
         // ActivityControlPlaneExtensions.WatchControlPlane.
         var serial = new System.Reactive.Disposables.SerialDisposable();
+        // 🚨 #991 — hold the PENDING re-establish so teardown cancels it. An uncancelled
+        // `Observable.Timer` sits on the process-wide TimerQueue (a strong GC root) and
+        // roots `Establish` → this closure → the thread hub for the whole delay, so a
+        // stream that faults as the hub tears down keeps the hub alive past disposal.
+        var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
         // 🚨 Stage 1 of the in-memory inbox channel. Resolve-or-create the per-thread
         // ThreadInboxChannel here (thread-hub init — single threaded, before any round),
@@ -381,14 +386,16 @@ internal static class ThreadSubmissionServer
                         "[SubmissionWatcher] stream errored for {ThreadPath} — re-establishing",
                         threadPath);
                     if (!disposed)
-                        System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                            .Subscribe(_ => Establish());
+                        pendingReEstablish.Disposable =
+                            System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
+                                .Subscribe(_ => Establish());
                 });
 
         Establish();
         return System.Reactive.Disposables.Disposable.Create(() =>
         {
             disposed = true;
+            pendingReEstablish.Dispose();
             serial.Dispose();
         });
     }

--- a/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
@@ -222,7 +222,9 @@ public static class ActivityControlPlaneExtensions
     /// release a single-flight guard a faulted in-flight dispatch may have left set.</param>
     /// <param name="scheduleReEstablish">Test seam for how a transient re-establish is
     /// scheduled. Production default is a 1 s <see cref="Observable.Timer(TimeSpan)"/>
-    /// off the action block.</param>
+    /// off the action block. Returns the <see cref="IDisposable"/> that CANCELS the pending
+    /// schedule — the returned watcher disposes it, so tearing the watcher down also drops
+    /// the timer off the process-wide <c>TimerQueue</c> (#991).</param>
     /// <param name="onPoisonedContent">Optional visible sink invoked (once, with the fault) when
     /// the watcher stops on poisoned own content — route it somewhere a user/operator can see
     /// (park registry, health surface), not just a log.</param>
@@ -233,10 +235,25 @@ public static class ActivityControlPlaneExtensions
         ILogger? logger,
         string faultLogContext,
         Action? onTransientFault = null,
-        Action<Action>? scheduleReEstablish = null,
+        Func<Action, IDisposable>? scheduleReEstablish = null,
         Action<Exception>? onPoisonedContent = null)
     {
         var serial = new System.Reactive.Disposables.SerialDisposable();
+        // 🚨 #991 — the PENDING re-establish must be cancellable, and cancelled by teardown.
+        // `Observable.Timer` parks its entry on the process-wide `TimerQueue`, which is a
+        // strong GC root: for as long as the timer is pending it holds the tick closure →
+        // the `Establish` delegate → THIS method's closure → `source` → whatever the caller's
+        // factory captured (in prod the per-NodeType hub, via NodeTypeCompilationHelpers).
+        // The old code DISCARDED the timer's IDisposable, so disposing the watcher only set
+        // `disposed` and killed `serial` — a hub whose stream faulted within the last second
+        // of its life stayed rooted past Mesh.Dispose() (the ClrMD chain on #991:
+        // TimerQueue → …ObservableImpl.Timer+Single+_ → Action<Int64> → DisplayClass2_1 →
+        // Action → DisplayClass2_0 → Func<IObservable<MeshNode>> → MessageHub[AccessAssignment]).
+        // Teardown at mesh disposal is exactly when that fault happens, which is why the leak
+        // sampled as an intermittent MeshHubDisposalLeakTest failure. Holding the schedule in a
+        // SerialDisposable also makes the dispose race safe: a schedule handed over after
+        // disposal is disposed on assignment.
+        var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
         var schedule = scheduleReEstablish
             ?? (reEstablish => Observable.Timer(TimeSpan.FromSeconds(1)).Subscribe(_ => reEstablish()));
@@ -276,13 +293,16 @@ public static class ActivityControlPlaneExtensions
                         faultLogContext, address);
                     onTransientFault?.Invoke();
                     if (!disposed)
-                        schedule(Establish);
+                        pendingReEstablish.Disposable = schedule(Establish);
                 });
         }
         Establish();
         return System.Reactive.Disposables.Disposable.Create(() =>
         {
             disposed = true;
+            // Drop the pending re-establish FIRST — that is the TimerQueue entry rooting
+            // this whole closure graph (#991); `serial` only holds the live subscription.
+            pendingReEstablish.Dispose();
             serial.Dispose();
         });
     }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
@@ -35,6 +35,28 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// surviving hub it attaches ClrMD to the live process and prints the GC-root
 /// chain (root kind → type chain) that pins the disposed mesh — i.e. "who holds
 /// the references".</para>
+///
+/// <para>🚨 <b>A PASS HERE PINS NOTHING — this is a sampling probe, not a regression
+/// test.</b> Do not add a leak fix and treat a green run as proof, and do not read a
+/// green run as "no leak":</para>
+/// <list type="bullet">
+///   <item><description><b>It samples.</b> A root that is live only for a bounded window
+///     (#991: an uncancelled 1 s <c>Observable.Timer</c> on the process-wide
+///     <c>TimerQueue</c>) is caught only if the probe's forced GC lands inside that window.
+///     Fire first → collected → green, with the defect fully present.</description></item>
+///   <item><description><b>It cannot attribute.</b> It reports the FIRST
+///     <c>MessageHub</c> reachable from ANY non-stack root. A green run says "no hub was
+///     reached within the visit budget", not "root X is fixed"; a red run names whatever
+///     chain it happened to walk, which may be a different defect than the one you are
+///     chasing.</description></item>
+///   <item><description><b>It is inconclusive off Linux.</b> ClrMD snapshot-attach throws
+///     on macOS, so a surviving hub SKIPs (#674) — locally you learn nothing either
+///     way.</description></item>
+/// </list>
+/// <para>So: pin the specific root with a deterministic test next to the code that owns it,
+/// and prove it by reverting the fix and watching that test fail. #991's pin lives in
+/// <c>MeshWeaver.Hosting.Test.ActivityControlPlaneResubscribeTest</c>. This probe's job is
+/// DISCOVERY — naming a root nobody knew about — not verification.</para>
 /// </summary>
 public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {

--- a/test/MeshWeaver.Hosting.Test/ActivityControlPlaneResubscribeTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ActivityControlPlaneResubscribeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
@@ -44,7 +45,11 @@ public class ActivityControlPlaneResubscribeTest
             new Address("mesh", "1"),
             logger: null,
             faultLogContext: "test",
-            scheduleReEstablish: reEstablish => { if (reEstablishes++ < 5) reEstablish(); });
+            scheduleReEstablish: reEstablish =>
+            {
+                if (reEstablishes++ < 5) reEstablish();
+                return System.Reactive.Disposables.Disposable.Empty;
+            });
 
         subscriptions.Should().Be(1,
             "a terminal NotFound on the own node must NOT trigger a resubscribe storm");
@@ -65,7 +70,11 @@ public class ActivityControlPlaneResubscribeTest
             new Address("mesh", "1"),
             logger: null,
             faultLogContext: "test",
-            scheduleReEstablish: reEstablish => { if (scheduled++ < 2) reEstablish(); });
+            scheduleReEstablish: reEstablish =>
+            {
+                if (scheduled++ < 2) reEstablish();
+                return System.Reactive.Disposables.Disposable.Empty;
+            });
 
         subscriptions.Should().Be(3,
             "a transient fault must re-establish (initial subscribe + 2 bounded re-establishes)");
@@ -92,13 +101,100 @@ public class ActivityControlPlaneResubscribeTest
             new Address("mesh", "1"),
             logger: null,
             faultLogContext: "test",
-            scheduleReEstablish: reEstablish => { if (reEstablishes++ < 5) reEstablish(); },
+            scheduleReEstablish: reEstablish =>
+            {
+                if (reEstablishes++ < 5) reEstablish();
+                return System.Reactive.Disposables.Disposable.Empty;
+            },
             onPoisonedContent: ex => { sinkCalls++; sunk = ex; });
 
         subscriptions.Should().Be(1,
             "poisoned content replays on every resubscribe — re-establishing is a poison loop");
         sinkCalls.Should().Be(1, "the fault must land in the visible sink exactly once");
         sunk.Should().BeSameAs(poison);
+    }
+
+    /// <summary>
+    /// #991 — deterministic contract half: disposing the watcher must CANCEL a re-establish
+    /// that is already scheduled. The old code discarded the schedule's <see cref="IDisposable"/>
+    /// entirely, so nothing could cancel it.
+    /// </summary>
+    [Fact]
+    public void Dispose_CancelsAPendingReEstablishSchedule()
+    {
+        var scheduleCancelled = false;
+
+        var watcher = ActivityControlPlaneExtensions.SubscribeWithReEstablish<int>(
+            () => Observable.Throw<int>(new InvalidOperationException("transient hub hiccup")),
+            _ => { },
+            new Address("mesh", "1"),
+            logger: null,
+            faultLogContext: "test",
+            // Stand-in for the production `Observable.Timer(1s).Subscribe(...)`: hands back the
+            // handle that cancels the pending schedule instead of dropping it on the floor.
+            scheduleReEstablish: _ => System.Reactive.Disposables.Disposable.Create(
+                () => scheduleCancelled = true));
+
+        scheduleCancelled.Should().BeFalse("the transient fault armed a re-establish that is still pending");
+
+        watcher.Dispose();
+
+        scheduleCancelled.Should().BeTrue(
+            "tearing the watcher down must cancel the pending re-establish — an uncancelled "
+            + "Observable.Timer parks on the process-wide TimerQueue (a strong GC root) and pins "
+            + "everything the source factory captured, including the owning hub (#991)");
+    }
+
+    /// <summary>
+    /// #991 — the leak itself, with the REAL production schedule (no seam): a watcher whose
+    /// stream faults arms a 1 s <c>Observable.Timer</c>. That timer lives on the process-wide
+    /// <c>TimerQueue</c>, a strong GC root, and the tick closure holds
+    /// <c>Establish</c> → the method closure → the caller's <c>source</c> factory → whatever it
+    /// captured. In production that last hop is the per-NodeType <c>MessageHub</c> (ClrMD chain
+    /// on #991: <c>TimerQueue → …Timer+Single+_ → Action&lt;Int64&gt; → DisplayClass2_1 →
+    /// Action → DisplayClass2_0 → Func&lt;IObservable&lt;MeshNode&gt;&gt; → MessageHub</c>), which
+    /// is why <c>MeshHubDisposalLeakTest</c> intermittently caught a hub surviving
+    /// <c>Mesh.Dispose()</c> — teardown is exactly when the watched stream faults.
+    /// </summary>
+    [Fact]
+    public void Dispose_ReleasesTheSourceFactory_SoAPendingTimerCannotRootIt()
+    {
+        var weak = ArmProductionTimerThenDispose();
+
+        // One blocking collection is all it takes: the leak holds the capture for a FULL second,
+        // far longer than this runs, so a surviving target here is the leak, not GC latency.
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+
+        weak.IsAlive.Should().BeFalse(
+            "after the watcher is disposed nothing may still reach what its source factory "
+            + "captured — a pending re-establish timer on the TimerQueue would root it (#991)");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference ArmProductionTimerThenDispose()
+    {
+        // Stands in for the hub the production source factory closes over.
+        var captured = new object();
+
+        IDisposable? watcher = ActivityControlPlaneExtensions.SubscribeWithReEstablish<int>(
+            () => Observable.Defer(() =>
+            {
+                GC.KeepAlive(captured);
+                return Observable.Throw<int>(new InvalidOperationException("transient hub hiccup"));
+            }),
+            _ => { },
+            new Address("mesh", "1"),
+            logger: null,
+            faultLogContext: "test");
+        // No scheduleReEstablish ⇒ the real 1 s Observable.Timer is now pending.
+
+        watcher.Dispose();
+        watcher = null;
+        GC.KeepAlive(watcher);
+
+        return new WeakReference(captured);
     }
 
     [Fact]


### PR DESCRIPTION
Four watchers scheduled their self-healing re-establish as `Observable.Timer(1s).Subscribe(...)` and threw the returned `IDisposable` away. Nothing could cancel it, so tearing the watcher down left the timer pending — and an Rx timer lives on the process-wide `TimerQueue`, which is a strong GC root. While it is pending it holds the tick closure, the `Establish` delegate, the method closure, the caller's `source` factory, and everything that factory captured: a `MessageHub` and its entire graph.

Fixes #991.

## The finding that matters: three of the four are on the live thread path

#991 was filed against `ActivityControlPlaneExtensions`, because that is the arm the ClrMD dump happened to catch. Auditing for the same shape turned up three more copies — hand-rolled versions of the same primitive in `ThreadSubmission.InstallSubmissionWatcher` and both watchers in `ThreadExecution`. Those are production code on the thread submission/execution path, not a test-only surface. So the honest framing is not "a leak test was flaky"; it is a leak in shipped code that a flaky test exposed.

**Severity, quantified — because "leak" alone is too coarse.** I checked what each watcher's lifetime actually is rather than assuming the worst:

- All four are **one per hub**, installed at hub init. In particular `_Exec` is created eagerly once per thread hub (`InstallExecutionHub`, `HostedHubCreation.Always`), **not per round**, so this does *not* accumulate per submitted message or per agent round.
- Each occurrence is **bounded at roughly one timer interval (~1 s)**: when the tick lands, `Establish` early-returns on `disposed` and does not re-arm. Retention, not unbounded growth.
- What it costs is **teardown waves**. Disposing a hub faults its own-node stream, so arming this timer is one of the last things many hubs do before dying. NodeType recompile churn, grain deactivation, thread-hub idle collection and portal shutdown all tear down many hubs inside the same second, so the retained graphs overlap and peak memory carries an extra generation of hub graphs.

A root that accumulated per message would be far worse than this; it does not, and I would rather say so than let the diff imply it.

## What was actually wrong

`SubscribeWithReEstablish` is the sanctioned subscription primitive for any watcher whose death would leave a hub half-alive, so every per-NodeType hub installs three of them (compile, sources, release-request). Its teardown was:

```csharp
disposed = true;
serial.Dispose();       // kills the live subscription…
                        // …but nothing owns the pending re-establish timer
```

The source matches the ClrMD chain on #991 exactly, including the display-class ordinals: `DisplayClass2_1` is the `reEstablish => Observable.Timer(...)` lambda's scope, `DisplayClass2_0` is `SubscribeWithReEstablish`'s own closure (it holds `source`), and `SubscribeWithReEstablish` is the third closure-bearing method in the class, hence ordinal 2.

All four now hold the schedule in a `SerialDisposable` that teardown disposes. The `scheduleReEstablish` test seam changed from `Action<Action>` to `Func<Action, IDisposable>` so that a scheduled re-establish is expressible as cancellable at all — the old signature could not represent it.

## This eliminates the window; it does not merely narrow it

Stating it plainly, since it is the load-bearing claim: after `Dispose()` returns, the `TimerQueue` entry is gone and the closure graph is immediately unreachable. There is no residual window — not a shorter one.

The scope of that claim is this root. The guard reds on *any* non-stack root reaching a hub, so if it reds again with a different chain, that is a different root and needs its own fix.

## This is a class, not four one-off fixes — follow-up filed

Worth more to a reviewer than this diff: the same root-holding pattern has now been found **three separate times, by the same probe**, before this PR — each fixed in isolation, each with a comment in the code naming the leak it caused:

| Where | Shape | Fix at the time |
|---|---|---|
| `MessageHub` disposal watchdog | uncancelled `Task.Delay(25s)` rooting the whole hub graph after **every** dispose | `Observable.Timer` + `TakeUntil(disposalCompleted)` |
| `MessageHub.InstallStaleCallbackScanner` | `Observable.Interval` closure capturing `this` | `WeakReference<MessageHub>` + self-dispose on dead target |
| `JsonSynchronizationStream` heartbeat | `Observable.Interval` closure capturing `hub` | `WeakReference<IMessageHub>` + self-dispose |

Add this PR's four and it is seven sites of one defect: *an Rx timer whose subscription is not owned by anything that dies with the thing its closure captured*. Two sub-shapes — the subscription is discarded outright (this PR), or it is held but strongly pins an owner that may never be disposed (the `WeakReference` three). Each was found by a probe firing at random on an unrelated PR, months apart, which is an expensive way to find the eighth.

Filed as #995: audit every `Observable.Timer` / `Observable.Interval` in `src/` for a subscription that reaches no owner's disposal chain, and decide whether this is worth enforcing rather than remembering. That issue lays out the options (do nothing / write the convention down / enumerate the sites in a test / a Roslyn analyzer for the discarded-subscription shape) but deliberately leaves the call to a maintainer — the incident rate is low, and the audit should size it first.

## How this was verified

I did not take the ClrMD chain on faith. `ActivityControlPlaneResubscribeTest` gains two tests, and I ran the negative control both ways:

- `Dispose_CancelsAPendingReEstablishSchedule` — the contract, no timing involved: disposing the watcher must dispose the handle the schedule returned.
- `Dispose_ReleasesTheSourceFactory_SoAPendingTimerCannotRootIt` — the leak itself, with the real production 1 s timer and no seam: fault the watcher, dispose it, force a blocking gen-2 collect, assert what the `source` factory captured is gone.

With the two capture lines reverted (defect restored, signature unchanged) both fail with the expected messages; with the fix both pass. That is the pin.

## `MeshHubDisposalLeakTest` pins nothing — now documented on the test

It should not be read as verification for this or any future leak fix, so this PR says so in its docstring rather than leaving a future reader to assume a green run means something it does not. It **samples** (a bounded-window root is caught only if the forced GC lands inside the window — the issue says this outright), it **cannot attribute** (it reports the first hub reachable from any non-stack root), and on macOS ClrMD snapshot-attach is unsupported so a survivor SKIPs as inconclusive (#674). I verified that SKIP is identical on unmodified `origin/main` in a throwaway worktree before attributing it to #674 rather than to this change. Its job is discovery — naming a root nobody knew about — which is exactly what it did here.

## Why this was worth prioritising

The defect has been reddening PR #984 at random — a diff of five files containing no C# at all, which cannot create a GC root. An unrelated PR was blocked by this, and while it is live a genuine new leak would be hard to tell from the noise.

## Testing

- Solution builds clean under CI's flags (`-c Release -p:CIRun=true -warnaserror`), 0 warnings, including the new `VerifyXunitRunnerConfigCopied` guard from #979.
- `MeshWeaver.Hosting.Test` — 131/131.
- `MeshWeaver.AI.Test` — 1090 passed, 5 skipped (pre-existing env-gated E2E).
- `MeshWeaver.Hosting.Monolith.Test` — 498 passed, 4 skipped, 0 failed.

## No What's New entry

Deliberate. The user-visible symptom a What's New entry would describe is a portal accumulating leaked hubs over a long session, and that is specifically what this is *not*: the retention is bounded per teardown and does not grow with usage. Nothing an operator or user would observe changes — this is hub teardown hygiene.
