### PR TITLE
perf(ci): drop free-disk-space from every job — the runner already has 88G free

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -100,6 +100,22 @@ env:
   CI_GREEN_PRUNE_SECONDS: 1209600  # 14 d
 
 jobs:
+  # 🚨 No `jlumbroso/free-disk-space` in any job — do not re-add it. Removed 2026-08-09 after
+  # measuring what the runner actually has. From the reclaim step's OWN "BEFORE CLEAN-UP" line
+  # on run 31306383220 (and identically on every CD job):
+  #
+  #     /dev/root  145G  58G used  88G available  40% /
+  #
+  # It then spent ~71 s in `build` and ~53 s in EVERY shard reclaiming ~15 GiB, to go from 88G
+  # free to ~103G free. Nothing here comes close to needing that: the whole test-bin tarball set
+  # is ~3.3 GB and the pgvector image is a couple more. The "default ~14 GB" the old comments
+  # guarded against is simply not what hosted runners ship any more.
+  #
+  # Cost of keeping it: ~71 s on the critical path in `build`, plus ~53 s on the long-pole shard,
+  # plus ~5 min of runner time per run across the six shards — to free space that was never scarce.
+  # If a job ever genuinely fills the disk it fails loudly with ENOSPC; reclaim selectively THEN,
+  # against a measurement, rather than pre-emptively everywhere.
+  #
   # ──────────────────────────── PRECHECK ───────────────────────────
   # Is the tree we are about to test ALREADY green? See the green-tree-reuse
   # section in the file header for why this exists and why it is safe.
@@ -206,28 +222,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    # The full-solution build outputs + the test-bin tarball overflow the
-    # default ~14 GB free. Reclaim the runner bloat a .NET build never touches.
-    # large-packages (the slowest removal, ~40-60 s of apt) is OFF since the
-    # artifact stopped carrying obj/ + the NuGet cache — the reclaimed space is
-    # no longer needed. Keep .NET + the hosted tool cache (setup-dotnet uses them).
-    - name: Free disk space
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        dotnet: false
-        android: true          # 11 GiB, the bulk of the reclaim
-        haskell: true          # 3.6 GiB
-        large-packages: false  # slowest removal (~40-60 s of apt), not needed
-        # docker-images OFF: it prunes the runner's PRE-BAKED images (node,
-        # buildpack-deps — 2 GiB), none of which is the pgvector image the
-        # Testcontainers tests then pull anyway. Pure cost.
-        docker-images: false
-        # swap-storage OFF: deleting the swapfile on a job that runs
-        # memory-heavy hosts is how you turn a slow test into an OOM kill
-        # (Persistence.Test already carries a memory watchdog). It reclaimed
-        # 0 B on the measured run.
-        swap-storage: false
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -340,25 +334,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    # Extracted test bins + the pgvector Testcontainers image + per-project test
-    # outputs don't fit the default ~14 GB. Same trimmed reclaim as the build job.
-    - name: Free disk space
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        dotnet: false
-        android: true          # 11 GiB, the bulk of the reclaim
-        haskell: true          # 3.6 GiB
-        large-packages: false  # slowest removal (~40-60 s of apt), not needed
-        # docker-images OFF: it prunes the runner's PRE-BAKED images (node,
-        # buildpack-deps — 2 GiB), none of which is the pgvector image the
-        # Testcontainers tests then pull anyway. Pure cost.
-        docker-images: false
-        # swap-storage OFF: deleting the swapfile on a job that runs
-        # memory-heavy hosts is how you turn a slow test into an OOM kill
-        # (Persistence.Test already carries a memory watchdog). It reclaimed
-        # 0 B on the measured run.
-        swap-storage: false
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -54,6 +54,25 @@ jobs:
   # Two parallel legs, one per image. No `dotnet workload restore` in either:
   # CI logs prove it installs nothing ("No workloads installed for this feature
   # band … Successfully updated workload(s): .") and burned ~75 s per run.
