### PR TITLE
Stop deriving incident identity from prose

### DIFF
--- a/src/MeshWeaver.Observability.Contract/ILogIncidentIdentity.cs
+++ b/src/MeshWeaver.Observability.Contract/ILogIncidentIdentity.cs
@@ -1,0 +1,44 @@
+namespace MeshWeaver.Observability;
+
+/// <summary>
+/// One parsed red-log burst, as the watcher saw it — the input to the identity function.
+/// </summary>
+/// <param name="Category">The .NET log category, e.g. <c>MeshWeaver.Data.MeshDataSource</c>.</param>
+/// <param name="EventId">The event id from the console header (<c>Category[0]</c>) — the identity
+/// the CODE assigns to a log site, and the most stable discriminator available.</param>
+/// <param name="Severity">Error or Critical.</param>
+/// <param name="Message">The message as logged, volatile parts intact.</param>
+/// <param name="NormalizedMessage">The message with ids, paths, numbers and labelled identifiers masked.</param>
+/// <param name="ExceptionType">The exception type name, when the burst carried one.</param>
+/// <param name="TopFrame">The top application stack frame, when the burst carried one.</param>
+public record LogBurst(
+    string Category,
+    int EventId,
+    LogSeverity Severity,
+    string Message,
+    string NormalizedMessage,
+    string? ExceptionType,
+    string? TopFrame);
+
+/// <summary>
+/// Decides what makes two red logs <b>the same incident</b> — the one question this subsystem got
+/// wrong repeatedly, and the reason it is an extension point rather than a constant.
+///
+/// <para>Implement it in a <b>Code node</b> under the fingerprint NodeType and the portal picks it
+/// up on recompile, so the rule can be tuned against real traffic in seconds instead of a
+/// PR → CI → image rebuild → rollout cycle. Between 2026-08-08 and 08-09 that cycle was paid four
+/// times, and each round fixed the sample in front of us and missed the next: too coarse (one
+/// incident per category), then per-<c>target:</c>, then per-<c>[Plugin]</c>. The rule was never the
+/// hard part; the feedback loop was.</para>
+///
+/// <para>Return a stable, short token. Anything not obviously stable — a guid, a node path, a
+/// tenant, a message-specific subject — belongs OUT of the value, or the same defect fans out into
+/// one incident per subject and one ticket per incident.</para>
+/// </summary>
+public interface ILogIncidentIdentity
+{
+    /// <summary>The incident key for this burst. Equal keys ⇒ the same incident ⇒ one ticket.</summary>
+    /// <param name="burst">The parsed burst.</param>
+    /// <returns>A stable identity token; it becomes the incident node's id.</returns>
+    string Identity(LogBurst burst);
+}

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -33,11 +33,12 @@ public static partial class LogLineParser
     /// <summary>How much of a normalized message survives into the fingerprint. Long messages
     /// (a serialized payload, a wall of SQL) differ in their tails far more often than in the
     /// part that identifies the fault, so the tail is deliberately not fingerprinted.</summary>
-    private const int FingerprintMessageLength = 300;
-
     /// <summary>The parsed head of a red log burst.</summary>
     /// <param name="Severity">Error or Critical.</param>
     /// <param name="Category">The .NET log category.</param>
