### PR TITLE
Green CI never compiled the 12k lines of C# that live in mesh nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,17 @@ CI builds **Release with warnings-as-errors**: `dotnet build --no-restore -c Rel
 
 Full PR/merge gate: the `pullrequest` skill (CI must be GREEN before merge — main's image feeds the self-update).
 
+## 🚨🚨🚨 ABSOLUTE: Green CI does NOT mean the mesh compiles — in-mesh source is invisible to `dotnet build`
+
+**Every `.cs` stored in a mesh node — NodeType `Source/*.cs`, Scripts, layout areas — compiles at RUNTIME in the portal, NEVER in CI.** The repo's node trees are `<None>` content (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so **12k+ lines of C# under `samples/Graph/Data/` and `content/` are never type-checked by any build or any test.** Worse, **the deployed mesh's copy outranks the repo's** — a node carries its own version history and drifts from the file that seeded it, so reading the repo file does NOT tell you what the portal will compile.
+
+**A framework-version bump recompiles EVERY dynamic NodeType** (`HasUsableBuild` rule 3), so breakage never trickles in — the whole accumulated backlog detonates on one deploy. A NodeType left at `CompileError` **refuses portal readiness** and parks every instance hub for the full **60 s** activation budget: hung pages, failed liveness probes, dropped silos.
+
+- **Deleting or renaming ANY public framework surface is a breaking change to code the compiler cannot see.** Extension methods on `MessageHubConfiguration` / `IMessageHub`, `Controls.*`, `host.*` helpers, content base types — before you delete one: `grep -rn "<Symbol>" content samples/*/Data` **AND** search the live mesh (`search_chunks`), which may hold callers the repo has already dropped. Port or delete them in the SAME change. A clean `-c Release -warnaserror` build proves nothing here.
+- **Before prod, sweep every NodeType green.** `Search('nodeType:NodeType')` → `LspDiagnosticsForNode` per type → fix roots first (a red upstream makes every dependent `UpstreamFailed`) → re-sweep until all read `Ok`. **Warnings count**: `stayed an untyped JsonElement`/unregistered-`$type` means a view **renders empty** and layout areas "cannot be found"; `CS0105`/`CS8632` noise is the camouflage that hides the one fatal diagnostic.
+
+Full protocol: [`/code` skill](content/ai/Skill/code.md) → "In-mesh source is NEVER compiled by CI" + "The pre-prod sweep". Mechanism: [NodeTypeCompilation.md](src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md).
+
 ## 🚨🚨🚨 ABSOLUTE: No band-aids — root cause only, literally always
 
 **The user is LITERALLY NEVER interested in a band-aid, workaround, mitigation, or symptom-suppression.** When something hangs, deadlocks, flakes, or errors, find the EXACT defect and fix THAT — never paper over it.

--- a/content/ai/Skill/code.md
+++ b/content/ai/Skill/code.md
@@ -30,6 +30,58 @@ These rules apply just as strictly to test code: a NodeType test that does `awai
 
 **Tests are reactive role models — no `await` in the test body.** The platform runs reactive end-to-end, so its tests do too: assert on the stream directly instead of bridging to a `Task`. Replace `await x.FirstAsync().ToTask(ct)` with `x.Should().Match(predicate)` / `.Be(expected)` / `.Emit()`, and drive reactive creates/updates from the assertion's subscribe (`CreateNode(node).Should().Emit()`) — the `[Fact]` becomes a plain `void`. Folding the assertion into the predicate (`.Match(items => items.Count == 2)`) waits for the *right* state, removing the "wait, then assert" race that flakes in CI. Where production runs work on an activity hub, drive it through `RequestedStatus` and observe the activity stream — test the same path production takes. Use the test base, never mock `IMessageHub` / `IMeshService`. Full pattern + API: [Reactive Test Assertions](@/Doc/Architecture/ReactiveTestAssertions).
 
+# 🚨🚨🚨 ABSOLUTE: In-mesh source is NEVER compiled by CI — sweep it green before prod
+
+**Every `.cs` that lives in a mesh node — NodeType `Source/*.cs`, Script nodes, layout areas — compiles at RUNTIME in the portal, never in `dotnet build`.** The repo's node trees are `<None>` content, not code (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so **12k+ lines of C# under `samples/Graph/Data/` and `content/` are invisible to the compiler, to `-warnaserror`, and to every test.** Green build, green CI, clean review and a merged PR say **nothing** about whether the mesh still compiles.
+
+**The deployed mesh's copy outranks the repo's.** A node carries its own version history and drifts from the file that seeded it. Reading the repo file does not tell you what the portal will compile.
+
+**A framework-version bump recompiles EVERY dynamic NodeType** ([rule 3 of `HasUsableBuild`](@/Doc/Architecture/NodeTypeCompilation)). Breakage therefore does not trickle in — the entire accumulated backlog detonates on one deploy.
+
+**A NodeType at `CompileError` is an OUTAGE, not a cosmetic defect.** It refuses portal readiness, and every instance hub burns the full **60 s** activation budget before faulting: pages hang, probes fail, silos drop. The failure shape to recognise — an in-mesh type calling a framework API that `src/` deleted:
+
+```
+CS1061: 'MessageHubConfiguration' does not contain a definition for 'AddTracking'
+  → type = CompileError → every dependent = UpstreamFailed → REFUSING READINESS
+```
+
+## Two standing obligations
+
+**Removing or renaming ANY public framework surface is a breaking change to code you cannot see.** Extension methods on `MessageHubConfiguration` / `IMessageHub`, `Controls.*`, `host.*` helpers, content base types — before you delete one, `grep -rn "<Symbol>" content samples/*/Data` **and** search the live mesh (`search_chunks`), which may hold callers the repo has already dropped. Port or delete them in the same change.
+
+**In-mesh source is pinned to the live framework and WILL be recompiled against a newer one.** Stay on documented surface, `LspCheckNode` before every `Patch`, and never leave a type at `Error`.
+
+# 🚨 The pre-prod sweep — mandatory, errors AND warnings
+
+**Shipping is not "my change compiles". It is "nothing in the mesh is red, and nothing is one framework bump away from red."** Hunting these down is your job, not the operator's.
+
+## The sweep
+
+Run this whenever you finish NodeType work, and always before a release or a framework upgrade:
+
+1. **Enumerate.** `Search('nodeType:NodeType')` for the whole mesh, or `Search('nodeType:NodeType namespace:{target} scope:descendants')` for one area. That list is the work list — do not sample it.
+2. **Read status without recompiling.** `LspDiagnosticsForNode('@{path}')` returns diagnostics from the *current cached* compilation — far cheaper than `Compile`, and the right tool for a sweep. `GetDiagnostics('@{path}')` gives the `status` flip.
+3. **Triage in dependency order.** A red upstream produces `UpstreamFailed` noise in every dependent, so a flat list badly overstates the damage. Fix the roots first and re-check — most "failures" evaporate.
+4. **Fix, pre-flighted.** `LspCheckNode({nodeTypePath, sourcePath, proposedCode})` until `ok: true` → `Patch`/`Update` → `Compile` + `GetDiagnostics` for the real emit.
+5. **Re-sweep until the whole list reads `Ok`.** A red type you did not author is still an outage waiting for the next deploy. Fix it, or escalate it **by name** — never ship behind "my part is green".
+
+## What counts as a finding — warnings included
+
+| Signal | Why it is a prod risk | Fix |
+|---|---|---|
+| `status: Error` / `CompileError` | Refuses portal readiness; every instance hub parks 60 s, then faults | Fix the source |
+| `CS1061` / `CS0103` against framework surface | The API was removed or renamed under you — in-mesh source is not in CI (section above) | Port to the current API |
+| `stayed an untyped JsonElement … TypeRegistry lacks the $type discriminator` | `Content is X` fails ⇒ the view **renders empty**, reactive waits time out, layout areas "cannot be found" | `WithType(typeof(X), nameof(X))` on the **receiving** hub |
+| `Unregistered type … auto-registered under its SHORT name` | Works by luck; collides across namespaces | Register it explicitly |
+| `reconcile is NOT CONVERGING` | A write loop — every pass rewrites the same node | Fix the predicate, never ignore the line |
+| `CS0105` duplicate usings · `CS1570` malformed XML · `CS8632` nullable context | Camouflage — they bury the one diagnostic that matters | Clean them so the next sweep is readable |
+
+🚨 **The warnings you tolerate are the camouflage for the next error.** A fatal `CS1061` buried in a twelve-line block of `CS0105`s and `CS8632`s is a line everyone has learned to scroll past. Keep the diagnostic output clean and the real failure is unmissable — that is the whole reason warnings are in scope for this sweep.
+
+## The gate
+
+Every type from step 1 reads `Ok`, and the type-registry warnings are gone from the log. Only then is it shippable. Verifying compile status is not optional polish — it is the last thing standing between an in-mesh edit and a portal that will not start.
+
 # Mutations go through `GetMeshNodeStream(path).Update(...)`
 
 Every mesh-node mutation goes through `workspace.GetMeshNodeStream(path).Update(current => modified)`

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -308,6 +308,66 @@ loaded on it keep running until they cycle.
 
 ---
 
+## 🚨 That recompile can FAIL — and nothing upstream can warn you
+
+Rule 3 guarantees a framework upgrade recompiles **every** dynamic NodeType. That recompile
+builds source **stored in the mesh** against the **new** framework — and nothing in the build
+pipeline has ever type-checked it.
+
+### Where NodeType source actually lives
+
+|  | Repo file | Mesh node |
+|---|---|---|
+| Example | `samples/Graph/Data/SocialMedia/Post/Source/*.cs` | `SocialMedia/Post/Source/*` |
+| Role | **import seed** — declared `<None Include="**/*" …>` in `MeshWeaver.Samples.Graph.csproj` | **the runtime source of truth** |
+| Compiled by `dotnet build` / CI | **Never.** It is content, not code — no `<Compile>` item, no `-warnaserror`, no test | Compiled at runtime by `RunCompile` |
+| Edited by | git | in-mesh edit, `Patch`, GitSync import |
+
+The two **drift**. A node carries its own version history, so the mesh can hold source that is
+*older* than the repo's: a repo grep comes back clean while the deployed mesh still calls the API
+you removed. Treat the repo file as a seed, never as the answer to "what will the portal compile?"
+
+### The failure cascade
+
+A failed type produces no assembly, so everything downstream of it is *skipped* rather than built
+(`NodeTypeDependencyGraph.FirstBlockedBy`), and `DynamicTypePreWarmer` refuses readiness for any
+type that regressed against its pre-bake baseline:
+
+```
+framework API deleted in src/  →  in-mesh caller no longer compiles
+  → NodeType = CompileError
+  → every dependent = UpstreamFailed          (transitive, in topological order)
+  → DynamicTypePreWarmer: REFUSING READINESS
+  → instance hubs never activate → each SubscribeRequest waits the full 60 s → faults
+  → hung pages, failed liveness probes, dropped silo
+```
+
+The shape in the log is a `CS1061` / `CS0103` against framework surface:
+
+```
+CS1061: 'MessageHubConfiguration' does not contain a definition for 'AddTracking'
+```
+
+### The obligation on framework changes
+
+Removing or renaming any public framework surface — extension methods on
+`MessageHubConfiguration` / `IMessageHub`, `Controls.*`, `host.*` helpers, content base types — is
+a **breaking change to code the compiler cannot see**. Before deleting one:
+
+1. `grep -rn "<Symbol>" content samples/*/Data` — catches in-repo node source.
+2. Search the **live mesh** (`search_chunks`) — catches nodes that drifted from the repo.
+3. Port or delete the callers in the same change, then sweep.
+
+### The pre-prod sweep
+
+`Search('nodeType:NodeType')` → `LspDiagnosticsForNode('@{path}')` per type (reads the *cached*
+compilation, no re-emit) → fix roots first, since one red upstream reports as a failure in every
+dependent → re-check until every type reads `Ok`. Warnings are in scope: an unregistered `$type`
+leaves content as an untyped `JsonElement`, which renders **empty** rather than erroring. The full
+protocol lives in the `/code` skill.
+
+---
+
 ## Quick reference
 
 | I want to… | Do this |
@@ -323,3 +383,6 @@ loaded on it keep running until they cycle.
 | Pin instances to a fixed release | Set `NodeTypeDefinition.RequestedReleasePath` |
 | Understand why it recompiled | `HasUsableBuild` failed rule 2 (assembly gone) or rule 3 (framework changed) |
 | Understand a "Compile leg '…' did not complete within Ns" error | That stage stopped answering — see [Every stage is bounded](#every-stage-is-bounded--a-compile-can-never-park-at-compiling) |
+| Delete or rename a public framework API | Grep `content` + `samples/*/Data` **and** search the live mesh for callers first — CI never compiles in-mesh source |
+| Check the mesh is shippable | `Search('nodeType:NodeType')` → `LspDiagnosticsForNode` per type → every one reads `Ok` |
+| Understand why one bad NodeType took the portal down | `CompileError` → dependents `UpstreamFailed` → readiness refused → 60 s hub-activation faults |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-green-build-does-not-mean-node-types-compile.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-green-build-does-not-mean-node-types-compile.md
@@ -1,0 +1,26 @@
+---
+Name: Why a green build does not mean your node types still compile
+Category: Feature
+Description: New documentation explains that code stored in mesh nodes is compiled by the portal at runtime rather than by the build, and gives the check to run before shipping.
+Icon: Sparkle
+Order: -20260809
+---
+
+# Why a green build does not mean your node types still compile
+
+Code that lives in a mesh node — a node type's source, a script, a layout area — is compiled by the
+portal when it runs, not by the build that produces the portal. That makes it possible for
+everything to look healthy right up until a deployment: the build passes, the tests pass, the change
+is reviewed and shipped, and only then does a node type turn out not to compile any more.
+
+It also matters that a node keeps its own history. The copy stored in your mesh can be older than
+the file it was originally created from, so checking that file is not the same as checking what the
+portal will actually build.
+
+Because every node type is rebuilt whenever the platform itself is updated, problems of this kind do
+not appear one at a time. They accumulate quietly and then all surface together on a single update,
+where a node type that fails to build can hold back the whole portal.
+
+The documentation now spells this out, along with the check to run before shipping: list every node
+type, read its diagnostics, and fix the ones reporting problems — including warnings, since an
+unregistered content type is what makes a page render empty instead of showing an error.


### PR DESCRIPTION
## What happened

`memex.meshweaver.cloud` wedged today. Root cause: `eafd353ed` deleted the `AddTracking` extension on `MessageHubConfiguration`, while the **live mesh** copy of `SocialMedia/Post` still called it.

```
CS1061: 'MessageHubConfiguration' does not contain a definition for 'AddTracking'
  → SocialMedia/Post = CompileError
  → PostsHub / PostTarget / Profile = UpstreamFailed
  → DynamicTypePreWarmer: REFUSING READINESS
  → the Posts hub never activates → every SubscribeRequest burns the full 60 s → faults
```

Hung pages, failed liveness probes, a dropped silo, and the surviving pod at 17.7 GiB after recompiling all 232 NodeTypes.

## Why nothing caught it

Two independent blind spots, and it needed both:

1. **In-mesh source is never compiled by CI.** The repo's node trees are `<None>` content (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so ~12k lines of C# under `samples/Graph/Data/` and `content/` are invisible to the compiler, to `-warnaserror`, and to every test.
2. **The mesh copy had drifted from the repo's.** `eafd353ed` never touched `samples/Graph/Data/SocialMedia/`, and the repo copy does not call `AddTracking` — so a repo-wide grep returns clean while the deployed node still breaks.

And because a framework-version bump recompiles *every* dynamic NodeType (`HasUsableBuild` rule 3), breakage never trickles in — the whole backlog detonates on one deploy.

## What this changes

Documentation only — no code. The rule is stated in the three places it needs to be unmissable:

- **`AGENTS.md`** — a new `ABSOLUTE` section, so it loads every session.
- **`content/ai/Skill/code.md`** — the rule, the two standing obligations (grep the repo trees **and** the live mesh before deleting framework surface; never leave a type at `Error`), and a **mandatory pre-prod sweep**: `Search('nodeType:NodeType')` → `LspDiagnosticsForNode` per type → fix roots first → re-sweep until all read `Ok`. Warnings are in scope — an unregistered `$type` leaves content an untyped `JsonElement` that renders **empty** rather than erroring.
- **`NodeTypeCompilation.md`** — the mechanism: a repo-file vs mesh-node table (import seed vs runtime source of truth, and how they drift), the failure cascade, the delete-an-API checklist, three quick-reference rows.

Written as a rule rather than an incident history, per review feedback.

## Verification

- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` — 2/2 passed
- `dotnet build src/MeshWeaver.Documentation -c Release -p:CIRun=true -warnaserror` — 0 warnings, 0 errors
- Branch is up to date with `origin/main`

## Not fixed here

**The prod outage is still live.** `SocialMedia/Post` has not been touched — this PR documents the class of failure, it does not repair the instance. Also still open on that portal: `Underwriting/*` content types missing from the receiving hub's TypeRegistry (renders empty / "cannot find layout area"), `Doc/DataMesh/SocialMedia/Post` failing on `CS0103 'host'`, and a `PluginGating DataModelling: reconcile is NOT CONVERGING` write loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQKMhQDpitUzsW1MqTVhH