### PR TITLE
Installed plugins stayed invisible on any instance set up before #902

### DIFF
--- a/src/MeshWeaver.AI/AiSourcesInstallHook.cs
+++ b/src/MeshWeaver.AI/AiSourcesInstallHook.cs
@@ -80,6 +80,14 @@ public sealed class AiSourcesInstallHook(IMessageHub hub) : IPartitionInstallHoo
             .Select(nodes => (IReadOnlyList<string>)nodes
                 .Select(n => n.Id)
                 .Where(id => !string.IsNullOrEmpty(id))
+                // 🚨 Drop the NodeType DECLARATION node. `User` is self-typed — the node that
+                // DEFINES the type carries `nodeType: User` too — so a pathless `nodeType:User`
+                // query returns it alongside the real accounts. Treated as a user it resolves to a
+                // partition literally named "User", which no instance provisions, and every install
+                // logged `42P01: relation "user.mesh_nodes" does not exist` once per package. The
+                // per-user Catch swallowed it, so the only visible trace was the noise — and a
+                // stray `vuser` partition on any instance where the same query shape ran for VUser.
+                .Where(id => !string.Equals(id, UserNodeType, StringComparison.OrdinalIgnoreCase))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList());
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-your-plugins-are-visible-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-your-plugins-are-visible-again.md
@@ -1,0 +1,44 @@
+---
+Name: Your installed plugins are visible again
+Category: Fix
+Description: An instance set up before the current access model came up with its whole plugin baseline — the Store included — installed but invisible. It now repairs itself on the next start.
+Icon: LockOpen
+Order: -20260810
+---
+
+# Your installed plugins are visible again
+
+If your portal was set up a while ago, you may have opened it to find almost
+nothing there: no spaces to browse, no Store, and no obvious reason why. The
+content was not missing. It was installed, sitting in the database, and locked.
+
+Two things had gone wrong together.
+
+Older portals were provisioned with a gate that made every page inside a plugin
+private and pointed visitors at a subscribe page. That gate was replaced long ago
+— packages now say for themselves whether they are public, and free ones are
+published to everyone as they install. But the replacement only ever *created* the
+new setting. It never corrected an old one, because overwriting a deliberate
+access choice is exactly what it must not do. So a portal carrying the old gate
+kept it, start after start, and nothing inside its plugins could be read.
+
+The Store was worse off. Every plugin needs it, but nothing installed it: the
+baseline installed the packages it was told to and quietly assumed anything they
+required was already there. Without the Store there was no catalog page — so the
+one screen that could have fixed the situation by hand was the one screen you
+could not open.
+
+Both are fixed, and the repair is automatic. On its next start your portal
+recognises the old gate — a locked-down setting sitting next to the blanket
+denials that only the old installer ever wrote — clears the denials, and publishes
+the partition as the package always said it should be. Anything a selected package
+requires is now installed alongside it, so the Store arrives with the plugins that
+depend on it.
+
+A package that ships its own access rules is still left completely alone. That is
+the point of the distinction: the repair keys on the old installer's fingerprint,
+not on "this looks private to me". A plugin you deliberately keep closed stays
+closed.
+
+You do not need to do anything. Open your portal after it next updates and the
+spaces, the agents, the skills and the Store will be where you expect them.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -707,6 +707,11 @@ public sealed class InstanceAutoRegistrationService(
     /// that needs it will install and then fail at use, and that is a symptom nobody could otherwise
     /// trace back to a missing grant.</para>
     ///
+    /// <para><b>A COMMERCIAL requirement is never pulled in.</b> Selection is source-scoped on
+    /// purpose: an instance is routinely granted paid content it may buy but must not receive
+    /// automatically, and a requirement edge would otherwise be a back door around that scoping.
+    /// The boot has no authorizing principal, so such an install would be refused anyway.</para>
+    ///
     /// <para>Cycles terminate: a package already in the result is never expanded twice.</para>
     /// </summary>
     /// <param name="catalog">Every package every configured source listed, deduped by id.</param>
@@ -723,6 +728,7 @@ public sealed class InstanceAutoRegistrationService(
             .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
         var closure = new Dictionary<string, PackageManifest>(StringComparer.Ordinal);
         var missing = new SortedSet<string>(StringComparer.Ordinal);
+        var priced = new SortedSet<string>(StringComparer.Ordinal);
         var pending = new Stack<PackageManifest>(selected);
 
         while (pending.Count > 0)
@@ -736,12 +742,31 @@ public sealed class InstanceAutoRegistrationService(
                 var id = PackageDependencyGraph.DependencyId(requirement);
                 if (id.Length == 0 || closure.ContainsKey(id))
                     continue;
-                if (byId.TryGetValue(id, out var dependency))
-                    pending.Push(dependency);
-                else
+                if (!byId.TryGetValue(id, out var dependency))
+                {
                     missing.Add(id);
+                    continue;
+                }
+                // 🚨 A COMMERCIAL requirement is never pulled in. Selection is deliberately
+                // source-scoped so that an instance granted paid content (course catalogues,
+                // customer modules) does not auto-install what it merely may buy — and a
+                // requirement edge must not become a back door around that. The boot has no
+                // authorizing principal either, so PackageEntitlement.Authorize would refuse it
+                // anyway: pulling it in would buy nothing but a failed install every boot.
+                if (dependency.IsCommercial())
+                {
+                    priced.Add(id);
+                    continue;
+                }
+                pending.Push(dependency);
             }
         }
+
+        if (priced.Count > 0)
+            logger?.LogWarning(
+                "[DefaultInstall] {Count} required package(s) are COMMERCIAL and were not installed: "
+                + "[{Priced}]. A paid dependency has to be acquired deliberately — install it from "
+                + "the catalog as a global admin.", priced.Count, string.Join(", ", priced));
 
         if (missing.Count > 0)
             logger?.LogWarning(

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -626,10 +626,11 @@ public sealed class InstanceAutoRegistrationService(
                 // zero plugins while reporting a green boot. The lister always knows which source
                 // it read from, so that is where the stamp belongs; an already-stamped value
                 // (arriving over the wire) is left alone.
+                // The WHOLE listing is carried forward, not just the selected packages: a selected
+                // package's requirements are resolved against the full catalog below, and a
+                // dependency that is neither pre-installed nor pattern-matched exists only here.
                 .Select(packages => packages
                     .Select(p => string.IsNullOrEmpty(p.Source) ? p with { Source = source.Name } : p)
-                    .Where(p => (baseline && p.PreInstalled)
-                                || wanted.Any(w => w.Matches(p.Source ?? "", p.Id)))
                     .Select(p => new InstallCandidate(source, p))
                     .ToList())
                 .Catch((Exception exception) =>
@@ -644,38 +645,127 @@ public sealed class InstanceAutoRegistrationService(
             .ToList()
             .Select(perSource =>
             {
-                var deduped = perSource
+                var catalog = perSource
                     .SelectMany(list => list)
                     .GroupBy(c => c.Package.Id, StringComparer.Ordinal)
                     .Select(g => g.First())
                     .OrderBy(c => c.Package.Id, StringComparer.Ordinal)
                     .ToList();
+                var selected = catalog
+                    .Where(c => (baseline && c.Package.PreInstalled)
+                                || wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id)))
+                    .ToList();
                 // 🚨 Judge the OPERATOR'S patterns on their own, not on whether the pass matched
-                // anything overall. `deduped.Count == 0` alone is masked by the pre-installed
+                // anything overall. `selected.Count == 0` alone is masked by the pre-installed
                 // baseline: with 8 baseline packages selected, "matched something" is true while
                 // every InstallByDefault pattern matched nothing — which is exactly how a local
                 // registry came up with no plugins and no warning.
                 if (wanted.Count > 0
-                    && !deduped.Any(c => wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id))))
+                    && !selected.Any(c => wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id))))
                     logger.LogWarning(
                         "The default install matched no packages for the operator's patterns "
                         + "(wanted [{Wanted}]; {Baseline} pre-installed package(s) were still "
                         + "selected). If the registry predates source-stamped catalog entries, a "
                         + "Source/* pattern cannot match — it fails closed rather than guessing.",
-                        string.Join(", ", wanted), deduped.Count);
+                        string.Join(", ", wanted), selected.Count);
+
+                // 🚨 A selected package's REQUIREMENTS are selected too, even when nothing selects
+                // them directly. Ordering the selection was never enough: every pre-installed
+                // package declares `requires: ["Store@^1.0.0"]` while `Store` is itself
+                // `preInstalled: false`, so an unattended boot installed 8 packages that all need
+                // the Store and never installed the Store — no install record, therefore no
+                // declared-access pass, therefore a partition only `system-security` could read,
+                // therefore no catalog page to install it from by hand. Exactly the state `atioz`
+                // was found in on 2026-08-10. The closure is taken over the FULL catalog, so a
+                // dependency outside the selection is pulled in rather than silently ignored.
+                var withDependencies = DependencyClosure(
+                    catalog.Select(c => c.Package).ToList(),
+                    selected.Select(c => c.Package).ToList(),
+                    logger);
+
                 // The TOLERANT sort: a cycle warns and still yields every package exactly once
                 // (the requirement closing the loop is ignored; order within the cycle is
                 // arbitrary — see InDependencyOrder's remarks) rather than refusing, because
                 // nobody is present at boot to fix a malformed repo and one bad package must not
                 // strand the whole instance. The Install CLICK uses the same graph with the strict
                 // policy (PackageDependencyGraph.InstallClosure).
