### PR TITLE
A failed delivery on the routing path reached no one

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
@@ -54,6 +54,26 @@ Two edges were missing: the deferred read/write **dropped** the user identity, a
 
 Opening a node whose NodeType won't compile subscribes to its layout area. The grain churned (compile fault → `DeactivateOnIdle`); the in-flight `SubscribeRequest` hit *"invalid activation. Rejecting now."* and the router **dead-ended it onto a subscriber-less memory stream** → 60 s timeout → *"Subscribing to {path}…"* forever. The missing edge was the router silently dropping a transient rejection. The fix retries the delivery so the grain **reactivates** (a fresh instance answers), and on a terminal failure **NACKs the sender** — never the silent dead-end. Once the grain is reached, the compilation-error overlay renders the error into the **Overview area** (the GUI sink). See [Node Type Compilation](/Doc/Architecture/NodeTypeCompilation) and [Debugging Message Flow](/Doc/Architecture/DebuggingMessageFlow).
 
+### A delivery that ROUTING failed while passing through (router → requester)
+
+A hub that is not the delivery's target only *forwards* it. When forwarding failed, `MessageService`
+returned the failed delivery to its own turn loop and nothing else happened — the state was never
+inspected on that branch, so **no `DeliveryFailure` was posted and the requester's `hub.Observe(...)`
+never resolved**. The tell is a request that was dequeued and handled, every queue empty, nothing
+wedged on an action block, and a caller waiting anyway.
+
+The routing sites that hit it are all disposal races, and none of them NACKs on its own: a hosted hub
+that quiesces *after* its parent reached `DisposeHostedHubs` still posts to that parent, and the
+reply can never come. The missing edge was the router keeping the failure to itself.
+
+The invariant restored: **routing failures report like every other failure.** The failing site records
+two things ON the delivery — the `ErrorType` verdict (decided where the condition is known, never
+re-derived downstream from message text) and whether it already answered the sender — and
+`MessageService` NACKs every unanswered one. Disposal races report as the transient
+`ErrorType.ShuttingDown`, so a `SynchronizationStream` rides them out instead of tearing down; a
+routing loop reports as `ErrorType.RoutingLoop`. A site that posts its own NACK (the routing
+services' `NotFound`, on a hot path) marks the delivery answered so the sender never gets two.
+
 ### Long-running operations (activity → activity log)
 
 An import / compile / mirror runs as an activity. A fault must not strand the activity "Running" forever — it writes `Status = Error` with the message onto the activity node, which the activity log and any progress reader render. Persistence at the bottom of the stack never re-gates and never fail-closes a write that was already approved; it forwards. See [Activity Control Plane](/Doc/Architecture/ActivityControlPlane) and [Activity Operations](/Doc/Architecture/ActivityOperations).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-a-request-that-cannot-be-routed-now-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-a-request-that-cannot-be-routed-now-says-so.md
@@ -1,0 +1,19 @@
+---
+Name: A request that cannot be routed now says so
+Category: Fix
+Description: Requests that failed while being routed used to spin forever instead of reporting an error.
+Icon: Sparkle
+Order: -20260809
+---
+
+# A request that cannot be routed now says so
+
+When a request could not be routed onward — because the hub it had to travel through was in the
+middle of shutting down, or because it was caught bouncing between hubs with nowhere to land — the
+failure was thrown away instead of being sent back. Nothing was broken and nothing was busy; the
+caller simply waited for an answer that no longer existed. In the browser that looked like a page or
+a panel that spins indefinitely.
+
+Those failures are now reported. The caller gets a real error naming what went wrong, and where the
+cause is a hub restarting, it is reported as temporary so anything that can recover on its own —
+a live view, an open document — reconnects instead of giving up.

--- a/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
@@ -82,17 +82,25 @@ internal class MonolithRoutingService(
         logger.LogWarning("No route found for {MessageType} → {Address}. Node: {NodePath}, NodeType: {NodeType}, Sender: {Sender}, ShuttingDown: {ShuttingDown}",
             delivery.Message.GetType().Name, address, node?.Path, node?.NodeType, delivery.Sender, isShuttingDown);
 
-        if (delivery.Message is not DeliveryFailure && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+        var errorType = isShuttingDown ? ErrorType.Failed : ErrorType.NotFound;
+        var senderNacked = delivery.Message is not DeliveryFailure
+            && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs;
+        if (senderNacked)
         {
             Mesh.Post(
                 new DeliveryFailure(delivery)
                 {
-                    ErrorType = isShuttingDown ? ErrorType.Failed : ErrorType.NotFound,
+                    ErrorType = errorType,
                     Message = errorMessage
                 }, o => o.ResponseFor(delivery)
             );
         }
-        return delivery.Failed(errorMessage);
+        // Declare whether the sender was answered — MessageService now NACKs any unanswered Failed
+        // delivery it finishes, and this path is hot enough that a duplicate would multiply every
+        // NotFound in the mesh. See RoutingServiceBase.PostNotFound for the full rationale.
+        return senderNacked
+            ? delivery.FailedAndNacked(errorMessage)
+            : delivery.Failed(errorMessage, errorType);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -335,9 +335,10 @@ namespace MeshWeaver.Hosting
                 "RouteMessage: NotFound for {MessageType} → {Address}. {FailureMessage}",
                 delivery.Message.GetType().Name, originalAddress, failureMessage);
 
-            if (delivery.Message is not DeliveryFailure
+            var senderNacked = delivery.Message is not DeliveryFailure
                 && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
-                && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+                && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs;
+            if (senderNacked)
             {
                 // 🚨 Routing infrastructure's OWN NotFound NACK. As in NackRouteFailure:
                 // ResponseFor carries the request's user when known; else System, never null.
@@ -350,7 +351,15 @@ namespace MeshWeaver.Hosting
                             Message = failureMessage
                         }, o => o.ResponseFor(delivery));
             }
-            return delivery.Failed(failureMessage);
+            // 🚨 Say WHETHER the sender was answered. This routing path is hot — every message to a
+            // missing / undeployed node takes it — and MessageService now NACKs any unanswered
+            // Failed delivery it finishes. Marking the answered case keeps that from doubling every
+            // NotFound in the mesh; the unanswered case (DeliveryFailure / [CanBeIgnored] / mesh
+            // shutting down) is classified so it can still be reported, and ReportFailure's own
+            // guards suppress exactly the same three shapes.
+            return senderNacked
+                ? delivery.FailedAndNacked(failureMessage)
+                : delivery.Failed(failureMessage, ErrorType.NotFound);
         }
 
         /// <summary>

