### PR TITLE
Every stored image in a pixel-faithful deck export was printing blank

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -95,6 +95,19 @@ public static class ContentFileResolver
         string reference,
         AccessContext? caller = null)
     {
+        // 🚨 TRAVERSAL GUARD, on the DECODED reference, before anything else. `%2E%2E` and `%2F`
+        // survive URL normalisation and only become `..` and `/` once a caller has decoded per
+        // segment — and FileSystemStreamProvider resolves a collection-relative path with a bare
+        // Path.Combine, so an un-guarded `..` reads outside the collection's BasePath, i.e. another
+        // partition's files. It lives HERE rather than in each caller because the export's
+        // references come out of user-authored slide markup with raw-HTML passthrough: a slide could
+        // otherwise point the server at anything the portal can read. (The content route also checks
+        // this before calling us; belt and braces on a path where the cost of being wrong is a file
+        // disclosure.)
+        if (!StaticAssetMount.IsSafeRelativePath(reference))
+            return Observable.Return(
+                ContentFileResolutionResult.NotFound("Invalid content path"));
+
         // Cold: nothing is resolved and nothing is posted until somebody subscribes.
         return Observable.Defer(() => hub.ServiceProvider
             .GetRequiredService<IPathResolver>()

--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -1,0 +1,236 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContentCollections;
+
+/// <summary>
+/// One <c>/api/content/…</c> reference, resolved to the collection and the collection-relative file
+/// path a server-side read needs.
+/// </summary>
+/// <param name="Collection">
+/// The owning node's collection config, exactly as that node reported it — <b>unrenamed</b>, so a
+/// caller can still read <see cref="ContentCollectionConfig.IsStatic"/> and report the collection's
+/// real name.
+/// </param>
+/// <param name="QualifiedName">
+/// <c>{nodePath}/{collectionName}</c> — the name the config must be registered under before it is
+/// read, so two nodes inheriting the same ancestor collection cannot collide in one content
+/// service's cache.
+/// </param>
+/// <param name="FilePath">The path of the file <b>within that collection</b>.</param>
+/// <param name="Owner">The node the reference resolved to.</param>
+public sealed record ContentFileResolution(
+    ContentCollectionConfig Collection,
+    string QualifiedName,
+    string FilePath,
+    Address Owner)
+{
+    /// <summary>The config renamed to <see cref="QualifiedName"/> and attributed to <see cref="Owner"/>.</summary>
+    public ContentCollectionConfig QualifiedConfig =>
+        Collection with { Name = QualifiedName, Address = Owner };
+}
+
+/// <summary>
+/// Outcome of <see cref="ContentFileResolver.Resolve"/>: either a resolution or the reason there
+/// isn't one. The reason is a plain sentence a caller can put in a 404 or a log line.
+/// </summary>
+/// <param name="Resolution">The resolution, or <c>null</c>.</param>
+/// <param name="Reason">Why there is none, or <c>null</c> when there is one.</param>
+public sealed record ContentFileResolutionResult(ContentFileResolution? Resolution, string? Reason)
+{
+    /// <summary>An unresolvable reference, with the reason.</summary>
+    public static ContentFileResolutionResult NotFound(string reason) => new(null, reason);
+
+    /// <summary>A resolved reference.</summary>
+    public static ContentFileResolutionResult Found(ContentFileResolution resolution) =>
+        new(resolution, null);
+}
+
+/// <summary>
+/// 🚨 THE ONE server-side reading of a content reference: <c>{node}/{collection}/{file}</c> or
+/// <c>{node}/{file…}</c> → the collection to open and the path inside it.
+///
+/// <para><b>Two shapes, one rule.</b> The owning node is resolved with
+/// <see cref="IPathResolver"/> (longest real-node prefix). When the first remaining segment names a
+/// collection on that node it IS the collection and the rest is the file; otherwise the whole
+/// remainder is a path in the node's default <c>content</c> collection, put back behind the node's
+/// own path when the collection is inherited from an ancestor
+/// (<see cref="CombineOwnerRelative"/>).</para>
+///
+/// <para><b>Why this is shared rather than re-derived per caller.</b> A second, "obvious" reading —
+/// treat the FIRST segment as the collection name — is right for an authored
+/// <c>content:{collection}/{path}</c> reference and wrong for every URL the product renders, where
+/// the first segment is the node's partition. The two readings agree on the file path and disagree
+/// on the collection, so the wrong one fails as "collection not found" and a caller that treats
+/// that as "asset missing" produces a silently broken image. The deck export did exactly that
+/// (issue #990). Callers ask here instead of splitting the string themselves.</para>
+///
+/// <para>Reading the node's collections goes through a <c>GetDataRequest</c> to the owning node,
+/// which carries <c>[RequiresPermission(Read)]</c> — so the resolution is gated by exactly the
+/// decision an ordinary node read makes. There is no parallel rule set here to drift, and no config
+/// cache: caching the answer would let one authorized caller warm a short-circuit every later
+/// caller reuses.</para>
+/// </summary>
+public static class ContentFileResolver
+{
+    /// <summary>
+    /// Resolves a content reference. <paramref name="reference"/> is the part AFTER
+    /// <see cref="ContentCollectionsExtensions.ContentFileRoutePrefix"/> —
+    /// <c>{node}/{collection}/{file}</c> or <c>{node}/{file…}</c> — already percent-decoded
+    /// (<see cref="ContentCollectionsExtensions.DecodeCollectionPath"/>).
+    /// </summary>
+    /// <param name="hub">The hub used to resolve the path and ask the owning node.</param>
+    /// <param name="reference">The decoded, prefix-less reference.</param>
+    /// <param name="caller">
+    /// The identity to attribute the collection-config read to, or <c>null</c> to let the post
+    /// pipeline stamp the ambient one (in-mesh callers already run under the user's context).
+    /// </param>
+    /// <returns>A single-emission observable carrying the resolution or the reason there is none.</returns>
+    public static IObservable<ContentFileResolutionResult> Resolve(
+        IMessageHub hub,
+        string reference,
+        AccessContext? caller = null)
+    {
+        // Cold: nothing is resolved and nothing is posted until somebody subscribes.
+        return Observable.Defer(() => hub.ServiceProvider
+            .GetRequiredService<IPathResolver>()
+            .ResolvePath(reference))
+            .Take(1).SelectMany(resolution =>
+        {
+            if (resolution is null || string.IsNullOrEmpty(resolution.Prefix))
+                return Observable.Return(
+                    ContentFileResolutionResult.NotFound("No matching node found for path"));
+            if (string.IsNullOrEmpty(resolution.Remainder))
+                return Observable.Return(
+                    ContentFileResolutionResult.NotFound("File path is required"));
+
+            var remainderParts = resolution.Remainder.Split('/');
+            var explicitCollection =
+                ContentCollectionsExtensions.DecodeCollectionName(remainderParts[0]);
+            var defaultCollection = ContentCollectionsExtensions.DefaultCollectionName;
+            var targetAddress = (Address)resolution.Prefix;
+
+            // ONE round trip for both candidate shapes: the named collection (when there is a file
+            // path after it) and the node's default content collection.
+            var candidates = remainderParts.Length >= 2 && explicitCollection != defaultCollection
+                ? new[] { explicitCollection, defaultCollection }
+                : [defaultCollection];
+
+            return hub.Observe(
+                    new GetDataRequest(new ContentCollectionReference(candidates)),
+                    o =>
+                    {
+                        o = o.WithTarget(targetAddress);
+                        return caller is null ? o : o.WithAccessContext(caller);
+                    })
+                .Take(1)
+                .Select(delivery =>
+                {
+                    var configs = ReadCollectionConfigs(delivery);
+
+                    // Prefer the explicitly-named collection — there the file path is relative to
+                    // the COLLECTION's own root, exactly as the file browser lists it.
+                    //
+                    // Otherwise the node's default collection, with the whole remainder as a
+                    // NODE-relative path.
+                    var (sourceConfig, filePath) =
+                        remainderParts.Length >= 2
+                        && configs?.FirstOrDefault(c => c.Name == explicitCollection) is { } named
+                            ? (named, string.Join('/', remainderParts.Skip(1)))
+                            : (configs?.FirstOrDefault(c => c.Name == defaultCollection),
+                                CombineOwnerRelative(
+                                    configs?.FirstOrDefault(c => c.Name == defaultCollection)?.Address,
+                                    resolution.Prefix,
+                                    resolution.Remainder!));
+
+                    if (sourceConfig is null)
+                        return ContentFileResolutionResult.NotFound(
+                            $"No content collection at '{resolution.Prefix}' serves '{resolution.Remainder}'");
+
+                    if (string.IsNullOrEmpty(filePath))
+                        return ContentFileResolutionResult.NotFound("File path is required");
+
+                    return ContentFileResolutionResult.Found(new ContentFileResolution(
+                        sourceConfig,
+                        $"{resolution.Prefix}/{sourceConfig.Name}",
+                        filePath,
+                        targetAddress));
+                });
+        });
+    }
+
+    /// <summary>
+    /// Puts the resolved node's OWN path back in front of a node-relative file path when the
+    /// collection is inherited from an ancestor.
+    ///
+    /// <para>A Space's <c>content</c> collection is mounted on the partition root with
+    /// <c>ExposeInChildren</c>, so a child hub reports the ancestor's config verbatim — same
+    /// <c>BasePath</c>. The file of node <c>Org/Project</c> therefore lives at
+    /// <c>Project/{file}</c> inside it. Owner == node (or an unknown owner) ⇒ no prefix.</para>
+    /// </summary>
+    /// <param name="collectionOwner">The address the collection is registered on, if known.</param>
+    /// <param name="nodePath">The node the request resolved to.</param>
+    /// <param name="filePath">The node-relative file path.</param>
+    /// <returns>The collection-relative file path.</returns>
+    public static string CombineOwnerRelative(Address? collectionOwner, string nodePath, string filePath)
+    {
+        var owner = collectionOwner?.ToString()?.Trim('/');
+        var node = nodePath.Trim('/');
+        if (string.IsNullOrEmpty(owner)
+            || string.Equals(owner, node, StringComparison.OrdinalIgnoreCase)
+            || !node.StartsWith(owner + "/", StringComparison.OrdinalIgnoreCase))
+            return filePath;
+        return $"{node[(owner.Length + 1)..]}/{filePath}";
+    }
+
+    /// <summary>
+    /// Projects the collection configs out of the owning hub's <c>GetDataResponse</c>. The remote
+    /// form arrives as a <see cref="JsonElement"/>; <see cref="ContentCollectionConfig.IsStatic"/>
+    /// and <see cref="ContentCollectionConfig.Address"/> MUST survive that projection — without the
+    /// first, every legitimately-published remote collection fails a caller's mount check; without
+    /// the second, an inherited collection loses its owner and a child node's file resolves against
+    /// the ancestor's folder. <c>IsStatic</c> is suppressed when false, so an absent property means
+    /// false — the safe value either way.
+    /// </summary>
+    /// <param name="delivery">The response delivery, or <c>null</c>.</param>
+    /// <returns>The configs, or <c>null</c> when the response carried none.</returns>
+    public static IReadOnlyCollection<ContentCollectionConfig>? ReadCollectionConfigs(
+        IMessageDelivery? delivery) =>
+        delivery?.Message switch
+        {
+            GetDataResponse { Data: JsonElement je } => je.EnumerateArray()
+                .Select(e => new ContentCollectionConfig
+                {
+                    Name = e.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? "" : "",
+                    SourceType = e.TryGetProperty("sourceType", out var typeProp) ? typeProp.GetString() ?? "" : "",
+                    BasePath = e.TryGetProperty("basePath", out var pathProp) ? pathProp.GetString() : null,
+                    IsStatic = e.TryGetProperty("isStatic", out var staticProp)
+                               && staticProp.ValueKind == JsonValueKind.True,
+                    Address = e.TryGetProperty("address", out var addressProp)
+                        ? ToAddress(addressProp)
+                        : null,
+                })
+                .ToArray(),
+            GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
+            _ => null
+        };
+
+    /// <summary>
+    /// Reads a collection config's owning address off the wire. Absent, non-string or empty ⇒
+    /// <c>null</c>, which <see cref="CombineOwnerRelative"/> treats as "owner unknown" and leaves
+    /// the file path alone — the conservative reading.
+    /// </summary>
+    private static Address? ToAddress(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            return null;
+        var value = element.GetString();
+        if (string.IsNullOrEmpty(value))
+            return null;
+        return value;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-pictures-in-a-printed-deck-are-actually-there.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-pictures-in-a-printed-deck-are-actually-there.md
@@ -1,0 +1,42 @@
+---
+Name: Pictures in a pixel-faithful deck export are actually there
+Category: Fix
+Description: A deck exported with pixel fidelity printed every stored image as a blank space. The export was asking for the picture under the wrong name and could not say so.
+Icon: Sparkle
+Order: -20260809
+---
+
+# Pictures in a pixel-faithful deck export are actually there
+
+Exporting a deck with **pixel fidelity** gave you the slides exactly as they look
+on screen — gradients, layout, raw HTML and all — except for one thing: every
+picture stored alongside the deck came out as empty space. The text was right,
+the backgrounds were right, and where the image belonged there was nothing.
+
+A printed deck is produced offline, deliberately: the print document is not
+allowed to reach out to the network for anything, so every picture has to be
+carried *inside* it. Collecting those pictures is therefore not a shortcut, it is
+the only way one reaches the page. And the step that collected them was looking
+in the wrong place.
+
+An image on a slide is addressed by the slide it belongs to. The export read the
+first part of that address as the name of the *folder* the picture lives in —
+but the first part names the **space**, not the folder. So it asked for a folder
+that does not exist, got nothing back, and printed the slide without the
+picture. Because the document may not fetch anything, there was no second chance:
+the missing image could not quietly load itself the slow way, it was simply
+absent.
+
+There is now one shared answer to "where does this file actually live", used both
+by the export and by the page you look at in the browser — so the two can no
+longer disagree about it. Every way an image can be referenced resolves the same
+way in both: a picture stored with the slide, a picture stored in a named folder,
+and a folder or file name containing spaces or slashes.
+
+## And when a picture genuinely is missing, the export says so
+
+If a slide points at a file that has been deleted or renamed, the export used to
+carry on silently and hand you a deck with a hole in it — indistinguishable from
+the bug above. The export log now names every picture it could not find and says
+it will print blank, so a missing file looks like a missing file rather than a
+rendering fault.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -379,161 +379,42 @@ public static class BlazorHostingExtensions
         if (!StaticAssetMount.IsSafeRelativePath(decodedPath))
             return Observable.Return(Results.NotFound("Invalid content path"));
 
-        var pathResolver = mainHub.ServiceProvider.GetRequiredService<IPathResolver>();
-        return pathResolver.ResolvePath(decodedPath).Take(1).SelectMany(resolution =>
+        // 🚨 ONE resolution, shared. Which segments name the node and which name the collection is
+        // decided by ContentFileResolver — the same reading every server-side content read uses.
+        // A second, private copy of this logic is what let the deck export ask for a collection
+        // named after the partition and silently print blank images (issue #990).
+        return ContentFileResolver.Resolve(mainHub, decodedPath, caller).SelectMany(result =>
         {
-            if (resolution == null || string.IsNullOrEmpty(resolution.Prefix))
-                return Observable.Return(Results.NotFound("No matching node found for path"));
-            if (string.IsNullOrEmpty(resolution.Remainder))
-                return Observable.Return(Results.NotFound("File path is required"));
+            if (result.Resolution is not { } resolution)
+                return Observable.Return(Results.NotFound(result.Reason));
 
-            var remainderParts = resolution.Remainder.Split('/');
-            var explicitCollection = DecodeCollectionName(remainderParts[0]);
-            var defaultCollection = ContentCollectionsExtensions.DefaultCollectionName;
+            var sourceConfig = resolution.Collection;
 
-            var targetAddress = (Address)resolution.Prefix;
+            // 🚨 MOUNT CHECK, default-closed. A collection is servable by URL only when it
+            // declares it (ContentCollectionConfig.IsStatic). The flag existed but was read
+            // NOWHERE — set at two sites, consulted at zero — so every collection registered
+            // anywhere on the mesh was fetchable by URL. Not declared ⇒ 404, for every
+            // caller alike (publishing is a hosting decision, not an access one).
+            if (!sourceConfig.IsStatic)
+                return Observable.Return(NotServable(sourceConfig.Name));
 
-            // ONE round trip for both candidate shapes: the named collection (when there is a file
-            // path after it) and the node's default content collection.
-            var candidates = remainderParts.Length >= 2 && explicitCollection != defaultCollection
-                ? new[] { explicitCollection, defaultCollection }
-                : [defaultCollection];
+            // The portal hub is where the resolved config is cached and the bytes are read.
+            // Fall back to the mesh hub for hosts that do not run the Blazor portal (the
+            // sidecar, tests) — the access decision has already been made above.
+            var portal = mainHub.ServiceProvider.GetService<PortalApplication>()?.Hub ?? mainHub;
+            var portalContentService = portal.ServiceProvider.GetService<IContentService>();
+            if (portalContentService is null)
+                return Observable.Return(Results.NotFound("Content service not configured"));
 
-            return mainHub.Observe(
-                    new GetDataRequest(new ContentCollectionReference(candidates)),
-                    o => o.WithTarget(targetAddress).WithAccessContext(caller))
-                .Take(1)
-                .SelectMany(collectionResponse =>
-                {
-                    var configs = ReadCollectionConfigs(collectionResponse);
-
-                    // Prefer the explicitly-named collection — there the file path is relative to
-                    // the COLLECTION's own root, exactly as the file browser lists it.
-                    //
-                    // Otherwise the node's default collection, with the whole remainder as a
-                    // NODE-relative path. A Space's `content` collection is mounted on the partition
-                    // ROOT and inherited by children (ExposeInChildren), so an inherited config
-                    // carries the ROOT's BasePath — the resolved node's own path relative to the
-                    // collection's owner has to be put back in front of the file. That is the
-                    // `content/{nodePath}/{file}` layout the backing store has always had, and the
-                    // reason `/static/storage/content/{nodePath}/{file}` resolved correctly.
-                    var (sourceConfig, filePath) =
-                        remainderParts.Length >= 2
-                        && configs?.FirstOrDefault(c => c.Name == explicitCollection) is { } named
-                            ? (named, string.Join('/', remainderParts.Skip(1)))
-                            : (configs?.FirstOrDefault(c => c.Name == defaultCollection),
-                                CombineOwnerRelative(
-                                    configs?.FirstOrDefault(c => c.Name == defaultCollection)?.Address,
-                                    resolution.Prefix,
-                                    resolution.Remainder!));
-
-                    if (sourceConfig is null)
-                        return Observable.Return(Results.NotFound(
-                            $"No content collection at '{resolution.Prefix}' serves '{resolution.Remainder}'"));
-
-                    // 🚨 MOUNT CHECK, default-closed. A collection is servable by URL only when it
-                    // declares it (ContentCollectionConfig.IsStatic). The flag existed but was read
-                    // NOWHERE — set at two sites, consulted at zero — so every collection registered
-                    // anywhere on the mesh was fetchable by URL. Not declared ⇒ 404, for every
-                    // caller alike (publishing is a hosting decision, not an access one).
-                    if (!sourceConfig.IsStatic)
-                        return Observable.Return(NotServable(sourceConfig.Name));
-
-                    if (string.IsNullOrEmpty(filePath))
-                        return Observable.Return(Results.NotFound("File path is required"));
-
-                    var qualifiedCollectionName = $"{resolution.Prefix}/{sourceConfig.Name}";
-                    var collectionConfig = sourceConfig with
-                    {
-                        Name = qualifiedCollectionName, Address = targetAddress
-                    };
-
-                    // The portal hub is where the resolved config is cached and the bytes are read.
-                    // Fall back to the mesh hub for hosts that do not run the Blazor portal (the
-                    // sidecar, tests) — the access decision has already been made above.
-                    var portal = mainHub.ServiceProvider.GetService<PortalApplication>()?.Hub ?? mainHub;
-                    var portalContentService = portal.ServiceProvider.GetService<IContentService>();
-                    if (portalContentService is null)
-                        return Observable.Return(Results.NotFound("Content service not configured"));
-
-                    portalContentService.AddConfiguration(collectionConfig);
-                    // Pure composition — collection resolution and the file read both run on the
-                    // collection's own IIoPool; ServeFile only shapes the (already-read) result.
-                    return portalContentService.GetCollection(qualifiedCollectionName)
-                        .SelectMany(contentCollection => contentCollection == null
-                            ? Observable.Return(Results.NotFound($"Content collection '{sourceConfig.Name}' not found"))
-                            : ServeFile(context, contentCollection, filePath));
-                });
+            portalContentService.AddConfiguration(resolution.QualifiedConfig);
+            // Pure composition — collection resolution and the file read both run on the
+            // collection's own IIoPool; ServeFile only shapes the (already-read) result.
+            return portalContentService.GetCollection(resolution.QualifiedName)
+                .SelectMany(contentCollection => contentCollection == null
+                    ? Observable.Return(Results.NotFound($"Content collection '{sourceConfig.Name}' not found"))
+                    : ServeFile(context, contentCollection, resolution.FilePath));
         });
     }
-
-    /// <summary>
-    /// Puts the resolved node's OWN path back in front of a node-relative file path when the
-    /// collection is inherited from an ancestor.
-    ///
-    /// <para>A Space's <c>content</c> collection is mounted on the partition root with
-    /// <c>ExposeInChildren</c>, so a child hub reports the ancestor's config verbatim — same
-    /// <c>BasePath</c>. The file of node <c>Org/Project</c> therefore lives at
-    /// <c>Project/{file}</c> inside it. Owner == node (or an unknown owner) ⇒ no prefix.</para>
-    /// </summary>
-    /// <param name="collectionOwner">The address the collection is registered on, if known.</param>
-    /// <param name="nodePath">The node the request resolved to.</param>
-    /// <param name="filePath">The node-relative file path.</param>
-    /// <returns>The collection-relative file path.</returns>
-    internal static string CombineOwnerRelative(Address? collectionOwner, string nodePath, string filePath)
-    {
-        var owner = collectionOwner?.ToString()?.Trim('/');
-        var node = nodePath.Trim('/');
-        if (string.IsNullOrEmpty(owner)
-            || string.Equals(owner, node, StringComparison.OrdinalIgnoreCase)
-            || !node.StartsWith(owner + "/", StringComparison.OrdinalIgnoreCase))
-            return filePath;
-        return $"{node[(owner.Length + 1)..]}/{filePath}";
-    }
-
-    /// <summary>
-    /// Projects the collection configs out of the owning hub's <c>GetDataResponse</c>. The remote
-    /// form arrives as a <see cref="JsonElement"/>; <see cref="ContentCollectionConfig.IsStatic"/>
-    /// and <see cref="ContentCollectionConfig.Address"/> MUST survive that projection — without the
-    /// first, every legitimately-published remote collection fails the mount check; without the
-    /// second, an inherited collection loses its owner and a child node's file resolves against the
-    /// ancestor's folder. <c>IsStatic</c> is suppressed when false, so an absent property means
-    /// false — the safe value either way.
-    /// </summary>
-    /// <summary>
-    /// Reads a collection config's owning address off the wire. Absent, non-string or empty ⇒
-    /// <c>null</c>, which <see cref="CombineOwnerRelative"/> treats as "owner unknown" and leaves
-    /// the file path alone — the conservative reading.
-    /// </summary>
-    private static Address? ToAddress(JsonElement element)
-    {
-        if (element.ValueKind != JsonValueKind.String)
-            return null;
-        var value = element.GetString();
-        if (string.IsNullOrEmpty(value))
-            return null;
-        return value;
-    }
-
-    private static IReadOnlyCollection<ContentCollectionConfig>? ReadCollectionConfigs(IMessageDelivery? delivery) =>
-        delivery?.Message switch
-        {
-            GetDataResponse { Data: JsonElement je } => je.EnumerateArray()
-                .Select(e => new ContentCollectionConfig
-                {
-                    Name = e.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? "" : "",
-                    SourceType = e.TryGetProperty("sourceType", out var typeProp) ? typeProp.GetString() ?? "" : "",
-                    BasePath = e.TryGetProperty("basePath", out var pathProp) ? pathProp.GetString() : null,
-                    IsStatic = e.TryGetProperty("isStatic", out var staticProp)
-                               && staticProp.ValueKind == JsonValueKind.True,
-                    Address = e.TryGetProperty("address", out var addressProp)
-                        ? ToAddress(addressProp)
-                        : null,
-                })
-                .ToArray(),
-            GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
-            _ => null
-        };
 
     /// <summary>
     /// The response for a collection that exists but does not declare itself servable by URL
@@ -613,14 +494,6 @@ public static class BlazorHostingExtensions
                     downloadName,
                     enableRangeProcessing: true));
             });
