### PR TITLE
Fix: a partition root permanently bound to the default hub configuration (plugin-gate Store/Catalog RED)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-a-freshly-installed-space-shows-its-own-pages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-a-freshly-installed-space-shows-its-own-pages.md
@@ -1,0 +1,25 @@
+---
+Name: A freshly installed space no longer opens with only the generic pages
+Category: Fix
+Description: A space whose main page was first visited while it was still being set up could stay stuck on the standard pages forever; it now picks up its own pages as soon as they exist.
+Icon: Sparkle
+Order: -20260809
+---
+
+# A freshly installed space no longer opens with only the generic pages
+
+Opening a space's main page for the first time — while the space was still being created, or in the
+first moments of installing a package into it — could leave that page permanently showing only the
+standard set of pages every node gets (Overview, Settings, Versions and so on). None of the pages
+the space itself defines appeared, and following a link to one answered "Area not found". Nothing
+was logged, nothing recovered, and only restarting the portal brought the missing pages back.
+
+The portal was remembering a stand-in for the space that it invents while the real one is still
+being written, and it kept serving that stand-in even after the real space had landed. Two related
+mix-ups did it: the invented stand-in was remembered as though it were real, and an answer worked
+out just before the space was saved could still be remembered just after — at which point nothing
+was left to correct it.
+
+Invented stand-ins are no longer remembered at all, and an answer is only remembered if nothing
+changed underneath it while it was being worked out. A page that opens early now simply picks up
+the real space on the next visit instead of being stuck with the placeholder.

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -70,6 +70,22 @@ namespace MeshWeaver.Hosting;
 /// permanent 404 (repro: <c>PathResolutionCacheTest.NullResolution_IsNotCached</c>).
 /// Only a non-null resolution is added to the map, so negatives are never served.</para>
 ///
+/// <para>🚨 <b>Positive-only is not enough on its own</b> — two ways a non-null answer is
+/// still a negative in disguise, both of which pinned a path PERMANENTLY:
+/// <list type="bullet">
+///   <item><b>A fill that lands after its own invalidation.</b> The query is a live
+///     round-trip; a write during it invalidates a cache entry that does not exist yet, so
+///     the sweep finds nothing and the pre-write answer is stored afterwards — and no later
+///     event removes it. A resolution therefore CLAIMS its key before querying
+///     (<see cref="_pendingFills"/>) and commits only if the claim survived.</item>
+///   <item><b>A fabricated bare-partition-root placeholder.</b>
+///     <see cref="SynthesizePartitionRoot"/> invents a NodeType-less node so a bare
+///     partition path can still answer Ping. It is applied OUTSIDE the cache and never
+///     stored; caching it silently binds the partition root's hub to the mesh default
+///     configuration for the life of the process.</item>
+/// </list>
+/// Repros: <c>PathResolutionCachePoisonTest</c>.</para>
+///
 /// <para><b>Invalidation</b>: the constructor subscribes the optional
 /// <see cref="IMeshChangeFeed"/> (the same post-commit broadcast
 /// <c>MeshNodeStreamCache</c> uses). Any <see cref="MeshChangeEvent"/> with path
@@ -101,6 +117,20 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// </summary>
     private readonly ConcurrentDictionary<string, AddressResolution>? _resolutionCache;
 
+    /// <summary>
+    /// In-flight fill claims: joined segment path → the monotonic claim stamped when its
+    /// resolution query started. <see cref="OnMeshChange"/> drops matching claims, so an
+    /// answer computed from a PRE-change snapshot can no longer be committed to
+    /// <see cref="_resolutionCache"/> after the invalidation swept an entry that did not
+    /// exist yet. Bounded by the number of CONCURRENT resolutions (entries are removed in
+    /// the resolution's <c>Finally</c>), never by the number of paths. Non-null exactly
+    /// when <see cref="_resolutionCache"/> is.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, long>? _pendingFills;
+
+    /// <summary>Monotonic source for <see cref="_pendingFills"/> claims.</summary>
+    private long _fillSequence;
+
     /// <summary>Change-feed invalidation subscription; disposed with the singleton.</summary>
     private readonly IDisposable? _changeFeedSubscription;
 
