### PR TITLE
perf(test): parallelise Hosting.Monolith.Test — 314.7s → 122.5s

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
@@ -30,6 +30,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// scope, keeps the timer alive, and asserts the capture target is collectible
 /// after the scope is disposed.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class ConsoleCaptureExecutionContextLeakTest
 {
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/test/MeshWeaver.Hosting.Monolith.Test/GcReachabilityCollection.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GcReachabilityCollection.cs
@@ -1,0 +1,36 @@
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The collection for tests that assert PROCESS-WIDE GC reachability — "after disposing X,
+/// nothing still roots it" — via <c>WeakReference</c> + a forced full <c>GC.Collect</c>.
+///
+/// <para>🚨 <b>This is scoping, not a band-aid.</b> Those assertions are statements about the
+/// whole process, so they are only meaningful when the rest of the process is quiet. With other
+/// classes concurrently allocating and holding live object graphs, a forced collect cannot be
+/// relied on to reclaim the target, and the test reports a "leak" that is really just a busy heap.
+/// Under parallelism such a test is not flaky — it is WRONG, because its precondition no longer
+/// holds. Declaring that precondition is the fix; suppressing, retrying or widening a timeout
+/// would be the band-aid.</para>
+///
+/// <para><c>DisableParallelization</c> makes xUnit run this collection on its own rather than
+/// alongside the parallel ones, which restores the quiet process these tests require. Everything
+/// else in the assembly keeps running at <c>maxParallelThreads</c> (see
+/// <c>test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json</c>).</para>
+///
+/// <para>Measured: enabling parallelism on this assembly without this collection reds
+/// <c>NodeTypeAssemblyLeakTest.NodeTypeAssemblyContext_IsCollected_AfterMeshDisposal</c> and
+/// <c>MeshHubDisposalLeakTest.MeshHub_IsCollected_AfterMeshAndServiceProviderDisposal</c> —
+/// both purely because a neighbour was allocating.</para>
+///
+/// <para>Add a class here ONLY if it asserts reachability/collection of an object after disposal.
+/// A test that is merely slow, or that races on shared STATE, does not belong — that is a real
+/// defect and serialising it would hide it.</para>
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class GcReachabilityCollection
+{
+    /// <summary>The collection name; referenced by <c>[Collection(GcReachabilityCollection.Name)]</c>.</summary>
+    public const string Name = "GC reachability (must run without parallel neighbours)";
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
@@ -39,6 +39,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>ScriptState</c>/<c>CSharpCompilation</c>/<c>AssemblyMetadata</c> is still
 /// reachable, the printed chain names the pin.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
@@ -58,6 +58,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>MeshWeaver.Hosting.Test.ActivityControlPlaneResubscribeTest</c>. This probe's job is
 /// DISCOVERY — naming a root nobody knew about — not verification.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
@@ -40,6 +40,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// fire or a second managed reference (e.g. a TypeRegistry that outlives the node)
 /// still pins the generated type.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class NodeTypeAssemblyLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json
+++ b/test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4,
+  "methodTimeout": 30000
+}


### PR DESCRIPTION
The heaviest project in the suite, and the one that sets the shard floor — `shard-assign.sh`: *"The floor for ANY sharding is the heaviest single project."*

```
threads=1   512 tests, 0 failed, 314.7s
threads=4   512 tests, 0 failed, 122.5s     2.57x
```

Held back in #979 because `threads=4` red two tests. Both are now resolved, neither by suppression.

## 1. The durable-seed failure is gone

`StaleActivationDurableFirstSeedTest` was the blocker in #979. #980 closed it as **already fixed** by the store-level write CAS (#971 / PR #988): the read-back of a value *below* the one written was never a visibility lag, it was a concurrent **rollback**, which the CAS now refuses at the store. Verified — it does not reproduce at `threads=4` on current main.

## 2. The GC-reachability family is scoped — and this is the part worth reading

Four classes assert **process-wide** reachability ("after disposing X, nothing still roots it") using `WeakReference` + a forced full `GC.Collect`:

- `MeshHubDisposalLeakTest`
- `NodeTypeAssemblyLeakTest`
- `KernelScriptMemoryLeakTest`
- `ConsoleCaptureExecutionContextLeakTest`

That assertion is only meaningful in a **quiet process**. With neighbours concurrently allocating and holding live object graphs, a forced collect cannot be relied on to reclaim the target — so the test reports a "leak" that is really a busy heap.

**Under parallelism such a test is not flaky, it is wrong**: its precondition no longer holds. Declaring that precondition with `[CollectionDefinition(DisableParallelization = true)]` *is* the fix. A retry, a widened timeout, or a `[Skip]` would have been the band-aid.

All four are tagged, not just the one that failed locally — `NodeTypeAssemblyLeakTest` red here, while `MeshHubDisposalLeakTest` red identically on CI run 31300348689 this morning and passed this run purely on timing. Same defect class; scoping one and waiting for the others to bite would be worse than useless.

🚨 The collection is documented as being for **reachability assertions only**. A test that is merely slow, or that races on shared *state*, must not be added — that is a real defect, and serialising it would hide it.

Everything else in the assembly still runs at `maxParallelThreads: 4`.

## Why this matters beyond one project

Total measured test work is 36.7 min across 8,817 tests. Monolith is the single largest block and the floor under any sharding change — cutting it 2.57x is what makes reducing shard count viable later (ideal per-shard is 5.4 min at 6 shards today, 8.1 at 4; that arithmetic only improves once the 36.7 min shrinks).

## No What's New entry

Test infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.