### PR TITLE
Arm the NodeType bake gate — and fix the two things that made arming it useless

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -268,8 +268,21 @@ reverts them):
 | Knob | What it does |
 |---|---|
 | `config.memex_portal.PreWarm__DynamicTypes: "true"` | every new pod sweeps + compiles ALL dynamic NodeTypes at start (resumes from the shared `/data` cache — warm restarts are cheap) |
-| `config.memex_portal.PreWarm__GateReadiness` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **⛔ OFF** — tried 2026-08-02 and reverted the same day: the first gated roll stalled on 7 FALSE regressions that were cross-silo `SubscribeRequest` timeouts, not compile errors (#694 residue, see SELF-UPDATE.md). Do NOT re-enable by widening the probe budget — the sweep is erroring, not slow |
-| `probes.startup: {periodSeconds: 10, failureThreshold: 1080}` | ⚠️ REQUIRED with the gate: a cold bake is ~90 s/type, sequential — the default 5 min budget kills the pod mid-bake forever |
+| `config.memex_portal.PreWarm__GateReadiness: "true"` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **✅ ON.** It was tried 2026-08-02 and reverted the same day on 7 FALSE regressions — all cross-silo `SubscribeRequest` timeouts, not compile errors (#694 residue). The gate no longer reads "no answer" as "it broke": a `TimedOut` outcome is filed as *unevaluated* and can never gate, and that leniency now survives the cascade (a dependent of an unevaluated upstream is `UpstreamUnevaluated`, also non-gating). Only a `CompileError` — or an `UpstreamFailed` cascading from one — on a **previously-healthy** type stalls a roll |
+| `probes.startup: {periodSeconds: 10, failureThreshold: 1080}` | ⚠️ REQUIRED with the gate: a cold bake is ~90 s/type, sequential — the default 5 min budget kills the pod mid-bake forever. `progressDeadlineSeconds` is DERIVED from these two in the chart, so raising them can't leave it behind |
+
+**🚨 Before you trust the gate, verify the namespace actually reads it.** The gate protects a
+portal through exactly two deployment facts, and on 2026-08-10 two of the three portals had drifted
+away from both. A gated config in a namespace missing either is *false confidence* — it reports and
+the outage happens anyway.
+
+| Must be true | Why | Check |
+|---|---|---|
+| a `startupProbe` exists **on `/health`** | that probe is the ONLY reader of the gate; no startupProbe (or one on `/alive` / `/healthz`) ignores it entirely | `kubectl -n <ns> get deploy memex-portal-deployment -o jsonpath='{.spec.template.spec.containers[0].startupProbe}'` |
+| `strategy.maxUnavailable: 0` | surge-first keeps the old pod serving until the new one passes; at `maxUnavailable:1` with `replicas:1` the only serving pod can be deleted BEFORE the replacement is ready | `kubectl -n <ns> get deploy memex-portal-deployment -o jsonpath='{.spec.strategy.rollingUpdate}'` |
+
+Both are rendered correctly by the chart — a `helm upgrade` restores them. A per-env `portal-patch.json`
+or a hand `kubectl patch` can still override them, which is how the drift happened.
 
 ⛔ **The bake Job (`bake.enabled`) stays OFF on AKS until core asserts fingerprint-match.** On its
 first AKS run (memex-cloud, 2026-07-30) `memex-bake:3.0.0-ci.1565` computed a **different framework

--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -32,25 +32,40 @@ NodeTypes at start, so an un-visited type can no longer sit "no definition" unti
 Managed envs run the sweep ON — an env with it off has no deploy-time compile at all on this
 channel.
 
-**⛔ The self-update does NOT currently wait for the compile.** The companion readiness gate
-(`PreWarm__GateReadiness`) is designed to do exactly that — hold the new pod's `/health` red until
-every NodeType is built against ITS image, with the `startupProbe` on `/health` and
-`maxUnavailable: 0` keeping the old pod serving — so a regressed type STALLS the roll instead of
-surfacing as user-facing errors. It is **off**.
+**✅ The self-update waits for the compile.** The companion readiness gate
+(`PreWarm__GateReadiness`) holds the new pod's `/health` red until every NodeType is built against
+ITS image; with the `startupProbe` on `/health` and `maxUnavailable: 0` keeping the old pod serving,
+a regressed type STALLS the roll instead of surfacing as user-facing errors.
 
 It was enabled on 2026-08-02 and reverted the same day. The first gated roll on memex-cloud stalled
 with `7 NodeType(s) regressed on this image`, and those were **false** regressions: the pod log
 contained no `CS####` compile error at all, only the sweep timing out across the roll window —
 `No response received in hub cache/… within 00:01:00 for request SubscribeRequest → target
 Claims / Reinsurance / SocialMedia / ClaimsDeepfield / RiskTransfer`. During a roll the baking pod
-and the serving pod are two silos and the sweep cannot resolve shared sources across that boundary.
-This is core #694 residue: #718 + #719 (2026-07-29) did NOT close it, so the earlier 2026-07-30
-observation stands unexplained by them.
+and the serving pod are two silos and the sweep cannot always resolve shared sources across that
+boundary — core #694 residue, which #718 + #719 (2026-07-29) did NOT close.
 
-Until the sweep's cross-silo source resolution is fixed, database migration is the only part of the
-roll that is gated (the unconditional `db_version` health check), and NodeType compiles fall back to
-the pod-side sweep with lazy compile on failure. ⚠️ Do not re-enable the gate by widening the probe
-budget — the sweep is not slow, it is erroring.
+**What makes it safe now is that the gate stopped treating "no answer" as "it broke".** Core #694 is
+still open; the gate simply no longer depends on it being closed:
+
+- A `TimedOut` outcome is filed under **unevaluated** and can never set `Regressed`. Every one of
+  the 7 false regressions was exactly this shape.
+- That leniency survives the **cascade**. A dependent of an unevaluated upstream is reported
+  `UpstreamUnevaluated` (also non-gating) rather than `UpstreamFailed`. Without this the leniency
+  stopped at depth 1: one timed-out shared source — `Claims`, say — still gated through every
+  previously-healthy type that drew source from it, and the same stall returned one hop downstream.
+- Only a real verdict on a **previously-healthy** type gates: a `CompileError`, or an
+  `UpstreamFailed` cascading from one. A type already broken before the deploy never gates, so one
+  abandoned NodeType cannot freeze the fleet.
+
+Non-blocking is not invisible — unevaluated types are named in the `/health` payload, so a swallowed
+timeout still surfaces instead of hiding a genuine regression.
+
+⚠️ The gate is only as real as the namespace it runs in: it needs a `startupProbe` **on `/health`**
+(nothing else reads it) and `strategy.maxUnavailable: 0` (otherwise the serving pod can be deleted
+before the replacement is ready). Verify both before trusting it — see DEPLOY-RUNBOOK.md §7. And if
+a roll DOES stall, investigate it: the old image keeps serving, so there is no outage, but
+self-update stops advancing until someone looks.
 
 ## Update policy (Admin → Platform updates)
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -128,30 +128,53 @@ config:
     # /health red until they are built against THIS image — with the deployment's
     # maxSurge 1 / maxUnavailable 0, a regressed type stalls the ROLLOUT (old
     # image keeps serving) instead of surfacing as user-facing errors.
-    # ⚠️ Enabling the gate REQUIRES the raised probes.startup budget below —
-    # paired settings, never change one without the other.
-    # ⛔ Gate OFF — core #694 (cross-silo reply routing) is NOT fully fixed.
-    # Enabled 2026-08-02 on the reasoning that #718 + #719 (both 2026-07-29)
-    # closed #694; reverted the SAME DAY after the first gated roll on
-    # memex-cloud stalled with "7 NodeType(s) regressed on this image".
-    # Those were FALSE regressions: the pod log contains no CS#### compile
-    # error at all, only cross-silo subscribe timeouts from the sweep —
+    #
+    # ✅ Gate ON. It was enabled 2026-08-02 and reverted the same day: the first
+    # gated roll on memex-cloud stalled with "7 NodeType(s) regressed on this
+    # image", and every one was FALSE — no CS#### diagnostic anywhere in the pod
+    # log, only cross-silo subscribe timeouts from the sweep,
     #   No response received in hub cache/… within 00:01:00 for request
     #   SubscribeRequest → target Claims / Reinsurance / SocialMedia /
     #   ClaimsDeepfield / RiskTransfer
-    # i.e. during a roll the baking pod and the serving pod are two silos and
-    # the sweep cannot resolve shared sources across that boundary, exactly as
-    # this comment warned before. The types compile fine; the sweep cannot
-    # reach them. So the 2026-07-30 observation was NOT explained by #718/#719.
-    # The gate's failure mode is a STALLED rollout (old image keeps serving —
-    # no outage, but self-update silently stops advancing), which is why this
-    # must stay off until the sweep's cross-silo source resolution is fixed.
-    # ⚠️ Do NOT re-enable by widening the probe budget — the sweep is not slow,
-    # it is erroring. Fix the cross-silo SubscribeRequest first.
-    # The sweep itself stays ON: deploys still compile every type at pod start;
-    # failures fall back to lazy compile instead of holding readiness.
+    # During a roll the baking pod and the serving pod are two silos, and the
+    # sweep cannot always resolve shared sources across that boundary (core #694
+    # residue). The types compiled fine; the sweep could not reach them.
+    #
+    # What changed — the gate no longer treats "no answer" as "it broke":
+    #   • A TIMEOUT IS NOT A VERDICT. NodeTypeBakeGateState.MarkOutcome files a
+    #     TimedOut outcome under "unevaluated" and it can never set Regressed.
+    #     Every one of the 7 false regressions was this shape.
+    #   • That leniency now survives the CASCADE. A dependent of an unevaluated
+    #     upstream is reported UpstreamUnevaluated (also non-gating) instead of
+    #     UpstreamFailed — without that, one timed-out shared source still gated
+    #     through its dependents and the same stall returned one hop downstream.
+    #   • Only a real verdict on a previously-healthy type gates: a CompileError
+    #     (Roslyn rejected it on THIS image) or an UpstreamFailed cascading from
+    #     one. A type already broken before the deploy never gates, so one
+    #     abandoned NodeType cannot freeze every future rollout.
+    # Non-blocking is not invisible: unevaluated types are named in the /health
+    # payload, so a swallowed timeout still shows up rather than hiding a real
+    # regression. (Pinned by NodeTypeBakeGateStateTest + DynamicTypePreWarmerTest.)
+    #
+    # ⚠️ THREE prerequisites, all of which must be true in the LIVE namespace —
+    # verify, do not assume, because two of the three portals had drifted:
+    #   1. probes.startup raised to cover a full COLD bake (below: 10 × 1080 = 3h).
+    #      Without it Kubernetes kills the pod mid-bake, every time, forever.
+    #   2. The startupProbe must actually EXIST and point at /health — that probe
+    #      is the only thing that reads this gate. A namespace with no startupProbe
+    #      (or one probing /alive or /healthz) ignores the gate completely.
+    #   3. strategy.maxUnavailable MUST be 0. The gate protects a portal only by
+    #      making the new pod refuse readiness; at maxUnavailable:1 with replicas:1
+    #      the serving pod can be deleted first, so the gate reports and the outage
+    #      happens anyway — false confidence.
+    # The chart renders 1 and 3 correctly; a per-env patch or a hand `kubectl` can
+    # still override them, so CHECK before trusting the gate (DEPLOY-RUNBOOK §7).
+    #
+    # Failure mode if the gate DOES fire on a real regression: a stalled rollout
+    # with the old image still serving — no outage, but self-update stops
+    # advancing, so a stalled roll must be investigated, not waited out.
     PreWarm__DynamicTypes: "true"
-    PreWarm__GateReadiness: "false"
+    PreWarm__GateReadiness: "true"
     # ---- Platform self-update cadence --------------------------------------
     # The poller's built-in default is 6h, which is why a freshly published image
     # could sit unpicked for hours and look like "self-update is broken" (memex,

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -41,10 +41,22 @@ data:
   #   image stalls the rollout with the previous image still serving, instead of erroring
   #   in front of users. Only a type that WAS working can gate — a pre-existing broken type
   #   is logged and skipped, so one abandoned NodeType can't freeze every future deploy.
+  #   And only a real VERDICT gates: a compile error, or a dependent blocked by one. A type
+  #   the sweep could not evaluate (a timeout — or a dependent of something that timed out)
+  #   is reported as unevaluated and named in the /health payload, never counted as a
+  #   regression. That distinction is what makes the gate safe to arm while cross-silo
+  #   source resolution (core #694) is still imperfect.
   #
-  # ⚠️ Enabling GateReadiness REQUIRES a startupProbe budget covering a full COLD bake
-  #    (~90 s per NodeType, sequential). See probes.startup in values — turning the gate on
-  #    without raising it means Kubernetes kills the pod mid-bake, every time, forever.
+  # ⚠️ GateReadiness has THREE prerequisites; missing any one makes it silently useless:
+  #    1. PreWarm__DynamicTypes must ALSO be true — the gate reads state only the sweep
+  #       writes, so gate-without-sweep is permanently green. The portal logs that
+  #       combination at Critical on startup.
+  #    2. A startupProbe ON /health with a budget covering a full COLD bake (~90 s per
+  #       NodeType, sequential). See probes.startup in values — turning the gate on without
+  #       raising it means Kubernetes kills the pod mid-bake, every time, forever. Nothing
+  #       else reads the gate: a namespace probing /alive or /healthz ignores it entirely.
+  #    3. strategy.maxUnavailable: 0 — the gate works by making the NEW pod refuse
+  #       readiness, which protects nothing if the serving pod was already deleted.
   PreWarm__DynamicTypes: "{{ .Values.config.memex_portal.PreWarm__DynamicTypes }}"
   PreWarm__GateReadiness: "{{ .Values.config.memex_portal.PreWarm__GateReadiness }}"
   Deployment__Orleans__Clustering: "{{ .Values.config.memex_portal.Deployment__Orleans__Clustering }}"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -257,12 +257,33 @@ spec:
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1
   revisionHistoryLimit: 3
+  # ⏱️ How long a rollout may be "not progressing" before k8s marks it ProgressDeadlineExceeded.
+  #
+  # 🚨 The k8s DEFAULT IS 600s, and against this deployment that default is simply WRONG: the
+  # startupProbe budget above is periodSeconds × failureThreshold, which managed envs set to
+  # 10 × 1080 = 3 HOURS to cover a cold NodeType bake. A legitimately-baking pod is therefore
+  # declared failed after 10 minutes — and `kubectl rollout status` reports a perfectly healthy
+  # long bake as a failed rollout, which is exactly the signal an operator would act on by
+  # rolling back the good image.
+  #
+  # DERIVED, never a second free-standing number: it is the full startup budget plus headroom for
+  # image pull + the wait-for-postgres initContainer. Tying it to the same two values means raising
+  # probes.startup can never silently leave the deadline behind it.
+  progressDeadlineSeconds: {{ add (mul .Values.probes.startup.periodSeconds .Values.probes.startup.failureThreshold) 600 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
-      # 0 → the OLD pod is kept serving until the NEW pod passes its readiness probe (/health). With
-      # a single replica this is what turns a rollout from "brief outage" into zero-downtime: traffic
+      # 🚨 0 is load-bearing — do NOT raise it, and do not let a per-env patch raise it.
+      #
+      # 0 → SURGE-FIRST: the OLD pod keeps serving until the NEW pod passes its probes. With a
+      # single replica this is what turns a rollout from "brief outage" into zero-downtime: traffic
       # only moves once the replacement actually serves. (If the new pod can't come up — e.g. the PG
       # connection-exhaustion wedge — the rollout simply stalls with the old pod still serving, no 502.)
+      #
+      # It is also the ENTIRE mechanism behind the NodeType bake gate (PreWarm__GateReadiness): the
+      # gate protects a portal only by making the new pod refuse readiness, and "refuse readiness"
+      # is worth nothing if k8s already deleted the pod that was serving. At maxUnavailable:1 with
+      # replicas:1 the only serving pod can go away before the replacement is ready, so a gated
+      # rollout there buys FALSE CONFIDENCE — the gate reports, and the outage happens anyway.
       maxUnavailable: 0
     type: "RollingUpdate"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -293,10 +293,31 @@ config:
     ASPNETCORE_HTTP_PORTS: "8080"
     Deployment__Backend: "Filesystem"
     Deployment__DataRoot: "/data"
-    # Both OFF by default. The bake is a deliberate operational choice, not something a
-    # self-host should inherit: it front-loads every NodeType compile into startup, and the
-    # gate can hold a pod out of rotation. Enable them together, and raise probes.startup
-    # in the same change. See config.yaml for what each one does.
+    # 🔗 ONE setting in two keys — they are not independent, and the gate is worthless
+    # without the sweep. GateReadiness gates on state that ONLY the sweep writes, and the
+    # health check reports Healthy while the sweep has not started (by design: a config
+    # mistake must never black-hole a pod). So GateReadiness=true with DynamicTypes=false
+    # is a gate that is registered, permanently green, and protects NOTHING — silently.
+    # The portal now logs that combination at Critical on startup rather than letting a
+    # deployment believe it is gated ("NodeType bake gate requested but the sweep is off").
+    #
+    # Both stay OFF by default — a considered decision, not an oversight:
+    #   • The sweep enumerates EVERY NodeType across EVERY partition and activates and
+    #     compiles each dynamic one. On a large mesh that is a boot-time subscribe/compile
+    #     storm that starves the hubs; multi-silo it starved the Orleans membership probes
+    #     into the "I have been told I am dead" restart loop (memex, 2026-07-22). Turning
+    #     that on for every chart consumer — including single-node k3s, e2e and dev
+    #     instances — would ship a known incident by default.
+    #   • Correctness never needs it: types compile lazily on first access. The sweep buys
+    #     deploy-time latency and a gateable signal, which is an operational trade a MANAGED
+    #     env makes knowingly (see deploy/aks/values.aks.yaml, where both are "true").
+    #   • The gate additionally needs a startupProbe on /health with a budget covering a full
+    #     cold bake (~90 s per type, sequential — HOURS on a real mesh) and
+    #     strategy.maxUnavailable:0. Defaulting it on with the chart's 5-minute startup
+    #     budget would kill every pod mid-bake, forever.
+    # An instance that wants the protection turns BOTH on and raises probes.startup in the
+    # same change; progressDeadlineSeconds follows probes.startup automatically. See
+    # config.yaml for what each key does.
     PreWarm__DynamicTypes: "false"
     PreWarm__GateReadiness: "false"
     Deployment__Orleans__Clustering: "Localhost"

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -303,12 +303,32 @@ builder.Services.AddNodeTypeBakeGate();
 // intentional deployment choice, not something a self-host inherits by accident. It also
 // REQUIRES a startupProbe budget large enough for a full cold bake (see values.aks.yaml) —
 // without that, Kubernetes kills the pod mid-bake and it never converges.
-if (bool.TryParse(builder.Configuration[NodeTypeBakeGateExtensions.EnabledConfigKey], out var gateBake)
-    && gateBake)
+var gateBake = bool.TryParse(builder.Configuration[NodeTypeBakeGateExtensions.EnabledConfigKey], out var g) && g;
+var bakeSweepEnabled =
+    bool.TryParse(builder.Configuration[DynamicTypePreWarmerHostedService.EnabledConfigKey], out var s) && s;
+
+if (gateBake)
     builder.Services.AddHealthChecks()
         .AddCheck<Memex.Portal.Distributed.NodeTypeBakeHealthCheck>("nodetype_bake");
 
 var app = builder.Build();
+
+// 🚨 The two PreWarm keys are ONE setting. The gate reads bake state that only the SWEEP writes,
+// and the health check reports Healthy while the bake is NotStarted — deliberately, so a config
+// mistake can never black-hole a pod forever. The consequence is that GateReadiness=true with
+// DynamicTypes=false yields a gate that is registered, permanently green, and protects nothing.
+// That is precisely the failure this gate exists to prevent, so it must not be the quiet outcome:
+// say it at Critical, where a deployment that believes it is protected will actually see it.
+if (gateBake && !bakeSweepEnabled)
+    app.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("MeshWeaver.Hosting.NodeTypeBakeGate")
+        .LogCritical(
+            "NodeType bake gate is ENABLED ({GateKey}=true) but the pre-warm sweep is OFF "
+            + "({SweepKey}!=true). The gate has nothing to measure, so it will report healthy on "
+            + "every rollout and protect NOTHING. Enable the sweep, or turn the gate off so the "
+            + "configuration stops claiming a protection that is not there.",
+            NodeTypeBakeGateExtensions.EnabledConfigKey,
+            DynamicTypePreWarmerHostedService.EnabledConfigKey);
 
 app.MapDefaultEndpoints();
 app.StartMemexApplication<Memex.Portal.Shared.App>();

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -348,6 +348,28 @@ The shape in the log is a `CS1061` / `CS0103` against framework surface:
 CS1061: 'MessageHubConfiguration' does not contain a definition for 'AddTracking'
 ```
 
+**A timeout is not a verdict, and it does not cascade like one.** The chain above starts with a
+`CompileError` — Roslyn's answer that the type is broken. When the sweep instead gets *no* answer
+(`TimedOut`: the per-type budget elapsed, typically a cross-silo `SubscribeRequest` during a roll),
+that is not evidence of breakage and must never stall a rollout. So the two cascade differently:
+
+| Upstream outcome | Dependent reported as | Refuses readiness? |
+|---|---|---|
+| `CompileError` / `Faulted` | `UpstreamFailed` | **yes** |
+| `TimedOut` | `UpstreamUnevaluated` | no |
+| `UpstreamUnevaluated` | `UpstreamUnevaluated` | no |
+
+Both no-answer statuses are filed by `NodeTypeBakeGateState` under *unevaluated* — they can never
+set `Regressed`, but they are **named in the `/health` payload**, because non-blocking must not mean
+invisible. Only a failure on a type that was **healthy before this image** gates at all: a type
+already sitting at `Error` before the deploy is pre-existing damage, and gating on it would let one
+abandoned NodeType freeze every future rollout.
+
+That distinction is what makes the readiness gate safe to arm. Counting timeouts as regressions
+stalled memex-cloud on 2026-08-02 with "7 NodeType(s) regressed" and not one `CS####` diagnostic;
+counting only *direct* timeouts leniently still let one timed-out shared source gate through its
+dependents, which reproduced the same stall one hop downstream.
+
 ### The obligation on framework changes
 
 Removing or renaming any public framework surface — extension methods on

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-broken-nodetype-cannot-reach-you.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-broken-nodetype-cannot-reach-you.md
@@ -1,0 +1,24 @@
+---
+Name: A broken NodeType can no longer reach you
+Category: Fix
+Description: A deploy that would break a working NodeType now stops itself, leaving the previous version serving, instead of shipping the breakage to your pages.
+Icon: ShieldCheckmark
+Order: -20260810
+---
+
+# A broken NodeType can no longer reach you
+
+Every platform update recompiles the types your pages are built on. Until now, if
+one of them stopped compiling against the new version, the update shipped anyway
+— and you found out when a page hung or came up empty.
+
+The update now checks its own work before taking over. A new version compiles
+every type first, and it only starts serving once they are built. If a type that
+was working stops working, the update stops there: the previous version keeps
+serving your pages, unchanged, and nothing reaches you.
+
+The check is deliberately careful about what counts as broken. If it simply
+cannot get an answer about a type in time, that is not treated as a failure —
+neither for that type nor for the ones built on top of it — so a slow check never
+stalls an update on its own. Only a type that genuinely no longer compiles, and
+that was working before, will hold an update back.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -35,6 +35,24 @@ public enum PreWarmStatus
     /// doing that for a fan-out of dependents is how one broken type used to stall a whole sweep.
     /// </summary>
     UpstreamFailed,
+    /// <summary>
+    /// NOT ATTEMPTED, and NOT a verdict: a NodeType this one draws sources from was itself never
+    /// evaluated (it timed out, or ITS upstream did). The sweep therefore knows nothing about this
+    /// type either — "I don't know" propagates as "I don't know".
+    ///
+    /// <para>🚨 This member exists because the alternative silently freezes the fleet. A cross-silo
+    /// <c>SubscribeRequest</c> timeout on a shared upstream (core #694) is not evidence that anything
+    /// is broken, and <see cref="NodeTypeBakeGateState"/> correctly refuses to gate on a direct
+    /// <see cref="TimedOut"/>. But before this status existed, that same unevaluated upstream turned
+    /// every previously-healthy DEPENDENT into <see cref="UpstreamFailed"/> — which DOES gate. So the
+    /// leniency stopped at depth 1 and the false regression simply reappeared one hop downstream,
+    /// re-creating the 2026-08-02 memex-cloud stall through the back door.</para>
+    ///
+    /// <para>Deliberately distinct from <see cref="UpstreamFailed"/>: a dependent of a genuinely
+    /// broken (<see cref="CompileError"/>) upstream still gates, because that upstream IS a verdict.
+    /// Only "no answer" propagates as "no answer".</para>
+    /// </summary>
+    UpstreamUnevaluated,
     /// <summary>The warm subscription faulted (best-effort — the lazy path still works).</summary>
     Faulted
 }
@@ -350,16 +368,33 @@ public static class DynamicTypePreWarmer
                 cyclic.Count, string.Join(", ", cyclic));
 
         // FAIL GRACEFULLY DOWNSTREAM. A type whose upstream did not reach a usable build
-        // cannot build either, so it is not attempted: it is reported as UpstreamFailed
-        // naming the blocker, and joins the failed set so ITS dependents are skipped too
-        // — the propagation is transitive purely because we walk in topological order.
-        // Without this, one broken type costs every dependent a full per-type budget of
-        // waiting for something that cannot succeed.
+        // cannot build either, so it is not attempted: it is reported naming the blocker,
+        // and joins a skip set so ITS dependents are skipped too — the propagation is
+        // transitive purely because we walk in topological order. Without this, one broken
+        // type costs every dependent a full per-type budget of waiting for something that
+        // cannot succeed.
         //
-        // The set is mutated inside a Concat, which subscribes strictly one at a time,
+        // 🚨 TWO skip sets, not one, because "it broke" and "I never found out" must NOT
+        // propagate as the same thing. A readiness gate may stall a rollout on the first
+        // and must never stall on the second:
+        //
+        //   verdictFailed — the sweep got an answer and the answer was bad (CompileError,
+        //     Faulted, or a dependent of one of those). Dependents get UpstreamFailed,
+        //     which GATES.
+        //   unevaluated   — the sweep got no answer at all (TimedOut, or a dependent of
+        //     something unevaluated). Dependents get UpstreamUnevaluated, which does NOT
+        //     gate. A cross-silo SubscribeRequest timeout on a shared upstream (core #694)
+        //     is not evidence that anything is broken, so it must not become one downstream.
+        //
+        // Collapsing these back into one set is exactly how the 2026-08-02 memex-cloud
+        // stall would return: the direct-timeout leniency in NodeTypeBakeGateState would
+        // still hold, and the false regression would simply reappear one hop downstream.
+        //
+        // The sets are mutated inside a Concat, which subscribes strictly one at a time,
         // so there is no concurrent access — and each step is wrapped in Defer so it
-        // reads the set as it stands WHEN ITS TURN COMES, not when the chain was built.
-        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // reads them as they stand WHEN ITS TURN COMES, not when the chain was built.
+        var verdictFailed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unevaluated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
         // has completed, so "dependencies first" is structural rather than a convention.
@@ -379,20 +414,33 @@ public static class DynamicTypePreWarmer
                         return Observable.Return(new PreWarmOutcome(
                             p, PreWarmStatus.AlreadyBaked, "assembly store already holds this build"));
 
-                    var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, failed);
+                    // A real verdict upstream wins over a merely-unevaluated one: if ANY dependency
+                    // actually failed to compile, this type is genuinely blocked and must gate,
+                    // regardless of some other dependency having also timed out.
+                    var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, verdictFailed);
+                    var unevaluatedBlocker = blocker is null
+                        ? NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, unevaluated)
+                        : null;
                     var missingBytes = bytesMissing.Contains(p);