@@ -121,6 +151,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
         if (changeFeed is not null)
         {
             _resolutionCache = new ConcurrentDictionary<string, AddressResolution>(StringComparer.Ordinal);
+            _pendingFills = new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
             _changeFeedSubscription = changeFeed.Subscribe(OnMeshChange);
         }
         // Gates the partition-root MeshNode synthesis below — we only fall back
@@ -207,16 +238,35 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// null / errored / never-emitting query caches nothing and can never poison the
     /// path (see the class doc). Without a registered <see cref="IMeshChangeFeed"/>
     /// there is no cache and every call queries.
+    ///
+    /// <para>🚨 The <see cref="SynthesizePartitionRoot"/> fallback is appended HERE, past
+    /// the cache write, so a fabricated bare-partition-root placeholder is never stored —
+    /// see that method for why pinning it is a permanent, silent mis-binding of the
+    /// partition root's hub.</para>
     /// </summary>
     private IObservable<AddressResolution?> ResolveSegments(string[] segments)
     {
-        if (_resolutionCache is null)
-            return ResolveSegmentsCore(segments);
+        if (_resolutionCache is null || _pendingFills is null)
+            return ResolveSegmentsCore(segments)
+                .SelectMany(resolution => resolution is not null
+                    ? Observable.Return<AddressResolution?>(resolution)
+                    : SynthesizePartitionRoot(segments));
 
         var key = string.Join("/", segments);
         if (_resolutionCache.TryGetValue(key, out var cached))
             return Observable.Return<AddressResolution?>(cached);
 
+        // 🚨 CLAIM the fill BEFORE the query runs. The query is a live round-trip that
+        // can take milliseconds-to-seconds under load; a write landing WHILE it is in
+        // flight invalidates an entry that does not exist yet, so the sweep in
+        // OnMeshChange finds nothing and the answer computed from the PRE-write snapshot
+        // is added AFTERWARDS — and nothing ever removes it again, because the write
+        // that would have invalidated it has already happened. That fill-after-invalidate
+        // race is how a freshly-created node answers "No node found" (or resolves to its
+        // ancestor with a remainder) for the rest of the process.
+        // Repro: PathResolutionCachePoisonTest.InvalidationDuringInFlightQuery_DoesNotPinThePreChangeAnswer.
+        var claim = Interlocked.Increment(ref _fillSequence);
+        _pendingFills[key] = claim;
         return ResolveSegmentsCore(segments)
             .Do(resolution =>
             {
@@ -225,10 +275,33 @@ internal class PathResolutionService : IPathResolver, IDisposable
                 // be propagating — and a query that never emits or errors stores
                 // nothing at all, so it can only stall its own caller, never the
                 // whole path. The change feed invalidates positive entries on write.
-                if (resolution is not null)
-                    _resolutionCache.TryAdd(key, resolution);
-            });
+                if (resolution is null)
+                    return;
+                if (!ClaimStillHeld(key, claim))
+                    return;
+                _resolutionCache.TryAdd(key, resolution);
+                // Re-check AFTER the add: an invalidation that ran between the check
+                // above and the add would have swept an empty slot. Undoing here makes
+                // the pair safe in BOTH interleavings — worst case the entry is dropped
+                // twice and the next resolution re-queries.
+                if (!ClaimStillHeld(key, claim))
+                    _resolutionCache.TryRemove(key, out _);
+            })
+            .Finally(() => _pendingFills.TryRemove(new KeyValuePair<string, long>(key, claim)))
+            .SelectMany(resolution => resolution is not null
+                ? Observable.Return<AddressResolution?>(resolution)
+                : SynthesizePartitionRoot(segments));
     }
+
+    /// <summary>
+    /// True while this resolution's fill claim is still the live one for <paramref name="key"/>:
+    /// no invalidation for that key has run since the query started
+    /// (<see cref="OnMeshChange"/> drops matching claims).
+    /// </summary>
+    private bool ClaimStillHeld(string key, long claim) =>
+        _pendingFills is not null
+        && _pendingFills.TryGetValue(key, out var current)
+        && current == claim;
 
     /// <summary>
     /// Change-feed invalidation: any Created/Updated/Deleted event with path
