### PR TITLE
The scrub put two partitions on one schema, in the test that keeps them apart

### DIFF
--- a/content/ai/Agent/ToolsReference.md
+++ b/content/ai/Agent/ToolsReference.md
@@ -38,7 +38,7 @@ When the user asks "what type is this?", "open the type", or "show me the model"
 
 ## Path Rules
 
-**Every tool argument that expects a node reference MUST be the node's `path` property — never its `name`, `id`, or any human-readable label.** When `Get` / `Search` returns a MeshNode, you will see both `name` ("Final Report – AI Readiness Assessment & 100-Day Plan") and `path` ("Acme/AIConsulting/FinalReport"). **Use the `path` value.** Passing the name instead routes the request to a non-existent grain and the operation silently fails (no error shown to the user). If you only know the display name, call `Search('name:"...the name..."')` first and read the `path` field off the match.
+**Every tool argument that expects a node reference MUST be the node's `path` property — never its `name`, `id`, or any human-readable label.** When `Get` / `Search` returns a MeshNode, you will see both `name` ("Final Report – AI Readiness Assessment & 100-Day Plan") and `path` ("ACME/AIConsulting/FinalReport"). **Use the `path` value.** Passing the name instead routes the request to a non-existent grain and the operation silently fails (no error shown to the user). If you only know the display name, call `Search('name:"...the name..."')` first and read the `path` field off the match.
 
 **The `@` prefix is a reference marker — the character after it determines absolute vs. relative:**
 
@@ -55,14 +55,14 @@ Every user message carries a **"Current Application Context"** header. **You DO 
 
 ```json
 {
-  "address": "Acme/AIConsulting",   // owner (main-node) address of what the user is viewing
+  "address": "ACME/AIConsulting",   // owner (main-node) address of what the user is viewing
   "area": "Overview",                     // layout area, if any
   "areaId": "…",                          // layout area id, if any
   "path": "Tasks/123",                    // remaining path after the node, if any
   "parameters": { "from": "5" },          // optional ?k=v query params on the URL
   "node": {                               // the current node — IDENTITY only (content via Get)
-    "path": "Acme/AIConsulting/FinalReport",
-    "namespace": "Acme/AIConsulting",
+    "path": "ACME/AIConsulting/FinalReport",
+    "namespace": "ACME/AIConsulting",
     "id": "FinalReport",
     "nodeType": "Markdown",
     "name": "Final Report – …"
@@ -72,9 +72,9 @@ Every user message carries a **"Current Application Context"** header. **You DO 
 
 `node.path` (== `namespace`/`id`) **is the canonical path to use when resolving `@...` relative references** and to act on the current node. It is IDENTITY only — load the node's CONTENT on demand with the `Get` tool. Examples:
 
-- Context = `Acme/AIConsulting`, agent calls `Get('@FinalReport')` → resolves to `@/Acme/AIConsulting/FinalReport`.
-- Context = `Acme/AIConsulting`, agent calls `Get('@/OrgA/Docs/other')` → resolves to `@/OrgA/Docs/other` (absolute — context ignored).
-- Context = `Acme/AIConsulting`, agent calls `Get('@content/report.docx')` → resolves to `@/Acme/AIConsulting/content/report.docx`.
+- Context = `ACME/AIConsulting`, agent calls `Get('@FinalReport')` → resolves to `@/ACME/AIConsulting/FinalReport`.
+- Context = `ACME/AIConsulting`, agent calls `Get('@/OrgA/Docs/other')` → resolves to `@/OrgA/Docs/other` (absolute — context ignored).
+- Context = `ACME/AIConsulting`, agent calls `Get('@content/report.docx')` → resolves to `@/ACME/AIConsulting/content/report.docx`.
 - Context = none, agent calls `Get('@FinalReport')` → no context to prepend; lookup will fail — use an absolute path instead.
 
 ### Output links
@@ -208,11 +208,11 @@ Queries consist of space-separated terms. Each term can be:
 
 #### Field Filters
 
-**Equality:** `nodeType:Organization`, `name:Acme`, `status:Active`
+**Equality:** `nodeType:Organization`, `name:ACME`, `status:Active`
 
 **Negation:** `-status:Archived`
 
-**Wildcard Patterns:** `name:*claims*` (contains), `name:Acme*` (starts with), `name:*Corp` (ends with)
+**Wildcard Patterns:** `name:*claims*` (contains), `name:ACME*` (starts with), `name:*Corp` (ends with)
 
 **Comparison Operators:** `price:>100`, `price:<50`, `price:>=100`, `price:<=50`
 

--- a/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
@@ -101,7 +101,7 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     /// <returns>A status message with the uploaded content reference, or the reason the upload failed.</returns>
     [Description("Uploads text content (SVG, markdown, JSON, CSS, etc.) to a node's content collection. Use for storing diagrams, images (SVG), stylesheets, or any text-based files alongside a node.")]
     public Task<string> UploadContent(
-        [Description("Canonical path to the node that owns the collection — use the MeshNode's `path` property, NOT its `name`. Use @/full/path for absolute or @relative/path relative to the current context. Example: @/Acme/AIConsulting or @FinalReport. If you only know the display name, call Search('name:\"...\"') first and use the path field of the match.")] string nodePath,
+        [Description("Canonical path to the node that owns the collection — use the MeshNode's `path` property, NOT its `name`. Use @/full/path for absolute or @relative/path relative to the current context. Example: @/ACME/AIConsulting or @FinalReport. If you only know the display name, call Search('name:\"...\"') first and use the path field of the match.")] string nodePath,
         [Description("File name/path within the collection (e.g., 'diagram.svg', 'images/architecture.svg')")] string filePath,
         [Description("The text content to upload (SVG markup, markdown, JSON, etc.)")] string content,
         [Description("Collection name (default: 'content')")] string collectionName = ContentCollectionsExtensions.DefaultCollectionName,

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SatelliteEntities.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SatelliteEntities.md
@@ -83,7 +83,7 @@ Each satellite entity links back to its parent via the `MainNode` property, whic
 var threadNode = new MeshNode(threadId, $"{contextPath}/_Thread")
 {
     NodeType = "Thread",
-    MainNode = contextPath,  // e.g. "Acme/AiConsulting" — the real entity
+    MainNode = contextPath,  // e.g. "ACME/AiConsulting" — the real entity
     Content = new Thread()
 };
 
@@ -93,7 +93,7 @@ var threadNode = new MeshNode(threadId, $"{contextPath}/_Thread")
     NodeType = "Thread",
     Content = new Thread()
 };
-// MainNode defaults to "Acme/AiConsulting/_Thread/threadId" — not a real entity
+// MainNode defaults to "ACME/AiConsulting/_Thread/threadId" — not a real entity
 ```
 
 # Sub-Namespace Conventions

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
@@ -1,8 +1,9 @@
 ---
 Name: Checking that a deployment is up to date, from inside or outside
