### PR TITLE
The plugin gate stopped covering every commercial package, silently

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
@@ -97,6 +97,16 @@ public class PluginGateRunnerTest(ITestOutputHelper output)
         }
         """;
 
+    // ── a COMMERCIAL package: identical to the good one except it carries a price. `price: -1`
+    //    is the coupon-only shape the plugins repo's `Manufacturing` ships; any non-zero price
+    //    makes PackageEntitlement.IsCommercial true, which is the whole point of the fixture. ──
+
+    private const string PricedIndexJson =
+        """{"$type":"MeshNode","id":"Priced","namespace":"","path":"Priced","mainNode":"Priced","name":"Priced Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A commercial plugin.","price":-1,"currency":"CHF"}}""";
+
+    private const string PricedThingNodeTypeJson =
+        """{"$type":"MeshNode","id":"Thing","namespace":"Priced","path":"Priced/Thing","mainNode":"Priced/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
+
     [Fact(Timeout = 300_000)]
     public async Task GoodPackage_CompilesRendersAndExecutesTestsGreen_ExitsZero()
     {
@@ -168,6 +178,39 @@ public class PluginGateRunnerTest(ITestOutputHelper output)
             var widget = report.Packages.Single(p => p.Id == "Widget");
             widget.Success.Should().BeTrue(
                 $"the good package must stay green; log:\n{log}");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task CommercialPackage_InstallsAndGatesGreen()
+    {
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Priced/index.json", PricedIndexJson);
+            WriteFile(root, "Priced/Thing.json", PricedThingNodeTypeJson);
+            WriteFile(root, "Priced/Thing/Source/Thing.cs", ThingSource);
+        });
+        try
+        {
+            var (report, log) = await RunGate(repo);
+
+            var priced = report.Packages.Single(p => p.Id == "Priced");
+            // The regression this pins: the gate installs as an EXPLICIT global admin. With no
+            // authorizing principal PackageEntitlement (#830) refuses every priced package, and
+            // the gate reported `PackageAuthorizationException` without compiling a line of it —
+            // i.e. it silently stopped covering commercial packages altogether.
+            priced.InstallError.Should().BeNull(
+                $"a commercial package must install through the gate; log:\n{log}");
+            log.Should().NotContain("PackageAuthorizationException");
+
+            var thing = priced.NodeTypes.Single(t => t.Path == "Priced/Thing");
+            thing.Compile.Should().Be(CheckOutcome.Passed,
+                $"the priced package's type must actually be compiled; detail: {thing.CompileDetail}");
+            report.ExitCode.Should().Be(0, $"all green must exit 0; log:\n{log}");
         }
         finally
         {

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -113,7 +113,13 @@ public static class PluginGateRunner
             {
                 options.Output.WriteLine($"── {package.Id}: installing {files.Count} file(s)…");
                 var types = DiscoverNodeTypes(package, files);
-                return PackageInstaller.Install(harness.Mesh, package, files, snapshot.CommitSha)
+                // The authorizing principal is EXPLICIT — see GateMesh.AuthorizingUserId. Passing
+                // nothing means "nobody authorized this", which PackageEntitlement refuses for any
+                // priced package; the gate would then report a commercial package as failed
+                // without ever having compiled a line of it.
+                return PackageInstaller
+                    .Install(harness.Mesh, package, files, snapshot.CommitSha,
+                        authorizingUserId: GateMesh.AuthorizingUserId)
                     .SelectMany(install =>
                     {
                         options.Output.WriteLine(
@@ -128,7 +134,8 @@ public static class PluginGateRunner
                             // Runs after the compile gates so an enriched NodeType (compile stamps)
                             // is the realistic re-install input.
                             .SelectMany(typeResults => PackageInstaller
-                                .Install(harness.Mesh, package, files, snapshot.CommitSha)
+                                .Install(harness.Mesh, package, files, snapshot.CommitSha,
+                                    authorizingUserId: GateMesh.AuthorizingUserId)
                                 .Select(second => new PackageResult(package.Id)
                                 {
                                     NodeCount = install.Total,
@@ -432,21 +439,49 @@ public static class PluginGateRunner
 
         // Root-scope Admin for everyone: the gate is a throwaway single-user mesh; the install
         // itself runs system-impersonated, this grant is what lets the render client READ.
+        //
+        // 🚨 …AND the same grant on the Admin PARTITION, which is a different thing and is what
+        // makes the gate's principal a GLOBAL ADMIN. `hub.IsGlobalAdmin(userId)` reads
+        // `Permission.All` at scope `Admin` — an AccessAssignment in `Admin/_Access` — and a ROOT
+        // grant is deliberately not that shape (AccessControl.md → "The Admin partition"). Without
+        // it the gate could install nothing commercial: PackageEntitlement (#830) refuses a priced
+        // package unless the authorizing principal is a global admin, so `Manufacturing`
+        // (price -1 CHF, coupon-only) failed the MeshWeaver.Plugins gate with
+        // `PackageAuthorizationException` the moment that repo's image pin moved onto eb330e1a2 —
+        // not because anything about the package was broken, but because the harness had no
+        // admin to offer. Mirrors TestUsers.PublicAdminAccess, which seeds both scopes.
         private static MeshNode[] RootAdminAccess() =>
         [
-            new(WellKnownUsers.Public + "_Access", "_Access")
+            GateAdminAccess(""),
+            GateAdminAccess(AdminPartition),
+        ];
+
+        /// <summary>The Admin partition — the scope <c>IsGlobalAdmin</c> evaluates.</summary>
+        private const string AdminPartition = "Admin";
+
+        /// <summary>
+        /// The gate principal (<see cref="WellKnownUsers.Public"/>) — the identity that AUTHORIZES
+        /// every install in a gate run. A CI gate is an attended, operator-run check, so it presents
+        /// an admin rather than installing as "nobody" (which
+        /// <see cref="PackageEntitlement.Authorize"/> correctly refuses for priced packages).
+        /// </summary>
+        public static string AuthorizingUserId => WellKnownUsers.Public;
+
+        private static MeshNode GateAdminAccess(string ns) =>
+            // Root-scope assignments live at "_Access" (not ""), so the security service maps them
+            // to scope "" — an empty namespace would land them at "Public_Access" with no scope.
+            new(WellKnownUsers.Public + "_Access", ns.Length > 0 ? ns + "/_Access" : "_Access")
             {
                 NodeType = "AccessAssignment",
                 Name = "Public Access",
-                MainNode = "",
+                MainNode = ns,
                 Content = new AccessAssignment
                 {
                     AccessObject = WellKnownUsers.Public,
                     DisplayName = "Public",
                     Roles = [new RoleAssignment { Role = "Admin" }],
                 },
-            },
-        ];
+            };
 
         private static IMessageHub CreateClient(IMessageHub mesh)
         {


### PR DESCRIPTION
## The hole

`#830` put the free/commercial boundary **on the action**: `PackageInstaller.Install` refuses a
priced package unless an explicit `authorizingUserId` is a global admin. That is right, and it
deliberately closed the machine paths — the unattended default install and `PluginUpdateWatcher`'s
auto-update.

**The plugin GATE is a machine path too, and it was not moved with it.** `PluginGateRunner` calls

```csharp
PackageInstaller.Install(harness.Mesh, package, files, snapshot.CommitSha)
```

— `authorizingUserId` defaults to `null`, i.e. *"nobody authorized this"*. So every priced package
is refused before a single node is written, and the gate reports it as failed on install having
compiled, rendered and tested **none** of it. A gate that cannot test a whole class of package is
not a strict gate; it is a hole that happens to be loud.

## It is live, not hypothetical

`MeshWeaver.Plugins` [PR #383](https://github.com/Systemorph/MeshWeaver.Plugins/pull/383) bumped its
image pin onto `eb330e1a2`, and `Manufacturing` (`price: -1 CHF`, coupon-only) went red with
`PackageAuthorizationException` — nothing wrong with the package, no principal to authorize it.
Every other package in that repo passed.

Measured on that repo's `Store` + `Manufacturing` subset, one variable at a time:

| tester / image | `Manufacturing` | exit |
|---|---|---|
| old pin `631b3eed` (pre-#830) | `[PASS]` | 0 |
| new pin `e772e609`, unpatched | `[FAIL] install: PackageAuthorizationException` | 1 |
| new pin `e772e609`, `price` forced to `0` | `[PASS]` | 0 |
| **this fix**, locally | installs 86 nodes, **9/9 NodeTypes compile + render** | — |

Row 3 is the control: with the price the only thing changed, the same image installs the same
package happily. The refusal is about authorization, nothing else.

## The fix — two halves, because the harness was missing both

1. **`GateMesh` seeded its Admin grant at ROOT `_Access` only.** `IsGlobalAdmin` reads
   `Permission.All` at scope `Admin` — an `AccessAssignment` in `Admin/_Access` — and a root grant
   is deliberately *not* that shape (AccessControl.md → "The Admin partition"). So even a principal
   passed in would not have been an admin. Now seeded at both scopes, mirroring
   `TestUsers.PublicAdminAccess`.
2. **Both `Install` call sites pass that principal explicitly** (the install and the idempotence
   re-install). A CI gate is an attended, operator-run check; it presents an admin rather than
   installing as nobody.

## Pinned by a test

`PluginGateRunnerTest.CommercialPackage_InstallsAndGatesGreen` — a fixture package carrying
`price: -1` must install and compile green through the gate, and the run must not contain
`PackageAuthorizationException`. It fails without **either** half of this change.

```
Discovered 1 package(s), install order: Priced
── Priced: installed (3 written, 0 unchanged); checking 1 NodeType(s)…
   ok  Priced/Thing [compile:Passed render:Passed tests:Skipped]
[PASS] Priced (3 node(s), 1 type(s))
ALL GREEN.
```

`dotnet build … -c Release -warnaserror` clean for both touched projects.

## One thing this change UNCOVERED but does not cause

With the package finally installing, the gate reaches the idempotence pin — and locally, on this
branch, `Manufacturing` re-install writes 4 nodes instead of 0:

```
idempotence: re-install of the unchanged snapshot wrote 4 node(s) (expected 0):
  Manufacturing/EnergyPrice/DE20260423, .../DE20260424, .../DE20260425Forecast,
  Manufacturing/Operator/MarcoRossi
```

**Not caused by this change** — it reproduces identically with the price forced to `0` (no
authorization involved at all), and it does **not** reproduce in the pinned image
(`e772e609` / core `8e7d862`, same package, same free variant → `[PASS]`). `src/MeshWeaver.PluginCatalog/`
has no commits between `8e7d862` and `main`, so the remaining candidates are a serialization/typing
change elsewhere in that window (e.g. `32883fc70`) or a host difference (macOS vs the linux
container). Filed here as an observation with its evidence rather than chased — it deserves its own
attribution, and it is exactly the kind of finding that stayed invisible while the gate could not
install the package at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQKMhQDpitUzsW1MqTVhH