@@ -239,6 +312,12 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// resolved to or through P. Runs synchronously on the publisher's thread —
     /// pure dictionary ops, no I/O, no hub post. Full-dictionary iteration is
     /// deliberate: change events are rare relative to resolutions.
+    ///
+    /// <para>The SAME sweep is applied to the IN-FLIGHT fill claims: a resolution whose
+    /// query started before this event computed its answer from a pre-change snapshot,
+    /// so dropping its claim is what stops that answer from being cached once it lands.
+    /// The pending map is bounded by the number of concurrent resolutions, not by the
+    /// number of paths.</para>
     /// </summary>
     private void OnMeshChange(MeshChangeEvent change)
     {
@@ -248,10 +327,20 @@ internal class PathResolutionService : IPathResolver, IDisposable
         var childPrefix = path + "/";
         foreach (var key in _resolutionCache.Keys)
         {
-            if (string.Equals(key, path, StringComparison.Ordinal)
-                || key.StartsWith(childPrefix, StringComparison.Ordinal))
+            if (Affected(key))
                 _resolutionCache.TryRemove(key, out _);
         }
+        if (_pendingFills is null)
+            return;
+        foreach (var key in _pendingFills.Keys)
+        {
+            if (Affected(key))
+                _pendingFills.TryRemove(key, out _);
+        }
+
+        bool Affected(string key) =>
+            string.Equals(key, path, StringComparison.Ordinal)
+            || key.StartsWith(childPrefix, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -326,55 +415,79 @@ internal class PathResolutionService : IPathResolver, IDisposable
             })
             // Query returns Observable.Empty when no provider matches.
             // Without DefaultIfEmpty the chain dies silently on completion and
