### PR TITLE
A green check suite is not evidence a test ran

### DIFF
--- a/.claude/skills/pullrequest/SKILL.md
+++ b/.claude/skills/pullrequest/SKILL.md
@@ -40,6 +40,27 @@ same bytes (marker refs `refs/ci-green/<tree>/<epoch>`, 24 h TTL; see the workfl
 still concludes `success`, main-cd still ships the image — ~22 min earlier. If main moved, the tree
 differs and the full suite runs; there is no way to skip an untested tree.
 
+> 🚨 **Read from the other end, that same mechanism is a trap: `conclusion: SUCCESS` on the check
+> suite can coexist with `Run tests = skipped`.** The tree was tested *earlier*, on the PR that
+> produced it — which is sound for "did this tree pass", but says **nothing** about a test the run
+> never executed. So a green suite is NOT evidence that a NEW test passed, and "this test is green on
+> main" is NOT evidence it is green at all if main's latest run reused a tree.
+>
+> This is not hypothetical: a PR merged on such a green introduced a racy test that had genuinely run
+> only once, and it then reddened an unrelated PR. Separately, "main is green so this failure is
+> mine" was nearly concluded from a main run that had skipped every shard and therefore never ran the
+> project in question.
+>
+> **Before treating any run as evidence a test passed, check the shard jobs' own conclusions:**
+>
+> ```bash
+> gh run view <run-id> --repo Systemorph/MeshWeaver --json jobs \
+>   --jq '[.jobs[] | select(.name | startswith("Run tests")) | .conclusion]'
+> ```
+>
+> All `skipped` ⇒ that run executed no tests. Go back to the run that actually did — or, for a PR
+> adding tests, require a run whose shards executed before believing the new test is green.
+
 ## The procedure
 
 ```bash


### PR DESCRIPTION
One paragraph added to the `pullrequest` skill, next to the passage it qualifies.

## The gap

The skill already explains already-green-tree reuse from one end: *"A main run with skipped build/test jobs is not a run that didn't happen"* — the identical tree was tested on the PR that produced it, so reusing that green is sound.

Read from the other end, the same mechanism is a trap: **`conclusion: SUCCESS` on the check suite coexists with `Run tests = skipped`.** A run that executed no tests is sound evidence that *the tree* passed, and no evidence at all about a test that run never executed.

## It cost twice today

- **A PR merged on such a green** had added a new test. That test had genuinely executed only once in CI — it was racy, and it went on to redden an unrelated PR whose diff was five files containing no C#.
- **An investigation nearly concluded "main is green, so this failure is mine"** from a main run that had skipped every shard and therefore never ran the project the failure was in.

Both are the same misreading, from opposite directions — one over-trusting a green, one over-trusting a green *as a baseline*.

## The change

A blockquote directly under the existing reuse paragraph, stating the inverse reading and giving the command that settles it:

```bash
gh run view <run-id> --repo Systemorph/MeshWeaver --json jobs \
  --jq '[.jobs[] | select(.name | startswith("Run tests")) | .conclusion]'
```

All `skipped` ⇒ that run executed no tests; go back to the run that actually did. For a PR **adding** tests, require a run whose shards executed before believing the new test is green.

Placed beside the reuse explanation rather than in a new section, because someone who has just read *why* skipping is legitimate is exactly the person about to over-trust it.

## Scope

Documentation only — one file, no code, no behaviour change. No What's New entry: this is contributor process guidance with nothing a portal user observes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)