### PR TITLE
Stop teaching the /static content route that #587 retired

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-course-and-product-videos-play-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-course-and-product-videos-play-again.md
@@ -1,0 +1,33 @@
+---
+Name: Course and product videos play again
+Category: Fix
+Description: Video players on course and product pages had been coming up empty, and share previews showed no image. The files were fine the whole time — the pages were asking for them at an address that had been retired.
+Icon: Sparkle
+Order: -20260809
+---
+
+# Course and product videos play again
+
+Open a course, or a product page like Claims or Underwriting, and the two-minute
+intro video was simply not there. Not an error, not a spinner — an empty black
+player, on every page that had one. Sharing any of those pages produced a link
+preview with no picture. It looked exactly like a permissions problem, and it was
+reported as one: *this person cannot see the videos*.
+
+It was not a permissions problem. Nobody could see them. The videos, posters and
+preview images were all sitting in place, readable by anyone, including visitors
+who are not signed in — and they still are. What had gone stale was the
+**address the pages used to ask for them**.
+
+Files stored on the platform used to be reachable at a second, unguarded address
+as well as their real one. That shortcut was removed a while back, because it
+handed out *every* space's uploads to anyone who could guess a URL — a genuine
+leak, and closing it was right. But the pages that pointed at media through the
+old shortcut were never updated, so from that moment on they were asking for
+their own videos at an address that no longer answers.
+
+Every one of those pages now asks at the real address: course intros and module
+videos, the Claims and Underwriting product films, cover images and share
+previews. Nothing about who may view what has changed — material that was public
+stays public, and material that is not stays protected, now on the one route that
+actually checks.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1601,7 +1601,10 @@ public static class PackageInstaller
             || ModuleManifest.IsManifestPath(file.RelativePath)
             // A `{package}/content/**` asset is NOT a node — its bytes go to the partition root's
             // content collection (SyncPackageContent), which is where the served
-            // `/static/{root}/content/…` URL resolves. Same split GitHubSyncService.ParseSnapshot
+            // `/api/content/{root}/content/…` URL resolves. (It used to be `/static/{root}/content/…`;
+            // #587 unmounted content from /static entirely, so that shape is now 404 for everyone —
+            // an authored asset URL must name the access-controlled route.) Same split
+            // GitHubSyncService.ParseSnapshot
             // makes, and the one NodePathForFile below has always asserted. Skipping it here also
             // silences the "No parser for …/videos/x.mp4" warning every course emitted per install.
             || ContentAssetMapper.IsContentPath(file.RelativePath))

