### PR TITLE
An unanswered type-registration lookup is not a verdict

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-values-no-longer-render-empty-after-an-update.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-values-no-longer-render-empty-after-an-update.md
@@ -1,0 +1,30 @@
+---
+Name: Values no longer render empty after an update
+Category: Fix
+Description: A page could come back blank after a portal update — not because its data was lost, but because a lookup that ran out of time was mistaken for a definite answer.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Values no longer render empty after an update
+
+After a portal update, an occasional page came back empty. Its fields showed nothing, tools reading
+the same item answered "unavailable", and anything waiting for the value simply timed out. The data
+was never gone: opening the item's contents directly still showed everything, filled in.
+
+Every portal update rebuilds the custom item types the portal serves, and they are rebuilt one after
+another, which can take several minutes. During that window the portal asks, for each item, "which
+type is this?" — and that question is given a short deadline so a genuinely unknown type is reported
+quickly instead of stalling the page. The mistake was treating a deadline that ran out as if it were
+an answer. Under the rebuild the question sometimes could not be answered in time, and the portal
+concluded the type was unusable, then served the item without it. With no type in hand it could not
+read the item's own fields, so they came back blank — and, because that conclusion was reached once
+and kept, the page stayed blank long after the type had finished rebuilding and was working
+perfectly. Since it depended on timing, it hit some servers and not others, which made it look
+arbitrary.
+
+Now an unanswered lookup is treated as what it is: not yet known, rather than known to be bad. The
+portal waits for the type to actually appear — which it does as soon as its rebuild finishes — and
+then serves the item with its fields intact. A type that genuinely is not registered is still
+reported straight away, and if a type never turns up at all the page explains that it is a lookup
+problem rather than telling you to fix code that was never at fault.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -170,19 +170,36 @@ internal static class NodeTypeEnrichmentHelpers
                     }
                     if (outcome == ProbeOutcome.Indeterminate)
                     {
-                        var msg =
-                            $"The registration lookup for NodeType '{nodeType}' did not complete within "
-                            + $"{NodeTypeProbeTimeout.TotalSeconds:0}s.\n"
-                            + $"Instance '{node.Path}' is rendering this fallback until the lookup succeeds.";
-                        var (intro, callToAction, guidance) = OverlayCopy(OverlayCause.LookupTimedOut);
-                        // NULL version gate for the same reason as the missing case:
-                        // no type node was ever read here, so the first usable
-                        // emission is genuine news.
-                        return Observable.Return(
-                            WithOverlaySelfHeal(
-                                WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration,
-                                    guidance: guidance, intro: intro, callToAction: callToAction),
-                                meshHub, nodeType, typeVersionAtOverlay: null, logger));
+                        // 🚨 INDETERMINATE IS NOT A VERDICT — so it must not be as FINAL as
+                        // "definitely absent". This branch used to return a terminal overlay,
+                        // and THAT is the one-way degradation behind the memex 2026-08-09
+                        // '@Store' incident: every self-update roll changes the framework hash,
+                        // all ~240 dynamic NodeTypes rebuild sequentially (~10 min), the 3 s
+                        // probe loses that race for a handful of them, and the instance is
+                        // bound — for the grain's whole lifetime — to a config that never ran
+                        // the type's `WithContentType<T>()`. Its row's '$type' then resolves on
+                        // NO registry, MeshNodeTypeSource degrades Content to an untyped
+                        // JsonElement, and the value renders empty / reactive waits time out
+                        // long after the type finished compiling. It is a RACE, so it hit only
+                        // 2 of 5 pods in 24 h — the worst kind of "works on the other pod".
+                        //
+                        // The remedy is NOT a bigger NodeTypeProbeTimeout (that just moves the
+                        // race). The probe exists for exactly ONE job: fail FAST when the mesh
+                        // ANSWERS "nothing is registered there" (the Missing branch above). An
+                        // unanswered lookup grants no licence to fail fast, so we fall through
+                        // to the same reactive path a Registered outcome takes:
+                        // BuildEnrichmentChain subscribes the NodeType's OWN mesh-node stream
+                        // and settles the moment the type actually shows up — registration and
+                        // compile completion ARE emissions on that stream. No poll, no timer,
+                        // no retry loop: the re-resolution is the framework's own observable.
+                        // The wait is bounded exactly as the Registered path is
+                        // (WaitForCompileSettled: a wall clock only while NOTHING is
+                        // compiling, disarmed while a compile is genuinely in flight), and it
+                        // still ends in the graceful sink — an overlay whose copy names the
+                        // unanswered LOOKUP, never "correct the code".
+                        return BuildEnrichmentChain(
+                            meshHub, meshConfiguration, compilationService, node, nodeType, logger,
+                            afterIndeterminateProbe: true);
                     }
                     return BuildEnrichmentChain(meshHub, meshConfiguration, compilationService, node, nodeType, logger);
                 });