-            // RoutingServiceBase's .Take(1) waits forever.
-            .DefaultIfEmpty()
-            // Partition-root fallback runs AFTER DefaultIfEmpty so the empty-
-            // upstream case (no match for the requested path or any ancestor)
-            // gets a chance to synthesize. Doing this inside the upstream Select
-            // wouldn't help: when Query emits nothing, Scan never emits,
-            // Select never runs — the only emission is the null from
-            // DefaultIfEmpty. The Select below intercepts that null.
-            //
-            // If the request is for a bare partition path (a single segment)
-            // AND there's at least one writable partition provider that could
-            // own it, synthesize a placeholder MeshNode so MessageHubGrain.
-            // OnActivateAsync sees something to bind to. The grain then
-            // activates against DefaultNodeHubConfiguration; PingRequest and
-            // other default-hub operations route normally. Without this, the
-            // routing-grain emits NotFound and the user's home page hangs the
-            // full Orleans response budget — prod symptom: /rbuergi start
-            // screen blank, 30s "Response did not arrive on time".
-            // Repro: PartitionRootActivationTest.BarePartitionPath_NoMeshNode_RespondsToPing.
-            .SelectMany(resolution =>
+            // RoutingServiceBase's .Take(1) waits forever. The null it emits is what
+            // ResolveSegments turns into the bare-partition-root synthesis — which
+            // runs AFTER this (and OUTSIDE the cache; see SynthesizePartitionRoot),
+            // because when Query emits nothing the Select above never runs at all and
+            // the only emission is this default.
+            .DefaultIfEmpty();
+    }
+
+    /// <summary>
+    /// The bare-partition-root fallback: when a SINGLE-segment path matches no node but
+    /// there is at least one writable partition provider that could own it, fabricate a
+    /// placeholder <see cref="MeshNode"/> so <c>MessageHubGrain.OnActivateAsync</c> has
+    /// something to bind to. The grain then activates against
+    /// <c>DefaultNodeHubConfiguration</c>; <c>PingRequest</c> and other default-hub
+    /// operations route normally. Without it the routing grain emits NotFound and the
+    /// user's home page hangs the full Orleans response budget — prod symptom: /rbuergi
+    /// start screen blank, 30s "Response did not arrive on time".
+    /// Repro: <c>PartitionRootActivationTest.BarePartitionPath_NoMeshNode_RespondsToPing</c>.
+    ///
+    /// <para>🚨 Synthesize a placeholder root ONLY for a partition that actually exists.
+    /// A single-segment path that matches no node AND no provisioned partition — a
+    /// mistyped/garbage URL like <c>markdown</c>, <c>code</c>, <c>search?q=…</c>,
+    /// <c>login?returnurl=…</c> — must resolve to NotFound (a clean 404), NOT a synthetic
+    /// root. The synthetic activated a grain that queried the never-provisioned
+    /// <c>&lt;segment&gt;.mesh_nodes</c> schema → Npgsql 42P01, and the bogus segment
+    /// leaked into a junk partition schema (prod log storm). Existence is a global OR
+    /// across the WRITABLE providers: synthesize unless a provider that could own it
+    /// definitively says it is absent (some <c>false</c>, none <c>true</c>).
+    /// <c>true</c>/<c>null</c> (indeterminate, InMemory test, probe hiccup) still
+    /// synthesize, so the real-partition home-page fast path (<c>/rbuergi</c>) is never
+    /// regressed.</para>
+    ///
+    /// <para>🚨 <b>Never cached.</b> This is a FABRICATION, not an observed fact — the
+    /// node carries no NodeType and no Content. Pinning it in the resolution cache is the
+    /// same defect as pinning a <c>null</c> (a permanent 404), only harder to see: every
+    /// later activation of that partition root then routes on a NodeType-less node, so
+    /// <c>NodeTypeEnrichmentHelpers.EnrichWithNodeType</c> takes its silent
+    /// <c>string.IsNullOrEmpty(nodeType)</c> branch and binds the mesh
+    /// <c>DefaultNodeHubConfiguration</c> — the root serves ONLY the framework's default
+    /// layout areas and none of its real NodeType's, with no log line and no self-heal,
+    /// for the life of the process. That was the plugin gate's <c>Store/Catalog</c> RED
+    /// ("No renderer is registered for area <c>Tests</c> on hub <c>Store</c>", listing
+    /// exactly the framework defaults): the install provisions the <c>Store</c> partition
+    /// BEFORE writing its root, so any routed touch inside that window fabricated the
+    /// placeholder, and the fabrication outlived every later write.
+    /// Repro: <c>PathResolutionCachePoisonTest.SynthesizedPartitionRoot_IsNotCached</c>.</para>
+    /// </summary>
+    private IObservable<AddressResolution?> SynthesizePartitionRoot(string[] segments)
+    {
+        if (segments.Length != 1
+            || string.IsNullOrEmpty(segments[0])
+            || !_hasWritablePartitionProvider)
+            return Observable.Return<AddressResolution?>(null);
+        var partitionPath = segments[0];
+        return PartitionConfirmedAbsent(partitionPath)
+            .Select<bool, AddressResolution?>(confirmedAbsent =>
             {
-                if (resolution is not null)
-                    return Observable.Return<AddressResolution?>(resolution);
-                if (segments.Length != 1
-                    || string.IsNullOrEmpty(segments[0])
-                    || !_hasWritablePartitionProvider)
-                    return Observable.Return<AddressResolution?>(null);
-                var partitionPath = segments[0];
-                // 🚨 Synthesize a placeholder root ONLY for a partition that actually
-                // exists. A single-segment path that matches no node AND no provisioned
-                // partition — a mistyped/garbage URL like `markdown`, `code`,
-                // `search?q=…`, `login?returnurl=…` — must resolve to NotFound (a clean
-                // 404), NOT a synthetic root. The synthetic activated a grain that queried
-                // the never-provisioned `<segment>.mesh_nodes` schema → Npgsql 42P01, and
-                // the bogus segment leaked into a junk partition schema (prod log storm).
-                // Existence is a global OR across the WRITABLE providers: synthesize unless
-                // a provider that could own it definitively says it is absent (some `false`,
-                // none `true`). `true`/`null` (indeterminate, InMemory test, probe hiccup)
-                // still synthesize, so the real-partition home-page fast path (`/rbuergi`)
-                // is never regressed.
-                return PartitionConfirmedAbsent(partitionPath)
-                    .Select<bool, AddressResolution?>(confirmedAbsent => confirmedAbsent
-                        ? null
-                        : BuildResolution(partitionPath, segments, matchedSegments: 1,
-                            matchedNode: new MeshNode(partitionPath)
-                            {
-                                Name = partitionPath,
-                                State = MeshNodeState.Active
-                            }));
+                if (confirmedAbsent)
+                    return null;
+                // Greppable, because the consequence is invisible otherwise: whoever
+                // routes on this resolution activates the partition root against the
+                // mesh DEFAULT hub configuration (the node has no NodeType to bind).
+                _logger?.LogDebug(
+                    "PathResolution: no node at bare partition path '{Partition}' — synthesizing a "
+                    + "placeholder root; its hub activates on the default configuration until the "
+                    + "real root node is visible",
+                    partitionPath);
+                return BuildResolution(partitionPath, segments, matchedSegments: 1,
+                    matchedNode: new MeshNode(partitionPath)
+                    {
+                        Name = partitionPath,
+                        State = MeshNodeState.Active
+                    });
             });
     }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1342,6 +1342,17 @@ public static class PackageInstaller
                     // is-invisible incident) until someone manually recycles it. Dispose is the
                     // recycle idiom (RecycleLayoutArea): fire-and-forget, next access re-activates
                     // with the final type. Only when the placeholder dance actually ran.
