### PR TITLE
Grain activation no longer times out waiting on itself

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-plugin-pages-stop-timing-out.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-plugin-pages-stop-timing-out.md
@@ -1,0 +1,26 @@
+---
+Name: Plugin pages stop timing out on themselves
+Category: Fix
+Description: Installed plugins such as courses could become unreachable, retry forever, and never recover on their own.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Plugin pages stop timing out on themselves
+
+An installed plugin — a course area, a skills or agents section — could stop opening altogether.
+The page never rendered, tools reading the same content answered "unavailable", and the portal kept
+retrying without ever getting further. Nothing was actually broken: the content was there, and the
+part of the portal that starts a section up was working on it.
+
+The cause was a section asking the portal for its own page while it was still starting up. That
+question could only be answered once start-up had finished, so it always ran out of time — and the
+portal treated running out of time as proof that the section had failed. Start-up was abandoned at
+exactly the moment it was about to succeed, and each retry inherited the same stale answer, so the
+section could never get going again. It hit hardest where a section legitimately takes a little
+longer to prepare, which is precisely where the extra patience was designed to go.
+
+Now a section no longer treats a question it can only answer itself as a verdict on whether it
+started. Sections that need longer to prepare are given that time, a genuinely broken one shows the
+explanatory page it was always meant to show, and a section that is missing is reported straight
+away instead of after a wait. Recovery no longer needs a restart.

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
@@ -221,9 +222,12 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         else
         {
             logger.LogDebug("[ACTIVATE] Grain {StreamId}: no static node with HubConfig, merging path resolver + mesh-node cache", streamId);
-            // Path resolver gives a fast in-process answer (no SubscribeRequest round-trip)
-            // for routable paths; the mesh-node cache backs it up for dynamic / freshly-
-            // created nodes that the path resolver hasn't indexed yet.
+            // Path resolver gives the AUTHORITATIVE in-process answer (no SubscribeRequest
+            // round-trip) for routable paths; the mesh-node cache is an ACCELERATOR that
+            // replays an already-hydrated entry (a reader kept this path warm across an idle
+            // collection) so a reactivation can skip the storage read. It can only ever
+            // contribute a VALUE — see ComposeActivationSource for why its terminal is
+            // meaningless by construction and must not fault this activation.
             var pathResolver = meshHub.ServiceProvider.GetRequiredService<IPathResolver>();
             var accessService = meshHub.ServiceProvider.GetService<AccessService>();
             // 🚨 Grain activation is INFRASTRUCTURE — reading the node to learn its
@@ -243,11 +247,18 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                 using (accessService?.ImpersonateAsSystem())
                     return streamCache.GetStream(addressPath, meshHub.JsonSerializerOptions);
             });
-            sourceStream = Observable.Merge(
+            sourceStream = ComposeActivationSource(
                 pathResolver.ResolvePath(addressPath)
                     .Where(r => r is { Node: not null })
                     .Select(r => r!.Node!),
-                cacheStream);
+                cacheStream,
+                ex => logger.LogWarning(ex,
+                    "[ACTIVATE] Grain {StreamId}: the mesh-node-cache read of this grain's OWN address " +
+                    "('{Path}') terminated with an error. That read is a SubscribeRequest routed back to " +
+                    "THIS grain, so it cannot be answered until this activation completes — its terminal " +
+                    "says nothing about the node and must not fault the activation. Node resolution " +
+                    "continues on the path resolver.",
+                    streamId, addressPath));
         }
 
         // Non-blocking activation: subscribe to the source stream; when it emits a
@@ -273,19 +284,16 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // the source emits, Amb commits to it and the timer is unsubscribed, so a
         // legitimately slow enrichment (cold compile, bounded internally by the
         // slow-path budgets) is never cut short.