@@ -192,12 +209,21 @@ internal static class NodeTypeEnrichmentHelpers
     }
 
     /// <summary>
-    /// Existence probe timeout — short on purpose. The probe is a one-shot
-    /// "does a node at path:{nodeType} exist" query against the static and
-    /// storage providers; missing-type scenarios should surface in &lt;1s on
-    /// a healthy mesh. Anything longer almost certainly means a real backend
-    /// problem the operator needs to see, so we treat probe timeouts as
-    /// "missing" and emit the error overlay.
+    /// Existence probe timeout — short on purpose, and short is SAFE because a
+    /// timeout here is not a verdict. The probe is a one-shot "does a node at
+    /// path:{nodeType} exist" query against the static and storage providers;
+    /// missing-type scenarios should surface in &lt;1s on a healthy mesh, and
+    /// that ANSWERED absence is the only thing this budget is allowed to decide
+    /// (<see cref="ProbeOutcome.Missing"/> → fail fast with the "not registered"
+    /// overlay).
+    ///
+    /// <para>🚨 A probe that does not answer inside the budget yields
+    /// <see cref="ProbeOutcome.Indeterminate"/>, which falls through to the
+    /// normal reactive enrichment chain — so widening this number can never be
+    /// the fix for a type that "renders empty after a deploy". The old code DID
+    /// treat a timeout as terminal, and under a post-roll recompile storm
+    /// (~240 dynamic NodeTypes rebuilding sequentially) that permanently bound
+    /// healthy instances to a fallback config.</para>
     /// </summary>
     private static readonly TimeSpan NodeTypeProbeTimeout = TimeSpan.FromSeconds(3);
 
@@ -220,13 +246,23 @@ internal static class NodeTypeEnrichmentHelpers
         Indeterminate
     }
 
