### PR TITLE
Two more pending timers nobody owned — one discarded, one only the next keystroke could cancel

### DIFF
--- a/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
@@ -31,7 +32,16 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
     private List<MeshNode> _results = new();
     private List<MeshNode>? _cachedResults;
     private CancellationTokenSource? _loadCts;
-    private IDisposable? _debounceSub;
+    // 🚨 #995 — the pending debounce timer is owned by the COMPONENT, not by the next keystroke.
+    // A SerialDisposable keeps the original semantics (assigning cancels the previous pending
+    // timer) and, because it is registered ONCE in BlazorView.Disposables (see OnInitialized),
+    // DisposeAsync cancels the LAST one too. Before this the field was assigned but disposed
+    // only by the *next* OnSearchInput, so a user who typed and then navigated away left a
+    // 200 ms Observable.Timer on the process-wide TimerQueue — a strong GC root holding the
+    // tick closure → this component → the injected IMeshService → the mesh services, past
+    // component teardown. Holding a subscription in a field looks like ownership to a static
+    // analyzer, which is exactly why this one survived the #996 sweep.
+    private readonly SerialDisposable _debounceSub = new();
     private int _inputKey;
     private const int DebounceMs = 200;
 
@@ -67,6 +77,19 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
     // Compact "thin" rendering + open-upward dropdown, driven by the control's Layout/Open.
     private bool IsThin => ViewModel?.Layout == MeshNodePickerLayout.Thin;
     private bool OpensUp => ViewModel?.Open == MeshNodePickerOpenDirection.Up;
+
+    /// <summary>
+    /// Puts the debounce timer under the component's own disposal (<c>BlazorView.Disposables</c>,
+    /// released by <c>DisposeAsync</c>) so the last pending search cannot outlive the component.
+    /// Registered here — once per component — rather than in <c>BindData</c>, which re-runs on
+    /// every binding-relevant parameter change and would both duplicate the entry and drop a
+    /// debounce the user is still mid-typing.
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Disposables.Add(_debounceSub);
+    }
 
     /// <summary>
     /// Binds the pre-loaded <c>Items</c> collection from the view-model and delegates to the
@@ -228,8 +251,9 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         // Reactive debounce: each keystroke disposes the prior pending Observable.Timer
         // and arms a new one — same semantics as the old CTS-cancel + Task.Delay loop,
         // but stays on Rx scheduling rather than ad-hoc CancellationTokenSource churn.
-        _debounceSub?.Dispose();
-        _debounceSub = Observable.Timer(TimeSpan.FromMilliseconds(DebounceMs))
+        // Assignment disposes the previous pending timer (SerialDisposable), and the component's
+        // Disposables entry disposes whatever is still pending at teardown (#995).
+        _debounceSub.Disposable = Observable.Timer(TimeSpan.FromMilliseconds(DebounceMs))
             .Subscribe(_ => LoadResultsAsync());
     }
 

--- a/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
@@ -248,11 +248,11 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
 
         // Debounce remote queries. Do NOT call StateHasChanged here — typing must never
         // trigger a component re-render. LoadResultsAsync will render when results arrive.
-        // Reactive debounce: each keystroke disposes the prior pending Observable.Timer
-        // and arms a new one — same semantics as the old CTS-cancel + Task.Delay loop,
-        // but stays on Rx scheduling rather than ad-hoc CancellationTokenSource churn.
-        // Assignment disposes the previous pending timer (SerialDisposable), and the component's
-        // Disposables entry disposes whatever is still pending at teardown (#995).
+        // Reactive debounce: assigning into the SerialDisposable cancels the prior pending
+        // Observable.Timer and arms a new one — same semantics as the old CTS-cancel +
+        // Task.Delay loop, but on Rx scheduling rather than ad-hoc CancellationTokenSource
+        // churn, and the handle is the component's (registered in OnInitialized), so teardown
+        // cancels the last one too rather than leaving it to the next keystroke (#995).
         _debounceSub.Disposable = Observable.Timer(TimeSpan.FromMilliseconds(DebounceMs))
             .Subscribe(_ => LoadResultsAsync());
     }

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Data;
@@ -57,6 +58,29 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
     private long _lastPublishTicks;
     private int _publishScheduled;
 
