### PR TITLE
Verify a deployment is current — from the About tab, and from outside with no sign-in

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
@@ -23,22 +23,28 @@ public class VirtualUserMiddleware(RequestDelegate next, ILogger<VirtualUserMidd
 {
     private const string CookieName = "meshweaver_virtual_user";
 
-    // 🚨 Anonymous, high-frequency infrastructure routes belong here. They are polled by machines
-    // that keep no cookie, so the VUser flow can only ever churn: it re-derives an id and stamps a
-    // guest context on EVERY request, and it is the path that produced the 2026-06-12 outage
-    // (~15 VUsers/minute from kube-probe alone, 10 000+ leaked hubs). /api/version is exactly that
-    // shape — an unauthenticated build-identity poll target that must stay answerable, and cheap,
-    // when the mesh is unhealthy.
     private static readonly string[] ExcludedPrefixes =
-    [
-        "/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap",
-        "/healthz", "/api/version"
-    ];
+        ["/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap", "/healthz"];
+
+    // 🚨 Anonymous, high-frequency infrastructure routes. They are polled by machines that keep no
+    // cookie, so the VUser flow can only ever churn: it re-derives an id and stamps a guest context
+    // on EVERY request, and it is the path that produced the 2026-06-12 outage (~15 VUsers/minute
+    // from kube-probe alone, 10 000+ leaked hubs). /api/version is exactly that shape — an
+    // unauthenticated build-identity poll target that must stay answerable, and cheap, when the mesh
+    // is unhealthy.
+    //
+    // Matched EXACTLY, not as a prefix: these are leaf routes with no children, and a prefix match
+    // would silently exempt anything that merely starts with the same text (/api/versioning) from
+    // the VUser flow. An exclusion list that is broader than it reads is how routes end up skipping
+    // machinery nobody meant to skip. (The prefix list above is genuinely prefix-shaped — subtrees
+    // like /_content/… and /static/… — so it keeps StartsWith.)
+    private static readonly string[] ExcludedExactPaths = ["/api/version"];
 
     public async Task InvokeAsync(HttpContext context)
     {
         var path = context.Request.Path.Value ?? "";
-        if (ExcludedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+        if (ExcludedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase))
+            || ExcludedExactPaths.Any(p => string.Equals(path, p, StringComparison.OrdinalIgnoreCase)))
         {
             await next(context);
             return;

--- a/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
@@ -23,8 +23,17 @@ public class VirtualUserMiddleware(RequestDelegate next, ILogger<VirtualUserMidd
 {
     private const string CookieName = "meshweaver_virtual_user";
 
+    // 🚨 Anonymous, high-frequency infrastructure routes belong here. They are polled by machines
+    // that keep no cookie, so the VUser flow can only ever churn: it re-derives an id and stamps a
+    // guest context on EVERY request, and it is the path that produced the 2026-06-12 outage
+    // (~15 VUsers/minute from kube-probe alone, 10 000+ leaked hubs). /api/version is exactly that
+    // shape — an unauthenticated build-identity poll target that must stay answerable, and cheap,
+    // when the mesh is unhealthy.
     private static readonly string[] ExcludedPrefixes =
-        ["/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap", "/healthz"];
+    [
+        "/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap",
+        "/healthz", "/api/version"
+    ];
 
     public async Task InvokeAsync(HttpContext context)
     {

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -169,12 +169,18 @@ public static class ServiceDefaults
     private static readonly JsonSerializerOptions VersionJsonOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// The assembly that represents this build. Normally the entry assembly (the portal executable),
-    /// which <c>Directory.Build.props</c> stamps with both the version and the commit. When the
-    /// process was launched by a host that is NOT part of this build — a test runner, a generic
-    /// launcher — the entry assembly carries no <c>CommitHash</c>, and this assembly is used
-    /// instead: the SAME build stamps every assembly with the SAME commit, so the answer is
-    /// identical rather than a foreign host's version.
+    /// The assembly that represents this build. In the portal this is the entry assembly — the
+    /// executable — which the root <c>Directory.Build.props</c> stamps with both the platform
+    /// version and the commit (<c>memex/Directory.Build.props</c> imports the root, so every
+    /// portal project inherits the stamps). Reading the entry assembly is what keeps this endpoint
+    /// and the About tab reporting the same build.
+    ///
+    /// <para>When the process was launched by a host that is NOT part of this build, the entry
+    /// assembly carries no <c>CommitHash</c> and reading it would report the HOST's version — a
+    /// test runner's <c>1.0.0</c> with no commit. (<c>test/Directory.Build.props</c> deliberately
+    /// does not import the root props, so this is exactly the shape under test.) The fallback is
+    /// this assembly: the same build stamps every one of its assemblies with the same commit, so
+    /// the answer is the real one rather than a foreign host's.</para>
     /// </summary>
     internal static Assembly SelectBuildAssembly()
     {

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -1,5 +1,10 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -113,9 +118,104 @@ public static class ServiceDefaults
         // Only health checks tagged with "live" must pass for app to be considered alive
         app.MapHealthChecks("/alive", new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
 
+        app.MapVersionEndpoint();
+
         return app;
     }
+
+    /// <summary>
+    /// The route the build identity is served on. Sits beside <c>/health</c> and <c>/alive</c>
+    /// deliberately: like them it is infrastructure, answers without a session, and reports only
+    /// what the process IS — never what it holds.
+    /// </summary>
+    public const string VersionRoute = "/api/version";
+
+    /// <summary>
+    /// Maps <c>GET /api/version</c> → <c>{"version":"…","commit":"…"}</c>, ANONYMOUS.
+    ///
+    /// <para><b>Why unauthenticated.</b> "Is this deployment current?" is the question issue #956
+    /// asks, and the Settings → About tab now answers it — but only to someone who can sign in.
+    /// Verifying a roll-out from outside (a monitor, a deploy check, a user comparing against
+    /// GitHub) needs an answer without a session. Nothing is disclosed by it: MeshWeaver is a
+    /// PUBLIC repository, so the version and the commit SHA are already readable on GitHub. This
+    /// endpoint says which of those public commits is running, and nothing else.</para>
+    ///
+    /// <para><b>The response is exactly two fields</b> — no environment name, no cluster or
+    /// namespace, no configuration, no partition names, no user data. Serialized with explicit
+    /// local options so the wire contract cannot drift if the host later configures global JSON
+    /// settings.</para>
+    ///
+    /// <para>Reads only assembly metadata, so it is answerable even when storage or the mesh is
+    /// unhealthy — it touches no hub, no node and no database. Registered separately from
+    /// <c>/health</c> and <c>/alive</c>, whose shapes are the Kubernetes probe contract and are
+    /// deliberately left untouched.</para>
+    /// </summary>
+    public static IEndpointRouteBuilder MapVersionEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(VersionRoute, () => Results.Json(Build, VersionJsonOptions))
+            .AllowAnonymous()
+            .WithName("BuildVersion");
+        return endpoints;
+    }
+
+    /// <summary>
+    /// The build identity of THIS process, resolved once at startup — the values are compile-time
+    /// constants baked into the assembly, so re-reading them per request would buy nothing.
+    /// Immutable and never written after initialization (a constant, not a cache).
+    /// </summary>
+    public static BuildIdentity Build { get; } = ReadBuildIdentity(SelectBuildAssembly());
+
+    /// <summary>Web defaults ⇒ camelCase, so the contract is <c>{"version":…,"commit":…}</c>.</summary>
+    private static readonly JsonSerializerOptions VersionJsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// The assembly that represents this build. Normally the entry assembly (the portal executable),
+    /// which <c>Directory.Build.props</c> stamps with both the version and the commit. When the
+    /// process was launched by a host that is NOT part of this build — a test runner, a generic
+    /// launcher — the entry assembly carries no <c>CommitHash</c>, and this assembly is used
+    /// instead: the SAME build stamps every assembly with the SAME commit, so the answer is
+    /// identical rather than a foreign host's version.
+    /// </summary>
+    internal static Assembly SelectBuildAssembly()
+    {
+        var entry = Assembly.GetEntryAssembly();
+        return entry is not null && CommitOf(entry) is not null ? entry : typeof(ServiceDefaults).Assembly;
+    }
+
+    /// <summary>
+    /// Projects an assembly's build stamps to the wire record. Mirrors the reflection behind the
+    /// About tab (<c>ShippedReleaseSeed.InstalledPlatformVersion</c> / <c>.CommitHash</c>) — the two
+    /// readers are separate only because <c>Memex.Portal.Shared</c> sits far above this
+    /// infrastructure project and must not be pulled into it; both read the SAME two attributes, so
+    /// the page and the endpoint report the same build.
+    /// </summary>
+    public static BuildIdentity ReadBuildIdentity(Assembly assembly) => new(
+        assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "unknown",
+        CommitOf(assembly) ?? "");
+
+    /// <summary>
+    /// The git SHA baked in as <c>AssemblyMetadata("CommitHash")</c> by the
+    /// <c>AddCommitHashMetadata</c> target, or null when the build carried no source-control
+    /// information (a git-less source drop).
+    /// </summary>
+    private static string? CommitOf(Assembly assembly) =>
+        assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, "CommitHash", StringComparison.OrdinalIgnoreCase))
+            ?.Value is { Length: > 0 } sha
+            ? sha
+            : null;
 }
+
+/// <summary>
+/// The <c>/api/version</c> response — the whole of it. Which build is running, and which public
+/// commit it was produced from; deliberately nothing else.
+/// </summary>
+/// <param name="Version">The platform version (<c>3.0.0-rc1.ci.{run}</c> for CI builds).</param>
+/// <param name="Commit">The full git SHA the build was produced from, or empty when the build
+/// carried no source-control information.</param>
+public record BuildIdentity(string Version, string Commit);
 
 /// <summary>
 /// Distributed cluster configuration constants for Memex.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
@@ -1,0 +1,50 @@
+---
+Name: Checking that a deployment is up to date, from inside or outside
+Category: What's New
+Description: Every user can now see on About whether their build is current, and a new anonymous /api/version endpoint answers the same question from outside the portal.
+Icon: ArrowSync
+---
+
+# Checking that a deployment is up to date, from inside or outside
+
+Knowing *what* a portal is running has never been the hard part — Settings → About has
+long named the version, the git commit it was built from (linked to the commit on
+GitHub), the runtime and the installed plugins. The awkward question was the next one:
+**is that the newest build?** Until now it could only be answered by a platform admin,
+on the Updates tab, after signing in.
+
+Both halves of that are now closed.
+
+## On the About page, for every user
+
+About carries one more line:
+
+- ✅ **Up to date** — no newer build has been detected.
+- ⬆️ **Update available** — followed by the version that supersedes the running one.
+
+Only the verdict is shown. The update *strategy* (continuous, stable or off), the
+CI-verified-builds setting and the update poller's own bookkeeping stay on the admin
+tab, because those are decisions about the deployment rather than facts about it.
+
+If the line is absent, that is deliberate: an installation with no update checking
+configured — or one where automatic checks have been switched off — has no evidence
+either way, and a reassuring "up to date" on the strength of a check that never ran
+would be worse than silence.
+
+## From outside, with no sign-in
+
+A deploy check, an uptime monitor, or anyone comparing a running portal against the
+repository needs the answer *without* a session. `GET /api/version` now returns it:
+
+```json
+{ "version": "3.0.0-rc1.ci.2340", "commit": "3e184262a3b68879bf05155e428304776154fa40" }
+```
+
+It sits beside `/health` and `/alive` and behaves like them: no authentication, and no
+dependency on storage or the mesh — the two values are compiled into the build, so the
+endpoint still answers when the database is having a bad day.
+
+The response is those two fields and nothing else. No environment name, no cluster or
+namespace, no configuration, no partition names, no user data. Nothing is disclosed that
+was not already public: MeshWeaver is a public repository, so every version and commit
+SHA is readable on GitHub already — the endpoint only says which of them is running.

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <!-- VersionEndpointTest drives GET /api/version over a real HTTP pipeline (TestServer) to
+         prove it answers with NO authenticated session — the whole point of the endpoint. -->
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
+    <!-- MapDefaultEndpoints / MapVersionEndpoint live here, beside /health and /alive. -->
+    <ProjectReference Include="..\..\memex\aspire\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <!-- OAuthCodeStoreTest runs against a full monolith mesh (the store persists
          authorization codes as mesh nodes — the multi-replica safety contract). -->

--- a/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -137,16 +138,41 @@ public class VersionEndpointTest
     }
 
     /// <summary>
-    /// The projection itself, off a known assembly: both stamps are read from the assembly the build
-    /// produced — no poller, no node, no configuration key involved.
+    /// The projection itself, off an assembly THIS build stamped: both values come from assembly
+    /// metadata — no poller, no node, no configuration key involved.
     /// </summary>
     [Fact]
-    public void ReadBuildIdentity_reads_the_stamps_off_the_assembly()
+    public void ReadBuildIdentity_reads_the_stamps_off_a_build_assembly()
     {
-        var identity = Defaults.ReadBuildIdentity(typeof(VersionEndpointTest).Assembly);
+        var identity = Defaults.ReadBuildIdentity(typeof(BuildIdentity).Assembly);
 
         identity.Version.Should().NotBeNullOrWhiteSpace();
-        identity.Commit.Should().NotBeNullOrWhiteSpace();
+        identity.Commit.Should().NotBeNullOrWhiteSpace(
+            "AddCommitHashMetadata stamps every assembly built from this repo");
+    }
+
+    /// <summary>
+    /// The fallback that makes the endpoint answer correctly under a host that is not part of this
+    /// build — and this test run IS that case, which is what gives the assertion teeth.
+    ///
+    /// <para><c>test/Directory.Build.props</c> deliberately does NOT import the root props, so
+    /// <c>AddCommitHashMetadata</c> never runs for test projects and the entry assembly here carries
+    /// no <c>CommitHash</c>. Reading the entry assembly blindly would report the runner's <c>1.0.0</c>
+    /// and an empty commit; the fallback reports the real build instead. Production is the other
+    /// branch — <c>memex/Directory.Build.props</c> imports the root, so the portal executable IS
+    /// stamped and wins, which is what keeps this endpoint and the About tab in agreement.</para>
+    /// </summary>
+    [Fact]
+    public void Build_falls_back_to_a_stamped_assembly_when_the_host_is_not_part_of_this_build()
+    {
+        var entry = Assembly.GetEntryAssembly();
+        entry.Should().NotBeNull();
+
+        // Non-vacuity guard: the host really is unstamped, so the fallback really is exercised.
+        Defaults.ReadBuildIdentity(entry!).Commit.Should().BeEmpty();
+
+        Defaults.Build.Commit.Should().NotBeNullOrWhiteSpace();
+        Defaults.Build.Version.Should().NotBeNullOrWhiteSpace();
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.ServiceDefaults;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The <c>/api/version</c> contract (issue #956, second half): a machine-readable build identity
+/// that answers WITHOUT a session, so a deployment can be checked from outside the portal.
+///
+/// <para>Anonymity is the entire point — an endpoint that quietly required a login would satisfy
+/// nothing — so it is proved the only way that means anything: the pipeline under test carries a
+/// deny-by-default authorization fallback, and a control endpoint in the SAME pipeline is refused.
+/// Without that control the 200 would be vacuous (any route answers when nothing is guarding).</para>
+///
+/// <para>The other half of the contract is what the response must NOT contain. It is exactly two
+/// fields; no environment, cluster, namespace, configuration or user data may ever ride along, so
+/// the property set is asserted exhaustively rather than by presence.</para>
+/// </summary>
+public class VersionEndpointTest
+{
+    /// <summary>A route with no <c>AllowAnonymous</c> — the proof the fallback policy is real.</summary>
+    private const string GuardedRoute = "/guarded";
+
+    /// <summary>
+    /// The pipeline under test: the REAL <see cref="ServiceDefaults.MapDefaultEndpoints"/> composition
+    /// (so this pins the endpoint as it actually ships, not a hand-mapped copy), behind authentication
+    /// and an authorization fallback that denies everything not explicitly anonymous.
+    /// </summary>
+    private static WebApplication BuildApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.AddDefaultHealthChecks();
+
+        // Deny by default. AllowAnonymous on the version endpoint is what must beat this.
+        builder.Services.AddAuthorizationBuilder()
+            .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => false)
+                .Build());
+
+        var app = builder.Build();
+        app.UseAuthorization();
+        app.MapDefaultEndpoints();
+        app.MapGet(GuardedRoute, () => "secret");
+        return app;
+    }
+
+    private static async Task<(HttpResponseMessage Response, string Body)> GetAsync(string route)
+    {
+        var app = BuildApp();
+        await using (app)
+        {
+            await app.StartAsync(TestContext.Current.CancellationToken);
+            using var client = app.GetTestClient();
+            var response = await client.GetAsync(route, TestContext.Current.CancellationToken);
+            var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            return (response, body);
+        }
+    }
+
+    /// <summary>
+    /// Non-vacuity guard: the pipeline really does refuse an unauthenticated caller. If this ever
+    /// passes, the anonymity assertion below is proving nothing.
+    /// </summary>
+    [Fact]
+    public async Task A_guarded_route_in_the_same_pipeline_refuses_an_anonymous_caller()
+    {
+        var (response, _) = await GetAsync(GuardedRoute);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>The point of the endpoint: it answers with no session at all, and both fields carry a value.</summary>
+    [Fact]
+    public async Task Version_endpoint_answers_anonymously_with_version_and_commit()
+    {
+        var (response, body) = await GetAsync(ServiceDefaults.VersionRoute);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "verifying a deployment from outside must not require a login");
+
+        var payload = JsonSerializer.Deserialize<BuildIdentity>(body, JsonSerializerOptions.Web)!;
+        payload.Version.Should().NotBeNullOrWhiteSpace();
+        payload.Commit.Should().NotBeNullOrWhiteSpace(
+            "the git SHA is stamped into every assembly by the AddCommitHashMetadata target");
+    }
+
+    /// <summary>
+    /// The disclosure contract, asserted exhaustively: the body has these two properties and no
+    /// others. A future field added carelessly here would be published to anonymous callers.
+    /// </summary>
+    [Fact]
+    public async Task Version_endpoint_discloses_nothing_beyond_version_and_commit()
+    {
+        var (_, body) = await GetAsync(ServiceDefaults.VersionRoute);
+
+        using var document = JsonDocument.Parse(body);
+        document.RootElement.EnumerateObject().Select(p => p.Name)
+            .Should().BeEquivalentTo(["version", "commit"]);
+    }
+
+    /// <summary>
+    /// The projection itself, off a known assembly: both stamps are read from the assembly the build
+    /// produced — no poller, no node, no configuration key involved.
+    /// </summary>
+    [Fact]
+    public void ReadBuildIdentity_reads_the_stamps_off_the_assembly()
+    {
+        var identity = ServiceDefaults.ReadBuildIdentity(typeof(VersionEndpointTest).Assembly);
+
+        identity.Version.Should().NotBeNullOrWhiteSpace();
+        identity.Commit.Should().NotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    /// A build with no source-control information reports an EMPTY commit rather than throwing or
+    /// inventing one — the same "not recorded" case the About tab renders as a note.
+    /// </summary>
+    [Fact]
+    public void ReadBuildIdentity_reports_an_empty_commit_when_the_build_carries_no_sha()
+    {
+        // The framework's own assembly is built outside this repo, so it carries no CommitHash.
+        var identity = ServiceDefaults.ReadBuildIdentity(typeof(object).Assembly);
+
+        identity.Commit.Should().BeEmpty();
+        identity.Version.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
@@ -1,17 +1,21 @@
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Json;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Memex.Portal.ServiceDefaults;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Xunit;
+
+// The class and its namespace share the name "ServiceDefaults", so the bare name binds to the
+// namespace here. Alias it so the endpoint's own constants stay readable.
+using Defaults = Memex.Portal.ServiceDefaults.ServiceDefaults;
 
 namespace Memex.Portal.Shared.Test;
 
@@ -33,10 +37,13 @@ public class VersionEndpointTest
     /// <summary>A route with no <c>AllowAnonymous</c> — the proof the fallback policy is real.</summary>
     private const string GuardedRoute = "/guarded";
 
+    private const string TestScheme = "NoSession";
+
     /// <summary>
     /// The pipeline under test: the REAL <see cref="ServiceDefaults.MapDefaultEndpoints"/> composition
-    /// (so this pins the endpoint as it actually ships, not a hand-mapped copy), behind authentication
-    /// and an authorization fallback that denies everything not explicitly anonymous.
+    /// (so this pins the endpoint as it actually ships, not a hand-mapped copy), behind the real
+    /// authentication + authorization middleware with a fallback policy that denies everything not
+    /// explicitly marked anonymous — i.e. the shape of a portal that requires a login by default.
     /// </summary>
     private static WebApplication BuildApp()
     {
@@ -45,6 +52,11 @@ public class VersionEndpointTest
         builder.Logging.ClearProviders();
         builder.AddDefaultHealthChecks();
 
+        // A scheme that never authenticates anyone: every caller here is anonymous, and a challenge
+        // answers 401 (the handler's default) instead of throwing for want of a registered scheme.
+        builder.Services.AddAuthentication(TestScheme)
+            .AddScheme<AuthenticationSchemeOptions, NoSessionHandler>(TestScheme, _ => { });
+
         // Deny by default. AllowAnonymous on the version endpoint is what must beat this.
         builder.Services.AddAuthorizationBuilder()
             .SetFallbackPolicy(new AuthorizationPolicyBuilder()
@@ -52,10 +64,20 @@ public class VersionEndpointTest
                 .Build());
 
         var app = builder.Build();
+        app.UseAuthentication();
         app.UseAuthorization();
         app.MapDefaultEndpoints();
         app.MapGet(GuardedRoute, () => "secret");
         return app;
+    }
+
+    /// <summary>Authenticates nobody — the "no session" the endpoint must answer under.</summary>
+    private sealed class NoSessionHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
     }
 
     private static async Task<(HttpResponseMessage Response, string Body)> GetAsync(string route)
@@ -87,7 +109,7 @@ public class VersionEndpointTest
     [Fact]
     public async Task Version_endpoint_answers_anonymously_with_version_and_commit()
     {
-        var (response, body) = await GetAsync(ServiceDefaults.VersionRoute);
+        var (response, body) = await GetAsync(Defaults.VersionRoute);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK,
             "verifying a deployment from outside must not require a login");
@@ -105,11 +127,13 @@ public class VersionEndpointTest
     [Fact]
     public async Task Version_endpoint_discloses_nothing_beyond_version_and_commit()
     {
-        var (_, body) = await GetAsync(ServiceDefaults.VersionRoute);
+        var (_, body) = await GetAsync(Defaults.VersionRoute);
 
         using var document = JsonDocument.Parse(body);
-        document.RootElement.EnumerateObject().Select(p => p.Name)
-            .Should().BeEquivalentTo(["version", "commit"]);
+        var properties = document.RootElement.EnumerateObject()
+            .Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        properties.Should().Equal("commit", "version");
     }
 
     /// <summary>
@@ -119,7 +143,7 @@ public class VersionEndpointTest
     [Fact]
     public void ReadBuildIdentity_reads_the_stamps_off_the_assembly()
     {
-        var identity = ServiceDefaults.ReadBuildIdentity(typeof(VersionEndpointTest).Assembly);
+        var identity = Defaults.ReadBuildIdentity(typeof(VersionEndpointTest).Assembly);
 
         identity.Version.Should().NotBeNullOrWhiteSpace();
         identity.Commit.Should().NotBeNullOrWhiteSpace();
@@ -133,7 +157,7 @@ public class VersionEndpointTest
     public void ReadBuildIdentity_reports_an_empty_commit_when_the_build_carries_no_sha()
     {
         // The framework's own assembly is built outside this repo, so it carries no CommitHash.
-        var identity = ServiceDefaults.ReadBuildIdentity(typeof(object).Assembly);
+        var identity = Defaults.ReadBuildIdentity(typeof(object).Assembly);
 
         identity.Commit.Should().BeEmpty();
         identity.Version.Should().NotBeNullOrWhiteSpace();

--- a/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionEndpointTest.cs
@@ -95,8 +95,9 @@ public class VersionEndpointTest
     }
 
     /// <summary>
-    /// Non-vacuity guard: the pipeline really does refuse an unauthenticated caller. If this ever
-    /// passes, the anonymity assertion below is proving nothing.
+    /// Non-vacuity guard: the pipeline really does refuse an unauthenticated caller. Should this
+    /// route ever start answering instead, the anonymity assertion below would be proving nothing —
+    /// every route answers when nothing is guarding.
     /// </summary>
     [Fact]
     public async Task A_guarded_route_in_the_same_pipeline_refuses_an_anonymous_caller()

--- a/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
+++ b/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
@@ -16,6 +16,9 @@ public class VirtualUserMiddlewareExclusionTest
     [InlineData("/static/images/logo.png")]
     [InlineData("/favicon.ico")]
     [InlineData("/mcp")]
+    // The anonymous build-identity endpoint: polled by machines that keep no cookie, so the VUser
+    // flow could only churn — and it must stay answerable when the mesh is unhealthy.
+    [InlineData("/api/version")]
     public async Task ExcludedPrefixes_SkipVirtualUserAssignment(string path)
     {
         var nextCalled = false;

--- a/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
+++ b/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
@@ -42,6 +42,10 @@ public class VirtualUserMiddlewareExclusionTest
     [InlineData("/ACME/Overview")]
     [InlineData("/User/Alice")]
     [InlineData("/")]
+    // /api/version is excluded EXACTLY, so a route that merely starts with the same text is not.
+    // A prefix match here would silently exempt future routes nobody meant to exempt.
+    [InlineData("/api/versioning")]
+    [InlineData("/api/version/history")]
     public async Task NonExcludedPaths_AttemptVirtualUserAssignment(string path)
     {
         RequestDelegate next = _ => Task.CompletedTask;


### PR DESCRIPTION
Closes the remaining half of #956: a machine-readable, **unauthenticated** `GET /api/version`.

The first half — the running-vs-latest verdict on the ungated **About** tab, for every user rather than only platform admins — shipped in #985. This PR adds the outside-the-portal surface, so the issue is complete.

## Why an anonymous endpoint

"Is this deployment current?" now has an in-portal answer, but only for someone who can sign in. A deploy check confirming a roll-out landed, an uptime monitor, or anyone comparing a running portal against the repository needs it **without a session**.

Disclosure was the only real question, and the repository being **public** settles it: every version and commit SHA is already readable on GitHub. The endpoint says which of those public commits is running, and nothing else.

```json
{ "version": "3.0.0-rc1.ci.2340", "commit": "3e184262a3b68879bf05155e428304776154fa40" }
```

## What it does and does not touch

- **No new state.** `Directory.Build.props` already stamps the version and the git SHA into every assembly (`AddCommitHashMetadata`); the endpoint is a projection of assembly metadata. No poller, no node, no config key.
- **No dependency on the mesh.** It reads no hub, no node and no database — so it still answers when storage is unhealthy, which is what makes it usable as a deploy check.
- **`/health` and `/alive` are untouched.** Those are the Kubernetes probe contract; this is a separate route registered beside them in `MapDefaultEndpoints`, which both the monolith and the distributed portal already call.
- **Exactly two fields.** No environment name, cluster, namespace, configuration, partition names or user data. Asserted **exhaustively** — a field added carelessly later would be published to anonymous callers, and a presence-only assertion would not notice. (#983 scrubbed such identifiers out of this public repo; nothing is reintroduced here.)

## Anonymity is proved, not assumed

The pipeline under test carries a deny-by-default authorization fallback, and a control route in the **same** pipeline is refused. Without that control the 200 would be vacuous — any route answers when nothing is guarding.

## Two things worth a reviewer's eye

**The version poll is excluded from `VirtualUserMiddleware`.** It is shaped exactly like the traffic behind the 2026-06-12 outage: an anonymous route polled by machines that keep no cookie. The VUser flow would re-derive an id and stamp a guest context on every request. `/healthz` is in that exclusion list for the same reason; this is what makes the "touches no hub" property true rather than aspirational.

**The build stamps are read off the entry assembly only when that assembly is part of this build.** `test/Directory.Build.props` deliberately does not import the root props, so test assemblies carry no `CommitHash` — reading the entry assembly blindly under a test runner reports `1.0.0` and an empty commit. The fallback is the ServiceDefaults assembly, which the same build stamps with the same commit. Production takes the other branch (`memex/Directory.Build.props` imports the root), so the portal executable wins — which is what keeps this endpoint and the About tab naming the same build. This was found by a failing test, and both branches are now pinned.

## Verification

- `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` → 0 warnings, 0 errors
- `dotnet test test/Memex.Portal.Shared.Test -c Release` → **257 passed, 0 failed**, including six new `VersionEndpointTest` cases and the new `/api/version` VUser-exclusion case

## Note on the non-admin read question raised in #956

The issue's last comment flagged as unverified whether an ordinary user can read `Admin/UpdatePolicy`. #985 settled it against a real mesh: they **cannot** — an ordinary identity resolves to `Permission.None` on that path and the read gate throws `UnauthorizedAccessException`. That is why the About line is a projection read as System exposing only the verdict, rather than a widened grant.

Fixes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)