-                    if (blocker is not null)
+                    if (blocker is not null || unevaluatedBlocker is not null)
                     {
-                        failed.Add(p);
+                        var isVerdict = blocker is not null;
+                        var named = blocker ?? unevaluatedBlocker!;
+                        var outcome = isVerdict
+                            ? PreWarmStatus.UpstreamFailed
+                            : PreWarmStatus.UpstreamUnevaluated;
+                        (isVerdict ? verdictFailed : unevaluated).Add(p);
+                        // {Outcome} carries WHICH cascade this is as a queryable token — the two
+                        // differ in whether they may stall a rollout, so a log that blurred them
+                        // would hide the thing an operator most needs to know.
                         logger?.LogWarning(
                             "DynamicTypePreWarmer: skipping {TypePath} — its dependency {Blocker} "
-                            + "did not reach a usable build, so it cannot compile either "
+                            + "did not yield a usable build ({Outcome}), so it cannot compile either "
                             + "(lazy compile still applies if the upstream recovers)",
-                            p, blocker);
+                            p, named, outcome);
                         // No pacing for a skip: it activates nothing, so there is no
                         // burst to spread out and no reason to slow the sweep down.
-                        return Observable.Return(new PreWarmOutcome(
-                            p, PreWarmStatus.UpstreamFailed, $"blocked by {blocker}"));
+                        return Observable.Return(new PreWarmOutcome(p, outcome, $"blocked by {named}"));
                     }
 
                     // 🚨 A type whose BYTES are gone cannot be warmed by activation alone.
