### PR TITLE
A dead sibling subscriber silenced the change feed, so live views stopped updating

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-live-views-stop-going-quiet.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-09-live-views-stop-going-quiet.md
@@ -1,0 +1,22 @@
+---
+Name: Live views no longer go quiet after a save
+Category: Fix
+Description: A list, table or search result could silently stop updating after new content appeared; it now always catches the change.
+Icon: Sparkle
+Order: -20260809
+---
+
+# Live views no longer go quiet after a save
+
+Everything you see in the portal is live: create a page and the folder listing next to it grows, add
+content and an open search result picks it up. Occasionally that stopped happening — the item was
+saved correctly, but a view already on screen kept showing the world as it was a moment earlier, and
+only a reload brought it back in line.
+
+The cause was one notification reaching some watchers and not others. Whenever anything was saved,
+every open view was told about it in turn, and a single watcher that was in the middle of closing
+could cut the announcement short — so every view further down the line was never told at all, with
+nothing reported anywhere.
+
+Each view is now told independently, so no view can be silenced by another, and a watcher that does
+run into trouble is recorded instead of disappearing.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-live-views-stop-going-quiet.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-live-views-stop-going-quiet.md
@@ -3,7 +3,7 @@ Name: Live views no longer go quiet after a save
 Category: Fix
 Description: A list, table or search result could silently stop updating after new content appeared; it now always catches the change.
 Icon: Sparkle
-Order: -20260809
+Order: -20260810
 ---
 
 # Live views no longer go quiet after a save

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosStorageAdapter.cs
@@ -1,6 +1,5 @@
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Text.Json;
 using Microsoft.Azure.Cosmos;
 using MeshWeaver.Mesh;
@@ -21,10 +20,16 @@ public class CosmosStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposable
     private CosmosChangeFeedProcessor? _changeFeedProcessor;
     // Every Cosmos round-trip runs inside the I/O pool (Invoke), never a bare _ioPool.Invoke.
     private readonly IIoPool _ioPool;
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // 🚨 An IsolatedChangeFeed, NEVER a plain Subject<T>: Subject.OnNext delivers synchronously
+    // in subscription order, so ONE subscriber throwing (a synced query caught mid-teardown, with
+    // a disposed changeBuffer still attached) aborts delivery to every subscriber after it — and
+    // the publish sites' `catch { }` made that silent. Issues #889 (Postgres) and #1053 (in-memory).
+    // No logger is wired on this adapter, so an isolated fault is not reported here; the fan-out
+    // guarantee still holds. Pass one the moment Cosmos plumbs an ILogger through.
+    private readonly IsolatedChangeFeed _changes = new(null, "cosmos");
 
     /// <inheritdoc />
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// Internal hook for <see cref="CosmosChangeFeedProcessor"/> to push

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosStorageAdapter.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Cosmos;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting.Cosmos;
 
@@ -24,9 +25,7 @@ public class CosmosStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposable
     // in subscription order, so ONE subscriber throwing (a synced query caught mid-teardown, with
     // a disposed changeBuffer still attached) aborts delivery to every subscriber after it — and
     // the publish sites' `catch { }` made that silent. Issues #889 (Postgres) and #1053 (in-memory).
-    // No logger is wired on this adapter, so an isolated fault is not reported here; the fan-out
-    // guarantee still holds. Pass one the moment Cosmos plumbs an ILogger through.
-    private readonly IsolatedChangeFeed _changes = new(null, "cosmos");
+    private readonly IsolatedChangeFeed _changes;
 
     /// <inheritdoc />
     public IObservable<DataChangeNotification> Changes => _changes;
@@ -53,14 +52,24 @@ public class CosmosStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposable
     /// <param name="nodesContainer">The Cosmos container that stores <see cref="MeshNode"/> documents.</param>
     /// <param name="partitionsContainer">The Cosmos container that stores partition objects.</param>
     /// <param name="ioPool">Optional I/O pool used to run Cosmos round-trips off the calling scheduler; defaults to the unbounded pool.</param>