--- a/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
@@ -95,6 +95,72 @@ public interface IMessageDelivery
     /// <param name="message">The failure message.</param>
     /// <returns>The failed delivery.</returns>
     IMessageDelivery Failed(string message) => ChangeState(MessageDeliveryState.Failed).WithProperty(nameof(Error), message);
+
+    /// <summary>
+    /// Property key under which <see cref="Failed(string, ErrorType)"/> records the classification
+    /// the FAILING SITE decided on.
+    /// </summary>
+    public const string FailureErrorTypeProperty = "FailureErrorType";
+
+    /// <summary>
+    /// Property key under which <see cref="FailedAndNacked"/> records that the failing site has
+    /// already answered the sender itself.
+    /// </summary>
+    public const string SenderNackedProperty = "SenderNacked";
+
+    /// <summary>
+    /// Transitions this delivery to <see cref="MessageDeliveryState.Failed"/>, recording BOTH the
+    /// failure message and the <see cref="ErrorType"/> the failing site decided on.
+    ///
+    /// <para>The classification is decided WHERE THE CONDITION IS KNOWN and carried on the delivery,
+    /// never reconstructed downstream by pattern-matching the message text — that drifts the moment
+    /// someone rewords a string. It matters concretely: a disposal race MUST reach the sender as the
+    /// transient <see cref="ErrorType.ShuttingDown"/> so consumers with their own recovery machinery
+    /// (chiefly <c>SynchronizationStream</c>'s resubscribe latch) ride it out instead of tearing
+    /// down.</para>
+    ///
+    /// <para>Using this overload also DECLARES that the failing site did NOT answer the sender —
+    /// whoever finishes the delivery owes it a <see cref="DeliveryFailure"/>. A site that posts its
+    /// own NACK must use <see cref="FailedAndNacked"/> instead, or the sender gets two.</para>
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    /// <param name="errorType">The classification for the resulting <see cref="DeliveryFailure"/>.</param>
+    /// <returns>The failed delivery, carrying its classification.</returns>
+    IMessageDelivery Failed(string message, ErrorType errorType) =>
+        Failed(message).WithProperty(FailureErrorTypeProperty, errorType);
+
+    /// <summary>
+    /// Transitions this delivery to <see cref="MessageDeliveryState.Failed"/> and records that the
+    /// failing site has ALREADY posted its own <see cref="DeliveryFailure"/> to the sender, so
+    /// downstream reporting must not NACK it a second time.
+    ///
+    /// <para>Used by the routing services, whose "no node at this address" path posts a
+    /// <see cref="ErrorType.NotFound"/> NACK before failing the delivery. That path is hot — every
+    /// message to a missing/undeployed node takes it — so a duplicate NACK there is a traffic
+    /// multiplier, not a harmless extra log line.</para>
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    /// <returns>The failed delivery, marked as already answered.</returns>
+    IMessageDelivery FailedAndNacked(string message) =>
+        Failed(message).WithProperty(SenderNackedProperty, true);
+
+    /// <summary>
+    /// True when the site that failed this delivery already answered the sender with its own
+    /// <see cref="DeliveryFailure"/> (see <see cref="FailedAndNacked"/>).
+    /// </summary>
+    bool SenderWasNacked => Properties.ContainsKey(SenderNackedProperty);
+
+    /// <summary>
+    /// The classification recorded by <see cref="Failed(string, ErrorType)"/>, or
+    /// <paramref name="fallback"/> when the failing site recorded none.
+    /// </summary>
+    /// <param name="fallback">The verdict to use when the failing site classified nothing.</param>
+    /// <returns>The recorded classification, or <paramref name="fallback"/>.</returns>
+    ErrorType GetFailureErrorType(ErrorType fallback) =>
+        Properties.TryGetValue(FailureErrorTypeProperty, out var value) && value is ErrorType errorType
+            ? errorType
+            : fallback;
+
     /// <summary>
     /// Returns a copy of this delivery with a single property set.
     /// </summary>