--- a/test/Memex.Portal.Shared.Test/SeoResolverContentTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoResolverContentTest.cs
@@ -26,22 +26,22 @@ public class SeoResolverContentTest
     [Fact]
     public void ExtractImage_UntypedJson_ReadsPosterThenThumbnail()
     {
-        Assert.Equal("/static/S/p.png", SeoResolver.ExtractImage(Node(Json(new { poster = "/static/S/p.png" }))));
-        Assert.Equal("/static/S/t.png", SeoResolver.ExtractImage(Node(Json(new { thumbnail = "/static/S/t.png" }))));
+        Assert.Equal("/api/content/S/p.png", SeoResolver.ExtractImage(Node(Json(new { poster = "/api/content/S/p.png" }))));
+        Assert.Equal("/api/content/S/t.png", SeoResolver.ExtractImage(Node(Json(new { thumbnail = "/api/content/S/t.png" }))));
     }
 
     [Fact]
     public void ExtractImage_TypedMarkdownContent_ReadsThumbnail()
     {
-        var content = new MarkdownContent { Content = "# page", Thumbnail = "/static/S/videos/x.poster.png" };
+        var content = new MarkdownContent { Content = "# page", Thumbnail = "/api/content/S/videos/x.poster.png" };
 
-        Assert.Equal("/static/S/videos/x.poster.png", SeoResolver.ExtractImage(Node(content)));
+        Assert.Equal("/api/content/S/videos/x.poster.png", SeoResolver.ExtractImage(Node(content)));
     }
 
     [Fact]
     public void ExtractImage_TypedContent_ReadsPoster()
     {
-        Assert.Equal("/static/S/og.png", SeoResolver.ExtractImage(Node(new FakePluginContent("/static/S/og.png", 900m))));
+        Assert.Equal("/api/content/S/og.png", SeoResolver.ExtractImage(Node(new FakePluginContent("/api/content/S/og.png", 900m))));
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/PackageContentAssetInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PackageContentAssetInstallTest.cs
@@ -113,7 +113,7 @@ public class PackageContentAssetInstallTest(ITestOutputHelper output) : Monolith
     [
         new($"{PackageId}/index.json",
             """{"$type":"MeshNode","id":"Course","namespace":"","path":"Course","mainNode":"Course","name":"A Course","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A course with video."}}"""),
-        new($"{PackageId}/Lesson.md", "# Lesson\n\n<video src=\"/static/Course/content/videos/clip.mp4\"></video>\n"),
+        new($"{PackageId}/Lesson.md", "# Lesson\n\n<video src=\"/api/content/Course/content/videos/clip.mp4\"></video>\n"),
         new($"{PackageId}/content/videos/clip.mp4", "", VideoBytes),
         new($"{PackageId}/content/videos/clip.poster.png", "", PosterBytes),
         new($"{PackageId}/content/notes.txt", TextAssetContent),
@@ -155,9 +155,11 @@ public class PackageContentAssetInstallTest(ITestOutputHelper output) : Monolith
 
         // The collection is mounted at {contentRoot}/{root}, and ContentAssetMapper maps a repo path
         // {package}/content/<file> onto collection-relative <file>. So the bytes must be readable at
-        // exactly the layout /api/content/Course/videos/clip.mp4 (and the legacy
-        // /static/Course/content/videos/clip.mp4) resolve to — which is what the Lesson markup above
-        // already points at.
+        // exactly the layout /api/content/Course/videos/clip.mp4 resolves to — and equally at
+        // /api/content/Course/content/videos/clip.mp4, since `content` names the default collection.
+        // That second shape is what the Lesson markup above points at. 🚨 The pre-#587
+        // /static/Course/content/… shape is NOT an alias: /static carries build assets only and 404s
+        // for every caller, so authored asset URLs must name /api/content.
         var collectionRoot = Path.Combine(_contentRoot, PackageId);
 
         ReadAsset(collectionRoot, "videos/clip.mp4").Should().Equal(VideoBytes,


### PR DESCRIPTION
## The report

*"mkleiner does not see the videos on Claims."* It looked like a permissions problem. It was not — **nobody** could see them.

```
GET /static/Claims/content/videos/claims-process.mp4      → 404  "not a static build asset"
GET /api/content/Claims/content/videos/claims-process.mp4 → 200  video/mp4, 5,490,866 bytes  (ANONYMOUS)
```

`Claims/_Access` already carries `Anonymous — Viewer` *and* `Public — Viewer`. The bytes were never restricted and never moved. The **URL** was retired.

## Why ~100 URLs went dead

PR #911 (issue #587) unmounted mesh content from `/static` — correctly: that route was handing out every partition's uploads at a guessable URL. `/static` now serves application build assets only (two mounts, `NodeTypeIcons` and `DocContent`) and 404s everything else, identically for every caller. Content moved to the access-controlled `/api/content/{node}/{collection}/{file}`.

The authored content was never migrated with it. An org-wide sweep found **100 references across 5 repos**, all the same shape: every course intro and module video (`AgenticEngineering` mod1–mod9, `AgenticPrimer` + `De`, `DataModeling`, `AgenticOffice`, `AdvancedBusinessRules`, `RiskTransfer`…), the Claims / Underwriting / ClaimsDeepfield / UWDeepfield product films, every `og.png`, and a space logo. Every one an empty player or a broken image, for everyone, since #911 merged.

## What this PR changes

Three places in **this** repo still model the retired shape — and one of them is why nobody caught it:

| | |
|---|---|
| `PackageInstaller.cs` | The comment on the content-asset split names `/static/{root}/content/…` as *"the served URL"*. It is the one line telling a reader where a package's committed bytes surface — and it named a 404. |
| `PackageContentAssetInstallTest.cs` | The fixture authors `<video src="/static/…">`, and the comment calls that shape a still-working *"legacy"* alias. It is not an alias; it is gone. |
| `SeoResolverContentTest.cs` | The `og:image` fixtures are all `/static/S/…` URLs. |

No behaviour changes — comments and fixtures now name `/api/content`, where the bytes actually are. Both touched projects build clean under `-c Release -warnaserror`.

## The user-visible repair ships alongside

| Repo | PR | Refs |
|---|---|---|
| education | Systemorph/education#121 | 67 |
| MeshWeaver.Plugins | Systemorph/MeshWeaver.Plugins#372 | 18 |
| MeshWeaver.Reinsurance | Systemorph/MeshWeaver.Reinsurance#48 | 13 |
| MeshWeaver.SocialMedia | Systemorph/MeshWeaver.SocialMedia#15 | 1 |
| agentic-pensions | Systemorph/agentic-pensions#17 | 1 |

The Plugins PR matters most for recurrence: `Skill/plugin.json` and `Skill/create-course.json` both *instructed* agents to write the retired shape, so every course authored from them inherited a dead URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU2kBewK9hnv2WLQB6H8GH