### PR TITLE
A container leg that pushed nothing reported success

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -73,6 +73,24 @@ jobs:
   # Measured cost of the round trip: ~143 s per image job, ~9.5 min of runner time per CD run.
   # If a leg ever genuinely runs out of disk it will fail loudly with ENOSPC — reclaim
   # selectively THEN, against a measurement, rather than pre-emptively on every job.
+  #
+  # 🚨 TRIAGE: "Cannot create image index because provided images are invalid" is NOT an
+  # image-index defect and NOT a defect in the failing project. It means one per-RID leg
+  # produced no image, because Microsoft.NET.Build.Containers' CreateNewImage catches a
+  # cancellation, logs the bare warning "The operation was canceled." and STILL returns
+  # success. The cancellation is that library's hard-coded 30 s
+  # SocketsHttpHandler.ConnectTimeout on a stalled connect to the base registry
+  # (mcr.microsoft.com) or to ACR — its inner TimeoutException is dropped, so nothing in the
+  # log names a host. Read the ~30 s gap in the timestamps before the warning, not the error.
+  # Root Directory.Build.props now fails the leg AT that point (error MW1026) with both
+  # registries named, so a recurrence is one line to attribute — see issue #1026 for the
+  # full trace (CD run 31322066110, bake's linux-arm64 leg, 16:01:03.9 → 16:01:34.1).
+  #
+  # 🚨 Each image job pushes INDEPENDENTLY: a leg that dies this way leaves a PARTIAL
+  # release — 4f0c35cfc shipped memex-portal-ai:3.0.0-rc1.ci.2470 with no memex-bake:ci.2470,
+  # i.e. a portal version the NodeType bake gate never certified. Do NOT paper that over by
+  # retrying the publish, dropping a RID or `continue-on-error`; if CD should refuse to ship a
+  # partial set, that is a delivery-policy change to make deliberately.
   # ─────────────────────────────── DELIVERY GATE ───────────────────────────────
   # 🚨 Gate on the REQUIRED CHECK, not on the workflow run's umbrella conclusion.
   # A run's conclusion is `failure` if ANY job ends cancelled — including a job that

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -500,6 +500,90 @@ jobs:
           docker push ${{ env.ACR }}/memex-portal-next:${{ steps.vars.outputs.sha }}
           docker push ${{ env.ACR }}/memex-portal-next:main
 