+    // 🚨 #995 — OWNERSHIP of the tail-flush timer. `Observable.Timer` parks its entry on the
+    // process-wide TimerQueue, which is a strong GC root: while the timer is pending it holds
+    // the tick closure → THIS logger → the primary-ctor `hub` it posts to. The old code
+    // DISCARDED the Subscribe result, so nothing could cancel a flush that was still pending
+    // when the hub tore down and the hub stayed rooted past its own disposal (same shape as
+    // the four watcher timers fixed in #996, 10× shorter window).
+    //
+    // Holding it in a SerialDisposable registered on the hub closes that: hub teardown
+    // disposes the composite, which cancels the pending timer. Assignment also disposes the
+    // previous entry, which is either a spent (self-detached) sink or nothing — `_publishScheduled`
+    // guarantees at most one timer is ever pending, so a live flush can never be clobbered.
+    // The registration itself retains only this SerialDisposable (~32 B): a FIRED Rx timer
+    // subscription no longer reaches its callback closure (measured), so a settled logger and
+    // its message list stay collectable while the hub lives on.
+    private readonly SerialDisposable pendingFlush = RegisterPendingFlush(hub);
+
+    private static SerialDisposable RegisterPendingFlush(IMessageHub hub)
+    {
+        var pending = new SerialDisposable();
+        hub.RegisterForDisposal(pending);
+        return pending;
+    }
+
     IDisposable? ILogger.BeginScope<TState>(TState state) => null;
 
     public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