+    /// <param name="logger">
+    /// Logger the change feed reports isolated subscriber faults through. Supply it: a null one
+    /// leaves a dropped or faulting observer reported NOWHERE, which is exactly the silence
+    /// <see cref="IsolatedChangeFeed"/> exists to end. The DI path
+    /// (<c>CosmosStorageAdapterFactory.Create</c>) resolves it; only the eager
+    /// <c>IServiceCollection</c> helpers that build an adapter from a caller-supplied
+    /// <see cref="CosmosClient"/> — outside any container — leave it null.
+    /// </param>
     public CosmosStorageAdapter(
         Container nodesContainer,
         Container partitionsContainer,
-        IIoPool? ioPool = null)
+        IIoPool? ioPool = null,
+        ILogger<CosmosStorageAdapter>? logger = null)
     {
         _nodesContainer = nodesContainer;
         _partitionsContainer = partitionsContainer;
         _ioPool = ioPool ?? IoPool.Unbounded;
+        _changes = new IsolatedChangeFeed(logger, "cosmos");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting.Cosmos/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/PersistenceExtensions.cs
@@ -37,8 +37,13 @@ public class CosmosStorageAdapterFactory(
         var partitionsContainer = serviceProvider.GetKeyedService<Container>(opts.PartitionsContainerName);
         logger?.LogDebug("partitions={Found}", partitionsContainer != null);
 
+        // The change feed's logger comes from the SAME provider — an IsolatedChangeFeed built with a
+        // null logger reports a dropped/faulting observer NOWHERE, which is the silence it exists to
+        // end (the regression the Postgres provider already carries a comment about).
+        var adapterLogger = serviceProvider.GetService<ILogger<CosmosStorageAdapter>>();
+
         if (nodesContainer != null && partitionsContainer != null)
-            return new CosmosStorageAdapter(nodesContainer, partitionsContainer);
+            return new CosmosStorageAdapter(nodesContainer, partitionsContainer, logger: adapterLogger);
 
         // Fallback: create CosmosClient manually from connection string (non-Aspire scenarios)
         var connectionString = opts.ConnectionString
@@ -58,7 +63,8 @@ public class CosmosStorageAdapterFactory(
         var database = cosmosClient.GetDatabase(opts.DatabaseName);
         return new CosmosStorageAdapter(
             database.GetContainer(opts.NodesContainerName),
-            database.GetContainer(opts.PartitionsContainerName));
+            database.GetContainer(opts.PartitionsContainerName),
+            logger: adapterLogger);
     }
 }
 

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionStorageProvider.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionStorageProvider.cs
@@ -45,6 +45,13 @@ public sealed class SnowflakePartitionStorageProvider : IPartitionStorageProvide
     private readonly SnowflakeStorageOptions _options;
     private readonly IEmbeddingProvider? _embeddingProvider;
     private readonly ILogger<SnowflakePartitionStorageProvider>? _logger;
