### PR TITLE
perf(ci): cache the NuGet global-packages folder in the build job

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -226,6 +226,28 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
+    # Cache the NuGet global-packages folder. `Restore dependencies` below is the ONLY
+    # restore in this workflow (the shards consume prebuilt bins and never restore), and
+    # it cost a remarkably stable 40-41 s across runs 31309290210 / 31311680838 /
+    # 31313253809 — i.e. it re-downloads the same closure every single run.
+    #
+    # Key on the files that actually determine the closure. Central Package Management
+    # means every VERSION lives in Directory.Packages.props, so a csproj that adds a
+    # PackageReference without changing a version reuses the cache and restores only the
+    # delta — which is the behaviour we want, not a miss. nuget.config pins the sources,
+    # and global.json the SDK band, both of which can change what resolves.
+    #
+    # 🚨 The restore is NOT removed or made conditional — a cache miss (or a poisoned
+    # entry) must degrade to a slower restore, never to a wrong or absent one. That is
+    # also why there is a restore-keys fallback: a partial hit still beats a cold fetch,
+    # and `dotnet restore` reconciles whatever it finds against the lock of the graph.
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', 'nuget.config', 'global.json') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
`Restore dependencies` is the **only** restore in this workflow — the six shards consume prebuilt bins and never restore — and it costs a remarkably stable 40–41s every run:

| run | restore |
|---|---|
| 31309290210 | 41s |
| 31311680838 | 40s |
| 31313253809 | 41s |

That is the same package closure re-fetched from nuget.org on every build. There is currently **no `actions/cache` anywhere in the repository**.

## Why this is worth a small change

Current CI profile (3-run average):

| | time | share of critical path |
|---|---|---|
| Build job | 8.13 min | **47%** |
| Slowest shard | 8.4 min | 49% |

Inside the build job: compile 341s (70%), pack 61s, uploads 45s, **restore 41s**. The compile needs hardware or fewer projects; the restore is pure repeated I/O and is the one part addressable for free.

## Key design

Keyed on what actually determines the closure — `Directory.Packages.props` (Central Package Management puts every version there), `nuget.config` (the sources), `global.json` (the SDK band, if one is ever added).

A csproj adding a `PackageReference` without changing a version reuses the cache and restores only the delta. That is the wanted behaviour, not a miss.

🚨 **The restore is not removed or made conditional.** A cache miss — or a poisoned entry — must degrade to a slower restore, never to a wrong or absent one. `restore-keys` exists for the same reason: a partial hit beats a cold fetch, and `dotnet restore` reconciles whatever it finds against the real graph.

## Not included, deliberately

Overlapping each shard's artifact download (11–18s) with its Testcontainers pre-pull (15–17s), worth ~15s. That pre-pull is a **designed infra guard** — bounded retries with backoff, explicit failure — added so a Docker Hub blip could not masquerade as 412 phantom test failures (run 31137723323). Backgrounding it requires cross-shell sentinel-file syncing and blunts precisely the diagnostic clarity it exists for. Not worth 15s.

## Expected effect

~−33s on the critical path. Modest and honestly so — after three over-optimistic estimates from me today, this one is bounded by a step whose cost I measured three times and which varies by 1s.

## No What's New entry

Pure CI infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.