-
-    /// <summary>
-    /// Decodes a collection name from a URL by replacing '~' back to '/'.
-    /// Collection names with slashes (e.g., "Submissions@Microsoft/2026") are encoded
-    /// with '~' in URLs to avoid path parsing issues.
-    /// </summary>
-    private static string DecodeCollectionName(string encodedName)
-        => ContentCollectionsExtensions.DecodeCollectionName(encodedName);
 
     /// <summary>
     /// URL-decodes a content-collection file path captured from the <c>/static/{**path}</c>

--- a/src/MeshWeaver.Markdown.Export/Pixel/SlideAssetInliner.cs
+++ b/src/MeshWeaver.Markdown.Export/Pixel/SlideAssetInliner.cs
@@ -1,0 +1,150 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Markdown.Export.Pixel;
+
+/// <summary>
+/// One content-collection asset the print document referenced and the export could NOT read.
+/// </summary>
+/// <param name="Reference">The reference exactly as it appears in the document.</param>
+/// <param name="Reason">Why it could not be read — a sentence, safe to log or show.</param>
+public sealed record UnresolvedSlideAsset(string Reference, string Reason);
+
+/// <summary>
+/// The result of inlining a print document's assets: the rewritten document plus, explicitly, what
+/// was and was not resolved.
+///
+/// <para><b>Unresolved is a RESULT, not a log line.</b> Under the print document's CSP
+/// (<c>default-src 'none'; img-src data:</c>) an un-inlined reference is a <b>blank image</b> — the
+/// browser cannot fall back to fetching it. So "which assets did not resolve" has to leave this
+/// method as data the caller can act on, rather than a warning that scrolls past.</para>
+/// </summary>
+/// <param name="Html">The document with every resolved reference replaced by its <c>data:</c> URI.</param>
+/// <param name="Inlined">The references that were replaced.</param>
+/// <param name="Unresolved">The references that were left as links, each with its reason.</param>
+public sealed record SlideAssetInlining(
+    string Html,
+    ImmutableArray<string> Inlined,
+    ImmutableArray<UnresolvedSlideAsset> Unresolved);
+
+/// <summary>
+/// Reads every content-collection asset a composed print document references and rewrites it to a
+/// <c>data:</c> URI, so the document the headless browser prints is genuinely self-contained.
+///
+/// <para>The browser prints from a local file with no network and no session, and the document's
+/// CSP allows images only from <c>data:</c> — so this step is not an optimisation, it is the only
+/// way a stored picture reaches the PDF at all.</para>
+///
+/// <para><b>Resolution goes through <see cref="ContentFileResolver"/></b> — the same reading of an
+/// <c>/api/content/…</c> reference the content route itself performs (resolve the owning node, then
+/// its named-or-default collection, putting the node's own path back in front of the file when the
+/// collection is inherited). Splitting the string here instead is what made a stored slide image
+/// silently fail to inline: the markdown pipeline writes <c>api/content/{nodePath}/{file}</c>, whose
+/// first segment is the node's PARTITION, and reading that first segment as the collection name
+/// asks for a collection that does not exist (issue #990).</para>
+/// </summary>
+public static class SlideAssetInliner
+{
+    /// <summary>
+    /// Inlines the document's content-collection assets.
+    /// </summary>
+    /// <param name="html">The composed print document.</param>
+    /// <param name="hub">
+    /// The hub the export runs on — used to resolve the reference (path resolution + the owning
+    /// node's collection configs) and to read the bytes. The read runs under the caller's identity.
+    /// </param>
+    /// <returns>A single-emission observable of the rewritten document and what did not resolve.</returns>
+    public static IObservable<SlideAssetInlining> Inline(string html, IMessageHub hub)
+    {
+        var references = SlidePrintComposer.CollectAssetReferences(html);
+        if (references.Length == 0)
+            return Observable.Return(new SlideAssetInlining(html, [], []));
+
+        var contentService = hub.ServiceProvider.GetService<IContentService>();
+        if (contentService is null)
+            return Observable.Return(new SlideAssetInlining(html, [],
+                [.. references.Select(r => new UnresolvedSlideAsset(r,
+                    "this hub has no content service, so no collection can be read"))]));
+
+        // Independent reads, each on its collection's own I/O pool; Merge lets them overlap and
+        // ToArray waits for all of them. Order is restored from `references` below, so the result
+        // does not depend on which read finished first.
+        return references
+            .Select(reference => Read(hub, contentService, reference))
+            .Merge()
+            .ToArray()
+            .Select(reads => Apply(html, references, reads));
+    }
+
+    private static SlideAssetInlining Apply(
+        string html, ImmutableArray<string> references, IList<AssetRead> reads)
+    {
+        var byReference = reads.ToDictionary(r => r.Reference, StringComparer.Ordinal);
+        var dataUris = new Dictionary<string, string>(StringComparer.Ordinal);
+        var inlined = ImmutableArray.CreateBuilder<string>();
+        var unresolved = ImmutableArray.CreateBuilder<UnresolvedSlideAsset>();
+
+        foreach (var reference in references)
+        {
+            var read = byReference[reference];
+            if (read.Bytes is null)
+            {
+                unresolved.Add(new UnresolvedSlideAsset(reference, read.Reason ?? "unresolved"));
+                continue;
+            }
+            dataUris[reference] = SlidePrintComposer.ToDataUri(read.FilePath!, read.Bytes);
+            inlined.Add(reference);
+        }
+
+        return new SlideAssetInlining(
+            SlidePrintComposer.InlineAssets(html, dataUris),
+            inlined.ToImmutable(),
+            unresolved.ToImmutable());
+    }
+
+    private static IObservable<AssetRead> Read(
+        IMessageHub hub, IContentService contentService, string reference)
+    {
+        var relative = SlidePrintComposer.ToContentReference(reference);
+        if (relative is null)
+            return Observable.Return(
+                AssetRead.Failed(reference, "not a content-collection reference"));
+
+        return ContentFileResolver.Resolve(hub, relative)
+            .SelectMany(result =>
+            {
+                if (result.Resolution is null)
+                    return Observable.Return(
+                        AssetRead.Failed(reference, result.Reason ?? "could not be resolved"));
+
+                var resolution = result.Resolution;
+                // Register under the qualified name before reading, exactly as the content route
+                // does: two nodes inheriting the same ancestor collection must not share one cache
+                // entry.
+                contentService.AddConfiguration(resolution.QualifiedConfig);
+                return contentService.GetCollection(resolution.QualifiedName)
+                    .SelectMany(collection => collection is null
+                        ? Observable.Return(AssetRead.Failed(reference,
+                            $"content collection '{resolution.Collection.Name}' could not be opened"))
+                        : collection.GetContentBytes(resolution.FilePath)
+                            .Select(bytes => bytes is null
+                                ? AssetRead.Failed(reference,
+                                    $"'{resolution.FilePath}' is not in content collection "
+                                    + $"'{resolution.Collection.Name}'")
+                                : new AssetRead(reference, bytes, resolution.FilePath, null)));
+            })
+            // A faulted read is one asset's problem, and it must be REPORTED rather than either
+            // swallowed or allowed to fail the whole export — the caller decides what a missing
+            // picture is worth.
+            .Catch((Exception ex) => Observable.Return(AssetRead.Failed(reference, ex.Message)));
+    }
+
+    private sealed record AssetRead(string Reference, byte[]? Bytes, string? FilePath, string? Reason)
+    {
+        public static AssetRead Failed(string reference, string reason) =>
+            new(reference, null, null, reason);
+    }
+}

