### PR TITLE
Wait on the activity write's own completion, not on the query index catching up

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
@@ -62,15 +62,21 @@ public sealed class ActivityWriteTracker
     // sides of this one are concurrent by construction: Begin runs on whichever hub handled the
     // request, Release runs on the detached pipeline's thread whenever that write ends. Same
     // reasoning as MeshNodeStreamCache's eviction subject.
-    private readonly BehaviorSubject<int> countSubject = new(0);
-    private readonly IObserver<int> count;
-    private readonly IObservable<int> counts;
+    //
+    // The subject carries the WHOLE in-flight map, not just its total: Drain needs "is anything
+    // running", WhenSettled needs "is THIS path running", and deriving both from one notification
+    // keeps a single ordered channel (two subjects could interleave and let a per-path observer
+    // see a state the count never reported).
+    private readonly BehaviorSubject<ImmutableDictionary<string, int>> stateSubject =
+        new(ImmutableDictionary<string, int>.Empty);
+    private readonly IObserver<ImmutableDictionary<string, int>> state;
+    private readonly IObservable<ImmutableDictionary<string, int>> states;
 
     /// <summary>Creates an empty tracker.</summary>
     public ActivityWriteTracker()
     {
-        count = Observer.Synchronize(countSubject, preventReentrancy: true);
-        counts = countSubject.AsObservable();
+        state = Observer.Synchronize(stateSubject, preventReentrancy: true);
+        states = stateSubject.AsObservable();
     }
 
     /// <summary>Paths currently being written — what a drain overrun names.</summary>
@@ -102,13 +108,13 @@ public sealed class ActivityWriteTracker
         // outside it would let a Release's "0" overtake a concurrent Begin's "1", and a drain
         // watching for zero would then complete while a write that had just started was still
         // running — the exact loss this class exists to prevent. Safe to hold `gate` across the
-        // notification: the observer is synchronized with preventReentrancy, and the only
-        // subscriber is Drain's Where/Take filter, which never calls back in here.
+        // notification: the observer is synchronized with preventReentrancy, and the subscribers
+        // are Drain's and WhenSettled's Where/Take filters, neither of which calls back in here.
         lock (gate)
         {
             inFlight = inFlight.SetItem(
                 activityPath, inFlight.TryGetValue(activityPath, out var c) ? c + 1 : 1);
-            count.OnNext(inFlight.Values.Sum());
+            state.OnNext(inFlight);
         }
         return new Registration(this, activityPath);
     }
@@ -119,8 +125,49 @@ public sealed class ActivityWriteTracker
         {
             if (inFlight.TryGetValue(activityPath, out var c))
                 inFlight = c <= 1 ? inFlight.Remove(activityPath) : inFlight.SetItem(activityPath, c - 1);
-            count.OnNext(inFlight.Values.Sum());
+            state.OnNext(inFlight);
         }
+    }
+
+    /// <summary>
+    /// Completes once the write for <paramref name="activityPath"/> has ENTERED and then LEFT the
+    /// in-flight set — the detached pipeline's own termination signal (success, error, or an
+    /// unsubscribe forced by disposal; <c>Begin</c>'s registration is cleared from a <c>Finally</c>,
+    /// so every ending counts).
+    ///
+    /// <para>🚨 <b>Subscribe BEFORE you trigger the write.</b> This deliberately does NOT complete
+    /// on a path that has never been in flight — that is the whole difference from
+    /// <see cref="Drain"/>, which "completes IMMEDIATELY when nothing is in flight" and therefore
+    /// races <see cref="Begin"/> when called right after a <c>Post</c>: it would return before the
+    /// write was even registered and turn a timing flake into a deterministic false pass. A
+    /// subscriber that attaches after the write already finished waits forever (by design — the
+    /// alternative is that false pass), so subscribe first, then post.</para>
+    ///
+    /// <para>This is the signal to wait on instead of polling a query for the node the write
+    /// produces: <c>IMeshService.Query</c> is eventually consistent, so a poll asserts "the index
+    /// caught up within N seconds" rather than "the write finished" (issue #993). Wait here, then
+    /// read the node authoritatively.</para>
+    ///
+    /// <para><b>Scope of the signal.</b> It completes the first time NO write for this path is
+    /// outstanding, having seen at least one. Writes that OVERLAP are therefore all awaited (the
+    /// per-path counter only reaches zero when the last of them ends — the create-vs-update race
+    /// stays covered). A later, NON-overlapping write for the same path is a separate cycle and
+    /// needs its own subscription; this is a "my write finished" signal, not "no write will ever
+    /// run again".</para>
+    /// </summary>
+    /// <param name="activityPath">The activity node path passed to <see cref="Begin"/>.</param>
+    public IObservable<Unit> WhenSettled(string activityPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(activityPath);
+        return states
+            .Select(s => s.ContainsKey(activityPath))
+            .DistinctUntilChanged()
+            // Drop the leading "not started yet" — SkipWhile begins forwarding at the first `true`,
+            // so the `false` that follows is unambiguously a LEAVE and never the initial state.
+            .SkipWhile(running => !running)
+            .Where(running => !running)
+            .Take(1)
+            .Select(_ => Unit.Default);
     }
 
     /// <summary>
