### PR TITLE
A failed status write must never block the self-update roll-forward

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -19,7 +19,14 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// its own portal + migration Deployments to the new version so k8s rolls them. Outside Kubernetes it
 /// records the available version for detect-and-notify. Mirrors <c>ShippedReleaseSeedHostedService</c>
 /// (raw <see cref="IHostedService"/>, <c>SubscribeOn(TaskPoolScheduler.Default)</c>, one subscription).
-/// Not sealed: <see cref="ReadPolicyStream"/> is the fault-injection seam for the resilience test.
+/// Not sealed: <see cref="ReadPolicyStream"/> and <see cref="RecordAvailable"/> are the
+/// fault-injection seams for the resilience test — they are the only two mesh touches this poller
+/// makes, and therefore the only two ways a degraded mesh could ever stop an install rolling forward.
+///
+/// <para>🔁 wedges-to-zero, the standing invariant here: NEITHER mesh touch may gate the roll-forward.
+/// The registry poll and the k8s PATCH speak only to ACR and the API server, so they keep working
+/// while the mesh is degraded — and a fresh image is precisely what recovers a degraded pod. The
+/// policy READ was decoupled in #611; the availability WRITE in #1020.</para>
 /// </summary>
 public class SelfUpdateHostedService : IHostedService
 {
@@ -148,19 +155,55 @@ public class SelfUpdateHostedService : IHostedService
             .Where(target => !string.IsNullOrEmpty(target)
                           && VersionSelect.IsNewer(target!, ShippedReleaseSeed.InstalledPlatformVersion))
             .SelectMany(target => RecordAvailable(target!)
-                .SelectMany(_ => _updater.CanPatch
-                    ? _http.Invoke(ct => _updater.PatchToVersionAsync(target!, ct))
-                        .Do(_ => _logger?.LogInformation(
-                            "[SelfUpdate] applying update {Tag} (was {Current}).",
-                            target, ShippedReleaseSeed.InstalledPlatformVersion))
-                    : Observable.Return(Unit.Default)
-                        .Do(_ => _logger?.LogInformation(
-                            "[SelfUpdate] update available: {Tag} (detect-and-notify — this install does not self-patch).",
-                            target))));
+                // 🚨 BOOKKEEPING, NOT A GATE (#1020). RecordAvailable writes two cosmetic fields
+                // (LatestAvailableTag / CheckedAt) that drive the admin tab; the ROLL-FORWARD does not
+                // depend on them. Chaining Apply after it with .SelectMany made a failed status write
+                // abort the update: on atioz the Admin/UpdatePolicy node hub was unreachable (its
+                // SubscribeRequest never answered — the silo's routing was wedged), every 6 h tick
+                // timed out after 30 s in this write, and the portal sat 37 h on a stale image while
+                // the poller kept ticking and the ACR check kept succeeding. The update it would not
+                // apply is exactly what recovers a degraded pod, so the write must never gate it:
+                // surface the fault (never swallow it — the warning names the tag and the node) and
+                // carry on to Apply, which touches only ACR + the k8s API and works while the mesh
+                // is degraded. Concat, not Merge — the record still lands FIRST when it succeeds.
+                .Catch((Exception ex) =>
+                {
+                    _logger?.LogWarning(ex,
+                        "[SelfUpdate] could not record available tag {Tag} on {Node}; applying the update anyway.",
+                        target, UpdatePolicyNodeType.NodePath);
+                    return Observable.Return(Unit.Default);
+                })
+                .Concat(Apply(target!)));
+
+    /// <summary>
+    /// Applies the picked target: patch the workloads where this install is armed, else record-only
+    /// (detect-and-notify). The intent is announced BEFORE the attempt, so a failing apply is
+    /// diagnosable: the tick's error sink logs a generic "check failed", and until #1020 that was the
+    /// ONLY trace a stalled install left — it read like a registry problem while the registry was
+    /// fine. Deferred so the announcement runs per subscription (per tick), not at composition.
+    /// </summary>
+    private IObservable<Unit> Apply(string target) =>
+        Observable.Defer(() =>
+        {
+            if (!_updater.CanPatch)
+            {
+                _logger?.LogInformation(
+                    "[SelfUpdate] update available: {Tag} (detect-and-notify — this install does not self-patch).",
+                    target);
+                return Observable.Return(Unit.Default);
+            }
+
+            _logger?.LogInformation(
+                "[SelfUpdate] applying update {Tag} (was {Current}).",
+                target, ShippedReleaseSeed.InstalledPlatformVersion);
+            return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
+        });
 
     /// <summary>Record the newest available tag on the policy node (as System). Drives the admin tab