-        _activationSubscription = Observable.Amb(
+        _activationSubscription = BuildActivationChain(
                 sourceStream,
-                Observable.Timer(FirstNodeResolutionTimeout).SelectMany(_ =>
-                    Observable.Throw<MeshNode>(new TimeoutException(
-                        $"No MeshNode emitted for '{addressPath}' within {FirstNodeResolutionTimeout.TotalSeconds:0}s. " +
-                        "Either the node does not exist or no query provider claims its partition."))))
-            .SelectMany(node =>
-            {
-                logger.LogDebug("[ACTIVATE] Grain {StreamId}: source emitted node={Path} NodeType={NodeType} hasHubConfig={HasConfig}",
-                    streamId, node.Path, node.NodeType ?? "(null)", node.HubConfiguration != null);
-                return ResolveHubConfigurationObservable(node);
-            })
-            .Take(1)
+                addressPath,
+                FirstNodeResolutionTimeout,
+                node =>
+                {
+                    logger.LogDebug("[ACTIVATE] Grain {StreamId}: source emitted node={Path} NodeType={NodeType} hasHubConfig={HasConfig}",
+                        streamId, node.Path, node.NodeType ?? "(null)", node.HubConfiguration != null);
+                    return ResolveHubConfigurationObservable(node);
+                })
             .Subscribe(
                 node => CompleteActivation(streamId, address, grainScheduler, node, sourceStream),
                 ex =>
@@ -314,6 +322,96 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
 
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Composes the activation SOURCE from its two branches, and neutralises the one branch
+    /// whose terminal is meaningless by construction.
+    ///
+    /// <para><b>The branches.</b> <paramref name="pathResolverStream"/> is authoritative: it reads
+    /// the node straight out of storage, in-process, with no hub round-trip.
+    /// <paramref name="ownAddressCacheStream"/> is an ACCELERATOR: when the process-wide
+    /// <c>IMeshNodeStreamCache</c> already holds a hydrated entry for this path (a reader kept it
+    /// warm across an idle-collection), it replays the node instantly and activation skips the
+    /// storage read.</para>
+    ///
+    /// <para>🚨 <b>Why the cache branch may supply a VALUE but never a TERMINAL.</b> The cache
+    /// opens its upstream with <c>GetMeshNodeStreamBypassCache(path)</c> — a
+    /// <c>SubscribeRequest</c> addressed at <c>path</c>. For the grain's OWN address that request
+    /// is routed straight back to THIS grain, where <see cref="DeliverMessage"/> parks it on
+    /// <see cref="_hubReadyRaw"/> until <see cref="CompleteActivation"/> runs. So on a COLD entry
+    /// the branch is a strict self-loop: it cannot answer until the very activation it feeds has
+    /// finished. Its only possible terminal is "the grain did not answer itself", which carries no
+    /// information about the node — and letting <c>Observable.Merge</c> forward it made that
+    /// terminal the ACTIVATION's terminal.
+    ///
+    /// <para>Measured consequence (memex.systemorph.com, 2026-08-09/10 — ~36 activation faults an
+    /// hour, every one of them a <c>nodeType:Store/Plugin</c> node): the cache hub's request budget
+    /// (<c>MessageHubConfiguration.RequestTimeout</c>, 60 s) became a hard 60 s ceiling on TOTAL
+    /// activation, and it fired as <c>"No response received in hub cache/… for request
+    /// SubscribeRequest → target Edu"</c> — an error naming the activating grain as an unreachable
+    /// target. That ceiling pre-empted BOTH of the deliberate slow-path designs downstream:
+    /// <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c> DISARMS its wall clock while a
+    /// compile is in flight (a cold pod compiling many dynamic types legitimately runs past the
+    /// budget), and <c>BuildEnrichmentChain</c> catches a stuck type into a visible
+    /// compilation-error OVERLAY so the hub activates anyway. Neither could ever be reached: the
+    /// self-loop faulted the activation first, 100% of the time. Orleans then retried, the cache's
+    /// transient-streak breaker replayed the cached timeout into each fresh activation, and the
+    /// retries faulted in milliseconds — the node stayed unreadable to users and to MCP.</para></para>
+    ///
+    /// <para><b>This is not a swallowed fault.</b> The exception is logged in full via
+    /// <paramref name="onOwnAddressCacheFault"/>, and activation keeps a COMPLETE set of terminal
+    /// outcomes without it: a node from the path resolver drives enrichment; nothing from either
+    /// branch within <see cref="FirstNodeResolutionTimeout"/> throws the precise
+    /// "no MeshNode emitted / no query provider claims its partition" TimeoutException; both
+    /// branches finishing with no node completes the source (the "no usable node" handler in
+    /// <see cref="OnActivateAsync"/>); and an enrichment fault surfaces as the overlay. Collapsing
+    /// the branch to <c>Empty</c> rather than <c>Never</c> is what keeps that last case PROMPT —
+    /// a genuinely missing node is reported immediately instead of waiting out the budget.</para>
+    /// </summary>
+    internal static IObservable<MeshNode> ComposeActivationSource(
+        IObservable<MeshNode> pathResolverStream,
+        IObservable<MeshNode> ownAddressCacheStream,
+        Action<Exception> onOwnAddressCacheFault)
+        => Observable.Merge(
+            pathResolverStream,
+            ownAddressCacheStream.Catch<MeshNode, Exception>(ex =>
+            {
+                onOwnAddressCacheFault(ex);
+                // The branch stops contributing — exactly as if it had never had anything to
+                // say, which is the truth for a request routed back at the activating grain.
+                return Observable.Empty<MeshNode>();
+            }));
+
+    /// <summary>
+    /// The activation chain: bound the wait for the FIRST node, enrich it with a
+    /// HubConfiguration, and take the first enriched result.
+    ///
+    /// <para>The <c>Amb</c> timer bounds ONLY the wait for the first source emission — once the
+    /// source emits, Amb commits to it and the timer is unsubscribed, so a legitimately slow
+    /// enrichment (a cold compile, bounded internally by the slow-path budgets) is never cut
+    /// short. That "never cut short" property is only real because
+    /// <see cref="ComposeActivationSource"/> has already stopped the self-referential cache branch
+    /// from injecting its own deadline into the same chain.</para>
+    ///
+    /// <para><paramref name="scheduler"/> exists so the budget can be driven in virtual time by
+    /// <c>MessageHubGrainActivationSourceTest</c> (same seam as
+    /// <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c>); production passes null and uses
+    /// the default scheduler.</para>
+    /// </summary>
+    internal static IObservable<MeshNode> BuildActivationChain(
+        IObservable<MeshNode> sourceStream,
+        string addressPath,
+        TimeSpan firstNodeResolutionTimeout,
+        Func<MeshNode, IObservable<MeshNode>> enrich,
+        IScheduler? scheduler = null)
+        => Observable.Amb(
+                sourceStream,
+                Observable.Timer(firstNodeResolutionTimeout, scheduler ?? Scheduler.Default)
+                    .SelectMany(_ => Observable.Throw<MeshNode>(new TimeoutException(
+                        $"No MeshNode emitted for '{addressPath}' within {firstNodeResolutionTimeout.TotalSeconds:0}s. " +
+                        "Either the node does not exist or no query provider claims its partition."))))
+            .SelectMany(enrich)
+            .Take(1);
 
     /// <summary>
     /// Builds the hosted hub and feeds it onto <see cref="_hubReadyRaw"/>. Called from

--- a/test/MeshWeaver.Hosting.Orleans.Test/MessageHubGrainActivationSourceTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MessageHubGrainActivationSourceTest.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the activation-source composition of <see cref="MessageHubGrain"/>: the mesh-node-cache
+/// branch reads THIS grain's OWN address, so its upstream <c>SubscribeRequest</c> is routed back
+/// to this grain and parks until the activation it feeds has completed. It may hand over a warm
+/// VALUE; its TERMINAL says nothing about the node and must never fault the activation.
+///
+/// <para>The prod defect (memex.systemorph.com, 2026-08-09/10): <c>Observable.Merge</c> forwarded
+/// that branch's terminal, so the cache hub's 60 s request budget became a hard ceiling on TOTAL
+/// activation and surfaced as <c>"[ACTIVATE] Grain Edu: activation faulted"</c> /
+/// <c>"No response received in hub cache/… for request SubscribeRequest → target Edu"</c>. Every
+/// faulting grain was a <c>nodeType:Store/Plugin</c> node whose NodeType sat at
+/// <c>CompilationStatus = Error</c>, i.e. exactly the case where enrichment legitimately runs long:
+/// <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c> DISARMS its wall clock while a compile is
+/// in flight, and <c>BuildEnrichmentChain</c> falls back to a visible compilation-error overlay so
+/// the hub activates anyway. The self-loop pre-empted both, every time, and Orleans retried
+/// forever.</para>
+///
+/// <para>Virtual time throughout — the 60 s budget is driven by a <see cref="TestScheduler"/>, not
+/// the wall clock, so the repro is deterministic and instant.</para>
+/// </summary>
+public class MessageHubGrainActivationSourceTest
+{
+    private static readonly TimeSpan FirstNodeBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>The verbatim prod failure the cache branch injects at its 60 s request budget.</summary>
+    private static TimeoutException OwnAddressSubscribeTimeout() => new(
+        "No response received in hub cache/tYwK_RNWZUSCQGvEPNvvzg within 00:01:00 for request " +
+        "SubscribeRequest (id=Hxehbnok-kG7064Sy_Ga9g) → target Edu. The request may have been " +
+        "undeliverable or the target hub was not found.");
+
+    private static MeshNode Node(string path, string? nodeType = null) =>
+        new(path) { NodeType = nodeType };
+
+    /// <summary>
+    /// Asserts the activation did not fault, and NAMES the exception when it did — a bare
+    /// <c>Assert.Empty</c> reports only "Collection was not empty", which hides the very signature
+    /// this suite exists to pin.
+    /// </summary>
+    private static void AssertActivationDidNotFault(List<Exception> errors) =>
+        Assert.True(errors.Count == 0,
+            errors.Count == 0
+                ? string.Empty
+                : $"Activation faulted, but no branch of it had anything to fault ON. " +
+                  $"{errors[0].GetType().Name}: {errors[0].Message}");
+
+    /// <summary>
+    /// Runs the grain's real activation chain in virtual time and reports what the subscriber saw.
+    /// Mirrors <c>OnActivateAsync</c>: compose the source, bound the first emission, enrich, Take(1).
+    /// </summary>
+    private static (List<MeshNode> Nodes, List<Exception> Errors, int Completions) RunActivation(
+        TestScheduler scheduler,
+        IObservable<MeshNode> pathResolverStream,
+        IObservable<MeshNode> ownAddressCacheStream,
+        Func<MeshNode, IObservable<MeshNode>> enrich,
+        List<Exception>? loggedCacheFaults = null)
+    {
+        var nodes = new List<MeshNode>();
+        var errors = new List<Exception>();
+        var completions = 0;
+
+        var source = MessageHubGrain.ComposeActivationSource(
+            pathResolverStream,
+            ownAddressCacheStream,
+            ex => loggedCacheFaults?.Add(ex));
+
+        using var _ = MessageHubGrain
+            .BuildActivationChain(source, "Edu", FirstNodeBudget, enrich, scheduler)
+            .Subscribe(nodes.Add, errors.Add, () => completions++);
+
+        scheduler.Start();
+        return (nodes, errors, completions);
+    }
+
+    /// <summary>
+    /// 🚨 THE REPRO. The path resolver has already handed over a perfectly good node, and enrichment
+    /// is legitimately still running (a NodeType compile in flight — the case
+    /// <c>WaitForCompileSettled</c> deliberately does NOT bound). At 60 s the self-referential cache
+    /// read times out. The activation must survive that and complete on the enriched node.
+    ///
+    /// <para>Before the fix (<c>Observable.Merge</c> forwarding the branch's terminal) this test
+    /// fails with the TimeoutException surfacing as the activation's error at 60 s — the exact prod
+    /// signature.</para>
+    /// </summary>
+    [Fact]
+    public void OwnAddressCacheTimeout_DoesNotFaultActivation_WhileEnrichmentIsStillRunning()
+    {
+        var scheduler = new TestScheduler();
+        var resolved = Node("Edu", "Store/Plugin");
+        var enriched = Node("Edu", "Store/Plugin");
+        var loggedFaults = new List<Exception>();
+
+        // Path resolver answers at 2 s and completes. Cache self-loop errors at its 60 s request
+        // budget. Enrichment (compile in flight) settles only at 90 s — past the cache's budget.
+        var (nodes, errors, completions) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Return(resolved)
+                .Delay(TimeSpan.FromSeconds(2), scheduler),
+            ownAddressCacheStream: Observable.Throw<MeshNode>(OwnAddressSubscribeTimeout())
+                .Delay(TimeSpan.FromSeconds(60), scheduler),
+            enrich: _ => Observable.Return(enriched).Delay(TimeSpan.FromSeconds(90), scheduler),
+            loggedCacheFaults: loggedFaults);
+
+        AssertActivationDidNotFault(errors);
+        Assert.Same(enriched, Assert.Single(nodes));
+        Assert.Equal(1, completions);
+
+        // Not swallowed: the operator still gets the exception, in full.
+        Assert.Contains("SubscribeRequest", Assert.Single(loggedFaults).Message);
+    }
+
+    /// <summary>
+    /// The instant-replay variant of the same defect. Once the first activation faulted, the cache's
+    /// transient-streak breaker replays the cached TimeoutException to the NEXT subscriber without
+    /// re-opening an upstream — so every Orleans retry faulted in milliseconds (the 0 s/1 s/2 s/3 s
+    /// burst measured at 03:57Z). A branch that fails before the path resolver has even answered
+    /// must still not decide the activation.
+    /// </summary>
+    [Fact]
+    public void OwnAddressCacheReplaysCachedFault_ActivationStillResolvesFromPathResolver()
+    {
+        var scheduler = new TestScheduler();
+        var resolved = Node("Edu", "Store/Plugin");
+
+        var (nodes, errors, _) = RunActivation(
+            scheduler,
+            // Path resolver is slower than the breaker's instant replay.
+            pathResolverStream: Observable.Return(resolved).Delay(TimeSpan.FromSeconds(5), scheduler),
+            ownAddressCacheStream: Observable.Throw<MeshNode>(OwnAddressSubscribeTimeout()),
+            enrich: Observable.Return);
+
+        AssertActivationDidNotFault(errors);
+        Assert.Same(resolved, Assert.Single(nodes));
+    }
+
+    /// <summary>
+    /// The accelerator still works: a warm cache entry that replays the node before the path
+    /// resolver reaches storage drives the activation, so a reactivation skips the storage read.
+    /// </summary>
+    [Fact]
+    public void WarmOwnAddressCacheValue_DrivesActivation()
+    {
+        var scheduler = new TestScheduler();
+        var warm = Node("Edu", "Store/Plugin");
+        var fromStorage = Node("Edu", "Store/Plugin");
+
+        var (nodes, errors, _) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Return(fromStorage).Delay(TimeSpan.FromSeconds(3), scheduler),
+            ownAddressCacheStream: Observable.Return(warm),
+            enrich: Observable.Return);
+
+        AssertActivationDidNotFault(errors);
+        Assert.Same(warm, Assert.Single(nodes));
+    }
+
+    /// <summary>
+    /// A genuinely missing node must still be reported PROMPTLY. Collapsing the faulted cache branch
+    /// to <c>Empty</c> (not <c>Never</c>) lets the merged source complete as soon as both branches
+    /// are done, so <c>OnActivateAsync</c>'s "source completed with no usable node" handler fires at
+    /// once instead of waiting out the 30 s first-emission budget.
+    /// </summary>
+    [Fact]
+    public void NoNodeAnywhere_CompletesImmediately_RatherThanBurningTheBudget()
+    {
+        var scheduler = new TestScheduler();
+
+        var (nodes, errors, completions) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Empty<MeshNode>(),
+            ownAddressCacheStream: Observable.Throw<MeshNode>(OwnAddressSubscribeTimeout()),
+            enrich: Observable.Return);
+
+        Assert.Empty(nodes);
+        AssertActivationDidNotFault(errors);
+        Assert.Equal(1, completions);
+    }
+
+    /// <summary>
+    /// Guard against over-reach: only the SELF-REFERENTIAL branch is neutralised. The path resolver
+    /// reads storage — its failure is real news about the node and must still fault the activation
+    /// (the caller gets a deterministic NACK and the grain deactivates for retry-on-next-access).
+    /// </summary>
+    [Fact]
+    public void PathResolverFailure_StillFaultsActivation()
+    {
+        var scheduler = new TestScheduler();
+        var storageFailure = new InvalidOperationException("storage adapter unavailable");
+
+        var (nodes, errors, _) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Throw<MeshNode>(storageFailure),
+            ownAddressCacheStream: Observable.Never<MeshNode>(),
+            enrich: Observable.Return);
+
+        Assert.Empty(nodes);
+        Assert.Same(storageFailure, Assert.Single(errors));
+    }
+
+    /// <summary>
+    /// The first-emission budget is intact: when NEITHER branch produces a node the activation still
+    /// faults with the precise, actionable diagnostic — never a silent park.
+    /// </summary>
+    [Fact]
+    public void NeitherBranchEmits_FaultsWithTheFirstNodeResolutionDiagnostic()
+    {
+        var scheduler = new TestScheduler();
+
+        var (nodes, errors, _) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Never<MeshNode>(),
+            ownAddressCacheStream: Observable.Never<MeshNode>(),
+            enrich: Observable.Return);
+
+        Assert.Empty(nodes);
+        var error = Assert.Single(errors);
+        Assert.IsType<TimeoutException>(error);
+        Assert.Contains("No MeshNode emitted for 'Edu'", error.Message);
+    }
+
+    /// <summary>
+    /// And the budget bounds ONLY the first emission — once a node arrives, Amb commits to the
+    /// source and a legitimately slow enrichment (cold compile) runs past the budget unharmed.
+    /// </summary>
+    [Fact]
+    public void SlowEnrichment_IsNotCutShortByTheFirstNodeBudget()
+    {
+        var scheduler = new TestScheduler();
+        var enriched = Node("Edu", "Store/Plugin");
+
+        var (nodes, errors, _) = RunActivation(
+            scheduler,
+            pathResolverStream: Observable.Return(Node("Edu", "Store/Plugin"))
+                .Delay(TimeSpan.FromSeconds(1), scheduler),
+            ownAddressCacheStream: Observable.Never<MeshNode>(),
+            enrich: _ => Observable.Return(enriched).Delay(TimeSpan.FromMinutes(4), scheduler));
+
+        AssertActivationDidNotFault(errors);
+        Assert.Same(enriched, Assert.Single(nodes));
+    }
+}


