### PR TITLE
Suppress the duplicate failure, never the only one

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -792,6 +792,7 @@ public sealed class MessageHub : IMessageHub
                 logger.LogWarning(
                     "Unhandled {MessageType} (ID: {MessageId}) in fallback hub {Address} - answering {ErrorType} NACK: {Reason}",
                     delivery.Message.GetType().Name, delivery.Id, Address, nackPolicy.ErrorType, nackPolicy.Reason);
+                var nackPosted = false;
                 try
                 {
                     Post(new DeliveryFailure(delivery)
@@ -800,17 +801,21 @@ public sealed class MessageHub : IMessageHub
                         NodeTypePath = nackPolicy.NodeTypePath,
                         Message = nackPolicy.Reason
                     }, o => o.ResponseFor(delivery));
+                    nackPosted = true;
                 }
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "Failed to post fallback NACK for {MessageType} (ID: {MessageId}) in {Address}",
                         delivery.Message.GetType().Name, delivery.Id, Address);
                 }
-                // The typed NACK above IS this request's failure response — mark it so no
-                // unclassified follow-up is posted for the same delivery (see
-                // MessageService.FailureAlreadyReported).
-                return delivery.Failed(nackPolicy.Reason)
-                    .WithProperty(MessageService.FailureAlreadyReported, true);
+                // 🚨 Mark ONLY when the typed NACK actually went out — see
+                // MessageService.FailureAlreadyReported. Marking after a THROWN post would suppress
+                // the follow-up and leave the caller with NO failure response, which is the silent
+                // park this NACK path exists to prevent.
+                var failed = delivery.Failed(nackPolicy.Reason);
+                return nackPosted
+                    ? failed.WithProperty(MessageService.FailureAlreadyReported, true)
+                    : failed;
             }
 
             // Check if this is a request that expects a response

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1413,6 +1413,7 @@ public class MessageService : IMessageService
                 var reason = $"{nackPolicy.Reason} (inbound type '{jsonType}' is not registered in this hub's TypeRegistry)";
                 logger.LogWarning("Unhandled {JsonType} in fallback hub {Address} - answering {ErrorType} NACK: {Reason}",
                     jsonType, Address, nackPolicy.ErrorType, reason);
+                var nackPosted = false;
                 try
                 {
                     Post(new DeliveryFailure(delivery)
@@ -1421,16 +1422,20 @@ public class MessageService : IMessageService
                         NodeTypePath = nackPolicy.NodeTypePath,
                         Message = reason
                     }, new PostOptions(Address).ResponseFor(delivery));
+                    nackPosted = true;
                 }
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "Failed to post fallback NACK for '{JsonType}' (ID: {MessageId}) in {Address}",
                         jsonType, delivery.Id, Address);
                 }
-                // The typed NACK above IS this request's failure response. Mark it so the
-                // Failed-state check on the way out does not post an unclassified second one and
-                // race it to the caller's subject.
-                return delivery.Failed(reason).WithProperty(FailureAlreadyReported, true);
+                // 🚨 Mark ONLY when the typed NACK actually went out. The marker suppresses the
+                // unclassified follow-up, so setting it after a THROWN post would leave the caller
+                // with no failure response at all — turning a swallowed exception into the silent
+                // park this whole NACK path exists to prevent. Suppress the duplicate, never the
+                // only answer.
+                var failed = delivery.Failed(reason);
+                return nackPosted ? failed.WithProperty(FailureAlreadyReported, true) : failed;
             }
 
             return ReportFailure(delivery.Failed(failureMessage));


### PR DESCRIPTION
Self-review of #1061, which I merged an hour ago. It had a narrow hole in the wrong direction.

## The hole

`FailureAlreadyReported` was set **unconditionally** — including on the path where the typed NACK's `Post` threw and the exception was swallowed and logged:

```csharp
try { Post(new DeliveryFailure(delivery) { ErrorType = … }); }
catch (Exception ex) { logger.LogError(…); }              // swallowed
return delivery.Failed(reason).WithProperty(FailureAlreadyReported, true);
```

In that window the marker suppressed the unclassified follow-up while **no typed failure had gone out**, so the caller got no failure response at all — a silent park. That is precisely the wedge this NACK path exists to prevent, so #1061 traded a wrong classification for a possible hang. Narrow, but the wrong direction.

## The fix

The marker is set only when the `Post` actually returned, in both NACK branches (`MessageService`'s RawJson path and `MessageHub`'s unhandled-message path).

**Suppress the duplicate, never the only answer.**

## Verified

`MeshWeaver.Messaging.Hub.Test` **167/167** · `OrleansBrokenNodeTypeAccessTest` **2/2**, including under `DOTNET_PROCESSOR_COUNT=4` (the CI-load reproduction).

## Not this PR

`OrleansBrokenNodeTypeAccessTest.Subscribe_ToLayoutAreaOf_NonCompilingNodeTypeInstance_SurfacesError_NotWedge` is currently red on main. It is **not** caused by #1061 — it passes locally 2/2 even under the CPU constraint, and it is documented failing on PRs #1051 and #1048, both predating that work. It is the GUI-subscription half of the same wedge and still needs its own root-cause pass; it is what is keeping CD's gate shut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU2kBewK9hnv2WLQB6H8GH