@@ -409,8 +457,13 @@ public static class DynamicTypePreWarmer
                         .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes)
                         .Do(o =>
                         {
-                            if (!o.ReachedUsableBuild)
-                                failed.Add(p);
+                            // A timeout is not a verdict — route it to `unevaluated` so its
+                            // dependents inherit "no answer", not "it broke". Everything else that
+                            // missed a usable build (CompileError, Faulted) is a verdict.
+                            if (o.Status is PreWarmStatus.TimedOut)
+                                unevaluated.Add(p);
+                            else if (!o.ReachedUsableBuild)
+                                verdictFailed.Add(p);
                         });
                 }))
                 .Concat()

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -95,10 +95,14 @@ public sealed class DynamicTypePreWarmerHostedService(
                         case PreWarmStatus.AlreadyBaked: Interlocked.Increment(ref alreadyBaked); break;
                         case PreWarmStatus.CompileError: Interlocked.Increment(ref errored); break;
                         case PreWarmStatus.TimedOut: Interlocked.Increment(ref timedOut); break;
-                        // A type skipped because its upstream failed is not a FAULT — it is a
-                        // deliberate, reported outcome. Counting it as one made the summary read
-                        // like the warmer had crashed N times when one dependency was broken.
-                        case PreWarmStatus.UpstreamFailed: Interlocked.Increment(ref skipped); break;
+                        // A type skipped because its upstream failed — or because its upstream was
+                        // never evaluated — is not a FAULT; it is a deliberate, reported outcome.
+                        // Counting it as one made the summary read like the warmer had crashed N
+                        // times when one dependency was broken. (Which of the two it was is not
+                        // lost: the gate files UpstreamUnevaluated under "not evaluated" and names
+                        // it in the health payload, while UpstreamFailed gates.)
+                        case PreWarmStatus.UpstreamFailed:
+                        case PreWarmStatus.UpstreamUnevaluated: Interlocked.Increment(ref skipped); break;
                         default: Interlocked.Increment(ref faulted); break;
                     }
                 },

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -86,10 +86,17 @@ public sealed class NodeTypeBakeGateState
         // outage), but self-update silently stopped advancing, which for an auto-updating fleet is
         // the worse failure.
         //