+                    //
+                    // 🚨 This recycle is NECESSARY but was not SUFFICIENT: the identical symptom
+                    // recurred 2026-08-09 because PathResolutionService PINNED a fabricated
+                    // partition-root placeholder (no NodeType → the root's hub binds the mesh
+                    // DEFAULT configuration), so every re-activation after this Dispose re-read
+                    // the same fabrication. Partition provisioning runs BEFORE the root write, so
+                    // any routed touch inside that window fabricated it. Fixed at the source —
+                    // synthesized resolutions are never cached, and a fill that lands after its
+                    // own invalidation is discarded (PathResolutionCachePoisonTest). If this
+                    // symptom ever reappears, check BOTH: is the hub recycled, and is the
+                    // resolution for the bare root path serving a real node?
                     .Select(rest =>
                     {
                         if (placeholderRoot is not null && root is not null)

--- a/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
@@ -50,33 +51,53 @@ public class PathResolutionCachePoisonTest
             => (IObservable<QueryResultChange<T>>)(object)_behaviour(Interlocked.Increment(ref _calls));
     }
 
+    /// <summary>
+    /// A WRITABLE partition provider (<see cref="IsReadOnly"/> false) whose partition
+    /// definitively EXISTS. Both are required for the bare-partition-root placeholder
+    /// synthesis (<c>PathResolutionService.SynthesizePartitionRoot</c>) to fire.
+    /// </summary>
+    private sealed class ExistingWritablePartitionProvider : IPartitionStorageProvider
+    {
+        public string Name => "test-writable";
+        public bool IsReadOnly => false;
+        public IStorageAdapter Adapter => throw new NotSupportedException("not used by path resolution");
+        public IObservable<bool?> PartitionExists(string @namespace) => Observable.Return<bool?>(true);
+    }
+
     private static (PathResolutionService Svc, SequencedQueryCore Query) BuildService(
-        Func<int, IObservable<QueryResultChange<MeshNode>>> behaviour)
+        Func<int, IObservable<QueryResultChange<MeshNode>>> behaviour,
+        IMeshChangeFeed? changeFeed = null,
+        IEnumerable<IPartitionStorageProvider>? partitionProviders = null)
     {
         var hub = Substitute.For<IMessageHub>();
         var sp = Substitute.For<IServiceProvider>();
         hub.ServiceProvider.Returns(sp);
         hub.JsonSerializerOptions.Returns(new JsonSerializerOptions());
         // A registered change feed is what ENABLES caching (without it the service
-        // resolves uncached). Real InProcessMeshChangeFeed — no writes fire in this test.
-        sp.GetService(typeof(IMeshChangeFeed)).Returns(new InProcessMeshChangeFeed());
+        // resolves uncached). Real InProcessMeshChangeFeed — pass one in to drive
+        // invalidation from the test; the default is never published to.
+        sp.GetService(typeof(IMeshChangeFeed)).Returns(changeFeed ?? new InProcessMeshChangeFeed());
         // No AccessService → ImpersonateAsSystem() is a no-op (Disposable.Empty).
 
         var query = new SequencedQueryCore(behaviour);
-        var svc = new PathResolutionService(hub, query, Array.Empty<IPartitionStorageProvider>());
+        var svc = new PathResolutionService(hub, query,
+            partitionProviders ?? Array.Empty<IPartitionStorageProvider>());
         return (svc, query);
     }
 