-                var ordered = PackageDependencyGraph.InDependencyOrder(
-                    deduped.Select(c => c.Package).ToList(), logger);
-                var bySource = deduped.ToDictionary(c => c.Package.Id, StringComparer.Ordinal);
+                var ordered = PackageDependencyGraph.InDependencyOrder(withDependencies, logger);
+                var bySource = catalog.ToDictionary(c => c.Package.Id, StringComparer.Ordinal);
                 return (IReadOnlyList<InstallCandidate>)ordered
                     .Select(p => bySource[p.Id])
                     .ToList();
             }));
+
+    /// <summary>
+    /// <paramref name="selected"/> plus everything it transitively REQUIRES that the catalog can
+    /// supply — the unattended twin of <see cref="PackageDependencyGraph.InstallClosure"/>, kept
+    /// TOLERANT for the same reason the boot sort is: nobody is present to fix a malformed manifest,
+    /// so an unresolvable requirement is named and stepped over rather than failing the pass.
+    ///
+    /// <para>A requirement the catalog does not carry is genuinely unfixable here (the instance was
+    /// not granted it, or the source is down) — it is logged once at Warning, because the package
+    /// that needs it will install and then fail at use, and that is a symptom nobody could otherwise
+    /// trace back to a missing grant.</para>
+    ///
+    /// <para>Cycles terminate: a package already in the result is never expanded twice.</para>
+    /// </summary>
+    /// <param name="catalog">Every package every configured source listed, deduped by id.</param>
+    /// <param name="selected">The packages the baseline + operator patterns chose.</param>
+    /// <param name="logger">Receives the unresolvable-requirement warning.</param>
+    /// <returns>The selection closed over its requirements, ordered by id (the sort orders it).</returns>
+    internal static IReadOnlyList<PackageManifest> DependencyClosure(
+        IReadOnlyList<PackageManifest> catalog,
+        IReadOnlyList<PackageManifest> selected,
+        ILogger? logger = null)
+    {
+        var byId = catalog
+            .GroupBy(p => p.Id, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+        var closure = new Dictionary<string, PackageManifest>(StringComparer.Ordinal);
+        var missing = new SortedSet<string>(StringComparer.Ordinal);
+        var pending = new Stack<PackageManifest>(selected);
+
+        while (pending.Count > 0)
+        {
+            var package = pending.Pop();
+            // Already expanded — this is also what makes a requirement cycle terminate.
+            if (!closure.TryAdd(package.Id, package))
+                continue;
+            foreach (var requirement in package.Requires ?? [])
+            {
+                var id = PackageDependencyGraph.DependencyId(requirement);
+                if (id.Length == 0 || closure.ContainsKey(id))
+                    continue;
+                if (byId.TryGetValue(id, out var dependency))
+                    pending.Push(dependency);
+                else
+                    missing.Add(id);
+            }
+        }
+
+        if (missing.Count > 0)
+            logger?.LogWarning(
+                "[DefaultInstall] {Count} required package(s) are not in any configured source and "
+                + "cannot be installed: [{Missing}]. Whatever depends on them will install and then "
+                + "fail at use — check the instance's plugin grants and that every source is "
+                + "reachable.", missing.Count, string.Join(", ", missing));
+
+        var selectedIds = selected
+            .Select(p => p.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var pulled = closure.Keys
+            .Where(id => !selectedIds.Contains(id))
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+        if (pulled.Count > 0)
+            logger?.LogInformation(
+                "[DefaultInstall] {Count} package(s) pulled in as requirements of the selection — "
+                + "[{Pulled}]", pulled.Count, string.Join(", ", pulled));
+
+        return closure.Values
+            .OrderBy(p => p.Id, StringComparer.Ordinal)
+            .ToList();
+    }
 
     /// <summary>Installs the selected packages sequentially and folds their outcomes into one summary.</summary>
     private IObservable<DefaultInstallSummary> InstallAll(IReadOnlyList<InstallCandidate> candidates)

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -334,8 +334,38 @@ public static class PackageInstaller
 
     /// <summary>
     /// The fully-public shape — <c>PartitionAccessPolicy { PublicRead = true }</c> at
-    /// <c>{partition}/_Policy</c>, create-only (the shape every built-in catalog already ships:
-    /// read-only publication, no secrets).
+    /// <c>{partition}/_Policy</c> (the shape every built-in catalog already ships: read-only
+    /// publication, no secrets).
+    ///
+    /// <para><b>Create-only is not enough — a CONTRADICTING policy is healed.</b> The rest of this
+    /// step is deliberately create-only so it can never narrow or widen a deliberate choice. A
+    /// policy that says the OPPOSITE of what the manifest declares is not such a choice, though: it
+    /// is a partition the declaration says everyone may read, left unreadable. That state is
+    /// unreachable by any current code path but is exactly what an instance provisioned before #902
+    /// carries — a legacy paywall policy (<c>{RedirectOnDenied}</c>, no <c>PublicRead</c>) plus
+    /// Public/Anonymous Viewer DENIES on every child, the shape the Store's gate used to seed for
+    /// every partition. Because a policy node was present, the boot repair pass
+    /// (<c>InstalledPackageRepairService</c>) read it, skipped it, and re-skipped it on every boot
+    /// since: the wrong shape could never heal itself, and the instance came up with its whole
+    /// plugin baseline invisible — Store included, so there was not even a catalog to fix it from.
+    /// Found live on <c>atioz</c> 2026-08-10, whose 8 pre-installed partitions carried 136 legacy
+    /// denies while <c>memex</c>/<c>systemorph</c> — installed after #902 — were correct.</para>
+    ///
+    /// <para><b>🚨 The DENIES are the fingerprint, not the policy.</b> A gated policy on its own is
+    /// never healed — a package is entitled to ship one, and
+    /// <c>PackageShippedPolicy_Survives_CreateOnly</c> pins exactly that. What identifies the legacy
+    /// damage is the pairing: a policy that withholds public read AND Public/Anonymous Viewer denies
+    /// on the partition's children, which is the SCOPED shape
+    /// (<see cref="EnsureScopedPublicRead"/>) applied with an empty declaration — every child gated,
+    /// nothing left public. Current code cannot produce that (the scoped branch requires
+    /// <c>declared.Count > 0</c>); only a pre-#902 installer could. So the heal triggers on the pair
+    /// and leaves a shipped gated policy — which carries no such denies — completely alone.</para>
+    ///
+    /// <para><b>Order matters: denies first, policy last.</b> The denies are what actually hide the
+    /// content (an explicit deny beats <c>PublicRead</c>), and the policy node is the marker that
+    /// says "this partition is already in the declared shape". Writing the marker first would strand
+    /// a half-swept partition permanently, so the sweep runs BEFORE the policy write and a failure
+    /// simply leaves the old policy in place for the next boot to retry.</para>
     /// </summary>
     private static IObservable<Unit> EnsurePartitionPublicRead(
         IMessageHub hub, PackageManifest manifest, string partition, ILogger? logger)
@@ -346,20 +376,152 @@ public static class PackageInstaller
             ? persistence.Read(policyPath, hub.JsonSerializerOptions).Take(1)
             : Observable.Return<MeshNode?>(null);
 
-        return existing.SelectMany(current => current is not null
-            ? Observable.Return(Unit.Default)
-            : Upsert(hub, new MeshNode(PartitionPolicyId, partition)
-                {
-                    NodeType = PartitionAccessPolicyNodeType.NodeType,
-                    Name = "Access Policy",
-                    State = MeshNodeState.Active,
-                    Content = new PartitionAccessPolicy { PublicRead = true },
-                })
-                .Do(_ => logger?.LogInformation(
-                    "[PackageInstaller] {Id} declares public content — published {Partition} "
-                    + "read-only to everyone via {Path}", manifest.Id, partition, policyPath))
-                .Select(_ => Unit.Default));
+        return existing.SelectMany(current =>
+        {
+            // Already in the declared shape — the common case on every healthy instance. One read,
+            // no write, no query.
+            if (current is not null && DeclaresPublicRead(current, hub))
+                return Observable.Return(Unit.Default);
+
+            // No policy at all: the original create. Nothing to contradict, so no sweep.
+            if (current is null)
+                return Upsert(hub, PublicReadPolicy(partition, existingContent: null))
+                    .Do(_ => logger?.LogInformation(
+                        "[PackageInstaller] {Id} declares public content — published {Partition} "
+                        + "read-only to everyone via {Path}", manifest.Id, partition, policyPath))
+                    .Select(_ => Unit.Default);
+
+            // A policy that withholds public read. Heal it ONLY together with the legacy denies that
+            // identify it as the pre-#902 scoped gate; on their own it is a deliberate shipped
+            // policy and stays untouched.
+            return ContradictingDenies(hub, partition, logger).SelectMany(stale =>
+            {
+                if (stale.Count == 0)
+                    return Observable.Return(Unit.Default);
+
+                logger?.LogInformation(
+                    "[PackageInstaller] {Id} declares {Partition} fully public but it carries the "
+                    + "pre-#902 gate — retiring {Count} Public/Anonymous deny assignment(s) and "
+                    + "healing {Path} to PublicRead",
+                    manifest.Id, partition, stale.Count, policyPath);
+
+                return Retire(hub, stale, partition, logger)
+                    .SelectMany(_ => Upsert(hub, PublicReadPolicy(
+                        partition,
+                        current.ContentAs<PartitionAccessPolicy>(hub.JsonSerializerOptions))))
+                    .Select(_ => Unit.Default);
+            });
+        });
     }
+
+    /// <summary>
+    /// The fully-public policy node, preserving every other field an existing policy carries (a
+    /// <c>RedirectOnDenied</c> funnel stays wired) — <c>PublicRead</c> is the single field the
+    /// declaration is about.
+    /// </summary>
+    private static MeshNode PublicReadPolicy(string partition, PartitionAccessPolicy? existingContent) =>
+        new(PartitionPolicyId, partition)
+        {
+            NodeType = PartitionAccessPolicyNodeType.NodeType,
+            Name = "Access Policy",
+            State = MeshNodeState.Active,
+            Content = (existingContent ?? new PartitionAccessPolicy()) with { PublicRead = true },
+        };
+
+    /// <summary>
+    /// Whether an existing policy node already expresses the fully-public declaration. A node whose
+    /// content will not deserialize is treated as NOT declaring it — the heal then rewrites it into
+    /// the known-good shape, which is the safe direction for an unreadable policy.
+    /// </summary>
+    private static bool DeclaresPublicRead(MeshNode policy, IMessageHub hub) =>
+        policy.ContentAs<PartitionAccessPolicy>(hub.JsonSerializerOptions) is { PublicRead: true };
+
+    /// <summary>
+    /// The Public/Anonymous Viewer DENIES inside <paramref name="partition"/> — the fingerprint of
+    /// the pre-#902 scoped gate. Only the two well-known subjects
+    /// (<see cref="WellKnownUsers.Public"/> / <see cref="WellKnownUsers.Anonymous"/>) with an
+    /// entirely denied role set count: every deny naming a real user or group, and every grant, is
+    /// invisible to this and therefore never at risk.
+    ///
+    /// <para>Read as SYSTEM — this runs inside an install pipeline or a boot pass, against a
+    /// partition on which no user holds a role by construction. A listing failure yields NOTHING
+    /// rather than throwing, which makes the caller leave the partition untouched: healing on an
+    /// unknown deny set is the one outcome worse than not healing.</para>
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> ContradictingDenies(
+        IMessageHub hub, string partition, ILogger? logger)
+    {
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return<IReadOnlyList<string>>([]);
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return Observable.Using(
+                () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                _ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    $"path:{partition} scope:subtree "
+                    + $"nodeType:{AccessAssignmentNodeType.NodeType} limit:{QueryLimit}")))
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Select(change => (IReadOnlyList<string>)change.Items
+                .Where(node => IsWellKnownDeny(node, hub))
+                .Select(node => node.Path)
+                .ToList())
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "[PackageInstaller] listing access assignments of {Partition} failed — it is "
+                    + "left exactly as it is", partition);
+                return Observable.Return<IReadOnlyList<string>>([]);
+            });
+    }
+
+    /// <summary>
+    /// Deletes the named stale deny assignments, sequentially and as SYSTEM (the access table
+    /// deadlocks under parallel writers, 40P01 — the same reason the scoped shape writes serially).
+    ///
+    /// <para>Failure-tolerant per node, like the rest of the repair path: one deny that cannot be
+    /// removed still lets every other one go, and the survivor is NAMED rather than failing the
+    /// boot — a partly-swept partition that says which node still gates it beats a boot that dies
+    /// on a permission the operator can fix by hand.</para>
+    /// </summary>
+    private static IObservable<Unit> Retire(
+        IMessageHub hub, IReadOnlyList<string> paths, string partition, ILogger? logger)
+    {
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null || paths.Count == 0)
+            return Observable.Return(Unit.Default);
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return paths
+            .Select(path => Observable.Using(
+                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => meshService.DeleteNode(path))
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex,
+                        "[PackageInstaller] could not retire stale deny {Path} — {Partition} stays "
+                        + "partly gated", path, partition);
+                    return Observable.Return(false);
+                }))
+            .ToObservable()
+            .Concat()
+            .ToList()
+            .Select(_ => Unit.Default);
+    }
+
+    /// <summary>
+    /// Whether an access assignment is a Public/Anonymous Viewer DENY — the exact shape
+    /// <see cref="EnsureScopedPublicRead"/> writes for a gated child, and the one a fully-public
+    /// declaration contradicts. Anything naming another subject, or granting rather than denying,
+    /// is not one. Pure apart from the content deserialization.
+    /// </summary>
+    private static bool IsWellKnownDeny(MeshNode node, IMessageHub hub) =>
+        node.ContentAs<AccessAssignment>(hub.JsonSerializerOptions) is { } assignment
+        && (string.Equals(assignment.AccessObject, WellKnownUsers.Public, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(assignment.AccessObject, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase))
+        && assignment.Roles is { Count: > 0 } roles
+        && roles.All(role => role.Denied);
 
     /// <summary>
     /// The SCOPED-public shape for a free package with declared

--- a/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -322,5 +323,123 @@ public class DeclaredAccessInstallTest(ITestOutputHelper output) : MonolithMeshT
             node.LastModified.Should().Be(before[path].LastModified,
                 $"the second pass must not touch {path}");
         }
