### PR TITLE
Wire the missing silo logger: 45 seconds of silence nobody could see

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
@@ -115,22 +115,38 @@ internal static class OrleansClusterDisposal
     /// <summary>
     /// The gate every cluster teardown passes through — BOUNDED, not <see cref="IoPool.Unbounded"/>.
     ///
-    /// <para>🚨 Unbounded was the cross-test starvation. Each disposal is made hot immediately so the
-    /// next class's cluster can start, which is correct — but with no bound, every cluster this
-    /// assembly ever built could be shutting down AT ONCE underneath the class currently running.
-    /// Silo shutdown is not cheap, and on a 4-vCPU runner those overlapping teardowns starve the
-    /// live test's render: it waits on a stream that never gets scheduled and dies on its own
-    /// 30s Timeout. That is the shard-0 Orleans flake — a DIFFERENT test each run, because the
-    /// victim is simply whoever is running when enough teardowns pile up.</para>
+    /// <para>Unbounded meant every cluster this assembly ever built could be shutting down AT ONCE
+    /// underneath the class currently running. Each disposal is made hot immediately so the next
+    /// class's cluster can start, which is correct — but silo shutdown is not cheap, so the bound
+    /// keeps teardown from competing with the suite.</para>
     ///
-    /// <para>Reproduced with <c>DOTNET_PROCESSOR_COUNT=4</c> (the runner's shape): the whole project
-    /// fails there and passes unconstrained, and the victim class passes ALONE under the same
-    /// constraint — so it is the overlap, not the test.</para>
+    /// <para>🚨 The previous wording claimed this bound IS the shard-0 Orleans flake fix. It is not,
+    /// and the flake is NOT resource contention. Measured 2026-08-10 on the real 4-vCPU runner, whole
+    /// project per iteration (<c>Flake repro (manual)</c>): with <c>maxParallelThreads:4</c> it failed
+    /// at iteration 3/6 (OrleansDelegationTest.Resubmit_AfterDelegation_DoesNotDeadlock); with the
+    /// suite-wide SERIAL config it failed at iteration 2/6 (OrleansSubmitFromIdleTest +
+    /// ThreadStartWedgeReproTest). Removing the parallelism changes nothing.</para>
+    ///
+    /// <para>Nor is the process starved when it happens. Across five serial local runs of the whole
+    /// project the PASSING tests keep an identical profile — median 0.57-0.62 s, p90 1.33-1.84 s,
+    /// 131-136 s in total — whether the run is green at ~136 s or red at ~230 s. The entire extra
+    /// wall-clock of a red run is the victim's own 45 s budget. Everything else runs at full speed
+    /// while exactly one test waits.</para>
+    ///
+    /// <para>What it actually looks like, with the silo logger finally wired (see
+    /// <c>DynamicCompilationSiloConfigurator</c>): the victim creates its node, and then the silo
+    /// logs NOTHING for the whole 45 s — no <c>[ACTIVATE]</c>, no <c>[ENRICH-DIAG]</c>, no
+    /// <c>[COMPILE-TRACE]</c> — while other Information-level lines keep flowing. The request never
+    /// reaches the grain. The victim rotates because it is whoever asks during the window, and the
+    /// class recovers instantly afterwards (OrleansBrokenNodeTypeAccessTest's second test passes in
+    /// 2.26 s right after the first has burned 46.6 s; the class ALONE runs both in 3.2 s). Do not
+    /// re-derive "starvation" from the rotating names — that has now been asserted and refuted
+    /// three times.</para>
     ///
     /// <para>Bounding is the framework's own prescription for this ("concurrency bounding channels
     /// through <c>IIoPool</c>"), not a tuning knob: it keeps teardown off the xUnit thread — which is
