### PR TITLE
Fix two teardown hazards in the thread watchers' hand-rolled re-establish loops

### DIFF
--- a/src/MeshWeaver.AI/ReEstablishSchedule.cs
+++ b/src/MeshWeaver.AI/ReEstablishSchedule.cs
@@ -1,0 +1,129 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The scheduling half of the thread watchers' HAND-ROLLED re-establish loops
+/// (<c>ThreadExecution.InstallExecRoundWatcher</c>,
+/// <c>ThreadExecution.InitializeThreadLifecycle</c>,
+/// <c>ThreadSubmissionServer.InstallServerWatcher</c>).
+///
+/// <para>🚨 These three loops are NOT
+/// <see cref="MeshWeaver.Mesh.ActivityControlPlaneExtensions.SubscribeWithReEstablish{T}"/>
+/// and do NOT inherit its terminal fault classification (own-node-gone / poisoned
+/// content): they re-establish on EVERY fault. Converting them is a separate change
+/// — <c>InstallExecRoundWatcher</c> watches the PARENT hub's node, so the
+/// address-scoped classification would need <c>parentHub.Address</c> to match at all.
+/// This helper deliberately fixes only the SCHEDULING hazards the three loops shared;
+/// it changes no classification behaviour.</para>
+///
+/// <para>Two hazards, both in the window where the hub is being torn down:</para>
+/// <list type="number">
+///   <item><description><b>The 1 s timer was armed after checking <c>disposed</c>, but the
+///     TICK never re-checked it.</b> Arm-time is the wrong time: the whole point of the
+///     delay is that a second passes. Teardown inside that second left a live tick that
+///     re-subscribed a dead hub's stream — the #991 shape, a <c>TimerQueue</c> entry (a
+///     strong GC root) holding <c>Establish</c> → the watcher closure → the hub. The
+///     <c>SerialDisposable</c> cancels the schedule, but a tick already dispatched to the
+///     pool still runs its handler, so the flag must be re-read at FIRE time. The
+///     sanctioned helper does exactly this (<c>if (disposed) return;</c> at the head of
+///     its own <c>Establish</c>).</description></item>
+///   <item><description><b>A synchronous throw out of <c>establish</c> escaped onto the
+///     timer's thread-pool thread.</b> Re-establishing resolves services off the hub's DI
+///     scope (<c>GetWorkspace()</c> is <c>ServiceProvider.GetRequiredService&lt;IWorkspace&gt;()</c>,
+///     and <c>GetMeshNodeStream().Subscribe()</c> resolves too); after teardown that scope
+///     is gone and throws <see cref="ObjectDisposedException"/> straight out of
+///     <c>Subscribe</c>. Rx does not swallow a throw from an <c>OnNext</c> handler — on the
+///     default (thread-pool) scheduler it becomes an UNHANDLED exception and takes the
+///     process down. Every fault must reach a graceful sink instead.</description></item>
+/// </list>
+/// </summary>
+internal static class ReEstablishSchedule
+{
+    /// <summary>
+    /// The production re-establish delay. Long enough to hop off the synchronous error
+    /// stack (a Subscribe-time fault re-entering <c>Establish</c> inline recurses to a
+    /// stack overflow) and to let the disposal hook set the <c>disposed</c> flag; short
+    /// enough that a genuinely transient fault leaves the thread unobserved only briefly.
+    /// Matches <c>SubscribeWithReEstablish</c>'s default.
+    /// </summary>
+    internal static readonly TimeSpan Delay = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Arms a single delayed re-establish and hands back the handle that CANCELS it.
+    /// Assign the result to the watcher's <c>pendingReEstablish</c>
+    /// <see cref="SerialDisposable"/> so teardown drops the pending
+    /// <c>TimerQueue</c> entry (#991); assigning into an already-disposed
+    /// <see cref="SerialDisposable"/> disposes the schedule immediately, which closes
+    /// the arm-vs-teardown race.
+    /// </summary>
+    /// <param name="isDisposed">Reads the watcher's teardown flag. Evaluated at ARM time
+    /// AND again when the timer FIRES — the second read is the fix.</param>
+    /// <param name="establish">Re-subscribes the watcher's source. May throw synchronously
+    /// (a disposed DI scope does); the throw is contained here, never on the timer thread.</param>
+    /// <param name="logger">Sink for the contained fault. Optional, as everywhere else in
+    /// these watchers.</param>
+    /// <param name="context">Short watcher name for the fault log, e.g. <c>ExecRoundWatcher</c>.</param>
+    /// <param name="threadPath">Thread path for the fault log.</param>
+    /// <param name="scheduler">Test seam. Production default is
+    /// <see cref="DefaultScheduler"/>, i.e. the same thread-pool timer the loops used
+    /// before.</param>
+    /// <returns>A handle that cancels the pending re-establish, or
+    /// <see cref="Disposable.Empty"/> when the watcher is already torn down and nothing
+    /// was armed.</returns>
+    internal static IDisposable Arm(
+        Func<bool> isDisposed,
+        Action establish,
+        ILogger? logger,
+        string context,
+        string threadPath,
+        IScheduler? scheduler = null)
+    {
+        // Nothing to arm once the watcher is gone — the fault is then permanent (the
+        // scope is gone), so retrying is futile AND would root the hub for a second.
+        if (isDisposed())
+            return Disposable.Empty;
+
+        return Observable.Timer(Delay, scheduler ?? DefaultScheduler.Instance)
+            .Subscribe(_ =>
+            {
+                // 🚨 RE-check at FIRE time. A second passed since the arm-time check, and
+                // teardown very likely happened inside it — teardown is exactly when the
+                // watched stream faults. A tick already dispatched to the pool runs even
+                // though the SerialDisposable cancelled the schedule, so this read is the
+                // only thing standing between a disposed hub and a fresh subscription.
+                if (isDisposed())
+                    return;
+                try
+                {
+                    establish();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    // The teardown race the flag alone cannot close: `disposed` is still
+                    // false (the hub's disposal hook has not run yet) but the DI scope is
+                    // already gone. Expected during shutdown, and terminal — the scope never
+                    // comes back, so re-arming would be a 1 Hz storm against a dead hub.
+                    logger?.LogWarning(ex,
+                        "[{Context}] re-establish for {ThreadPath} hit a disposed scope — " +
+                        "the hub is tearing down; watcher stops (no re-arm)",
+                        context, threadPath);
+                }
+                catch (Exception ex)
+                {
+                    // NOT a swallow: an unexpected synchronous fault out of Establish is
+                    // surfaced at Error with full context. It is contained rather than
+                    // rethrown because rethrowing here is an UNHANDLED exception on a
+                    // thread-pool thread, which kills the process — the loudest possible
+                    // failure and the least useful one.
+                    logger?.LogError(ex,
+                        "[{Context}] re-establish for {ThreadPath} threw synchronously — " +
+                        "watcher stops; the thread is no longer observed",
+                        context, threadPath);
+                }
+            });
+    }
+}

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -187,6 +187,15 @@ internal static class ThreadExecution
         // stream FAULTS it must not die silently — a dead watcher means a claimed
         // round never dispatches (Status stuck at StartingExecution, IsExecuting
         // forever): the live-path "observer dies" deadlock. On fault, re-establish.
