### PR TITLE
A hub that answered the sender then declared it hadn't, so the sender got two answers

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-broken-nodetype-error-names-the-cause.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-broken-nodetype-error-names-the-cause.md
@@ -1,0 +1,25 @@
+---
+Name: Opening a broken page now tells you what is broken
+Category: Fix
+Description: A page whose code does not compile now reliably reports the compilation error and names the type at fault, instead of sometimes showing a generic failure.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Opening a broken page now tells you what is broken
+
+Opening a page whose underlying code does not compile is supposed to tell you exactly
+that: a compilation error, naming the type at fault, with a route to the compile log.
+Most of the time it did. Sometimes, for the very same broken page, you got an
+unhelpful generic failure instead — no error kind, no type name, nothing to act on.
+Reloading could give you the good message, or the bad one again.
+
+The page was being answered **twice**. The part of the system that stands in for a
+broken type sent a proper diagnosis — "this NodeType did not compile, here it is" —
+and then a second, generic "delivery failed" answer was sent for the same request.
+Whichever arrived first is the one you saw, so the quality of the error depended on
+timing rather than on what was wrong.
+
+A request now gets exactly one answer, and it is the one from the place that actually
+knows what went wrong. The compilation error, the name of the broken type, and the
+link to the compile log are what you get, every time.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -480,6 +480,12 @@ public class MessageService : IMessageService
                 // every other caller's behaviour. See /async + the no-handler path in MessageHub.FinishDelivery.
                 Post(new DeliveryFailure(delivery, message) { ErrorType = errorType },
                     new PostOptions(Address).ResponseFor(delivery));
+                // The sender has now been answered. Record that ON the delivery — the same marker
+                // IMessageDelivery.FailedAndNacked sets — so no later stage answers the same request a
+                // second time. Only on the path that actually posted: the shutdown short-circuit and the
+                // suppressed-control-traffic branch below answer nobody, and a Post that threw did not
+                // either, so none of them may claim the sender was nacked.
+                delivery = delivery.WithProperty(IMessageDelivery.SenderNackedProperty, true);
             }
             catch (Exception ex)
             {
@@ -820,7 +826,7 @@ public class MessageService : IMessageService
                     name, Address, delivery.Id);
 
             if (delivery.State == MessageDeliveryState.Failed)
-                return Observable.Return(ReportFailure(delivery));
+                return Observable.Return(ReportOnTargetFailure(delivery));
         }
 
 
@@ -998,6 +1004,32 @@ public class MessageService : IMessageService
         return ReportFailure(delivery, errorType);
     }
 
+    /// <summary>
+    /// Reports a delivery that failed ON TARGET — i.e. in <see cref="UnpackIfNecessary"/>, before any
+    /// handler saw it — extending it the same two courtesies <see cref="ReportRoutingFailure"/> gives
+    /// the routing branch, both read off the delivery rather than re-derived here:
+    /// <list type="bullet">
+    ///   <item><see cref="IMessageDelivery.SenderWasNacked"/> — the failing site already answered the
+    ///     sender itself. The fallback-hub (<see cref="UnhandledMessageNack"/>) path does exactly that,
+    ///     posting a typed <see cref="ErrorType.CompilationFailed"/> NACK naming the broken NodeType.
+    ///     Reporting again sent the sender a SECOND <see cref="DeliveryFailure"/> for the one request —
+    ///     same message text, but the generic <see cref="ErrorType.Unknown"/> and no NodeTypePath — so
+    ///     a caller's <c>Observe(...).FirstAsync()</c> resolved on whichever answer won the race. That
+    ///     is the non-deterministic <c>CompilationFailed</c>/<c>Unknown</c> flip behind the
+    ///     <c>OrleansBrokenNodeTypeAccessTest</c> / <c>BrokenNodeTypeAccessTest</c> CI failures.</item>
+    ///   <item><see cref="IMessageDelivery.GetFailureErrorType"/> — the verdict the failing site
+    ///     recorded, which it reached WHERE the condition was known. Falling back to
+    ///     <see cref="ErrorType.Unknown"/> keeps every unclassified site's historical behaviour.</item>
+    /// </list>
+    /// </summary>
+    private IMessageDelivery ReportOnTargetFailure(IMessageDelivery delivery)
+    {
+        if (delivery.SenderWasNacked)
+            return delivery;
+
+        return ReportFailure(delivery, delivery.GetFailureErrorType(ErrorType.Unknown));
+    }
+
     private static string GetMessageType(IMessageDelivery delivery)
     {
         if (delivery.Message is RawJson rawJson)
@@ -1080,7 +1112,7 @@ public class MessageService : IMessageService
             delivery = UnpackIfNecessary(delivery);
 
             if (delivery.State == MessageDeliveryState.Failed)
-                return Observable.Return(ReportFailure(delivery));
+                return Observable.Return(ReportOnTargetFailure(delivery));
         }
 
         delivery = hierarchicalRouting.RouteMessageAsync(delivery, cancellationToken);