+    private static QueryResultChange<MeshNode> Snapshot(params MeshNode[] items) =>
+        new() { ChangeType = QueryChangeType.Initial, Items = items };
+
     private static IObservable<QueryResultChange<MeshNode>> InitialWith(string id, string ns) =>
-        Observable
-            .Return(new QueryResultChange<MeshNode>
-            {
-                ChangeType = QueryChangeType.Initial,
-                Items = new List<MeshNode> { new(id, ns) { NodeType = "Markdown" } }
-            })
-            // Live queries stay open after the Initial snapshot; ResolveSegmentsCore
-            // takes the first Initial and disposes, so the trailing Never is never observed.
-            .Concat(Observable.Never<QueryResultChange<MeshNode>>());
+        Answer(Snapshot(new MeshNode(id, ns) { NodeType = "Markdown" }));
+
+    /// <summary>
+    /// One Initial snapshot, then open forever. Live queries stay open after the Initial
+    /// snapshot; <c>ResolveSegmentsCore</c> takes the first Initial and disposes, so the
+    /// trailing Never is never observed.
+    /// </summary>
+    private static IObservable<QueryResultChange<MeshNode>> Answer(QueryResultChange<MeshNode> snapshot) =>
+        Observable.Return(snapshot).Concat(Observable.Never<QueryResultChange<MeshNode>>());
 
     [Fact(Timeout = 30000)]
     public async Task HungFirstQuery_DoesNotPoisonCache()
@@ -125,5 +146,102 @@ public class PathResolutionCachePoisonTest
         }
         Assert.Equal("A/B", synchronous!.Prefix);
         Assert.Equal(callsAfterFirst, query.Calls); // no extra query on the cache hit