--- a/src/MeshWeaver.Messaging.Hub/HierarchicalRouting.cs
+++ b/src/MeshWeaver.Messaging.Hub/HierarchicalRouting.cs
@@ -197,9 +197,14 @@ internal class HierarchicalRouting
         {
             logger.LogDebug("Cannot route to parent hub {ParentAddress} - parent is also disposing. Message: {MessageType}",
                 parentHub.Address, delivery.Message.GetType().Name);
+            // 🚨 The wording carries the "is shutting down" marker on purpose. Three classifiers —
+            // MeshNodeStreamCache.IsTransientOwnerFailure, AreaErrorClassifier.IsTransientHubFailure
+            // and SynchronizationStream's transient check — still recognise a transient hub reject by
+            // that substring, so a NACK phrased any other way would be filed as a PERMANENT owner
+            // failure and cached as one.
             return delivery.Failed(
-                $"Cannot route {delivery.Message.GetType().Name} to {delivery.Target} from {hub.Address} — "
-                + $"parent hub {parentHub.Address} is disposing (RunLevel={parentHub.RunLevel}). "
+                $"Hub {hub.Address} cannot route {delivery.Message.GetType().Name} to {delivery.Target} — "
+                + $"its parent hub {parentHub.Address} is shutting down (RunLevel={parentHub.RunLevel}). "
                 + "The address may reactivate (recycle / restart); retry to get the authoritative answer.",
                 ErrorType.ShuttingDown);
         }

--- a/src/MeshWeaver.Messaging.Hub/HierarchicalRouting.cs
+++ b/src/MeshWeaver.Messaging.Hub/HierarchicalRouting.cs
@@ -131,7 +131,13 @@ internal class HierarchicalRouting
                         }, o => o.ResponseFor(delivery)
                     );
                 }
-                return isDisposing ? delivery.Failed("Hub disposing") : delivery.NotFound();
+                // While disposing no NACK is posted above, so the delivery leaves here classified
+                // and UNANSWERED — MessageService owes the sender a DeliveryFailure (a bare
+                // Failed(...) used to be dropped on the not-on-target path and the caller waited
+                // forever). TRANSIENT (ShuttingDown): the address may reactivate on the next probe.
+                return isDisposing
+                    ? delivery.Failed(errorMessage, ErrorType.ShuttingDown)
+                    : delivery.NotFound();
             }
         }
         else
@@ -171,15 +177,31 @@ internal class HierarchicalRouting
                     }, o => o.ResponseFor(delivery)
                 );
             }
-            return isDisposing ? delivery.Failed("Hub disposing") : delivery.NotFound();
+            // Same contract as the hosted-route branch above: the disposing arm posted no NACK, so
+            // it leaves CLASSIFIED and UNANSWERED for MessageService to report.
+            return isDisposing
+                ? delivery.Failed(errorMessage, ErrorType.ShuttingDown)
+                : delivery.NotFound();
         }
 