### PR DESCRIPTION
## The defect

On **memex.systemorph.com** (AKS ns `memex`) Orleans grain activations faulted and retried forever:

```
fail: MeshWeaver.Hosting.Orleans.MessageHubGrain[0]
      [ACTIVATE] Grain Edu: activation faulted for Edu
System.TimeoutException: No response received in hub cache/tYwK_RNWZUSCQGvEPNvvzg within 00:01:00
for request SubscribeRequest (id=...) → target Edu.
```

The error names the activating grain as an unreachable target — because the request was the grain's own.

## Root cause

`MessageHubGrain.OnActivateAsync` merged `streamCache.GetStream(addressPath)` — the grain's **OWN**
address — into the activation source. The cache opens that upstream with
`GetMeshNodeStreamBypassCache(path)`, i.e. a `SubscribeRequest` addressed at `path`, which the
RoutingGrain delivers straight back to **this** grain, where `DeliverMessage` parks it on
`_hubReadyRaw` until `CompleteActivation` runs.

So on a cold entry the branch is a **strict self-loop**: it cannot answer until the very activation
it feeds has finished. Its only possible terminal is "the grain did not answer itself" — no
information about the node. `Observable.Merge` forwarded that terminal anyway, so the cache hub's
60 s `RequestTimeout` became a **hard ceiling on TOTAL activation**.