+    }
+
+    /// <summary>
+    /// 🚨 A SYNTHESIZED bare-partition-root placeholder is a FABRICATION, not an observed
+    /// fact, and must never be cached.
+    ///
+    /// <para>When a single-segment path matches nothing but its partition exists,
+    /// <c>ResolveSegmentsCore</c> fabricates a placeholder <see cref="MeshNode"/> so the
+    /// grain can still answer Ping (<c>PartitionRootActivationTest</c>). That placeholder
+    /// carries <b>no NodeType and no Content</b>. Caching it pins the fabrication exactly the
+    /// way caching a <c>null</c> pins a permanent 404 — the hazard the positive-only cache
+    /// exists to avoid, wearing a disguise: once pinned, every later activation of the
+    /// partition root routes on a NodeType-less node, so <c>EnrichWithNodeType</c> takes its
+    /// silent <c>string.IsNullOrEmpty(nodeType)</c> branch and binds the mesh
+    /// <c>DefaultNodeHubConfiguration</c> — the root then serves ONLY the framework's default
+    /// layout areas and none of its real NodeType's, with no log line and no self-heal.
+    /// That is the plugin gate's <c>Store/Catalog</c> RED: "No renderer is registered for
+    /// area `Tests` on hub `Store`", listing exactly the 37 default areas.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SynthesizedPartitionRoot_IsNotCached()
+    {
+        // Query #1: the root's write has not reached the read index yet (eventually
+        // consistent — the install writes the node through the owning hub's DEBOUNCED
+        // persist). Query #2: the real, TYPED root is visible.
+        var (svc, query) = BuildService(
+            call => call == 1
+                ? Answer(Snapshot())
+                : Answer(Snapshot(new MeshNode("Store") { NodeType = "Store/Catalog" })),
+            partitionProviders: new IPartitionStorageProvider[] { new ExistingWritablePartitionProvider() });
+
+        var synthesized = await svc.ResolvePath("Store")
+            .Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.NotNull(synthesized);
+        Assert.Equal("Store", synthesized!.Prefix);
+        // The fabrication: a bare node with no NodeType — enough to answer Ping, never
+        // enough to bind the root's real hub configuration.
+        Assert.Null(synthesized.Node!.NodeType);
+
+        // The fabrication must NOT have been pinned: the next resolution re-queries and
+        // returns the REAL typed root. Before the fix this returns the cached placeholder
+        // (NodeType null) forever — nothing ever invalidates it, because the create event
+        // that would have fired already fired while the first query was in flight.
+        var real = await svc.ResolvePath("Store")
+            .Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.NotNull(real);
+        Assert.Equal("Store", real!.Prefix);
+        Assert.Equal("Store/Catalog", real.Node!.NodeType);
+        Assert.True(query.Calls >= 2, "the synthesized placeholder must not be served from cache");
+    }
+
+    /// <summary>
+    /// 🚨 Fill-after-invalidate: a resolution computed from a PRE-change snapshot must never
+    /// be committed to the cache after the change event for that key has already run.
+    ///
+    /// <para>The invalidation hook removes matching keys from the cache — but a resolution
+    /// that is still IN FLIGHT is not in the cache yet, so the event sweeps nothing and the
+    /// query's stale answer is added AFTERWARDS. Nothing removes it again (the write that
+    /// would have invalidated it has already happened), so the path is pinned to the
+    /// pre-change answer for the rest of the process. Here <c>A/B</c> is created while its
+    /// resolution query is open; the query answers with the pre-create snapshot (only the
+    /// ancestor <c>A</c> matched → remainder <c>B</c> → routing NACKs NotFound), and every
+    /// later resolution must NOT be served that answer.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task InvalidationDuringInFlightQuery_DoesNotPinThePreChangeAnswer()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        // Query #1 is held open by the test so the change event lands mid-flight.
+        var inFlight = new Subject<QueryResultChange<MeshNode>>();
+        var (svc, query) = BuildService(
+            call => call == 1 ? inFlight : InitialWith("B", "A"),
+            changeFeed: feed);
+
+        AddressResolution? stale = null;
+        using var subscription = svc.ResolvePath("A/B").Take(1).Subscribe(r => stale = r);
+
+        // The node is CREATED while the resolution query is open. The cache holds nothing
+        // for "A/B" yet, so this invalidation sweeps nothing.
+        feed.Publish(MeshChangeEvent.Created(new MeshNode("B", "A") { NodeType = "Markdown" }));
+
+        // …and only now does the in-flight query answer, from its PRE-create snapshot:
+        // only the ancestor "A" exists, so "A/B" resolves to prefix "A" remainder "B".
+        inFlight.OnNext(Snapshot(new MeshNode("A")));
+        Assert.NotNull(stale);
+        Assert.Equal("A", stale!.Prefix);
+        Assert.Equal("B", stale.Remainder);
+
+        // That answer must not have been pinned. A fresh resolution re-queries and finds
+        // the created node. Before the fix this replays the stale ancestor match forever —
+        // the "row was written and then answered `No node found` forever" failure mode.
+        var fresh = await svc.ResolvePath("A/B")
+            .Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.NotNull(fresh);
+        Assert.Equal("A/B", fresh!.Prefix);
+        Assert.Null(fresh.Remainder);
+        Assert.True(query.Calls >= 2, "the pre-change answer must not be served from cache");
     }
 }


### PR DESCRIPTION
## Symptom

The MeshWeaver.Plugins cross-repo gate (`mw-plugin-test`) failed on run
[31334845551](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/31334845551):

```
RED Store/Catalog: compile=Ok render=ok tests=FAILED
    **Area not found**
    No renderer is registered for area `Tests` on hub `Store`.
    Available named areas: `$Data`, `$Model`, `$Schema`, `AccessControl`, `Catalog`, … `Versions`
```

Intermittent and load-sensitive: run 31327968786 was green on the **same image digest**
(`sha256:631b3ee…`), and two local runs of that exact image with the full 21-package repo passed.

## What the evidence actually said