+  # ─────────────────────────── DID IT ACTUALLY SHIP? ──────────────────────────
+  # Assert the IMAGES exist, never the green tick. Each image job pushes independently, so ONE leg
+  # failing leaves main with a PARTIAL release — 4f0c35cfc shipped memex-portal-ai:3.0.0-rc1.ci.2470
+  # with no memex-bake:ci.2470 (issue #1026), i.e. a portal increment the NodeType bake gate never
+  # certified, while the self-updater happily picks the newest version tag. A per-job red says "CD
+  # failed"; it does not say WHICH image is missing, and nothing was checking that a given main
+  # commit ends up with the full set.
+  #
+  # `if: always()` on purpose: this runs whether the legs passed, failed or were cancelled, so the
+  # run's LAST word is a named list of what is missing from the registry rather than a stack trace
+  # from whichever leg died. That is the difference between "CD is red, go read four job logs" and
+  # "memex-bake:<sha> is missing".
+  #
+  # It also catches what a per-job red CANNOT: a leg that reports success while pushing nothing
+  # (Microsoft.NET.Build.Containers swallows a cancelled push as a warning and returns true — see
+  # the guard in the root Directory.Build.props), and an index that lost an architecture.
+  #
+  # Every leg pushes the short-SHA tag, so that is the one identity all five images share.
+  verify-images:
+    name: "Verify every image shipped"
+    needs: [gate, portal-image, migration-image, bake-image, plugin-test-image, portal-next-image]
+    if: always() && needs.gate.outputs.green == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Compute the commit tag every leg pushes
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Ensure Azure CLI
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      # Reads manifests through ARM (no `az acr login` needed — that one is for docker/push creds).
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Every image for this commit must exist in ACR
+        env:
+          SHA: ${{ steps.vars.outputs.sha }}
+        run: |
+          # No `-e`: every repository must be REPORTED, so one miss cannot hide the next.
+          set -uo pipefail
+          fail=0
+          report() { echo "::error::$1"; echo "- ❌ $1" >> "$GITHUB_STEP_SUMMARY"; fail=1; }
+          ok()     { echo "$1";         echo "- ✅ $1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          echo "### Images for main \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"
+
+          # The four .NET legs publish an OCI/Docker image INDEX over both linux architectures.
+          # Asserting the architectures — not just the tag — is what makes this more than a
+          # restatement of the job status: an index that lost a leg still resolves for one arch.
+          # `az acr manifest show` is an Azure-CLI PREVIEW command group (it prints a warning on
+          # stderr, discarded here). If it is ever withdrawn, the equivalent is
+          # `docker buildx imagetools inspect --raw <acr>/<repo>:<tag>` after `az acr login`.
+          for repo in memex-portal-ai memex-migration memex-bake mw-plugin-test; do
+            if ! m=$(az acr manifest show --registry meshweaver --name "$repo:$SHA" -o json 2>/dev/null); then
+              report "$repo:$SHA is MISSING from ACR — main $SHA shipped an INCOMPLETE release"
+              continue
+            fi
+            arches=$(printf '%s' "$m" | jq -r '[(.manifests // [])[] | select(.platform.os == "linux") | .platform.architecture] | sort | join(",")')
+            if [ "$arches" != "amd64,arm64" ]; then
+              report "$repo:$SHA is not a linux amd64+arm64 image index (architectures: '${arches:-<single-arch manifest>}')"
+            else
+              ok "$repo:$SHA (linux/amd64 + linux/arm64)"
+            fi
+          done
+
+          # portal-next is amd64-only BY DESIGN (every AKS node is amd64) — existence is the check.
+          if ! az acr manifest show --registry meshweaver --name "memex-portal-next:$SHA" -o json >/dev/null 2>&1; then
+            report "memex-portal-next:$SHA is MISSING from ACR — main $SHA shipped an INCOMPLETE release"
+          else
+            ok "memex-portal-next:$SHA (linux/amd64)"
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::main $SHA did NOT ship a complete image set. Every self-updating install stays on the previous image until a CD run publishes all of them. Fix the failing leg and merge again — a manual re-run of Build-and-Test cannot ship (main-cd gates on workflow_run.event == 'push')."
+            exit 1
+          fi
+          echo "All five images exist in ACR for $SHA."
+
   # ───────────────────────────── FAILURE ALERTING ────────────────────────────
   # A red CD after a green merge is otherwise INVISIBLE (nobody watches the Actions tab), and the
   # consequence is severe: the merged commit never gets a deployable image, so every pull-based
@@ -508,11 +592,13 @@ jobs:
   # files (or comments on) a GitHub issue labeled `ci-failure`.
   # - `if: failure()` with `needs`: fires only when at least one image job actually FAILED —
   #   not when they were skipped (PR-triggered workflow_run) and not on cancellation.
+  #   `verify-images` is in that list so a registry that is MISSING an image alerts too, even in
+  #   the case where every publish leg reported success.
   # - Idempotent: one open `ci-failure` issue collects repeat failures as comments; a new issue is
   #   only created when none is open (close the issue once CD is green again).
   alert-on-failure:
     name: "Alert: CD failed on main"
-    needs: [portal-image, migration-image, bake-image, plugin-test-image, portal-next-image]
+    needs: [portal-image, migration-image, bake-image, plugin-test-image, portal-next-image, verify-images]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -137,7 +137,12 @@
        failure, names the RID and both registries, and — on the SINGLE-RID path, where there is no
        CreateImageIndex downstream — it is the ONLY thing standing between a swallowed cancellation and
        a publish that reports success while pushing nothing at all.
-       Inert on every healthy publish (the metadata is populated) and on archive/local-daemon flows. -->
+       Inert on every healthy publish (the metadata is populated) and on archive/local-daemon flows.
+
+       It lives in the PROPS, next to the rest of the multi-arch container block, deliberately: a new
+       root Directory.Build.targets would be shadowed outright by the existing test/Directory.Build.targets
+       (MSBuild imports only the NEAREST one), so splitting this off would scatter the container reasoning
+       across two files for no gain. AfterTargets is resolved after evaluation, so an early import is fine. -->
   <Target Name="_MeshWeaverGuardContainerLegProducedAnImage"
           AfterTargets="_PublishSingleContainer"
           Condition="'$(ContainerRegistry)' != '' and '$(ContainerArchiveOutputPath)' == ''">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -146,9 +146,18 @@
   <Target Name="_MeshWeaverGuardContainerLegProducedAnImage"
           AfterTargets="_PublishSingleContainer"
           Condition="'$(ContainerRegistry)' != '' and '$(ContainerArchiveOutputPath)' == ''">
+    <!-- Name the leg defensively. ComputeContainerBaseImage defaults ContainerRuntimeIdentifier from
+         RuntimeIdentifier (and multi-arch legs are handed it explicitly), so it is normally set by the
+         time we get here — but this message is the whole point of the target, and a diagnostic that
+         says "RuntimeIdentifier ''" would be worth nothing on the single-RID path this also guards. -->
+    <PropertyGroup>
+      <_MeshWeaverFailedLegRid>$(ContainerRuntimeIdentifier)</_MeshWeaverFailedLegRid>
+      <_MeshWeaverFailedLegRid Condition="'$(_MeshWeaverFailedLegRid)' == ''">$(RuntimeIdentifier)</_MeshWeaverFailedLegRid>
+      <_MeshWeaverFailedLegRid Condition="'$(_MeshWeaverFailedLegRid)' == ''">&lt;unspecified&gt;</_MeshWeaverFailedLegRid>
+    </PropertyGroup>
     <Error Condition="'$(GeneratedContainerDigest)' == '' or '$(GeneratedContainerManifest)' == '' or '$(GeneratedContainerConfiguration)' == '' or '$(GeneratedContainerMediaType)' == ''"
            Code="MW1026"
-           Text="Container publish for RuntimeIdentifier '$(ContainerRuntimeIdentifier)' reported success but produced NO image — CreateNewImage set no Manifest/Config/Digest. That task logs a swallowed cancellation as the bare warning 'The operation was canceled.' and still returns true, so the true fault is the warning IMMEDIATELY ABOVE this error, not this target. In CI it is a stalled connect (Microsoft.NET.Build.Containers hard-codes SocketsHttpHandler.ConnectTimeout=30s and drops the inner TimeoutException, so no host is logged): check the base registry '$(ContainerBaseRegistry)/$(ContainerBaseName):$(ContainerBaseTag)' and the output registry '$(ContainerRegistry)/$(ContainerRepository)', and look for a ~30 s gap in the timestamps before the warning. Do NOT respond by dropping a RID, disabling the image index, wrapping the publish in a retry, or suppressing this error — see issue #1026." />
+           Text="Container publish for RuntimeIdentifier '$(_MeshWeaverFailedLegRid)' reported success but produced NO image — CreateNewImage set no Manifest/Config/Digest. That task logs a swallowed cancellation as the bare warning 'The operation was canceled.' and still returns true, so the true fault is the warning IMMEDIATELY ABOVE this error, not this target. In CI it is a stalled connect (Microsoft.NET.Build.Containers hard-codes SocketsHttpHandler.ConnectTimeout=30s and drops the inner TimeoutException, so no host is logged): check the base registry '$(ContainerBaseRegistry)/$(ContainerBaseName):$(ContainerBaseTag)' and the output registry '$(ContainerRegistry)/$(ContainerRepository)', and look for a ~30 s gap in the timestamps before the warning. Do NOT respond by dropping a RID, disabling the image index, wrapping the publish in a retry, or suppressing this error — see issue #1026." />
   </Target>
   <!-- Two version channels — CONTINUOUS (CI) vs RELEASED (CD):
        • RELEASED  (-p:PublicRelease=true, the CD/release pipeline): clean $(PlatformVersion).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,6 +106,45 @@
   <PropertyGroup Condition="'$(ContainerRuntimeIdentifiers)' != ''">
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
+  <!-- 🚨 A container leg that pushed NOTHING must fail HERE, not two tasks later as "invalid metadata".
+       The SDK's CreateNewImage task is written to swallow cancellation:
+
+           try { Task.Run(() => ExecuteAsync(_cts.Token)).GetAwaiter().GetResult(); }
+           catch (TaskCanceledException ex)    { Log.LogWarningFromException(ex); }
+           catch (OperationCanceledException ex){ Log.LogWarningFromException(ex); }
+           return !Log.HasLoggedErrors;                         // ← WARNING, so the task SUCCEEDS
+
+       and Microsoft.NET.Build.Containers' registry client hard-codes
+       `new SocketsHttpHandler { ConnectTimeout = TimeSpan.FromSeconds(30) }`. A stalled TCP/TLS
+       connect to the base registry (mcr.microsoft.com) or the output registry therefore surfaces as
+       TaskCanceledException("The operation was canceled.") — whose inner
+       TimeoutException("A connection could not be established within the configured ConnectTimeout.")
+       LogWarningFromException DROPS, so the log names neither the host nor the timeout.
+
+       The task then returns SUCCESS having produced no image, `_PublishSingleContainer` emits its
+       GeneratedContainer item UNCONDITIONALLY (with every metadata value empty), and the failure only
+       lands ~100 ms later in CreateImageIndex as
+
+           error : Cannot create image index because provided images are invalid.
+                   Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.
+
+       — an error that blames the image index for a network stall. That is CD run 31322066110 / issue
+       #1026: main 4f0c35cfc shipped memex-portal-ai:3.0.0-rc1.ci.2470 with NO matching memex-bake,
+       because the bake job's linux-arm64 leg sat exactly 30.2 s (16:01:03.9 → 16:01:34.1) between
+       "publish/" and that warning, and nothing in the log said why.
+
+       Refusing a "success" that produced no artifact is the fix we own: it fails at the true point of
+       failure, names the RID and both registries, and — on the SINGLE-RID path, where there is no
+       CreateImageIndex downstream — it is the ONLY thing standing between a swallowed cancellation and
+       a publish that reports success while pushing nothing at all.
+       Inert on every healthy publish (the metadata is populated) and on archive/local-daemon flows. -->
+  <Target Name="_MeshWeaverGuardContainerLegProducedAnImage"
+          AfterTargets="_PublishSingleContainer"
+          Condition="'$(ContainerRegistry)' != '' and '$(ContainerArchiveOutputPath)' == ''">
+    <Error Condition="'$(GeneratedContainerDigest)' == '' or '$(GeneratedContainerManifest)' == '' or '$(GeneratedContainerConfiguration)' == '' or '$(GeneratedContainerMediaType)' == ''"
+           Code="MW1026"
+           Text="Container publish for RuntimeIdentifier '$(ContainerRuntimeIdentifier)' reported success but produced NO image — CreateNewImage set no Manifest/Config/Digest. That task logs a swallowed cancellation as the bare warning 'The operation was canceled.' and still returns true, so the true fault is the warning IMMEDIATELY ABOVE this error, not this target. In CI it is a stalled connect (Microsoft.NET.Build.Containers hard-codes SocketsHttpHandler.ConnectTimeout=30s and drops the inner TimeoutException, so no host is logged): check the base registry '$(ContainerBaseRegistry)/$(ContainerBaseName):$(ContainerBaseTag)' and the output registry '$(ContainerRegistry)/$(ContainerRepository)', and look for a ~30 s gap in the timestamps before the warning. Do NOT respond by dropping a RID, disabling the image index, wrapping the publish in a retry, or suppressing this error — see issue #1026." />
+  </Target>
   <!-- Two version channels — CONTINUOUS (CI) vs RELEASED (CD):
        • RELEASED  (-p:PublicRelease=true, the CD/release pipeline): clean $(PlatformVersion).
          This is what NuGet packages AND the Docker image carry, e.g. 3.0.0-rc1. Tag the repo


### PR DESCRIPTION
Fixes #1026

CD has since gone green on its own (`31324251944`, all five images for `86578a4`), so this is an
**intermittent** failure — which is the worse kind, because when it fires it silently skips image
publication. This PR does not declare it transient and walk away: it establishes the exact mechanism,
rules out the repo-side hypotheses with evidence, and makes both the build failure and the missing
image impossible to mistake for anything else.

## The exact mechanism

**Timeline from the bake job log** (`linux-x64` had already pushed at 16:01:00.9):

| time | event |
|---|---|
| 16:01:03.9 | `Memex.NodeType.Bake -> …/linux-arm64/publish/` |
| — | 30.2 s of complete silence; `Building image …-linux-arm64` is **never** logged |
| 16:01:34.1 | `warning : The operation was canceled.` |
| 16:01:34.2 | `error : Cannot create image index …` |

Every step of the chain is in the SDK:

1. `CreateNewImage` fetches the **base image manifest** (`mcr.microsoft.com/dotnet/aspnet:10.0`)
   *before* it logs `Building image …`. That message is absent, so the 30 s was spent in that fetch,
   not in the index.
2. `Microsoft.NET.Build.Containers` builds its registry client as
   `new SocketsHttpHandler { UseCookies = false, ConnectTimeout = TimeSpan.FromSeconds(30) }`
   (`DefaultRegistryAPI`). A stalled connect surfaces as
   `TaskCanceledException("The operation was canceled.")` with an inner
   `TimeoutException("A connection could not be established within the configured ConnectTimeout.")`
   — dotnet/runtime [#47484](https://github.com/dotnet/runtime/issues/47484),
   [#78070](https://github.com/dotnet/runtime/issues/78070). **30.2 s is that timeout, to the tenth.**
3. `CreateNewImage.Execute()` catches it, calls `Log.LogWarningFromException` — which logs only
   `ex.Message`, dropping the inner `TimeoutException` that names the host and the timeout — and
   returns `!Log.HasLoggedErrors`, i.e. **success**, having produced no image.
4. `_PublishSingleContainer` emits its `GeneratedContainer` item **unconditionally**, every metadata
   value empty.
5. `CreateImageIndex.ParseImages` rejects the empty metadata → the misleading error.

So **the index never sees a race**: it sees an item a leg was allowed to publish while failing. The
answer to "why intermittently" is simply "only when a registry connect stalls ≥ 30 s".

## Hypotheses checked, with evidence

**A multi-arch race (the `ProduceReferenceAssembly` prior art, PR #552 / CS0009).** Ruled out, two ways:

- That guard **is** active for `Memex.NodeType.Bake` — it lives in the root `Directory.Build.props`
  under `'$(ContainerRuntimeIdentifiers)' != ''`, not per-csproj, so it reaches the whole closure.
  Queried directly for a library in that closure:
  ```
  dotnet msbuild src/MeshWeaver.Graph -getProperty:ProduceReferenceAssembly -getProperty:BaseOutputPath \
    -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64" -p:ContainerRuntimeIdentifier=linux-arm64
  → { "ProduceReferenceAssembly": "false", "BaseOutputPath": "bin/container/linux-arm64/" }
  ```
  Both the ref-assembly gate and the per-leg output isolation apply.
- The signature is wrong anyway. That race breaks the **compile** (CS0009 / MSB3883). Here both legs
  compiled *and* wrote their publish directories — `…/linux-arm64/publish/` is right there in the log.
  The failure is strictly **after** the build, in a registry call.

**The #979 job split changing concurrency.** Ruled out — it moved in the *safe* direction. GitHub gives
every job its own fresh VM, so after the split `nodetype-bake` shares no runner, no NuGet cache and no
output path with any other image job; **before** the split it was a second step in the migration job,
i.e. strictly *more* sharing. Within the job the two RID legs run in parallel either way (the SDK's
`BuildInParallel` default) — #979 did not touch that. And the job had been green in every run since it
was split at 00:08 that day, including 11 minutes before the failure.

**Frequency.** 1 failure in 27 image-building CD runs (last 100 completed runs: 26 success, 73 skipped,
1 failure). The runs immediately before (`cb25f07`) and after (`d2db7dc`, a superset tree containing
`4f0c35cfc`) both published `memex-bake`. On the **same commit**, the `migration` job did the identical
multi-arch publish against the identical base image and pushed both legs 12 s apart.

**Conclusion:** an upstream stall, amplified by an SDK defect that reports it as success. There is no
repo-side change that prevents a connect from stalling — and per the ground rules this PR adds no retry,
drops no architecture, disables no index and sets no `continue-on-error`, because none of those would
have produced an image.

## What this PR changes — two detection layers

**1. A leg that produced no image no longer reports success** (root `Directory.Build.props`,
`error MW1026`). It fails where the failure actually happened, naming the RID and both registries and
pointing at the warning above it, instead of letting an empty item travel two tasks downstream to be
blamed on the image index.

It matters most on the **single-RID** path, where there is no `CreateImageIndex` at all: today a
swallowed cancellation there means `dotnet publish` exits 0 having pushed **nothing**.

**2. `verify-images` — assert the image, never the tick** (`main-cd.yml`). Runs `if: always()` after
every leg and asserts all five images carry this commit's short-SHA tag, and that the four .NET ones are
linux `amd64+arm64` **indexes** rather than a surviving single arch. Every repository is reported, so one
miss cannot hide the next, and it is in `alert-on-failure`'s `needs`, so a missing image opens the
`ci-failure` issue even when every publish leg reported success.

This closes the gap the issue actually left open. The alerting *did* fire for #1026 — but "CD failed"
never said **which** image was missing, and nothing was checking that a main commit ends up with the
full set:

```
memex-portal-ai   3.0.0-rc1.ci.2470, 4f0c35c   ← shipped
memex-bake        (neither tag)                ← missing
```

`ci.2470` is a portal increment the NodeType bake gate never certified, and the self-updater picks the
newest version tag regardless.

## Verification

- `verify-images` logic run against the **real registry**, both directions: on `4f0c35c` it names
  `memex-bake:4f0c35c is MISSING from ACR` and exits 1; on `86578a4` it passes clean — reproducing
  #1026 from ACR state alone.
- MW1026 guard exercised against the real SDK targets: healthy legs → runs once per RID after
  `_PublishSingleContainer`, sees all four `Generated*` properties populated, stays silent; forced to
  fire → `error MW1026`, **exit 1**, `CreateImageIndex` never runs.
- Full multi-arch `Memex.NodeType.Bake` publish with CD's flags (`-c Release --no-self-contained
  -t:PublishContainer -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64" -p:CIRun=true`) completes
  green with the guard in place — both legs valid, index built, no MW1026.

## Not decided here

Whether CD should **refuse to ship a partial set** (e.g. hold the portal tag until every leg lands) is a
delivery-policy call for the maintainer. `verify-images` makes the partial release loud and named; it
does not change what gets published.

## No What's New entry

Build/CI-only change with no user-visible behaviour.