--- a/src/MeshWeaver.Markdown.Export/Pixel/SlideAssetInliner.cs
+++ b/src/MeshWeaver.Markdown.Export/Pixel/SlideAssetInliner.cs
@@ -69,12 +69,14 @@ public static class SlideAssetInliner
                 [.. references.Select(r => new UnresolvedSlideAsset(r,
                     "this hub has no content service, so no collection can be read"))]));
 
-        // Independent reads, each on its collection's own I/O pool; Merge lets them overlap and
-        // ToArray waits for all of them. Order is restored from `references` below, so the result
-        // does not depend on which read finished first.
+        // One asset at a time. Concat subscribes the next read only after the previous one
+        // completes, so a deck with a hundred pictures cannot fan a hundred simultaneous
+        // GetDataRequests at their owning hubs — the reads are pooled at the I/O leaf, but the
+        // resolution hop in front of each one is not. The bytes are the cost here, not the
+        // round-trips, and they are the same either way.
         return references
             .Select(reference => Read(hub, contentService, reference))
-            .Merge()
+            .Concat()
             .ToArray()
             .Select(reads => Apply(html, references, reads));
     }

--- a/src/MeshWeaver.Markdown.Export/Pixel/SlidePrintComposer.cs
+++ b/src/MeshWeaver.Markdown.Export/Pixel/SlidePrintComposer.cs
@@ -169,13 +169,18 @@ public static partial class SlidePrintComposer
     /// image.</para>
     ///
     /// <para>Percent-escapes are undone <b>per segment</b>
