### PR TITLE
The release note that documents a green deploy is what turned main red

### DIFF
--- a/.claude/skills/pullrequest/SKILL.md
+++ b/.claude/skills/pullrequest/SKILL.md
@@ -185,8 +185,13 @@ newest-first; each entry is a normal doc node you can open.
 - **One file per PR** (`<YYYY-MM-DD>-<slug>.md`) — the date prefix drives newest-first ordering, and
   a distinct filename per PR means two concurrent PRs never conflict on the feed (the reason we do
   NOT prepend to a single rolling file).
-- **Front-matter**: `Name` (title shown in the list), `Category: What's New`, `Description`
-  (one-liner), `Icon` (a Fluent icon name, e.g. `Sparkle`). Body is plain-language user-facing prose.
+- **Front-matter**: `Name` (title shown in the list), `Category` — **`Feature` or `Fix`, nothing else**
+  (`feat/ perf/ chore/ docs/` → `Feature`, rendered in full; `fix/` → `Fix`, bundled into the day's
+  one-line summary) — `Description` (one-liner), `Icon` (a Fluent icon name, e.g. `Sparkle`), and
+  `Order: -YYYYMMDD` (a **negative** ship date, matching the filename's date) so the doc tree sorts
+  newest-first instead of alphabetically by title. Body is plain-language user-facing prose.
+  `WhatsNewEntryIntegrityTest` enforces all five — a wrong `Category` or a missing `Order` turns
+  **main** red, not just your PR, because the entry only reaches CI once it has merged.
 - **When to skip**: pure-internal PRs (refactors, tests, CI, dependency bumps) with no user-visible
   change don't need an entry — note the skip in the PR body so a reviewer knows it was deliberate.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-check-a-deployment-is-current.md
@@ -1,8 +1,9 @@
 ---
 Name: Checking that a deployment is up to date, from inside or outside
-Category: What's New
+Category: Feature
 Description: Every user can now see on About whether their build is current, and a new anonymous /api/version endpoint answers the same question from outside the portal.
 Icon: ArrowSync
+Order: -20260809
 ---
 
 # Checking that a deployment is up to date, from inside or outside


### PR DESCRIPTION
Main is red at `fd277b36f` on `WhatsNewEntryIntegrityTest.EveryEntry_CarriesTheFrontmatterTheFeedRendersFrom` (shard 4). This is the fix.

## What happened

`2026-08-09-check-a-deployment-is-current.md`, the release note for #956, shipped with `Category: What's New` and no `Order`. The integrity test requires `Category` to be **`Feature`** or **`Fix`**, and `Order` to be the **negative ship date** (`-20260809`) — without which the doc tree sorts the entry alphabetically by title instead of newest-first.

**The timing is the whole point: a What's New entry does not meet this test until it has already merged.** The PR that adds one is green, and `main` goes red on the merge commit. So this failure mode always lands on main, never on the PR that caused it.

The entry now matches its five siblings from today.

## The generator, not just the instance

The `pullrequest` skill contradicted itself. Its **procedure block** (step 0.5) had been updated for the current contract — `Category: <Feature|Fix>`, `Order: -${DATE//-/}`. Its **prose section** further down still said:

> **Front-matter**: `Name`, `Category: What's New`, `Description`, `Icon`

No `Order` at all, and a `Category` value the test rejects outright. That is the half a reader quotes when hand-writing an entry, which is exactly how this one was written.

Both halves now state the same contract, and the prose names the consequence — a wrong `Category` or a missing `Order` reds **main**, not your PR. Fixing only the entry would have left the next author with the same instructions that produced it.

## Verification

Frontmatter now reads `Category: Feature` / `Order: -20260809`, matching `2026-08-09-write-conflicts-merge-not-vanish.md` and the other four entries from today that pass. Two files, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)