### PR TITLE
Correct the AddTracking post-mortem: C# in JSON, not mesh drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Full PR/merge gate: the `pullrequest` skill (CI must be GREEN before merge — m
 
 ## 🚨🚨🚨 ABSOLUTE: Green CI does NOT mean the mesh compiles — in-mesh source is invisible to `dotnet build`
 
-**Every `.cs` stored in a mesh node — NodeType `Source/*.cs`, Scripts, layout areas — compiles at RUNTIME in the portal, NEVER in CI.** The repo's node trees are `<None>` content (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so **12k+ lines of C# under `samples/Graph/Data/` and `content/` are never type-checked by any build or any test.** Worse, **the deployed mesh's copy outranks the repo's** — a node carries its own version history and drifts from the file that seeded it, so reading the repo file does NOT tell you what the portal will compile.
+**Every `.cs` stored in a mesh node — NodeType `Source/*.cs`, Scripts, layout areas — compiles at RUNTIME in the portal, NEVER in CI.** The repo's node trees are `<None>` content (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so **12k+ lines of C# under `samples/Graph/Data/` and `content/` are never type-checked by any build or any test.** Worse, **a NodeType's `configuration` lambda is C# stored in a JSON string field** — so it is invisible to every `.cs`-shaped habit at once: `grep --include='*.cs'`, `dotnet build`, and any compile gate that only scans `Source/`. When you delete a framework symbol, search the node **JSON** too.
 
 **A framework-version bump recompiles EVERY dynamic NodeType** (`HasUsableBuild` rule 3), so breakage never trickles in — the whole accumulated backlog detonates on one deploy. A NodeType left at `CompileError` **refuses portal readiness** and parks every instance hub for the full **60 s** activation budget: hung pages, failed liveness probes, dropped silos.
 

--- a/content/ai/Skill/code.md
+++ b/content/ai/Skill/code.md
@@ -34,7 +34,7 @@ These rules apply just as strictly to test code: a NodeType test that does `awai
 
 **Every `.cs` that lives in a mesh node — NodeType `Source/*.cs`, Script nodes, layout areas — compiles at RUNTIME in the portal, never in `dotnet build`.** The repo's node trees are `<None>` content, not code (`samples/Graph/MeshWeaver.Samples.Graph.csproj`), so **12k+ lines of C# under `samples/Graph/Data/` and `content/` are invisible to the compiler, to `-warnaserror`, and to every test.** Green build, green CI, clean review and a merged PR say **nothing** about whether the mesh still compiles.
 
-**The deployed mesh's copy outranks the repo's.** A node carries its own version history and drifts from the file that seeded it. Reading the repo file does not tell you what the portal will compile.
+**A NodeType's `configuration` lambda is C# stored in a JSON string field.** That is the blind spot that shipped the outage: C# no `.cs`-shaped habit can see — not `grep --include='*.cs'`, not `dotnet build`, not a compile gate that only scans `Source/`. When you remove a framework symbol, search the node **JSON** as well.
 
 **A framework-version bump recompiles EVERY dynamic NodeType** ([rule 3 of `HasUsableBuild`](@/Doc/Architecture/NodeTypeCompilation)). Breakage therefore does not trickle in — the entire accumulated backlog detonates on one deploy.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -323,9 +323,9 @@ pipeline has ever type-checked it.
 | Compiled by `dotnet build` / CI | **Never.** It is content, not code — no `<Compile>` item, no `-warnaserror`, no test | Compiled at runtime by `RunCompile` |
 | Edited by | git | in-mesh edit, `Patch`, GitSync import |
 
-The two **drift**. A node carries its own version history, so the mesh can hold source that is
-*older* than the repo's: a repo grep comes back clean while the deployed mesh still calls the API
-you removed. Treat the repo file as a seed, never as the answer to "what will the portal compile?"
+🚨 **The `configuration` lambda is C# inside a JSON string field**, so it is not reached by any
+`.cs`-shaped search or build. A `grep --include='*.cs'` for a deleted symbol comes back clean while
+three NodeTypes still call it from their JSON. Search the node JSON too.
 
 ### The failure cascade
 


### PR DESCRIPTION
The docs shipped in #1032 taught the wrong lesson, and the error is mine.

They claimed the deployed mesh's copy "outranks the repo's" and had **drifted** from it. False. The `.AddTracking()` call was in the repo the whole time — in `MeshWeaver.SocialMedia`'s `SocialMedia/Post.json`, inside the `configuration` lambda. The grep that "came back clean" searched the **core** repo's `samples/Graph/Data/SocialMedia/` (a different, *sample* copy) and only `*.cs` files.

## The real insight, which is narrower and more useful

**A NodeType's `configuration` lambda is C# stored in a JSON string field.** That single fact is what defeated every `.cs`-shaped habit at once:

- `grep --include='*.cs'` — never sees it
- `dotnet build` / `-warnaserror` — never compiles it
- a compile gate that scans only `Source/` — never reads it

`grep -rl AddTracking --include='*.json'` in the plugin repo finds all three call sites instantly.

## Why the wrong version is worth naming rather than quietly deleting

"The mesh drifted" is the *tempting* explanation — it is plausible, it fits the symptom, and it sent the first investigation down the wrong path for a long time. The corrected text calls it out as a trap so the next reader doesn't re-derive it.

Corrects three files: `AGENTS.md`, `content/ai/Skill/code.md`, `NodeTypeCompilation.md`.

Also worth recording: it was **memex-cloud only**, not all three portals — `SocialMedia` is not installed on memex or atioz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQKMhQDpitUzsW1MqTVhH