-    /// (<see cref="ContentCollectionsExtensions.DecodeCollectionPath"/>), never across the whole
-    /// string — the same decode the content route applies, and for the same reason: a top-level
-    /// segment IS a partition and the router lowercases it. Per-segment decoding cannot introduce
-    /// or remove a <c>/</c>, so it can never split, merge or rename a segment, and therefore cannot
-    /// create or mask a partition collision. The <c>~</c> form of a qualified collection name
-    /// (<see cref="ContentCollectionsExtensions.EncodeCollectionName"/>) is left for the resolver,
-    /// which decodes it on the one segment that can be a collection.</para>
+    /// (<see cref="ContentCollectionsExtensions.DecodeCollectionPath"/>) — the same decode the
+    /// content route applies, so a folder named <c>Data Extraction</c> matches whether it arrives
+    /// escaped or not.</para>
+    ///
+    /// <para><b>Decoding CAN introduce a separator</b>, and the guard for that is not here: an
+    /// escaped <c>%2F</c> unescapes to <c>/</c>, so a segment can become two. That is exactly why
+    /// <see cref="ContentFileResolver.Resolve"/> rejects an unsafe decoded reference
+    /// (<see cref="StaticAssetMount.IsSafeRelativePath"/>) before it resolves anything — this
+    /// method's job is to hand over the decoded string, not to decide it is safe. The <c>~</c> form
+    /// of a qualified collection name
+    /// (<see cref="ContentCollectionsExtensions.EncodeCollectionName"/>) is likewise left for the
+    /// resolver, which decodes it on the one segment that can be a collection.</para>
     /// </summary>
     /// <param name="reference">An asset reference as it appears in the composed document.</param>
     /// <returns>The decoded, prefix-less reference, or <c>null</c>.</returns>

--- a/src/MeshWeaver.Markdown.Export/Pixel/SlidePrintComposer.cs
+++ b/src/MeshWeaver.Markdown.Export/Pixel/SlidePrintComposer.cs
@@ -153,50 +153,52 @@ public static partial class SlidePrintComposer
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Splits an asset reference into the collection name and collection-relative path a
-    /// server-side read needs, or null when it is not a content-collection route.
+    /// Strips the content-route prefix off an asset reference and percent-decodes it, yielding the
+    /// <c>{node}/{collection}/{file}</c>-or-<c>{node}/{file…}</c> form
+    /// <see cref="ContentFileResolver.Resolve"/> takes — or null when the reference is not a
+    /// content-collection route at all.
     ///
-    /// <para>Normalisation goes through the framework's own reader,
-    /// <see cref="ContentPathReference.TryGetRelativePath"/> — which also folds out the
-    /// default-collection segment of <c>/api/content/{collection}/content/{path}</c> — and the
-    /// first-segment-names-the-collection split is the same one <c>BrandingResolver</c> uses for
-    /// exactly this job. One convention for reading content server-side, not two.</para>
+    /// <para><b>It does NOT split off a collection, deliberately.</b> Which segments name the node
+    /// and which name the collection cannot be read off the string: the markdown pipeline writes
+    /// <c>api/content/{nodePath}/{file}</c>, where the first segment is the node's PARTITION rather
+    /// than a collection, and a node path is any number of segments long. Only the resolver — which
+    /// resolves the owning node and asks it which collections it has — can tell the two shapes
+    /// apart. Splitting here instead is exactly how a stored slide image came to fail silently
+    /// (issue #990): the split asked the content service for a collection named after the
+    /// partition, which does not exist, and the CSP turned the un-inlined reference into a blank
+    /// image.</para>
     ///
-    /// <para><b>Both segments are decoded, each with the decoder that matches how it was
-    /// encoded.</b> A collection name carries <c>/</c> as <c>~</c>
-    /// (<see cref="ContentCollectionsExtensions.EncodeCollectionName"/>), so leaving it encoded
-    /// asks the content service for a collection that does not exist and the asset silently stays
-    /// broken. Percent-escapes are then undone <b>per segment</b>
+    /// <para>Percent-escapes are undone <b>per segment</b>
     /// (<see cref="ContentCollectionsExtensions.DecodeCollectionPath"/>), never across the whole
-    /// string: that is deliberate, because a top-level segment IS a partition and the router
-    /// lowercases it. Per-segment decoding cannot introduce or remove a <c>/</c>, so it can never
-    /// split, merge or rename a segment — and therefore cannot create or mask a partition
-    /// collision. Nothing here case-folds; the value is passed through exactly as authored.</para>
+    /// string — the same decode the content route applies, and for the same reason: a top-level
+    /// segment IS a partition and the router lowercases it. Per-segment decoding cannot introduce
+    /// or remove a <c>/</c>, so it can never split, merge or rename a segment, and therefore cannot
+    /// create or mask a partition collision. The <c>~</c> form of a qualified collection name
+    /// (<see cref="ContentCollectionsExtensions.EncodeCollectionName"/>) is left for the resolver,
+    /// which decodes it on the one segment that can be a collection.</para>
     /// </summary>