@@ -1371,7 +1403,12 @@ public class MessageService : IMessageService
             if (string.Equals(jsonType, nameof(DeliveryFailure), StringComparison.Ordinal))
             {
                 logger.LogWarning("Suppressing DeliveryFailure-on-DeliveryFailure ping-pong: {Message}", failureMessage);
-                return delivery.Failed(failureMessage);
+                // FailedAndNacked, NOT Failed — "swallow without responding" only holds if the
+                // reporter downstream is told no answer is owed. Plain Failed() left it owing one,
+                // and since this delivery's Message is RawJson (not DeliveryFailure), ReportFailure's
+                // own type guard could not see what it was: the guard logged its suppression and a
+                // DeliveryFailure went out regardless — feeding the very ping-pong it names.
+                return delivery.FailedAndNacked(failureMessage);
             }
 
             // Fallback-hub contract (UnhandledMessageNack): on a hub standing in for
@@ -1400,7 +1437,12 @@ public class MessageService : IMessageService
                     logger.LogError(ex, "Failed to post fallback NACK for '{JsonType}' (ID: {MessageId}) in {Address}",
                         jsonType, delivery.Id, Address);
                 }
-                return delivery.Failed(reason);
+                // FailedAndNacked, NOT Failed: this site just answered the sender itself with the
+                // policy's typed diagnosis. Plain Failed() declares the opposite ("whoever finishes
+                // this delivery owes the sender a DeliveryFailure"), which made the on-target reporter
+                // post a SECOND, generic Unknown NACK for the same request — and the caller then saw
+                // whichever of the two arrived first.
+                return delivery.FailedAndNacked(reason);
             }
 
             return ReportFailure(delivery.Failed(failureMessage));

