### PR TITLE
perf(test): per-class test partition — fixes the parallelism blocker, re-lands AI.Test at 2.11x

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -57,7 +57,10 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// (e.g., "TestData/mynode") and they'll have proper mesh node hubs.
     /// Registered as a Markdown node so the hub gets AddMeshDataSource + WithNodeOperationHandlers.
     /// </summary>
-    public const string TestPartition = "TestData";
+    /// <summary>Per-class overridable so concurrently-running classes do not contend on one
+    /// partition hub. Default is unchanged ("TestData"): only a project that opts in — by
+    /// overriding in its own base — gets isolation, so no existing test moves. See #1040.</summary>
+    public virtual string TestPartition => "TestData";
 
     /// <summary>
     /// Quiescing budget for test-mesh hubs.

--- a/test/MeshWeaver.AI.Test/AITestBase.cs
+++ b/test/MeshWeaver.AI.Test/AITestBase.cs
@@ -10,6 +10,12 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public abstract class AITestBase(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+
+    /// <summary>Per-class partition, so concurrently-running AI.Test classes do not contend on one
+    /// partition hub — the root cause behind the parallel failures in #1040 (a partition has ONE
+    /// owning hub that serialises every write routed through it). Overriding here covers all
+    /// AI.Test classes in one place; other projects keep the "TestData" default and are unaffected.</summary>
+    public override string TestPartition => $"TestData{GetType().Name}";
     /// <inheritdoc />
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder).AddAI();

--- a/test/MeshWeaver.AI.Test/AutoRouterDispatchTest.cs
+++ b/test/MeshWeaver.AI.Test/AutoRouterDispatchTest.cs
@@ -376,12 +376,12 @@ public class AutoRouterDispatchTest(ITestOutputHelper output) : AITestBase(outpu
     private async Task<string> SeedThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Auto Dispatch Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = TestUser }
         }).Should().Within(30.Seconds()).Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/CancellationAckTest.cs
+++ b/test/MeshWeaver.AI.Test/CancellationAckTest.cs
@@ -56,12 +56,12 @@ public class CancellationAckTest : AITestBase
     {
         var ct = TestContext.Current.CancellationToken;
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Cancellation Ack Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         }).Should().Emit();
 

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -551,7 +551,7 @@ public class ChatClientCredentialResolverTest : AITestBase
         // Seed the user's MASTER composer pinned to a GONE model (never created in the catalog) — the
         // exact stuck-selection the maintainer reported.
         var user = Mesh.ServiceProvider.GetRequiredService<AccessService>().Context?.ObjectId
-                   ?? MonolithMeshTestBase.TestPartition;
+                   ?? TestPartition;
         var masterPath = ThreadComposerNodeType.PathFor(user);
         var goneModel = $"gone-model-{suffix}";
         await MeshService.CreateNode(MeshNode.FromPath(masterPath) with

--- a/test/MeshWeaver.AI.Test/ChatCommandSubmissionTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatCommandSubmissionTest.cs
@@ -147,7 +147,7 @@ public class ChatCommandSubmissionTest : AITestBase
         var client = GetClient();
 
         client.StartThread(
-            MonolithMeshTestBase.TestPartition,
+            TestPartition,
             "   ",
             agentName: "Assistant",
             createdBy: "rbuergi@systemorph.com",
@@ -180,12 +180,12 @@ public class ChatCommandSubmissionTest : AITestBase
     private async Task<string> SeedEmptyThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         }).Should().Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/CrossHubPatchAtomicityTest.cs