-        // Deliberately narrow: only TimedOut is reclassified. A CompileError is Roslyn's verdict
-        // that the type is broken on this image, and an UpstreamFailed still gates — see
+        // UpstreamUnevaluated is the SAME condition one hop downstream: the sweep never got an
+        // answer about this type's upstream, so it has no answer about this type either. Without
+        // it the leniency stopped at depth 1 — one timed-out shared source turned every
+        // previously-healthy dependent into a gating UpstreamFailed and the 2026-08-02 stall came
+        // straight back. "I don't know" has to propagate as "I don't know".
+        //
+        // Deliberately narrow: only the two no-answer statuses are reclassified. A CompileError is
+        // Roslyn's verdict that the type is broken on this image, and an UpstreamFailed — a
+        // dependent of a type that genuinely failed to compile — still gates; see
         // UpstreamFailedOnAPreviouslyHealthyType_AlsoGates for why that one is intentional.
-        if (outcome.Status is PreWarmStatus.TimedOut)
+        if (outcome.Status is PreWarmStatus.TimedOut or PreWarmStatus.UpstreamUnevaluated)
         {
             unevaluated[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
             return;

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -202,4 +202,88 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
                 "a broken type contains its blast radius to its own dependents; unrelated types "
                 + "must still end up with a usable build");
     }