-        // Check if parent hub is also disposing before routing up
+        // Check if parent hub is also disposing before routing up.
+        //
+        // 🚨 Nothing has answered the sender at this point and nothing downstream will unless the
+        // failure is CLASSIFIED: a bare Failed(...) here is not on-target, so MessageService's
+        // routing tail used to return it unreported and the requester's hub.Observe(...) waited
+        // indefinitely. This is the teardown shape from #981 — a hosted hub quiescing AFTER its
+        // parent reached DisposeHostedHubs still posts to that parent, and the reply can never come.
+        // TRANSIENT (ShuttingDown), never terminal: the parent may reactivate, and long-lived
+        // consumers (SynchronizationStream's resubscribe latch) must ride it out rather than die.
         if (parentHub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
         {
             logger.LogDebug("Cannot route to parent hub {ParentAddress} - parent is also disposing. Message: {MessageType}",
                 parentHub.Address, delivery.Message.GetType().Name);
-            return delivery.Failed("Parent hub disposing");
+            return delivery.Failed(
+                $"Cannot route {delivery.Message.GetType().Name} to {delivery.Target} from {hub.Address} — "
+                + $"parent hub {parentHub.Address} is disposing (RunLevel={parentHub.RunLevel}). "
+                + "The address may reactivate (recycle / restart); retry to get the authoritative answer.",
+                ErrorType.ShuttingDown);
         }
 
         // Per-routed-message; gate to skip GetType().Name + boxing.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -689,7 +689,13 @@ public class MessageService : IMessageService
             {
                 logger.LogWarning("Routing loop detected for {MessageType} (ID: {MessageId}) in {Address} targeting {Target} - failing message",
                     name, delivery.Id, Address, delivery.Target);
-                return Observable.Return(delivery.Failed($"Routing loop: no hub found for target {delivery.Target}"));
+                // 🚨 REPORT it. A routing loop is terminal — the message will never reach a target —
+                // so the requester must get a DeliveryFailure. Returning the Failed delivery alone
+                // dropped it (the not-on-target path never inspected the state) and the caller's
+                // hub.Observe(...) waited indefinitely.
+                return Observable.Return(ReportRoutingFailure(
+                    delivery.Failed($"Routing loop: no hub found for target {delivery.Target}",
+                        ErrorType.RoutingLoop)));
             }
             // On-target re-visit is legitimate (e.g. deferred messages)
         }
@@ -840,7 +846,40 @@ public class MessageService : IMessageService
             return deliveryPipeline.Invoke(delivery, cancellationToken);
         }
 
-        return Observable.Return(delivery);
+        // 🚨 NOT on target — and the routing above may have FAILED the delivery. This used to
+        // `return Observable.Return(delivery)` unconditionally, so a Failed state here was dropped
+        // in total silence: no DeliveryFailure was posted and the requester's hub.Observe(...) never
+        // resolved. That is the "wedges to zero" violation behind #981 — a request dequeued and
+        // handled, every queue empty, nothing wedged, and a caller waiting for a reply that no one
+        // owes any more. The on-target branch has always reported its Failed deliveries (above);
+        // this makes the routing branch keep the same promise.
+        return Observable.Return(ReportRoutingFailure(delivery));
+    }
+
+    /// <summary>
+    /// Reports a delivery that ROUTING failed, so no caller is left waiting on a reply that will
+    /// never come. Non-failed deliveries pass through untouched.
+    ///
+    /// <para>Two things the failing site tells us, both carried on the delivery rather than
+    /// re-derived from its message text:</para>
+    /// <list type="bullet">
+    ///   <item><see cref="IMessageDelivery.SenderWasNacked"/> — the site already answered the
+    ///     sender itself (the routing services' NotFound NACK). Reporting again would DOUBLE every
+    ///     NotFound in the mesh, which is a traffic multiplier on a known storm-prone path.</item>
+    ///   <item><see cref="IMessageDelivery.GetFailureErrorType"/> — the verdict. Every current
+    ///     unanswered site is a disposal race and says <see cref="ErrorType.ShuttingDown"/>, which
+    ///     consumers with their own recovery machinery (<c>SynchronizationStream</c>'s resubscribe
+    ///     latch) ride out instead of tearing down. An unclassified site falls back to
+    ///     <see cref="ErrorType.Unavailable"/> — "no verdict was reached, retry" — which is the
+    ///     honest answer when we do not know, and never a denial or an absence.</item>
+    /// </list>
+    /// </summary>
+    private IMessageDelivery ReportRoutingFailure(IMessageDelivery delivery)
+    {
+        if (delivery.State != MessageDeliveryState.Failed || delivery.SenderWasNacked)
+            return delivery;
+
+        return ReportFailure(delivery, delivery.GetFailureErrorType(ErrorType.Unavailable));
     }
 
     private static string GetMessageType(IMessageDelivery delivery)
@@ -932,7 +971,9 @@ public class MessageService : IMessageService
             return deliveryPipeline.Invoke(delivery, cancellationToken);
         }
 
-        return Observable.Return(delivery);
+        // Same contract as NotifyAsync's routing tail — a gate-deferred message that fails routing
+        // once the gate opens must not vanish either.
+        return Observable.Return(ReportRoutingFailure(delivery));
     }
 
     private volatile CancellationTokenSource cancellationTokenSource = new();