+++ b/test/MeshWeaver.AI.Test/CrossHubPatchAtomicityTest.cs
@@ -84,7 +84,7 @@ public class CrossHubPatchAtomicityTest(ITestOutputHelper output) : AITestBase(o
         for (var round = 0; round < rounds; round++)
         {
             var nodeId = Guid.NewGuid().AsString();
-            var path = $"{MonolithMeshTestBase.TestPartition}/CrossHubAtomicity/{nodeId}";
+            var path = $"{TestPartition}/CrossHubAtomicity/{nodeId}";
 
             // Fresh node per round, empty merge-safe dict. NodeType is a plain "Markdown"
             // node (NOT Thread) so NO submission watcher runs — this isolates the OWNER
@@ -93,7 +93,7 @@ public class CrossHubPatchAtomicityTest(ITestOutputHelper output) : AITestBase(o
             {
                 Name = $"Atomicity Node {nodeId}",
                 NodeType = "Markdown",
-                MainNode = MonolithMeshTestBase.TestPartition,
+                MainNode = TestPartition,
                 Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
             }).FirstAsync().ToTask(ct);
 

--- a/test/MeshWeaver.AI.Test/DocumentNodeGetTest.cs
+++ b/test/MeshWeaver.AI.Test/DocumentNodeGetTest.cs
@@ -21,7 +21,7 @@ namespace MeshWeaver.AI.Test;
 public class DocumentNodeGetTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     /// <summary>The collection segment is deliberately the UCR keyword <c>content</c>.</summary>
-    private static readonly string Collection = TestPartition + "/content";
+    private string Collection => TestPartition + "/content";
 
     /// <summary>Registers the Document NodeType + sink on the test mesh.</summary>
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
+++ b/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
@@ -123,7 +123,7 @@ public class HarnessInstallGateTest : AITestBase
         // The absent-node case emits only after the InstallProbeTimeout elapses — give the
         // assertion strictly more than that so it never races the probe.
         var resolved = await HarnessNodeType
-            .ResolveInstalledHarness(hub, $"{MonolithMeshTestBase.TestPartition}/Harness/{GatedId}")
+            .ResolveInstalledHarness(hub, $"{TestPartition}/Harness/{GatedId}")
             .Should().Within(HarnessNodeType.InstallProbeTimeout + TimeSpan.FromSeconds(10)).Emit();
         resolved.Should().BeNull(
             "a RequiresInstall harness without its installed node must fall back — this is what " +
@@ -138,7 +138,7 @@ public class HarnessInstallGateTest : AITestBase
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
         // The node the Store plugin's install localizes into the viewer's partition.
-        var installed = new MeshNode(GatedId, $"{MonolithMeshTestBase.TestPartition}/Harness")
+        var installed = new MeshNode(GatedId, $"{TestPartition}/Harness")
         {
             NodeType = HarnessNodeType.NodeType,
             Name = "Gated CLI",
@@ -182,9 +182,9 @@ public class HarnessInstallGateTest : AITestBase
     {
         var client = GetClient();
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-        var harnessPath = $"{MonolithMeshTestBase.TestPartition}/Harness/{GatedId}";
+        var harnessPath = $"{TestPartition}/Harness/{GatedId}";
 
-        await meshService.CreateNode(new MeshNode(GatedId, $"{MonolithMeshTestBase.TestPartition}/Harness")
+        await meshService.CreateNode(new MeshNode(GatedId, $"{TestPartition}/Harness")
         {
             NodeType = HarnessNodeType.NodeType,
             Name = "Gated CLI",
@@ -194,12 +194,12 @@ public class HarnessInstallGateTest : AITestBase
 
         var threadCreated = new System.Reactive.Subjects.AsyncSubject<MeshNode>();
         client.StartThread(
-            namespacePath: MonolithMeshTestBase.TestPartition,
+            namespacePath: TestPartition,
             userText: "run on the gated harness",
             agentName: "Agent/Assistant",
             modelName: "_Provider/Fake/fake-model",
             harness: harnessPath,
-            contextPath: MonolithMeshTestBase.TestPartition,
+            contextPath: TestPartition,
             createdBy: "rbuergi@systemorph.com",
             onCreated: node => { threadCreated.OnNext(node); threadCreated.OnCompleted(); });
 
@@ -222,16 +222,16 @@ public class HarnessInstallGateTest : AITestBase
     {
         var client = GetClient();
         // A picked path whose node deliberately does not exist (uninstalled / never installed).
-        var harnessPath = $"{MonolithMeshTestBase.TestPartition}/Harness/never-installed-{GatedId}";
+        var harnessPath = $"{TestPartition}/Harness/never-installed-{GatedId}";
 
         var threadCreated = new System.Reactive.Subjects.AsyncSubject<MeshNode>();
         client.StartThread(
-            namespacePath: MonolithMeshTestBase.TestPartition,
+            namespacePath: TestPartition,
             userText: "run without an install",
             agentName: "Agent/Assistant",
             modelName: "_Provider/Fake/fake-model",
             harness: harnessPath,
-            contextPath: MonolithMeshTestBase.TestPartition,
+            contextPath: TestPartition,
             createdBy: "rbuergi@systemorph.com",
             onCreated: node => { threadCreated.OnNext(node); threadCreated.OnCompleted(); });
 

--- a/test/MeshWeaver.AI.Test/InboxToolIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/InboxToolIntegrationTest.cs
@@ -697,7 +697,7 @@ public class InboxToolIntegrationTest : AITestBase
     private async Task<string> SeedEmptyThreadAsync(CancellationToken ct)
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         // FromPath splits the namespace ("TestData/_Thread") from the id — `new MeshNode(path)`
         // would bake the slashes into the Id with an EMPTY namespace, which the
         // PartitionWriteGuard (correctly) rejects as a malformed top-level node.
@@ -705,7 +705,7 @@ public class InboxToolIntegrationTest : AITestBase
         {
             Name = $"Inbox Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         });
         return threadPath;

--- a/test/MeshWeaver.AI.Test/McpCompileInFlightTruthTest.cs
+++ b/test/MeshWeaver.AI.Test/McpCompileInFlightTruthTest.cs
@@ -66,7 +66,7 @@ public class McpCompileInFlightTruthTest(ITestOutputHelper output) : AITestBase(
     }
 
     private const string TypeName = "InFlightTruthType";
-    private static readonly string RunningActivityPath =
+    private string RunningActivityPath =>
         TestPartition + "/" + TypeName + "/_Activity/compile-inflight-under-test";
 
     [Fact(Timeout = 120000)]

--- a/test/MeshWeaver.AI.Test/McpFailureSurfacingTest.cs
+++ b/test/MeshWeaver.AI.Test/McpFailureSurfacingTest.cs
@@ -37,8 +37,8 @@ public class McpFailureSurfacingTest(ITestOutputHelper output) : MonolithMeshTes
     private Task<string> PatchAsync(string path, string fields) =>
         new MeshOperations(Mesh).Patch(path, fields).FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
 
-    private MeshNode ValidMarkdown(string id, string ns = TestPartition) =>
-        new(id, ns) { Name = id, NodeType = "Markdown", Content = new MarkdownContent { Content = $"# {id}" } };
+    private MeshNode ValidMarkdown(string id, string? ns = null) =>
+        new(id, ns ?? TestPartition) { Name = id, NodeType = "Markdown", Content = new MarkdownContent { Content = $"# {id}" } };
 
     [Fact(Timeout = 60000)]
     public async Task Create_InvalidJson_ReturnsError()

--- a/test/MeshWeaver.AI.Test/McpNegativeOperationsTest.cs
+++ b/test/MeshWeaver.AI.Test/McpNegativeOperationsTest.cs
@@ -29,8 +29,8 @@ public class McpNegativeOperationsTest(ITestOutputHelper output) : MonolithMeshT
     private Task<string> Run(IObservable<string> op) =>
         op.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
 
-    private MeshNode ValidMarkdown(string id, string ns = TestPartition) =>
-        new(id, ns) { Name = id, NodeType = "Markdown", Content = new MarkdownContent { Content = $"# {id}" } };
+    private MeshNode ValidMarkdown(string id, string? ns = null) =>
+        new(id, ns ?? TestPartition) { Name = id, NodeType = "Markdown", Content = new MarkdownContent { Content = $"# {id}" } };
 
     private static string Unique(string prefix) => prefix + Guid.NewGuid().ToString("N")[..8];
 

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -251,12 +251,12 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
     private async Task<string> SeedThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Model Substitution Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = TestUser }
         }).Should().Within(30.Seconds()).Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/ProviderRefusalRoundTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderRefusalRoundTest.cs
@@ -276,12 +276,12 @@ public class ProviderRefusalRoundTest(ITestOutputHelper output) : AITestBase(out
     private async Task<string> SeedThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Provider Refusal Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = TestUser }
         }).Should().Within(TimeSpan.FromMilliseconds(SeedMs)).Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/RoundFaultTerminalStateTest.cs
+++ b/test/MeshWeaver.AI.Test/RoundFaultTerminalStateTest.cs
@@ -51,12 +51,12 @@ public class RoundFaultTerminalStateTest : AITestBase
     public async Task StreamThrows_AfterExecutingFlip_ThreadReachesTerminalState_NoWatchdog()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Fault Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         }).Should().Emit();
 

--- a/test/MeshWeaver.AI.Test/StreamingTimeoutTest.cs
+++ b/test/MeshWeaver.AI.Test/StreamingTimeoutTest.cs
@@ -63,12 +63,12 @@ public class StreamingTimeoutTest : AITestBase
     public async Task StreamHangsForever_RoundEndsWithTimeoutError_NotSilentWedge()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Streaming Timeout Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         }).Should().Emit();
 

--- a/test/MeshWeaver.AI.Test/ThreadComposerFlowTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadComposerFlowTest.cs
@@ -74,13 +74,13 @@ public class ThreadComposerFlowTest : AITestBase
             Harness = $"{HarnessNodeType.RootNamespace}/{Harnesses.MeshWeaver}",
             AgentName = "Agent/Assistant",
             ModelName = "_Provider/Fake/fake-model",
-            ContextPath = MonolithMeshTestBase.TestPartition,
-            Attachments = ImmutableList.Create("TestData/SomeDoc"),
+            ContextPath = TestPartition,
+            Attachments = ImmutableList.Create($"{TestPartition}/SomeDoc"),
             OpenThreadPath = "stale/_Thread/previous" // must never carry onto the thread
         };
 
         client.StartThread(
-            namespacePath: MonolithMeshTestBase.TestPartition,
+            namespacePath: TestPartition,
             userText: composer.MessageContent!,
             agentName: composer.AgentName,
             modelName: composer.ModelName,
@@ -92,7 +92,7 @@ public class ThreadComposerFlowTest : AITestBase
 
         var created = await threadCreated.Should().Emit();
         created!.Path.Should().StartWith(
-            $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/",
+            $"{TestPartition}/{ThreadNodeType.ThreadPartition}/",
             "the thread must live under {context}/_Thread/{speakingId}");
 
         var thread = (created.Content as MeshThread)!;
@@ -123,7 +123,7 @@ public class ThreadComposerFlowTest : AITestBase
             Harness = $"{HarnessNodeType.RootNamespace}/{Harnesses.MeshWeaver}",
             AgentName = "Agent/Assistant",
             ModelName = "_Provider/Fake/fake-model",
-            Attachments = ImmutableList.Create("TestData/Chip")
+            Attachments = ImmutableList.Create($"{TestPartition}/Chip")
         });
         var client = GetClient();
 
