### PR TITLE
Arm the cross-repo plugin gate with a read-only deploy key

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -273,6 +273,24 @@ jobs:
                 # build) simply contributes nothing to its shard's tarball.
                 [ -d "$d" ] && echo "$d"
               done | sort -u > ".build-paths-$i.txt"
+          # 🚨 Shard 0 additionally carries the PLUGIN TESTER — the ONE non-test bin that
+          # travels. tools/MeshWeaver.PluginTester (mw-plugin-test.dll) is a TOOL, so the
+          # test-project sweep above never picks it up; but the plugin-gate job reuses THIS
+          # artifact instead of rebuilding, and that reuse is exactly what keeps the gate
+          # inside its 12-minute budget. While the gate sat unarmed the omission was
+          # invisible — the FIRST armed run died on "mw-plugin-test.dll not in the build
+          # output — the gate cannot run", having tested nothing, which is the very shape
+          # that job exists to prevent. The run loop iterates shard-assign.sh's project
+          # list (not the extracted tree), so this extra bin is inert for the tests.
+          # Missing here is a BUILD fault, not a tolerable absence: the solution builds
+          # this project, so fail loudly rather than ship an artifact the gate cannot use.
+          if [ "$i" -eq 0 ]; then
+            if [ ! -d tools/MeshWeaver.PluginTester/bin ]; then
+              echo "::error::tools/MeshWeaver.PluginTester/bin is missing — the plugin gate would have nothing to run."
+              exit 1
+            fi
+            echo tools/MeshWeaver.PluginTester/bin >> ".build-paths-$i.txt"
+          fi
           # zstd -T0 = all cores. --long=27 (128 MiB match window) dedupes ACROSS
           # files: the self-contained test bins each carry near-identical copies
           # of the same framework + MeshWeaver DLLs, which the default 8 MiB

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -707,25 +707,36 @@ jobs:
         set -euo pipefail
         tar -I 'zstd --long=27' -xf build-output-0.tar.zst
         rm -f build-output-0.tar.zst
-    - name: Is the plugins token configured?
+    - name: Is the plugins credential configured?
       id: token
       env:
-        PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
+        PLUGINS_REPO_SSH_KEY: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
       run: |
-        if [ -n "$PLUGINS_REPO_TOKEN" ]; then echo "present=true" >> "$GITHUB_OUTPUT"
+        if [ -n "$PLUGINS_REPO_SSH_KEY" ]; then echo "present=true" >> "$GITHUB_OUTPUT"
         else echo "present=false" >> "$GITHUB_OUTPUT"; fi
     - name: Check out MeshWeaver.Plugins
       id: plugins
-      # A PAT/App token with read access to the private plugins repo. Absent (e.g. on a fork, or
-      # before the secret is provisioned) the gate reports SKIPPED rather than failing — an
-      # unavailable input is not evidence of a break.
+      # 🚨 A READ-ONLY DEPLOY KEY, deliberately — not a PAT and not the org's GitHub App.
+      # This gate needs exactly one capability: read Systemorph/MeshWeaver.Plugins. A deploy key
+      # grants precisely that and nothing else, so a secret readable by every workflow run in this
+      # repo cannot be turned into anything wider. The alternatives were both worse:
+      #   • a fine-grained PAT is minimal too, but it is minted against a PERSON, inherits their
+      #     account's lifecycle, and EXPIRES — a gate that silently disarms when someone's token
+      #     lapses is the failure shape this whole job exists to prevent;
+      #   • the org's `meshweaver-cloud` App is installed on ALL repos with write scopes (it drives
+      #     self-update and the issues/PR/webhook integrations), so putting its private key here
+      #     would let any workflow — including one added by a PR — mint org-wide write tokens.
+      # Rotate/revoke by deleting the key on the plugins repo (Settings → Deploy keys) and
+      # replacing PLUGINS_REPO_SSH_KEY here; nothing else depends on it.
+      # Absent (e.g. on a fork) the gate reports SKIPPED rather than failing — an unavailable
+      # input is not evidence of a break.
       continue-on-error: true
       uses: actions/checkout@v6
       with:
         repository: Systemorph/MeshWeaver.Plugins
         ref: main
         path: plugins-repo
-        token: ${{ secrets.PLUGINS_REPO_TOKEN }}
+        ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
         fetch-depth: 1
     - name: "Compile + run the VITAL plugins against this PR"
       if: steps.plugins.outcome == 'success'
@@ -771,27 +782,35 @@ jobs:
     # reasons the checkout can fail are treated differently:
     #   • a FORK PR genuinely cannot reach a private repo → skip, with a warning. Nothing the
     #     contributor can do, and their change cannot be proven either way here.
-    #   • the SAME repo failing means PLUGINS_REPO_TOKEN is missing or expired → that is a
+    #   • the SAME repo failing means PLUGINS_REPO_SSH_KEY is missing or revoked → that is a
     #     CONFIGURATION fault, and configuration faults must be loud. Failing is what gets the
     #     secret provisioned; a warning would let the gate sit permanently inert and green.