+    /// <param name="afterIndeterminateProbe">
+    /// True when the existence probe reached NO verdict and this chain is the
+    /// re-resolution that replaces it (see the <see cref="ProbeOutcome.Indeterminate"/>
+    /// branch of <see cref="EnrichWithNodeType"/>). It changes nothing about how the
+    /// chain WAITS — only what the overlay says if the wait also comes up empty: the
+    /// cause is then the unanswered LOOKUP, not an unsettled build, so the operator is
+    /// not sent chasing a compile that was never consulted (#641's mistake, one layer
+    /// down).
+    /// </param>
     private static IObservable<MeshNode> BuildEnrichmentChain(
         IMessageHub meshHub,
         MeshConfiguration meshConfiguration,
         IMeshNodeCompilationService? compilationService,
         MeshNode node,
         string nodeType,
-        ILogger? logger)
+        ILogger? logger,
+        bool afterIndeterminateProbe = false)
     {
         // Slow path: subscribe to the NodeType MeshNode stream directly via
         // the mesh hub's workspace. The workspace's per-(addr, ref) cache
@@ -278,7 +314,19 @@ internal static class NodeTypeEnrichmentHelpers
                 // that page swaps the "correct the code" copy for the
                 // auto-recovery story (see UnsettledBuildIntro/Guidance).
                 var timedOut = ex is TimeoutException;
-                var userMessage = timedOut
+                // 🚨 When we got here BECAUSE the registration lookup never answered, the
+                // honest cause is still "the lookup did not answer" — the build was never
+                // consulted, so "the build did not settle" would be a guess dressed as a
+                // diagnostic. Keep the LookupTimedOut copy and name BOTH budgets that
+                // elapsed, so the operator can tell a slow storage/mesh-hub from a genuinely
+                // unsettled compile.
+                var lookupNeverAnswered = timedOut && afterIndeterminateProbe;
+                var userMessage = lookupNeverAnswered
+                    ? $"The registration lookup for NodeType '{nodeType}' did not complete within "
+                      + $"{NodeTypeProbeTimeout.TotalSeconds:0}s, and the type did not show up on its own "
+                      + $"stream within a further {SlowPathTimeout.TotalSeconds:0}s.\n"
+                      + $"Instance '{node.Path}' is rendering this fallback until the lookup succeeds."
+                    : timedOut
                     ? $"NodeType '{nodeType}' build did not settle within {SlowPathTimeout.TotalSeconds:0}s.\n"
                       + $"Instance '{node.Path}' is rendering this fallback until the type's build settles."
                     // A non-timeout abort still isn't the author's code: name the
@@ -286,7 +334,9 @@ internal static class NodeTypeEnrichmentHelpers
                     : $"NodeType '{nodeType}' could not be prepared for instance '{node.Path}'\n"
                       + $"{ex.GetType().Name}: {ex.Message}";
                 var (intro, callToAction, guidance) = OverlayCopy(
-                    timedOut ? OverlayCause.BuildNotSettled : OverlayCause.EnrichmentFaulted);
+                    lookupNeverAnswered ? OverlayCause.LookupTimedOut
+                    : timedOut ? OverlayCause.BuildNotSettled
+                    : OverlayCause.EnrichmentFaulted);
                 // Self-heal with a NULL version gate: no type node is in hand
                 // here, and a currently-usable state would have settled instead
                 // of timing out — so the first usable emission is genuine news

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -116,6 +116,16 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     // persisted bytes). See GraftRoutingEnrichment.
     private MeshNode? _latestRoutingNode;
 