The initial read — "the fluent chain is half-applied, `Catalog` landed but the `.WithView("Tests", …)`
right after it did not" — is not what happened. `Catalog` is a **framework** area
(`DomainLayoutAreas.AddDomainLayoutAreas`, reached from `MeshNodeLayoutAreas.AddDefaultLayoutAreas`).
Every one of the 37 listed areas is produced by `MeshConfiguration.DefaultNodeHubConfiguration`
alone (`GraphConfigurationExtensions` + the layout system's default `AddStandardViews`), and **not
one** comes from `Store/Catalog`. The NodeType's configuration was not partially applied — it was
never applied at all, and the hub ran on the mesh default.

Two further facts pinned it down:

* The gate job logged **zero framework warnings**, which rules out every enrichment branch that
  logs (probe-missing / indeterminate / slow-path fault / assembly-missing / reflection fault /
  NACK fallback). Only the silent branches remain.
* Of the four `Store` types whose `Tests` area ran, only `Store/Catalog` failed — and it is the
  only one whose test host is the **single-segment partition root** (`Store`). The other hosts are
  deeper paths.

## Root cause

`PathResolutionService`'s positive-only resolution cache pinned **two kinds of non-null answer that
are negatives in disguise**:

1. **The bare-partition-root synthesis.** When a single-segment path matches no node but its
   partition exists, resolution fabricates a placeholder `MeshNode` so the grain can answer Ping
   (`PartitionRootActivationTest`). That placeholder carries **no NodeType**, so
   `NodeTypeEnrichmentHelpers.EnrichWithNodeType` takes its silent
   `string.IsNullOrEmpty(nodeType)` branch and binds `DefaultNodeHubConfiguration` — and because
   enrichment short-circuits on `HubConfiguration != null`, the hub never re-enriches. Caching the
   fabrication made every later activation of that root re-read it. A package install provisions
   the partition **before** writing its root, so any routed touch inside that window fabricated it.

2. **A fill that lands after its own invalidation.** The resolution query is a live round-trip. A
   write during it invalidates a cache entry that does not exist yet, so the sweep in
   `OnMeshChange` finds nothing and the answer computed from the pre-write snapshot is added
   *afterwards* — with nothing left to remove it. That is also the shape of the 2026-08-05
   incident where a written `Store/Plugin` row answered "No node found" forever.

Together: the fabricated `Store` root was pinned past the write that should have evicted it, so the
installer's placeholder-hub recycle (`PackageInstaller`'s `DisposeRequest`, which exists for exactly
this symptom) could not help — every re-activation re-read the same fabrication.

## Fix

`src/MeshWeaver.Hosting/PathResolutionService.cs`:

* The synthesis moved **out of the cached path** into `SynthesizePartitionRoot`, applied after the
  cache write. A fabrication is never stored.
* Every fill **claims its key before the query runs** (`_pendingFills`, monotonic stamp) and commits
  only if the claim survived; the claim is re-checked after the add so both interleavings are safe.
  `OnMeshChange` sweeps in-flight claims alongside cached entries. The claim map is bounded by
  concurrent resolutions, not by paths.
* A `LogDebug` line makes a fabricated root greppable — the failure was previously invisible.

`src/MeshWeaver.PluginCatalog/PackageInstaller.cs`: comment only — the existing recycle comment now
records that the recycle is necessary but was not sufficient, and where the second half lives.

No retry, no watchdog, no timer, no widened bound.

## Repro

`test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs`, both **failing before / passing
after**, both deterministic (a `Subject` sequences the in-flight query against the change event):

* `SynthesizedPartitionRoot_IsNotCached` — before: `Expected: "Store/Catalog" Actual: null`
  (the fabrication is served forever).
* `InvalidationDuringInFlightQuery_DoesNotPinThePreChangeAnswer` — before:
  `Expected: "A/B" Actual: "A"` (the pre-create ancestor match is pinned forever).

## Verification

| Check | Result |
|---|---|
| `MeshWeaver.Hosting.Test` | 133 passed |
| `MeshWeaver.PathResolution.Test` | 123 passed |
| `MeshWeaver.Persistence.Test` | 510 passed |
| Orleans `PartitionRootActivationTest` | 1 passed |
| `WhatsNewEntryIntegrityTest` | 1 passed |
| `dotnet build -c Release -warnaserror` (Hosting, Hosting.Test, PluginCatalog) | 0 warnings, 0 errors |

Branch merged with `origin/main` before push.

## Residual

A hub already activated from a synthesized root is still not recycled when the real node lands; the
installer's `DisposeRequest` covers the install flow, and with the fabrication no longer pinned the
re-activation now binds correctly. Worth a follow-up only if the symptom is ever seen outside an
install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