@@ -140,8 +187,8 @@ public sealed class ActivityWriteTracker
                 "Activity drain: waiting for {Count} in-flight write(s) before disposal: {Paths}",
                 Count, string.Join(", ", InFlight));
 
-            return counts
-                .Where(n => n == 0)
+            return states
+                .Where(s => s.Count == 0)
                 .Take(1)
                 .Select(_ => Unit.Default)
                 .Timeout(DrainTimeout)

--- a/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
@@ -177,4 +177,99 @@ public class ActivityWriteTrackerTest
         tracker.Count.Should().Be(0, "every write released — a torn subject would leave a residue");
         await tracker.Drain().Timeout(TimeSpan.FromSeconds(3)).FirstAsync();
     }
+
+    /// <summary>
+    /// 🚨 The #993 signal. A caller that has just triggered a detached write needs "THIS write
+    /// finished" — and must get it without polling an eventually-consistent query for the node the
+    /// write produces. WhenSettled completes on the ENTER→LEAVE transition of that one path.
+    /// </summary>
+    [Fact]
+    public async Task WhenSettled_CompletesWhenThatPathsWriteEndsAndNotBefore()
+    {
+        var tracker = new ActivityWriteTracker();
+        // Subscribed BEFORE the write starts — the documented usage.
+        var settled = tracker.WhenSettled("alice/_UserActivity/Doc_Page").FirstAsync().ToTask();
+
+        var early = await Task.WhenAny(settled, Task.Delay(200));
+        early.Should().NotBe(settled, "the write has not even started — completing here is the false pass");
+
+        var write = tracker.Begin("alice/_UserActivity/Doc_Page");
+
+        var stillRunning = await Task.WhenAny(settled, Task.Delay(200));
+        stillRunning.Should().NotBe(settled, "the write is in flight — settling now would be a lie");
+
+        write.Dispose();
+
+        await settled.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    /// <summary>
+    /// The exact trap that makes <see cref="ActivityWriteTracker.Drain"/> unusable as a
+    /// "did my write finish" signal: Drain completes IMMEDIATELY when nothing is in flight, so a
+    /// caller who subscribes right after Post wins the race against the handler's Begin and gets a
+    /// deterministic FALSE PASS. WhenSettled must not have that property.
+    /// </summary>
+    [Fact]
+    public async Task WhenSettled_DoesNotCompleteOnAnIdleTracker_WhereDrainWould()
+    {
+        var tracker = new ActivityWriteTracker();
+
+        // Drain: completes at once on an idle tracker — correct for shutdown, wrong as a write signal.
+        await tracker.Drain().Timeout(TimeSpan.FromSeconds(2)).FirstAsync();
+
+        var settled = tracker.WhenSettled("alice/_UserActivity/NeverStarted").FirstAsync().ToTask();
+        var raced = await Task.WhenAny(settled, Task.Delay(300));
+        raced.Should().NotBe(settled,
+            "an unstarted write must never report settled — that is the whole difference from Drain");
+    }
+
+    /// <summary>
+    /// One user's write must not settle another's. The signal is per-path because the caller is
+    /// waiting for the specific node it caused to be written.
+    /// </summary>
+    [Fact]
+    public async Task WhenSettled_IgnoresOtherPaths()
+    {
+        var tracker = new ActivityWriteTracker();
+        var settled = tracker.WhenSettled("alice/_UserActivity/Mine").FirstAsync().ToTask();
+
+        var other = tracker.Begin("bob/_UserActivity/Theirs");
+        other.Dispose();
+
+        var raced = await Task.WhenAny(settled, Task.Delay(300));
+        raced.Should().NotBe(settled, "bob's write says nothing about alice's");
+
+        tracker.Begin("alice/_UserActivity/Mine").Dispose();
+        await settled.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    /// <summary>
+    /// Same-path concurrency is the documented create-vs-update race: the caller's write is not
+    /// settled until the LAST outstanding write for that path has ended, or it would read a node
+    /// another write is still mutating.
+    /// </summary>
+    [Fact]
+    public async Task WhenSettled_WaitsForEveryConcurrentWriteToTheSamePath()
+    {
+        var tracker = new ActivityWriteTracker();
+        var settled = tracker.WhenSettled("alice/_UserActivity/Same").FirstAsync().ToTask();
+
+        var first = tracker.Begin("alice/_UserActivity/Same");
+        var second = tracker.Begin("alice/_UserActivity/Same");
+        first.Dispose();
+
+        var raced = await Task.WhenAny(settled, Task.Delay(300));
+        raced.Should().NotBe(settled, "the second write to the same path is still running");
+
+        second.Dispose();
+        await settled.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    /// <summary>An empty or whitespace path is a caller bug, same contract as <c>Begin</c>.</summary>
+    [Fact]
+    public void WhenSettled_RejectsAnEmptyPath()
+    {
+        var tracker = new ActivityWriteTracker();
+        Assert.Throws<ArgumentException>(() => tracker.WhenSettled(" "));
+    }
 }

--- a/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
@@ -92,6 +90,7 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
     {
         const string user = "dave";
         const string nodePath = "dave/MyDoc";
+        var activityPath = $"{user}/_UserActivity/{nodePath.Replace("/", "_")}";
 
         // ONBOARD-FIRST gate: activity tracking never creates a partition ahead of onboarding.
         await OnboardPartitionRoot(user);
@@ -109,6 +108,29 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
         // cache — so wherever the request is handled, the write goes through cache/{meshRootId}.
         connHub.Address.Should().NotBe(connHub.GetActivityTrackingHub().Address);
 
+        // 🚨 Wait on the WRITE'S OWN COMPLETION, not on a query poll (issue #993).
+        //
+        // HandleTrackActivity detaches its write on purpose — TrackLogin sits on the cold-login hot
+        // path and must not stall behind a node write — so Post returns while a three-round-trip
+        // pipeline (existence probe → onboard-gate storage read → CreateNode) is still running.
+        // The previous shape gave that pipeline a fixed 15 s and then asserted on
+        // IMeshService.Query, which is EVENTUALLY CONSISTENT: it asserted "the index caught up in
+        // time", not "the write finished", and burned its whole budget on CI (run 31301311379)
+        // with nothing to attribute it to. Per CqrsAndContentAccess.md, polling a query for a node
+        // you just caused to be written is the wrong primitive — and per AGENTS.md the wait belongs
+        // on the actual condition. ActivityWriteTracker IS that condition: the handler registers
+        // every detached write with it and clears the registration from a Finally.
+        //
+        // Subscribe BEFORE the Post. WhenSettled requires the path to ENTER and then LEAVE the
+        // in-flight set, so it cannot win the race against the handler's Begin(...) the way a bare
+        // Drain() after Post would (Drain completes immediately when nothing is in flight — that
+        // would be a deterministic FALSE PASS). Replay(1) holds the completion for the assertion's
+        // own subscribe below.
+        var tracker = connHub.GetActivityTrackingHub()
+            .ServiceProvider.GetRequiredService<ActivityWriteTracker>();
+        var settled = tracker.WhenSettled(activityPath).Replay(1);
+        using var settledSubscription = settled.Connect();
+
         connHub.Post(new TrackActivityRequest(
             NodePath: nodePath,
             UserId: user,
@@ -116,20 +138,17 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
             NodeType: "Markdown",
             Namespace: user));
 
-        // 🚨 Wait on the QUERY, not on GetMeshNodeStream(path). This looks like the wrong
-        // primitive — the query index is eventually consistent — but it is the only one that
-        // WAITS for a node that does not exist yet. Both authoritative reads terminate instead:
-        // ReadNode is a one-shot GetMeshNode that returns null on NotFound and completes, and
-        // GetMeshNodeStream(path) on a not-yet-created node likewise COMPLETES rather than staying
-        // open until the write lands. #772 switched to the stream and turned an occasional 15s
-        // timeout into a deterministic 250ms "completed without a value" on CI (afe2fc6ea) — the
-        // whole wait collapsed. Reverted; the poll is correct here precisely because it retries.
-        var node = await PollForFirst($"namespace:{user}/_UserActivity nodeType:UserActivity");
+        await settled.Should().Within(TimeSpan.FromSeconds(15)).Emit(
+            "the detached activity write must run to completion — a timeout here means the handler's " +
+            "pipeline stalled (see the MeshWeaver.Graph.ActivityTracking trace for which stage was last)");
 
-        node.Should().NotBeNull(
+        // Now read AUTHORITATIVELY. The write has terminated, so the node either exists or the
+        // handler skipped/failed the create — no eventual consistency in the assertion.
+        var node = await ReadNode(activityPath).Should().Match(n => n is not null,
             "a track posted to a connection-style hub must still land a UserActivity node — " +
             "the handler originates the write from the dedicated tracking hub, not the caller");
-        node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
+
+        node!.Path.Should().Be(activityPath);
         node.NodeType.Should().Be("UserActivity");
 
         // 🚨 The write ran under the CALLER's identity, not system/empty. The handler builds
@@ -157,15 +176,4 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
 
         await ReadNode(user).Should().Match(n => n is { State: MeshNodeState.Active });
     }
-
-    private async Task<MeshNode?> PollForFirst(string query)
-        => await MeshQuery
-            .Query<MeshNode>(MeshQueryRequest.FromQuery(query))
-            .Scan(ImmutableList<MeshNode>.Empty, (acc, c) =>
-                c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset
-                    ? c.Items.ToImmutableList()
-                    : acc.AddRange(c.Items))
-            .Where(list => list.Count > 0)
-            .Select(list => list[0])
-            .Should().Within(TimeSpan.FromSeconds(15)).Emit();
 }

--- a/test/MeshWeaver.Query.Test/UserActivityTrackingTests.cs
+++ b/test/MeshWeaver.Query.Test/UserActivityTrackingTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Activity;
@@ -54,6 +56,16 @@ public class UserActivityTrackingTests(ITestOutputHelper output) : MonolithMeshT
         // always has it (onboarding ran first); reproduce that precondition here.
         await OnboardPartitionRoot(user);
 
+        var activityPath = $"{user}/_UserActivity/{nodePath.Replace("/", "_")}";
+
+        // 🚨 Same shape as ActivityTrackingHubTest (#993): the handler DETACHES its write, so wait
+        // on the write's own completion rather than polling the eventually-consistent query index,
+        // then read authoritatively. Subscribe before the Post — WhenSettled needs the ENTER.
+        var tracker = Mesh.GetActivityTrackingHub()
+            .ServiceProvider.GetRequiredService<ActivityWriteTracker>();
+        var settled = tracker.WhenSettled(activityPath).Replay(1);
+        using var settledSubscription = settled.Connect();
+
         Mesh.Post(new TrackActivityRequest(
             NodePath: nodePath,
             UserId: user,
@@ -61,10 +73,12 @@ public class UserActivityTrackingTests(ITestOutputHelper output) : MonolithMeshT
             NodeType: "Markdown",
             Namespace: "alice"));
 
-        var node = await PollForFirst($"namespace:{user}/_UserActivity nodeType:UserActivity");
+        await settled.Should().Within(TimeSpan.FromSeconds(15)).Emit(
+            "the detached activity write must run to completion");
 
-        node.Should().NotBeNull("a UserActivity node must be created at {user}/_UserActivity after a TrackActivityRequest");
-        node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
+        var node = await ReadNode(activityPath).Should().Match(n => n is not null,
+            "a UserActivity node must be created at {user}/_UserActivity after a TrackActivityRequest");
+        node!.Path.Should().Be(activityPath);
         node.NodeType.Should().Be("UserActivity");
     }
 

--- a/test/MeshWeaver.Query.Test/appsettings.json
+++ b/test/MeshWeaver.Query.Test/appsettings.json
@@ -4,17 +4,21 @@
       "Default": "Warning",
       "Microsoft": "Warning",
       "System": "Warning",
-      // 🔍 Diagnosability for the shard-1 CI flake (2026-07-30, red twice on main):
-      // ActivityTrackingHubTest.TrackActivity_InitiatedFromConnectionHub_LandsNode — PollForFirst
-      // "no value within 15s" ONLY on GH runners; not reproducible locally (full-project bulk,
-      // DOTNET_PROCESSOR_COUNT=2, and a 2-CPU Linux container all green). These channels put the
-      // landing path's stages — the TrackActivity handler (MeshWeaver.Graph.ActivityTracking),
-      // the save/persistence chain, the stream-cache write handle, and the query provider — into
-      // the xUnit-captured log (the FAIL block's "Output:" section in the shard log), so the next
-      // CI occurrence shows WHICH stage stalled instead of a bare timeout. ServiceSetup loads this
-      // file from the test output dir (reloadOnChange). Scoped to this one test project.
-      "MeshWeaver.Graph": "Debug",
-      "MeshWeaver.Hosting.Persistence": "Debug",
+      // 🔍 Diagnosability for the #993 landing path:
+      // ActivityTrackingHubTest.TrackActivity_InitiatedFromConnectionHub_LandsNode waits on the
+      // detached write's own completion (ActivityWriteTracker.WhenSettled). If that wait ever
+      // times out, these three channels name WHICH stage of the handler's pipeline was last:
+      //   ENTER → (existence probe) → "Read {user} → hit" (onboard gate) → CREATE/SKIP → Write.
+      // ServiceSetup loads this file from the test output dir (reloadOnChange).
+      //
+      // 🚨 Scoped to the exact categories, NOT their parents. The parent scopes
+      // ("MeshWeaver.Graph", "MeshWeaver.Hosting.Persistence") also switch on
+      // MeshWeaver.Graph.SyncedQuery and …Persistence.Query.StorageAdapterMeshQueryProvider,
+      // which emit per-node lines for all 363 tests in this project and grew the trx to 33 MB
+      // (1.8 MB compressed) — 83% of it from those two. The test no longer depends on the query
+      // index, so those channels buy nothing here.
+      "MeshWeaver.Graph.ActivityTracking": "Debug",
+      "MeshWeaver.Hosting.Persistence.InMemoryStorageAdapter": "Debug",
       "MeshWeaver.Hosting.MeshNodeStreamCache": "Debug"
     }
   }