+        //
+        // 🚨 This is a HAND-ROLLED loop, NOT
+        // ActivityControlPlaneExtensions.SubscribeWithReEstablish — it re-establishes on
+        // EVERY fault and therefore does NOT have that helper's terminal classification
+        // (own-node-gone / poisoned content). Converting it is a separate change: this
+        // watcher observes the PARENT thread hub's node, so the helper's address-scoped
+        // own-node-gone detection would need parentHub.Address passed through or it
+        // would silently never match. Only the SCHEDULING of the re-establish is shared,
+        // via ReEstablishSchedule.Arm.
         IDisposable? sub = null;
         // 🚨 #991 — hold the PENDING re-establish so teardown cancels it. An uncancelled
         // `Observable.Timer` sits on the process-wide TimerQueue (a strong GC root) and
@@ -194,6 +203,14 @@ internal static class ThreadExecution
         // faults as the hub tears down keeps the hub alive past disposal.
         var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
+        // 🚨 Resolve the workspace ONCE, at install time, while the hub's DI scope is
+        // alive. Re-resolving inside Establish() (GetWorkspace() is
+        // ServiceProvider.GetRequiredService<IWorkspace>()) put a live
+        // ObjectDisposedException source on the re-establish path: a timer tick that beat
+        // the disposal flag threw straight out of the Rx OnNext handler on a thread-pool
+        // thread — unhandled, process-fatal. IWorkspace is scoped per hub, so hoisting
+        // resolves the identical instance.
+        var workspace = parentHub.GetWorkspace();
         // 🚨 Observe the PARENT thread hub's AUTHORITATIVE own MeshNode stream —
         // NOT the cross-hub IMeshNodeStreamCache. The cache opens a remote
         // subscription to the owning grain and, on Orleans, replays/reorders:
@@ -211,7 +228,7 @@ internal static class ThreadExecution
         // single time and never sees a phantom re-claim. (Using the THREAD
         // hub's workspace here, never the _Exec child's, also matches
         // feedback_synced_query_thread_hub.md.)
-        void Establish() => sub = parentHub.GetWorkspace().GetMeshNodeStream()
+        void Establish() => sub = workspace.GetMeshNodeStream()
             // Pair each emission with its current Status so DistinctUntilChanged
             // dedupes on the Status field only — concurrent field updates that
             // happen while Status stays StartingExecution must NOT re-fire.
@@ -277,10 +294,11 @@ internal static class ThreadExecution
                 {
                     logger?.LogWarning(ex,
                         "[ExecRoundWatcher] stream errored for {ThreadPath} — re-establishing", threadPath);
-                    if (!disposed)
-                        pendingReEstablish.Disposable =
-                            System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                                .Subscribe(_ => Establish());
+                    // Re-checks `disposed` at FIRE time (not only here at arm time) and
+                    // routes a synchronous Establish() throw to the logger instead of onto
+                    // the timer's thread-pool thread. See ReEstablishSchedule.
+                    pendingReEstablish.Disposable = ReEstablishSchedule.Arm(
+                        () => disposed, Establish, logger, "ExecRoundWatcher", threadPath);
                 });
 
         Establish();
@@ -593,23 +611,30 @@ internal static class ThreadExecution
                     // terminal/valid state must restart the watcher.) Without this a
                     // faulted observation left the stale thread stuck forever.
                     //
-                    // 🚨 Two guards make this self-heal safe — mirroring the sanctioned
-                    // SubscribeWithReEstablish pattern (disposed-terminal + scheduled,
-                    // never-synchronous re-establish):
+                    // 🚨 This is a HAND-ROLLED loop. It is NOT
+                    // ActivityControlPlaneExtensions.SubscribeWithReEstablish and does NOT
+                    // inherit its terminal fault classification — it re-establishes on
+                    // EVERY fault, including an own-node-gone NotFound or poisoned content
+                    // that the sanctioned helper stops on. Converting it is a separate
+                    // change; only the SCHEDULING is shared, via ReEstablishSchedule.Arm:
                     //   • `disposed` stops re-establishing once the hub is torn down —
                     //     the fault is then permanent (scope gone), so retrying is futile.
+                    //     Read HERE and AGAIN when the timer fires (a second passes, and
+                    //     teardown is exactly when the stream faults).
                     //   • the 1 s Timer hops the re-establish OFF the synchronous error
                     //     stack. A Subscribe-time fault re-entering Establish inline would
                     //     recurse to a stack overflow; deferring also lets the disposal
                     //     hook set `disposed` past the teardown window.
+                    //   • a synchronous throw out of Establish (disposed DI scope) reaches
+                    //     the logger, never the timer's thread-pool thread as an unhandled
+                    //     exception.
                     if (disposed)
                         return;
                     logger?.LogWarning(ex,
                         "[ThreadExec] Init observation faulted for {ThreadPath} — re-establishing recovery",
                         threadPath);
-                    pendingReEstablish.Disposable =
-                        System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                            .Subscribe(_ => { if (!disposed) Establish(); });
+                    pendingReEstablish.Disposable = ReEstablishSchedule.Arm(
+                        () => disposed, Establish, logger, "ThreadExec Init", threadPath);
                 });
 
         Establish();

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -277,8 +277,13 @@ internal static class ThreadSubmissionServer
         // silently — a dead watcher means the resubmit is never claimed and the
         // thread parks forever (the live-path "observer dies" deadlock behind
         // Resubmit_AfterExecution_DoesNotDeadlock). On fault, re-establish after a
-        // short delay. Mirrors ThreadExecution.InitializeThreadLifecycle and
-        // ActivityControlPlaneExtensions.WatchControlPlane.
+        // short delay.
+        //
+        // 🚨 This is a HAND-ROLLED loop, NOT
+        // ActivityControlPlaneExtensions.SubscribeWithReEstablish / WatchControlPlane —
+        // it does NOT inherit their terminal fault classification and re-establishes on
+        // EVERY fault, including an own-node-gone NotFound. Converting it is a separate
+        // change; only the SCHEDULING is shared, via ReEstablishSchedule.Arm.
         var serial = new System.Reactive.Disposables.SerialDisposable();
         // 🚨 #991 — hold the PENDING re-establish so teardown cancels it. An uncancelled
         // `Observable.Timer` sits on the process-wide TimerQueue (a strong GC root) and
@@ -286,6 +291,14 @@ internal static class ThreadSubmissionServer
         // stream that faults as the hub tears down keeps the hub alive past disposal.
         var pendingReEstablish = new System.Reactive.Disposables.SerialDisposable();
         var disposed = false;
+        // 🚨 Resolve the workspace ONCE, at install time, while the hub's DI scope is
+        // alive. Re-resolving inside Establish() (GetWorkspace() is
+        // ServiceProvider.GetRequiredService<IWorkspace>()) put a live
+        // ObjectDisposedException source on the re-establish path: a timer tick that beat
+        // the disposal flag threw straight out of the Rx OnNext handler on a thread-pool
+        // thread — unhandled, process-fatal. IWorkspace is scoped per hub, so hoisting
+        // resolves the identical instance.
+        var workspace = threadHub.GetWorkspace();
         // 🚨 Stage 1 of the in-memory inbox channel. Resolve-or-create the per-thread
         // ThreadInboxChannel here (thread-hub init — single threaded, before any round),
         // so check_inbox (Stage 2) and the round-end reconcile resolve the same instance.
@@ -293,7 +306,7 @@ internal static class ThreadSubmissionServer
         // messages that arrive mid-round WITHOUT writing the thread node — the node write
         // that used to happen here (and in check_inbox) is what raced the round and wedged.
         var inboxChannel = ThreadInboxChannel.For(threadHub);
-        void Establish() => serial.Disposable = threadHub.GetWorkspace().GetMeshNodeStream()
+        void Establish() => serial.Disposable = workspace.GetMeshNodeStream()
             // 🚨 React ONLY to control-plane changes — Status, and the pending / ingested /
             // user-message id sets. A running round emits hundreds of StreamingText / Messages
             // updates; without this filter the watcher re-ran ReconcileUserMessageIds (an
@@ -339,7 +352,6 @@ internal static class ThreadSubmissionServer
                 triggerNode =>
                 {
                     logger?.LogDebug("[SubmissionWatcher] DISPATCH_TRIGGERED for {ThreadPath}", threadPath);
-                    var workspace = threadHub.GetWorkspace();
                     // 🚨 Re-stamp the thread OWNER's identity for the claim own-write (see the
                     // identity note at the top of this method). The .Update().Subscribe() below
                     // posts the UpdateStreamRequest SYNCHRONOUSLY on this thread, so capturing the
@@ -385,10 +397,11 @@ internal static class ThreadSubmissionServer
                     logger?.LogWarning(ex,
                         "[SubmissionWatcher] stream errored for {ThreadPath} — re-establishing",
                         threadPath);
-                    if (!disposed)
-                        pendingReEstablish.Disposable =
-                            System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1))
-                                .Subscribe(_ => Establish());
+                    // Re-checks `disposed` at FIRE time (not only here at arm time) and
+                    // routes a synchronous Establish() throw to the logger instead of onto
+                    // the timer's thread-pool thread. See ReEstablishSchedule.
+                    pendingReEstablish.Disposable = ReEstablishSchedule.Arm(
+                        () => disposed, Establish, logger, "SubmissionWatcher", threadPath);
                 });
 
         Establish();

--- a/src/MeshWeaver.Documentation/Data/Architecture/SubscriptionOwnership.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SubscriptionOwnership.md
@@ -56,7 +56,9 @@ if (Interlocked.CompareExchange(ref _publishScheduled, 1, 0) == 0)
 
 `SerialDisposable` is the right holder rather than a plain field for two reasons that both matter: assigning a new value **disposes the previous one**, so re-arming can never orphan a pending timer; and a value assigned *after* the `SerialDisposable` has been disposed is disposed on assignment, so there is no race in which teardown and a last-moment arm cross.
 
-The same shape, with a re-establish rather than a flush, is what `ActivityControlPlaneExtensions.SubscribeWithReEstablish`, `ThreadSubmission.InstallSubmissionWatcher` and `ThreadExecution` do: a stream that faults schedules a 1 s retry, and the schedule goes into a `pendingReEstablish` `SerialDisposable` that the watcher's own `Dispose` drops **before** it drops the live subscription — the pending timer is what roots the closure graph, the live subscription is merely what is running.
+The same shape, with a re-establish rather than a flush, is what `ActivityControlPlaneExtensions.SubscribeWithReEstablish`, `ThreadSubmissionServer.InstallServerWatcher` and `ThreadExecution`'s two watchers do: a stream that faults schedules a 1 s retry, and the schedule goes into a `pendingReEstablish` `SerialDisposable` that the watcher's own `Dispose` drops **before** it drops the live subscription — the pending timer is what roots the closure graph, the live subscription is merely what is running.
+
+Same *shape*, not the same *code*: the three thread watchers are hand-rolled loops that share only the scheduling (`ReEstablishSchedule.Arm`, which re-reads the `disposed` flag when the timer fires and sinks a synchronous re-establish throw into the logger). They do **not** route through `SubscribeWithReEstablish` and so do **not** have its terminal fault classification — an own-node-gone `NotFound` or poisoned content re-establishes there rather than stopping. Converting them is open work; don't read the shared shape as shared behaviour.
 
 ## Sub-shape 2 — held, but pinning an owner that may never be disposed
 

--- a/test/MeshWeaver.AI.Test/ReEstablishScheduleTest.cs
+++ b/test/MeshWeaver.AI.Test/ReEstablishScheduleTest.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Contract for <see cref="ReEstablishSchedule"/> — the scheduling half the three
+/// HAND-ROLLED thread re-establish loops share
+/// (<c>ThreadExecution.InstallExecRoundWatcher</c>,
+/// <c>ThreadExecution.InitializeThreadLifecycle</c>,
+/// <c>ThreadSubmissionServer.InstallServerWatcher</c>). Those loops are NOT
+/// <c>ActivityControlPlaneExtensions.SubscribeWithReEstablish</c> — they only imitate it —
+/// so the two teardown hazards below were never covered by that helper's tests, and had
+/// no coverage of their own at all.
+///
+/// <para>Both hazards live in the same window: the 1 s delay between a stream faulting
+/// and the re-establish firing. Teardown is EXACTLY when a watched stream faults, so that
+/// window is the common case, not the rare one.</para>
+///
+/// <list type="number">
+///   <item><description><b>The tick never re-read <c>disposed</c>.</b> The flag was checked
+///     when the timer was ARMED; a second later, on a hub that had since been torn down,
+///     <c>Establish()</c> ran anyway and re-subscribed a dead hub's stream — the #991 shape
+///     (a <c>TimerQueue</c> entry, a strong GC root, holding the hub).</description></item>
+///   <item><description><b>A synchronous throw escaped onto the timer thread.</b>
+///     <c>Establish()</c> resolved <c>GetWorkspace()</c> — i.e.
+///     <c>ServiceProvider.GetRequiredService&lt;IWorkspace&gt;()</c> — from inside the
+///     factory; after teardown that scope is gone and throws
+///     <see cref="ObjectDisposedException"/>. Rx rethrows out of an <c>OnNext</c> handler,
+///     and on the default (thread-pool) scheduler an unhandled exception there kills the
+///     process. A wedges-to-zero violation: the fault must reach a graceful sink.</description></item>
+/// </list>
+///
+/// <para>All virtual-time via <see cref="HistoricalScheduler"/> — no wall clock, no
+/// <c>Task.Delay</c>, deterministic.</para>
+/// </summary>
+public class ReEstablishScheduleTest
+{
+    private const string Context = "TestWatcher";
+    private const string ThreadPath = "TestPartition/_Thread/thread-1";
+
+    /// <summary>
+    /// 🚨 HAZARD 1. Models the real teardown race: the fault arms the re-establish while the
+    /// watcher is still live, teardown flips <c>disposed</c> during the 1 s delay, and the
+    /// tick fires anyway. The schedule is deliberately NOT disposed here — that is the point.
+    /// In production teardown does dispose it, but disposing an Rx timer is best-effort
+    /// against a tick already dispatched to the pool, so the flag re-read at FIRE time is the
+    /// only thing that can stop the re-establish. Arm-time is the wrong time to ask.
+    /// </summary>
+    [Fact]
+    public void Tick_DoesNotReEstablish_WhenDisposalLandsDuringTheDelay()
+    {
+        var scheduler = new HistoricalScheduler();
+        var disposed = false;
+        var establishes = 0;
+
+        // Live at arm time — a genuinely transient fault on a healthy hub.
+        using var pending = ReEstablishSchedule.Arm(
+            () => disposed, () => establishes++, logger: null, Context, ThreadPath, scheduler);
+
+        // …and the hub tears down inside the delay.
+        disposed = true;
+
+        scheduler.AdvanceBy(ReEstablishSchedule.Delay);
+
+        establishes.Should().Be(0,
+            "the re-establish must re-read the disposal flag when the timer FIRES, not only "
+            + "when it was armed — a second passes in between, and teardown is exactly when "
+            + "the watched stream faults. Re-subscribing a disposed hub's stream is the #991 "
+            + "leak shape: the TimerQueue entry roots Establish → the watcher closure → the hub");
+    }
+
+    /// <summary>
+    /// 🚨 HAZARD 2. <c>Establish()</c> re-resolving <c>GetWorkspace()</c> inside the factory
+    /// makes a disposed DI scope throw SYNCHRONOUSLY out of the timer tick. This reproduces
+    /// the exact mechanism — <c>GetRequiredService</c> on a disposed
+    /// <see cref="ServiceProvider"/> — rather than a stand-in exception.
+    ///
+    /// <para><see cref="HistoricalScheduler"/>'s <c>AdvanceBy</c> runs the tick on THIS thread, so an
+    /// escape shows up as a throw out of <c>AdvanceBy</c>. In production the tick runs on a
+    /// thread-pool thread, where the same escape is an unhandled exception and takes the
+    /// process down.</para>
+    /// </summary>
+    [Fact]
+    public void Tick_ContainsASynchronousEstablishThrow_AndSinksItToTheLogger()
+    {
+        var scheduler = new HistoricalScheduler();
+        var faults = new List<(LogLevel Level, Exception? Exception)>();
+        var logger = new CapturingLogger(faults);
+
+        // The hub's DI scope after teardown. GetWorkspace() is exactly this call.
+        var services = new ServiceCollection()
+            .AddSingleton<WorkspaceStandIn>()
+            .BuildServiceProvider();
+        services.Dispose();
+
+        // `disposed` is still FALSE: the hub's RegisterForDisposal hook has not run yet, but
+        // the scope is already gone. This is the window the flag alone cannot close, and the
+        // reason the throw must be contained rather than merely avoided.
+        using var pending = ReEstablishSchedule.Arm(
+            () => false,
+            () => services.GetRequiredService<WorkspaceStandIn>(),
+            logger, Context, ThreadPath, scheduler);
+
+        var tick = () => scheduler.AdvanceBy(ReEstablishSchedule.Delay);
+
+        tick.Should().NotThrow(
+            "a disposed scope must not throw out of the timer tick — on the production "
+            + "(thread-pool) scheduler that is an UNHANDLED exception that kills the process. "
+            + "Every fault has to reach a graceful sink");
+
+        faults.Should().ContainSingle("the contained fault must be surfaced, not swallowed")
+            .Which.Exception.Should().BeOfType<ObjectDisposedException>();
+    }
+
+    /// <summary>
+    /// The arm-time guard, kept explicit: once the watcher is torn down NOTHING is armed —
+    /// not a cancelled timer, no <c>TimerQueue</c> entry at all.
+    /// </summary>
+    [Fact]
+    public void Arm_WhenAlreadyDisposed_ArmsNoTimerAtAll()
+    {
+        var scheduler = new HistoricalScheduler();
+        var establishes = 0;
+
+        var handle = ReEstablishSchedule.Arm(
+            () => true, () => establishes++, logger: null, Context, ThreadPath, scheduler);
+
+        scheduler.AdvanceBy(ReEstablishSchedule.Delay);
+
+        establishes.Should().Be(0, "a torn-down watcher must not re-establish");
+        handle.Should().BeSameAs(Disposable.Empty,
+            "nothing may be scheduled at all — an armed-then-cancelled timer still parks on "
+            + "the process-wide TimerQueue for the instant it exists (#991)");
+    }
+
+    /// <summary>
+    /// #991's other half, at this layer: the returned handle CANCELS the pending
+    /// re-establish, so assigning it into the watcher's <c>pendingReEstablish</c>
+    /// <see cref="SerialDisposable"/> lets teardown drop the TimerQueue entry.
+    /// </summary>
+    [Fact]
+    public void DisposingTheHandle_CancelsThePendingReEstablish()
+    {
+        var scheduler = new HistoricalScheduler();
+        var establishes = 0;
+
+        var handle = ReEstablishSchedule.Arm(
+            () => false, () => establishes++, logger: null, Context, ThreadPath, scheduler);
+        handle.Dispose();
+
+        scheduler.AdvanceBy(ReEstablishSchedule.Delay);
+
+        establishes.Should().Be(0,
+            "the handle must cancel the pending schedule — the watcher assigns it into a "
+            + "SerialDisposable that teardown disposes before the live subscription (#991)");
+    }
+
+    /// <summary>
+    /// Guard against over-fixing: a transient fault on a LIVE watcher must still re-establish,
+    /// and must do it OFF the synchronous error stack (a Subscribe-time fault re-entering
+    /// <c>Establish</c> inline recurses to a stack overflow — the Orleans-shard SIGABRT).
+    /// </summary>
+    [Fact]
+    public void Arm_WhileLive_ReEstablishesAfterTheDelay_AndNotBefore()
+    {
+        var scheduler = new HistoricalScheduler();
+        var establishes = 0;
+
+        using var pending = ReEstablishSchedule.Arm(
+            () => false, () => establishes++, logger: null, Context, ThreadPath, scheduler);
+
+        establishes.Should().Be(0,
+            "the re-establish must hop OFF the synchronous error stack, never run inline");
+
+        scheduler.AdvanceBy(ReEstablishSchedule.Delay - TimeSpan.FromMilliseconds(1));
+        establishes.Should().Be(0, "the delay has not elapsed yet");
+
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(1));
+        establishes.Should().Be(1,
+            "a live watcher whose stream faulted transiently must be re-established, or the "
+            + "thread is left unobserved and a claimed round never dispatches");
+    }
+
+    /// <summary>Stands in for <c>IWorkspace</c> — the service <c>GetWorkspace()</c> resolves.</summary>
+    private sealed class WorkspaceStandIn;
+
+    private sealed class CapturingLogger(List<(LogLevel Level, Exception? Exception)> sink) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => sink.Add((logLevel, exception));
+    }
+}


### PR DESCRIPTION
## What

Three watchers re-establish a faulted stream by hand — `ThreadExecution.InstallExecRoundWatcher`, `ThreadExecution.InitializeThreadLifecycle`, `ThreadSubmissionServer.InstallServerWatcher`. Their comments claimed they mirrored the sanctioned `ActivityControlPlaneExtensions.SubscribeWithReEstablish`. **They only imitated it**, so a reader — or a grep for the helper — concluded they had inherited its teardown fixes. They had not, and these branches had **zero test coverage**, which is part of why the hazards survived.

Two hazards, both in the 1 s window between a stream faulting and the re-establish firing. That window is the common case, not the rare one: teardown is exactly what faults the stream.

### Hazard 1 — the timer tick never re-read `disposed`

The flag was checked when the timer was **armed**; a second later, on a hub that had since been disposed, `Establish()` ran anyway and re-subscribed a dead hub's stream. That is the #991 shape: a `TimerQueue` entry (a strong GC root) holding `Establish` → the watcher closure → the hub. The `SerialDisposable` cancels the schedule, but disposing an Rx timer is best-effort against a tick already dispatched to the pool, so the flag must be re-read at **fire** time. The sanctioned helper does exactly this (`if (disposed) return;` at the head of its `Establish`).

### Hazard 2 — a synchronous throw escaped onto the timer thread