+
+    /// <summary>
+    /// The provider's logger, shared with the router's <see cref="IsolatedChangeFeed"/> so a
+    /// dropped or faulting change-feed observer is reported instead of vanishing (the PG twin's
+    /// null logger left the equivalent event logged NOWHERE for four investigations).
+    /// </summary>
+    internal ILogger? Logger => _logger;
     private readonly SnowflakeCapabilityHolder? _capabilities;
     // Registered partition definitions, keyed by namespace (first segment),
     // case-insensitive. Seeded by the boot-time static-partition provider, by

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -70,10 +69,14 @@ internal sealed class SnowflakePathRoutingAdapter : IStorageAdapter
     // Without this, the default interface Changes = Observable.Empty drops every
     // change event silently (the same bug pattern VersionWritingStorageAdapter
     // had — f28449035).
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // 🚨 An IsolatedChangeFeed, NEVER a plain Subject<T>: Subject.OnNext delivers synchronously
+    // in subscription order, so ONE subscriber throwing (a synced query caught mid-teardown, with
+    // a disposed changeBuffer still attached) aborts delivery to every subscriber after it — and
+    // the publish sites' `catch { }` made that silent. Issues #889 (Postgres) and #1053 (in-memory).
+    private readonly IsolatedChangeFeed _changes;
 
     /// <inheritdoc/>
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// The write side of the merged change feed — lets the cross-process change-feed
@@ -90,6 +93,7 @@ internal sealed class SnowflakePathRoutingAdapter : IStorageAdapter
     public SnowflakePathRoutingAdapter(SnowflakePartitionStorageProvider provider)
     {
         _provider = provider;
+        _changes = new IsolatedChangeFeed(provider.Logger, "sf-path-router");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageAdapter.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using System.Globalization;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using MeshWeaver.Hosting.Embeddings;
@@ -89,7 +88,11 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
     private readonly IIoPool _ioPool;
     private readonly SnowflakeCapabilityHolder _capabilities;
     private readonly SnowflakeStorageOptions _options;
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // 🚨 An IsolatedChangeFeed, NEVER a plain Subject<T>: Subject.OnNext delivers synchronously
+    // in subscription order, so ONE subscriber throwing (a synced query caught mid-teardown, with
+    // a disposed changeBuffer still attached) aborts delivery to every subscriber after it — and
+    // the publish sites' `catch { }` made that silent. Issues #889 (Postgres) and #1053 (in-memory).
+    private readonly IsolatedChangeFeed _changes;
 
     // Per-adapter cache of "does {schema}.content_chunks exist?" — drives whether the vector
     // search UNIONs the indexed-content branch. INSTANCE field (never static — the
@@ -109,7 +112,7 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
     /// via the <see cref="SnowflakeChangeFeedPoller"/> (Snowflake has no LISTEN/NOTIFY), which is
     /// attached to <see cref="ChangeObserver"/> by the hosting wiring.
     /// </remarks>
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// Internal hook for the <see cref="SnowflakeChangeFeedPoller"/> to push foreign-silo
@@ -146,6 +149,7 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
         _partitionDefinition = partitionDefinition;
         _schemaName = partitionDefinition?.Schema;
         _logger = logger;
+        _changes = new IsolatedChangeFeed(logger, partitionDefinition?.Schema ?? "public");
         _readPool = readPool ?? IoPool.Unbounded;
         _ioPool = ioPool ?? IoPool.Unbounded;
         _capabilities = capabilities ?? new SnowflakeCapabilityHolder();
@@ -477,12 +481,9 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
             // Fire the in-process Changes feed so same-process synced-query subscribers re-emit
             // without waiting for the change-feed poller round-trip. The poller's origin-id
             // filter drops this silo's own event-log echoes, so there is no double-fire.
-            try
-            {
-                _changes.OnNext(DataChangeNotification.Updated(
-                    string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
-            }
-            catch { /* never throw — change feed is best-effort */ }
+            // No try/catch: IsolatedChangeFeed already isolates and LOGS a faulty observer.
+            _changes.OnNext(DataChangeNotification.Updated(
+                string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
             return node;
         });
 
@@ -907,8 +908,7 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
         => _ioPool.Invoke(async ct =>
         {
             await DeleteAsyncCore(path, ct).ConfigureAwait(false);
-            try { _changes.OnNext(DataChangeNotification.Deleted(path)); }
-            catch { /* never throw — change feed is best-effort */ }
+            _changes.OnNext(DataChangeNotification.Deleted(path));
             return path;
         });
 
@@ -923,10 +923,7 @@ public class SnowflakeStorageAdapter : IScopedQueryStorageAdapter, IAsyncDisposa
         {
             var removed = await DeleteAsyncCore(path, ct).ConfigureAwait(false) > 0;
             if (removed)
-            {
-                try { _changes.OnNext(DataChangeNotification.Deleted(path)); }
-                catch { /* never throw — change feed is best-effort */ }
-            }
+                _changes.OnNext(DataChangeNotification.Deleted(path));
             return removed;
         });
 

--- a/src/MeshWeaver.Hosting.Sqlite/SqliteStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Sqlite/SqliteStorageAdapter.cs
@@ -1,6 +1,5 @@
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -29,7 +28,11 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
     private readonly ITextEmbedder? _embedder;
     private readonly ILogger? _logger;
     private readonly object _gate = new();
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // 🚨 An IsolatedChangeFeed, NEVER a plain Subject<T>: Subject.OnNext delivers synchronously
+    // in subscription order, so ONE subscriber throwing (a synced query caught mid-teardown, with
+    // a disposed changeBuffer still attached) aborts delivery to every subscriber after it — and
+    // the publish site's `catch { }` made that silent. Issues #889 (Postgres) and #1053 (in-memory).
+    private readonly IsolatedChangeFeed _changes;
 
     /// <summary>
     /// Opens the SQLite store, holding one dedicated connection for the adapter's lifetime and
@@ -48,6 +51,7 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
         _ioPool = ioPool ?? IoPool.Unbounded;
         _embedder = embedder;
         _logger = logger;
+        _changes = new IsolatedChangeFeed(logger, "sqlite");
         // One dedicated connection held for the adapter's lifetime — pooling is pointless and would
         // retain the file handle past Dispose (so the DB file can't be deleted/reopened cleanly).
         var csb = new SqliteConnectionStringBuilder(connectionString) { Pooling = false };
@@ -57,7 +61,7 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
     }
 
     /// <inheritdoc />
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     private static string Norm(string? path) => path?.Trim('/') ?? "";
 
@@ -153,7 +157,8 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
                 cmd.Parameters.AddWithValue("$emb", vector is null ? DBNull.Value : ToBlob(vector));
                 cmd.ExecuteNonQuery();
             }
-            try { _changes.OnNext(DataChangeNotification.Updated(path, node)); } catch { /* never throw */ }
+            // No try/catch: IsolatedChangeFeed already isolates and LOGS a faulty observer.
+            _changes.OnNext(DataChangeNotification.Updated(path, node));
             return node;
         }));
     }
@@ -225,7 +230,7 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
                 cmd.Parameters.AddWithValue("$p", p);
                 cmd.ExecuteNonQuery();
             }
-            try { _changes.OnNext(DataChangeNotification.Deleted(p, null)); } catch { /* never throw */ }
+            _changes.OnNext(DataChangeNotification.Deleted(p, null));
             return path;
         });
 

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -22,10 +21,20 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
     private readonly ConcurrentDictionary<string, MeshNode> _nodes;
     private readonly ConcurrentDictionary<string, List<object>> _partitionObjects;
     private readonly ILogger? _logger;