-    public static (string Collection, string Path)? ParseAssetReference(string reference)
+    /// <param name="reference">An asset reference as it appears in the composed document.</param>
+    /// <returns>The decoded, prefix-less reference, or <c>null</c>.</returns>
+    public static string? ToContentReference(string reference)
     {
         if (!AssetReferenceRegex().IsMatch(reference))
             return null;
 
-        // TryGetRelativePath matches on the rooted route prefix; our references are captured from
-        // markup and may be site-relative.
-        var rooted = reference.StartsWith('/') ? reference : "/" + reference;
-        var relative = ContentPathReference.TryGetRelativePath(rooted);
-        if (string.IsNullOrEmpty(relative))
+        // References are captured from markup and are site-relative (no leading slash); the route
+        // prefix is rooted.
+        var rooted = reference.Replace('\\', '/');
+        if (!rooted.StartsWith('/'))
+            rooted = "/" + rooted;
+
+        var prefix = ContentCollectionsExtensions.ContentFileRoutePrefix + "/";
+        if (!rooted.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             return null;
 
-        relative = relative.Replace('\\', '/').TrimStart('/');
-        var slash = relative.IndexOf('/');
-        if (slash <= 0 || slash == relative.Length - 1)
-            return null;
+        var relative = ContentCollectionsExtensions
+            .DecodeCollectionPath(rooted[prefix.Length..])
+            .TrimStart('/');
 
-        var collection = ContentCollectionsExtensions.DecodeCollectionPath(
-            ContentCollectionsExtensions.DecodeCollectionName(relative[..slash]));
-        var path = ContentCollectionsExtensions.DecodeCollectionPath(relative[(slash + 1)..]);
-
-        return string.IsNullOrEmpty(collection) || string.IsNullOrEmpty(path)
-            ? null
-            : (collection, path);
+        return string.IsNullOrEmpty(relative) ? null : relative;
     }
 
     // api/content/{collection}/{path} — optionally leading '/', stopping at a quote, whitespace,

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
@@ -147,8 +147,16 @@ if (rootNode.NodeType == DeckNodeType.NodeType)
 
         // Images live behind the access-controlled api/content route, which a file:// document
         // cannot fetch. Resolve them here — under the exporting user's identity — and inline them
-        // so the print document is genuinely self-contained.
-        html = await InlineSlideAssets(html, Mesh, Log, Ct);
+        // so the print document is genuinely self-contained. An asset that cannot be read is left
+        // as a link and named in the log: under the print document's CSP that is a BLANK image, so
+        // it must never pass unremarked.
+        var inlining = await SlideAssetInliner.Inline(html, Mesh).FirstAsync().ToTask(Ct);
+        html = inlining.Html;
+        foreach (var unresolved in inlining.Unresolved)
+            Log.LogWarning("Slide asset {Reference} could not be inlined ({Reason}); it will print "
+                           + "as a blank image", unresolved.Reference, unresolved.Reason);
+        Log.LogInformation("Inlined {Inlined}/{Total} slide assets",
+            inlining.Inlined.Length, inlining.Inlined.Length + inlining.Unresolved.Length);
 
         var pixelBytes = await renderer.Render(html).FirstAsync().ToTask(Ct);
         Log.LogInformation("Rendered {Bytes} bytes (pixel-faithful)", pixelBytes.Length);
@@ -237,61 +245,6 @@ return new RenderedDocument(
     Sanitize(title) + ".pdf",
     "application/pdf",
     bytes);
-
-// Resolves every `api/content/{collection}/{path}` reference the composed print document carries
-// and rewrites it to a data: URI, so the headless browser — which prints from a local file with no
-// network and no session — still sees the deck's images. An asset that cannot be read is left as a
-// link and logged: a missing picture must not fail the whole export, it renders broken exactly as
-// it would on screen.
-static async Task<string> InlineSlideAssets(
-    string html, IMessageHub mesh, ILogger log, CancellationToken ct)
-{
-    var references = SlidePrintComposer.CollectAssetReferences(html);
-    if (references.Length == 0)
-        return html;
-
-    var contentService = mesh.ServiceProvider.GetService<IContentService>();
-    if (contentService is null)
-    {
-        log.LogWarning("No content service available; {Count} slide asset(s) stay as links", references.Length);
-        return html;
-    }
-
-    var inlined = new Dictionary<string, string>(StringComparer.Ordinal);
-    foreach (var reference in references)
-    {
-        var parsed = SlidePrintComposer.ParseAssetReference(reference);
-        if (parsed is null)
-            continue;
-
-        try
-        {
-            var stream = await contentService
-                .GetContent(parsed.Value.Collection, parsed.Value.Path)
-                .FirstAsync()
-                .ToTask(ct);
-            if (stream is null)
-            {
-                log.LogWarning("Slide asset {Reference} not found; leaving it as a link", reference);
-                continue;
-            }
-
-            using (stream)
-            {
-                using var buffer = new MemoryStream();
-                await stream.CopyToAsync(buffer, ct);
-                inlined[reference] = SlidePrintComposer.ToDataUri(parsed.Value.Path, buffer.ToArray());
-            }
-        }
-        catch (Exception ex)
-        {
-            log.LogWarning(ex, "Could not inline slide asset {Reference}; leaving it as a link", reference);
-        }
-    }
-
-    log.LogInformation("Inlined {Inlined}/{Total} slide assets", inlined.Count, references.Length);
-    return SlidePrintComposer.InlineAssets(html, inlined);
-}
 
 static string ExtractMarkdown(MeshNode node)
 {

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
@@ -4,16 +4,20 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Messaging;
 using MeshWeaver.Markdown.Export.Pixel;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using UglyToad.PdfPig;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Monolith.Test;
@@ -90,9 +94,9 @@ public class DeckAssetInliningTest(ITestOutputHelper output) : MonolithMeshTestB
     {
         var (space, _, slidePath) = await CreateDeck("![logo](logo.png)");
         var logo = Payload(1);
-        // Where the portal puts a node's image: the partition root's `content` collection, at the
-        // node-relative path. Written through the SAME resolution the reader uses, so the test
-        // cannot quietly agree with itself about a layout the product does not use.
+        // Where the portal puts a node's image: the node's default `content` collection. Written
+        // through the SAME resolution the reader uses, so the test cannot quietly agree with itself
+        // about a layout the product does not use.
         await StoreAsset($"{slidePath}/logo.png", logo);
 
         var inlining = await Inline(space, slidePath, "![logo](logo.png)");
@@ -173,6 +177,79 @@ public class DeckAssetInliningTest(ITestOutputHelper output) : MonolithMeshTestB
                  })
             inlining.Html.Should().Contain($"data:image/png;base64,{Convert.ToBase64String(payload)}",
                 because: $"the {label} shape must reach the document as its own bytes");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
+    /// The whole path, through the mesh: a real <c>ExportDocumentRequest</c> with
+    /// <see cref="ExportFidelity.Pixel"/> against a deck whose slide references a stored image.
+    ///
+    /// <para>Never skipped. The pixel branch needs a headless browser and whether one exists is a
+    /// property of the machine, so this asks the renderer's own probe and asserts the contract that
+    /// applies: with a browser, a PDF that actually carries an embedded image; without one, the
+    /// actionable refusal. The inlining assertion — that the activity reported no unresolved asset
+    /// — is checked whenever the export ran at all.</para>
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task The_export_embeds_the_stored_image_or_refuses_clearly()
+    {
+        var (space, deck, slidePath) = await CreateDeck("# Cover\n\n![logo](logo.png)");
+        await StoreAsset($"{slidePath}/logo.png", Payload(7));
+
+        var request = new ExportDocumentRequest(deck, new DocumentExportOptions
+        {
+            Format = ExportFormat.Pdf,
+            Fidelity = ExportFidelity.Pixel,
+            CoverPage = false,
+            TableOfContents = false
+        });
+
+        var dispatch = await Mesh
+            .Observe<ExportDocumentResponse>(request, o => o.WithTarget(new Address(deck)))
+            .Should().Within(30.Seconds()).Emit();
+        dispatch.Message.Error.Should().BeNullOrEmpty("the export should start successfully");
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var terminal = await workspace
+            .GetMeshNodeStream(dispatch.Message.ActivityPath)
+            .Select(node => node?.Content as ActivityLog)
+            .Should().Within(2.Minutes())
+            .Match(log => log is not null && log.Status != ActivityStatus.Running);
+
+        // Ask the SAME probe the export asked, so the expectation can never disagree with what the
+        // script actually found.
+        var renderer = Mesh.ServiceProvider.GetRequiredService<IPixelPdfRenderer>();
+        var executable = await renderer.Probe().FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        Output.WriteLine($"Pixel renderer executable: {executable ?? "<none>"}");
+
+        var messages = string.Join("\n  ", terminal!.Messages.Select(m => $"[{m.LogLevel}] {m.Message}"));
+
+        if (executable is null)
+        {
+            terminal.Status.Should().Be(ActivityStatus.Failed,
+                because: "pixel fidelity without a browser must refuse, never quietly downgrade. "
+                         + $"Messages:\n  {messages}");
+            messages.Should().Contain("headless Chromium");
+            await NodeFactory.DeleteNode(space).Should().Emit();
+            return;
+        }
+
+        terminal.Status.Should().Be(ActivityStatus.Succeeded, because: $"Messages:\n  {messages}");
+        messages.Should().Contain("Inlined 1/1 slide assets",
+            because: $"the deck's one stored image had to be inlined. Messages:\n  {messages}");
+        messages.Should().NotContain("blank image",
+            because: $"nothing may have been left unresolved. Messages:\n  {messages}");
+
+        var rendered = terminal.ReturnValue!.Value.Deserialize<RenderedDocument>(Mesh.JsonSerializerOptions);
+        rendered!.Content.Should().NotBeNull().And.NotBeEmpty();
+
+        using var pdf = PdfDocument.Open(rendered.Content);
+        var images = pdf.GetPages().SelectMany(p => p.GetImages()).ToList();
+        Output.WriteLine($"pages={pdf.NumberOfPages} images={images.Count}");
+        images.Should().NotBeEmpty(
+            "the stored PNG must reach the printed page — the CSP denies every other way it could, "
+            + "so an empty page here IS the blank-image defect this test exists to catch");
 
         await NodeFactory.DeleteNode(space).Should().Emit();
     }

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Pixel;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The end-to-end contract for the pixel export's asset inlining (issue #990): a slide that
+/// references an image stored in a REAL content collection prints with that image <b>embedded as a
+/// <c>data:</c> URI</b>.
+///
+/// <para><b>Why this is not a nice-to-have.</b> The print document declares
+/// <c>default-src 'none'; img-src data:</c> and the browser runs with no DNS, so a reference that
+/// fails to inline cannot fall back to fetching itself: it is a <b>blank image in the user's PDF</b>.
+/// Inlining is therefore load-bearing for correctness, and "the parse is unit-tested" does not cover
+/// it — the parse never meets a collection. This test does, on a mesh that mounts content the way
+/// the portal does: a default <c>content</c> collection per node over a shared store, plus named
+/// collections beside it, so both of the content route's shapes
+/// (<c>{node}/{collection}/{file}</c> and <c>{node}/{file…}</c>) are exercised.</para>
+///
+/// <para>Composing and inlining need no browser, so the whole contract runs on every machine. The
+/// last test drives the real export through the mesh and asserts whichever contract the machine
+/// supports, exactly as <see cref="DeckPixelExportScriptRelayTest"/> does.</para>
+/// </summary>
+public class DeckAssetInliningTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly string storageRoot =
+        Path.Combine(Path.GetTempPath(), $"mw-deck-assets-{Guid.NewGuid():N}");
+
+    /// <summary>A qualified collection name — its '/' travels through a URL as '~'.</summary>
+    private const string QualifiedCollection = "Media/2026";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMarkdownExport(cfg => cfg.PixelRendering = cfg.PixelRendering with
+            {
+                // Chromium's sandbox needs unprivileged user namespaces, which Ubuntu 24.04 (and
+                // therefore the CI runner) restricts by default.
+                NoSandbox = OperatingSystem.IsLinux(),
+            })
+            .ConfigureDefaultNodeHub(config =>
+            {
+                // Per-node collections over a shared store — the shape the content route serves and
+                // the shape `MapContentCollection("attachments", "storage", $"attachments/{node}")`
+                // gives every node in the portal. A default `content` collection plus two named
+                // ones, so the test exercises both of the route's shapes.
+                var nodePath = config.Address.ToString();
+                if (string.IsNullOrEmpty(nodePath))
+                    return config;
+
+                return config
+                    .AddContentCollection(_ => Collection(
+                        ContentCollectionsExtensions.DefaultCollectionName, "content", nodePath))
+                    .AddContentCollection(_ => Collection("attachments", "attachments", nodePath))
+                    .AddContentCollection(_ => Collection(QualifiedCollection, "media", nodePath));
+            });
+
+    private ContentCollectionConfig Collection(string name, string folder, string nodePath)
+    {
+        var dir = Path.Combine(storageRoot, folder, nodePath);
+        Directory.CreateDirectory(dir);
+        return new ContentCollectionConfig
+        {
+            Name = name,
+            SourceType = "FileSystem",
+            BasePath = dir,
+            IsEditable = true,
+            ExposeInChildren = true,
+            IsStatic = true,
+            Settings = new Dictionary<string, string> { ["BasePath"] = dir },
+        };
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task A_stored_slide_image_is_embedded_as_a_data_uri()
+    {
+        var (space, _, slidePath) = await CreateDeck("![logo](logo.png)");
+        var logo = Payload(1);
+        // Where the portal puts a node's image: the partition root's `content` collection, at the
+        // node-relative path. Written through the SAME resolution the reader uses, so the test
+        // cannot quietly agree with itself about a layout the product does not use.
+        await StoreAsset($"{slidePath}/logo.png", logo);
+
+        var inlining = await Inline(space, slidePath, "![logo](logo.png)");
+
+        inlining.Unresolved.Should().BeEmpty(
+            "a stored image must resolve; under the print CSP an un-inlined reference is a blank image");
+        inlining.Inlined.Should().HaveCount(1);
+        inlining.Html.Should().Contain($"data:image/png;base64,{Convert.ToBase64String(logo)}",
+            "the document must carry the image's own bytes, not a link to them");
+        inlining.Html.Should().NotContain("api/content/",
+            "every reference was resolved, so none may survive as a link the CSP will block");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task An_unresolvable_reference_is_reported_rather_than_silently_blank()
+    {
+        var (space, _, slidePath) = await CreateDeck("![missing](nowhere.png)");
+
+        var inlining = await Inline(space, slidePath, "![missing](nowhere.png)");
+
+        inlining.Inlined.Should().BeEmpty();
+        inlining.Unresolved.Should().HaveCount(1,
+            "the export must SAY an asset did not resolve — the CSP turns a quiet miss into a blank "
+            + "image, which looks like a rendering bug rather than a missing file");
+        var unresolved = inlining.Unresolved.Single();
+        unresolved.Reference.Should().EndWith("nowhere.png");
+        unresolved.Reason.Should().NotBeNullOrWhiteSpace(
+            "the report has to name what went wrong, or it is just a different kind of silence");
+        Output.WriteLine($"unresolved: {unresolved.Reference} — {unresolved.Reason}");
+
+        inlining.Html.Should().Contain(unresolved.Reference,
+            "an unresolved reference is left alone rather than dropped, so the document still shows "
+            + "where the picture belonged");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Every_reference_shape_resolves_against_a_real_collection()
+    {
+        // One slide carrying every shape the product renders or a user pastes back in.
+        var nodeRelative = Payload(2);      // api/content/{node}/{file}         → default collection
+        var explicitDefault = Payload(3);   // api/content/{node}/content/{file} → default, named
+        var namedCollection = Payload(4);   // api/content/{node}/attachments/…  → named collection
+        var tildeCollection = Payload(5);   // api/content/{node}/Media~2026/…   → '~' decoded to '/'
+        var percentEscaped = Payload(6);    // api/content/{node}/a%20folder/…   → per-segment decode
+
+        var (space, _, slidePath) = await CreateDeck("");
+
+        await StoreAsset($"{slidePath}/logo.png", nodeRelative);
+        await StoreAsset($"{slidePath}/content/banner.png", explicitDefault);
+        await StoreAsset($"{slidePath}/attachments/chart.png", namedCollection);
+        await StoreAsset($"{slidePath}/Media~2026/cover.png", tildeCollection);
+        await StoreAsset($"{slidePath}/a folder/logo two.png", percentEscaped);
+
+        var markdown =
+            "![node-relative](logo.png)\n\n"
+            + "![percent-escaped](a%20folder/logo%20two.png)\n\n"
+            + $"<img src=\"/api/content/{slidePath}/content/banner.png\" alt=\"explicit default\" />\n\n"
+            + $"<img src=\"/api/content/{slidePath}/attachments/chart.png\" alt=\"named\" />\n\n"
+            + $"<img src=\"/api/content/{slidePath}/Media~2026/cover.png\" alt=\"qualified\" />";
+
+        var inlining = await Inline(space, slidePath, markdown);
+
+        inlining.Unresolved.Should().BeEmpty(
+            "every one of these shapes is a shape the content route serves, so every one must inline");
+        inlining.Inlined.Should().HaveCount(5);
+
+        foreach (var (label, payload) in new (string, byte[])[]
+                 {
+                     ("node-relative", nodeRelative),
+                     ("explicit default collection", explicitDefault),
+                     ("named collection", namedCollection),
+                     ("'~'-encoded qualified collection name", tildeCollection),
+                     ("percent-escaped segments", percentEscaped),
+                 })
+            inlining.Html.Should().Contain($"data:image/png;base64,{Convert.ToBase64String(payload)}",
+                because: $"the {label} shape must reach the document as its own bytes");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
+    /// Creates a Space, a Deck and one Slide, and returns their paths. The slide node has to exist:
+    /// the reference resolves through <see cref="MeshWeaver.Mesh.Services.IPathResolver"/>, which is
+    /// what decides where the node path stops and the file path starts.
+    /// </summary>
+    private async Task<(string Space, string Deck, string Slide)> CreateDeck(string slideBody)
+    {
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        var deck = $"{space}/pitch";
+        var slide = $"{deck}/intro";
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Asset Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space()
+        }).Should().Emit();
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(deck) with
+        {
+            Name = "Pitch",
+            NodeType = DeckNodeType.NodeType,
+            Content = new DeckContent { Title = "Pitch", Slides = [slide] }
+        }).Should().Emit();
+
+        await NodeFactory.CreateNode(MeshNode.FromPath(slide) with
+        {
+            Name = "Intro",
+            NodeType = SlideNodeType.NodeType,
+            Order = 1,
+            Content = new SlideContent { Content = slideBody }
+        }).Should().Emit();
+
+        return (space, deck, slide);
+    }
+
+    /// <summary>
+    /// Composes the print document for one slide exactly as the export template does — the slide's
+    /// own path is both the markdown pipeline's node path and its collection — and inlines it.
+    /// </summary>
+    private async Task<SlideAssetInlining> Inline(string space, string slidePath, string markdown)
+    {
+        var html = SlidePrintComposer.Compose(
+            "Pitch", [new PrintSlide(new SlideContent { Content = markdown }, slidePath, slidePath)]);
+        foreach (var reference in SlidePrintComposer.CollectAssetReferences(html))
+            Output.WriteLine($"reference: {reference}");
+
+        var hub = Mesh.GetHostedHub(new Address(space), HostedHubCreation.Always)!;
+        return await SlideAssetInliner.Inline(html, hub)
+            .FirstAsync().ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Stores bytes at the location an <c>/api/content/…</c> reference names, using the product's
+    /// own resolution — the same one <c>MeshOperations.Upload</c> and the content route use. The
+    /// test therefore never encodes its own opinion about where a node's file lives on disk.
+    /// </summary>
+    private async Task StoreAsset(string reference, byte[] bytes)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var result = await ContentFileResolver.Resolve(Mesh, reference)
+            .FirstAsync().ToTask(ct);
+        result.Resolution.Should().NotBeNull(
+            because: $"the test cannot store '{reference}' if the product cannot say where it goes "
+                     + $"({result.Reason})");
+
+        var resolution = result.Resolution!;
+        var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
+        contentService.AddConfiguration(resolution.QualifiedConfig);
+        var collection = await contentService.GetCollection(resolution.QualifiedName)
+            .FirstAsync().ToTask(ct);
+        collection.Should().NotBeNull();
+
+        var directory = Path.GetDirectoryName(resolution.FilePath)?.Replace('\\', '/') ?? "";
+        await collection!
+            .SaveFile(directory, Path.GetFileName(resolution.FilePath), () => new MemoryStream(bytes))
+            .ToTask(ct);
+        Output.WriteLine(
+            $"stored '{reference}' → collection '{resolution.QualifiedName}' at '{resolution.FilePath}'");
+    }
+
+    /// <summary>
+    /// A real 1×1 PNG whose single pixel byte varies, so a test can tell one asset's bytes from
+    /// another's in the composed document.
+    /// </summary>
+    private static byte[] Payload(byte seed) =>
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE,
+        0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54,
+        0x08, 0xD7, 0x63, seed, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
+        0x18, 0xDD, 0x8D, 0xB0,
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    ];
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckAssetInliningTest.cs
@@ -136,6 +136,39 @@ public class DeckAssetInliningTest(ITestOutputHelper output) : MonolithMeshTestB
         await NodeFactory.DeleteNode(space).Should().Emit();
     }
 