--- a/test/MeshWeaver.Messaging.Hub.Test/FallbackNackDuplicateTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/FallbackNackDuplicateTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 A hub carrying an <see cref="UnhandledMessageNack"/> policy (the fallback/overlay hub that
+/// stands in for a node whose NodeType did not compile) answers an unregistered inbound type with
+/// its OWN typed <see cref="DeliveryFailure"/> — and must answer EXACTLY ONCE.
+///
+/// <para><b>The defect this pins.</b> <c>MessageService.DeserializeDelivery</c> posted the typed
+/// NACK (<see cref="ErrorType.CompilationFailed"/> + NodeTypePath) and then returned
+/// <c>delivery.Failed(reason)</c> — the overload that DECLARES "the failing site did not answer the
+/// sender". The on-target caller therefore ran <c>ReportFailure(delivery)</c> with its default
+/// <see cref="ErrorType.Unknown"/> and posted a SECOND <see cref="DeliveryFailure"/> for the same
+/// request, carrying the same message text but a different classification. Both are
+/// <c>ResponseFor</c> the one request, so a caller's <c>Observe(...).FirstAsync()</c> resolved on
+/// whichever won the race — <see cref="ErrorType.CompilationFailed"/> or
+/// <see cref="ErrorType.Unknown"/>, non-deterministically.</para>
+///
+/// <para>That flip is what made <c>OrleansBrokenNodeTypeAccessTest</c> (and its Monolith mirror
+/// <c>BrokenNodeTypeAccessTest</c>) fail intermittently on CI shard 0 with
+/// "Expected value to be CompilationFailed, but found Unknown" — an ASSERTION, not a timeout, with
+/// byte-identical message text in the passing and failing runs. The contract is spelled out on
+/// <see cref="IMessageDelivery.FailedAndNacked"/>: "A site that posts its own NACK must use
+/// FailedAndNacked instead, or the sender gets two."</para>
+///
+/// <para>Counting the NACKs pins the CAUSE (a duplicate answer) rather than the SYMPTOM (which of
+/// the two won), so it fails deterministically — no load, no CPU constraint, no Orleans cluster.</para>
+/// </summary>
+public class FallbackNackDuplicateTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string NodeTypePath = "type/BrokenNodeType";
+    private const string NackReason = "NodeType 'type/BrokenNodeType' has no usable hub configuration";
+
+    /// <summary>A type name deliberately absent from every hub's TypeRegistry, so the delivery
+    /// reaches the host as <see cref="RawJson"/> that cannot be materialised — the fallback path.</summary>
+    private const string UnregisteredType = "TotallyUnregisteredProbeRequest";
+
+    // Replay so an assertion that subscribes after the first NACK landed still sees it.
+    private readonly ReplaySubject<DeliveryFailure> nacks = new();
+
+    /// <summary>The host stands in for a broken NodeType's instance: it can serve what its own
+    /// configuration handles, and answers everything else with the policy's typed diagnosis.</summary>
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => configuration.Set(new UnhandledMessageNack(NackReason, ErrorType.CompilationFailed, NodeTypePath));
+
+    /// <summary>The client collects every NACK it is sent, so the test can assert on the COUNT.</summary>
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => configuration.WithHandler<DeliveryFailure>((_, delivery) =>
+        {
+            nacks.OnNext(delivery.Message);
+            return delivery.Processed();
+        });
+
+    [Fact(Timeout = 60_000)]
+    public async Task UnregisteredType_OnFallbackHub_IsNackedExactlyOnce_WithTheFallbackClassification()
+    {
+        GetHost();
+        var client = GetClient();
+
+        client.Post(new RawJson($$"""{"$type":"{{UnregisteredType}}"}"""),
+            o => o.WithTarget(CreateHostAddress()));
+
+        var first = await nacks.Should().Within(20.Seconds()).Emit(
+            "the fallback hub owes the sender a terminal answer — silence is the prod wedge this policy exists to prevent");
+
+        first.ErrorType.Should().Be(ErrorType.CompilationFailed,
+            "the classification must be the one the FAILING SITE decided on (it knows the NodeType did not compile), "
+            + "never the generic Unknown a downstream reporter would invent");
+        first.NodeTypePath.Should().Be(NodeTypePath,
+            "the NACK must name the broken NodeType so the caller can act on it");
+
+        // THE ROOT CAUSE: a second NACK for the same request. It is posted in the same delivery
+        // pass as the first, so a short window is enough — and it is the duplicate, not the
+        // ordering, that makes the observed ErrorType non-deterministic for the caller.
+        await nacks.Skip(1).Should().NotEmit(3.Seconds(),
+            "the fallback hub already answered this request; a second DeliveryFailure makes the "
+            + "caller's ErrorType depend on which answer wins the race");
+    }
+}


### PR DESCRIPTION
## The failure

