### PR TITLE
Bound Orleans cluster teardown so it stops starving the running test

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
@@ -113,12 +113,34 @@ internal static class OrleansClusterDisposal
     }
 
     /// <summary>
-    /// Runs one <see cref="Task"/>-returning leaf on <see cref="IoPool.Unbounded"/> and projects it to
+    /// The gate every cluster teardown passes through — BOUNDED, not <see cref="IoPool.Unbounded"/>.
+    ///
+    /// <para>🚨 Unbounded was the cross-test starvation. Each disposal is made hot immediately so the
+    /// next class's cluster can start, which is correct — but with no bound, every cluster this
+    /// assembly ever built could be shutting down AT ONCE underneath the class currently running.
+    /// Silo shutdown is not cheap, and on a 4-vCPU runner those overlapping teardowns starve the
+    /// live test's render: it waits on a stream that never gets scheduled and dies on its own
+    /// 30s Timeout. That is the shard-0 Orleans flake — a DIFFERENT test each run, because the
+    /// victim is simply whoever is running when enough teardowns pile up.</para>
+    ///
+    /// <para>Reproduced with <c>DOTNET_PROCESSOR_COUNT=4</c> (the runner's shape): the whole project
+    /// fails there and passes unconstrained, and the victim class passes ALONE under the same
+    /// constraint — so it is the overlap, not the test.</para>
+    ///
+    /// <para>Bounding is the framework's own prescription for this ("concurrency bounding channels
+    /// through <c>IIoPool</c>"), not a tuning knob: it keeps teardown off the xUnit thread — which is
+    /// what avoids the original deadlock — while stopping it from competing with the suite. Legs of
+    /// different clusters never wait on each other, so a bound cannot deadlock the drain.</para>
+    /// </summary>
+    private static readonly IIoPool DisposalPool = new IoPool(2);
+
+    /// <summary>
+    /// Runs one <see cref="Task"/>-returning leaf on <see cref="DisposalPool"/> and projects it to
     /// <see cref="Unit"/>, swallowing a benign shutdown-race so a failed leg completes rather than
     /// faulting the sequence. The pool IS the async boundary — nothing is <c>await</c>ed here.
     /// </summary>
     private static IObservable<Unit> RunVoid(Func<Task> leaf) =>
-        IoPool.Unbounded
+        DisposalPool
             .Run(_ => leaf().ContinueWith(static _ => Unit.Default, TaskScheduler.Default))
             .Catch(Observable.Return(Unit.Default));
 


### PR DESCRIPTION
The shard-0 Orleans flake is **one cross-test interaction wearing six names**. Across four runs it has failed as `OrleansStaticRepoImportTest`, `OrleansMeshTests.HubWorksAfterDisposal`, `DelegationCompletionTest`, `OrleansMarkdownExportTest` (twice, two different methods) and `OrleansBrokenNodeTypeAccessTest` — the last of those on #1045, whose entire diff adds `Class="@Class"` to four buttons in a `.razor`. None of them were anyone's diff.

## Root cause

`OrleansClusterDisposal` hands each `TestCluster`'s stop→dispose to `IoPool.**Unbounded**` and makes it hot immediately. Both of those are right on their own: teardown must not block the xUnit thread (awaiting it inline was the original deadlock this file was written to fix), and the next class should start at once.

With no bound, though, **every cluster the assembly has built can be shutting down at once underneath the class currently running.** Silo shutdown is not cheap. On a 4-vCPU runner those overlapping teardowns starve the live test's render, which then dies on its own 30s `Timeout`. The victim is whoever happens to be running when enough teardowns pile up — hence a different name every time, and hence it never correlated with any change.

## Reproduced deterministically

Not a stress harness — just the runner's shape, via `DOTNET_PROCESSOR_COUNT`:

| build | processors | result |
|---|---|---|
| unbounded | 18 (native) | 141/141 pass |
| unbounded | **4** | **1 FAILED** — 30s timeout |
| unbounded, victim class **alone** | 4 | 5/5 pass in 5s |
| bounded(2) | **4** | 141/141 pass |
| bounded(2) | **2** | 141/141 pass |

The third row is the one that settles it: the class that fails in the suite passes by itself under the same constraint, so it is the overlap and not the test.

## The fix

`IoPool(2)` instead of `IoPool.Unbounded` for the disposal legs.

This is the framework's own prescription rather than a tuning knob — AGENTS.md: *"concurrency bounding … channels through `IIoPool`"* — and `IoPool(int maxConcurrency)` already exists. Teardown stays **off** the teardown thread, so the deadlock the background disposal exists to avoid stays avoided; it simply stops competing with the suite for the runner. Legs of different clusters never wait on one another, so the bound cannot deadlock the final drain.

No What's New entry: test infrastructure, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)