That ceiling pre-empted both deliberate slow-path designs downstream, 100% of the time:

- `NodeTypeEnrichmentHelpers.WaitForCompileSettled` **disarms** its wall clock while a compile is in
  flight — a cold pod compiling many dynamic types is meant to run past the budget.
- `BuildEnrichmentChain` catches a stuck type into a visible compilation-error **overlay** so the hub
  activates anyway.

Neither could be reached. Orleans retried; the cache's transient-streak breaker then replayed the
cached `TimeoutException` into each fresh activation, so the retries faulted in milliseconds
(measured burst at 03:57Z: +0 s/+1 s/+2 s/+3 s). The `Edu` partition was unreadable to users and to
MCP with the identical exception.

## Why only this portal (same image on all three)

Measured over 30 h of Loki (ns `memex`): ~36 activation faults an hour, and **every faulting grain
was a `nodeType:Store/Plugin` node** — Edu (231), Feedback, Skill, Essentials, Publish,
Collaboration, DataModelling, Agent, Instances. Exactly the `nodeType:Store/Plugin` set.

- **memex.systemorph.com**: `Store/Plugin` is installed as a dynamic in-mesh NodeType sitting at
  `CompilationStatus = Error` — `CS0117: 'AiSettingsNodeType' does not contain a definition for
  'AddSkillSource'` (that method was deleted in #683; the in-mesh plugin source still calls it, and
  no build or test can see it). That is precisely the case where enrichment legitimately runs long.