+
+    /// <summary>
+    /// 🚨 "I don't know" must propagate as "I don't know" — the wiring behind the readiness gate's
+    /// timeout leniency.
+    ///
+    /// <para><see cref="NodeTypeBakeGateState"/> refuses to gate a rollout on a type that merely
+    /// TIMED OUT, because a cross-silo <c>SubscribeRequest</c> timeout (core #694) says nothing
+    /// about whether the type builds. That leniency was worth nothing while it stopped at depth 1:
+    /// the unevaluated upstream still turned every previously-healthy DEPENDENT into
+    /// <see cref="PreWarmStatus.UpstreamFailed"/>, which DOES gate — so the false regression that
+    /// stalled memex-cloud on 2026-08-02 simply reappeared one hop downstream.</para>
+    ///
+    /// <para>A budget too small for any real compile makes the upstream time out deterministically,
+    /// with no dependence on machine speed in the direction that matters: the assertion is that the
+    /// dependent is reported <see cref="PreWarmStatus.UpstreamUnevaluated"/> — NOT
+    /// <see cref="PreWarmStatus.UpstreamFailed"/> — and so cannot stall a roll.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task WarmDynamicTypes_DependentOfAnUnevaluatedUpstream_IsUnevaluatedNotFailed()
+    {
+        const string upstream = $"{Partition}Slow/SlowUpstream";
+        const string dependent = $"{Partition}Slow/SlowDependent";
+
+        // Perfectly VALID — the point is that the sweep never gets an answer about it, not that
+        // it is broken. With the sub-millisecond budget below it can only time out.
+        await NodeFactory.CreateNode(new MeshNode("SlowUpstream", $"{Partition}Slow")
+        {
+            Name = "Slow Upstream",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Compiles fine — but not within the budget this sweep allows.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("SlowDependent", $"{Partition}Slow")
+        {
+            Name = "Slow Dependent",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Draws source out of the slow upstream's subtree.",
+                Configuration = "config => config",
+                Sources = ["namespace:Source scope:subtree", $"shared=@{upstream}/Source"]
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("PreWarmUnevaluated");
+
+        var outcomes = await DynamicTypePreWarmer
+            .WarmDynamicTypes(Mesh, logger, perTypeBudget: TimeSpan.FromMilliseconds(1))
+            .Where(o => o.TypePath == upstream || o.TypePath == dependent)
+            .Take(2)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(110))
+            .ToTask();
+
+        foreach (var o in outcomes)
+            Output.WriteLine($"{o.TypePath} → {o.Status} {o.Detail}");
+
+        outcomes.Single(o => o.TypePath == upstream).Status
+            .Should().Be(PreWarmStatus.TimedOut,
+                "the budget is far too small for a real compile — this pins the premise of the test");
+
+        var blocked = outcomes.Single(o => o.TypePath == dependent);
+        blocked.Status.Should().Be(PreWarmStatus.UpstreamUnevaluated,
+            "a dependent of a type the sweep never evaluated is itself unevaluated — reporting it "
+            + "as UpstreamFailed would gate the rollout on a timeout, which is exactly the false "
+            + "regression the direct-timeout leniency exists to prevent");
+        blocked.Detail.Should().Contain(upstream,
+            "the outcome must NAME the blocker — 'something upstream' is not actionable");
+
+        // The gate is the consumer that matters: an unevaluated cascade must not hold readiness.
+        var gate = new NodeTypeBakeGateState();
+        gate.MarkRunning("go");
+        foreach (var o in outcomes)
+            gate.MarkOutcome(o);
+        gate.MarkComplete("done");
+
+        gate.Phase.Should().Be(BakePhase.Complete,
+            "a sweep that only failed to get answers has proved nothing bad — it must not stall the roll");
+        gate.Regressions.Should().BeEmpty();
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -165,6 +165,32 @@ public class NodeTypeBakeGateStateTest
     }
 
     /// <summary>
+    /// 🚨 The depth-1 hole. Refusing to gate on a DIRECT timeout is worth nothing if the same
+    /// unevaluated upstream gates through its dependents instead: a timed-out shared source turned
+    /// every previously-healthy dependent into <see cref="PreWarmStatus.UpstreamFailed"/>, which
+    /// gates — so the 2026-08-02 memex-cloud stall came straight back one hop downstream.
+    ///
+    /// <para>The warmer now distinguishes the two cascades, and a dependent of something that was
+    /// never evaluated is itself never evaluated. "I don't know" propagates as "I don't know".</para>
+    /// </summary>
+    [Fact]
+    public void UpstreamUnevaluatedOnAPreviouslyHealthyType_DoesNotGate()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Dependent", PreWarmStatus.UpstreamUnevaluated, "blocked by Slow/Up")
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+        state.Unevaluated.Keys.Should().Contain("Dependent");
+        state.Detail.Should().Contain("Dependent").And.Contain("not evaluated");
+    }
+
+    /// <summary>
     /// The leniency is scoped to timeouts ONLY. Roslyn rejecting the type is a verdict, and it must
     /// still stall the rollout — otherwise the gate stops being a gate.
     /// </summary>


### PR DESCRIPTION
## The gate existed, computed the right signal, and was never armed

`NodeTypeBakeHealthCheck` is registered on `/health` only when `PreWarm:GateReadiness` parses true.
It was `false` on **all three** portals while `PreWarm__DynamicTypes` was `true` — so every pod ran
the sweep, recorded regressions into `NodeTypeBakeGateState`, and nothing ever read them.

Arming it turned out to need more than flipping the flag. Verifying the preconditions against the
live cluster found **two further defects** — one in the gate's own logic, one in the deployments —
either of which would have made the flip useless or actively harmful.

---

### 1. The false-regression fix stopped one hop short (the reason the first attempt stalled)

The gate was turned on 2026-08-02 and reverted the same day: the first gated roll stalled on
`7 NodeType(s) regressed on this image`, every one a cross-silo `SubscribeRequest` timeout with no
`CS####` diagnostic anywhere. `974016bf4` addressed that by routing a **direct** `TimedOut` outcome
to *unevaluated* so it can never set `Regressed`.

That fix is real but incomplete. In `DynamicTypePreWarmer`, a type that times out still joined the
single `failed` set, and every dependent of it was then reported `UpstreamFailed` — which **does**
gate. So one timed-out shared source (`Claims`, `Reinsurance`, …) still stalled the rollout through
its dependents, and turning the gate on today would have reproduced the 2026-08-02 stall almost
exactly.

Fixed at the root: the warmer now keeps **two** skip sets and propagates them differently.

| Upstream outcome | Dependent reported as | Gates? |
|---|---|---|
| `CompileError` / `Faulted` — the sweep got an answer, and it was bad | `UpstreamFailed` | **yes** |
| `TimedOut` — the sweep got no answer at all | `UpstreamUnevaluated` (new) | no |

`NodeTypeBakeGateState.MarkOutcome` files `UpstreamUnevaluated` alongside `TimedOut` under
*unevaluated*, and both are still **named in the `/health` payload** — non-blocking must not mean
invisible. "I don't know" now propagates as "I don't know", at any depth. Core #694 is still open;
the gate simply no longer depends on it being closed.

Pinned by `NodeTypeBakeGateStateTest.UpstreamUnevaluatedOnAPreviouslyHealthyType_DoesNotGate` and
`DynamicTypePreWarmerTest.WarmDynamicTypes_DependentOfAnUnevaluatedUpstream_IsUnevaluatedNotFailed`
(which drives the real warmer with a budget too small to compile, so the upstream can only time out).
The existing `CompileError → UpstreamFailed → gates` cascade is unchanged and still pinned.

### 2. `progressDeadlineSeconds` was unset — k8s default 600s against a 3h startup budget

`probes.startup` on AKS is `10 × 1080` = **3 hours**, deliberately, to cover a cold bake. With
`progressDeadlineSeconds` unset, Kubernetes applied its 600s default, so a legitimately-baking pod
is marked `ProgressDeadlineExceeded` after 10 minutes — and `kubectl rollout status --timeout=300s`
(the runbook's own command) reports a healthy long bake as a **failed rollout**, which is exactly
the signal an operator would act on by rolling back a good image.

Now **derived** from the probe budget rather than added as a second free-standing number:

```
progressDeadlineSeconds: {{ add (mul .Values.probes.startup.periodSeconds .Values.probes.startup.failureThreshold) 600 }}
```

Renders `900` on chart defaults, `11400` (3h10m) with `values.aks.yaml`. Raising `probes.startup`
can never silently leave the deadline behind it again.

### 3. `PreWarm__DynamicTypes` chart default stays `false` — deliberately, and no longer silently

A gate with no sweep is worse than no gate: `NodeTypeBakeGateState` never leaves `NotStarted`, the
health check reports **Healthy** on `NotStarted` by design (a config mistake must never black-hole a
pod), so `GateReadiness=true` + `DynamicTypes=false` is a gate that is registered, permanently green,
and protects nothing — silently.

I did **not** flip the chart default to `true`. The sweep enumerates every NodeType across every
partition and compiles each dynamic one; on a large mesh that is a boot-time subscribe/compile storm
that starved the Orleans membership probes into the "I have been told I am dead" restart loop
(memex, 2026-07-22). Defaulting it on would ship a known incident to every chart consumer, including
single-node k3s/e2e/dev instances — and with the chart's 5-minute startup budget the gate would kill
every pod mid-bake anyway.

Instead the mismatch is made impossible to have **quietly**: the portal now logs at **Critical** when
the gate is requested without the sweep, and `values.yaml` documents the coupling and the reasoning.

### 4. Gate armed on AKS (`values.aks.yaml`)

`PreWarm__GateReadiness: "true"`, and the stale "⛔ Gate OFF" rationale — which argued entirely from
the pre-`974016bf4` code — is replaced with the current reasoning plus the three live preconditions.

---

## 🚨 What must be applied to the cluster, in this order

Repo changes alone change nothing live. **Live state verified 2026-08-10 04:55–04:58 UTC:**

| ns | replicas | maxSurge/maxUnavail | progressDeadline | startupProbe | readinessProbe | sweep | gate |
|---|---|---|---|---|---|---|---|
| `memex-cloud` | 1 | 1 / **0** ✅ | 600 (default) | `/health` 10×1080 ✅ | `/alive` | true | false |
| `atioz` | 1 | 1 / **0** ✅ | 600 (default) | **none** ❌ | `/healthz` | true | false |
| `memex` | 1 | 1 / **1** ❌ | 600 (default) | **none** ❌ | **none** ❌ | true | false |

Two findings that change the plan:

- **`maxUnavailable: 0` was already the chart default** (it has been since #145). `memex`'s `1` is
  **live drift**, not a chart gap — so task A needed no chart change, it needs a cluster apply.
- **`memex` and `atioz` have no `startupProbe` at all.** That probe is the *only* reader of the
  gate. Arming the gate in those namespaces as they stand today would change **nothing** — the
  config would claim protection that no probe consults.

**Order (each step's precondition is the step before it):**

1. **Merge this PR and let CD publish the image.** The gate must only ever be armed on an image that
   contains the `UpstreamUnevaluated` cascade fix — arming it on an older image reproduces the
   2026-08-02 stall. Verify the image, not the green tick:
   `az acr repository show-tags -n meshweaver --repository memex-portal-ai --orderby time_desc --top 5 -o tsv`
2. **Let each portal self-update to that image** (20-min poll on managed envs), or roll it manually.
   Confirm the running image before continuing.
3. **Propagate the two keys into each env's private `values.<env>.yaml`** in `Systemorph/Memex` —
   `PreWarm__GateReadiness: "true"` and `probes.startup: {periodSeconds: 10, failureThreshold: 1080}`.
   `deploy/aks/values.aks.yaml` here is the tracked *template*; the live deploys run
   `helm upgrade -f ./helm/values.yaml -f ./values.<env>.yaml`, so a key that stays only in this
   repo never reaches the cluster.
4. **`helm upgrade` per namespace.** This restores `maxUnavailable: 0`, the `/health` startupProbe,
   and the new `progressDeadlineSeconds` **in the same apply** as the gate config — so the pod the
   rollout creates has A, B and C together, and the new strategy governs that rollout. Check any
   per-env `portal-patch.json` first: `deploy.sh` applies it *after* helm, so a patch there can
   re-introduce the drift.
5. **Verify the shape before trusting the gate** (per namespace):
   ```bash
   kubectl -n <ns> get deploy memex-portal-deployment \
     -o jsonpath='{.spec.strategy.rollingUpdate}{"\n"}{.spec.progressDeadlineSeconds}{"\n"}{.spec.template.spec.containers[0].startupProbe}'
   ```
   Expect `maxUnavailable:0`, `11400`, and a startupProbe on **`/health`**.
6. **Expect the first gated roll to be long.** A cold bake is ~90 s/type, sequential — hours on a
   real mesh, with the old pod serving throughout. Do **not** use
   `kubectl rollout status --timeout=300s` to judge it; watch the sweep instead:
   ```bash
   kubectl -n <ns> logs <newest-pod> | grep "DynamicTypePreWarmer: warm-up complete"
   ```
7. **If a roll stalls, investigate — don't wait it out.** The old image keeps serving (no outage),
   but self-update stops advancing. `/health` names both the regressions and the unevaluated types.

`atioz` is prod, and its readiness probe points at `/healthz` rather than the chart's `/alive` —
worth confirming that divergence is intentional before the helm upgrade replaces it.

---

## Verification

- `dotnet build -c Release -warnaserror` clean: `MeshWeaver.Hosting`, `Memex.Portal.Distributed`,
  `MeshWeaver.Hosting.Monolith.Test`.
- `helm template` renders `progressDeadlineSeconds: 900` (chart defaults) and `11400` (AKS values),
  `maxUnavailable: 0` unchanged.
- Live cluster reads were **read-only** (`kubectl get` via `az aks command invoke`). No cluster
  object was mutated — the deploy is the user's decision.