CI shard 0 has been flapping on `MeshWeaver.Hosting.Orleans.Test` (3 of main's last 8 runs). The brief for this work said the cause was teardown starvation. **The evidence refutes that** — the three red runs have three *different* signatures, and two of them die at the FRONT of the assembly, where no teardown backlog exists:

| Run | Test | Signature |
|---|---|---|
| 31336834864 | `Instance_OfNonCompilingNodeType_AnswersTerminalError_NotSilence` | **assertion** `Expected CompilationFailed, but found Unknown` — 28 s in |
| 31336448666 | `OrleansMarkdownExportTest.ExportPdf_RoundTrips` | 60 s timeout, **first class in the assembly** |
| 31334386600 | `OrleansResubmitDeadlockTest.Resubmit_AfterExecution` | stuck at `Status = Executing` after 45 s |

This PR fixes the first — an assertion, not a timeout, and the only signature to appear twice.

## The defect

`MessageService.DeserializeDelivery`'s `UnhandledMessageNack` path — the fallback hub standing in for a node whose NodeType did not compile — **posts** its own typed `DeliveryFailure` (`CompilationFailed` + `NodeTypePath`), then returned `delivery.Failed(reason)`. That overload's documented meaning is the opposite of what just happened: *"the failing site did NOT answer the sender; whoever finishes this delivery owes it a `DeliveryFailure`."*

So the on-target reporter posted a **second** `DeliveryFailure` for the same request — same message text, but the generic `ErrorType.Unknown` and no `NodeTypePath`. Both are `ResponseFor` the one request, so the caller's `Observe(...).FirstAsync()` resolved on whichever arrived first. The error a user saw for a broken page was decided by scheduling.

That explains every observation: an assertion rather than a timeout, byte-identical message text in passing and failing runs, and a hit 28 s in where nothing could have starved it.

`IMessageDelivery` already states the contract: *"A site that posts its own NACK must use `FailedAndNacked` instead, or the sender gets two."* `ReportRoutingFailure` honours both markers a failing site records; the on-target branch never did — it called `ReportFailure` raw, discarding `SenderWasNacked` and any recorded classification.

## The change

- Fallback-NACK path returns `FailedAndNacked` — it *did* answer.
- `ReportOnTargetFailure` mirrors `ReportRoutingFailure`: skip when already answered, keep the verdict the site reached. `Unknown` stays the fallback, preserving unclassified sites' behaviour.
- `ReportFailure` records the marker on the delivery it answered, so the generic registry-hint path stops double-posting too.
- The `DeliveryFailure` ping-pong guard said *"swallow without responding"* but returned plain `Failed`, leaving the reporter owing an answer — and since that delivery's `Message` is `RawJson`, `ReportFailure`'s type guard could not see what it was. It logged its own suppression while a `DeliveryFailure` went out anyway, feeding the ping-pong it names. Now `FailedAndNacked`.

## Evidence

`FallbackNackDuplicateTest` pins the **cause** (two answers) rather than the **symptom** (which won), so it is deterministic — no Orleans, no load, no CPU constraint:

- **Before:** FAILS in 247 ms — `but it emitted DeliveryFailure { … ErrorType = Unknown, NodeTypePath = }`, same request Id and same message text as the good one.
- **After:** PASSES.

Running the Orleans victim **alone passed 10/10 before the fix** (`DOTNET_PROCESSOR_COUNT=4`) — the flip needs the loaded, multi-class assembly, which is why chasing the test name never reproduced it. That is why the proof is the deterministic repro rather than a local flake rate.

- `MeshWeaver.Messaging.Hub.Test`: **162/162** pass (run twice — after the main fix, and again after the ping-pong fix).
- `dotnet build -c Release -warnaserror` on `MeshWeaver.Messaging.Hub`: **0 warnings, 0 errors**.

## Scope — this does NOT make shard 0 green on its own

At least three distinct defects are reddening shard 0. This is the most frequent one. `ExportPdf_RoundTrips_AsTypedResponse` (60 s timeout as the first class, having printed only "Created Markdown node") and `Resubmit_AfterExecution_DoesNotDeadlock` (stuck at `Status=Executing`) are **separate and still open**. Merging this reduces the flap rate; it does not eliminate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)