### PR TITLE
A compile failure was logged twice, and the useless copy came first

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-failed-build-is-reported-once.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-failed-build-is-reported-once.md
@@ -1,0 +1,27 @@
+---
+Name: A failed build is reported once, not twice
+Category: Fix
+Description: When something you built does not compile, the failure is now recorded a single time, with the diagnostics and the source list attached — instead of twice, the first time with neither.
+Icon: Sparkle
+Order: -20260810
+---
+
+# A failed build is reported once, not twice
+
+When the C# behind one of your types does not compile, the platform records the
+failure so an operator can see it. Until now it recorded the same failure twice:
+once at the moment the compiler returned its errors, and again when the build
+pipeline handled the result.
+
+Only the second record was useful. It carried the compiler diagnostics, the type
+that failed, and the list of source files the build actually found — the thing
+you need to tell "my code has a typo" apart from "the build did not pick up my
+source files". The first record had none of that context, and because it arrived
+first, it was the one that got read. It made a plain compile error look like a
+problem with writing the built assembly to disk, which sent more than one
+investigation down the wrong path.
+
+The build now reports a failure in exactly one place: the one that knows the
+whole story. Nothing was made quieter — the same failure still surfaces on the
+type itself, in its build log, in the notification you get, and on the error page
+— and the duplicate that carried no detail is gone.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -956,6 +956,15 @@ internal class MeshNodeCompilationService(
                         }
                         return (finalPath, finalLog.Finish((int)hub.Version, ActivityStatus.Succeeded));
                     })