### PR DESCRIPTION
Refs #993 — **deliberately not `Fixes`**: read "Honest scope" below before closing it.

## What the working instrument showed

With #997 (appsettings copy race) and #1005 (the `AsyncLocal`-in-`async InitializeAsync` sink) both
in, `ActivityTrackingHubTest` finally emits its trace. The `=== TEST START: … ===` marker is present
and no `[FAULT-BUDGET]` suppression appears, so absences below are real absences:

```
17.181  TrackActivity ENTER  userId=dave activityPath=dave/_UserActivity/dave_MyDoc via activity/_tracking
17.184  [StaticNodeQueryProvider] 'namespace:dave/_UserActivity nodeType:UserActivity' -> 0     ← the TEST's poll opens
17.187  [SyncedQuery] Opening upstream 'path:dave/_UserActivity/dave_MyDoc …'                   ← the handler's probe
17.188  [SyncedQuery] change=Initial count=0
17.189  [InMemoryAdapter] Read dave → hit                                                       ← onboard-first gate
17.189  [WalkLevel] parent=dave/_UserActivity nodes=[]                                          ← the TEST's poll Initial: EMPTY
17.189  TrackActivity CREATE: dave/_UserActivity/dave_MyDoc
17.192  [InMemoryAdapter] Write dave/_UserActivity/dave_MyDoc (count=3)                         ← the write
17.194  [SyncedQuery] change=Added count=1
17.195  [WalkLevel] parent=dave/_UserActivity nodes=[dave/_UserActivity/dave_MyDoc]             ← the poll's re-query
```