-Category: What's New
+Category: Feature
 Description: Every user can now see on About whether their build is current, and a new anonymous /api/version endpoint answers the same question from outside the portal.
 Icon: ArrowSync
+Order: -20260809
 ---
 
 # Checking that a deployment is up to date, from inside or outside

--- a/test/MeshWeaver.Security.Test/GroupPermissionTests.cs
+++ b/test/MeshWeaver.Security.Test/GroupPermissionTests.cs
@@ -60,9 +60,15 @@ public class GroupPermissionTests(ITestOutputHelper output) : MonolithMeshTestBa
     {
         // The group + its membership live under one root; the grant lives under a DIFFERENT root.
         // The group set is resolved GLOBALLY, so the grant still reaches the member.
+        //
+        // 🚨 The root here must not case-collide with any other root in this class. A top-level
+        // segment IS a partition and its schema is segment.ToLowerInvariant(), so "Acme" and the
+        // "ACME" used above would be ONE partition — which quietly removes the separation this
+        // "CrossPartition" test exists to demonstrate. (It briefly was "Acme", from the
+        // identifier scrub.)
         await MeshService.CreateNode(
-            AssignmentNodeFactory.UserRole("Acme/Cohort", "Viewer", "Course")).Should().Emit();
-        await MeshService.CreateNode(Membership("carol", "Acme/Cohort")).Should().Emit();
+            AssignmentNodeFactory.UserRole("Zenith/Cohort", "Viewer", "Course")).Should().Emit();
+        await MeshService.CreateNode(Membership("carol", "Zenith/Cohort")).Should().Emit();
 
         await Mesh.GetEffectivePermissions("Course/Module", "carol")
             .Should().Match(p => p.HasFlag(Permission.Read));


### PR DESCRIPTION
Audited the remaining ~230 files of the identifier scrub (#983) for the class you caught in `29679dd6e` — tokens that are **compared, ordered, or used as a path segment**. One real defect left, same shape.

## The defect

`GroupPermissionTests.CrossPartitionGroup_LicensedElsewhere_ReachesMember` had its root rewritten to `Acme`, **four lines below** another test using `ACME`. A top-level segment is a partition and its schema is `segment.ToLowerInvariant()` — so those are one partition, which dissolves the separation a test named *CrossPartition* exists to demonstrate.

It still passed. Carol's grant and Alice's are on different subjects, so the assertion held — **asserting the right thing for the wrong reason**. Root is now `Zenith` (no case-collision anywhere in the repo), with a comment saying why the name must stay distinct.

## The rest of the audit, and what was checked

| Class | Result |
|---|---|
| Comparisons (`includes` / `Contains` / `StartsWith` / `==`) | Every hit predates the scrub except two, and both rewrote the token **consistently** — node id, name, url *and* the assertion — so they still mean what they did |
| Ordering | One touched file has an index assertion, but it's a `ContainSingle`, so no order depends on a renamed value |
| Path / partition collisions | Five files mix `Acme` and `ACME`: three are agent-facing docs and tool descriptions (normalized to `ACME` — a model reading two spellings of one sample partition in the same file cannot tell whether they're the same place), one is a unit test whose two usages are unrelated methods with no partition involved, and the fifth is the defect above |

## A method note, because the first pass of this audit was itself wrong

I classified files with `git show --stat`, which **truncates long paths** — it silently mis-cleared two files I then had to re-examine. `--name-only` is the reliable list. Worth knowing before trusting a "which files did that commit touch" check.

Build clean with CI's flags; `GroupPermissionTests` 5/5; doc-link integrity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEZMJc1GJRjnRsxnvCWRmK