+    /// <summary>
+    /// A slide body is user-authored and passes raw HTML through verbatim, so an author can point
+    /// the SERVER at a path of their choosing. The export reads under the portal's own filesystem
+    /// access, and a FileSystem-backed collection resolves a collection-relative path with a bare
+    /// <c>Path.Combine</c> — so a traversal would read another partition's files. <c>%2E%2E</c>
+    /// survives URL normalisation and only becomes <c>..</c> once the reference is decoded, which
+    /// is why the refusal has to happen after decoding and before resolving.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_traversal_reference_is_refused_rather_than_read()
+    {
+        var (space, _, slidePath) = await CreateDeck("");
+        // A file in ANOTHER node's collection — the slide has no reference that legitimately
+        // reaches it. Two levels up from the slide's own collection directory is exactly where it
+        // sits on disk, so without the guard this traversal succeeds and returns its bytes.
+        var secret = Payload(9);
+        await StoreAsset($"{space}/logo.png", secret);
+
+        var markdown =
+            $"<img src=\"/api/content/{slidePath}/content/%2E%2E/%2E%2E/logo.png\" alt=\"escape\" />";
+
+        var inlining = await Inline(space, slidePath, markdown);
+
+        inlining.Inlined.Should().BeEmpty("a traversal must never be read, however it is escaped");
+        inlining.Html.Should().NotContain(Convert.ToBase64String(secret),
+            "no byte reached the document through a '..' path");
+        inlining.Unresolved.Should().ContainSingle()
+            .Which.Reason.Should().Contain("Invalid content path",
+                "the refusal is explicit, so an author sees a rejected reference rather than silence");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
     [Fact(Timeout = 120000)]
     public async Task Every_reference_shape_resolves_against_a_real_collection()
     {

--- a/test/MeshWeaver.Markdown.Export.Test/SlidePrintComposerTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/SlidePrintComposerTests.cs
@@ -217,29 +217,17 @@ public class SlidePrintComposerTests
     }
 
     [Fact]
-    public void An_asset_reference_splits_into_collection_and_path()
+    public void A_reference_keeps_every_segment_the_resolver_needs()
     {
-        var parsed = SlidePrintComposer.ParseAssetReference("api/content/Space%2FDeck/images%2Fbg.png");
-
-        parsed.Should().NotBeNull();
-        // The COLLECTION is decoded too, not just the path. Handing the content service a still-
-        // encoded name asks for a collection that does not exist, and the asset silently stays
-        // broken — which now means a missing image, since the print document's CSP denies the
-        // remote fetch that used to paper over it.
-        parsed!.Value.Collection.Should().Be("Space/Deck");
-        parsed.Value.Path.Should().Be("images/bg.png");
-    }
-
-    [Fact]
-    public void A_qualified_collection_name_is_decoded_from_its_tilde_form()
-    {
-        // EncodeCollectionName maps '/' to '~' precisely because ASP.NET Core decodes %2F before
-        // route matching — so '~' is the shape a qualified name actually arrives in.
-        var parsed = SlidePrintComposer.ParseAssetReference("api/content/Submissions@Microsoft~2026/logo.png");
-
-        parsed.Should().NotBeNull();
-        parsed!.Value.Collection.Should().Be("Submissions@Microsoft/2026");
-        parsed.Value.Path.Should().Be("logo.png");
+        // Site-relative in, route-prefix off, nothing else touched. The node/collection boundary is
+        // NOT decided here: the markdown pipeline writes api/content/{nodePath}/{file}, whose first
+        // segment is the node's PARTITION, and a node path is any number of segments long. Only
+        // ContentFileResolver — which resolves the owning node and asks it which collections it has
+        // — can tell that apart from api/content/{node}/{collection}/{file}. Splitting the string
+        // here is what asked the content service for a collection named after the partition, and
+        // under the print CSP that miss is a blank image (issue #990).
+        SlidePrintComposer.ToContentReference("api/content/Space/Deck/s1/images/bg.png")
+            .Should().Be("Space/Deck/s1/images/bg.png");
     }
 
     [Fact]
@@ -249,29 +237,29 @@ public class SlidePrintComposerTests
         // introduce or remove a '/' could split, merge or rename a partition — creating or masking
         // exactly the Acme/ACME collision PR #983 hit. Per-segment decoding cannot: an escaped
         // separator stays inside its own segment, and nothing here case-folds.
-        var parsed = SlidePrintComposer.ParseAssetReference("api/content/Acme/a%20folder/file%20name.png");
-
-        parsed.Should().NotBeNull();
-        parsed!.Value.Collection.Should().Be("Acme", "the partition segment is passed through verbatim");
-        parsed.Value.Path.Should().Be("a folder/file name.png");
+        SlidePrintComposer.ToContentReference("api/content/Acme/a%20folder/file%20name.png")
+            .Should().Be("Acme/a folder/file name.png");
     }
 
     [Fact]