-    private readonly Subject<DataChangeNotification> _changes = new();
+    // 🚨 An IsolatedChangeFeed, NEVER a plain Subject<T> — the same rule the Postgres adapters
+    // follow, and for the same reason (issue #889 there, issue #1053 here). Subject.OnNext delivers
+    // synchronously in subscription order, so ONE subscriber throwing aborts delivery to every
+    // subscriber AFTER it; the publish sites' `catch { }` then made that silent. The thrower is not
+    // hypothetical: every live synced query owns a `persistence.Changes → changeBuffer` pipeline,
+    // and a pipeline caught in its teardown window has a DISPOSED changeBuffer while its feed
+    // subscription is still delivering (ObjectDisposedException). One-shot queries — QueryAsync,
+    // autocomplete, path resolution — open and tear one down constantly, so the window is hit
+    // whenever a write lands during a teardown. Symptom: a LIVE children query that silently stops
+    // re-emitting after a create that completed successfully.
+    private readonly IsolatedChangeFeed _changes;
 
     /// <inheritdoc />
-    public IObservable<DataChangeNotification> Changes => _changes.AsObservable();
+    public IObservable<DataChangeNotification> Changes => _changes;
 
     /// <summary>
     /// Creates an adapter with its own fresh, case-insensitive backing
@@ -56,6 +65,9 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         _nodes = nodes;
         _partitionObjects = partitionObjects;
         _logger = logger;
+        // The logger is passed on DELIBERATELY: an isolated fault that nobody logs is the silence
+        // this feed exists to end (see PostgreSqlPartitionStorageProvider's null-logger regression).
+        _changes = new IsolatedChangeFeed(logger, "in-memory");
     }
 
     private static string Norm(string? path) => path?.Trim('/') ?? "";
@@ -112,7 +124,11 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
 
             _logger?.LogDebug("[InMemoryAdapter#{Id:X}] Write {Path} (count={Count})",
                 GetHashCode(), Norm(node.Path), _nodes.Count);
-            try { _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node)); } catch { /* never throw */ }
+            // No try/catch: IsolatedChangeFeed already isolates and LOGS a faulty observer, so a
+            // throw escaping here would be a bug in the feed itself, not a subscriber's fault to
+            // swallow. The `catch { }` this replaces is precisely what made the dropped
+            // notification invisible.
+            _changes.OnNext(DataChangeNotification.Updated(Norm(node.Path), node));
             return Observable.Return<MeshNode?>(node);
         });
 
@@ -121,7 +137,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         => Observable.Defer(() =>
         {
             _nodes.TryRemove(Norm(path), out var removed);
-            try { _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed)); } catch { /* never throw */ }
+            _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed));
             return Observable.Return(path);
         });
 
