### PR TITLE
perf(test): parallelise AI.Test — 198.2s → 93.7s

### DIFF
--- a/test/MeshWeaver.AI.Test/xunit.runner.json
+++ b/test/MeshWeaver.AI.Test/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4,
+  "methodTimeout": 30000
+}


### PR DESCRIPTION
Second-heaviest project after Monolith — `shard-assign.sh` weight 177s, 1,138 tests, 39 classes carrying a `ShareMeshAcrossTests` opt-in.

```
threads=1   1138 tests, 0 failed, 198.2s
threads=4   1138 tests, 0 failed,  93.7s     2.11x
```

**One config file, nothing else.** Unlike `Hosting.Monolith.Test` (#1033) this needed no scoping:

- no GC-reachability assertions — no `WeakReference` + forced `GC.Collect`, so nothing here has a precondition that a busy heap invalidates
- no shared Testcontainers instance of the kind that keeps `Hosting.PostgreSql.Test` serial (25 classes on one `[Collection("PostgreSql")]`)

Ran clean at 4 threads first try.

## Correcting an earlier reading

An AI.Test run this morning showed 1 failure at `threads=1`, which I reported as "no clean local baseline, needs CI to judge". That was the nuget.org metadata flake this machine hit repeatedly today — not a defect. The baseline above is green at `threads=1` on the same machine, so the comparison is sound.

## Why this is safe

The isolation already exists: `MonolithMeshTestBase` keys its `IServiceProvider` cache by test-class `Type`, and xUnit's parallelism unit is the collection — one per class by default. Concurrent classes therefore already get independent meshes. Opt-in stays **per project**, because parallel safety is a property of the tests, not of the runner.

## Together with #1033

| project | 1 thread | 4 threads |
|---|---|---|
| `Monolith.Test` (#1033) | 314.7s | 122.5s |
| `AI.Test` (this) | 198.2s | 93.7s |
| **total** | **513s** | **216s** |

~5 minutes off the suite's 36.7 min of test work, from the two heaviest projects. That also moves the shard-count question: the ideal per-shard load only makes fewer/denser shards worthwhile once the total shrinks.

## No What's New entry

Test infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.