@@ -113,7 +137,10 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             // timer-queue one-shot: no immediate dispatch, no parked thread, no await.
             if (Interlocked.CompareExchange(ref _publishScheduled, 1, 0) == 0)
             {
-                Observable.Timer(TimeSpan.FromMilliseconds(ThrottleMs))
+                // Held, not discarded — see `pendingFlush` (#995). Once the hub is disposed the
+                // SerialDisposable is disposed too, so this assignment kills the new timer on
+                // the spot and a dead hub can never be woken by a tail flush.
+                pendingFlush.Disposable = Observable.Timer(TimeSpan.FromMilliseconds(ThrottleMs))
                     .Subscribe(_ =>
                     {
                         Interlocked.Exchange(ref _publishScheduled, 0);

--- a/test/MeshWeaver.AI.Test/ActivityLogTailFlushOwnershipTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogTailFlushOwnershipTest.cs
@@ -4,8 +4,10 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Fixture;
 using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -35,6 +37,24 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class ActivityLogTailFlushOwnershipTest(ITestOutputHelper output) : HubTestBase(output)
 {
+    /// <summary>
+    /// The logger publishes by posting a <c>DataChangeRequest</c> to the activity's address —
+    /// its own hub, as <c>KernelExecutor</c> does by default. Accept it and register the payload
+    /// types so the run leaves no DeliveryFailure or auto-short-name warnings behind: in
+    /// production the activity hub handles this message, and a test should not pay CI log volume
+    /// to prove otherwise.
+    /// </summary>
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .WithTypes(
+                typeof(DataChangeRequest),
+                typeof(UpdateOptions),
+                typeof(MeshNode),
+                typeof(ActivityLog),
+                typeof(LogMessage),
+                typeof(UserInfo))
+            .WithHandler<DataChangeRequest>((_, delivery) => delivery.Processed());
+
     /// <summary>
     /// Arm the throttled tail flush, then dispose the hub the logger posts to: the pending
     /// flush must go down with it.

--- a/test/MeshWeaver.AI.Test/ActivityLogTailFlushOwnershipTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogTailFlushOwnershipTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// #995 — <c>ActivityLogLogger</c>'s throttle tail-flush timer must be CANCELLABLE by the hub
+/// that owns it.
+///
+/// <para><b>The defect.</b> A burst of script log calls is coalesced by arming a 100 ms
+/// <c>Observable.Timer</c> that publishes the latest snapshot. The subscription it returned was
+/// discarded. <c>Observable.Timer</c> parks its entry on the process-wide <c>TimerQueue</c>, a
+/// strong GC root, so a pending flush held the tick closure → the logger → the <c>IMessageHub</c>
+/// it posts to. Nothing could cancel it, so a hub torn down within 100 ms of a script's last log
+/// call stayed rooted past its own disposal — the same shape as the four watcher timers fixed in
+/// #996, at a tenth of the window.</para>
+///
+/// <para><b>What this test pins, and why not GC.</b> The assertion is on OWNERSHIP, not on
+/// collectability: after the hub is disposed the handle holding the pending flush is disposed
+/// too. That is exact and timing-free — it holds whether or not the 100 ms timer has already
+/// fired, so the test can neither flake nor pass by accident. A <c>WeakReference</c> probe would
+/// instead be a sampling test of a 100 ms window (the reason <c>MeshHubDisposalLeakTest</c> pins
+/// nothing — see its remarks). Negative control: drop the <c>RegisterForDisposal</c> from
+/// <c>ActivityLogLogger.RegisterPendingFlush</c>, leaving the field a plain
+/// <c>new SerialDisposable()</c>, and the final assertion fails.</para>
+/// </summary>
+public class ActivityLogTailFlushOwnershipTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Arm the throttled tail flush, then dispose the hub the logger posts to: the pending
+    /// flush must go down with it.
+    /// </summary>
+    [Fact]
+    public async Task DisposingTheHub_CancelsThePendingTailFlush()
+    {
+        var hub = GetClient();
+        // Production default: the activity path IS the hub's own address (KernelExecutor).
+        var logger = new ActivityLogLogger(hub, hub.Address.ToString());
+
+        var pending = PendingFlushOf(logger);
+
+        // The FIRST append publishes immediately and stamps the throttle window; an append that
+        // lands inside that window is the one that arms the tail-flush timer. Append in a tight
+        // loop rather than assuming two adjacent statements run within 100 ms of each other —
+        // no sleeps, no fixed waits, just "keep appending until the throttle engages".
+        for (var i = 0; i < 100 && pending.Disposable is null; i++)
+            logger.LogInformation("append {Index}", i);
+
+        pending.Disposable.Should().NotBeNull(
+            "a throttled append must arm the tail-flush timer INTO the hub-owned handle — "
+            + "if nothing is armed this test is asserting on an empty slot");
+        pending.IsDisposed.Should().BeFalse("the hub is still alive");
+
+        hub.Dispose();
+        await hub.DisposalCompleted.FirstAsync().ToTask().WaitAsync(TimeSpan.FromSeconds(30));
+
+        pending.IsDisposed.Should().BeTrue(
+            "tearing down the hub must cancel a tail flush that is still pending — an "
+            + "uncancelled Observable.Timer sits on the process-wide TimerQueue (a strong GC "
+            + "root) and pins the logger, and through it the hub, past its own disposal (#995)");
+    }
+
+    /// <summary>
+    /// Reads the logger's pending-flush handle. Private by design — the guard turns a rename
+    /// into a loud failure instead of a silently vacuous test.
+    /// </summary>
+    private static SerialDisposable PendingFlushOf(ActivityLogLogger logger)
+    {
+        var field = typeof(ActivityLogLogger)
+            .GetField("pendingFlush", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull(
+            "ActivityLogLogger.pendingFlush is the handle this test is about — if it was "
+            + "renamed or retyped, update this test rather than losing the coverage");
+        return (SerialDisposable)field!.GetValue(logger)!;
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
@@ -84,8 +84,18 @@ public class MeshNodePickerDebounceOwnershipTest
             + "search path never writes to");
         debounce.IsDisposed.Should().BeFalse("the component is still alive");
 
+        // Swap the REAL timer the keystroke just armed for a stand-in. Its tick would call
+        // LoadResultsAsync → InvokeAsync, which needs a render handle this bare component does
+        // not have — so leaving it live would make the test depend on finishing inside 200 ms.
+        // The assignment cancels it, and the stand-in carries the same question to teardown.
+        var pendingCancelled = false;
+        debounce.Disposable = Disposable.Create(() => pendingCancelled = true);
+
         await probe.DisposeAsync();
 
+        pendingCancelled.Should().BeTrue(
+            "whatever debounce is pending when the component tears down must be cancelled by "
+            + "DisposeAsync releasing BlazorView.Disposables");
         debounce.IsDisposed.Should().BeTrue(
             "component teardown must cancel the debounce armed by the last keystroke; before "
             + "#995 only the NEXT keystroke disposed it, so typing and navigating away left a "

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reflection;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Components;
+using MeshWeaver.Layout;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// #995 — the mesh-node picker's 200 ms search debounce must be owned by the COMPONENT, not by
+/// the next keystroke.
+///
+/// <para><b>Why this one survived the #996 sweep.</b> The subscription was assigned to a field
+/// (<c>_debounceSub</c>), which is what "owned" looks like to any static rule — and indeed a
+/// discarded-<c>Subscribe</c> analyzer passes this file clean. But the only code that ever
+/// disposed that field was the *next* <c>OnSearchInput</c>. Type into the picker and navigate
+/// away, and the last <c>Observable.Timer</c> stays on the process-wide <c>TimerQueue</c> — a
+/// strong GC root — holding the tick closure → the component → its injected <c>IMeshService</c>,
+/// past component teardown. Capture was present; ownership was not.</para>
+///
+/// <para><b>What is asserted.</b> Both halves of the ownership, timing-free: a keystroke arms the
+/// debounce INTO the component-registered handle (observable as the previously pending debounce
+/// being cancelled), and <c>DisposeAsync</c> — the component's real teardown path, which releases
+/// <c>BlazorView.Disposables</c> — cancels whatever is still pending. Negative control: drop the
+/// <c>Disposables.Add(_debounceSub)</c> from <c>MeshNodePickerView.OnInitialized</c> and the
+/// "registered exactly one handle" assertion fails.</para>
+/// </summary>
+public class MeshNodePickerDebounceOwnershipTest
+{
+    /// <summary>
+    /// Drives the component through its REAL lifecycle methods (<c>OnInitialized</c>,
+    /// <c>DisposeAsync</c>) without a renderer — this test is about disposal wiring, not markup.
+    /// </summary>
+    private sealed class Probe : MeshNodePickerView
+    {
+        // A bare view-model with no Queries and no Items, so OnSearchInput takes the remote
+        // (debounced) branch rather than the in-memory filter. Stream/Area stay unset: neither
+        // lifecycle method under test reads them.
+        [SetsRequiredMembers]
+        public Probe()
+        {
+            ViewModel = new MeshNodePickerControl(new object());
+            Logger = NullLogger<MeshNodePickerView>.Instance;
+        }
+
+        public void Initialize() => OnInitialized();
+
+        public IReadOnlyList<IDisposable> Owned => Disposables;
+    }
+
+    /// <summary>
+    /// A keystroke arms the debounce into the component-owned handle, and component teardown
+    /// cancels it — not merely the next keystroke.
+    /// </summary>
+    [Fact]
+    public async Task DisposeAsync_CancelsTheLastPendingDebounce()
+    {
+        var probe = new Probe();
+        probe.Initialize();
+
+        var owned = probe.Owned.OfType<SerialDisposable>().ToArray();
+        owned.Should().ContainSingle(
+            "OnInitialized must register the debounce handle in BlazorView.Disposables — that "
+            + "registration is the ONLY thing that lets component teardown cancel a pending "
+            + "200 ms search timer (#995)");
+        var debounce = owned[0];
+
+        // Stand-in for a debounce that is already pending when the user types again.
+        var previousCancelled = false;
+        debounce.Disposable = Disposable.Create(() => previousCancelled = true);
+
+        InvokeSearchInput(probe, "acme");
+
+        previousCancelled.Should().BeTrue(
+            "each keystroke must arm into the component-owned handle, which cancels the "
+            + "previously armed debounce — otherwise the registration guards a slot the "
+            + "search path never writes to");
+        debounce.IsDisposed.Should().BeFalse("the component is still alive");
+
+        await probe.DisposeAsync();
+
+        debounce.IsDisposed.Should().BeTrue(
+            "component teardown must cancel the debounce armed by the last keystroke; before "
+            + "#995 only the NEXT keystroke disposed it, so typing and navigating away left a "
+            + "200 ms timer on the TimerQueue rooting the component and its injected services");
+    }
+
+    /// <summary>
+    /// Invokes the picker's private input handler — the debounce entry point. The guard turns a
+    /// rename into a loud failure instead of a silently vacuous test.
+    /// </summary>
+    private static void InvokeSearchInput(MeshNodePickerView view, string text)
+    {
+        var handler = typeof(MeshNodePickerView)
+            .GetMethod("OnSearchInput", BindingFlags.Instance | BindingFlags.NonPublic);
+        handler.Should().NotBeNull(
+            "MeshNodePickerView.OnSearchInput is the debounce entry point this test drives — "
+            + "if it was renamed, update this test rather than losing the coverage");
+        handler!.Invoke(view, [new ChangeEventArgs { Value = text }]);
+    }
+}


### PR DESCRIPTION
Closes the **two live defects** the #995 audit found — and only those. The 40 verified-safe sites and the 4 ambiguous ones are untouched; the audit measured them, and widening this diff would only add regression surface.

Both are the class #996 fixed: an Rx timer whose `IDisposable` never reaches an owner's disposal chain. `Observable.Timer` parks its entry on the process-wide `TimerQueue`, a strong GC root, so while the timer is pending it holds the tick closure and everything the closure captured — past the owner's disposal.

## The two sites

**`ActivityLogLogger.cs:116` — a discarded `Subscribe`.** Structurally identical to the four in #996, at a tenth of the window. A burst of script log calls is coalesced by arming a 100 ms tail-flush timer; the subscription it returned was dropped on the floor, so nothing could cancel a flush still pending when the kernel executor hub tore down. The pending flush held the logger, and the logger holds the `IMessageHub` it posts to.

Fix: the timer goes into a `SerialDisposable` registered on that hub (`RegisterForDisposal`). Teardown disposes the hub's composite, which cancels the timer. Assignment keeps the existing "arm one at a time" semantics — `_publishScheduled` already guarantees at most one is pending, so a live flush can never be clobbered — and a schedule handed over *after* disposal is disposed on assignment, so there is no dispose race either.

**`MeshNodePickerView.razor.cs:232` — capture without ownership.** This one reads correct: the subscription IS assigned to a field, and a discarded-`Subscribe` analyzer passes the file clean. But the only code that ever disposed that field was the *next* keystroke. The component never overrode `DisposeAsync` and the field was not in `BlazorView.Disposables`, so a user who typed into the picker and navigated away left the last 200 ms timer on the `TimerQueue`, rooting the component → its injected `IMeshService` → the mesh services.

Fix: same `SerialDisposable`, registered once in `OnInitialized` into the framework's existing `BlazorView.Disposables` (released by `DisposeAsync`) rather than a bespoke override. Registered there and not in `BindData`, which re-runs on every binding-relevant parameter change — that would both duplicate the entry and cancel a debounce the user is still mid-typing.

## Does this eliminate the window or narrow it?

**Eliminated in both cases**, not narrowed — the fix is ownership, not a shorter timer.

- Logger: the pending flush is cancelled synchronously as part of the hub's ShutDown-phase `disposables.Dispose()`. There is no interval in which a pending timer outlives the hub, and no race with a concurrent arm (`SerialDisposable` disposes an incoming value when already disposed).
- Picker: `DisposeAsync` releases `Disposables`. `OnInitialized` is guaranteed by Blazor to run before any event handler can fire, so there is no keystroke that can arm a timer outside the registration.

What remains bounded rather than zero is normal operation: while a hub or component is *alive*, a pending timer legitimately holds it for its 100/200 ms. That is the feature.

## Verification

Two targeted tests, one per site. **Deliberately not `MeshHubDisposalLeakTest`** — as its own remarks now say, it samples (a bounded-window root is caught only if the forced GC lands inside the window), it cannot attribute, and it SKIPs on macOS (#674). Both new tests assert the ownership property directly and timing-free: the handle holding the pending timer is disposed by the owner's teardown, which holds whether or not the timer has already fired. Neither can flake, and neither can pass by accident.

**Negative control run, per site** — revert only the ownership line, signature unchanged:

| Reverted | Result |
|---|---|
| `hub.RegisterForDisposal(pending)` in `ActivityLogLogger.RegisterPendingFlush` | `DisposingTheHub_CancelsThePendingTailFlush` FAILS: *"Expected value to be true because tearing down the hub must cancel a tail flush that is still pending … but found False"* |
| `Disposables.Add(_debounceSub)` in `MeshNodePickerView.OnInitialized` | `DisposeAsync_CancelsTheLastPendingDebounce` FAILS: *"Expected collection to contain a single item because OnInitialized must register the debounce handle in BlazorView.Disposables … but found 0"* |

Both restored, both green. The picker test also asserts that the keystroke path arms *into* the registered handle — without that, the registration could guard a slot nothing ever writes to and the test would still pass.

**One thing I measured rather than reasoned about**, since it decides whether `RegisterForDisposal` trades one leak for another: a *fired* `Observable.Timer(…).Subscribe(…)` handle, still held, does **not** retain its callback closure (Rx's sink detaches its observer on completion). Verified with a `WeakReference` probe alongside three controls, including "pending + discarded ⇒ ROOTED", which confirms the probe can see the defect shape. So the hub retains only the `SerialDisposable` itself (~32 B per logger); a settled logger and its message list stay collectable while the hub lives on.

Also green: `ActivityTerminalSettleTest`, `ActivityLogStreamTest`, `MultiLanguageCodeExecutionTest` (20 tests) — the kernel/activity-log paths through the changed logger. Full solution builds clean under CI's flags (`-c Release -warnaserror -p:CIRun=true`), 0 warnings.

## Notes

- **No What's New entry**: pure-internal leak fixes with no user-visible behaviour change.
- **`Refs #995`, deliberately not `Fixes`** — #995 tracks the defect *class*, and the maintainer's decision on option (2), writing the convention down next to `AsynchronousCalls.md`, is still open. This PR closes the two live sites, not the issue.

Refs #995