+    // Mesh-wide $type → CLR-Type map (see IMeshContentTypeRegistry). The per-hub
+    // ITypeRegistry consulted first in ResolveJsonElementContent only knows what THIS hub's
+    // HubConfiguration registered at construction — and for a dynamic NodeType that is a
+    // side effect of MeshDataSource.WithContentType, which never runs when enrichment bound
+    // the instance to a fallback config. This registry is the options-independent, process-
+    // wide answer the other three degrade seams (ObjectPolymorphicConverter.ReadObject,
+    // MeshNodeStreamCache, MeshNodeStreamHandle.EnsureTypedContent) already consult; the
+    // OWNING hub's own load was the one seam still missing from that list.
+    private readonly Mesh.Services.IMeshContentTypeRegistry? _contentTypeRegistry;
+
     internal MeshNodeTypeSource(
         IWorkspace workspace,
         object dataSource,
@@ -155,6 +165,8 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             .GetService<MeshDataSourceExtensions.OwnNodeCache>();
         _recentlyDeletedRegistry = workspace.Hub.ServiceProvider
             .GetService<RecentlyDeletedRegistry>();
+        _contentTypeRegistry = workspace.Hub.ServiceProvider
+            .GetService<Mesh.Services.IMeshContentTypeRegistry>();
         _logger?.LogDebug("MeshNodeTypeSource: Created for hubPath={HubPath} (routingSuppliedStream={Supplied})",
             hubPath, ownNodeStream != null);
 
@@ -990,6 +1002,31 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             if (shortName is null
                 || !registry.TryGetType(shortName, out typeDef) || typeDef?.Type == null)
             {
+                // 🚨 Before degrading, ask the MESH-WIDE map. This hub's ITypeRegistry only
+                // knows what its own HubConfiguration registered at construction, and for a
+                // dynamically compiled NodeType that registration (MeshDataSource
+                // .WithContentType) is a SIDE EFFECT of enrichment having resolved the real
+                // config. When enrichment degraded — an unanswered registration probe during
+                // a post-roll recompile storm, a fallback overlay, a re-import into a running
+                // process — the side effect never happened here, yet another hub in this
+                // process (or a later activation) may already have registered the very same
+                // CLR type. IMeshContentTypeRegistry is exactly that options-independent
+                // answer, and the other three degrade seams already consult it; the owning
+                // hub's own load was the last one that did not, so its workspace copy stayed
+                // untyped even after the type was known process-wide. Deserialises to the
+                // CONCRETE type explicitly, so nothing is adopted into this hub's frozen
+                // options (no collectible-ALC identity becomes a long-lived answer).
+                var recovered = _contentTypeRegistry?.TryRecover(je, _workspace.Hub.JsonSerializerOptions);
+                if (recovered is not null)
+                {
+                    _logger?.LogDebug(
+                        "MeshNodeTypeSource[{HubPath}]: content discriminator '$type': '{TypeName}' is not on "
+                        + "this hub's registry, but the mesh-wide content-type registry resolved it to {Type} "
+                        + "for {Path} — content typed from the mesh map.",
+                        _hubPath, typeName, recovered.GetType().Name, node.Path);
+                    return node with { Content = recovered };
+                }
+
                 // 🚨 Bad-data tolerance contract: degrade to JsonElement but LOUDLY.
                 // This is the OWNING hub failing to type its OWN node's content — the
                 // discriminator is unresolvable on the one registry that is canonical

--- a/test/MeshWeaver.Graph.Test/IndeterminateProbeReResolutionTest.cs
+++ b/test/MeshWeaver.Graph.Test/IndeterminateProbeReResolutionTest.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Regression guard for the memex 2026-08-09 <c>@Store</c> incident: a node whose data was
+/// intact answered <c>Unavailable: read reached no verdict within 10s</c>, and its value
+/// rendered empty, because the type-registration PROBE lost a race and its INDETERMINATE
+/// answer was treated as final.
+///
+/// <para>The mechanism, end to end:</para>
+/// <list type="number">
+///   <item>Every 6-hourly self-update roll changes the framework hash, so all ~240 dynamic
+///     NodeTypes rebuild sequentially (~10 min of Roslyn on the Compile pool).</item>
+///   <item>Under that load the 3 s existence probe in
+///     <see cref="NodeTypeEnrichmentHelpers.EnrichWithNodeType"/> does not answer →
+///     <c>ProbeOutcome.Indeterminate</c>.</item>
+///   <item>Indeterminate used to return a TERMINAL overlay configuration. The NodeType's own
+///     configuration — the one that calls <c>WithContentType&lt;T&gt;()</c> — therefore never
+///     ran, so the content <c>$type</c> discriminator was registered on NO registry.</item>
+///   <item><c>MeshNodeTypeSource.ResolveJsonElementContent</c> then degraded the row's Content
+///     to an untyped <see cref="JsonElement"/> — and, because enrichment binds ONCE per grain,
+///     it stayed that way long after the type finished compiling (the type's Release existed
+///     at 01:10:16, the compile logged green at 01:19:26, the content never re-typed).</item>
+/// </list>
+///
+/// <para>The fix is NOT a longer probe budget — that only moves the race. An unanswered lookup
+/// is not a verdict, so it now falls through to the same reactive chain a REGISTERED outcome
+/// takes: the NodeType's own mesh-node stream, on which registration/compile completion is an
+/// emission. This test pins exactly that: the probe never answers, the type shows up LATE, and
+/// the instance must still end up bound to the type's own content-type-registering
+/// configuration — i.e. with typed content rather than a permanently untyped JsonElement.</para>
+/// </summary>
+public class IndeterminateProbeReResolutionTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Stand-in for a dynamically compiled NodeType's content type. What matters is that it is
+    /// resolvable ONLY if the NodeType's own hub configuration was applied.
+    /// </summary>
+    private sealed record ProbeLateContent
+    {
+        public string? Title { get; init; }
+    }
+
+    private const string NodeTypePath = "ProbeSpace/Catalog";
+    private const string InstancePath = "ProbeSpace/Instance";
+
+    /// <summary>
+    /// When the NodeType shows up on its own stream, measured from the START of the test. Past
+    /// <c>NodeTypeEnrichmentHelpers.NodeTypeProbeTimeout</c> (3 s), so the registration lookup
+    /// has provably already given up when it lands — that is the state under test. The stream is
+    /// made HOT (Replay + Connect) so this really is "the type registers 5 s into the run",
+    /// independent of when anything subscribes.
+    /// </summary>
+    private static readonly TimeSpan LateRegistration = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The busy-mesh shape: the <c>path:{nodeType}</c> lookup never answers, so the probe times
+    /// out and reports <c>Indeterminate</c>. It counts its calls so the test can prove the probe
+    /// really ran (a test that accidentally skipped it would pass vacuously).
+    /// </summary>
+    private sealed class NeverAnsweringQueryCore : IMeshQueryCore
+    {
+        private int calls;
+        public int Calls => System.Threading.Volatile.Read(ref calls);
+
+        public IObservable<QueryResultChange<T>> Query<T>(
+            MeshQueryRequest request, JsonSerializerOptions options)
+        {
+            System.Threading.Interlocked.Increment(ref calls);
+            return Observable.Never<QueryResultChange<T>>();
+        }
+    }
+
+    /// <summary>
+    /// Serves the NodeType's mesh-node stream — the observable on which "the type is registered
+    /// now" actually arrives, and therefore the re-resolution signal the fix relies on.
+    /// </summary>
+    private sealed class TypeNodeStreamCache(IObservable<MeshNode> typeNodeStream) : IMeshNodeStreamCache
+    {
+        public IObservable<MeshNode> GetStream(string path) => typeNodeStream;
+        public IObservable<MeshNode> GetStream(string path, JsonSerializerOptions options)
+            => GetStream(path);
+        public IObservable<MeshNode> Update(string path, Func<MeshNode, MeshNode> update)
+            => Observable.Never<MeshNode>();
+        public IObservable<MeshNode> Update(string path, Func<MeshNode, MeshNode> update, JsonSerializerOptions options)
+            => Update(path, update);
+        public IObservable<MeshNode> Overwrite(string path, MeshNode node, JsonSerializerOptions options)
+            => Observable.Never<MeshNode>();
+        public void Invalidate(string path) { }
+        public IObservable<IEnumerable<MeshNode>>? GetQuery(object id) => null;
+        public IObservable<IEnumerable<MeshNode>> GetQuery(object id, JsonSerializerOptions options, params string[] queries)
+            => Observable.Never<IEnumerable<MeshNode>>();
+    }
+
+    /// <summary>
+    /// The pin. Probe never answers (Indeterminate); the NodeType registers 5 s into the run; the
+    /// enriched instance must carry the TYPE'S OWN configuration, which is what registers the
+    /// content discriminator and therefore what makes the node's content typed.
+    ///
+    /// <para>Before the fix this fails: the Indeterminate branch returned the overlay
+    /// configuration immediately at 3 s and never looked at the NodeType stream again, so
+    /// <c>ProbeLateContent</c> was registered nowhere and the row's content stayed an untyped
+    /// JsonElement for the grain's whole lifetime.</para>
+    /// </summary>
+    [HubFact]
+    public async Task IndeterminateProbe_ThenLateRegistration_EndsWithTypedContent()
+    {
+        // The NodeType's REAL configuration: the delegate that registers the content type.
+        // Production spells this `c => c.WithContentType<T>()`, which bottoms out in exactly
+        // this TypeRegistry.WithType call (MeshDataSource.WithContentType) — minus the
+        // data-source plumbing a bare configuration cannot build.
+        Func<MessageHubConfiguration, MessageHubConfiguration> typeOwnConfiguration =
+            c => c.WithType<ProbeLateContent>(nameof(ProbeLateContent));
+
+        var typeNode = new MeshNode("Catalog", "ProbeSpace")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition(),
+            HubConfiguration = typeOwnConfiguration,
+        };
+
+        // HOT: the type registers at LateRegistration from NOW, whether or not anyone is
+        // watching — so at the moment the probe gives up (3 s) the type genuinely is not there
+        // yet, and it appears afterwards on its own schedule. Replay(1) so the enrichment chain,
+        // which only subscribes after the probe has failed, still sees it.
+        var typeNodeStream = Observable.Timer(LateRegistration).Select(_ => typeNode).Replay(1);
+        using var _ = typeNodeStream.Connect();
+
+        var probe = new NeverAnsweringQueryCore();
+        var meshHub = Mesh.GetHostedHub(new Address("probemesh", "1"), c => c
+            .AddData()
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithServices(services => services
+                .AddSingleton<IMeshNodeStreamCache>(new TypeNodeStreamCache(typeNodeStream))
+                .AddSingleton<IMeshQueryCore>(probe)));
+
+        var instance = MeshNode.FromPath(InstancePath) with { NodeType = NodeTypePath };
+
+        var enriched = await NodeTypeEnrichmentHelpers
+            .EnrichWithNodeType(meshHub, new MeshConfiguration(Array.Empty<MeshNode>()),
+                compilationService: null, instance)
+            .Take(1)
+            .Should().Within(20.Seconds()).Emit();
+
+        probe.Calls.Should().BeGreaterThan(0,
+            "the existence probe must still run — this test is about what happens when it does " +
+            "NOT answer, not about removing it");
+
+        enriched.HubConfiguration.Should().BeSameAs(typeOwnConfiguration,
+            "an INDETERMINATE probe is not a verdict: the instance must end up bound to the " +
+            "NodeType's OWN configuration once the type shows up on its stream. Binding the " +
+            "fallback overlay instead is the one-way degradation — the type's " +
+            "WithContentType<T>() never runs, so its content discriminator is registered " +
+            "nowhere and the node renders empty even after the type compiles green.");
+
+        // The load-bearing consequence, stated directly: apply the resolved configuration and
+        // the content discriminator resolves — which is exactly what
+        // MeshNodeTypeSource.ResolveJsonElementContent needs to type the row instead of
+        // degrading it to a bare JsonElement.
+        var hubConfiguration = enriched.HubConfiguration!(
+            new MessageHubConfiguration(null, new Address("node", "probe-instance")));
+        hubConfiguration.TypeRegistry.TryGetType(nameof(ProbeLateContent), out var typeDefinition)
+            .Should().BeTrue(
+                "the content '$type' discriminator must resolve on the instance hub — that is " +
+                "the difference between typed content and the untyped JsonElement that renders " +
+                "empty and makes reactive waits time out");
+        typeDefinition!.Type.Should().Be(typeof(ProbeLateContent));
+    }
+}