+                    // 🚨 THE SINGLE REPORTER of a compile failure. Every CompilationException —
+                    // Roslyn diagnostics from the disk emit (EmitCompilationToDirectory) or the
+                    // in-memory emit (CompileToMemory), and the "could not be persisted" loss from
+                    // EmitToDiskWithRetry — funnels here, and ONLY here is the exception logged.
+                    // This is the only site that has all three of: the exception + its stack, the
+                    // node path, and the source-discovery report. The emit sites used to log the
+                    // same diagnostics too, which double-counted every failure in prod and put a
+                    // context-free record first — do not re-add a log next to a `throw new
+                    // CompilationException`.
                     .Catch<(string?, ActivityLog), CompilationException>(ex =>
                     {
                         var diag = BuildSourceDiscoveryReport(executedQueries, matchedCodePaths);
@@ -1780,44 +1789,78 @@ internal class MeshNodeCompilationService(
     /// 2026-06-22) — the grain never recompiled. We now re-emit the lost artifact (a genuine compile
     /// error is NOT retried) and, if it still cannot be persisted, surface a clear, loud failure
     /// instead of a silent poison. See <see cref="EmitToDiskWithRetry"/>.</para>
+    ///
+    /// <para>⚠️ The self-heal above is about a LOST WRITE, not about a failing emit. A Roslyn
+    /// emit that reports errors is a normal, deterministic outcome (the node's C# does not
+    /// compile) and travels out of here as a <see cref="CompilationException"/> — which is why
+    /// <see cref="EmitToDiskWithRetry"/> shows up on the stack of every compile failure without
+    /// having failed at anything. Do not read that frame as an IO fault.</para>
     /// </summary>
     private Task<string> CompileToDiskAsync(CSharpCompilation compilation, string nodeName, string nodePath, CancellationToken ct)
         => Task.FromResult(EmitToDiskWithRetry(
             cacheService.CacheDirectory, nodeName, DiskEmitAttempts, logger,
-            releaseDir =>
-            {
-                var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
-                var pdbPath = Path.Combine(releaseDir, $"{nodeName}.pdb");
-                var xmlDocPath = Path.Combine(releaseDir, $"DynamicNode_{nodeName}.xml");
+            releaseDir => EmitCompilationToDirectory(compilation, nodeName, nodePath, releaseDir, ct)));
 
-                using (var dllStream = File.Create(dllPath))
-                using (var pdbStream = File.Create(pdbPath))
-                using (var xmlDocStream = File.Create(xmlDocPath))
-                {
-                    var emitOptions = new EmitOptions(
-                        debugInformationFormat: DebugInformationFormat.PortablePdb,
-                        pdbFilePath: pdbPath);
+    /// <summary>
+    /// Runs the real Roslyn emit for <paramref name="nodeName"/> into <paramref name="releaseDir"/>
+    /// (dll + pdb + XML doc) and returns the DLL path it wrote. A failed emit throws a
+    /// <see cref="CompilationException"/> carrying the formatted diagnostics.
+    ///
+    /// <para>🚨 It does NOT log. A compile failure is reported EXACTLY ONCE, by the compile
+    /// pipeline's single <c>.Catch&lt;…, CompilationException&gt;</c> funnel in
+    /// <c>CompileAsyncCore</c> — the only place that also has the exception, its stack and the
+    /// source-discovery report (which queries ran, which Code nodes matched). Logging the same
+    /// diagnostics here as well double-counted EVERY compile failure in production: the ~150
+    /// ERROR lines/24h across the memex/memex-cloud/atioz portals were ~72 real failures logged
+    /// twice, and the duplicate came FIRST — context-free and exception-free, so red-log
+    /// fingerprinting (which keys on category+eventId+exception+frame) filed it as a second,
+    /// distinct fault whose only visible frame was the emit path. That is what made a plain
+    /// "your C# does not compile" read like an emit/IO defect. Extracted and <c>internal</c> so
+    /// the log-once contract is unit-testable against a real broken compilation.</para>
+    /// </summary>
+    internal static string EmitCompilationToDirectory(
+        CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir, CancellationToken ct)
+    {
+        var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
+        var pdbPath = Path.Combine(releaseDir, $"{nodeName}.pdb");
+        var xmlDocPath = Path.Combine(releaseDir, $"DynamicNode_{nodeName}.xml");
 
-                    var emitResult = compilation.Emit(
-                        dllStream, pdbStream, xmlDocumentationStream: xmlDocStream,
-                        options: emitOptions, cancellationToken: ct);
+        using (var dllStream = File.Create(dllPath))
+        using (var pdbStream = File.Create(pdbPath))
+        using (var xmlDocStream = File.Create(xmlDocPath))
+        {
+            var emitOptions = new EmitOptions(
+                debugInformationFormat: DebugInformationFormat.PortablePdb,
+                pdbFilePath: pdbPath);
 
-                    if (!emitResult.Success)
-                    {
-                        // Deterministic compile error — propagates straight out of the retry loop.
-                        var errorMessage = FormatCompileFailure(nodePath, emitResult.Diagnostics);
-                        logger.LogError("{ErrorMessage}", errorMessage);
-                        throw new CompilationException(nodePath, errorMessage);
-                    }
-                }
-                // Streams flushed + closed here, before EmitToDiskWithRetry verifies the file.
-                return dllPath;
-            }));
+            var emitResult = compilation.Emit(
+                dllStream, pdbStream, xmlDocumentationStream: xmlDocStream,
+                options: emitOptions, cancellationToken: ct);
+
+            if (!emitResult.Success)
+                // Deterministic compile error — propagates straight out of the retry loop,
+                // unlogged, to the pipeline's single reporting funnel.
+                throw new CompilationException(nodePath, FormatCompileFailure(nodePath, emitResult.Diagnostics));
+        }
+        // Streams flushed + closed here, before EmitToDiskWithRetry verifies the file.
+        return dllPath;
+    }
 
     /// <summary>
     /// Number of times <see cref="EmitToDiskWithRetry"/> re-emits when a "successful" Roslyn
     /// emit leaves no assembly on disk (ephemeral-cache eviction). Three attempts recover a
     /// transient lost write while still failing fast on a genuinely unwritable cache directory.
+    ///
+    /// <para>Why a retry is legitimate here (and is NOT covering for a defect of ours): the
+    /// condition is genuinely EXTERNAL and transient — a container runtime reclaiming an
+    /// ephemeral <c>/tmp</c> under memory pressure between our write and our read. Nothing in
+    /// this process can prevent it, there is no lock/slot/budget being leaked, and the retry is
+    /// bounded, stateless and timer-free: three synchronous attempts, then a loud terminal
+    /// failure. A deterministic compile error is explicitly NOT retried. Its counterfactual is a
+    /// permanently poisoned NodeType (prod AgenticPension/Datenpunkt, 2026-06-22), not a slower
+    /// recovery. Evidence that it is not masking anything: across memex + memex-cloud + atioz it
+    /// has fired ZERO times in 7 days (31M log lines) — every ERROR the compile service emits in
+    /// production is a genuine Roslyn diagnostic, never a lost write.</para>
     /// </summary>
     internal const int DiskEmitAttempts = 3;
 
@@ -1915,6 +1958,10 @@ internal class MeshNodeCompilationService(
 
     /// <summary>
     /// Compiles and loads assembly directly to memory (no disk I/O).
+    ///
+    /// <para>🚨 Like <see cref="EmitCompilationToDirectory"/>, a failed emit throws UNLOGGED —
+    /// the pipeline's single <c>.Catch&lt;…, CompilationException&gt;</c> funnel is the one
+    /// reporter of a compile failure.</para>
     /// </summary>
     private void CompileToMemory(CSharpCompilation compilation, string nodeName, string nodePath, CancellationToken ct)
     {
@@ -1927,11 +1974,7 @@ internal class MeshNodeCompilationService(
         var emitResult = compilation.Emit(dllStream, pdbStream, options: emitOptions, cancellationToken: ct);
 
         if (!emitResult.Success)
-        {
-            var errorMessage = FormatCompileFailure(nodePath, emitResult.Diagnostics);
-            logger.LogError("{ErrorMessage}", errorMessage);
-            throw new CompilationException(nodePath, errorMessage);
-        }
+            throw new CompilationException(nodePath, FormatCompileFailure(nodePath, emitResult.Diagnostics));
 
         // Load assembly from bytes immediately
         var assemblyBytes = dllStream.ToArray();

--- a/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// A compile failure is reported EXACTLY ONCE — the log-once contract of the compile pipeline.
+///
+/// <para><b>The production defect.</b> <c>MeshNodeCompilationService</c> logged ~150 ERROR
+/// lines/24h across the memex / memex-cloud / atioz portals, and every stack pointed at
+/// <c>EmitToDiskWithRetry → CompileToDiskAsync</c>, which reads like an emit/IO fault. It is not:
+/// the disk-emit self-heal has fired ZERO times in 7 days of production. Those ~150 lines were
+/// ~72 genuine Roslyn compile errors in mesh content, each logged TWICE — once by the emit site
+/// (<c>logger.LogError(errorMessage); throw new CompilationException(...)</c>, the classic
+/// log-and-throw) and again by the pipeline's <c>.Catch&lt;…, CompilationException&gt;</c> funnel
+/// in <c>CompileAsyncCore</c>. The duplicate came FIRST and carried no exception, no stack and no
+/// source-discovery report, so it fingerprinted as a second, distinct fault whose only visible
+/// frame was the emit path — which is exactly why "your C# does not compile" was read for weeks
+/// as "the emit is failing".</para>
+///
+/// <para><b>The contract these tests pin.</b> The emit leaf THROWS but never LOGS; the
+/// exception it throws carries the complete diagnostics so the single funnel can report the whole
+/// failure. Anything the emit path does log (the lost-write self-heal) stays, because that
+/// condition never reaches the funnel as an exception on its own.</para>
+/// </summary>
+public class CompileFailureReportedOnceTest : IDisposable
+{
+    private readonly string _cacheDir =
+        Path.Combine(Path.GetTempPath(), $"mesh-emit-logonce-{Guid.NewGuid():N}");
+
+    public CompileFailureReportedOnceTest() => Directory.CreateDirectory(_cacheDir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_cacheDir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>Captures every record written through it, so a test can assert on log VOLUME.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<(LogLevel Level, string Message)> records = [];
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Records => records;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => records.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    // Instance (never static — AGENTS.md "no static collections"): the runtime's reference set,
+    // so Roslyn compiles these snippets exactly as it does a real node's source.
+    private readonly IReadOnlyList<MetadataReference> references =
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+    /// <summary>
+    /// A real, genuinely-broken compilation — the same failure shape production hits
+    /// (<c>CS0103: The name 'host' does not exist in the current context</c>, the prod
+    /// <c>Doc/DataMesh/SocialMedia/Post</c> failure). Roslyn is run for real: no fake emit,
+    /// so the diagnostics and the throw are the ones the service actually produces.
+    /// </summary>
+    private CSharpCompilation BrokenCompilation(string assemblyName) =>
+        CSharpCompilation.Create(
+            assemblyName,
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(
+                    """
+                    public static class Broken
+                    {
+                        public static string Render() => host.Localize("ui.mdNoPosts");
+                    }
+                    """)
+            ],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    private CSharpCompilation ValidCompilation(string assemblyName) =>
+        CSharpCompilation.Create(
+            assemblyName,
+            syntaxTrees: [CSharpSyntaxTree.ParseText("public static class Fine { public static int Answer => 42; }")],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    [Fact]
+    public void Failed_emit_throws_the_full_diagnostics_and_logs_nothing()
+    {
+        // This is the whole prod defect in one assertion: the emit leaf must hand the failure UP,
+        // not report it. Logging here as well is what doubled every compile failure in the portals'
+        // error logs — and the duplicate carried no exception, so it read as an emit/IO fault.
+        const string nodeName = "Demo_BrokenSource";
+        var logger = new RecordingLogger();
+
+        var ex = Assert.Throws<CompilationException>(() =>
+            MeshNodeCompilationService.EmitToDiskWithRetry(
+                _cacheDir, nodeName, MeshNodeCompilationService.DiskEmitAttempts, logger,
+                releaseDir => MeshNodeCompilationService.EmitCompilationToDirectory(
+                    BrokenCompilation(nodeName), nodeName, "Acme/BrokenSource", releaseDir,
+                    CancellationToken.None)));
+
+        // The exception carries EVERYTHING the single funnel needs to report the failure once.
+        ex.NodePath.Should().Be("Acme/BrokenSource");
+        ex.Message.Should().Contain("CS0103", "the diagnostics travel on the exception, not in a log line");
+        ex.Message.Should().Contain("host", "the exception names the symbol that failed to resolve");
+
+        logger.Records.Should().BeEmpty(
+            "a compile failure is reported EXACTLY ONCE, by the pipeline's "
+            + ".Catch<…, CompilationException> funnel — the only site that also has the exception, "
+            + "its stack and the source-discovery report. Logging it at the emit site too is what "
+            + "made ~72 real failures show up as ~150 ERROR lines/24h in production");
+    }
+
+    [Fact]
+    public void A_failing_emit_is_attempted_once_and_leaves_no_artifact()
+    {
+        // Bounds the fix: removing the log must not turn a deterministic compile error into a
+        // retried one (three Roslyn runs per broken node), and the failed emit must still leave
+        // the discovery namespace clean.
+        const string nodeName = "Demo_BrokenOnce";
+        var emits = 0;
+
+        Assert.Throws<CompilationException>(() =>
+            MeshNodeCompilationService.EmitToDiskWithRetry(
+                _cacheDir, nodeName, MeshNodeCompilationService.DiskEmitAttempts, new RecordingLogger(),
+                releaseDir =>
+                {
+                    emits++;
+                    return MeshNodeCompilationService.EmitCompilationToDirectory(
+                        BrokenCompilation(nodeName), nodeName, "Acme/BrokenOnce", releaseDir,
+                        CancellationToken.None);
+                }));
+
+        emits.Should().Be(1, "a deterministic compile error must NOT be retried");
+        Directory.GetDirectories(_cacheDir, $"{nodeName}_*").Should()
+            .BeEmpty("a failed compile leaves no discoverable artifact");
+        Directory.GetDirectories(_cacheDir, ".staging-*").Should()
+            .BeEmpty("the failed staging dir is cleaned up");
+    }
+
+    [Fact]
+    public void A_successful_emit_writes_the_assembly_and_logs_nothing()
+    {
+        // Control: the extracted emit really does emit — dll + pdb + XML doc land in the release
+        // dir and the happy path is silent too (its Debug-level record belongs to the caller).
+        const string nodeName = "Demo_ValidSource";
+        var logger = new RecordingLogger();
+
+        var dllPath = MeshNodeCompilationService.EmitToDiskWithRetry(
+            _cacheDir, nodeName, MeshNodeCompilationService.DiskEmitAttempts, logger,
+            releaseDir => MeshNodeCompilationService.EmitCompilationToDirectory(
+                ValidCompilation(nodeName), nodeName, "Acme/ValidSource", releaseDir,
+                CancellationToken.None));
+
+        new FileInfo(dllPath).Length.Should().BeGreaterThan(0);
+        var releaseDir = Path.GetDirectoryName(dllPath)!;
+        File.Exists(Path.Combine(releaseDir, $"{nodeName}.pdb")).Should().BeTrue();
+        File.Exists(Path.Combine(releaseDir, $"DynamicNode_{nodeName}.xml")).Should().BeTrue();
+        logger.Records.Should().BeEmpty("a clean emit has nothing to say");
+    }
+
+    [Fact]
+    public void The_lost_write_self_heal_still_warns_because_it_never_reaches_the_funnel()
+    {
+        // The one thing the emit path legitimately logs. A lost write is recovered in-place and
+        // NEVER surfaces as an exception, so the .Catch funnel cannot report it — without this
+        // warning the self-heal would be invisible. Silencing it would be the over-correction.
+        const string nodeName = "Demo_LostWrite";
+        var logger = new RecordingLogger();
+        var emits = 0;
+
+        MeshNodeCompilationService.EmitToDiskWithRetry(
+            _cacheDir, nodeName, MeshNodeCompilationService.DiskEmitAttempts, logger,
+            releaseDir =>
+            {
+                emits++;
+                var path = MeshNodeCompilationService.EmitCompilationToDirectory(
+                    ValidCompilation(nodeName), nodeName, "Acme/LostWrite", releaseDir,
+                    CancellationToken.None);
+                if (emits == 1)
+                    File.Delete(path); // the ephemeral-/tmp eviction
+                return path;
+            });
+
+        emits.Should().Be(2);
+        logger.Records.Select(r => r.Level).Should()
+            .Equal([LogLevel.Warning], "the lost-write self-heal is the emit path's ONLY log — "
+                                       + "it is invisible to the funnel, so it must report itself");
+    }
+}


### PR DESCRIPTION
## The reported defect

`MeshWeaver.Graph.Configuration.MeshNodeCompilationService` logs ~150 ERROR lines/24h in production, every one stacked through `EmitToDiskWithRetry → CompileToDiskAsync`. That reads like the emit is failing.

## It is not. Evidence first

Loki, all three portals (`memex`, `memex-cloud`, `atioz`), 7 days, 31M lines scanned:

| probe | hits |
|---|---|
| `"re-emitting"` (the lost-write self-heal warning) | **0** |
| `"could not be persisted"` (the terminal emit failure) | **0** in 24h |

The disk-emit self-heal has **never fired in production**. `EmitToDiskWithRetry` is an innocent stack frame, not the failure.

What the ~150 lines actually are — reattaching the message BODY to its `fail:` header (they are separate Loki entries):

```
fail: MeshWeaver.Graph.Configuration.MeshNodeCompilationService[0]
      Compilation failed for 'Doc/DataMesh/SocialMedia/Post':
      CS0103 Error (line 180): The name 'host' does not exist in the current context
fail: MeshWeaver.Graph.Configuration.MeshNodeCompilationService[0]
      Failed to compile assembly for node Doc/DataMesh/SocialMedia/Post. Executed source queries (2): …
      MeshWeaver.Graph.Configuration.CompilationException: Compilation failed for '…': CS0103 …
         at …MeshNodeCompilationService.<CompileToDiskAsync>b__0(String releaseDir) :line 1810
         at …MeshNodeCompilationService.EmitToDiskWithRetry(…) :line 1875
```

~72 genuine Roslyn compile errors, **each logged twice, 4 ms apart** — 72 × 2 ≈ the ~150. Recurrence is one burst per new image (`DynamicTypePreWarmer` rebuilds every NodeType when the framework hash changes), ~4×/day × ~5-7 broken types × 3 portals.

## Root cause (file:line)

Two log sites for one failure:

1. `MeshNodeCompilationService.cs:1809` (disk emit) and `:1932` (in-memory) — `logger.LogError("{ErrorMessage}", errorMessage); throw new CompilationException(...)`, the classic **log-and-throw**.
2. `MeshNodeCompilationService.cs:962` — `CompileAsyncCore`'s `.Catch<…, CompilationException>` funnel logs the very exception it was handed.

Only (2) is useful: it carries the exception + stack, the node path, **and** the source-discovery report. That report is what separates *"CS0103, your C# has a typo"* from *"Matched Code nodes (0) — discovery found none of your sources"*, which is the real cause on 4 of the failing prod types (`KmuBasics/*`). (1) has none of it, and because it lands **first** — with no exception attached — red-log fingerprinting (`category+eventId+exception+frame`, #1002) files it as a second, distinct fault whose only visible frame is the emit path. That is precisely how "your code does not compile" came to look like an emit/IO defect.

## The change

- Delete the log-and-throw at both emit sites; `.Catch` becomes the documented **single reporter**.
- Extract the emit body as `internal static EmitCompilationToDirectory(...)` so the log-once contract is unit-testable against a real broken compilation.
- `CompileToReleaseAsync` and `ScriptCompilationService` **keep** their log — neither sits under that funnel, so there it is the only report.
- Nothing is made quieter: the failure still reaches the node's ActivityLog, its parked state, the Notification and the compile-error overlay, and the ERROR log still gets the full record — once.

## The retry survives, explicitly justified — not by default

Its condition is genuinely **external and transient**: a container runtime reclaiming an ephemeral `/tmp` between our write and our read. Nothing in-process can prevent it, no slot/lock/budget is leaked, it is bounded/stateless/timer-free (three synchronous attempts, then a loud terminal failure), and a deterministic compile error is explicitly never retried. Its counterfactual is a permanently poisoned NodeType (prod `AgenticPension/Datenpunkt`, 2026-06-22), not a slower recovery. Written into the `DiskEmitAttempts` doc comment.

**Ruled out with evidence** as causes of the emit path failing: file locking, missing path, disk exhaustion, two compiles racing one output path (staging dir + atomic `Directory.Move` already covers it), and an ALC pinning the previous assembly — the self-heal that would catch every one of those has fired zero times in 7 days.

## Test — observed failing before the fix

`test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs` drives the **real** Roslyn emit over genuinely broken source (the prod `CS0103 The name 'host' does not exist` shape) through `EmitToDiskWithRetry` with a recording logger.

Temporarily restoring the shipped log-and-throw:

```
CompileFailureReportedOnceTest.Failed_emit_throws_the_full_diagnostics_and_logs_nothing [FAIL]
  AssertionException : Expected collection to be empty because a compile failure is reported
  EXACTLY ONCE, by the pipeline's .Catch<…, CompilationException> funnel …, but found 1 item(s).
Failed!  - Failed: 1, Passed: 3, Total: 4
```

After the fix: `Passed! - Failed: 0, Passed: 4`.

## Build / tests

- `dotnet build -c Release -warnaserror`: `MeshWeaver.Graph.Test`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Documentation` — **0 warnings, 0 errors** (no CS9107).
- `MeshWeaver.Graph.Test` compile/NodeType/Emit/Recompile slice: **242 passed, 0 failed**.
- Branch merged with current `origin/main` before push.

## Not this PR

- Prod content that legitimately does not compile is unchanged by this: `Doc/DataMesh/SocialMedia/Post` is already fixed on main (b7ba74e08) and heals on the next image; `atioz`'s `MeshWeaver.BusinessRules` / `AddTracking` misses and `memex`'s deleted `AddSkillSource` are live-mesh-vs-repo drift; `KmuBasics/*` is user content whose Source nodes are missing. None is a defect in this code path.
- Not the `CompileWatcher` teardown misclassification fixed in #1054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)