@@ -151,7 +151,7 @@ public class ThreadComposerFlowTest : AITestBase
         userMessage.Text.Should().Be("typed into the composer");
         userMessage.AgentName.Should().Be("Agent/Assistant");
         userMessage.Harness.Should().Be($"{HarnessNodeType.RootNamespace}/{Harnesses.MeshWeaver}");
-        userMessage.Attachments.Should().Equal("TestData/Chip");
+        userMessage.Attachments.Should().Equal($"{TestPartition}/Chip");
     }
 
     [Fact]
@@ -238,12 +238,12 @@ public class ThreadComposerFlowTest : AITestBase
     private async Task<string> SeedThreadWithComposer(ThreadComposer composer)
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Composer Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread
             {
                 CreatedBy = "rbuergi@systemorph.com",

--- a/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
@@ -99,7 +99,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         var client = GetClient();
 
         client.StartThread(
-            MonolithMeshTestBase.TestPartition,
+            TestPartition,
             "New thread first message",
             createdBy: "rbuergi@systemorph.com",
             onCreated: node => { threadCreated.OnNext(node); threadCreated.OnCompleted(); });
@@ -438,7 +438,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
     public async Task ThreadComposer_PersistsMessageContentAndComboboxes_ReadBackViaGetMeshNodeStream()
     {
         var client = GetClient();
-        var chatInputPath = ThreadComposerNodeType.PathFor(MonolithMeshTestBase.TestPartition);
+        var chatInputPath = ThreadComposerNodeType.PathFor(TestPartition);
 
         // The per-user ThreadComposer singleton is seeded at onboarding (ThreadComposerSeedHandler),
         // so the composer always updates an EXISTING node. Mirror that here.
@@ -502,7 +502,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         var threadCreated = new System.Reactive.Subjects.AsyncSubject<MeshNode>();
 
         client.StartThread(
-            MonolithMeshTestBase.TestPartition,
+            TestPartition,
             "Compose then start",
             agentName: "Assistant",
             createdBy: "rbuergi@systemorph.com",
@@ -529,7 +529,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
     private async Task<string> SeedEmptyThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         // FromPath splits the namespace ("TestData/_Thread") from the id — `new MeshNode(path)`
         // would bake the slashes into the Id with an EMPTY namespace, which the
         // PartitionWriteGuard (correctly) rejects as a malformed top-level node.
@@ -537,7 +537,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         {
             Name = $"Test Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
         }).Should().Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -321,12 +321,12 @@ public class ThreadTokenUsageTest : AITestBase
     private async Task<string> SeedThread()
     {
         var threadId = Guid.NewGuid().AsString();
-        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        var threadPath = $"{TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
         await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
         {
             Name = $"Token Usage Thread {threadId}",
             NodeType = ThreadNodeType.NodeType,
-            MainNode = MonolithMeshTestBase.TestPartition,
+            MainNode = TestPartition,
             Content = new MeshThread { CreatedBy = TestUser }
         }).Should().Emit();
         return threadPath;

--- a/test/MeshWeaver.AI.Test/xunit.runner.json
+++ b/test/MeshWeaver.AI.Test/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4,
+  "methodTimeout": 30000
+}

--- a/test/MeshWeaver.Security.Test/ScriptTemplateExecuteAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/ScriptTemplateExecuteAccessTest.cs
@@ -157,7 +157,7 @@ public class ScriptTemplateExecuteAccessTest(ITestOutputHelper output) : Monolit
             "the Templates grant is scoped to Templates — it must confer nothing at ROOT");
 
         // A partition the user has no business in stays closed.