**The poll's Initial snapshot and the write are 3 ms apart.** That is the whole test: `Post` returns
while the handler's detached three-round-trip pipeline is still running, and the assertion is a live
`IMeshService.Query` that has to be *told* about the write afterwards. Which side of that 3 ms the
snapshot lands on decides whether the test's correctness rests on the initial read or on a change
notification propagating through the index. Neither is the thing under test.

So the test was asserting **"the query index caught up within 15 s"**, not **"the write finished"** —
against a write that is detached by design (`TrackLogin` sits on the cold-login hot path and must not
stall behind a node write). `CqrsAndContentAccess.md` names that shape outright: polling a query for
a node you just caused to be written is the wrong primitive, precisely because the index lags.

## The fix — wait on the write's own completion

`HandleTrackActivity` already registers every detached write with `ActivityWriteTracker` (that is
how hub disposal accounts for them). That register **is** the real completion signal; it just wasn't
observable per path. This PR exposes it and makes both activity-landing tests wait on it, then read
the node **authoritatively**:

```csharp
var settled = tracker.WhenSettled(activityPath).Replay(1);
using var settledSubscription = settled.Connect();   // subscribe BEFORE the Post
connHub.Post(new TrackActivityRequest(...));
await settled.Should().Within(TimeSpan.FromSeconds(15)).Emit();
var node = await ReadNode(activityPath).Should().Match(n => n is not null);
```