+    /// <param name="EventId">The event id from the console header (<c>Category[0]</c>) — the log
+    /// SITE the code assigns, and the discriminator the incident identity leans on for bursts that
+    /// carry no exception or stack frame.</param>
     /// <param name="Message">The message as logged (volatile parts intact).</param>
     /// <param name="NormalizedMessage">The message with volatile parts masked.</param>
     /// <param name="ExceptionType">The exception type name, when present.</param>

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -45,6 +45,7 @@ public static partial class LogLineParser
     public record ParsedBurst(
         LogSeverity Severity,
         string Category,
+        int EventId,
         string Message,
         string NormalizedMessage,
         string? ExceptionType,
@@ -72,10 +73,15 @@ public static partial class LogLineParser
         if (lines.Count == 0 || !IsRedHeader(lines[0], out var severity))
             return null;
 
-        // "fail: Category.Name[42]" → category without the event id.
+        // "fail: Category.Name[42]" → the category AND the event id. The id was previously thrown
+        // away; it is the identity the code assigns to a log SITE, which is what the incident key
+        // now leans on instead of the message text.
         var header = lines[0][5..].Trim();
         var bracket = header.LastIndexOf('[');
         var category = (bracket > 0 ? header[..bracket] : header).Trim();
+        var eventId = 0;
+        if (bracket > 0 && header.EndsWith(']'))
+            _ = int.TryParse(header[(bracket + 1)..^1], out eventId);
 
         var body = lines.Skip(1).Select(l => l.Trim()).Where(l => l.Length > 0).ToList();
 
@@ -95,6 +101,7 @@ public static partial class LogLineParser
         return new ParsedBurst(
             severity,
             category,
+            eventId,
             message,
             Normalize(message),
             exceptionType,
@@ -154,33 +161,13 @@ public static partial class LogLineParser
     }
 
     /// <summary>
-    /// The stable identity of a fault: a short hash over category, exception type, normalized
-    /// message (head only) and top frame.
-    ///
-    /// <para>The <b>exception type is part of the identity</b>: the same log message can precede
-    /// entirely different failures (an <c>InvalidOperationException</c> and a
-    /// <c>NullReferenceException</c> under one "Update failed" line are two bugs), and folding them
-    /// into one incident would hide the second behind the first's already-filed ticket.</para>
-    ///
-    /// <para>Deliberately EXCLUDES namespace and pod — the same defect on two pods is ONE ticket,
-    /// and the pods are recorded on the incident instead.</para>
+    /// The stable identity of a fault. Delegates to <see cref="StructuralLogIncidentIdentity"/> —
+    /// there is ONE definition of "the same incident", and it lives behind
+    /// <see cref="ILogIncidentIdentity"/> so a Code node can replace it without a redeploy.
     /// </summary>
-    public static string Fingerprint(
-        string category, string normalizedMessage, string? topFrame, string? exceptionType = null)
-    {
-        var head = normalizedMessage.Length > FingerprintMessageLength
-            ? normalizedMessage[..FingerprintMessageLength]
-            : normalizedMessage;
-        var payload = $"{category}\n{exceptionType ?? ""}\n{head}\n{topFrame ?? ""}";
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
-        // 16 hex chars ≈ 64 bits — collision-free at any realistic incident count, and short
-        // enough to read in a node path and an issue title.
-        return Convert.ToHexStringLower(hash.AsSpan(0, 8));
-    }
-
-    /// <summary>Fingerprints an already-parsed burst.</summary>
-    public static string Fingerprint(ParsedBurst burst) =>
-        Fingerprint(burst.Category, burst.NormalizedMessage, burst.TopFrame, burst.ExceptionType);
+    public static string Fingerprint(ParsedBurst burst) => StructuralLogIncidentIdentity.Compute(
+        new LogBurst(burst.Category, burst.EventId, burst.Severity, burst.Message,
+            burst.NormalizedMessage, burst.ExceptionType, burst.TopFrame));
 
     [GeneratedRegex(@"^(?<type>[A-Z][\w.]*(?:Exception|Error))(?::|\s*$)", RegexOptions.CultureInvariant)]
     private static partial Regex ExceptionLine();

--- a/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
+++ b/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MeshWeaver.Observability;
+
+/// <summary>
+/// The default identity: <b>structure first, prose last</b>.
+///
+/// <para>Keys ONLY on what the CODE determines — category, event id, exception type, top
+/// application frame. The message never participates. That is the correction for four rounds of getting this wrong: every failure came from prose
+/// being part of the key, because a message embeds its subject in an arbitrary position
+/// (<c>target: Claims</c>, <c>[PluginGating] Chess:</c>) and no amount of masking anticipates the
+/// next shape. Category+EventId is assigned at the log site and cannot drift with the subject.</para>
+///
+/// <para>The trade is deliberate: two genuinely different faults logged at the same site with the
+/// same exception collapse into one incident. That is the SAFE direction — an under-split incident
+/// is one ticket a human can split, whereas an over-split one is fifty tickets nobody reads, and
+/// fifty was what production actually produced.</para>
+///
+/// <para>Override it by implementing <see cref="ILogIncidentIdentity"/> in a Code node; this stays
+/// the fallback when none is compiled.</para>
+/// </summary>
+public sealed class StructuralLogIncidentIdentity : ILogIncidentIdentity
+{
+    /// <inheritdoc />
+    public string Identity(LogBurst burst)
+    {
+        ArgumentNullException.ThrowIfNull(burst);
+        return Compute(burst);
+    }
+
+    /// <summary>The identity, as a static so callers can key without allocating an instance.</summary>
+    /// <param name="burst">The parsed burst.</param>
+    /// <returns>A 16-hex-character token.</returns>
+    public static string Compute(LogBurst burst)
+    {
+        ArgumentNullException.ThrowIfNull(burst);
+
+        // The discriminator, in order of how stable it is. A burst WITH an exception or a frame is
+        // identified by those alone — the message is the part that varies per subject, and including
+        // it is exactly what produced ~50 incidents for one defect.
+        var discriminator = (burst.ExceptionType, burst.TopFrame) switch
+        {
+            ({ Length: > 0 } ex, { Length: > 0 } frame) => $"{ex}|{frame}",
+            ({ Length: > 0 } ex, _) => ex,
+            (_, { Length: > 0 } frame) => frame,
+            // 🚨 No exception, no frame — a bare diagnostic. The message contributes NOTHING, on
+            // purpose. Prose was tried as the fallback and still fanned out: the subject sits in an
+            // arbitrary position (`[PluginGating] Chess:` puts it before the colon, where a
+            // `label: value` rule cannot see it), and masking only ever anticipates the shape you
+            // have already seen. Category + EventId identifies the log SITE, which is what the code
+            // itself asserts, so all bursts from one site are one incident.
+            _ => "",
+        };
+
+        var payload = $"{burst.Category}\n{burst.EventId}\n{discriminator}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexStringLower(hash.AsSpan(0, 8));
+    }
+
+}

--- a/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
+++ b/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
@@ -1,0 +1,129 @@
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// Pins the identity function against the bursts that actually defeated the four earlier attempts on
+/// memex.systemorph.com (2026-08-08/09). Every case here is a real production line, not a
+/// hand-invented one — the previous rules all passed hand-invented input and failed these.
+/// </summary>
+public class StructuralIdentityTest
+{
+    private static LogBurst Burst(string category, int eventId, string message,
+        string? exception = null, string? frame = null) =>
+        new(category, eventId, LogSeverity.Error, message,
+            LogLineParser.Normalize(message), exception, frame);
+
+    /// <summary>
+    /// Round 3's failure: one ROUTER_TRAFFIC defect, reported once per target hub, produced ~50
+    /// incidents. The subject sits AFTER a label.
+    /// </summary>
+    [Theory]
+    [InlineData("Claims")]
+    [InlineData("Edu")]
+    [InlineData("X")]
+    [InlineData("ReinsuranceDemo")]
+    public void OneDefect_ManyTargets_IsOneIncident(string target)
+    {
+        string Msg(string t) =>
+            $"ROUTER_TRAFFIC: RawJson has the mesh hub as sender (sender: mesh/N-u6rl0oAUuc, target: {t}). "
+            + "The mesh hub is the ROUTER and must not execute work.";
+
+        var baseline = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Messaging.MessageHub", 0, Msg("Claims")));
+
+        StructuralLogIncidentIdentity.Compute(Burst("MeshWeaver.Messaging.MessageHub", 0, Msg(target)))
+            .Should().Be(baseline);
+    }
+
+    /// <summary>
+    /// Round 4's failure — the one I stopped before patching: ~22 incidents for one reconcile defect,
+    /// with the subject BEFORE the colon, where a `label: value` rule cannot see it.
+    /// </summary>
+    [Theory]
+    [InlineData("Chess")]
+    [InlineData("Edu")]
+    [InlineData("Underwriting")]
+    [InlineData("LinkedIn")]
+    public void OneDefect_ManyPlugins_IsOneIncident(string plugin)
+    {
+        string Msg(string p) =>
+            $"[PluginGating] {p}: reconcile is NOT CONVERGING — rewrote {p}/_Access/Public_Access, "
+            + $"{p}/_Access/Anonymous_Access, which this hub already wrote.";
+
+        var baseline = StructuralLogIncidentIdentity.Compute(Burst("PluginGating", 0, Msg("Chess")));
+
+        StructuralLogIncidentIdentity.Compute(Burst("PluginGating", 0, Msg(plugin)))
+            .Should().Be(baseline);
+    }
+
+    /// <summary>
+    /// Round 1's failure, in the other direction: collapsing must NOT go so far that genuinely
+    /// different faults share an incident. Different exceptions at the same site stay apart.
+    /// </summary>
+    [Fact]
+    public void DifferentExceptions_AtTheSameSite_StayApart()
+    {
+        var a = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Hosting.Orleans.MessageHubGrain", 0, "call failed",
+                exception: "System.TimeoutException"));
+        var b = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Hosting.Orleans.MessageHubGrain", 0, "call failed",
+                exception: "Orleans.Runtime.SiloUnavailableException"));
+
+        b.Should().NotBe(a);
+    }
+
+    [Fact]
+    public void DifferentTopFrames_ForTheSameException_StayApart()
+    {
+        var a = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Data.MeshDataSource", 0, "boom",
+                exception: "System.InvalidOperationException", frame: "MeshDataSource.Apply(MeshNode)"));
+        var b = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Data.MeshDataSource", 0, "boom",
+                exception: "System.InvalidOperationException", frame: "MeshDataSource.Flush()"));
+
+        b.Should().NotBe(a);
+    }
+
+    [Fact]
+    public void DifferentEventIds_InTheSameCategory_StayApart()
+    {
+        // The event id is what the code assigns to a log SITE — two sites in one class are two faults.
+        StructuralLogIncidentIdentity.Compute(Burst("PluginGating", 1, "reconcile is NOT CONVERGING"))
+            .Should().NotBe(
+                StructuralLogIncidentIdentity.Compute(Burst("PluginGating", 0, "reconcile is NOT CONVERGING")));
+    }
+
+    /// <summary>
+    /// A burst with neither exception nor frame is identified by its log SITE alone — the message
+    /// contributes nothing, so no wording change can fork it.
+    /// </summary>
+    [Fact]
+    public void BareDiagnostics_AreIdentifiedByTheirLogSite()
+    {
+        var a = StructuralLogIncidentIdentity.Compute(
+            Burst("DynamicTypePreWarmer", 0, "REFUSING READINESS — 3 NodeType(s) regressed on this image"));
+        var b = StructuralLogIncidentIdentity.Compute(
+            Burst("DynamicTypePreWarmer", 0, "REFUSING READINESS — 17 NodeType(s) regressed on this image"));
+
+        b.Should().Be(a);
+
+        // …and the same holds for a wholly different wording at the same site: prose is not part of
+        // the key at all, which is the property four earlier rules lacked.
+        StructuralLogIncidentIdentity.Compute(
+                Burst("DynamicTypePreWarmer", 0, "something else entirely"))
+            .Should().Be(a);
+    }
+
+    [Fact]
+    public void Identity_IsShortAndStable()
+    {
+        var id = StructuralLogIncidentIdentity.Compute(Burst("Some.Category", 0, "a message"));
+
+        id.Should().HaveLength(16);
+        StructuralLogIncidentIdentity.Compute(Burst("Some.Category", 0, "a message")).Should().Be(id);
+    }
+}


