### PR TITLE
perf(test): configurable hard deadline — suite's slowest test 95s → 8.6s

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -681,7 +681,36 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// that do. Widening it does not weaken any assertion — the test still fails, it just
     /// fails naming the operation instead of the harness.</para>
     /// </summary>
-    protected virtual TimeSpan TestHardDeadline => TimeSpan.FromSeconds(90);
+    protected virtual TimeSpan TestHardDeadline => DefaultHardDeadline;
+
+    /// <summary>
+    /// The default hard deadline: 90 s, overridable via the <c>MESHWEAVER_TEST_HARD_DEADLINE_SECONDS</c>
+    /// environment variable.
+    ///
+    /// <para>Configurable rather than a literal because a baked timeout is a value people edit to
+    /// get through a debugging session — which AGENTS.md forbids, since the committed number is a
+    /// contract (CI is sized for a cold Roslyn compile on a fresh runner; a laptop is not). An env
+    /// var lets a local run dial it without touching the tree, and lets a fixture that is TESTING
+    /// the watchdog run against a small floor instead of burning the real one in wall clock.</para>
+    ///
+    /// <para>🚨 <b>static readonly, read ONCE</b> — and it must stay that way. This is not a cache
+    /// (which the no-static-state rule bans); it is an immutable constant resolved at type init.
+    /// It cannot become instance state or a DI lookup: <c>HardDeadlineHonoursFactTimeoutTest</c>'s
+    /// static guard reads <see cref="TestHardDeadline"/> off a
+    /// <c>RuntimeHelpers.GetUninitializedObject</c> instance — no constructor, no fields, no
+    /// ServiceProvider — so anything instance-bound would throw or read garbage there.</para>
+    ///
+    /// <para>Malformed or non-positive values fall back to 90 s rather than failing: a typo in an
+    /// env var must not turn every test in the assembly red with a harness error.</para>
+    /// </summary>
+    private static readonly TimeSpan DefaultHardDeadline =
+        double.TryParse(
+            Environment.GetEnvironmentVariable("MESHWEAVER_TEST_HARD_DEADLINE_SECONDS"),
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var configuredSeconds) && configuredSeconds > 0
+            ? TimeSpan.FromSeconds(configuredSeconds)
+            : TimeSpan.FromSeconds(90);
 
     /// <summary>
     /// Headroom the watchdog keeps ABOVE a test's own declared <c>[Fact(Timeout)]</c>, so the

--- a/test/MeshWeaver.Hosting.Monolith.Test/HardDeadlineHonoursFactTimeoutTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/HardDeadlineHonoursFactTimeoutTest.cs
@@ -27,10 +27,35 @@ public class HardDeadlineHonoursFactTimeoutTest(ITestOutputHelper output)
     /// The sleep is the POINT of the test — it is what crosses the old deadline — not a wait for a
     /// condition, so it is not the forbidden <c>Task.Delay</c>-to-await-propagation pattern.
     /// </summary>
-    [Fact(Timeout = 150_000)]
+    /// <summary>
+    /// 🚨 Deliberately caps its OWN floor far below the 90 s default — the one class in the
+    /// assembly allowed to, and exempted by name in the guard below.
+    ///
+    /// <para>The invariant under test is a RELATION, not a magic number:
+    /// <c>EffectiveHardDeadline = max(TestHardDeadline, declared + HardDeadlineMargin)</c>, so a
+    /// test that runs past its floor but inside its declared budget must survive. Exercising that
+    /// at the real 90 s floor cost a 95 s sleep — the single slowest test in the entire suite by
+    /// more than 2x (95.1 s; the runner-up is 49 s). At a 5 s floor with a 30 s declared budget
+    /// the effective deadline is 60 s and an 8 s sleep proves exactly the same thing: it crosses
+    /// the floor (5 s) and stays inside the raised deadline (60 s). Pre-fix it would be killed at
+    /// 5 s, exactly as it used to be killed at 90 s.</para>
+    ///
+    /// <para>What is given up: this no longer pins the literal 90 s. That is covered structurally
+    /// and for EVERY class by the static guard below, at zero runtime cost — which is the better
+    /// place for it anyway.</para>
+    /// </summary>
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// This test declares a budget above its own floor and deliberately runs past that floor.
+    /// Before the fix the watchdog failed it at the floor; now the declared budget is honoured.
+    /// The sleep is the POINT of the test — it is what crosses the deadline — not a wait for a
+    /// condition, so it is not the forbidden <c>Task.Delay</c>-to-await-propagation pattern.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
     public async Task TestRunningPastTheDefaultDeadline_IsNotKilled_WhenItDeclaresALargerBudget()
     {
-        await Task.Delay(TimeSpan.FromSeconds(95), TestContext.Current.CancellationToken);
+        await Task.Delay(TimeSpan.FromSeconds(8), TestContext.Current.CancellationToken);
         Assert.True(true, "the watchdog must honour this test's declared [Fact(Timeout)]");
     }
 