@@ -136,9 +152,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         {
             var won = _nodes.TryRemove(Norm(path), out var removed);
             if (won)
-            {
-                try { _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed)); } catch { /* never throw */ }
-            }
+                _changes.OnNext(DataChangeNotification.Deleted(Norm(path), removed));
             return Observable.Return(won);
         });
 

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -270,9 +270,10 @@ public static class PersistenceExtensions
     /// <returns>The service collection for chaining</returns>
     public static IServiceCollection AddInMemoryPersistence(this IServiceCollection services)
     {
-        // The in-memory adapter owns its own change-feed Subject and surfaces
-        // it via IStorageAdapter.Changes — synced-query providers subscribe
-        // there. No standalone IDataChangeNotifier service needed.
+        // The in-memory adapter owns its own IsolatedChangeFeed and surfaces it via
+        // IStorageAdapter.Changes — synced-query providers subscribe there. No standalone
+        // IDataChangeNotifier service needed. (An IsolatedChangeFeed, never a plain Subject:
+        // see the field comment on InMemoryStorageAdapter for the fan-out abort it prevents.)
         services.TryAddSingleton<IStorageAdapter>(sp =>
             new InMemoryStorageAdapter(
                 sp.GetService<ILogger<InMemoryStorageAdapter>>()));

--- a/src/MeshWeaver.Mesh.Contract/Services/IsolatedChangeFeed.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IsolatedChangeFeed.cs
@@ -1,27 +1,35 @@
 using System.Collections.Immutable;
+using System.Reactive.Disposables;
 using Microsoft.Extensions.Logging;
-using MeshWeaver.Mesh.Services;
 
-namespace MeshWeaver.Hosting.PostgreSql;
+namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
-/// The storage adapter's in-process change feed: a hot broadcast where ONE faulty subscriber
-/// cannot starve the others.
+/// The change feed every <see cref="IStorageAdapter"/> publishes <see cref="IStorageAdapter.Changes"/>
+/// through: a hot broadcast where ONE faulty subscriber cannot starve the others.
 ///
-/// <para>This replaces a plain <see cref="System.Reactive.Subjects.Subject{T}"/>, which is
-/// fan-out-hostile in exactly the way that matters here. <c>Subject&lt;T&gt;.OnNext</c> delivers to
+/// <para>🚨 <b>A storage adapter must NEVER publish through a plain
+/// <see cref="System.Reactive.Subjects.Subject{T}"/>.</b> <c>Subject&lt;T&gt;.OnNext</c> delivers to
 /// its observers SYNCHRONOUSLY, IN SUBSCRIPTION ORDER, on the caller's thread — so the first
-/// observer that throws aborts delivery to every observer after it. The adapter then wrapped the
+/// observer that throws aborts delivery to every observer after it. Adapters then wrapped the
 /// publish in <c>catch { /* best-effort */ }</c>, which turned that into silence.</para>
 ///
-/// <para>The concrete failure (CI 31083356138 and again on main at 0744169c): a synced query being
-/// torn down disposes its buffer before the subscription feeding it, so a write landing in that
-/// window throws <see cref="ObjectDisposedException"/> into the fan-out. Every OTHER live
+/// <para>The concrete failure on Postgres (CI 31083356138 and again on main at 0744169c): a synced
+/// query being torn down disposes its buffer before the subscription feeding it, so a write landing
+/// in that window throws <see cref="ObjectDisposedException"/> into the fan-out. Every OTHER live
 /// subscriber — including the <c>$security-access</c> query the permission evaluator folds — never
 /// saw that notification. Its <c>Replay(1)</c> cache stayed frozen at the pre-write snapshot, the
 /// access fold never completed, and reads were evaluated against stale permissions until something
 /// else happened to re-trigger a query. In tests that surfaced as PaywallRealGateShapeTests timing
 /// out on its fold barrier; in a live portal it is a silently stale security cache.</para>
+///
+/// <para>The SAME defect was still live on the in-memory adapter — the feed behind every monolith
+/// test mesh and every in-memory partition — and surfaced there as issue #1053: a LIVE children
+/// query silently stopped re-emitting after a create that completed successfully. The subscriber
+/// that throws is not hypothetical on any backend: every live synced query owns a
+/// <c>persistence.Changes → changeBuffer</c> pipeline, and one-shot queries
+/// (<c>IMeshService.QueryAsync</c>, autocomplete, path resolution) open and tear one down
+/// constantly, so the disposal window is hit whenever a write lands during a teardown.</para>
 ///
 /// <para>So: deliver to a SNAPSHOT of the observers, isolate each one, and never let a throw from
 /// one reach another. A DISPOSED observer is dropped (provably dead — every later notification
@@ -30,7 +38,7 @@ namespace MeshWeaver.Hosting.PostgreSql;
 /// bug. Either way it is LOGGED: a swallowed fault on the security-fold path is precisely what
 /// made this take three CI runs to see.</para>
 /// </summary>
-internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, IObserver<DataChangeNotification>, IDisposable
+public sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, IObserver<DataChangeNotification>, IDisposable
 {
     private readonly ILogger? _logger;
     private readonly string _adapter;
@@ -41,12 +49,30 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
         ImmutableList<IObserver<DataChangeNotification>>.Empty;
     private bool _disposed;
 
+    /// <summary>
+    /// Creates a feed for one adapter.
+    /// </summary>
+    /// <param name="logger">
+    /// Logger for isolated-fault warnings. Pass a real logger — a null one restores exactly the
+    /// silence this class exists to end (see <c>PostgreSqlPartitionStorageProvider</c>, where the
+    /// per-schema feeds were once constructed with a null logger).
+    /// </param>
+    /// <param name="adapter">
+    /// Name of the owning adapter (a Postgres schema, <c>"path-router"</c>, <c>"in-memory"</c>, …),
+    /// used to attribute a warning to the feed it came from.
+    /// </param>
     public IsolatedChangeFeed(ILogger? logger, string adapter)
     {
         _logger = logger;
         _adapter = adapter;
     }
 
+    /// <summary>
+    /// Attaches <paramref name="observer"/> to the feed. Subscribing (or disposing) during a
+    /// publish is safe — <see cref="OnNext"/> walks a snapshot taken before delivery starts.
+    /// </summary>
+    /// <param name="observer">The observer to receive every subsequent notification.</param>
+    /// <returns>A subscription handle; disposing it detaches the observer.</returns>
     public IDisposable Subscribe(IObserver<DataChangeNotification> observer)
     {
         ArgumentNullException.ThrowIfNull(observer);
@@ -59,6 +85,11 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
         return new Subscription(this, observer);
     }
 
+    /// <summary>
+    /// Publishes <paramref name="value"/> to every attached observer, isolating each one: a throw
+    /// from any observer never reaches another, and never reaches the publishing write.
+    /// </summary>
+    /// <param name="value">The change notification to broadcast.</param>
     public void OnNext(DataChangeNotification value)
     {
         // Snapshot OUTSIDE the delivery loop: an observer is free to subscribe or dispose while we
@@ -97,6 +128,8 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
         }
     }
 
+    /// <summary>Forwards a terminal fault to every observer, isolating each one.</summary>
+    /// <param name="error">The fault to forward.</param>
     public void OnError(Exception error)
     {
         foreach (var observer in Volatile.Read(ref _observers))
@@ -106,6 +139,7 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
         }
     }
 
+    /// <summary>Forwards completion to every observer, isolating each one.</summary>
     public void OnCompleted()
     {
         foreach (var observer in Volatile.Read(ref _observers))
@@ -115,6 +149,10 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
         }
     }
 