-        var elsewhere = await EffectivePermissions(MonolithMeshTestBase.TestPartition);
+        var elsewhere = await EffectivePermissions(TestPartition);
         elsewhere.Should().NotHaveFlag(Permission.Read,
             "an ungranted partition must stay unreadable — the Templates grant must not widen it");
     }


### PR DESCRIPTION
Fixes the root cause behind #1040 and re-lands #1035.

## The defect

`MonolithMeshTestBase.TestPartition` was `public const string = "TestData"`, so **every test class in every project wrote into one partition** — and a partition has a single owning hub that serialises every write routed through it. Harmless while classes run one at a time; a contention point the moment they do not.

That is why #1035 red on CI: waits that never emitted, in a class that is **green in isolation under identical CPU pressure** (`ThreadTokenUsageTest`: 8/8 in 5.6s alone; fails alongside 1,130 neighbours).

🚨 Not a timeout budget — the failing shape is "observable emitted nothing at all", i.e. state changed underneath. Widening those waits would have hidden it.

## The fix — one line, opt-in per project

`TestPartition` becomes `public virtual` with the **default unchanged** (`"TestData"`), so no other project moves. Isolation is opted into by a project's own base class:

```csharp
// AITestBase — all 39 AI.Test classes get their own partition, from one line
public override string TestPartition => $"TestData{GetType().Name}";
```