@@ -55,6 +80,14 @@ public class HardDeadlineHonoursFactTimeoutTest(ITestOutputHelper output)
                 .DefaultIfEmpty(0)
                 .Max();
             if (declared <= 0)
+                continue;
+
+            // 🚨 The ONE sanctioned exemption: this class exists to prove the watchdog raises the
+            // floor to honour a larger declared budget, so it must cap its own floor BELOW its
+            // declared [Fact(Timeout)] — the exact shape this guard rejects everywhere else.
+            // Exempted by identity, not by a flag, so adding a second exemption is a deliberate
+            // edit here rather than an attribute someone can sprinkle to silence the guard.
+            if (type == typeof(HardDeadlineHonoursFactTimeoutTest))
                 continue;
 
             // Only an EXPLICIT override can now under-cut a declared budget; the inherited


### PR DESCRIPTION
`HardDeadlineHonoursFactTimeoutTest.TestRunningPastTheDefaultDeadline_…` is the **single slowest test in the suite at 95.1s** — more than 2× the runner-up — out of 8,817 tests totalling 36.7 min. Almost all of it is `Task.Delay`.

## Why it can shrink without losing coverage

The 95s was not arbitrary: the test proves the watchdog raises its floor to honour a larger declared `[Fact(Timeout)]`, so the sleep had to cross the 90s default. But the invariant is a **relation**, not a magic number:

```
EffectiveHardDeadline = max(TestHardDeadline, declared + HardDeadlineMargin)
```

| | floor | declared | effective | sleep |
|---|---|---|---|---|
| before | 90s | 150s | 180s | **95s** |
| after | 5s | 30s | 60s | **8s** |

Same code path — the sleep crosses the floor and stays inside the raised deadline. Pre-fix it would be killed at 5s exactly as it used to be killed at 90s.

**Measured: the class now runs 8.6s, both tests green.**

## And the deadline becomes configurable

`TestHardDeadline` now reads `MESHWEAVER_TEST_HARD_DEADLINE_SECONDS`, default unchanged at 90s. A baked timeout is a value people quietly edit to get through a debugging session — which AGENTS.md forbids, because the committed number is a contract sized for a cold Roslyn compile on a fresh CI runner, not a laptop.

🚨 **It is `static readonly`, read once, and must stay that way.** That is not a cache (which the no-static-state rule bans) but an immutable constant resolved at type init — and it *cannot* become instance state or a DI lookup, because the static guard in this same file reads the property off a `RuntimeHelpers.GetUninitializedObject` instance: no constructor, no fields, no ServiceProvider. Anything instance-bound would throw or read garbage there. A malformed env value falls back to 90s rather than reddening the assembly with a harness error.

## The guard exemption

`NoTestClass_OverridesHardDeadlineBelowItsOwnDeclaredFactTimeout` rejects any class capping its floor below its declared budget — which is precisely what this class must now do. It is exempted by `typeof()` identity, **not** an attribute, so a second exemption requires a deliberate edit here rather than a flag anyone can sprinkle to silence the check. Verified the guard still passes with every other class unchanged.

## What is given up

The runtime test no longer pins the literal 90s. That is covered structurally, for **every** class, by the static guard at zero runtime cost — which is the better place for it. Stating it plainly because it is a real, if small, reduction in what the runtime test proves.

## No What's New entry

Test infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.