`WhenSettled(path)` completes on the ENTER→LEAVE transition of that path's in-flight count.
It deliberately does **not** complete on a path that has never been in flight — that is the whole
difference from `Drain()`, which "completes IMMEDIATELY when nothing is in flight" and, called right
after a `Post`, would beat the handler's `Begin(...)` and turn a timing flake into a deterministic
**false pass**. Overlapping writes to the same path are all awaited (the counter only reaches zero
when the last ends), so the documented create-vs-update race stays covered.

No timeout was widened, no sleep or retry added, no assertion weakened — the assertions got
*stronger* (authoritative point read instead of an index snapshot). The 15 s bound now sits on a
signal that genuinely terminates, and a timeout there is attributable: it means the handler's
pipeline stalled, and the `MeshWeaver.Graph.ActivityTracking` trace names the last stage it reached.

## Honest scope

**This is a root cause of the failure mode reported, not of a framework-side index defect.** I did
not find one, and the trace does not show one. What the working instrument rules out, on top of what
was already ruled out on the issue:

- The awaited condition is satisfiable and the change feed does re-emit (`change=Added`, a second
  `WalkLevel`) — no impossible predicate.
- The whole landing path runs in ~14 ms against the 15 s budget; the machine on the CI occurrence was
  responsive too (class init → dispose was exactly the poll budget, nothing else was slow). This was
  never "slow under load".