+  #
+  # 🚨 No `jlumbroso/free-disk-space` in ANY leg either — do not re-add it. It was removed
+  # 2026-08-09 after measuring what the runner actually has. From the free-disk-space step's
+  # OWN "BEFORE CLEAN-UP" output on run 31304347053:
+  #
+  #     /dev/root  145G  58G used  88G available  40% /
+  #
+  # It then spent 123 s reclaiming 21 GiB to reach 108G available — on a job whose entire
+  # publish needs a small fraction of the 88G that was already free. The "~14 GB runner"
+  # the old comment guarded against no longer exists; hosted runners ship 145G.
+  #
+  # It was not merely useless, it was NEGATIVE: `large-packages: true` purges `azure-cli`,
+  # so the very next step (`Ensure Azure CLI`, `command -v az || curl … | sudo bash`) found
+  # it missing and spent ~20 s apt-reinstalling what the previous step had just deleted.
+  # Removing the reclaim keeps az preinstalled, so that guard short-circuits to ~0 s.
+  #
+  # Measured cost of the round trip: ~143 s per image job, ~9.5 min of runner time per CD run.
+  # If a leg ever genuinely runs out of disk it will fail loudly with ENOSPC — reclaim
+  # selectively THEN, against a measurement, rather than pre-emptively on every job.
   # ─────────────────────────────── DELIVERY GATE ───────────────────────────────
   # 🚨 Gate on the REQUIRED CHECK, not on the workflow run's umbrella conclusion.
   # A run's conclusion is `failure` if ANY job ends cancelled — including a job that
@@ -113,16 +132,6 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
       # The SDK container build + the publish output overflow the runner's ~14 GB; reclaim the
       # ~25 GB of preinstalled tooling a .NET build never touches (same as the test workflow).
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          dotnet: false
-          android: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -200,16 +209,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          dotnet: false
-          android: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -270,16 +269,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          dotnet: false
-          android: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -330,16 +319,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          dotnet: false
-          android: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
Both workflows ran `jlumbroso/free-disk-space` on every job to guard against a "~14 GB" runner. That runner no longer exists.

## The measurement

The reclaim step's **own** `BEFORE CLEAN-UP` output, on CD run 31304347053 and identically on CI run 31306383220:

```
/dev/root  145G  58G used  88G available  40% /
```

It then spends 71–123s reclaiming 15–21 GiB to reach ~103–108G free. Nothing in either workflow approaches that: the entire test-bin tarball set is ~3.3 GB, the pgvector image a couple more, an image publish a fraction. **The space was never scarce.**

## In CD it was actively negative

`large-packages: true` **purges `azure-cli`**. The very next step is:

```yaml
- name: Ensure Azure CLI
  run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
```

So it found az missing and spent ~20s apt-reinstalling precisely what the previous step had just deleted — confirmed by the apt output in the job log. Removing the reclaim keeps az preinstalled and that guard short-circuits to ~0s.

Also drops `swap-storage: true` from the CD legs, which deleted the swapfile on memory-heavy multi-arch publishes. `dotnet-test`'s own comment already flags that as *"how you turn a slow test into an OOM kill"* and had it off; CD had it on.

## Measured cost removed

| Workflow | Per job | Effect |
|---|---|---|
| `dotnet-test` build | −71s | critical path |
| `dotnet-test` shard | −53s × 6 | −53s on the long pole, ~5 min runner time |
| `main-cd` image jobs | −123s − ~20s az | × 4 jobs, ~9.5 min runner time |

Expected: **CI critical path −~2 min**, **CD −~2.4 min** (`portal-ai`, the current pole, 18.3 → ~15.9), **~16 min of runner time reclaimed per merge**.

## Not replaced with a smaller reclaim

A job that genuinely fills a 145G disk fails loudly with ENOSPC. Reclaim selectively *then*, against a measurement — not pre-emptively on every job forever. Both files carry a comment with the measurement so it doesn't get re-added on a hunch.

## No What's New entry

Pure CI infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.

## Separately: `memex-bake` is built on every merge and deployed nowhere

Not changed here, because it's a release-policy call rather than a measurement. But while profiling the CD legs I found `bake.enabled: false` in **both** `deploy/helm/values.yaml` and `deploy/aks/values.aks.yaml` — no environment runs the bake Job. CD nonetheless builds `memex-bake` on every merge: **610s of publish, 768s of job wall clock.**

`deploy/CHANGE-PROPAGATION.md` already anticipated this and names the lever:

> *"That is a real, recurring cost on every core release, paid whether or not the bake is enabled on any environment. If it ever needs cutting, the lever is publishing it on a schedule or only on release tags — not trimming its references."*

Worth doing, but it changes when the NodeType-regression gate runs, so it should be a deliberate decision rather than folded into a measurement-driven cleanup.