+    /// <summary>
+    /// Detaches every observer and refuses further subscriptions. Called when the owning adapter
+    /// is disposed.
+    /// </summary>
     public void Dispose()
     {
         lock (_gate)
@@ -142,11 +180,5 @@ internal sealed class IsolatedChangeFeed : IObservable<DataChangeNotification>, 
             if (o is not null)
                 feed.Remove(o);
         }
-    }
-
-    private sealed class Disposable : IDisposable
-    {
-        public static readonly IDisposable Empty = new Disposable();
-        public void Dispose() { }
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SyncedQueryChangeFeedStarvationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SyncedQueryChangeFeedStarvationTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// End-to-end pin for issue #1053: a LIVE children query must keep re-emitting after a create,
+/// no matter what state some OTHER subscriber of the change feed is in.
+///
+/// <para>The symptom was a 30 s timeout where a live listing never re-emitted although the create
+/// completed successfully — reported against
+/// <c>MeshNodeAgentFileStoreTest.ListChildren_StaysLive_AndReEmitsWhenAFileAppears</c> /
+/// <c>Search_StaysLive_AndReEmitsWhenMatchingContentAppears</c>, and intermittent because it needs
+/// a second subscriber to be mid-teardown when the write lands.</para>
+///
+/// <para><b>What this test makes deterministic.</b> Every live synced query owns a
+/// <c>persistence.Changes → changeBuffer</c> pipeline (<c>StorageAdapterMeshQueryProvider</c>), and
+/// a pipeline caught in its teardown window has a DISPOSED <c>changeBuffer</c> while its feed
+/// subscription is still delivering. One-shot queries — <c>IMeshService.QueryAsync</c>,
+/// autocomplete, path resolution — open and tear one down constantly, so on a busy mesh that
+/// window is hit routinely; here it is staged explicitly, and placed BEFORE the listing's own
+/// subscription because a plain <see cref="Subject{T}"/> fan-out aborts at the first throwing
+/// observer and starves everyone after it. The in-memory adapter then swallowed the
+/// <see cref="ObjectDisposedException"/> in a <c>catch { }</c>, so the dropped notification left no
+/// trace anywhere.</para>
+///
+/// <para>The listing here is a plain <c>hub.GetQuery</c> — the same synced-query surface every
+/// layout area and Blazor view data-binds to — so this is a liveness guarantee of the binding
+/// path, not a property of the agent file store that reported it.</para>
+/// </summary>
+public class SyncedQueryChangeFeedStarvationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Stages a query pipeline caught in its teardown window: the buffer it feeds is already
+    /// disposed while the feed subscription still delivers into it.
+    /// </summary>
+    private static IDisposable SubscribeDeadPipeline(IStorageAdapter adapter)
+    {
+        var deadBuffer = new Subject<DataChangeNotification>();
+        var feedSub = adapter.Changes.Subscribe(deadBuffer);
+        deadBuffer.Dispose();
+        return feedSub;
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ALiveChildrenQuery_ReEmits_EvenWhenATornDownPipelineSitsOnTheChangeFeed()
+    {
+        var folder = $"{TestPartition}/live-{Guid.NewGuid():N}";
+        await NodeFactory
+            .CreateNode(new MeshNode("one", folder) { Name = "one", NodeType = "Markdown" })
+            .FirstAsync().Timeout(Bound).ToTask();
+
+        // 🚨 ORDER IS THE POINT: the dead pipeline attaches BEFORE the listing opens its own, so a
+        // plain-Subject fan-out aborts before ever reaching the listing.
+        using var dead = SubscribeDeadPipeline(
+            Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>());
+
+        var listing = Mesh.GetQuery(
+            $"starvation:{folder}", $"path:{folder} scope:children select:path,id,name,nodeType");
+
+        // Establish the live subscription AND its snapshot before the second create — otherwise a
+        // late Initial could carry "two" and the test would pass without ever exercising a delta.
+        var seeded = await listing
+            .Where(nodes => nodes.Any(n => n.Path == $"{folder}/one"))
+            .FirstAsync().Timeout(Bound).ToTask();
+        seeded.Select(n => n.Path).Should().Contain($"{folder}/one");
+
+        var next = listing
+            .Where(nodes => nodes.Any(n => n.Path == $"{folder}/two"))
+            .FirstAsync().Timeout(Bound).ToTask();
+
+        await NodeFactory
+            .CreateNode(new MeshNode("two", folder) { Name = "two", NodeType = "Markdown" })
+            .FirstAsync().Timeout(Bound).ToTask();
+
+        (await next).Select(n => n.Path).Should().Contain([$"{folder}/one", $"{folder}/two"],
+            "the create completed, so an Added was OWED to every live subscriber of the change "
+            + "feed — a sibling subscriber caught mid-teardown must never be able to starve it "
+            + "(issue #1053: a data-bound view that silently stops updating)");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/InMemoryChangeFeedFanoutIsolationTest.cs
+++ b/test/MeshWeaver.Hosting.Test/InMemoryChangeFeedFanoutIsolationTest.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the fan-out contract of the IN-MEMORY storage adapter's change feed — the feed EVERY
+/// monolith test mesh (and every in-memory partition in a real portal) publishes writes on.
+///
+/// <para>These are the in-memory twins of <c>IsolatedChangeFeedTests</c> /
+/// <c>MergedFeedFanoutIsolationTests</c> over in the Postgres suite. The defect they killed on the
+/// Postgres feeds (issue #889) was never fixed here: <see cref="InMemoryStorageAdapter"/> published
+/// through a plain <see cref="Subject{T}"/> wrapped in <c>catch { }</c>, which is fan-out-hostile
+/// twice over — <c>Subject.OnNext</c> delivers synchronously in subscription order, so ONE
+/// subscriber throwing aborts delivery to every subscriber after it, and the <c>catch</c> then turns
+/// that into silence.</para>
+///
+/// <para>The subscriber that throws is not hypothetical. Every live synced query opens a
+/// <c>persistence.Changes → changeBuffer</c> pipeline (<c>StorageAdapterMeshQueryProvider</c>), and
+/// a pipeline caught in its teardown window has a DISPOSED <c>changeBuffer</c> while the feeding
+/// subscription is still delivering — the <see cref="ObjectDisposedException"/> shape. One-shot
+/// queries (<c>IMeshService.QueryAsync</c>, autocomplete, path resolution) open and tear down that
+/// pipeline constantly, so the window is hit whenever a write lands during a teardown.</para>
+///
+/// <para>Downstream symptom (issue #1053): a LIVE children query silently stops re-emitting after a
+/// create that completed successfully — the change notification was owed and never delivered, with
+/// no error and no log line anywhere.</para>
+/// </summary>
+public class InMemoryChangeFeedFanoutIsolationTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode Node(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        return slash < 0
+            ? new MeshNode(path) { NodeType = "Markdown" }
+            : new MeshNode(path[(slash + 1)..], path[..slash]) { NodeType = "Markdown" };
+    }
+
+    /// <summary>
+    /// A query pipeline caught in its teardown window: the buffer <see cref="Subject{T}"/> it feeds
+    /// is already disposed while the feed subscription still delivers into it — exactly what a
+    /// torn-down <c>StorageAdapterMeshQueryProvider</c> pipeline exposes to the adapter's feed.
+    /// </summary>
+    private static IDisposable SubscribeDeadPipeline(IStorageAdapter adapter)
+    {
+        var deadBuffer = new Subject<DataChangeNotification>();
+        var feedSub = adapter.Changes.Subscribe(deadBuffer);
+        deadBuffer.Dispose();
+        return new CompositeDisposable(feedSub, deadBuffer);
+    }
+
+    [Fact]
+    public void A_disposed_sibling_subscriber_must_not_abort_delivery_to_later_subscribers()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        // Subscription ORDER is the point: the dead pipeline sits BEFORE the victim, exactly like
+        // an ephemeral one-shot query relative to the long-lived synced query it out-orders.
+        using var dead = SubscribeDeadPipeline(adapter);
+        var received = new List<string>();
+        using var victim = adapter.Changes.Subscribe(n => received.Add(n.Path));
+
+        adapter.Write(Node("rbuergi/agent-files/two.md"), Options).Subscribe();
+
+        received.Should().Contain("rbuergi/agent-files/two.md",
+            "a disposed sibling subscriber must not abort the change-feed fan-out to the "
+            + "subscribers after it — that is a silently dropped change notification, and on a live "
+            + "children query it is a view that stops updating (issue #1053)");
+    }
+
+    [Fact]
+    public void A_disposed_sibling_subscriber_must_not_abort_a_delete_notification()
+    {
+        var adapter = new InMemoryStorageAdapter();
+        adapter.Write(Node("rbuergi/agent-files/gone.md"), Options).Subscribe();
+
+        using var dead = SubscribeDeadPipeline(adapter);
+        var received = new List<string>();
+        using var victim = adapter.Changes.Subscribe(n => received.Add(n.Path));
+
+        adapter.Delete("rbuergi/agent-files/gone.md").Subscribe();
+
+        received.Should().Contain("rbuergi/agent-files/gone.md",
+            "a delete is the notification a live collection MUST see — a subscriber that misses it "
+            + "keeps rendering a node that no longer exists");
+    }
+
+    /// <summary>
+    /// Throws on every notification, as an EXPLICIT observer: Rx's <c>Subscribe(Action&lt;T&gt;)</c>
+    /// wrapper auto-detaches itself when the handler throws, which would hide whether the FEED kept
+    /// the subscriber. This shape asks the feed the question directly.
+    /// </summary>
+    private sealed class Thrower : IObserver<DataChangeNotification>
+    {
+        public int Calls { get; private set; }
+        public void OnNext(DataChangeNotification value)
+        {
+            Calls++;
+            throw new InvalidOperationException("subscriber blew up");
+        }
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    [Fact]
+    public void A_transient_throw_isolates_but_keeps_the_subscriber_and_the_write_still_succeeds()
+    {
+        var adapter = new InMemoryStorageAdapter();
+
+        var thrower = new Thrower();
+        using var faulty = adapter.Changes.Subscribe(thrower);
+        var received = new List<string>();
+        using var victim = adapter.Changes.Subscribe(n => received.Add(n.Path));
+
+        MeshNode? written = null;
+        adapter.Write(Node("rbuergi/agent-files/a.md"), Options).Subscribe(n => written = n);
+        adapter.Write(Node("rbuergi/agent-files/b.md"), Options).Subscribe();
+
+        written.Should().NotBeNull("a subscriber's fault must never fail the write that published it");
+        thrower.Calls.Should().Be(2,
+            "a transient throw must not permanently disable a LIVE subscriber — dropping it would "
+            + "starve it of every future change, which is the very failure this isolation prevents");
+        received.Should().Equal("rbuergi/agent-files/a.md", "rbuergi/agent-files/b.md");
+    }
+}


### PR DESCRIPTION
## The defect

`InMemoryStorageAdapter` published `Write`/`Delete` through a plain `Subject<T>` wrapped in
`catch { /* never throw */ }`.

`Subject<T>.OnNext` delivers **synchronously, in subscription order**, on the caller's thread — so
the first observer that throws **aborts delivery to every observer after it**. The `catch` then
turned that into silence: no error, no log line, and the write itself reported success.

**The thrower is not hypothetical.** Every live synced query owns a
`persistence.Changes → changeBuffer` pipeline (`StorageAdapterMeshQueryProvider`), and a pipeline
caught in its teardown window has a **disposed `changeBuffer`** while the feed subscription is still
delivering into it → `ObjectDisposedException`. One-shot queries — `IMeshService.QueryAsync`,
autocomplete, path resolution — open and tear one of those down constantly, so on any busy mesh the
window is hit whenever a write lands during a teardown. That is exactly why #1053 is intermittent
and why it does not need parallelism to appear.

This is the **same defect the Postgres feeds killed in #889** (`IsolatedChangeFeed`,
`MergedFeedFanoutIsolationTests`). It was never fixed on the in-memory adapter — the feed behind
every monolith test mesh and every in-memory partition in a real portal.

## Evidence, not inference

`SyncedQueryChangeFeedStarvationTest` stages the teardown window deterministically and runs a plain
`hub.GetQuery` children listing over a real monolith mesh. **Negative control** (revert only the
adapter's feed, nothing else):

```
[FAIL] ALiveChildrenQuery_ReEmits_EvenWhenATornDownPipelineSitsOnTheChangeFeed
Failed: 1, Duration: 30 s
```

A 30-second timeout on a live children query that never re-emitted after a create that completed —
the reported signature verbatim. Restore the feed and it passes in 0.5 s. All four new tests were
confirmed red before the fix and green after.

That control also **rules out the two other live leads on the issue**, because it holds them fixed:

- *"Does the create's write publish on the watched path?"* — it does. Same publish, same path; only
  the fan-out changed between red and green.
- *"Does `PathMatcher.ShouldNotify` disagree for a children-scoped watcher?"* — it does not. Same
  matcher, same `scope:children` query; the notification is dropped **after** relevance matching, in
  delivery.

So the gap is neither publication nor relevance nor the synced-query fold: it is the fan-out.

## The fix

`IsolatedChangeFeed` moves from `MeshWeaver.Hosting.PostgreSql` to `MeshWeaver.Mesh.Contract`, next
to the `IStorageAdapter.Changes` contract it enforces, and every adapter now publishes through it —
in-memory, Sqlite, Cosmos and both Snowflake adapters carried the identical plain-Subject feed. The
guarantee belongs to the interface, not to the two backends that happened to get debugged.

Publish sites drop their `catch { }` per the Postgres precedent: the feed isolates each observer and
**logs** it, so a throw escaping there would be a bug in the feed rather than a subscriber's fault to
swallow. A disposed observer is dropped (provably dead); any other throw is isolated but the
subscriber is **kept**, since permanently disabling a live subscriber over a transient fault would
just relocate this very bug.

Snowflake's partition provider gains the same internal `Logger` accessor the Postgres one has, so
the router's feed reports an isolated fault instead of constructing with a null logger.

## Tests

| | |
|---|---|
| `InMemoryChangeFeedFanoutIsolationTest` (3, new) | the fan-out contract at the adapter |
| `SyncedQueryChangeFeedStarvationTest` (1, new) | the #1053 symptom end to end |
| `MeshNodeAgentFileStoreTest` | 24/24 — the family that reported it |
| `MeshWeaver.Hosting.Test` | 134/134 |

No timeout was widened, no retry or poll added, no assertion weakened.

## What's New

Shipped as `Category: Fix` — a view that silently stops updating is user-visible, and per the
skill's note that fixes are the entries that go missing, "would a user notice?" is the bar.

Fixes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)