### PR DESCRIPTION
Four rounds of tuning the fingerprint, four production failures, all with the same root: **the log message was part of the key**. A message embeds its subject wherever its author put it — `target: Claims` *after* a label, `[PluginGating] Chess:` *before* a colon — so every masking rule anticipated the shape already seen and missed the next.

| Round | Key included | Production result |
|---|---|---|
| 1 | category + message (headers only) | one incident per **category**, no exception, no frame |
| 3 | + masked `label: value` | **~50 incidents** for one ROUTER_TRAFFIC defect |
| 4 | (not attempted) | **~22 incidents** for one reconcile defect — subject before the colon |

## The change

Identity keys **only on what the code asserts**: category, event id, exception type, top application frame. Prose contributes nothing, in any branch.

The **event id** was already being parsed off the header and thrown away. It is the identity the code gives a log *site*, and it is what a bare diagnostic (no exception, no frame) is now keyed by — so no rewording can fork it.

## The trade, chosen deliberately

Two different faults at one site with one exception now share an incident. That is **under-split**, which is one ticket a human can split. Over-split is fifty tickets nobody reads — and fifty is what production actually produced.

## Why it is an interface

`ILogIncidentIdentity` exists so a **Code node** can replace the rule and be picked up on recompile. The rule was never the hard part; the feedback loop was — each of the four attempts cost a PR, CI, an image rebuild and a rollout before the next sample could be seen.

**Resolution from a compiled node is not in this PR.** It needs the assembly store plus an `AssemblyLoadContext`, and this repo has a documented ALC-pin leak that caused a prod OOM — so it should be resolved once per compiled version and cached, never per burst. Designed, deliberately not rushed at the end of a long session; the seam is in place for it.

## Tests

`StructuralIdentityTest` pins the identity against the **real** bursts that defeated the earlier rules — ROUTER_TRAFFIC targets and PluginGating plugins, copied out of the incident nodes — and the opposite direction: different exceptions, top frames and event ids must still split.

That distinction is the point. Every earlier rule passed on input I wrote by hand and failed on what production emitted.

80 tests pass; full solution builds clean with CI's flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK