### PR TITLE
The auto-execute tests asked for an agent that has not existed since May

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansAutoExecuteTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansAutoExecuteTest.cs
@@ -41,6 +41,18 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// </summary>
 public class OrleansAutoExecuteTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
 {
+    /// <summary>
+    /// The node PATH of the built-in default agent — the form the composer's picker
+    /// stores, so <c>AgentChatClient.ResolveSelectedAgent</c> resolves it by exact path.
+    /// <para>🚨 It must name an agent that actually SHIPS (<c>content/ai/Agent/*.md</c>).
+    /// These tests used to ask for <c>"Orchestrator"</c>, which was renamed to
+    /// <c>Assistant</c> in c31fd04da — since then no such agent has existed, so every
+    /// round could only ever produce the terminal "agent not found" error. The weak
+    /// assertions (any non-empty response text) accepted that error, and the
+    /// "Allocating agent..." placeholder, as success.</para>
+    /// </summary>
+    private const string DefaultAgentPath = "Agent/Assistant";
+
     private IMessageHub GetClient([CallerMemberName] string? name = null)
         => base.GetClient($"autoexec-{name}-{Guid.NewGuid():N}", "TestUser");
 
@@ -78,7 +90,7 @@ public class OrleansAutoExecuteTest(ITestOutputHelper output) : OrleansSharedTes
         // submission watcher claims — see ThreadNodeType.BuildThreadWithMessages.
         var (threadNode, userMsgId, _) = ThreadNodeType.BuildThreadWithMessages(
             "TestUser", "Hello Orleans auto-execute!",
-            createdBy: "TestUser", agentName: "Orchestrator");
+            createdBy: "TestUser", agentName: DefaultAgentPath);
         var threadPath = threadNode.Path!;
         Output.WriteLine($"Thread: {threadPath}, user={userMsgId}");
 
@@ -89,22 +101,36 @@ public class OrleansAutoExecuteTest(ITestOutputHelper output) : OrleansSharedTes
         Output.WriteLine("Thread created, waiting for execution...");
 
         // Subscribing to the thread stream also activates the per-thread hub
-        // (WatchForExecution → auto-execute dispatch). Wait for execution to settle.
-        var thread = await GetHubContent<MeshThread>(client, threadPath)
+        // (WatchForExecution → auto-execute dispatch). Wait for the watcher to
+        // claim and allocate the response cell. `Messages` only ever grows, so
+        // this predicate is monotonic — unlike `IsExecuting == false`, which is
+        // ALSO true in the pre-execution window and made the wait a coin flip.
+        var claimed = await GetHubContent<MeshThread>(client, threadPath)
             .Should().Within(30.Seconds())
-            .Match(t => t is { IsExecuting: false }
-                && t.Messages.Count >= 2);
-        Output.WriteLine("Thread execution complete");
+            .Match(t => t is { Messages.Count: >= 2 });
 
         // Response cell id is Messages[1] (user is [0], response is [1]) — the id
         // DispatchAfterClaim allocated for this round.
-        var responseMsgId = thread!.Messages[1];
+        var responseMsgId = claimed!.Messages[1];
         var responsePath = $"{threadPath}/{responseMsgId}";
+
+        // 🚨 The round-done gate is the response cell's TERMINAL Status write — the
+        // same signal the submission watcher treats as round-done. Waiting on "any
+        // non-empty Text" matched the "Allocating agent..." PLACEHOLDER the
+        // framework writes when it allocates the cell, so the test passed without
+        // any agent having run.
         var response = await GetHubContent<ThreadMessage>(client, responsePath)
             .Should().Within(30.Seconds())
-            .Match(m => !string.IsNullOrEmpty(m?.Text));
-        response!.Text.Should().NotBeNullOrEmpty("agent should have written response text");
+            .Match(m => m is { Status: ThreadMessageStatus.Completed });
+        response!.Text.Should().Contain("Echo:", "the echo agent should have written the response text");
         Output.WriteLine($"Response: {response.Text![..Math.Min(100, response.Text.Length)]}");
+
+        // Only NOW is "execution settled" a real observed condition: the terminal
+        // Status write has landed, so the thread must flip out of executing.
+        await GetHubContent<MeshThread>(client, threadPath)
+            .Should().Within(30.Seconds())
+            .Match(t => t is { IsExecuting: false });
+        Output.WriteLine("Thread execution complete");
 
         // Verify user cell exists.
         var userMsg = await GetHubContent<ThreadMessage>(client, $"{threadPath}/{userMsgId}")
@@ -128,7 +154,7 @@ public class OrleansAutoExecuteTest(ITestOutputHelper output) : OrleansSharedTes
 
         var (threadNode, _, _) = ThreadNodeType.BuildThreadWithMessages(
             "TestUser", "Test routing to response grain",
-            createdBy: "TestUser", agentName: "Orchestrator");
+            createdBy: "TestUser", agentName: DefaultAgentPath);
         var threadPath = threadNode.Path!;
 
         await client.Observe(new CreateNodeRequest(threadNode), o => o.WithTarget(new Address("TestUser")))
@@ -146,14 +172,17 @@ public class OrleansAutoExecuteTest(ITestOutputHelper output) : OrleansSharedTes
             .Should().Within(30.Seconds()).Match(t => t is { Messages.Count: >= 2 });
         var responsePath = $"{threadPath}/{claimed!.Messages[1]}";
 
-        // Wait for the response cell to have final text (not empty, not a placeholder).
+        // Wait for the response cell's TERMINAL Status write — the round-done gate.
+        // 🚨 Screening the text for placeholder PREFIXES is not enough: an agent
+        // selection failure also writes non-placeholder text (the "agent not found"
+        // error), so this passed on a round in which UpdateThreadMessageContent
+        // never routed anywhere. Assert the echo agent's actual output instead.
         var msg = await GetHubContent<ThreadMessage>(client, responsePath)
             .Should().Within(30.Seconds())
-            .Match(m => m?.Text is { Length: > 0 } text
-                && !text.StartsWith("Allocating")
-                && !text.StartsWith("Loading")
-                && !text.StartsWith("Generating"));
-        Output.WriteLine($"Response cell has final text: {msg!.Text![..Math.Min(80, msg.Text.Length)]}");
+            .Match(m => m is { Status: ThreadMessageStatus.Completed });
+        msg!.Text.Should().Contain("Echo:",
+            "the streamed agent output must reach the RESPONSE grain, not the thread grain");
+        Output.WriteLine($"Response cell has final text: {msg.Text![..Math.Min(80, msg.Text.Length)]}");
     }
 
     #region Echo LLM

--- a/test/MeshWeaver.Threading.Test/AutoExecuteFlowTest.cs
+++ b/test/MeshWeaver.Threading.Test/AutoExecuteFlowTest.cs
@@ -63,14 +63,17 @@ public class AutoExecuteFlowTest(ITestOutputHelper output) : MonolithMeshTestBas
         createResponse.Message.Success.Should().BeTrue(createResponse.Message.Error ?? "");
         Output.WriteLine("Thread created");
 
+        // 🚨 Name an agent that actually SHIPS. This asked for "Orchestrator", renamed to
+        // Assistant in c31fd04da — so the round could only ever produce the terminal
+        // "agent not found" error, which the old "any non-empty text" assertion accepted.
         var responseMsgId = await ThreadFlow.SubmitAndWait(client, threadPath,
-            "Hello portal flow!", contextPath: ContextPath, agentName: "Orchestrator",
+            "Hello portal flow!", contextPath: ContextPath, agentName: "Agent/Assistant",
             timeout: 30.Seconds()).Should().Within(30.Seconds()).Emit();
         Output.WriteLine($"Response msg id: {responseMsgId}");
 
         var response = await ThreadFlow.ReadMessage(client, threadPath, responseMsgId,
-            m => !string.IsNullOrEmpty(m.Text) && m.Status != ThreadMessageStatus.Streaming).Should().Within(30.Seconds()).Emit();
-        response.Text.Should().NotBeNullOrEmpty("agent should have written response");
+            m => m.Status == ThreadMessageStatus.Completed).Should().Within(30.Seconds()).Emit();
+        response.Text.Should().Contain("Echo:", "the echo agent should have written the response");
         Output.WriteLine($"Response: {response.Text[..Math.Min(80, response.Text.Length)]}");
     }
 


### PR DESCRIPTION
## The symptom

`OrleansAutoExecuteTest.AutoExecute_CreatesResponseCell_And_CompletesExecution` passed alone but failed in bulk with:

> Selected agent 'Orchestrator' was not found among the available agents ([Agent/Assistant … Agent/ThreadNamer])

Alone-passes + in-suite-fails reads like a shared-cluster ordering race. It isn't one.

## What was actually wrong

**`Orchestrator` was renamed to `Assistant` in c31fd04da (2026-05-23).** No such agent has shipped since. `OrleansThreadStreamingTest` already says so outright in a comment. Every round these tests drove could therefore *only* produce the terminal "agent not found" error — alone or in bulk.

The order dependence came entirely from assertions that never looked at the round's outcome:

- `Match(m => !string.IsNullOrEmpty(m.Text))` matched the **first** emission carrying any text — the `"Allocating agent..."` **placeholder** the framework writes when it allocates the response cell. Whether the subscription caught that emission or a later one is pure scheduling luck. Running alone, the observed response text was literally `Allocating agent...`: the test passed without any agent having run.
- `Match(t => t is { IsExecuting: false } && t.Messages.Count >= 2)` is satisfiable in the **pre-execution** window as well as after the round, so "wait for execution to settle" could return before execution started.
- The sibling test screened for placeholder *prefixes*, which the "agent not found" error does not start with — so it asserted an error message as "final text".

## Product vs. test — the convergence hypothesis is falsified

The suspicion was that `AgentChatClient` treats a **partially-converged** catalog as authoritative. It does not apply here. With a correct terminal-condition assertion the test fails **deterministically in 1 second running alone**, and the error names the **complete** 13-agent built-in catalog — the identical list seen in the bulk failure. The catalog is fully converged in both cases; `Orchestrator` is simply not in it.

`AgentChatClient` is behaving correctly and deliberately: an explicit-but-unresolvable selection surfaces a named terminal error rather than silently running a different agent (the documented fix for the prod wrong-agent confusion). Nothing was relaxed there.

## The fix

Point both tests at `Agent/Assistant` — the shipped default (`isDefault: true`), in the full node PATH form the picker stores — and wait on the framework's own round-done gate: the response cell's **terminal `Status` write**, then assert the echo agent's actual output. The `IsExecuting == false` check moves *after* the terminal write, where it is a real observed condition instead of a coin flip.

`AutoExecuteFlowTest` (MeshWeaver.Threading.Test) carried the identical stale name and the same "any non-empty text" assertion; fixed the same way.

## Deterministic pre-fix failure (verified by reverting)

With the terminal-Status assertion in place and `agentName: "Orchestrator"` restored, running **alone**:

```
Failed AutoExecute_CreatesResponseCell_And_CompletesExecution [1 s]
  Expected "Selected agent 'Orchestrator' was not found among the available agents
  ([Agent/Assistant, Agent/Researcher, Agent/TrainingSim, Agent/Tutor, Agent/Worker,
  Agent/ExecutiveAssistant, Agent/LogTriage, Agent/NotificationTriage, Agent/EmailRouter,
  Agent/PullRequestWriter, Agent/DescriptionWriter, Agent/NodeInitializer, Agent/ThreadNamer]).
  It may have been moved, renamed, or is not available in this context — pick another agent
  from the list." to contain "Echo:" because the echo agent should have written the response text.
```

Post-fix both tests report `Echo: 2 messages received.` — the agent actually ran.

## Verification

- `MeshWeaver.Hosting.Orleans.Test` full project, `DOTNET_PROCESSOR_COUNT=4`: **148/148 passed**
- `MeshWeaver.Threading.Test` full project: **128/128 passed**
- `dotnet build -c Release -warnaserror` clean for both projects

## No What's New entry

This change touches only test files — no user-visible behaviour changes, so there is nothing a user can notice (AGENTS.md scopes `Category: Fix` to user-noticeable fixes). Same shape as #1051, a test-infrastructure-only PR that shipped without an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)