### PR DESCRIPTION
## The defect

On `memex.meshweaver.cloud`, `get @Store` answered `Unavailable: read reached no verdict within 10s` and the value rendered empty — while `get @Store/data/` returned the node **fully populated**. The data was never lost; only the typed single-node read path failed.

From that portal's own logs:

```
01:09:47  DynamicTypePreWarmer: 241 of 241 dynamic NodeType(s) need building …
          alreadyBaked=0 frameworkstale=236 previouslybroken=5
01:10:18  EnrichWithNodeType probe for NodeType 'Store/Catalog' faulted (TimeoutException)
          — registration is INDETERMINATE, not missing
01:10:19  MeshNodeTypeSource[Store]: content discriminator '$type': 'StoreContent' is not a
          registered type on the owning hub — content stays an untyped JsonElement
01:19:32  DynamicTypePreWarmer: warm-up complete in 00:09:51 — compiled=237 compileErrors=4
```

`EnrichWithNodeType`'s existence probe has **three** outcomes — Registered / Missing / Indeterminate — and the distinction is deliberate and correct. The bug was that **Indeterminate was as FINAL as "definitely absent"**: it returned a terminal overlay `HubConfiguration`. The NodeType's own configuration — the one that calls `WithContentType<StoreContent>()` — therefore never ran, so the `$type` discriminator was registered on **no** registry, and `MeshNodeTypeSource.ResolveJsonElementContent` degraded `Content` to an untyped `JsonElement`.