- `namespace:`-scoped change relevance is fine: the parser derives `Path=dave/_UserActivity` and a
  child scope, so `PathMatcher.ShouldNotify` matches the write. (Worth stating — `ShouldNotify` *is*
  blind to namespace-only queries whose base path is empty, but that is not this query.)
- `MeshQuery`'s provider merge always forwards live `Added`/`Updated` frames
  (`TryFilterDuplicateLiveChange`), including before the merged `Initial`, so the merge layer does
  not swallow the arrival either.

The remaining unattributed possibility is a lost/late change notification somewhere between
`InMemoryStorageAdapter._changes` and the poll's re-query. That is now moot for this test — it no
longer depends on that path to decide correctness — but it is why this PR does not claim to have
found a change-feed bug.

## Also in here (the deferred cost item from #993)

`test/MeshWeaver.Query.Test/appsettings.json` raised whole parent scopes
(`MeshWeaver.Graph`, `MeshWeaver.Hosting.Persistence`) to `Debug`, which also switched on
`MeshWeaver.Graph.SyncedQuery` and `…Persistence.Query.StorageAdapterMeshQueryProvider` for all 363
tests — 83% of a **33 MB** trx (1.8 MB compressed). Narrowing was explicitly deferred until #993
closed. The channels are now scoped to the exact categories the landing path needs
(`MeshWeaver.Graph.ActivityTracking`, `MeshWeaver.Hosting.Persistence.InMemoryStorageAdapter`), which
still prints `ENTER → gate read → CREATE/SKIP → Write → DONE`.

Measured on a full local run of the project: **33 MB → 2.8 MB**, 363/363 green.

## Changes

- `src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs` — the notification subject now carries
  the whole in-flight map instead of just its total (one ordered channel for both consumers);
  new `WhenSettled(path)`.
- `test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs` — settle-then-authoritative-read.
- `test/MeshWeaver.Query.Test/UserActivityTrackingTests.cs` — the identical twin poll, same migration.
- `test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs` — five tests pinning `WhenSettled`,
  including the "must NOT behave like `Drain` on an idle tracker" false-pass guard.
- `test/MeshWeaver.Query.Test/appsettings.json` — narrowed channels.

No What's New entry: no user-visible behaviour changes (test determinism + a framework signal the
tests wait on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