--- a/src/MeshWeaver.Messaging.Hub/RouteConfiguration.cs
+++ b/src/MeshWeaver.Messaging.Hub/RouteConfiguration.cs
@@ -43,10 +43,17 @@ public record RouteConfiguration(IMessageHub Hub)
     public RouteConfiguration RouteAddressToHub(string addressType, Func<Address, IMessageHub?> hubFactory)
         => RouteAddress(addressType, (routedAddress, d) =>
         {
-            // Check if the parent hub is disposing before attempting to create/route to hosted hubs
+            // Check if the parent hub is disposing before attempting to create/route to hosted hubs.
+            // CLASSIFIED and unanswered — MessageService's routing tail owes the sender the NACK
+            // (an unclassified Failed on the not-on-target path used to vanish; see #981), and it
+            // must be TRANSIENT because the hub may reactivate.
             if (Hub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
             {
-                return d.Failed("Parent hub disposing");
+                return d.Failed(
+                    $"Cannot route {d.Message.GetType().Name} to {d.Target} — routing hub "
+                    + $"{Hub.Address} is disposing (RunLevel={Hub.RunLevel}). Retry to get the "
+                    + "authoritative answer.",
+                    ErrorType.ShuttingDown);
             }
 
             var hub = hubFactory.Invoke(routedAddress);
@@ -117,9 +124,14 @@ public record RouteConfiguration(IMessageHub Hub)
                 // Match when Target.Host.Type equals addressType - route to the Host hub first
                 if (delivery.Target?.Host?.Type == addressType)
                 {
+                    // Classified + unanswered, as in RouteAddressToHub above.
                     if (Hub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
                     {
-                        return Observable.Return(delivery.Failed("Parent hub disposing"));
+                        return Observable.Return(delivery.Failed(
+                            $"Cannot route {delivery.Message.GetType().Name} to {delivery.Target} — "
+                            + $"routing hub {Hub.Address} is disposing (RunLevel={Hub.RunLevel}). "
+                            + "Retry to get the authoritative answer.",
+                            ErrorType.ShuttingDown));
                     }
 
                     var hub = GetOrCreateHub(delivery.Target.Host);

--- a/test/MeshWeaver.Messaging.Hub.Test/RoutingFailureReportedTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RoutingFailureReportedTest.cs
@@ -1,0 +1,184 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Deterministic repro for the DROPPED ROUTING FAILURE: a delivery that ROUTING failed while it was
+/// NOT on this hub's target used to be returned unreported, so no <see cref="DeliveryFailure"/> was
+/// ever posted and the requester's <c>hub.Observe(...)</c> waited indefinitely.
+///
+/// <para><b>Where the hole was.</b> <c>MessageService.NotifyAsync</c> inspected
+/// <see cref="MessageDeliveryState.Failed"/> only on the pre-routing, ON-TARGET path. After
+/// <c>hierarchicalRouting.RouteMessageAsync</c> returned, the not-on-target branch fell through to a
+/// bare <c>Observable.Return(delivery)</c> with no state check at all — and routing has five sites
+/// that fail a delivery there without posting a NACK of their own (the two "no route while
+/// disposing" arms and the parent-disposing check in <c>HierarchicalRouting</c>, plus both RunLevel
+/// checks in <c>RouteConfiguration</c>). Every one of them stranded its caller.</para>
+///
+/// <para><b>Why it matters beyond a test.</b> This is the teardown shape captured in #981: a hosted
+/// hub that quiesces AFTER its parent has reached <c>DisposeHostedHubs</c> still posts to that
+/// parent, routing fails the delivery with "parent hub disposing", and the reply can never come.
+/// The pending callback then outlives the quiescing budget — which is how the defect was ever
+/// noticed, not what it is. It violates the framework's flat invariant: never a silent hang, every
+/// error reaches a graceful sink.</para>
+///
+/// <para><b>What is driven here.</b> A route handler on the client hub — the same public seam
+/// (<c>RouteConfiguration.WithHandler</c>) the SignalR, gRPC, Data and mesh routers register on —
+/// fails a not-on-target delivery exactly the way those five framework sites do. No disposal is
+/// involved, so there is nothing to time and no race to lose.</para>
+/// </summary>
+public class RoutingFailureReportedTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>Routing fails this one as a DISPOSAL RACE — the sender is owed a transient NACK.</summary>
+    private record StrandedRequest : IRequest<Ack>;
+
+    /// <summary>Routing fails this one as a ROUTING LOOP — a different, terminal verdict.</summary>
+    private record LoopedRequest : IRequest<Ack>;
+
+    /// <summary>Routing fails this one AFTER answering the sender itself — must not be NACKed twice.</summary>
+    private record AnsweredRequest : IRequest<Ack>;
+
+    /// <summary>Handled by the client itself; used as a FIFO barrier on the client's turn loop.</summary>
+    private record BarrierRequest : IRequest<Ack>;
+
+    private record Ack;
+
+    private static readonly Address ServerAddress = new("host", "1");
+
+    private int deliveryFailuresSeen;
+
+    /// <summary>
+    /// The host WOULD answer every one of these requests. So a passing NACK assertion can only come
+    /// from the routing failure — never from the request quietly getting through.
+    /// </summary>
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithTypes(typeof(StrandedRequest), typeof(LoopedRequest), typeof(AnsweredRequest), typeof(Ack))
+            .WithHandler<StrandedRequest>(AnswerWithAck)
+            .WithHandler<LoopedRequest>(AnswerWithAck)
+            .WithHandler<AnsweredRequest>(AnswerWithAck);
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .WithTypes(typeof(StrandedRequest), typeof(LoopedRequest), typeof(AnsweredRequest),
+                typeof(BarrierRequest), typeof(Ack))
+            .WithHandler<BarrierRequest>(AnswerWithAck)
+            .WithRoutes(routes => routes.WithHandler(FailInRouting));
+
+    private static IMessageDelivery AnswerWithAck(IMessageHub hub, IMessageDelivery delivery)
+    {
+        hub.Post(new Ack(), o => o.ResponseFor(delivery));
+        return delivery.Processed();
+    }
+
+    /// <summary>
+    /// Stands in for the framework's own routing-stage failures. Runs inside
+    /// <c>HierarchicalRouting</c>'s handler fold, so what it returns is exactly what those five
+    /// sites return — and it also SEES every inbound delivery (route handlers run before any
+    /// message handler), which is how the NACKs are counted without perturbing the response
+    /// machinery.
+    /// </summary>
+    private IObservable<IMessageDelivery> FailInRouting(IMessageDelivery delivery)
+    {
+        if (delivery.Message is DeliveryFailure)
+            Interlocked.Increment(ref deliveryFailuresSeen);
+
+        return Observable.Return(delivery.Message switch
+        {
+            // Classified + unanswered: MessageService owes the sender the NACK.
+            StrandedRequest => delivery.Failed("routing gave up: the target's host is disposing",
+                ErrorType.ShuttingDown),
+            LoopedRequest => delivery.Failed("routing gave up: no hub found for target",
+                ErrorType.RoutingLoop),
+            // Already answered: the site posted its own NACK, so MessageService must stay quiet.
+            AnsweredRequest => AnswerAndFail(delivery),
+            _ => delivery
+        });
+    }
+
+    private IMessageDelivery AnswerAndFail(IMessageDelivery delivery)
+    {
+        Hub.Post(
+            new DeliveryFailure(delivery) { ErrorType = ErrorType.NotFound, Message = "no node at that address" },
+            o => o.ResponseFor(delivery));
+        return delivery.FailedAndNacked("no node at that address");
+    }
+
+    private IMessageHub Hub => hub ??= GetClient();
+    private IMessageHub? hub;
+
+    /// <summary>
+    /// The core pin. WITHOUT the fix this task never completes — the delivery is failed, dropped,
+    /// and nothing ever resolves the callback — so the test dies on its timeout with no explanation,
+    /// which is precisely the production symptom.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task RoutingFailure_OffTarget_ReachesTheSender()
+    {
+        var failure = await Nack(new StrandedRequest());
+
+        failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown,
+            "a disposal race must reach the sender as TRANSIENT — the address may reactivate, and "
+            + "consumers with their own recovery machinery (SynchronizationStream's resubscribe "
+            + "latch) ride ShuttingDown out instead of tearing down");
+        failure.Failure.Message.Should().Contain("routing gave up",
+            "the NACK must carry the failing site's own reason — a generic message sends the next "
+            + "investigator hunting the wrong layer");
+    }
+
+    /// <summary>
+    /// The verdict is the one the FAILING SITE decided on, carried on the delivery — not a constant
+    /// baked into the reporting code, and not re-derived downstream by pattern-matching the failure
+    /// text (which drifts the moment someone rewords a string).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TheFailingSitesVerdict_IsTheOneReported()
+    {
+        var failure = await Nack(new LoopedRequest());
+
+        failure.Failure!.ErrorType.Should().Be(ErrorType.RoutingLoop,
+            "the classification travels with the delivery from the site that knows the condition");
+    }
+
+    /// <summary>
+    /// The anti-storm half. The routing services answer their own "no node at this address" before
+    /// failing the delivery, and that path is HOT — every message to a missing or undeployed node
+    /// takes it. Reporting it again would double every NotFound in the mesh, i.e. trade a hang for
+    /// a traffic multiplier on a known storm-prone path.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task AnAlreadyAnsweredRoutingFailure_IsNotNackedTwice()
+    {
+        var failure = await Nack(new AnsweredRequest());
+        failure.Failure!.ErrorType.Should().Be(ErrorType.NotFound);
+
+        // FIFO barrier, not a sleep. Both NACKs would be posted from the SAME routing turn, so a
+        // second one is already queued behind the first by the time its OnError fires. A round-trip
+        // the client answers ITSELF therefore cannot complete until that queued turn has drained.
+        await Hub.Observe<Ack>(new BarrierRequest(), o => o.WithTarget(Hub.Address))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        Volatile.Read(ref deliveryFailuresSeen).Should().Be(1,
+            "the failing site already answered the sender; a second NACK on this path multiplies "
+            + "every NotFound in the mesh");
+    }
+
+    private async Task<DeliveryFailureException> Nack(IRequest<Ack> request)
+    {
+        var response = Hub
+            .Observe<Ack>(request, o => o.WithTarget(ServerAddress))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => response);
+        Output.WriteLine($"{request.GetType().Name}: errorType={failure.Failure?.ErrorType} message={failure.Failure?.Message}");
+        failure.Failure.Should().NotBeNull();
+        return failure;
+    }
+}


### PR DESCRIPTION
## A failed delivery on the routing path reached no one

`MessageService.NotifyAsync` inspected a `Failed` delivery **only on the pre-routing, on-target
path**. After `hierarchicalRouting.RouteMessageAsync` returned, the **not-on-target** branch fell
through to a bare `return Observable.Return(delivery)` with no state check at all — so any `Failed`
state routing produced there was dropped in silence: no `DeliveryFailure` was posted and the
requester's `hub.Observe(...)` never resolved.

That is the framework's flat invariant broken (`ErrorPropagationAndWedges`: *never a silent hang;
every error reaches a graceful sink*), and it produces exactly #981's signature — a request dequeued
and handled, every queue empty, nothing wedged on an action block, and a caller waiting anyway.

### Confirmed, not read off a hypothesis

Five routing sites return `Failed` on that branch, **and none of them posts a NACK of its own**
(their `NotFound()` siblings do):

| site | condition |
|---|---|
| `HierarchicalRouting:134` | no hosted route **while this hub is disposing** |
| `HierarchicalRouting:174` | no route at the root **while this hub is disposing** |
| `HierarchicalRouting:182` | **parent** hub at `DisposeHostedHubs`, this hub live |
| `RouteConfiguration:49` | routing hub at `DisposeHostedHubs` |
| `RouteConfiguration:122` | routing hub at `DisposeHostedHubs` |

`ProcessDeferredMessage` had the identical tail, and the routing-loop early return
(`MessageService:692`) failed the delivery without reporting it either.

`HierarchicalRouting:182` is #981's teardown shape precisely: a hosted hub that quiesces **after**
its parent reached `DisposeHostedHubs` still posts to that parent, routing fails the delivery, and
the reply can never come. `RunLevel` ordering (`Quiescing` < `DisposeHostedHubs`) means the child is
fully able to post and fully able to be answered — it simply never was.

### The fix

The **failing site** records two things on the delivery; the routing tail acts on them.

- `Failed(message, ErrorType)` — the verdict, decided where the condition is known, never re-derived
  downstream by pattern-matching the failure text. Disposal races say `ShuttingDown`; the routing
  loop says `RoutingLoop`.
- `FailedAndNacked(message)` — "I already answered the sender". Used by the routing services, whose
  `NotFound` NACK is on a hot path.

`MessageService.ReportRoutingFailure` then NACKs every unanswered routing failure with the site's
own verdict, on both tails.

### Blast radius — enumerated, not assumed

**Only two sites can produce a `DeliveryFailure` that did not exist before.** `ReportFailure`
already returns early when `hub.RunLevel >= DisposeHostedHubs`, and that is the *same predicate*
as `isDisposing` in `HierarchicalRouting` and the `RunLevel` check in `RouteConfiguration` — so
four of the five sites above are **inert**: they only fire on a hub whose own `ReportFailure` is
already suppressed. What is genuinely new:

1. `HierarchicalRouting:182` (parent disposing, this hub live) → `ErrorType.ShuttingDown`.
2. The routing loop → `ErrorType.RoutingLoop`. Terminal by nature and **one NACK per message, not
   per bounce** — loop detection ends the delivery.

**Checked for cascade / storm:**

- **Sync streams do not tear down.** `SynchronizationStream:1019` and
  `JsonSynchronizationStream:375` explicitly ride out `ErrorType.ShuttingDown` (the CI-proven
  regression from run 30003419841). Both new disposal NACKs carry exactly that.
- **The transient classifiers still match.** `MeshNodeStreamCache.IsTransientOwnerFailure` and
  `AreaErrorClassifier.IsTransientHubFailure` recognise a transient hub reject by the `"is shutting
  down"` substring, so the parent-disposing NACK is worded to carry it — otherwise it would have
  been filed as a **permanent** owner failure and cached as one.
- **No double NACK on the hot path.** `RoutingServiceBase.PostNotFound` and
  `MonolithRoutingService.PostNotFound` already answer with `NotFound` before failing the delivery,
  and that path is taken by *every* message to a missing/undeployed node. They now mark the delivery
  answered, so this change adds **zero** NACKs there. (Their un-answered branches — `DeliveryFailure`,
  `[CanBeIgnored]`, mesh shutting down — are suppressed by `ReportFailure`'s own guards, so they add
  none either.)
- **Orleans adds none.** `OrleansRoutingService.DeliverMessage` dispatches to the grain in the
  background and returns `Forwarded`; the grain's `Failed` never reaches this tail.
- **No `DeliveryFailure` begets another.** `ReportFailure` skips `DeliveryFailure` and
  `[CanBeIgnored]`; `RunHandler`'s ignored-report skips `DeliveryFailure`; `HandleCallbacks` drops a
  reply with no subject.
- **No caller retries on this.** The three `CreateNodeRequest` awaiters propagate
  (`HubNodePersistence`, `NodeCopyHelper`) or swallow-and-continue (`ThreadSubmission`'s
  `.Catch(... Observable.Return(true))`). None re-posts.
- **No test asserts the silence.** No test references `"Parent hub disposing"` / `"Hub disposing"` /
  `"Routing loop"`, and no test asserts that a `DeliveryFailure` does **not** arrive.
- **One user-visible surface**: `PortalErrorSink` pops a modal for *un-awaited* portal-hub failures.
  It can only be reached here when the portal hub's parent (the mesh) is at `DisposeHostedHubs` —
  i.e. process teardown, on a circuit that is going away regardless.

### The pin

`RoutingFailureReportedTest` drives the framework's own routing seam (`RouteConfiguration.WithHandler`
— the same one SignalR / gRPC / Data / the mesh router register on) to fail a not-on-target delivery.
No disposal, nothing timed.

