### PR TITLE
One stuck delivery no longer wedges a whole silo's routing

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -176,7 +176,19 @@ Pools are keyed by resource class and resolved lazily from `IoPoolRegistry` (a m
 | `Http` | 16 | 2 |
 | `Compile` | `Environment.ProcessorCount` | 3 |
 | `Process` | 4 | 3 |
+| `Routing` | 256 | — |
 | `pg:{adapter}` (per Postgres adapter) | **1** (mirrors the adapter's single Npgsql connection) | — |
+
+**`Routing` is an ISOLATION boundary, not a throttle.** `RoutingGrain` is `[StatelessWorker(1)]` and
+non-reentrant, so a silo has exactly ONE routing turn — and Orleans' request timeout applies to
+callers *waiting on* a grain, never to the turn itself. Anything the turn does inline is therefore
+unbounded by construction and blocks every other message the silo needs to route. Prod (atioz,
+2026-08-07) had one `RouteMessage` turn executing for `06:00:22` with `NonReentrancyQueueSize=541`;
+Orleans' own diagnostics showed the work item still `Running` with `Total processed` frozen — i.e.
+`RouteMessage` had never returned, it was blocked in its own synchronous body. The cure is structural
+(you cannot time out a synchronously blocked thread): `RouteMessage` captures its activation-bound
+handles and hands the composed route to this pool via `SubscribeThroughPool`, so a leg that never
+terminates costs one slot and nothing else. See issue #1028.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-one-stuck-message-no-longer-stops-the-portal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-one-stuck-message-no-longer-stops-the-portal.md
@@ -1,0 +1,25 @@
+---
+Name: One stuck message no longer stops the whole portal from talking to itself
+Category: Fix
+Description: A single delivery that never finished could hold the portal's message router and silently queue up everything else behind it.
+Icon: Sparkle
+Order: -20260809
+---
+
+# One stuck message no longer stops the whole portal from talking to itself
+
+Everything in a portal — opening a page, saving an edit, running a chat round — is a message handed
+to one router that decides where it goes. That router handled one message at a time, and it did the
+delivery work itself. So a single delivery that got stuck was enough to hold the router, and every
+other message in the portal simply waited. Nothing reported it: the portal answered pages, looked
+healthy, and quietly stopped doing anything that needed a message delivered.
+
+In production this happened once and lasted 37 hours. A single delivery sat unfinished for six
+hours with more than five hundred messages queued behind it, and it only came to light later as
+"this portal is running an old version" — the update it needed was one of the messages in that
+queue. Restarting the portal cleared it, which is part of why it stayed hidden for so long.
+
+The router now hands each delivery off and moves straight on to the next one, so a delivery that
+gets stuck costs only itself. A delivery that cannot be completed now says so — the sender is told
+it failed instead of waiting forever — and a portal whose deliveries stop finishing reports it
+loudly in the log rather than leaving it to be discovered days later.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -182,47 +182,12 @@ internal class RoutingGrain(
         string addressPath,
         IStreamProvider streamProvider,
         IGrainFactory grainFactory)
-        => Observable.Defer(() =>
-        {
-            // Surface a failure back to the original sender as a DeliveryFailure MESSAGE so
-            // its hub.Observe(...) callback fires OnError instead of parking forever. Used for
-            // BOTH unresolvable paths (NotFound) AND a node that resolves but whose owning grain
-            // cannot service the delivery (Failed — an unmaterializable / unregistered node type,
-            // or an access/activation failure). The sender's hub matches the DeliveryFailure to
-            // its Observe(...) subject by RequestId and fires OnError. Without this the caller's
-            // callback parks until its client-side timeout and the GUI re-issues the request →
-            // the routing NotFound/Failed STORM (the 2026-06-08 prod event storm).
-            void PostFailureToSender(string failureMessage, ErrorType errorType)
-            {
-                if (delivery.Sender == null) return;
-                // [CanBeIgnored] messages (HeartBeatEvent, Shutdown/Dispose) are fire-and-forget: there is NO
-                // awaiting Observe callback to fail, so a DeliveryFailure for them is meaningless. It would be
-                // dropped as unhandled at the sender, or — for a permanently-gone owner that is heart-beaten
-                // every interval — re-posted forever, which IS the NotFound storm. Silently ignore, matching
-                // the monolith RoutingServiceBase.PostNotFound / NackRouteFailure guard so both routers agree.
-                if (delivery.Message is DeliveryFailure
-                    || delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() == true)
-                    return;
-                var failureDelivery = new MessageDelivery<DeliveryFailure>(
-                    new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },
-                    new PostOptions(address)
-                        .WithTarget(delivery.Sender)
-                        .WithProperty(PostOptions.RequestId, delivery.Id),
-                    System.Text.Json.JsonSerializerOptions.Default);
-                streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
-                    .OnNextAsync(failureDelivery)
-                    .ContinueWith(t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
-                            logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
-                        }
-                        else
-                            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
-                    }, TaskScheduler.Default);
-            }
+    {
+        void PostFailureToSender(string failureMessage, ErrorType errorType) =>
+            PostFailure(delivery, address, streamProvider, failureMessage, errorType);
 
+        return Observable.Defer(() =>
+        {
             // Config-driven memory-stream dispatch: any address-type prefix
             // declared as a static stream route goes via the cluster-wide
             // Orleans memory stream instead of grain activation. This is the
@@ -292,7 +257,66 @@ internal class RoutingGrain(
                     PostFailureToSender($"Path resolution for '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
                     return Observable.Return(Unit.Default);
                 });
+        })
+        // 🚨 Composition-time faults must ALSO reach the sender. Everything above now runs OFF the
+        // turn, so a synchronous throw here (the classic one: `GetStream` NRE'ing out of
+        // PersistentStreamProvider.IsRewindable while the stream provider is still starting) no
+        // longer propagates out of RouteMessage to the caller's own error path — without this it
+        // would be logged and the sender would park forever. Terminal answer, always.
+        .Catch<Unit, Exception>(ex =>
+        {
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage ROUTE_FAULT id={delivery.Id} addr={addressPath} ex={ex.Message}");
+            logger.LogError(ex, "[ROUTE] Routing {Address} failed before the delivery could be attempted", addressPath);
+            PostFailureToSender($"Routing to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+            return Observable.Return(Unit.Default);
         });
+    }
+
+    /// <summary>
+    /// Surfaces a failure back to the original sender as a <see cref="DeliveryFailure"/> MESSAGE so
+    /// its <c>hub.Observe(...)</c> callback fires OnError instead of parking forever. Used for BOTH
+    /// unresolvable paths (NotFound) AND a node that resolves but whose owning grain cannot service
+    /// the delivery (Failed — an unmaterializable / unregistered node type, or an access/activation
+    /// failure). The sender's hub matches the DeliveryFailure to its <c>Observe(...)</c> subject by
+    /// RequestId and fires OnError. Without this the caller's callback parks until its client-side
+    /// timeout and the GUI re-issues the request → the routing NotFound/Failed STORM (the
+    /// 2026-06-08 prod event storm).
+    /// </summary>
+    private void PostFailure(
+        IMessageDelivery delivery,
+        Address address,
+        IStreamProvider streamProvider,
+        string failureMessage,
+        ErrorType errorType)
+    {
+        if (delivery.Sender == null) return;
+        // [CanBeIgnored] messages (HeartBeatEvent, Shutdown/Dispose) are fire-and-forget: there is NO
+        // awaiting Observe callback to fail, so a DeliveryFailure for them is meaningless. It would be
+        // dropped as unhandled at the sender, or — for a permanently-gone owner that is heart-beaten
+        // every interval — re-posted forever, which IS the NotFound storm. Silently ignore, matching
+        // the monolith RoutingServiceBase.PostNotFound / NackRouteFailure guard so both routers agree.
+        if (delivery.Message is DeliveryFailure
+            || delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() == true)
+            return;
+        var failureDelivery = new MessageDelivery<DeliveryFailure>(
+            new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },
+            new PostOptions(address)
+                .WithTarget(delivery.Sender)
+                .WithProperty(PostOptions.RequestId, delivery.Id),
+            System.Text.Json.JsonSerializerOptions.Default);
+        streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
+            .OnNextAsync(failureDelivery)
+            .ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
+                    logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
+                }
+                else
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
+            }, TaskScheduler.Default);
+    }
 
     /// <summary>
     /// The memory-stream leg of a route: post the delivery, and make ANY non-delivery — a fault OR

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -1,9 +1,11 @@
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Connection.Orleans;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using MeshWeaver.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +50,70 @@ internal class RoutingGrain(
     private readonly GrainActivationFailureRegistry? activationFailures =
         meshHub.ServiceProvider.GetService<GrainActivationFailureRegistry>();
 
+    // 🚨 Issue #1028. The mesh-scoped pool every route runs on — NEVER the activation thread.
+    // See IoPoolNames.Routing for the prod evidence. Instance field: its lifetime is the mesh's.
+    private readonly IIoPool routingPool =
+        meshHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Routing)
+        ?? IoPool.Unbounded;
+
+    /// <summary>
+    /// Routes dispatched but not yet terminated. This is the back-pressure signal that used to be
+    /// INVISIBLE: before #1028 the only evidence a route had stopped making progress was Orleans'
+    /// own <c>NonReentrancyQueueSize</c> growing into the hundreds inside a "Response did not
+    /// arrive on time" warning — nothing reported it as a routing fault, so the symptom surfaced
+    /// 37 h later as "the deployment is stale". Reported at the DISPATCH site (event-driven, no
+    /// timer, no watchdog).
+    /// </summary>
+    private int inFlightRoutes;
+    private int saturationReported;
+
+    /// <summary>
+    /// In-flight route count at which routing is declared to be falling behind and reported at
+    /// <see cref="LogLevel.Critical"/> (once, until it recovers). Well above any healthy burst —
+    /// routes terminate in milliseconds — and well below the 541-deep queue prod reached.
+    /// </summary>
+    internal const int SaturationThreshold = 64;
+
+    /// <summary>
+    /// Terminal bound on ONE memory-stream post. The post's only await is a single Orleans grain
+    /// call (<c>IMemoryStreamQueueGrain.Enqueue</c>) which Orleans already bounds at its 30 s
+    /// <c>ResponseTimeout</c> — so this can only ever fire when the transport's own bound has
+    /// ALREADY been exceeded, i.e. when the post is never going to complete. It exists so that
+    /// case becomes a loud, NACK'd failure instead of a silent never-completing leg (the standing
+    /// "an error must reach a graceful sink, never a silent hang" invariant); it is NOT a retry and
+    /// NOT a queue bound.
+    /// </summary>
+    internal static readonly TimeSpan StreamPostTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Bound on path resolution, so a provider that never emits cannot park the delivery in
+    /// silence — the timeout surfaces through the fault branch, which NACKs the sender.
+    /// </summary>
+    internal static readonly TimeSpan ResolveTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// 🚨 THE TURN DOES O(1) WORK AND RETURNS — issue #1028.
+    ///
+    /// <para><c>RoutingGrain</c> is <c>[StatelessWorker(1)]</c> and NON-reentrant: this silo has
+    /// exactly ONE routing turn, and Orleans' request timeout does not apply INSIDE a turn. So any
+    /// work performed here is work that every other message the silo needs to route waits on, with
+    /// no bound of any kind. Prod (atioz, 2026-08-07) had one <c>RouteMessage</c> turn executing
+    /// for <c>06:00:22</c> behind <c>NonReentrancyQueueSize=541</c>; Orleans' diagnostics showed
+    /// the work item itself still <c>Running</c> (<c>Total processed</c> frozen), i.e.
+    /// <c>RouteMessage</c> had never even RETURNED — it was blocked in its own synchronous body,
+    /// which is why nothing timed it out.</para>
+    ///
+    /// <para>The cure is structural, not a timeout on the turn (you cannot abandon a synchronously
+    /// blocked thread): this method only captures the activation-bound handles it needs and hands
+    /// the delivery to <see cref="routingPool"/>. Path resolution, the memory-stream post, the
+    /// per-node grain hand-off and the DeliveryFailure NACK all run OFF the turn, so a delivery
+    /// leg that never terminates costs one pool slot and cannot stop the silo's routing.</para>
+    ///
+    /// <para>The returned value is unchanged: <c>Forwarded</c> immediately. It always was — even
+    /// the old stream branch returned <c>Forwarded</c> whether the post succeeded or faulted — so
+    /// no caller-visible contract moves. A delivery's real success/failure is surfaced through the
+    /// standard response / <see cref="DeliveryFailure"/> path on the sender's hub.</para>
+    /// </summary>
     public Task<IMessageDelivery> RouteMessage(IMessageDelivery delivery)
     {
         var address = GetHostAddress(delivery.Target!);
@@ -57,161 +123,225 @@ internal class RoutingGrain(
             delivery.Message.GetType().Name, addressPath);
         RoutingGrainTrace.Write($"RoutingGrain.RouteMessage ENTER target={delivery.Target} hostAddr={address} type={address.Type} msg={delivery.Message?.GetType().Name} id={delivery.Id}");
 
-        // 🚨 Pre-capture grain services on the activation thread.
-        // After the SelectMany hops to Scheduler.Default (because IPathResolver
-        // emits via Observable.FromAsync(..., Scheduler.Default) after the
-        // persistence refactor), accessing `this.GetStreamProvider` or
-        // `this.GrainFactory` directly throws "Activation access violation".
-        // IStreamProvider and IGrainFactory references are themselves thread-safe
-        // — they don't require the activation thread once obtained.
+        // 🚨 Pre-capture grain services on the activation thread. `this.GetStreamProvider` /
+        // `this.GrainFactory` are activation-bound accessors and throw "Activation access
+        // violation" off the turn; the IStreamProvider and IGrainFactory references they return
+        // are themselves thread-safe. Both are pure lookups — O(1), no I/O, no foreign code.
         var streamProvider = this.GetStreamProvider(StreamProviders.Memory);
         var grainFactory = GrainFactory;
 
-        // 🚨 Fire-and-forget. Per AsynchronousCalls.md: never bridge an
-        // observable to Task in hub-reachable code with .FirstAsync().ToTask()
-        // — if the upstream chain ever fails to emit (path-resolver waiting
-        // on a slow catalog init, target grain stuck behind hub-readiness)
-        // the grain task hangs forever and Orleans' caller eventually times
-        // out with no diagnostic. Subscribe in the background, return
-        // Forwarded immediately — the actual delivery's success/failure is
-        // surfaced through the standard response/DeliveryFailure path on the
-        // sender's hub.
-
-        // Config-driven memory-stream dispatch: any address-type prefix
-        // declared as a static stream route goes via the cluster-wide
-        // Orleans memory stream instead of grain activation. This is the
-        // "I'm a registered hosted hub, find me via my RegisterStream
-        // subscription" path — portal hubs (`portal/{userId}`), test
-        // client hubs (`client/{id}`), cache hub (`cache/mesh-node-cache`),
-        // etc. The list is populated by each module via
-        // `IMeshBuilder.AddStreamRoutedAddressType("…")`.
-        if (meshConfig.StreamRoutedAddressTypes.Contains(address.Type))
-        {
-            logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
-            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
-            var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
-            return s.OnNextAsync(delivery)
-                .ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                    {
-                        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_FAULT id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
-                        // 🚨 The memory-stream post FAULTED — the stream-routed hub
-                        // (messagehub/{partition}, portal/{user}, cache/…) was unreachable: a
-                        // silo-membership blip / stream-provider error. The delivery VANISHED, and a
-                        // dropped stream post has NO downstream response/DeliveryFailure path. WITHOUT
-                        // surfacing it here the sender's Observe parks FOREVER → its hub action block
-                        // hangs → /healthz stops responding → liveness SIGKILLs the pod. That is the
-                        // prod wedge ("Failed to forward message → messagehub/{partition}" then a
-                        // silent ~10-min hang). NACK the sender so it fails fast instead. See /storm.
-                        logger.LogWarning(t.Exception,
-                            "[ROUTE] Stream-routed forward to {Address} faulted — surfacing DeliveryFailure to sender {Sender}",
-                            addressPath, delivery.Sender);
-                        PostFailureToSender(
-                            $"Stream-routed delivery to '{addressPath}' failed: {t.Exception?.InnerException?.Message ?? t.Exception?.Message ?? "stream forward fault"}",
-                            ErrorType.Failed);
-                    }
-                    else
-                        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_OK id={delivery.Id}");
-                    return delivery.Forwarded(address);
-                }, TaskScheduler.Default);
-        }
-
-        // Surface a failure back to the original sender as a DeliveryFailure MESSAGE so
-        // its hub.Observe(...) callback fires OnError instead of parking forever. Used for
-        // BOTH unresolvable paths (NotFound) AND a node that resolves but whose owning grain
-        // cannot service the delivery (Failed — an unmaterializable / unregistered node type,
-        // or an access/activation failure). The sender's hub matches the DeliveryFailure to
-        // its Observe(...) subject by RequestId and fires OnError. Without this the caller's
-        // callback parks until its client-side timeout and the GUI re-issues the request →
-        // the routing NotFound/Failed STORM (the 2026-06-08 prod event storm).
-        void PostFailureToSender(string failureMessage, ErrorType errorType)
-        {
-            if (delivery.Sender == null) return;
-            // [CanBeIgnored] messages (HeartBeatEvent, Shutdown/Dispose) are fire-and-forget: there is NO
-            // awaiting Observe callback to fail, so a DeliveryFailure for them is meaningless. It would be
-            // dropped as unhandled at the sender, or — for a permanently-gone owner that is heart-beaten
-            // every interval — re-posted forever, which IS the NotFound storm. Silently ignore, matching
-            // the monolith RoutingServiceBase.PostNotFound / NackRouteFailure guard so both routers agree.
-            if (delivery.Message is DeliveryFailure
-                || delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() == true)
-                return;
-            var failureDelivery = new MessageDelivery<DeliveryFailure>(
-                new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },
-                new PostOptions(address)
-                    .WithTarget(delivery.Sender)
-                    .WithProperty(PostOptions.RequestId, delivery.Id),
-                System.Text.Json.JsonSerializerOptions.Default);
-            streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
-                .OnNextAsync(failureDelivery)
-                .ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                    {
-                        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
-                        logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
-                    }
-                    else
-                        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
-                }, TaskScheduler.Default);
-        }
-
-        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_BEGIN id={delivery.Id} addr={addressPath}");
-        pathResolver.ResolvePath(addressPath)
-            .Take(1)
-            // Bound resolution so a provider that never emits cannot park the
-            // delivery in silence — the timeout surfaces through the OnError
-            // branch below, which NACKs the sender deterministically.
-            .Timeout(TimeSpan.FromSeconds(30))
-            .Subscribe(resolution =>
-            {
-                var grainKey = resolution?.Prefix ?? addressPath;
-                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_EMIT id={delivery.Id} addr={addressPath} grainKey={grainKey} prefix={resolution?.Prefix ?? "(null)"} remainder={resolution?.Remainder ?? "(null)"}");
-
-                logger.LogDebug("[ROUTE] {MessageType} → resolved={Prefix} remainder={Remainder} grainKey={GrainKey}",
-                    delivery.Message?.GetType().Name ?? "(null)", resolution?.Prefix ?? "(null)",
-                    resolution?.Remainder ?? "(null)", grainKey);
-
-                if (resolution == null || !string.IsNullOrEmpty(resolution.Remainder))
-                {
-                    var failureMessage = resolution == null
-                        ? $"No node found at '{addressPath}'."
-                        : $"No node found at '{addressPath}'. Closest ancestor is '{resolution.Prefix}' (remainder='{resolution.Remainder}').";
-                    logger.LogWarning("[ROUTE] NotFound: {FailureMessage}", failureMessage);
-                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage NOT_FOUND id={delivery.Id} addr={addressPath} sender={delivery.Sender}");
-                    PostFailureToSender(failureMessage, ErrorType.NotFound);
-                    return;
-                }
-
-                logger.LogDebug("[ROUTE] Delivering {MessageType} to grain {GrainKey}", delivery.Message?.GetType().Name ?? "(null)", grainKey);
-                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL id={delivery.Id} grainKey={grainKey}");
-                // 🚨 Deliver with a TRANSIENT-rejection retry. A node grain that is mid-DeactivateOnIdle
-                // rejects the call with OrleansMessageRejectionException ("invalid activation"); each retry
-                // re-resolves the grain so Orleans activates a FRESH instance and the message lands on the
-                // reactivated hub. Previously this single call dead-ended on a transient fault: the fault
-                // branch pushed the delivery onto a memory stream that has NO subscriber (per-node grain
-                // hubs aren't stream-registered — those return at the StreamRoutedAddressTypes check above),
-                // so the SubscribeRequest never got a response, the cache hub timed out after 60 s, and the
-                // node wedged on "Subscribing to {path}…" until a portal restart (prod 2026-06-24).
-                DeliverToGrainWithRetry(
-                    () => grainFactory.GetGrain<IMessageHubGrain>(grainKey).DeliverMessage(delivery),
-                    grainKey, addressPath, delivery.Id, PostFailureToSender, logger,
-                    resolveActivationError: activationFailures is null
-                        ? null
-                        : activationFailures.TryGet);
-            },
-            ex =>
-            {
-                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_FAULT id={delivery.Id} addr={addressPath} ex={ex.Message}");
-                logger.LogWarning(ex, "[ROUTE] Path resolution failed for {Address}", addressPath);
-                // Never park the caller in silence: a faulted/timed-out resolution
-                // is a terminal answer for THIS delivery — NACK the sender so its
-                // Observe callback fires OnError instead of waiting forever.
-                PostFailureToSender($"Path resolution for '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
-            });
+        // 🚨 THE TURN'S WORK ENDS HERE. BuildRoute only COMPOSES a cold observable; every
+        // side effect runs when the routing pool subscribes it, on a ThreadPool thread.
+        Dispatch(BuildRoute(delivery, address, addressPath, streamProvider, grainFactory),
+            addressPath, delivery.Id);
 
         return Task.FromResult(delivery.Forwarded(address));
     }