## The cascade the compiler forced

Every one is a hard error, never a silent change:

| | |
|---|---|
| 42 static-qualified refs → instance access | 15 files |
| 3 hardcoded node paths → `$"{TestPartition}/…"` | `ThreadComposerFlowTest` |
| 2 × `CS1736` default-parameter values | → null-default + coalesce |
| 2 × `CS0236` static field initialisers | → instance properties |

The other 20 `"TestData"` strings in AI.Test are `Path.Combine(AppContext.BaseDirectory, "TestData")` — **on-disk directories**, unrelated to the partition — and are deliberately untouched.

🚨 The `CS1736` sites needed the `?? TestPartition` coalesce. `string? ns = null` alone would have passed `null` where the partition used to be — a silent behaviour change **the compiler could not have caught**.

## Verified on a representative machine

A dev Mac has 18 cores; the runner has 4 — so `maxParallelThreads: 4` means something completely different on each. That is precisely why #1033 and #1035 passed locally and red on CI. `DOTNET_PROCESSOR_COUNT=4` makes .NET size its thread pool and GC as though it had 4 cores:

```
before fix, DOTNET_PROCESSOR_COUNT=4 : 1138 tests, 2 FAILED (ThreadTokenUsageTest)
after  fix, DOTNET_PROCESSOR_COUNT=4 : 1138 tests, 0 failed, 117s
```

Serial baseline 198.2s → **2.11x**.

## Scope

`Hosting.Monolith.Test` (#1033, measured **2.57x**) is deliberately **not** re-enabled here — it additionally needs `GcReachabilityCollection` from branch `perf/share-mesh-cluster`. One project at a time, each independently revertible.

## No What's New entry

Test infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.