**That degradation was one-way.** Enrichment binds once per grain: `Store/Catalog`'s Release existed at 01:10:16 and the prewarmer logged it compiled at 01:19:26 — the content stayed untyped anyway. And because it is a race, only **2 of 5 pods** warned in 24 h.

## The fix

Not a wider `NodeTypeProbeTimeout` — that only moves the race, and is the forbidden shape.

The probe exists for exactly one job: fail **fast** when the mesh *answers* "nothing is registered there". That path (`Missing`) is untouched — `UnregisteredNodeTypeTest` still settles in under 0.5 s. An **unanswered** lookup grants no licence to fail fast, so `Indeterminate` now falls through to the same reactive chain a `Registered` outcome takes:

- `BuildEnrichmentChain` subscribes the NodeType's **own mesh-node stream** — registration and compile completion *are* emissions on it — and settles the moment the type actually shows up. **No poll, no timer, no retry loop:** the re-resolution is the framework's existing observable.
- The wait is bounded exactly as the Registered path is: `WaitForCompileSettled` arms its wall clock only while *nothing* is compiling and disarms it once a compile is genuinely in flight.
- It still ends in the graceful sink. If the type never appears either, the overlay copy names the unanswered **lookup** (`OverlayCause.LookupTimedOut`) and both elapsed budgets, rather than an unsettled build — nobody is sent to "correct the code" for a compile that was never consulted.