+
+    /// <summary>
+    /// Hands one composed route to the routing pool and returns. <see cref="IIoPool.SubscribeThroughPool{T}"/>
+    /// runs the SUBSCRIBE — the synchronous prologue that wedged prod — on a ThreadPool thread,
+    /// gated and drainable, so it is tracked at teardown and can never execute on the turn.
+    /// </summary>
+    private void Dispatch(IObservable<Unit> route, string addressPath, string deliveryId)
+    {
+        ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
+        routingPool.SubscribeThroughPool(route)
+            .Finally(() => ReportDrained(Interlocked.Decrement(ref inFlightRoutes)))
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[ROUTE] Route dispatch faulted for {Address} ({DeliveryId})", addressPath, deliveryId));
+    }
+
+    private void ReportSaturation(int inFlight, string addressPath)
+    {
+        if (inFlight < SaturationThreshold) return;
+        if (Interlocked.Exchange(ref saturationReported, 1) == 1) return;
+        logger.LogCritical(
+            "[ROUTE] {InFlight} route dispatches are in flight on this silo and not terminating (latest target {Address}). "
+            + "Routing is falling behind — a delivery leg is not completing. Before issue #1028 this was invisible: "
+            + "the only trace was Orleans' NonReentrancyQueueSize growing inside a 'Response did not arrive on time' warning.",
+            inFlight, addressPath);
+    }
+
+    private void ReportDrained(int inFlight)
+    {
+        if (inFlight > SaturationThreshold / 2) return;
+        if (Interlocked.Exchange(ref saturationReported, 0) == 0) return;
+        logger.LogInformation("[ROUTE] Routing back-pressure cleared — {InFlight} route(s) in flight", inFlight);
+    }
+
+    /// <summary>
+    /// Composes (does NOT run) the route for one delivery. Everything below executes on the
+    /// routing pool, never on the grain turn — see <see cref="RouteMessage"/>.
+    /// </summary>
+    private IObservable<Unit> BuildRoute(
+        IMessageDelivery delivery,
+        Address address,
+        string addressPath,
+        IStreamProvider streamProvider,
+        IGrainFactory grainFactory)
+        => Observable.Defer(() =>
+        {
+            // Surface a failure back to the original sender as a DeliveryFailure MESSAGE so
+            // its hub.Observe(...) callback fires OnError instead of parking forever. Used for
+            // BOTH unresolvable paths (NotFound) AND a node that resolves but whose owning grain
+            // cannot service the delivery (Failed — an unmaterializable / unregistered node type,
+            // or an access/activation failure). The sender's hub matches the DeliveryFailure to
+            // its Observe(...) subject by RequestId and fires OnError. Without this the caller's
+            // callback parks until its client-side timeout and the GUI re-issues the request →
+            // the routing NotFound/Failed STORM (the 2026-06-08 prod event storm).
+            void PostFailureToSender(string failureMessage, ErrorType errorType)
+            {
+                if (delivery.Sender == null) return;
+                // [CanBeIgnored] messages (HeartBeatEvent, Shutdown/Dispose) are fire-and-forget: there is NO
+                // awaiting Observe callback to fail, so a DeliveryFailure for them is meaningless. It would be
+                // dropped as unhandled at the sender, or — for a permanently-gone owner that is heart-beaten
+                // every interval — re-posted forever, which IS the NotFound storm. Silently ignore, matching
+                // the monolith RoutingServiceBase.PostNotFound / NackRouteFailure guard so both routers agree.
+                if (delivery.Message is DeliveryFailure
+                    || delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() == true)
+                    return;
+                var failureDelivery = new MessageDelivery<DeliveryFailure>(
+                    new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },
+                    new PostOptions(address)
+                        .WithTarget(delivery.Sender)
+                        .WithProperty(PostOptions.RequestId, delivery.Id),
+                    System.Text.Json.JsonSerializerOptions.Default);
+                streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
+                    .OnNextAsync(failureDelivery)
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
+                            logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
+                        }
+                        else
+                            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
+                    }, TaskScheduler.Default);
+            }
+
+            // Config-driven memory-stream dispatch: any address-type prefix
+            // declared as a static stream route goes via the cluster-wide
+            // Orleans memory stream instead of grain activation. This is the
+            // "I'm a registered hosted hub, find me via my RegisterStream
+            // subscription" path — portal hubs (`portal/{userId}`), test
+            // client hubs (`client/{id}`), cache hub (`cache/mesh-node-cache`),
+            // etc. The list is populated by each module via
+            // `IMeshBuilder.AddStreamRoutedAddressType("…")`.
+            if (meshConfig.StreamRoutedAddressTypes.Contains(address.Type))
+            {
+                logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
+                var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
+                return PostToStream(() => s.OnNextAsync(delivery), addressPath, delivery.Id,
+                    delivery.Sender, PostFailureToSender, logger, StreamPostTimeout);
+            }
+
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_BEGIN id={delivery.Id} addr={addressPath}");
+            return pathResolver.ResolvePath(addressPath)
+                .Take(1)
+                .Timeout(ResolveTimeout)
+                .Select(resolution =>
+                {
+                    var grainKey = resolution?.Prefix ?? addressPath;
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_EMIT id={delivery.Id} addr={addressPath} grainKey={grainKey} prefix={resolution?.Prefix ?? "(null)"} remainder={resolution?.Remainder ?? "(null)"}");
+
+                    logger.LogDebug("[ROUTE] {MessageType} → resolved={Prefix} remainder={Remainder} grainKey={GrainKey}",
+                        delivery.Message?.GetType().Name ?? "(null)", resolution?.Prefix ?? "(null)",
+                        resolution?.Remainder ?? "(null)", grainKey);
+
+                    if (resolution == null || !string.IsNullOrEmpty(resolution.Remainder))
+                    {
+                        var failureMessage = resolution == null
+                            ? $"No node found at '{addressPath}'."
+                            : $"No node found at '{addressPath}'. Closest ancestor is '{resolution.Prefix}' (remainder='{resolution.Remainder}').";
+                        logger.LogWarning("[ROUTE] NotFound: {FailureMessage}", failureMessage);
+                        RoutingGrainTrace.Write($"RoutingGrain.RouteMessage NOT_FOUND id={delivery.Id} addr={addressPath} sender={delivery.Sender}");
+                        PostFailureToSender(failureMessage, ErrorType.NotFound);
+                        return Unit.Default;
+                    }
+
+                    logger.LogDebug("[ROUTE] Delivering {MessageType} to grain {GrainKey}", delivery.Message?.GetType().Name ?? "(null)", grainKey);
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL id={delivery.Id} grainKey={grainKey}");
+                    // 🚨 Deliver with a TRANSIENT-rejection retry. A node grain that is mid-DeactivateOnIdle
+                    // rejects the call with OrleansMessageRejectionException ("invalid activation"); each retry
+                    // re-resolves the grain so Orleans activates a FRESH instance and the message lands on the
+                    // reactivated hub. Previously this single call dead-ended on a transient fault: the fault
+                    // branch pushed the delivery onto a memory stream that has NO subscriber (per-node grain
+                    // hubs aren't stream-registered — those return at the StreamRoutedAddressTypes check above),
+                    // so the SubscribeRequest never got a response, the cache hub timed out after 60 s, and the
+                    // node wedged on "Subscribing to {path}…" until a portal restart (prod 2026-06-24).
+                    DeliverToGrainWithRetry(
+                        () => grainFactory.GetGrain<IMessageHubGrain>(grainKey).DeliverMessage(delivery),
+                        grainKey, addressPath, delivery.Id, PostFailureToSender, logger,
+                        resolveActivationError: activationFailures is null
+                            ? null
+                            : activationFailures.TryGet);
+                    return Unit.Default;
+                })
+                .Catch<Unit, Exception>(ex =>
+                {
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_FAULT id={delivery.Id} addr={addressPath} ex={ex.Message}");
+                    logger.LogWarning(ex, "[ROUTE] Path resolution failed for {Address}", addressPath);
+                    // Never park the caller in silence: a faulted/timed-out resolution
+                    // is a terminal answer for THIS delivery — NACK the sender so its
+                    // Observe callback fires OnError instead of waiting forever.
+                    PostFailureToSender($"Path resolution for '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+                    return Observable.Return(Unit.Default);
+                });
+        });
+
+    /// <summary>
+    /// The memory-stream leg of a route: post the delivery, and make ANY non-delivery — a fault OR
+    /// a post that simply never completes — a loud, NACK'd terminal answer for the sender.
+    ///
+    /// <para>🚨 A dropped stream post has NO downstream response / <see cref="DeliveryFailure"/>
+    /// path of its own: the stream-routed hub (<c>messagehub/{partition}</c>, <c>portal/{user}</c>,
+    /// <c>cache/…</c>) simply never sees the message. Without surfacing it here the sender's
+    /// <c>Observe</c> parks FOREVER → its hub action block hangs → <c>/healthz</c> stops responding
+    /// → liveness SIGKILLs the pod (the prod wedge: "Failed to forward message →
+    /// messagehub/{partition}" then a silent ~10-min hang). NACK the sender so it fails fast.</para>
+    ///
+    /// <para>Emits exactly one <see cref="Unit"/> and completes in every case — success, fault, or
+    /// timeout — so the caller's pool slot and in-flight count are always released. Static with a
+    /// <paramref name="post"/> / <paramref name="scheduler"/> seam so the never-completing case is
+    /// deterministically testable without a cluster.</para>
+    /// </summary>
+    internal static IObservable<Unit> PostToStream(
+        Func<Task> post,
+        string addressPath,
+        string deliveryId,
+        Address? sender,
+        Action<string, ErrorType> postFailureToSender,
+        ILogger logger,
+        TimeSpan timeout,
+        IScheduler? scheduler = null)
+        => Observable.Defer(() => post().ToObservable())
+            .Timeout(timeout, scheduler ?? Scheduler.Default)
+            .Do(_ => RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_OK id={deliveryId}"))
+            .Catch<Unit, Exception>(ex =>
+            {
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_FAULT id={deliveryId} ex={ex.Message}");
+                if (ex is TimeoutException)
+                    // The post never completed. Its ONLY await is a grain call Orleans already bounds
+                    // at 30 s, so this is not slowness — the leg is dead. Loud, because a delivery that
+                    // neither lands nor reports is exactly the silent hang #1028 was made of.
+                    logger.LogError(ex,
+                        "[ROUTE] Stream-routed forward to {Address} did not complete within {Timeout} — the post is not going to land; surfacing DeliveryFailure to sender {Sender}",
+                        addressPath, timeout, sender);
+                else
+                    logger.LogWarning(ex,
+                        "[ROUTE] Stream-routed forward to {Address} faulted — surfacing DeliveryFailure to sender {Sender}",
+                        addressPath, sender);
+                var reason = ex is TimeoutException
+                    ? $"the post did not complete within {timeout}"
+                    : ex.Message;
+                postFailureToSender($"Stream-routed delivery to '{addressPath}' failed: {reason}", ErrorType.Failed);
+                return Observable.Return(Unit.Default);
+            });
 
     internal static Address GetHostAddress(Address address)
     {

--- a/src/MeshWeaver.Hosting/AssemblyInfo.cs
+++ b/src/MeshWeaver.Hosting/AssemblyInfo.cs
@@ -9,3 +9,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting.Monolith.Test")]
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting.PostgreSql.Test")]
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting.Sqlite.Test")]
+// RoutingGrainTurnIsolationTest (issue #1028) decorates the real PathResolutionService with one
+// whose Subscribe BLOCKS, to prove a stalled route leg can no longer wedge the silo's routing.
+[assembly: InternalsVisibleTo("MeshWeaver.Hosting.Orleans.Test")]

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
@@ -59,6 +59,26 @@ public static class IoPoolNames
     /// </summary>
     public const string AgentStore = "AgentStore";
 
+    /// <summary>
+    /// Silo-side message routing (<c>RoutingGrain.RouteMessage</c>), via
+    /// <see cref="IIoPool.SubscribeThroughPool{T}"/>. Exists so the routing SUBSCRIBE — path
+    /// resolution, the memory-stream post, the per-node grain hand-off and the DeliveryFailure
+    /// NACK — runs OFF the routing grain's activation thread.
+    ///
+    /// <para>🚨 This is the fix for issue #1028. <c>RoutingGrain</c> is <c>[StatelessWorker(1)]</c>
+    /// and NON-reentrant, so the silo has exactly ONE routing turn: any work the turn performs
+    /// inline is work the whole silo's routing waits on, and Orleans' request timeout does NOT
+    /// apply inside a turn. Prod (atioz, 2026-08-07) had a single <c>RouteMessage</c> turn
+    /// executing for <c>06:00:22</c> with <c>NonReentrancyQueueSize=541</c> — every other message
+    /// the silo needed to route was stuck behind it for 37 h. Routing work therefore never runs on
+    /// the turn; it runs here, where one stuck delivery costs one pool slot and nothing else.</para>
+    ///
+    /// <para>Generous cap: a drain hook + isolation boundary, not a throttle — the slot is held
+    /// only for the bounded subscribe window (see <see cref="IIoPool.SubscribeThroughPool{T}"/>),
+    /// and routing is the hottest path in the mesh.</para>
+    /// </summary>
+    public const string Routing = "Routing";
+
     /// <summary>CPU-bound compilation (Roslyn compile/script). Wave 3.</summary>
     public const string Compile = "Compile";
 
@@ -161,6 +181,15 @@ public sealed record IoPoolOptions
     /// </summary>
     public int AgentStore { get; init; } = 128;
 
+    /// <summary>
+    /// Concurrent silo-side routing subscribes (the <c>Routing</c> pool). A drain hook and an
+    /// isolation boundary, not a throttle — the slot is held only for the bounded subscribe
+    /// window — so the cap is generous (256): routing is the hottest path in the mesh and must
+    /// never queue behind itself. See <see cref="IoPoolNames.Routing"/> for why routing work is
+    /// not allowed on the routing grain's turn at all (issue #1028).
+    /// </summary>
+    public int Routing { get; init; } = 256;
+
     /// <summary>Concurrent compilations. CPU-bound; defaults to the processor count.</summary>
     public int Compile { get; init; } = Environment.ProcessorCount;
 
@@ -210,6 +239,7 @@ public sealed record IoPoolOptions
             IoPoolNames.Query => Query,
             IoPoolNames.Layout => Layout,
             IoPoolNames.AgentStore => AgentStore,
+            IoPoolNames.Routing => Routing,
             IoPoolNames.Compile => Compile,
             IoPoolNames.Process => Process,
             _ => Default,

--- a/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
@@ -37,6 +37,9 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Orleans.TestingHost" />
       <PackageReference Include="Microsoft.Orleans.Sdk" />
+      <!-- TestScheduler: RoutingGrainStreamPostBoundTest drives the stream-post timeout
+           deterministically (issue #1028) instead of waiting on the wall clock. -->
+      <PackageReference Include="Microsoft.Reactive.Testing" />
     </ItemGroup>
 
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainStreamPostBoundTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainStreamPostBoundTest.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the terminal contract of the memory-stream leg of a route (issue #1028).
+///
+/// <para><b>Why this leg needs a terminal bound.</b> A dropped memory-stream post has NO downstream
+/// response / <see cref="DeliveryFailure"/> path of its own — the stream-routed hub simply never
+/// sees the message. Before #1028 the post was AWAITED inside the routing grain's turn, so a post
+/// that never completed wedged the whole silo's routing AND told nobody. Now the post runs off the
+/// turn, which fixes the wedge; this test pins the other half: it must always TERMINATE (so the
+/// pool slot and the in-flight count are released) and the sender must always be told (so its
+/// <c>Observe</c> fires OnError instead of parking forever).</para>
+///
+/// <para>Deterministic — <see cref="TestScheduler"/> for the timeout, no cluster, no wall clock.</para>
+/// </summary>
+public class RoutingGrainStreamPostBoundTest
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+    private static readonly Address Sender = new("client", "sender-1");
+
+    [Fact]
+    public void PostThatNeverCompletes_TerminatesOnTimeout_AndNacksSender()
+    {
+        // The prod shape: the post is issued and its Task simply never completes.
+        var never = new TaskCompletionSource();
+        var nacks = new List<(string Message, ErrorType Type)>();
+        var scheduler = new TestScheduler();
+        var terminated = false;
+
+        RoutingGrain.PostToStream(
+                post: () => never.Task,
+                addressPath: "portal/user-1",
+                deliveryId: "d1",
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: NullLogger.Instance,
+                timeout: Timeout,
+                scheduler: scheduler)
+            .Subscribe(_ => { }, () => terminated = true);
+
+        // Before the bound elapses: still in flight, nobody has been told anything. Correct —
+        // a slow post is not a failed post.
+        scheduler.AdvanceBy(Timeout.Ticks - 1);
+        nacks.Should().BeEmpty("a post that has not yet exceeded its bound is not a failure");
+        terminated.Should().BeFalse();
+
+        scheduler.AdvanceBy(2);
+
+        // 🚨 The two things that must ALWAYS happen, and did not before #1028:
+        terminated.Should().BeTrue(
+            "the leg must complete so the routing pool slot and the in-flight route count are "
+            + "released — a never-terminating leg is how a bounded pool silently fills up");
+        var nack = nacks.Should().ContainSingle(
+            "a delivery that neither lands nor reports is exactly the silent hang #1028 was made of "
+            + "— the sender must get a DeliveryFailure so its Observe fires OnError").Subject;
+        nack.Type.Should().Be(ErrorType.Failed);
+        nack.Message.Should().Contain("portal/user-1");
+    }
+
+    [Fact]
+    public async Task PostThatFaults_NacksSender_AndStillCompletes()
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        await RoutingGrain.PostToStream(
+                post: () => Task.FromException(new InvalidOperationException("stream provider down")),
+                addressPath: "portal/user-2",
+                deliveryId: "d2",
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: NullLogger.Instance,
+                timeout: Timeout)
+            .ToTask();
+
+        var nack = nacks.Should().ContainSingle().Subject;
+        nack.Type.Should().Be(ErrorType.Failed);
+        nack.Message.Should().Contain("stream provider down");
+    }
+
+    [Fact]
+    public async Task PostThatSucceeds_CompletesWithoutNack()
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        var result = await RoutingGrain.PostToStream(
+                post: () => Task.CompletedTask,
+                addressPath: "portal/user-3",
+                deliveryId: "d3",
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: NullLogger.Instance,
+                timeout: Timeout)
+            .ToTask();
+
+        result.Should().Be(Unit.Default);
+        nacks.Should().BeEmpty("a delivered post must never NACK the sender");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL for the structural half of the fix. This is the SHAPE the routing grain's
+    /// turn used to have — <c>return s.OnNextAsync(delivery).ContinueWith(...)</c> — and it shows
+    /// why nothing bounded it: the turn's completion IS the post's completion, so a post that never
+    /// completes is a turn that never returns. <c>RoutingGrain</c> is <c>[StatelessWorker(1)]</c>
+    /// and non-reentrant, so that one turn is the silo's ONLY routing turn; Orleans' request
+    /// timeout applies to messages WAITING on a grain, never to the turn itself. Prod:
+    /// <c>06:00:22</c> executing, <c>NonReentrancyQueueSize=541</c>.
+    ///
+    /// <para>The cure is that <c>RouteMessage</c> no longer returns anything derived from the
+    /// delivery work — see <see cref="RoutingGrainTurnIsolationTest"/>, which proves it against a
+    /// real cluster.</para>
+    /// </summary>
+    [Fact]
+    public async Task NegativeControl_AwaitingThePostInsideTheTurn_NeverReturns()
+    {
+        var never = new TaskCompletionSource();
+
+        // The pre-#1028 turn body, verbatim in shape.
+        Task<IMessageDelivery> LegacyTurn() =>
+            never.Task.ContinueWith(_ => (IMessageDelivery)new MessageDelivery<string>(), TaskScheduler.Default);
+
+        var turn = LegacyTurn();
+
+        // A "wait to confirm nothing happened" negative test — there is no positive signal to
+        // filter for, because the whole point is that the turn produces none.
+        var settled = await Task.WhenAny(turn, Task.Delay(TimeSpan.FromMilliseconds(250)));
+
+        settled.Should().NotBe(turn,
+            "this is the defect: the turn's completion is the post's completion, so a post that "
+            + "never completes holds the silo's single non-reentrant routing turn forever, with no "
+            + "timeout anywhere on that path (issue #1028)");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Diagnostics;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Real Orleans regression for issue #1028 — "one non-reentrant RouteMessage can wedge a whole
+/// silo's routing".
+///
+/// <para><b>Prod evidence (atioz, 2026-08-07).</b> <c>RoutingGrain</c> is
+/// <c>[StatelessWorker(1)]</c> and NON-reentrant, so a silo has exactly ONE routing turn — and
+/// Orleans' request timeout does not apply INSIDE a turn. One <c>RouteMessage</c> sat executing for
+/// <c>06:00:22</c> with <c>NonReentrancyQueueSize=541</c>; Orleans' work-item diagnostics showed the
+/// work item still <c>Running</c> with <c>Total processed</c> frozen, i.e. <c>RouteMessage</c> had
+/// never RETURNED — it was blocked in its own synchronous body, which is exactly why nothing timed
+/// it out. Every message the silo needed to route queued behind it, and
+/// <c>Admin/UpdatePolicy</c> was unreachable for 37 h.</para>
+///
+/// <para><b>Invariant.</b> The turn captures its activation-bound handles and returns; the route
+/// itself (path resolution, the memory-stream post, the per-node grain hand-off, the
+/// <see cref="DeliveryFailure"/> NACK) runs OFF the turn on the <c>Routing</c>
+/// <see cref="MeshWeaver.Mesh.Threading.IIoPool"/>. So a leg that blocks forever costs ONE pool slot
+/// and the silo keeps routing.</para>
+///
+/// <para><b>Shape of the test.</b> The silo's <see cref="IPathResolver"/> is decorated with one whose
+/// <c>Subscribe</c> BLOCKS THE CALLING THREAD for a path under a magic partition — the prod failure
+/// mode, reproduced deterministically. We fire one delivery into that partition, wait (observing the
+/// silo-side decorator directly, no sleep-and-hope) until the routing grain is provably inside the
+/// stall, then ping an ordinary partition root. Pre-fix the ping cannot be served at all — the turn
+/// is blocked — and the probe times out. Post-fix it answers in milliseconds.</para>
+/// </summary>
+public class RoutingGrainTurnIsolationTest(ITestOutputHelper output)
+    : OrleansTestBase<StallingResolverSiloConfigurator>(output)
+{
+    /// <summary>
+    /// Budget for the probe ping. Comfortably above a healthy grain activation (&lt; 1 s) and
+    /// comfortably BELOW <see cref="StallingPathResolver.StallDuration"/>, so a pass can only mean
+    /// the probe overtook a still-running stall — never that it waited the stall out.
+    /// </summary>
+    private static readonly TimeSpan ProbeBudget = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task StalledRouteLeg_DoesNotBlockTheRestOfTheSilosRouting()
+    {
+        // The decorator must really be the silo's resolver — otherwise the test would pass
+        // vacuously (nothing stalls, everything routes). Assert the wiring, never assume it.
+        var resolver = Cluster.SiloServices().GetRequiredService<IPathResolver>() as StallingPathResolver;
+        resolver.Should().NotBeNull(
+            "the stalling decorator must be the silo's IPathResolver — without it nothing stalls "
+            + "and this test would pass without exercising #1028 at all");
+
+        var client = GetClient($"wedge{Guid.NewGuid():N}"[..16]);
+
+        try
+        {
+            // 1. A delivery whose PATH RESOLUTION blocks the subscribing thread. Pre-fix that thread
+            //    IS the routing grain's activation thread, so this single message wedges the silo.
+            client.Post(new PingRequest(),
+                o => o.WithTarget(new Address(StallingPathResolver.StallPartition, "wedged")));
+
+            // 2. Wait until the stall is PROVABLY in flight (read the silo-side decorator; the
+            //    standard interval-poll for a source that is not itself observable). No ordering
+            //    assumption, no sleep — without this the probe could overtake the stall and the
+            //    test would false-pass.
+            await Observable.Interval(TimeSpan.FromMilliseconds(25))
+                .StartWith(0L)
+                .Where(_ => resolver!.StallsEntered > 0)
+                .FirstAsync()
+                .ToTask(new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token);
+
+            Output.WriteLine("stall is in flight — probing the silo's routing");
+
+            // 3. Probe: an ordinary bare partition root, served by the default node hub. It needs
+            //    the routing grain, and nothing else about it is slow.
+            var partitionRoot = $"probe-{Guid.NewGuid():N}";
+            var sw = Stopwatch.StartNew();
+
+            var response = await client
+                .Observe(new PingRequest(), o => o.WithTarget(new Address(partitionRoot)))
+                .FirstAsync()
+                .ToTask(new CancellationTokenSource(ProbeBudget).Token);
+
+            sw.Stop();
+
+            response.Should().NotBeNull(
+                "a route whose leg never terminates must not stop the silo routing anything else — "
+                + "RoutingGrain is [StatelessWorker(1)] and non-reentrant, so any work the turn performs "
+                + "inline is work every other delivery waits on, with no bound of any kind (issue #1028)");
+
+            sw.Elapsed.Should().BeLessThan(ProbeBudget,
+                $"the probe must be served while the stalled route is still stalled. Actual: {sw.Elapsed.TotalSeconds:0.0}s.");
+
+            // The stall must STILL be running — otherwise the probe was served because the stall
+            // ended, not because routing is isolated from it, and the test proved nothing.
+            resolver!.StallsCompleted.Should().Be(0,
+                "the probe must be answered WHILE a route leg is stuck, not after it finally unblocked");
+
+            Output.WriteLine(
+                $"PASSED — probe answered in {sw.Elapsed.TotalMilliseconds:0}ms with {resolver.StallsEntered} route leg(s) still stalled");
+        }
+        finally
+        {
+            // Unblock the stalled leg so no thread and no routing-pool permit survives into teardown.
+            resolver!.Release();
+        }
+    }
+}
+
+/// <summary>
+/// <see cref="IPathResolver"/> decorator that BLOCKS THE SUBSCRIBING THREAD for any path under
+/// <see cref="StallPartition"/>, and delegates everything else to the real resolver. This is the
+/// prod failure mode of issue #1028 reproduced deterministically: a route leg whose synchronous
+/// prologue never returns. Self-releasing after <see cref="StallDuration"/> so the test can never
+/// leak a blocked thread past the run.
+/// </summary>
+internal sealed class StallingPathResolver(PathResolutionService inner) : IPathResolver, IDisposable
+{
+    /// <summary>First path segment whose resolution blocks. Nothing else in the mesh uses it.</summary>
+    internal const string StallPartition = "stalledroute";
+
+    /// <summary>
+    /// Safety net only: the longest a stalled subscribe can block if the test never calls
+    /// <see cref="Release"/> (an aborted run). The test releases it explicitly, so a healthy run
+    /// never waits this out and never leaves a pool permit held into teardown.
+    /// </summary>
+    private static readonly TimeSpan MaxStall = TimeSpan.FromSeconds(60);
+
+    private readonly ManualResetEventSlim released = new(false);
+    private int stallsEntered;
+    private int stallsCompleted;
+
+    /// <summary>Route legs that have entered the stall — the test's "the wedge is live" signal.</summary>
+    internal int StallsEntered => Volatile.Read(ref stallsEntered);
+
+    /// <summary>Route legs whose stall has ended; must stay 0 while the probe runs.</summary>
+    internal int StallsCompleted => Volatile.Read(ref stallsCompleted);
+
+    /// <summary>Unblocks every stalled leg so nothing holds a thread or a pool permit into teardown.</summary>
+    internal void Release() => released.Set();
+
+    public IObservable<AddressResolution?> ResolvePath(string path) => Stall(path) ?? inner.ResolvePath(path);
+
+    public IObservable<AddressResolution?> ResolveNavigationPath(string path) =>
+        Stall(path) ?? inner.ResolveNavigationPath(path);
+
+    private IObservable<AddressResolution?>? Stall(string path)
+    {
+        if (!path.StartsWith(StallPartition, StringComparison.Ordinal))
+            return null;
+        return Observable.Create<AddressResolution?>(observer =>
+        {
+            Interlocked.Increment(ref stallsEntered);
+            // 🚨 Deliberate fault INJECTION, not a wait-for-propagation sleep: this models a leaf
+            // whose synchronous prologue never returns (the prod wedge). Pre-fix this runs on the
+            // routing grain's activation thread and the whole silo stops routing.
+            released.Wait(MaxStall);
+            Interlocked.Increment(ref stallsCompleted);
+            // Unwind as an ordinary NotFound so the release path is clean.
+            observer.OnNext(null);
+            observer.OnCompleted();
+            return System.Reactive.Disposables.Disposable.Empty;
+        });
+    }
+
+    public void Dispose() => released.Set();
+}
+
+/// <summary>
+/// Canonical minimal silo (mirrors <c>PartitionRootSiloConfigurator</c>) plus the
+/// <see cref="StallingPathResolver"/> decorator. The decorator is registered LAST so it wins over
+/// the framework's <c>TryAddSingleton&lt;IPathResolver&gt;</c>; the test asserts the wiring took.
+/// </summary>
+public class StallingResolverSiloConfigurator : ISiloConfigurator, IHostConfigurator
+{
+    public void Configure(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.ConfigureMeshWeaverServer()
+            .AddMemoryGrainStorageAsDefault();
+    }
+
+    public void Configure(IHostBuilder hostBuilder)
+    {
+        hostBuilder.UseOrleansMeshServer()
+            .AddPartitionedInMemoryPersistence()
+            .ConfigurePortalMesh();
+
+        hostBuilder.ConfigureServices(services =>
+            services.AddSingleton<IPathResolver>(sp =>
+                new StallingPathResolver(sp.GetRequiredService<PathResolutionService>())));
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
@@ -46,9 +46,11 @@ public class RoutingGrainTurnIsolationTest(ITestOutputHelper output)
     : OrleansTestBase<StallingResolverSiloConfigurator>(output)
 {
     /// <summary>
-    /// Budget for the probe ping. Comfortably above a healthy grain activation (&lt; 1 s) and
-    /// comfortably BELOW <see cref="StallingPathResolver.StallDuration"/>, so a pass can only mean
-    /// the probe overtook a still-running stall — never that it waited the stall out.
+    /// Budget for the probe ping — comfortably above a healthy grain activation (&lt; 1 s). The stall
+    /// only ends when the test calls <see cref="StallingPathResolver.Release"/> in its finally, so
+    /// the probe can never simply wait it out; the
+    /// <see cref="StallingPathResolver.StallsCompleted"/> assertion after the probe is what proves
+    /// the stall was still live when the ping was answered.
     /// </summary>
     private static readonly TimeSpan ProbeBudget = TimeSpan.FromSeconds(10);
 


### PR DESCRIPTION
Fixes #1028.

## What the evidence actually says

I pulled the original wedge out of Loki (atioz, pod `memex-portal-deployment-76855f7cdd-gm69g`, 2026-08-07 15:14 UTC onward). Three facts fall out, and the third contradicts the issue's premise:

1. **The wedge starts on a fresh activation, ~35 s into pod startup**, during the startup burst (`ShippedReleaseSeed` firing ~20 `AgenticPension/*` release triggers, `DynamicTypePreWarmer` building 4 NodeTypes, `StaticRepoImport` syncing 4 sources) — all funnelled through the one routing worker. `IdlenessTimeSpan=00:00:34`, `Total Enqueued=3; Total processed=2`.

2. **`RouteMessage` never RETURNED — it was blocked in its own synchronous body.** Orleans' diagnostic reports `Executing Task Id=1 Status=Running for 00:00:29.463` with `QueuedWorkItems=0` and `Total processed` frozen at 2. Orleans' request work item completes as soon as the grain method returns its `Task`; a turn *awaiting* something would have shown `processed=3` and the activation merely waiting. It didn't. The turn was synchronously stuck.

3. **It was not an awaited grain call.** Grain calls are bounded by Orleans' 30 s `ResponseTimeout`, and those timeouts absolutely do get logged here — over the three days I queried there are **2068** `IRoutingGrain.RouteMessage` and **179** `IMessageHubGrain.DeliverMessage` "Response did not arrive on time" lines, and **zero** for `IMemoryStreamQueueGrain.Enqueue`.

That third point answers question 1 in the issue, in the negative. `IAsyncStream.OnNextAsync` on an Orleans memory stream has exactly one await — `queueGrain.Enqueue(...)` (`MemoryAdapterFactory.QueueMessageBatchAsync`, verified against Orleans v10.2.2 source) — and that award is bounded and would have been logged. **So "a memory-stream `OnNextAsync` that never completes" is not what happened.** What actually has no bound is the *synchronous* work `RouteMessage` performed on the turn, on **both** branches:

- stream branch: `GetStream(...)` plus `OnNextAsync`'s synchronous prologue (Orleans serialization of the delivery) — and then it **awaited** the post, so the turn's completion *was* the post's completion;
- grain branch: the entire synchronous prologue of `pathResolver.ResolvePath(...).Subscribe(...)` — a cache hit emits synchronously, so the whole handler (including the grain-call marshalling and the failure post) ran inline on the turn.

I could not identify the exact blocking primitive from the surviving evidence — the pod is gone and there is no dump — and I am not going to guess one. What is determinable is stronger and sufficient: **the turn executes an unbounded amount of foreign code, and `RoutingGrain` is `[StatelessWorker(1)]` + non-reentrant, so that is one shared, unbounded, silo-wide critical section by construction.**

## The fix (question 2)

A timeout on the turn is the wrong bound and could not have worked anyway: **you cannot abandon a synchronously blocked thread** — a `.Timeout(...)` wrapped around it never gets a chance to fire, because the calling thread never returns to observe it. The cure has to be structural.

`RouteMessage` now captures its two activation-bound handles (`GetStreamProvider`, `GrainFactory` — both O(1) lookups) and **returns**. The composed route — path resolution, the memory-stream post, the per-node grain hand-off, the `DeliveryFailure` NACK — is subscribed on a new mesh-scoped `Routing` `IIoPool` via `SubscribeThroughPool`, which runs the *subscribe* (the synchronous prologue that wedged prod) on a ThreadPool thread, gated and drainable. A leg that never terminates now costs one pool slot and nothing else.

**No caller-visible contract moves.** `RouteMessage` already returned `Forwarded` unconditionally — the old stream branch's `ContinueWith` returned `Forwarded` whether the post succeeded *or* faulted. A delivery's real outcome has always come back through the response / `DeliveryFailure` path on the sender's hub, and still does.

**Bounds that are about reporting, not suppression.** Each leg terminates and tells the sender:
- the stream post carries a 60 s `.Timeout` — it can only fire *after* Orleans' own 30 s bound on its single grain call has already been exceeded, i.e. when the post is provably never going to land. It converts a silent never-completing leg into a `LogError` + a `DeliveryFailure` at the sender, and releases the pool slot. It is not a retry and not a queue bound.
- a synchronous throw during route *composition* (the classic one: `GetStream` NRE'ing out of `PersistentStreamProvider.IsRewindable` while the stream provider is still starting — that NRE is in these very logs) now NACKs the sender explicitly. Pre-fix it faulted `RouteMessage` itself and reached the caller's error path; moving off the turn would otherwise have turned it into a log line and a parked sender. That gap is closed here.

**Detection.** The grain counts in-flight route dispatches and reports at `LogCritical` when 64 are outstanding and not terminating, with a recovery line when it drains. Event-driven at the dispatch site — no timer, no watchdog, no poller. This replaces the signal that was previously invisible: `NonReentrancyQueueSize` growing to 541 inside an Orleans warning that nobody was watching.

## Tests, and the negative control run explicitly

`RoutingGrainTurnIsolationTest` (real `OrleansTestBase` cluster) decorates the silo's real `IPathResolver` with one whose `Subscribe` **blocks the calling thread** for a magic partition — the prod failure mode, reproduced deterministically. It fires one delivery into that partition, waits (reading the silo-side decorator directly, so there is no ordering race and no sleep) until the routing grain is provably inside the stall, then pings an ordinary partition root and asserts the stall is *still* running when the ping is answered.

I verified the negative control by reverting `RoutingGrain.cs` to the pre-fix version and re-running:

| | result |
|---|---|
| pre-fix `RoutingGrain` | **FAIL** — `TaskCanceledException` at the 10 s probe budget; the probe cannot be served at all |
| post-fix | **PASS** — probe answered in **203 ms**, with 1 route leg still stalled |

`RoutingGrainStreamPostBoundTest` pins the terminal contract on a `TestScheduler`: a post that never completes still terminates *and* NACKs the sender; a faulting post NACKs; a delivered post does not. It also carries an explicit `NegativeControl_AwaitingThePostInsideTheTurn_NeverReturns` documenting why the old shape had no bound.

Local: 29/29 routing-focused Orleans tests green, `DocumentationLinkIntegrityTest` green, `dotnet build -c Release -p:CIRun=true -warnaserror` clean.

## Trade-off worth a reviewer's eye

Stream posts used to be serialized by the single in-turn await, so posts to a given target were de-facto FIFO. They are now concurrent. I judged that acceptable because Orleans gives **no** ordering guarantee for the grain calls *into* the routing grain in the first place (so nothing may depend on it end-to-end), and because the cross-hub write contract is explicitly eventual-consistency-safe — RFC 7396 merge patches applied against the owner's current state, documented in AGENTS.md as safe against concurrent writers. If you would rather keep strict FIFO, the alternative is a `Subject` + `Concat` serial queue off the turn; say the word and I will add it.

## Related, deliberately out of scope

`MessageHubGrain.DeliverMessage` has the same in-turn shape (`HubReady.Take(1).Subscribe(...)` running inline), but it is a per-node grain, so a wedge there is bounded to that one node's hub rather than the whole silo — consistent with the 179 `DeliverMessage` timeouts in the logs being spread across nodes. Worth a separate look, not a change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