`GetWorkspace()` was re-resolved **inside** the factory in two of the three loops. It is `ServiceProvider.GetRequiredService<IWorkspace>()`, so after teardown it throws `ObjectDisposedException` straight out of `Subscribe`. Rx rethrows out of an `OnNext` handler, and on the default (thread-pool) scheduler that is an **unhandled exception that kills the process** — a direct wedges-to-zero violation.

## Fix

- New `ReEstablishSchedule.Arm` (internal to `MeshWeaver.AI`): re-reads the disposal flag when the timer **fires**, and routes a synchronous `Establish()` throw to the logger — `Warning` for the expected disposed-scope case, `Error` for anything unexpected — instead of onto the timer thread. Not a swallow: every fault is surfaced with full context.
- Both loops that re-resolved the workspace now **hoist** it to install time, while the hub's scope is alive. `IWorkspace` is scoped per hub, so this resolves the identical instance — no behaviour change.
- Comments and `SubscriptionOwnership.md` now say plainly that these are hand-rolled loops sharing only the *scheduling*, and that converting them is open work.

## Deliberately NOT in this PR

Converting the three loops to `SubscribeWithReEstablish`. That changes terminal fault classification too, and: PR #1054 (own-hub-disposing classification) is still open, so converting now makes teardown *louder* until it lands; and `InstallExecRoundWatcher` watches the **parent** hub's node, so the helper's address-scoped own-node-gone detection would need `parentHub.Address` passed through or it would silently never match. Tracked as follow-up.

## Verification

Each hazard has a deterministic test (virtual time via `HistoricalScheduler` — no wall clock, no `Task.Delay`) that **fails before the fix**. Observed pre-fix failures, by temporarily reverting each guard:

**Hazard 1** — `Tick_DoesNotReEstablish_WhenDisposalLandsDuringTheDelay`:
```
Expected value to be 0 because the re-establish must re-read the disposal flag when the
timer FIRES, not only when it was armed ... but found 1.
```

**Hazard 2** — `Tick_ContainsASynchronousEstablishThrow_AndSinksItToTheLogger`:
```
Did not expect an exception because a disposed scope must not throw out of the timer tick
— on the production (thread-pool) scheduler that is an UNHANDLED exception that kills the
process. Every fault has to reach a graceful sink, but found ObjectDisposedException:
Cannot access a disposed object. Object name: 'IServiceProvider'.
```

Hazard 2's test reproduces the exact mechanism — `GetRequiredService` on a disposed `ServiceProvider` — rather than a stand-in exception.

- `dotnet build -c Release -warnaserror`: clean (`MeshWeaver.AI`, `MeshWeaver.AI.Test`, `MeshWeaver.Threading.Test`). No CS9107.
- `MeshWeaver.AI.Test --filter ReEstablishScheduleTest`: **5/5 pass**.
- `MeshWeaver.Threading.Test` (the suite that exercises these watchers): **128/128 pass**.

## What's New

No entry — this is internal robustness in the teardown window with no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)