### Second seam: the owning hub never asked the mesh-wide map

`ResolveJsonElementContent` consulted only this hub's frozen `ITypeRegistry`. `IMeshContentTypeRegistry` is the process-wide, options-independent `$type` → CLR-Type map that the **three** documented degrade seams already consult (`ObjectPolymorphicConverter.ReadObject`, `MeshNodeStreamCache`, `MeshNodeStreamHandle.EnsureTypedContent`). The **owning hub's own load** was the one still missing from that list, so its workspace copy stayed untyped even when the type was known process-wide. It now asks, and deserialises to the concrete type explicitly (nothing is adopted into the hub's frozen options).

## Verification

`IndeterminateProbeReResolutionTest` — the probe never answers, the type registers 5 s into the run on a hot stream, and the instance must end up bound to the type's own content-type-registering configuration (asserted both by identity and by applying it and resolving the discriminator).

Pre-fix (Indeterminate branch temporarily restored) it fails at **exactly 3 s** — the probe budget:

```
Failed … IndeterminateProbe_ThenLateRegistration_EndsWithTypedContent [3 s]
MeshWeaver.Reactive.Assertions.AssertionException : Expected value to refer to the same instance
because an INDETERMINATE probe is not a verdict: the instance must end up bound to the NodeType's
OWN configuration once the type shows up on its stream. …, but it did not.
```

Post-fix it passes in 5 s — i.e. it settles when the type registers, not when a clock runs out.

- `MeshWeaver.Graph.Test` — **890/890 passed**
- `MeshWeaver.Persistence.Test` `UnregisteredNodeTypeTest` — passed (fail-fast Missing path intact)
- `MeshWeaver.Documentation.Test` `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` — passed
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph`, `MeshWeaver.Graph.Test`, `MeshWeaver.Persistence.Test`, `MeshWeaver.Documentation.Test` (0 warnings)

What's New entry included (`Category: Fix` — user-noticeable: values rendered empty).

## Noted, not fixed here

- **`alreadyBaked=0` is by design, not a defect.** `BakeState.FrameworkStale` is documented as "the ordinary every-deploy state": the framework MVID is baked into the assembly-store filename *and* its lookup glob, so a new image misses the whole cache for ABI safety. That is precisely why every roll opens a ~10 min sequential-recompile window — which is what made this race reachable.
- **Two other genuinely terminal indeterminate-probe results found while auditing** (separate defects, not touched here):
  - `CompletionMemoryStore.cs:97-131` — a 15 s load timeout/fault is folded to an **empty** memory and cached (`loading` never has `TryRemove`, `memories` never reloads); the next `Record` marks it dirty and the debounced save writes that empty memory over the user's real acceptance history. Indeterminate read → **persisted data loss**.
  - `CircuitAccessHandler.cs:240-251` — on an unavailable identity lookup the circuit keeps the email-local-part `ObjectId` plus UTC/English for its whole lifetime; `UpdateUserContext` has zero callers, so nothing re-resolves when the index hydrates.
  - Minor: `MeshSearchView.razor.cs:1630-1641` folds a 10 s permission probe to `false` and `_permissionRequested` blocks any re-probe for the component's lifetime (fail-closed UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)