### PR TITLE
A static helper called host.Localize with no host in scope

### DIFF
--- a/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPostLayoutAreas.cs
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPostLayoutAreas.cs
@@ -102,12 +102,13 @@ public static class SocialMediaPostLayoutAreas
             ?? Observable.Return<PostNode[]?>(null);
 
         return postsStream.Select(posts => (UiControl?)BuildList(
+            host,
             (posts ?? Enumerable.Empty<PostNode>())
                 .Select(p => p.Node)
                 .ToImmutableList()));
     }
 
-    private static UiControl BuildList(ImmutableList<MeshNode> posts)
+    private static UiControl BuildList(LayoutAreaHost host, ImmutableList<MeshNode> posts)
     {
         var ordered = posts
             .OrderByDescending(p => GetDate(p, "scheduledAt") ?? DateTimeOffset.MinValue)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-social-media-doc-example-loads-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-social-media-doc-example-loads-again.md
@@ -1,0 +1,18 @@
+---
+Name: The Social Media documentation example loads again
+Category: Fix
+Description: The example's post list failed to build, which left its pages blank and could hold back a portal from starting.
+Icon: Sparkle
+Order: -20260809
+---
+
+# The Social Media documentation example loads again
+
+The Social Media example in the documentation stopped building. Its post list referred to the
+surrounding page in a place where that page was not available, so the whole example failed to
+compile and its pages came up blank.
+
+Because an example that will not build also counts against a portal's start-up checks, this could
+hold a portal back from starting rather than simply showing one broken page.
+
+The list now receives the page it belongs to, so the example builds and its pages render again.


### PR DESCRIPTION
## The break

`Doc/DataMesh/SocialMedia/Post` has not compiled on **any** prod portal:

```
CS0103 (line 219): The name 'host' does not exist in the current context
```

`BuildList` is a `private static` helper that takes only the post list. The mass localization pass — `632c16321`, *"Localize server-side layout areas (362 literals across 78 files)"* — rewrote its empty-state literal to `host.Localize("ui.mdNoPosts")`. There is no `host` in that scope.

## Why it shipped

Node source under `src/MeshWeaver.Documentation/Data` is a `<None>` content item. No build compiles it, `-warnaserror` never sees it, no test touches it. It only compiles inside a running portal — so a mechanical 78-file edit broke it silently and it reached **memex-cloud, memex and atioz alike**, where a NodeType at `CompileError` also counts as a readiness regression and can hold back start-up.

## The fix

`BuildList` now takes the `LayoutAreaHost`; the single call site passes it. `Localize` is an extension on `LayoutAreaHost`, used the same way at line 173.

I swept every in-repo node tree (`content/`, `samples/`, `MeshWeaver.Documentation/Data`) for the same shape — `host.*` referenced in a method with no `host` bound. This was the only real instance; the remaining candidates bind `host` via a lambda parameter or sit in an expression-bodied member.

## Noted, not fixed here

This file builds its output from hand-assembled HTML strings (`Controls.Html($"<h1 …")`, `<table style=…>`, `<td>`), which AGENTS.md marks forbidden for structured data. Converting it to `Controls.DataGrid` and friends is a real change with real risk, and it does not belong in an outage fix — flagging it for a follow-up rather than smuggling it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQKMhQDpitUzsW1MqTVhH