-    public void The_default_collection_segment_is_folded_out_like_every_other_server_side_read()
+    public void The_tilde_form_of_a_qualified_collection_name_is_left_for_the_resolver()
     {
-        // /api/content/{collection}/content/{path} is the shape the product renders; the framework's
-        // own reader folds the default-collection segment out, and this must agree with it rather
-        // than invent a second convention.
-        var parsed = SlidePrintComposer.ParseAssetReference("/api/content/Space/content/images/bg.png");
-
-        parsed.Should().NotBeNull();
-        parsed!.Value.Collection.Should().Be("Space");
-        parsed.Value.Path.Should().Be("images/bg.png");
+        // EncodeCollectionName maps '/' to '~' precisely because ASP.NET Core decodes %2F before
+        // route matching — so '~' is the shape a qualified name actually arrives in. Decoding it
+        // here would turn one segment into two and destroy the node/collection boundary before the
+        // resolver ever sees it; the resolver decodes it on the one segment that can be a collection.
+        SlidePrintComposer.ToContentReference("api/content/Space/Submissions@Microsoft~2026/logo.png")
+            .Should().Be("Space/Submissions@Microsoft~2026/logo.png");
     }
+
+    [Fact]
+    public void A_rooted_reference_and_a_site_relative_one_read_the_same()
+        => SlidePrintComposer.ToContentReference("/api/content/Space/content/images/bg.png")
+            .Should().Be(SlidePrintComposer.ToContentReference("api/content/Space/content/images/bg.png"));
 
     [Fact]
     public void A_non_content_reference_does_not_parse()
-        => SlidePrintComposer.ParseAssetReference("https://example.com/x.png").Should().BeNull();
+        => SlidePrintComposer.ToContentReference("https://example.com/x.png").Should().BeNull();
 
     private static int CountOf(string haystack, string needle)
     {

--- a/test/MeshWeaver.Markdown.Export.Test/SlidePrintComposerTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/SlidePrintComposerTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown.Export.Pixel;
@@ -231,14 +232,26 @@ public class SlidePrintComposerTests
     }
 
     [Fact]