**Verified it fails against the current code**: with the tail reverted, the caller never hears back
and the test dies on its 30 s timeout with `TaskCanceledException` — the production symptom exactly.
With the fix, all three pass in 318 ms. It also pins that the reported verdict is the one the
*failing site* recorded, and that an already-answered failure is not NACKed twice.

### Verified locally

Release `-warnaserror` clean for every touched project. `Messaging.Hub.Test` 160/160,
`Hosting.Monolith.Test` 498/502 (4 pre-existing skips), `Layout.Test` 392/392, `Data.Test` 304/304,
`Serialization.Test` 14/14, `DocumentationLinkIntegrityTest` green.

Merged with `main` after #1011 landed: both changes are kept on the routing-loop arm, and the new
seam records its own ledger stages (`ROUTING_FAILED_REPORTED errorType=…` /
`ROUTING_FAILED_ALREADY_NACKED`) so a future capture says outright whether the router answered the
sender instead of ending at `ROUTED onTarget=False state=Failed` with nothing after it.

### Why `Refs`, not `Fixes`

This removes a real, reproduced silent-hang defect that produces #981's exact shape in the **child
hub** position the captures show (`CreateOrUpdateNodeRequest@mesh/<self>`, pending on a hub at
`Quiescing` whose parent has moved past `Started`).

It does **not** demonstrably explain the callback the failing assertion actually names — the **mesh
hub's own** `CreateNodeRequest@mesh/<self>`, which #981's timing analysis shows unanswered 0.7–3.2 s
*before* `Dispose()` was ever invoked. That request is **on-target** (mesh → itself), so it never
takes the branch fixed here. Closing #981 on this would be inference, so it stays open.

### Adjacent gap, deliberately not widened

The **on-target** branch has the mirror hole *after* routing: a delivery that a route handler fails
on-target (e.g. `DataExtensions.RouteStreamMessage`'s two deserialize failures) is handed to
`deliveryPipeline.Invoke`, and `FinishDelivery` returns any non-`Submitted` delivery untouched — so
it is not reported either. Fixing it means skipping or changing the delivery pipeline for failed
deliveries, which is a different risk surface and deserves its own change.

Refs #981