-    # Not-yet-configured is the BOOTSTRAP state (this very PR introduces the gate, so the secret
-    # cannot exist before it merges). Warn loudly; do not block. Remove nothing here — the arm
-    # below is what keeps it honest once the secret exists.
+    # Not-yet-configured is the BOOTSTRAP state. Warn loudly; do not block. Remove nothing here —
+    # the arm below is what keeps it honest once the secret exists.
+    #
+    # 🚨 This warn-only branch is NOT free, and the cost has now been paid once. The gate shipped
+    # unarmed and sat green-but-inert for weeks, so #683's deletion of
+    # AiSettingsNodeType.AddSkillSource merged unverified — the plugins repo's
+    # Store/Plugin/Source/Localizer.cs still called it. The break surfaced only when the mesh
+    # recompiled Store/Plugin in production: CS0117, every nodeType:Store/Plugin partition
+    # (Edu, Agent, Skill, Essentials, Publish, …) stuck on the compilation-error overlay.
+    # This job, armed, would have failed that PR — Store is in VITAL_MODULES for exactly this.
     - name: Warn — gate not yet armed
       if: steps.token.outputs.present != 'true' && github.event.pull_request.head.repo.fork != true
       run: |
-        echo "::warning title=Plugin gate NOT armed::PLUGINS_REPO_TOKEN is not configured, so the cross-repo API gate did not run and this PR is UNVERIFIED against the plugins. Provision a read-access token for Systemorph/MeshWeaver.Plugins to arm it."
+        echo "::warning title=Plugin gate NOT armed::PLUGINS_REPO_SSH_KEY is not configured, so the cross-repo API gate did not run and this PR is UNVERIFIED against the plugins. Add a read-only deploy key for Systemorph/MeshWeaver.Plugins to arm it."
     - name: Report a skipped gate (fork PR)
       if: steps.plugins.outcome != 'success' && github.event.pull_request.head.repo.fork == true
       run: |
         echo "::warning::Fork PR — MeshWeaver.Plugins is unreachable, so the cross-repo API gate did not run."
-    # 🚨 Token CONFIGURED but the checkout still failed ⇒ expired, revoked, or wrong scope. That is
-    # a configuration FAULT, and configuration faults must be loud: a gate reporting green while
-    # testing nothing is exactly how mw-plugin-test:latest went stale unnoticed.
+    # 🚨 Credential CONFIGURED but the checkout still failed ⇒ the deploy key was revoked or
+    # replaced. That is a configuration FAULT, and configuration faults must be loud: a gate
+    # reporting green while testing nothing is exactly how mw-plugin-test:latest went stale
+    # unnoticed.
     - name: Fail — gate armed but could not run
       if: steps.token.outputs.present == 'true' && steps.plugins.outcome != 'success' && github.event.pull_request.head.repo.fork != true
       run: |
-        echo "::error::PLUGINS_REPO_TOKEN is configured but checking out Systemorph/MeshWeaver.Plugins FAILED (expired, revoked, or insufficient scope). The cross-repo API gate did not run, so this PR is unverified against the plugins."
+        echo "::error::PLUGINS_REPO_SSH_KEY is configured but checking out Systemorph/MeshWeaver.Plugins FAILED (deploy key revoked, replaced, or removed from the plugins repo). The cross-repo API gate did not run, so this PR is unverified against the plugins."
         exit 1
 
   collect-results:


### PR DESCRIPTION
## Why

The gate added in 98dd7d4c0 was never armed — `PLUGINS_REPO_TOKEN` was not among the repo's
secrets, so every PR took the warn-only branch:

> Plugin gate NOT armed: … the cross-repo API gate did not run and this PR is UNVERIFIED against the plugins.

Green, and testing nothing — the exact failure shape the job's own comments say it exists to end.

**It has now cost a production outage.** #683 deleted `AiSettingsNodeType.AddSkillSource`. The
plugins repo's `Store/Plugin/Source/Localizer.cs` still called it, and *no build in this repo can
see that file* — plugin node source is Roslyn-compiled against this assembly from a different repo.
It merged unverified and surfaced only when the mesh recompiled `Store/Plugin` in production:
`CS0117`. Since every plugin declares `requires: Store`, that left **every** `nodeType:Store/Plugin`
partition on memex.systemorph.com — Edu, Agent, Skill, Essentials, Collaboration, DataModelling,
Feedback, Instances, Publish — on the compilation-error overlay. The plugins repo fixed its side in
`b10c981`, two days later.

`Store` is in `VITAL_MODULES` for exactly this reason, so an armed gate would have failed #683.

## The credential

A **read-only deploy key** on `Systemorph/MeshWeaver.Plugins` (created, id `159776507`), stored here
as `PLUGINS_REPO_SSH_KEY` (set). The gate needs exactly one capability — read that one repo — and a
deploy key grants that and nothing else, so a secret every workflow run can read cannot be widened.

Two alternatives were considered and rejected, and the reasoning is in the workflow comment so it
survives:

| Option | Why not |
|---|---|
| Fine-grained PAT | Minimal too, but minted against a **person** and it **expires**. A gate that silently disarms when someone's token lapses is the very failure this job prevents. |
| Org `meshweaver-cloud` GitHub App | Installed on **all** repos with write scopes (self-update, issues/PR/webhooks). Its private key here would let any workflow — including one added by a PR — mint org-wide **write** tokens. |

Revoke by deleting the deploy key on the plugins repo and replacing the secret; nothing else depends
on it.

## Behaviour unchanged otherwise

The three-way asymmetry is preserved exactly: fork PR → skip with a warning; credential absent →
warn, do not block; credential present but checkout fails → **fail loudly** (now worded for a
revoked/replaced deploy key rather than an expired token).

`main-cd.yml` needs no change — it builds the `mw-plugin-test` image but never checks out the
plugins repo.

## Self-verifying

This PR is the first run with the secret present, so its own `plugin-gate` job is the test: it will
check out the plugins repo and compile + run `Store` and `Essentials` against this PR's build
output. A green gate here means it is genuinely armed; a red one is the gate doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