- **memex.meshweaver.cloud** (control): `Store/Plugin` does not exist at all, so enrichment's 3 s
  existence probe answers immediately and `Take(1)` disposes the self-loop long before 60 s.

**Data-dependent, not version-dependent** — consistent with all three portals running
`3.0.0-rc1.ci.2509`. The Monolith routing path has no equivalent self-loop, which is why no existing
test caught it.

## The fix

The cache branch may still supply a **VALUE** (a warm entry lets a reactivation skip the storage
read) but never a **TERMINAL**. `ComposeActivationSource` collapses a faulted self-referential branch
to `Empty` and logs the exception in full — it is not swallowed.

Activation keeps a complete set of terminal outcomes without it: the path resolver's node drives
enrichment; nothing within `FirstNodeResolutionTimeout` throws the precise "no MeshNode emitted / no
query provider claims its partition" error; both branches finishing with no node completes the
source (`Empty`, not `Never`, is what keeps the missing-node answer **prompt**); enrichment faults
surface as the overlay.

`ComposeActivationSource` / `BuildActivationChain` are extracted as `internal static` so the whole
chain runs in virtual time — same seam as `WaitForCompileSettled`, same precedent as
`LongRunningOperationCapExceeded`.

## Verification

`MessageHubGrainActivationSourceTest` — 7 tests, virtual time, 40 ms. Reverting only the composition
to plain `Observable.Merge` fails 3 of them with the prod signature verbatim:

```
Activation faulted, but no branch of it had anything to fault ON.
TimeoutException: No response received in hub cache/tYwK_RNWZUSCQGvEPNvvzg within 00:01:00
for request SubscribeRequest (id=...) → target Edu.
```

- `dotnet build -c Release -warnaserror` — `MeshWeaver.Hosting.Orleans` + its test project: 0 warnings, 0 errors.
- 20 grain tests green under Release/`-warnaserror`, including the 9 Orleans **cluster** tests that
  guard the semantics touched here — `GrainActivationCompletesFastTest.NonExistentPath_ActivationFailsFast_NotThirtySecondTimeout`,
  `OrleansBrokenNodeTypeAccessTest` (×2), `OrleansIdleReactivationNoWedgeTest` (×2),
  `OrleansUnresolvableNodeNoWedgeTest` (×3), `PartitionRootActivationTest`.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green.

## Follow-up (separate, not in this PR)

The aggravator is a data defect in the **plugins** repo: `Store/Plugin`'s in-mesh source calls
`AiSettingsNodeType.AddSkillSource`, deleted from the framework in #683. It needs porting to
`AiSourcesInstallHook`. This PR makes the platform survive it (the type shows its compilation-error
overlay instead of wedging every plugin partition), but the type still needs to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