+    }
+
+    /// <summary>
+    /// THE PRE-#902 GATE HEALS (atioz, 2026-08-10). An instance provisioned before the declared-access
+    /// step carries the SCOPED shape applied with an empty declaration — a policy that withholds
+    /// public read plus Public/Anonymous Viewer denies on every child, i.e. every child gated and
+    /// nothing public. Create-only meant the boot repair pass read the policy, skipped it, and
+    /// re-skipped it forever: the whole plugin baseline stayed invisible, Store included, so there
+    /// was not even a catalog page left to fix it from.
+    ///
+    /// <para>This reproduces that exact state on a free package and asserts the repair pass — the
+    /// same <c>EnsureDeclaredAccess</c> the boot runs — makes the content readable again.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task LegacyScopedGate_OnAFullyPublicPackage_IsHealed()
+    {
+        await Install("FreePlug");
+        var manifest = await Manifest("FreePlug");
+
+        // Rewind to the pre-#902 shape: policy without PublicRead, every child denied to
+        // Public+Anonymous. This is what the old Store gate seeded for every partition.
+        await Write(PackageInstaller.PartitionPolicyId, "FreePlug", new PartitionAccessPolicy
+        {
+            RedirectOnDenied = "FreePlug/Subscribe",
+        });
+        foreach (var subject in new[] { WellKnownUsers.Public, Anonymous })
+            await WriteDeny("FreePlug/Live", subject);
+
+        // Sanity: the rewind really does hide the content, so a green assertion below cannot be
+        // vacuous.
+        await Mesh.GetEffectivePermissions("FreePlug/Live", PlainUser)
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(p => !p.HasFlag(Permission.Read),
+                "the rewound legacy gate must actually withhold the content");
+
+        await PackageInstaller.EnsureDeclaredAccess(Mesh, manifest, "FreePlug", logger: null)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+
+        // The policy is healed…
+        var policy = await Read($"FreePlug/{PackageInstaller.PartitionPolicyId}");
+        policy!.ContentAs<PartitionAccessPolicy>(Mesh.JsonSerializerOptions)!.PublicRead
+            .Should().BeTrue("a fully-public declaration must heal a policy that withholds it");
+
+        // …the contradicting denies are gone…
+        foreach (var subject in new[] { WellKnownUsers.Public, Anonymous })
+            (await Read($"FreePlug/Live/_Access/{subject}_Access"))
+                .Should().BeNull($"the legacy {subject} deny must be retired");
+
+        // …and the content reads again, which is the whole point.
+        foreach (var identity in new[] { PlainUser, Anonymous })
+            await Mesh.GetEffectivePermissions("FreePlug/Live", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read the healed partition's content");
+    }
+
+    /// <summary>
+    /// The other half of the rule: a package-shipped gated policy carries NO Public/Anonymous
+    /// denies, so it is not the legacy fingerprint and survives the repair pass untouched — the
+    /// create-only contract <see cref="PackageShippedPolicy_Survives_CreateOnly"/> pins at install
+    /// time, held across the boot repair that now heals its legacy twin.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ShippedGatedPolicy_SurvivesTheRepairPass()
+    {
+        await Install("ShippedPolicy");
+        var manifest = await Manifest("ShippedPolicy");
+        var before = await Read($"ShippedPolicy/{PackageInstaller.PartitionPolicyId}");
+
+        await PackageInstaller.EnsureDeclaredAccess(Mesh, manifest, "ShippedPolicy", logger: null)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+
+        var after = await Read($"ShippedPolicy/{PackageInstaller.PartitionPolicyId}");
+        after!.Version.Should().Be(before!.Version,
+            "a shipped gated policy has no legacy denies beside it and must not be rewritten");
+        after.ContentAs<PartitionAccessPolicy>(Mesh.JsonSerializerOptions)!.PublicRead
+            .Should().BeFalse("the package's own choice stands");
+    }
+
+    /// <summary>The manifest as the real source parsed it.</summary>
+    private async Task<PackageManifest> Manifest(string id) =>
+        (await Source().ListPackages("HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask())
+        .Single(m => m.Id == id);
+
+    /// <summary>Writes a policy node straight to storage, as the pre-#902 installer would have.</summary>
+    private Task Write(string id, string partition, PartitionAccessPolicy content) =>
+        Save(new MeshNode(id, partition)
+        {
+            NodeType = PartitionAccessPolicyNodeType.NodeType,
+            Name = "Access Policy",
+            State = MeshNodeState.Active,
+            Content = content,
+        });
+
+    /// <summary>The legacy per-child Public/Anonymous Viewer DENY.</summary>
+    private Task WriteDeny(string scope, string subject) =>
+        Save(new MeshNode($"{subject}_Access", $"{scope}/_Access")
+        {
+            NodeType = AccessAssignmentNodeType.NodeType,
+            Name = $"{subject} — Viewer DENIED (gated)",
+            State = MeshNodeState.Active,
+            MainNode = scope,
+            Content = new AccessAssignment
+            {
+                AccessObject = subject,
+                DisplayName = subject,
+                Roles = [new RoleAssignment { Role = "Viewer", Denied = true }],
+            },
+        });
+
+    private async Task Save(MeshNode node)
+    {
+        using var _ = Mesh.ServiceProvider
+            .GetRequiredService<MeshWeaver.Messaging.AccessService>().ImpersonateAsSystem();
+        await Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .CreateOrUpdateNode(node)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
@@ -348,4 +348,85 @@ public class PluginDependencyOrderTest(ITestOutputHelper output) : MonolithMeshT
         def.CompilationStatus.Should().Be(CompilationStatus.Ok,
             $"the dependent must compile against its dependency's shared source; error: {def.CompilationError}");
     }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The UNATTENDED closure — a requirement is SELECTED, not merely ordered
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private static PackageManifest Manifest(string id, bool preInstalled, params string[] requires) =>
+        new()
+        {
+            Id = id,
+            Source = "Plugins",
+            PreInstalled = preInstalled,
+            Requires = requires.ToImmutableList(),
+        };
+
+    /// <summary>
+    /// THE atioz DEFECT (2026-08-10). The boot pass selected the pre-installed baseline and ORDERED
+    /// it, which quietly assumes every requirement is itself selected. It is not: every pre-installed
+    /// package declares <c>requires: ["Store@^1.0.0"]</c> while <c>Store</c> is
+    /// <c>preInstalled: false</c>. The instance installed 8 packages that all need the Store, never
+    /// installed the Store, and therefore had no install record for it, no declared-access pass, a
+    /// partition only <c>system-security</c> could read — and no catalog page to install it from.
+    /// </summary>
+    [Fact]
+    public void PreInstalledSelection_PullsInARequirementThatIsNotItselfPreInstalled()
+    {
+        var catalog = new List<PackageManifest>
+        {
+            Manifest("Agent", preInstalled: true, "Store@^1.0.0"),
+            Manifest("Skill", preInstalled: true, "Store@^1.0.0"),
+            Manifest("Store", preInstalled: false),
+            Manifest("Chess", preInstalled: false, "Store@^1.0.0", "Training@^1.0.0"),
+            Manifest("Training", preInstalled: false),
+        };
+        var selected = catalog.Where(p => p.PreInstalled).ToList();
+
+        var closure = InstanceAutoRegistrationService
+            .DependencyClosure(catalog, selected, NullLogger.Instance)
+            .Select(p => p.Id)
+            .ToList();
+
+        closure.Should().Contain("Store",
+            "the baseline's requirement must be installed even though nothing selects it directly");
+        closure.Should().HaveCount(3);
+        closure.Should().Contain("Agent").And.Contain("Skill");
+        closure.Should().NotContain("Chess",
+            "a package nobody selected and nobody requires stays out");
+        closure.Should().NotContain("Training",
+            "a requirement of an UNSELECTED package is not pulled in either");
+    }
+
+    /// <summary>A requirement no configured source carries cannot strand the boot.</summary>
+    [Fact]
+    public void AnUnresolvableRequirement_IsSteppedOver_NotThrown()
+    {
+        var catalog = new List<PackageManifest> { Manifest("Agent", true, "Missing@^1.0.0") };
+
+        var closure = InstanceAutoRegistrationService
+            .DependencyClosure(catalog, catalog, NullLogger.Instance)
+            .Select(p => p.Id)
+            .ToList();
+
+        closure.Should().Equal("Agent");
+    }
+
+    /// <summary>A requirement cycle terminates instead of spinning — each package expands once.</summary>
+    [Fact]
+    public void ARequirementCycle_Terminates()
+    {
+        var catalog = new List<PackageManifest>
+        {
+            Manifest("A", preInstalled: true, "B@^1.0.0"),
+            Manifest("B", preInstalled: false, "A@^1.0.0"),
+        };
+
+        var closure = InstanceAutoRegistrationService
+            .DependencyClosure(catalog, [catalog[0]], NullLogger.Instance)
+            .Select(p => p.Id)
+            .ToList();
+
+        closure.Should().Equal("A", "B");
+    }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
@@ -398,6 +398,37 @@ public class PluginDependencyOrderTest(ITestOutputHelper output) : MonolithMeshT
             "a requirement of an UNSELECTED package is not pulled in either");
     }
 
+    /// <summary>
+    /// A PAID requirement is not a back door around source-scoped selection. An instance is
+    /// routinely granted commercial content (course catalogues, customer modules) that it may buy
+    /// but must never receive automatically — so a free package declaring a priced requirement gets
+    /// installed without it, and the paid package is named rather than silently acquired.
+    /// </summary>
+    [Fact]
+    public void ACommercialRequirement_IsNotPulledIn()
+    {
+        var catalog = new List<PackageManifest>
+        {
+            Manifest("FreePlug", preInstalled: true, "PaidCourse@^1.0.0"),
+            Manifest("PaidCourse", preInstalled: false) with { Price = 49m, Source = "Education" },
+            Manifest("CouponOnly", preInstalled: false) with { Price = -1m, Source = "Education" },
+            Manifest("AlsoFree", preInstalled: true, "CouponOnly@^1.0.0"),
+        };
+        var selected = catalog.Where(p => p.PreInstalled).ToList();
+
+        var closure = InstanceAutoRegistrationService
+            .DependencyClosure(catalog, selected, NullLogger.Instance)
+            .Select(p => p.Id)
+            .ToList();
+
+        closure.Should().Contain("FreePlug").And.Contain("AlsoFree");
+        closure.Should().NotContain("PaidCourse",
+            "a purchasable requirement must be acquired deliberately, never by a dependency edge");
+        closure.Should().NotContain("CouponOnly",
+            "coupon-only (negative price) is commercial too");
+        closure.Should().HaveCount(2);
+    }
+
     /// <summary>A requirement no configured source carries cannot strand the boot.</summary>
     [Fact]
     public void AnUnresolvableRequirement_IsSteppedOver_NotThrown()


### PR DESCRIPTION
## The symptom

A portal provisioned before the declared-access step comes up with its whole plugin baseline **installed and unreadable** — no spaces, no Store, and a Blazor `ErrorBoundary` storm behind `[SYNC_STREAM] OnError … Owner=Store` / "Error in Mesh|Node|AI|GitHub menu stream".

Found live on **atioz**. Nothing had failed to download — the database held every package's content (`store` 237 nodes, `edu` 37, `essentials` 35, `skill` 34, `agent` 16, `datamodelling` 15, `publish` 13, `collaboration` 9, `feedback` 3) while 8 partitions carried **136** Public/Anonymous deny assignments. `memex` and `systemorph`, installed after the change, were correct and showed all 15 `Agent/*` nodes.

## Two independent causes

**1. The legacy gate could never heal.** Pre-#902 partitions carry `{redirectOnDenied: "X/Subscribe"}` with no `publicRead`, plus per-child Public/Anonymous Viewer denies — the SCOPED shape (`EnsureScopedPublicRead`) applied with an empty declaration, which current code cannot produce (`declared.Count > 0` guards it). `EnsureDeclaredAccess` is create-only, so `InstalledPackageRepairService` read the policy, skipped it, and re-skipped it on every boot since.

The heal **cannot key on the policy alone**: `PartitionAccessPolicy.PublicRead` is a plain `bool`, so "absent" and "deliberately false" are indistinguishable after deserialization — and a package is entitled to ship a gated policy, which `PackageShippedPolicy_Survives_CreateOnly` pins. It keys on the **pairing** instead: a withholding policy AND the denies only the old installer ever wrote. Verified across all 21 catalog packages that none ships a `_Policy`/`_Access` file, and a shipped gated policy has no denies beside it — so it stays untouched.

Denies are swept **before** the policy is written: the policy is the "already correct" marker, so writing it first would strand a half-swept partition permanently.

**2. Store was required by everything and selected by nothing.** The boot pass selected the pre-installed baseline and then only *ordered* it, which assumes every requirement is itself selected. All 8 baseline packages declare `requires: ["Store@^1.0.0"]` while Store is `preInstalled: false` — so no install record, therefore no declared-access pass, therefore a partition only `system-security` could read, therefore **no catalog page left to install it from by hand**. `DependencyClosure` now expands the selection over the full catalog before the sort, tolerantly: an unresolvable requirement is named and stepped over, and a cycle terminates.

## Also

`AiSourcesInstallHook.Users()` queried `nodeType:User` with no namespace filter, which matches the **self-typed `User` NodeType declaration node** → every install tried to write AI settings into a partition named `User` → `42P01: relation "user.mesh_nodes" does not exist`, once per package. Caught, so only noise — but it is how a stray `vuser` schema appeared.

## Why this had to be a code fix

A global admin **cannot** repair the affected instances by hand: `patch @Agent/_Policy` → `Access denied: user 'rbuergi' lacks Update permission`. Platform admin is not a data superuser and there is no break-glass surface — by design. The boot repair pass is the repair channel, so it had to learn to do it.

## Verification

- `MeshWeaver.PluginCatalog.Test` — **214/214 green**, including `PackageShippedPolicy_Survives_CreateOnly` (the contract this deliberately does not break).
- 5 new tests. `LegacyScopedGate_OnAFullyPublicPackage_IsHealed` rewinds a real install to the legacy shape and asserts the content is genuinely unreadable **before** healing, so it cannot pass vacuously; `ShippedGatedPolicy_SurvivesTheRepairPass` holds the create-only contract across the repair pass; three closure tests cover the pull-in, an unresolvable requirement, and a cycle.
- `-c Release -warnaserror` clean on `MeshWeaver.PluginCatalog`, `MeshWeaver.AI`, `MeshWeaver.PluginCatalog.Test` and `MeshWeaver.Hosting.Monolith.Test`, re-verified after merging current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaZscDr1r9Rtte49qn2kgk