### PR TITLE
perf(test): parallelise Hosting.Monolith.Test — 317.6s → 110.2s (2.88x)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
@@ -30,6 +30,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// scope, keeps the timer alive, and asserts the capture target is collectible
 /// after the scope is disposed.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class ConsoleCaptureExecutionContextLeakTest
 {
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/test/MeshWeaver.Hosting.Monolith.Test/GcReachabilityCollection.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GcReachabilityCollection.cs
@@ -1,0 +1,36 @@
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The collection for tests that assert PROCESS-WIDE GC reachability — "after disposing X,
+/// nothing still roots it" — via <c>WeakReference</c> + a forced full <c>GC.Collect</c>.
+///
+/// <para>🚨 <b>This is scoping, not a band-aid.</b> Those assertions are statements about the
+/// whole process, so they are only meaningful when the rest of the process is quiet. With other
+/// classes concurrently allocating and holding live object graphs, a forced collect cannot be
+/// relied on to reclaim the target, and the test reports a "leak" that is really just a busy heap.
+/// Under parallelism such a test is not flaky — it is WRONG, because its precondition no longer
+/// holds. Declaring that precondition is the fix; suppressing, retrying or widening a timeout
+/// would be the band-aid.</para>
+///
+/// <para><c>DisableParallelization</c> makes xUnit run this collection on its own rather than
+/// alongside the parallel ones, which restores the quiet process these tests require. Everything
+/// else in the assembly keeps running at <c>maxParallelThreads</c> (see
+/// <c>test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json</c>).</para>
+///
+/// <para>Measured: enabling parallelism on this assembly without this collection reds
+/// <c>NodeTypeAssemblyLeakTest.NodeTypeAssemblyContext_IsCollected_AfterMeshDisposal</c> and
+/// <c>MeshHubDisposalLeakTest.MeshHub_IsCollected_AfterMeshAndServiceProviderDisposal</c> —
+/// both purely because a neighbour was allocating.</para>
+///
+/// <para>Add a class here ONLY if it asserts reachability/collection of an object after disposal.
+/// A test that is merely slow, or that races on shared STATE, does not belong — that is a real
+/// defect and serialising it would hide it.</para>
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class GcReachabilityCollection
+{
+    /// <summary>The collection name; referenced by <c>[Collection(GcReachabilityCollection.Name)]</c>.</summary>
+    public const string Name = "GC reachability (must run without parallel neighbours)";
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
@@ -39,6 +39,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>ScriptState</c>/<c>CSharpCompilation</c>/<c>AssemblyMetadata</c> is still
 /// reachable, the printed chain names the pin.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshHubDisposalLeakTest.cs
@@ -58,6 +58,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>MeshWeaver.Hosting.Test.ActivityControlPlaneResubscribeTest</c>. This probe's job is
 /// DISCOVERY — naming a root nobody knew about — not verification.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class MeshHubDisposalLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeAssemblyLeakTest.cs
@@ -40,6 +40,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// fire or a second managed reference (e.g. a TypeRegistry that outlives the node)
 /// still pins the generated type.</para>
 /// </summary>
+[Collection(GcReachabilityCollection.Name)]
 public class NodeTypeAssemblyLeakTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)

--- a/test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json
+++ b/test/MeshWeaver.Hosting.Monolith.Test/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4,
+  "methodTimeout": 30000
+}


### PR DESCRIPTION
The heaviest project in the suite, and the one that sets the shard floor — `shard-assign.sh`: *"The floor for ANY sharding is the heaviest single project."*

```
threads=1   513 tests, 0 failed, 317.6s
threads=4   513 tests, 0 failed, 110.2s     2.88x
```

Both measured with `DOTNET_PROCESSOR_COUNT=4` — the runner's core count, not this 18-core dev box. That distinction is exactly why the earlier attempt (#1033) passed locally and red on CI: "4 threads" means four competing for four cores there, four spread across eighteen here.

## `GcReachabilityCollection` — scoping, not a band-aid

Four classes assert **process-wide** reachability ("after disposing X, nothing still roots it") using `WeakReference` + a forced full `GC.Collect`:

`MeshHubDisposalLeakTest` · `NodeTypeAssemblyLeakTest` · `KernelScriptMemoryLeakTest` · `ConsoleCaptureExecutionContextLeakTest`

Test classes do **not** share a mesh — `ShareMeshClusterEnabled` is `false`, so every `[Fact]` builds its own — but they **do share the heap**. With neighbours allocating, a forced collect cannot be relied on to reclaim the target, so the test reports a "leak" that is really a busy heap.

Under parallelism such a test is not flaky, it is **wrong**: its precondition no longer holds. `[CollectionDefinition(DisableParallelization = true)]` declares that precondition. A retry, a widened timeout or a `[Skip]` would have been the band-aid.

🚨 Documented on the type: the collection is for **reachability assertions only**. A test that is merely slow, or races on shared *state*, must not be added — that is a real defect and serialising it would hide it.

## The other two #1033 failures are gone

`PixelFidelityOfferedOnlyWhenAvailableTest` and `StoreLevelWriteConflictTest` do not reproduce on current main at `threads=4`. Consistent with the store-level write CAS (#971 / #988) having hardened the path the latter exercises — the same fix that closed #980.

## Verification

- Like-for-like pair at 4 simulated CPUs, both green
- **Full solution build** clean under CI's flags — building only the touched project is what let `CS0236` reach CI on an earlier attempt

## Diff

Six files: the collection, four one-line `[Collection]` attributes, and one config. No base-class change, no cascade.

## No What's New entry

Test infrastructure, no user-visible effect — the `pullrequest` skill's step 0.5 says to skip and say so.