-    public void Decoding_never_changes_how_many_segments_a_reference_has()
+    public void Percent_escaped_segments_are_decoded_so_a_real_folder_name_matches()
     {
-        // A top-level segment IS a partition and the router lowercases it, so a decoder that could
-        // introduce or remove a '/' could split, merge or rename a partition — creating or masking
-        // exactly the Acme/ACME collision PR #983 hit. Per-segment decoding cannot: an escaped
-        // separator stays inside its own segment, and nothing here case-folds.
+        // A folder named "Data Extraction" arrives as "Data%20Extraction"; the collection's item
+        // names carry the decoded characters, so an undecoded reference never matches and the asset
+        // silently stays broken. Nothing here case-folds — a top-level segment IS a partition.
         SlidePrintComposer.ToContentReference("api/content/Acme/a%20folder/file%20name.png")
             .Should().Be("Acme/a folder/file name.png");
+    }
+
+    [Fact]
+    public void An_escaped_separator_really_does_become_one_which_is_why_the_resolver_guards()
+    {
+        // Decoding CAN split a segment: %2F unescapes to '/'. This method does not pretend
+        // otherwise and does not police it — ContentFileResolver rejects an unsafe decoded
+        // reference before resolving anything, which is where a traversal has to be stopped
+        // (%2E%2E survives URL normalisation and only becomes '..' here).
+        SlidePrintComposer.ToContentReference("api/content/Acme/%2E%2E%2F%2E%2E/secrets.png")
+            .Should().Be("Acme/../../secrets.png");
+        StaticAssetMount.IsSafeRelativePath("Acme/../../secrets.png").Should().BeFalse(
+            "the decoded reference is what the resolver refuses");
     }
 
     [Fact]


### PR DESCRIPTION
Refs #990

## The gap PR #1009 flagged, and what was hiding in it

#1009 shipped pixel-faithful deck export and closed with one open item, in its own words:

> **Asset inlining has no end-to-end test against a real content collection.** … "a slide with a stored image exports with that image embedded" is unverified. This matters more under the new CSP: a reference that fails to resolve is now a **missing image** rather than a silently-remote one.

I wrote that test. It failed. **Every stored slide image printed blank**, and had done since the feature merged.

## The defect

The markdown pipeline rewrites a slide's `![logo](logo.png)` onto `api/content/{nodePath}/{file}` — the same href the live view renders (`MarkdownView` passes `Stream.Owner`, the composer passes `slide.Path`; they agree by construction). The **first segment of that href is the node's partition**.

`ParseAssetReference` read the first segment as the **collection name**. So for a slide at `Space123/pitch/intro` the export asked `IContentService.GetContent("Space123", "pitch/intro/logo.png")`. There is no collection named `Space123`; `GetContent` throws for an unknown collection; the export template caught it, logged a warning and moved on.

Before #1009 that produced a slow-but-correct PDF, because the un-inlined `api/content/…` reference was still fetchable. Under the new CSP (`default-src 'none'; img-src data:`) plus the no-DNS process flags, it cannot be fetched. So the visible result changed from "slow" to **blank**, which is exactly the risk #1009 named.

The convention itself is not wrong, it is *the wrong reader for this shape*: first-segment-names-the-collection is right for an authored `content:{collection}/{path}` reference (what `BrandingResolver` reads) and wrong for every URL the product renders. The two readings agree on the file path and disagree on the collection — which is why it fails as "collection not found" rather than as anything that looks like a bug.

## The fix: one server-side reading of a content reference, not two

`ContentFileResolver` (new, in `MeshWeaver.ContentCollections`) holds the algorithm the HTTP content route already implemented privately: resolve the owning node with `IPathResolver` (longest real-node prefix), ask **that node's hub** for its collections via the `[RequiresPermission(Read)]`-carrying `GetDataRequest`, then take the named collection when the first remaining segment is one and the node's default `content` collection otherwise, putting the node's own path back in front of the file when the collection is inherited (`CombineOwnerRelative`).

- **`BlazorHostingExtensions.ResolveContentFile` now delegates to it.** Same permission hop, same `IsStatic` mount check, same 404 texts — the logic moved, it did not change.
- **The export uses it too**, through a new `SlideAssetInliner`, which also lifts the inlining loop out of `ExportPdf.csx` — where it was untestable, which is *why* the gap existed.
- `ParseAssetReference` is replaced by **`ToContentReference`**: strips the route prefix and percent-decodes per segment, and deliberately does **not** split off a collection. Which segments name the node cannot be read off the string, and pretending otherwise is the whole bug. (It also no longer folds the `/content/` segment out — that fold is correct for an authored `content:` reference and would, on a route URL, let a folder named like a collection win over the collection.)

## Unresolved is now a result, not a log line

`SlideAssetInlining` returns `Inlined` and `Unresolved` (each with a reason), and the template logs one warning per unresolved reference **saying it will print as a blank image**. The old code had a bare `continue` for an unparseable reference — no log at all — and a `LogWarning` for the rest, with the export still reporting success. A user got a PDF with a hole in it and, at best, a line buried in the activity log.

## Tests — and proof they bite

`DeckAssetInliningTest` (`MeshWeaver.Hosting.Monolith.Test`, `MonolithMeshTestBase`, no mocks) runs a real mesh with real FileSystem content collections and real stored PNGs:

1. **Happy path** — a stored image is embedded: the document carries `data:image/png;base64,{its own bytes}` and no `api/content/` reference survives.
2. **Unresolved is reported** — a reference to a file that isn't there comes back in `Unresolved` with a reason, and is left in the document rather than dropped.
3. **Every reference shape**, each against a real collection: node-relative `{node}/{file}`, explicit default `{node}/content/{file}`, a named collection `{node}/attachments/{file}`, a `~`-encoded qualified name `{node}/Media~2026/{file}` → collection `Media/2026`, and percent-escaped segments `{node}/a%20folder/logo%20two.png`.
4. **The whole path through the mesh** — a real `ExportDocumentRequest` with `Fidelity = Pixel`. Never skipped: it asks the renderer's own probe and asserts whichever contract the machine supports — with a browser, a PDF whose page carries an **embedded image** (PdfPig `GetImages()`) and an activity log saying `Inlined 1/1`; without one, the actionable refusal. Verified locally against Chrome 151: `pages=1 images=1`.

**The suite was checked against the defect.** Reinstating #1009's first-segment split fails 3 of the 4, and the export test's failure carries the cause verbatim:

```
[Warning] Slide asset api/content/Space…/pitch/intro/logo.png could not be inlined
          (Collection 'Space…' not found); it will print as a blank image
```

The fourth (unresolved-is-reported) passes either way, correctly: an unresolvable reference is unresolvable under both readings.

Test writing also had to establish where a node's file actually lives, so the fixture stores every asset **through the product's own resolution** rather than by guessing a disk layout — a test that agreed with itself about the layout would have proved nothing.

## Not test-only, so there is a What's New entry

The task was scoped as verification, and I would have said "test-only, no What's New". It isn't: this repairs a user-visible defect in a feature that shipped today, so `2026-08-09-pictures-in-a-printed-deck-are-actually-there.md` (`Category: Fix`) is included.

## 🔒 A hole this PR opened, found in review and closed

Copilot caught it and it was real. The content route validates the **decoded** path with `StaticAssetMount.IsSafeRelativePath` before resolving anything; my extraction left that check in the route, so the route stayed safe — but the **export** path had none, and its references come straight out of user-authored slide markup with raw-HTML passthrough. `FileSystemStreamProvider` resolves a collection-relative path with a bare `Path.Combine`, so `%2E%2E` — which survives URL normalisation and only becomes `..` once decoded per segment — walked out of the collection's BasePath into another node's files, under the portal's own filesystem access. Exactly the server-side-fetch hazard #1009 spent a review round closing, re-opened through a different door.

The guard now lives in `ContentFileResolver.Resolve`, so every caller inherits it rather than each remembering it — which is the entire point of there being one resolver. The route keeps its own check in front of the call as well.

**Proven, not assumed.** `A_traversal_reference_is_refused_rather_than_read` stores a PNG in a *different node's* collection and has a slide reach two levels up for it. With the guard disabled the traversal succeeds and the file is inlined (`Inlined` = 1); with it, the reference is refused with `Invalid content path` and no byte reaches the document.

Copilot's other comment was also correct: the doc claim that per-segment decoding "cannot introduce or remove a `/`" is false — `Uri.UnescapeDataString("%2F")` is `/`. The comment (inherited wording) now says so and points at the guard that makes it safe, and `SlidePrintComposerTests` pins that behaviour instead of the false claim.

## One observation I did not act on

Node hubs are hosted flat under the mesh hub, so `ExposeInChildren` means *hub* children, not *path* children. `MemexConfiguration` mounts the `content` collection only on partition roots (`!nodePath.Contains('/')`), so a **child** node's hub reports no `content` collection at all and `/api/content/{Space}/{child}/{file}` finds nothing to serve — independently of anything in this PR, and equally in the live view. `CombineOwnerRelative` exists for exactly the inherited case that this mount shape never produces. The tests here mount `content` per node, which is the shape the route demonstrably serves. Worth a look, but it is a separate question from this fix and I did not want to change a content-mount policy inside a bug fix.

## Verification

Release `-warnaserror` builds clean for `MeshWeaver.ContentCollections`, `MeshWeaver.Markdown.Export` and `MeshWeaver.Hosting.Blazor`. Locally green:

| Suite | Result |
|---|---|
| `DeckAssetInliningTest` | 5/5 (real Chrome: `pages=1 images=1`) |
| `MeshWeaver.Markdown.Export.Test` | 52/52 |
| `MeshWeaver.Hosting.Blazor.Test` | 263/263 |
| `MeshWeaver.Persistence.Test` | 503/503 |
| `MeshWeaver.Content.Test` | 257/258 (1 pre-existing skip) |
| `MeshWeaver.ContentCollections.Test` | 29/29 |
| `DeckExportScriptRelayTest` + `DeckPixelExportScriptRelayTest` | 6/6 |

Plus the two deliberate-breakage checks: 3/4 red against the reinstated collection split, and the traversal test red with the guard disabled.

**Not merged** — reporting back for your call.