-    /// what avoids the original deadlock — while stopping it from competing with the suite. Legs of
-    /// different clusters never wait on each other, so a bound cannot deadlock the drain.</para>
+    /// what avoids the original deadlock. Legs of different clusters never wait on each other, so a
+    /// bound cannot deadlock the drain.</para>
     /// </summary>
     private static readonly IIoPool DisposalPool = new IoPool(2);
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDynamicCompilationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDynamicCompilationTest.cs
@@ -389,7 +389,16 @@ public class DynamicCompilationSiloConfigurator : ISiloConfigurator, IHostConfig
     public void Configure(ISiloBuilder siloBuilder)
     {
         siloBuilder.ConfigureMeshWeaverServer()
-            .AddMemoryGrainStorageAsDefault();
+            .AddMemoryGrainStorageAsDefault()
+            // 🚨 Same reason TestSiloConfigurator does it, and this configurator was the
+            // one place missing it: without an xUnit logger on the SILO, a failure in a
+            // class built on this configurator shows only the test's own Output.WriteLine.
+            // OrleansBrokenNodeTypeAccessTest is exactly that shape — it times out waiting
+            // for enrichment to produce an overlay, and every line that says WHICH overlay
+            // branch was taken (the [ENRICH-DIAG] trace, the probe-faulted warning) is
+            // written by the silo. Two days of this cluster were investigated with those
+            // lines invisible.
+            .ConfigureLogging(logging => logging.AddXUnitLogger());
         siloBuilder.ConfigureServices(services =>
             services.AddFileSystemAssemblyStore(TestSiloConfigurator.AssemblyStoreRoot));
     }


### PR DESCRIPTION
> **This PR does not fix the flake.** It fixes the reason nobody can see it. Read the
> measurements below before spending another session on a theory — three have now been
> refuted with data, two of them mine, in this PR's own history.

## What the failure actually is

`OrleansBrokenNodeTypeAccessTest` fails **two different ways**, and they are not the same bug:

| CI run | test | failure | timing |
|---|---|---|---|
| 31358230786 | `Subscribe_ToLayoutAreaOf_…_SurfacesError_NotWedge` | `System.TimeoutException` at line 198 — **nothing emitted** | START 05:30:45.206 → FAILED 05:31:33.797 = **48.6 s** (45 s budget + 3.6 s setup) |
| 31357286162 | `Instance_OfNonCompilingNodeType_…` | `Expected value to be CompilationFailed, but found Unknown` — a **wrong value** | reached the assertion in ~13 s |

The second is the double-answer race #1061 fixed and #1070 finished. The first is a **wedge** and
is untouched by either.

## The wedge, with the silo finally talking

`DynamicCompilationSiloConfigurator` — the configurator behind this very class — never wired
`AddXUnitLogger`, though `TestSiloConfigurator` does and explains why. So every CI log of every one
of these failures contained two `Output.WriteLine`s and a timeout, and nothing about what the silo
was doing. That is what this PR changes. With it wired, a local in-suite reproduction reads:

```
08:36:18.975  Node created at type/OrleansBrokenSub…/broken-sub-instance
08:36:18.992  MESSAGE_FLOW: CreateNodeResponse
              ← 45 seconds of complete silo silence ←
08:37:03.997  === TEST FAILED: The operation has timed out.
```

No `[ACTIVATE]`, no `[ENRICH-DIAG]`, no `[COMPILE-TRACE]`, while Information-level lines flow freely
on either side of the gap. **The request never reaches the grain.** A second victim, in a different
class, reads identically — 45.2 s of silence, thread stuck at `Status = Executing` with
`LastActivityAt == ExecutionStartedAt`, i.e. the round began and produced zero activity.

## Refuted today, with numbers

**1. It is not that test, and not cold Roslyn.** Run ALONE the class does both tests in **3.2 s**,
4/4 green. In-suite the same first test burns **46.6 s** and fails — and its own sibling passes in
**2.26 s** immediately afterwards on the same cluster. The machinery is fine at that moment.

**2. It is not resource starvation.** Five serial local runs of the whole project (whole assembly,
one process, `DOTNET_PROCESSOR_COUNT=4`), passing tests only:

| run | wall | median | p90 | Σ passing | failures |
|---|---|---|---|---|---|
| armA-6 | 134.5 s | 0.60 s | 1.33 s | 131.3 s | – |
| armC-1 | 135.8 s | 0.59 s | 1.57 s | 133.1 s | – |
| armD-1 | 136.5 s | 0.57 s | 1.66 s | 133.4 s | – |
| armD-2 | 186.7 s | 0.59 s | 1.59 s | 135.9 s | 1 |
| armB-1 | 229.6 s | 0.62 s | 1.84 s | 134.0 s | 2 |

The passing-test profile is **identical** in green and red runs. The whole extra wall-clock of a red
run is the victim's own 45 s budget. Nothing is slow; exactly one thing never happens.

Three further serial runs (armD-3/4/5) are deliberately **excluded** from that table: I was building
and downloading CI logs beside them, and one overlapped a second test process outright (Σ passing
310.9 s inside a 109.8 s wall). Their profiles are degraded (Σ passing 177–225 s) and they cannot
support a profile comparison. armD-3 is still where the traced 45-second-silence log above came
from, and its failure is real; it is just not admissible as a *timing* datum. Excluding them, serial
is 2 red of 5; including them, 3 red of 5 (rerunning this will not reproduce the exact numbers
unless the machine is otherwise idle).

**3. It is not the intra-project parallelism** — this was my first conclusion and it is wrong.
`maxParallelThreads: 4` (81e782191, #1010) landed on main at 2026-08-09 14:16 UTC, and the
correlation is genuinely striking: **1 Orleans victim in the 20 named red main runs before it, 11 of
11 after**, rotating across 9 distinct tests. But a controlled before/after on the **real 4-vCPU
runner** (`Flake repro (manual)`, whole project per iteration, 6 iterations each) says it is not causal:

| arm | config | result |
|---|---|---|
| [31361513174](https://github.com/Systemorph/MeshWeaver/actions/runs/31361513174) — `main` | `maxParallelThreads: 4` | **failed iteration 3/6** — `OrleansDelegationTest.Resubmit_AfterDelegation_DoesNotDeadlock` |
| [31361522935](https://github.com/Systemorph/MeshWeaver/actions/runs/31361522935) — branch | suite-wide serial | **failed iteration 2/6** — `OrleansSubmitFromIdleTest.SubmitFromIdle_ThreeSequential_EachReachesIdle` + `ThreadStartWedgeReproTest.StartThread_NewChat_ReachesTerminal_AndHubStaysResponsive` |

Serial is not better, and is not faster (3 m 40 s – 5 m 19 s per iteration against 3 m 14 s). The
revert was in this PR and has been dropped; only the diagnostics remain.

## The shape to hunt next

Across today's controlled runs the victims were `OrleansDelegationTest`, `OrleansSubmitFromIdleTest`,
`ThreadStartWedgeReproTest`, `DelegationCompletionTest` (×2), `OrleansResubmitDeadlockTest`,
`OrleansMarkdownExportTest` (×2, two different tests), `OrleansBrokenNodeTypeAccessTest`,
`OrleansPostgresLifecycleTest` — layout-area subscribes, agent
rounds and imports alike. Every one waits on a stream emission behind a 30–45 s budget. In every
traced case the silo is **silent** for the whole budget and healthy on both sides of it, and the
class recovers the instant the test ends.

So: a request to a freshly-created node's grain occasionally never arrives, once per run or two,
independent of parallelism and independent of load. That is where the next session should start —
with these logs, which now exist.

## Also corrected

`OrleansClusterDisposal.DisposalPool`'s comment claimed the `IoPool(2)` teardown bound **is** the
shard-0 fix, and told the story of starvation as established fact. Both are measured false above.
The comment now carries the measurements instead. The bound itself stays — it is right on its own
merits (teardown belongs off the xUnit thread and behind `IIoPool`).

## Verification

- `dotnet build test/MeshWeaver.Hosting.Orleans.Test -c Release -warnaserror` — 0 warnings, 0 errors.
- Branch merged with current `main`.
- **No What's New entry**: test-diagnostics only, no user-visible change — the skip the `pullrequest`
  skill calls for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