-    /// and the detect-and-notify path. Touches only the bookkeeping fields; preserves Policy.</summary>
-    private IObservable<Unit> RecordAvailable(string tag)
+    /// and the detect-and-notify path. Touches only the bookkeeping fields; preserves Policy.
+    /// Virtual: the second fault-injection seam for the resilience test (alongside
+    /// <see cref="ReadPolicyStream"/>) — it is where the #1020 prod stall surfaced.</summary>
+    protected virtual IObservable<Unit> RecordAvailable(string tag)
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
         var jsonOptions = _hub.JsonSerializerOptions;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-portals-keep-updating-when-the-portal-is-unwell.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-portals-keep-updating-when-the-portal-is-unwell.md
@@ -1,0 +1,24 @@
+---
+Name: A portal no longer stops updating itself when something else goes wrong
+Category: Fix
+Description: A portal that could not write its own "latest version available" note used to stop applying updates entirely, silently, for as long as the pod ran.
+Icon: Sparkle
+Order: -20260809
+---
+
+# A portal no longer stops updating itself when something else goes wrong
+
+A portal checks for a new version a few times a day and rolls itself forward. Before applying an
+update it also wrote a small note to its own settings — the newest version it had seen, and when it
+last looked — which is what the Update Policy tab shows you.
+
+If that note could not be written, the update was abandoned along with it. One production portal
+spent 37 hours on an old version for exactly this reason: the version check itself was working
+perfectly and had picked the right new version every time, but a piece of bookkeeping stood in front
+of it. Nothing about the portal looked broken, so the drift was only noticed by comparing version
+numbers by hand.
+
+Applying the update no longer depends on that note. If the note cannot be written the portal says so
+and rolls forward anyway — which matters most precisely when the portal is unwell, because the newer
+version is usually what puts it right. The log now also names the version it is about to apply, so a
+portal that fails to update says which update it was trying to install.

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
@@ -109,6 +110,70 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
             var channel = new Subject<UpdatePolicyContent>();
             Volatile.Write(ref _current, channel);
             return base.ReadPolicyStream().Merge(channel);
+        }
+    }
+
+    /// <summary>
+    /// Injects the #1020 prod fault shape: the availability BOOKKEEPING write to
+    /// <c>Admin/UpdatePolicy</c> times out. On atioz that node's hub was unreachable (its
+    /// <c>SubscribeRequest</c> never answered — the silo's routing was wedged), so every tick died
+    /// here 30 s in. Everything else — the registry check, the version pick, the k8s patch — was
+    /// healthy, which is why the install looked fine and drifted 37 h.
+    /// </summary>
+    private sealed class FaultingRecordService(
+        IMessageHub hub,
+        IAcrTagLister acr,
+        IDeploymentUpdater updater,
+        SelfUpdateOptions options,
+        ILogger<SelfUpdateHostedService>? logger)
+        : SelfUpdateHostedService(hub, acr, updater, options, logger)
+    {
+        private int _attempts;
+
+        public int RecordAttempts => Volatile.Read(ref _attempts);
+
+        protected override IObservable<Unit> RecordAvailable(string tag)
+        {
+            Interlocked.Increment(ref _attempts);
+            return Observable.Throw<Unit>(new TimeoutException(
+                $"Update aborted: no initial state arrived for '{UpdatePolicyNodeType.NodePath}' within 30s."));
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Failed_availability_write_never_blocks_the_roll_forward()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var acr = new FakeAcrTagLister();
+        var updater = new RecordingUpdater();
+        var options = new SelfUpdateOptions
+        {
+            PollInterval = TimeSpan.FromMilliseconds(500),
+            DefaultPolicy = UpdatePolicyKind.Continuous,
+        };
+        var service = new FaultingRecordService(
+            Mesh, acr, updater, options,
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>());
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            // The bookkeeping write fails on EVERY tick — exactly the atioz shape. Pre-fix the patch
+            // was chained after it with .SelectMany, so the tick errored into the poller's warning
+            // sink and NOTHING was ever applied: this await timed out while the registry check kept
+            // succeeding. The roll-forward must happen regardless.
+            var applied = await updater.Patched
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+            applied.Should().Be(FakeAcrTagLister.CiTag);
+
+            // …and it really went THROUGH the failing write, not around it.
+            service.RecordAttempts.Should().BeGreaterThan(0);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
         }
     }
 


### PR DESCRIPTION
Fixes #1020

## The poll never stopped — every tick failed on a status write

The restart masked the fault, but Loki kept the stalled pod's logs. `memex-portal-deployment-7d477dd8b6-7xzcq` (the `ci.2151` pod) shows the poller ticking on schedule for its whole 37 h life, and **failing every single time**:

```
t0        [SelfUpdate] starting; version=3.0.0-rc1.ci.2151 … canPatch=True, interval=06:00:00.
t0+60s    [SelfUpdate] policy stream faulted; re-establishing in 06:00:00.
t0+6h00m30s   [SelfUpdate] check failed (policy=Continuous).
t0+12h00m30s  [SelfUpdate] check failed (policy=Continuous).
…every 6 h, six times, until the restart
```

The `30 s` offset from each tick is the tell. Unfiltered, the exception is:

```
warn: MeshWeaver.Mesh.MeshNodeStreamHandle[0]
      [UpdateRemote] ERROR hub=cache/hp4PbexBOkqjtxhnolk9aQ target=Admin/UpdatePolicy type=TimeoutException
warn: MeshWeaver.Hosting.MeshNodeStreamCache[0]
      [UpdateQueue] FAILED path=Admin/UpdatePolicy seq=5 elapsedMs=30005.2
      System.TimeoutException: Update aborted: no initial state arrived for 'Admin/UpdatePolicy' within 30s.
warn: Memex.Portal.Shared.SelfUpdate.SelfUpdateHostedService[0]
      [SelfUpdate] check failed (policy=Continuous).
```

So everything the issue suspected was **fine**: the federated credential worked, ACR answered, and `VersionSelect.PickTarget` picked the right newer tag every time. The tick got all the way past the `IsNewer` gate and then died writing two cosmetic fields.

`RunOnce` chained the k8s PATCH *after* `RecordAvailable` with `.SelectMany`. `RecordAvailable` writes `LatestAvailableTag` + `CheckedAt` to `Admin/UpdatePolicy` — bookkeeping for the admin tab. **A status field held the deploy hostage.**

That inverts the invariant #611 established for the policy *read*: neither mesh touch may gate the roll-forward, because a fresh image is exactly what recovers a degraded pod. The read was decoupled then; the write was left on the critical path.

## Why only atioz

`FAILED path=Admin/UpdatePolicy` appears in **no other namespace** all week — only atioz, exactly six times, one per stalled tick. Its `Admin/UpdatePolicy` node hub was unreachable because the silo's Orleans routing was wedged (`RoutingGrain`, `[StatelessWorker(1)]`, one `RouteMessage` executing for `06:00:22` with `NonReentrancyQueueSize=541`). **That wedge is a separate, deeper defect and is not fixed here** — see the note below.

## The fix

`RecordAvailable`'s failure is surfaced by name (tag + node) and no longer aborts the tick; `Apply` runs regardless, over `Concat` so a successful record still lands first. Nothing is swallowed — the warning carries the exception.

`Apply` also announces the tag **before** the attempt. Previously the only trace a stalled install left was `[SelfUpdate] check failed`, which reads like a registry problem while the registry was fine — that is why this took 37 h and a manual version comparison to spot.

No watchdog, no retry, no shortened interval, no restart job. The poller's cadence is untouched.

## Proof

`Failed_availability_write_never_blocks_the_roll_forward` injects the prod fault at `RecordAvailable` (now a fault-injection seam alongside `ReadPolicyStream`) with the exact prod exception text, against a real monolith mesh.

Reverting only the coupling — `.Catch(…).Concat(Apply(…))` back to `.SelectMany(_ => Apply(…))` — reproduces atioz byte-for-byte and the test fails:

```
[Warning] [SelfUpdate] check failed (policy=Continuous).
Exception: System.TimeoutException: Update aborted: no initial state arrived for 'Admin/UpdatePolicy' within 30s.
…× every tick, no patch ever applied…
=== TEST FAILED: The operation has timed out.
Failed! - Failed: 1, Passed: 0
```

With the fix, all 3 tests in the class pass in 4 s. `Memex.Portal.Shared` and `MeshWeaver.Hosting.Monolith.Test` build clean at `-c Release -warnaserror`.

## What's New

`Category: Fix` — an operator can notice this: a portal that silently stops taking updates.

## What actually ships this

Merging this PR is not what deploys it. `main-cd.yml` gates every image job on
`workflow_run.event == 'push'`, so the image that carries this fix is published by the **real push to
main that this merge creates** — and only then. A `workflow_dispatch` re-run of Build and Test would
turn main green while publishing nothing.

So after merge, verify the IMAGE, never the green tick:

```bash
az acr repository show-tags -n meshweaver --repository memex-portal-ai --orderby time_desc --top 5 -o tsv
```

The three portals then pick it up on their own 6 h poll — which, with this change, no longer depends
on `Admin/UpdatePolicy` being writable.

## ⚠️ Still open — the underlying wedge

atioz's routing wedge is untouched by this PR. It was confined to that one pod: lines containing
`NonReentrancyQueueSize` came **only** from `memex-portal-deployment-7d477dd8b6-7xzcq` (~8.4 M on
08-Aug, ~6.0 M on 09-Aug up to the restart) and the current pod has emitted **zero** in the five
hours since. So the restart did clear it and nothing is bleeding right now — but nothing explains
what started it either, so it can recur.

`RoutingGrain` is `[StatelessWorker(1)]` and non-reentrant, so a single `RouteMessage` whose
memory-stream `OnNextAsync` never completes wedges the whole silo's routing, with no timeout on that
path. Worth its own issue.

One upside of this PR: when it does recur, the install now rolls forward on the next 6 h tick, and
rolling forward restarts the pod — so the wedge self-clears instead of needing a human to notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
