### PR TITLE
Two updates for one page could swap places in the router, and the loser was dropped forever

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-pages-no-longer-stall-on-building-layout.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-pages-no-longer-stall-on-building-layout.md
@@ -1,0 +1,25 @@
+---
+Name: Pages no longer stall on "Building layout…"
+Category: Fix
+Description: A page could open, connect, and then sit on its loading frame forever because one update overtook another in transit and the real content was discarded as stale.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Pages no longer stall on "Building layout…"
+
+Occasionally a page would connect normally and then never finish: the loading
+frame stayed up, nothing failed, and nothing appeared in the logs. Reloading
+usually fixed it, which made it look like a hiccup rather than a bug.
+
+It was not a hiccup. Updates for one page travel from the node that owns it to
+your browser as a numbered sequence, and the receiving side deliberately ignores
+an update older than the one it already applied — that is what stops a delayed
+message from undoing newer state. The distributed router, however, was sending
+those updates on independent threads, so two of them could swap places on the
+way. When the swap happened to hop over the update carrying the page's actual
+content, that content was ignored as "old" and never sent again: the page kept
+the loading frame it started with, forever.
+
+Updates for the same destination are now sent strictly in the order they were
+produced, so the page always receives its content.

--- a/src/MeshWeaver.Hosting.Orleans/OrderedRouteDispatcher.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrderedRouteDispatcher.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// Runs route legs OFF the routing grain's turn (issue #1028) while keeping the mesh's
+/// send order intact PER DESTINATION: two deliveries handed in for the same address are
+/// subscribed strictly one after the other, in arrival order. Legs for different addresses
+/// never wait on each other.
+///
+/// <para><b>Why FIFO per destination is a correctness requirement, not a nicety.</b> The data-sync
+/// protocol is a DELTA protocol with a receive-side monotonicity guard: a frame whose owner
+/// version is below the mirror's current version is discarded as stale
+/// (<c>SynchronizationStream.UpdateStream</c>), and nothing ever re-sends it. That guard is only
+/// sound while frames arrive in the order the owner produced them. Handing each leg to the I/O
+/// pool independently — <c>pool.SubscribeThroughPool(leg)</c> per delivery, which hops every
+/// subscribe onto its own thread-pool thread — discards that order, so two frames of ONE stream
+/// can swap: the later one lands first, and the earlier one (carrying the layout area's actual
+/// content) is then dropped as "stale" FOREVER. The subscriber stays on the "Building layout…"
+/// base frame and its wait dies on its own timeout, with nothing logged above Debug on either
+/// side. That is the same visible failure the wrong-clock bug produced (see
+/// <c>SynchronizationStream.OwnerVersion</c>'s remarks) — reached here through arrival order
+/// instead of through a wrong version stamp.</para>
+///
+/// <para>The routing grain's turn is the LAST point at which the order is still authoritative
+/// (<c>[StatelessWorker(1)]</c>, non-reentrant — one turn per silo), which is why the FIFO is
+/// claimed there and drained here.</para>
+///
+/// <para>Nothing runs on the turn and nothing is awaited: each leg is still subscribed through
+/// the mesh's drainable routing <see cref="IIoPool"/>, so teardown can cancel + join it. The
+/// queue is a plain lock-protected <see cref="ImmutableQueue{T}"/> — a synchronous data-structure
+/// guard, never an async gate — and a destination's entry is removed the moment its queue drains,
+/// so a silo that has served millions of short-lived <c>portal/{user}</c> addresses holds none of
+/// them.</para>
+///
+/// <para><b>Head-of-line, deliberately.</b> One in-flight post PER DESTINATION is the point: a FIFO
+/// channel cannot overtake itself. It costs nothing on the healthy path (a post's only await is
+/// <c>IMemoryStreamQueueGrain.Enqueue</c> — sub-millisecond, and already bounded by Orleans' own
+/// 30 s response timeout under <c>RoutingGrain.StreamPostTimeout</c>), and destinations never wait
+/// on each other, so a stalled subscriber slows only its own channel. That backlog is exactly what
+/// <c>RoutingGrain.ReportSaturation</c> already reports at <c>Critical</c>.</para>
+/// </summary>
+internal sealed class OrderedRouteDispatcher(IIoPool pool, ILogger logger)
+{
+    private readonly record struct QueuedLeg(IObservable<Unit> Leg, Action OnCompleted);
+
+    private sealed class DestinationQueue
+    {
+        public ImmutableQueue<QueuedLeg> Pending = ImmutableQueue<QueuedLeg>.Empty;
+    }
+
+    private readonly object gate = new();
+    private readonly Dictionary<string, DestinationQueue> queues = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Destinations that currently hold a queue. Diagnostics / tests only — a healthy silo drains
+    /// to zero, so a non-zero steady state means a leg is not completing.
+    /// </summary>
+    internal int ActiveDestinations
+    {
+        get { lock (gate) return queues.Count; }
+    }
+
+    /// <summary>
+    /// Enqueues one composed (cold) route leg for <paramref name="destination"/> and starts
+    /// draining if this destination is idle. Returns immediately — the leg runs on the pool.
+    /// </summary>
+    /// <param name="destination">The target address path; the FIFO key.</param>
+    /// <param name="leg">The cold route observable; its side effects run when the drain subscribes it.</param>
+    /// <param name="onLegCompleted">Invoked once per leg after it terminates (success or fault),
+    /// on the completing thread — the in-flight bookkeeping the caller owns.</param>
+    public void Enqueue(string destination, IObservable<Unit> leg, Action onLegCompleted)
+    {
+        var queued = new QueuedLeg(leg, onLegCompleted);
+        lock (gate)
+        {
+            if (queues.TryGetValue(destination, out var existing))
+            {
+                // An entry exists ⇒ a drain for this destination is running (or is about to be
+                // started by its creator, which still holds the leg it enqueued). Appending is
+                // therefore enough: that drain picks this leg up when the one ahead completes.
+                existing.Pending = existing.Pending.Enqueue(queued);
+                return;
+            }
+            queues[destination] = new DestinationQueue { Pending = ImmutableQueue.Create(queued) };
+        }
+        DrainNext(destination);
+    }
+
+    /// <summary>
+    /// Subscribes the next leg for <paramref name="destination"/>, or removes the destination's
+    /// entry when its queue is empty. Re-entered from each leg's terminal notification, so exactly
+    /// one leg per destination is ever in flight. No recursion depth to worry about: every leg is
+    /// subscribed through the pool, which hops to a thread-pool thread, so a leg can never complete
+    /// inside its own subscribe call.
+    /// </summary>
+    private void DrainNext(string destination)
+    {
+        QueuedLeg next;
+        lock (gate)
+        {
+            if (!queues.TryGetValue(destination, out var queue) || queue.Pending.IsEmpty)
+            {
+                queues.Remove(destination);
+                return;
+            }
+            queue.Pending = queue.Pending.Dequeue(out next);
+        }
+
+        pool.SubscribeThroughPool(next.Leg)
+            .Finally(() =>
+            {
+                next.OnCompleted();
+                DrainNext(destination);
+            })
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[ROUTE] Ordered route leg faulted for {Destination}", destination));
+    }
+}

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -57,6 +57,16 @@ internal class RoutingGrain(
         ?? IoPool.Unbounded;
 
     /// <summary>
+    /// Per-destination FIFO for the stream-routed branch. Instance field — its lifetime is this
+    /// activation's, and it holds an entry only while a destination has work in flight.
+    /// See <see cref="OrderedRouteDispatcher"/> for why the order is a correctness requirement.
+    /// </summary>
+    private readonly OrderedRouteDispatcher orderedDispatcher = new(
+        meshHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Routing)
+        ?? IoPool.Unbounded,
+        logger);
+
+    /// <summary>
     /// Routes dispatched but not yet terminated. This is the back-pressure signal that used to be
     /// INVISIBLE: before #1028 the only evidence a route had stopped making progress was Orleans'
     /// own <c>NonReentrancyQueueSize</c> growing into the hundreds inside a "Response did not
@@ -130,10 +140,25 @@ internal class RoutingGrain(
         var streamProvider = this.GetStreamProvider(StreamProviders.Memory);
         var grainFactory = GrainFactory;
 
-        // 🚨 THE TURN'S WORK ENDS HERE. BuildRoute only COMPOSES a cold observable; every
-        // side effect runs when the routing pool subscribes it, on a ThreadPool thread.
-        Dispatch(BuildRoute(delivery, address, addressPath, streamProvider, grainFactory),
-            addressPath, delivery.Id);
+        // 🚨 THE TURN'S WORK ENDS HERE. The Build*Route helpers only COMPOSE a cold observable;
+        // every side effect runs when the routing pool subscribes it, on a ThreadPool thread.
+        //
+        // 🚨 …but for a STREAM-ROUTED destination the order in which those legs are subscribed
+        // is part of the contract, so that branch is drained through a per-destination FIFO
+        // (see OrderedRouteDispatcher for why a delta protocol cannot tolerate reordering).
+        // The branch decision is a pure set lookup — O(1), safe on the turn — and is made HERE
+        // precisely because the turn is the last point at which the send order is authoritative.
+        if (meshConfig.StreamRoutedAddressTypes.Contains(address.Type))
+        {
+            ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
+            orderedDispatcher.Enqueue(
+                addressPath,
+                BuildStreamRoute(delivery, address, addressPath, streamProvider),
+                () => ReportDrained(Interlocked.Decrement(ref inFlightRoutes)));
+        }
+        else
+            Dispatch(BuildGrainRoute(delivery, address, addressPath, streamProvider, grainFactory),
+                addressPath, delivery.Id);
 
         return Task.FromResult(delivery.Forwarded(address));
     }
@@ -173,10 +198,50 @@ internal class RoutingGrain(
     }
 
     /// <summary>
-    /// Composes (does NOT run) the route for one delivery. Everything below executes on the
-    /// routing pool, never on the grain turn — see <see cref="RouteMessage"/>.
+    /// Composes (does NOT run) the MEMORY-STREAM leg of a route: the "I'm a registered hosted hub,
+    /// find me via my RegisterStream subscription" path — portal hubs (<c>portal/{userId}</c>),
+    /// test client hubs (<c>client/{id}</c>), the cache hub (<c>cache/mesh-node-cache</c>), the
+    /// root mesh hub. The set is populated by each module via
+    /// <c>IMeshBuilder.AddStreamRoutedAddressType("…")</c>.
+    ///
+    /// <para>This is the channel every data-sync frame travels on, so its legs are drained through
+    /// <see cref="OrderedRouteDispatcher"/> — one at a time per destination, in arrival order.</para>
     /// </summary>
-    private IObservable<Unit> BuildRoute(
+    private IObservable<Unit> BuildStreamRoute(
+        IMessageDelivery delivery,
+        Address address,
+        string addressPath,
+        IStreamProvider streamProvider)
+    {
+        void PostFailureToSender(string failureMessage, ErrorType errorType) =>
+            PostFailure(delivery, address, streamProvider, failureMessage, errorType);
+
+        return Observable.Defer(() =>
+        {
+            logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
+            var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
+            return PostToStream(() => s.OnNextAsync(delivery), addressPath, delivery.Id,
+                delivery.Sender, PostFailureToSender, logger, StreamPostTimeout);
+        })
+            // Composition-time faults must ALSO reach the sender — see BuildGrainRoute's trailing
+            // Catch for the full rationale (the classic one: GetStream NRE'ing out of
+            // PersistentStreamProvider.IsRewindable while the stream provider is still starting).
+            .Catch<Unit, Exception>(ex =>
+            {
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage ROUTE_FAULT id={delivery.Id} addr={addressPath} ex={ex.Message}");
+                logger.LogError(ex, "[ROUTE] Routing {Address} failed before the delivery could be attempted", addressPath);
+                PostFailureToSender($"Routing to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>
+    /// Composes (does NOT run) the PER-NODE-GRAIN route for one delivery: path resolution, then the
+    /// grain hand-off. Everything below executes on the routing pool, never on the grain turn —
+    /// see <see cref="RouteMessage"/>.
+    /// </summary>
+    private IObservable<Unit> BuildGrainRoute(
         IMessageDelivery delivery,
         Address address,
         string addressPath,
@@ -188,23 +253,6 @@ internal class RoutingGrain(
 
         return Observable.Defer(() =>
         {
-            // Config-driven memory-stream dispatch: any address-type prefix
-            // declared as a static stream route goes via the cluster-wide
-            // Orleans memory stream instead of grain activation. This is the
-            // "I'm a registered hosted hub, find me via my RegisterStream
-            // subscription" path — portal hubs (`portal/{userId}`), test
-            // client hubs (`client/{id}`), cache hub (`cache/mesh-node-cache`),
-            // etc. The list is populated by each module via
-            // `IMeshBuilder.AddStreamRoutedAddressType("…")`.
-            if (meshConfig.StreamRoutedAddressTypes.Contains(address.Type))
-            {
-                logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
-                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
-                var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
-                return PostToStream(() => s.OnNextAsync(delivery), addressPath, delivery.Id,
-                    delivery.Sender, PostFailureToSender, logger, StreamPostTimeout);
-            }
-
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_BEGIN id={delivery.Id} addr={addressPath}");
             return pathResolver.ResolvePath(addressPath)
                 .Take(1)

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrderedRouteDispatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrderedRouteDispatcherTest.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Orleans;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 The routing contract this pins: deliveries to the SAME destination are posted in the order
+/// the routing grain received them.
+///
+/// <para><b>Why it is a correctness requirement.</b> Data sync is a DELTA protocol with a
+/// receive-side monotonicity guard — <c>SynchronizationStream.UpdateStream</c> discards any frame
+/// whose owner version is below the mirror's current version, and nothing re-sends it. Reorder two
+/// frames of one stream and the earlier one (which may be the one carrying the layout area's actual
+/// content) is dropped as "stale" FOREVER: the subscriber keeps the "Building layout…" base frame,
+/// its wait dies on its own timeout, and NOTHING is logged above Debug on either side. Measured on
+/// a single Orleans test-suite run before this fix: 854 stream-routed deliveries, 46 destinations
+/// with out-of-order posts, 115 inverted pairs — which is exactly the "one random layout-area
+/// subscribe times out per run" flake.</para>
+///
+/// <para><see cref="UnorderedPoolDispatch_StartsEveryLegConcurrently"/> is the negative control: it
+/// pins the behaviour of the shape this replaced (one <c>SubscribeThroughPool</c> per delivery),
+/// which starts every leg at once and therefore cannot preserve any order.</para>
+/// </summary>
+public class OrderedRouteDispatcherTest(ITestOutputHelper output) : TestBase(output)
+{
+    private const string Destination = "client/subscriber-1";
+    private const string OtherDestination = "client/subscriber-2";
+
+    /// <summary>A leg that announces its subscribe on <paramref name="starts"/> and terminates only
+    /// when <paramref name="gate"/> fires — so "did the next leg start?" is directly observable.</summary>
+    private static IObservable<Unit> GatedLeg(int id, IObserver<int> starts, IObservable<Unit> gate) =>
+        Observable.Create<Unit>(observer =>
+        {
+            starts.OnNext(id);
+            return gate.Take(1).Subscribe(observer);
+        });
+
+    [Fact(Timeout = 30_000)]
+    public async Task SameDestination_SubscribesLegsInOrder_OneAtATime()
+    {
+        using var pool = new IoPool(8);
+        var dispatcher = new OrderedRouteDispatcher(pool, NullLogger.Instance);
+        var starts = new ReplaySubject<int>();
+        var gates = new[] { new Subject<Unit>(), new Subject<Unit>(), new Subject<Unit>() };
+
+        for (var i = 0; i < gates.Length; i++)
+            dispatcher.Enqueue(Destination, GatedLeg(i, starts, gates[i]), () => { });
+
+        // Leg 0 starts…
+        (await starts.Take(1).Timeout(10.Seconds()).ToTask()).Should().Be(0);
+
+        // …and NOTHING else does while leg 0 is still in flight. No positive signal exists for
+        // "the second leg did not start", so the bounded absence IS the assertion.
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            starts.Skip(1).Take(1).Timeout(1.Seconds()).ToTask());
+
+        for (var i = 0; i < gates.Length - 1; i++)
+        {
+            gates[i].OnNext(Unit.Default);
+            gates[i].OnCompleted();
+            (await starts.Skip(i + 1).Take(1).Timeout(10.Seconds()).ToTask()).Should().Be(i + 1,
+                "each leg is subscribed only after the one ahead of it has completed, in arrival order");
+        }
+
+        gates[^1].OnCompleted();
+        var order = await starts.Take(3).ToList().Timeout(10.Seconds()).ToTask();
+        order.Should().Equal([0, 1, 2], "the destination's FIFO must preserve the routing grain's arrival order");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task DifferentDestinations_NeverWaitOnEachOther()
+    {
+        using var pool = new IoPool(8);
+        var dispatcher = new OrderedRouteDispatcher(pool, NullLogger.Instance);
+        var starts = new ReplaySubject<int>();
+        var blocked = new Subject<Unit>();
+        var free = new Subject<Unit>();
+
+        dispatcher.Enqueue(Destination, GatedLeg(0, starts, blocked), () => { });
+        dispatcher.Enqueue(OtherDestination, GatedLeg(1, starts, free), () => { });
+
+        var seen = await starts.Take(2).ToList().Timeout(10.Seconds()).ToTask();
+        seen.Should().Contain(1,
+            "a stalled destination must not hold up any other destination's routing");
+        seen.Should().HaveCount(2);
+
+        blocked.OnCompleted();
+        free.OnCompleted();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task DrainedDestination_IsReleased_SoTheSiloHoldsNoPerAddressState()
+    {
+        using var pool = new IoPool(8);
+        var dispatcher = new OrderedRouteDispatcher(pool, NullLogger.Instance);
+        var starts = new ReplaySubject<int>();
+        var gate = new Subject<Unit>();
+        var completed = new Subject<Unit>();
+
+        dispatcher.Enqueue(Destination, GatedLeg(0, starts, gate), () => completed.OnNext(Unit.Default));
+        await starts.Take(1).Timeout(10.Seconds()).ToTask();
+        dispatcher.ActiveDestinations.Should().Be(1);
+
+        var drained = completed.Take(1).Timeout(10.Seconds()).ToTask();
+        gate.OnCompleted();
+        await drained;
+
+        // The entry is removed on the drain that follows the leg's completion — observe the
+        // released state rather than asserting on a single instant.
+        var released = await Observable.Interval(20.Milliseconds()).StartWith(0L)
+            .Select(_ => dispatcher.ActiveDestinations)
+            .Where(count => count == 0)
+            .FirstAsync()
+            .Timeout(10.Seconds())
+            .ToTask();
+        released.Should().Be(0,
+            "a destination holds a FIFO entry only while it has work in flight — a silo that has "
+            + "served millions of short-lived portal/{user} addresses must retain none of them");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL — the shape that was there before: every delivery handed to the pool as its
+    /// own <c>SubscribeThroughPool</c> leg. All three legs start while none has completed, i.e. the
+    /// pool imposes no order at all, which is what let two frames of one sync stream swap places.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task UnorderedPoolDispatch_StartsEveryLegConcurrently()
+    {
+        using var pool = new IoPool(8);
+        var starts = new ReplaySubject<int>();
+        var gates = new[] { new Subject<Unit>(), new Subject<Unit>(), new Subject<Unit>() };
+        var subscriptions = new List<IDisposable>();
+
+        for (var i = 0; i < gates.Length; i++)
+            subscriptions.Add(pool.SubscribeThroughPool(GatedLeg(i, starts, gates[i]))
+                .Subscribe(_ => { }, _ => { }));
+
+        var seen = await starts.Take(3).ToList().Timeout(10.Seconds()).ToTask();
+        seen.Should().HaveCount(3,
+            "the unordered dispatch subscribes all three legs even though none has completed — "
+            + "there is no per-destination ordering, which is the defect OrderedRouteDispatcher fixes");
+
+        foreach (var gate in gates) gate.OnCompleted();
+        foreach (var subscription in subscriptions) subscription.Dispose();
+    }
+}


### PR DESCRIPTION
## The defect

`RoutingGrain` handed **every** delivery to the routing I/O pool as its own `SubscribeThroughPool` leg, so each leg's subscribe hopped onto an independent thread-pool thread. For a **stream-routed** destination (`portal/{user}`, `client/{id}`, `cache/…`, `mesh/{id}`) that is the channel every data-sync frame travels on.

Data sync is a **delta protocol**: `SynchronizationStream.UpdateStream` discards any frame whose owner version is below the mirror's current version — the guard that stops a delayed patch from corrupting a mirror. That guard is only sound while frames arrive in the order the owner produced them. Reordering two frames of one stream therefore does not merely delay one of them: **the earlier one is dropped as "stale" and nothing ever re-sends it.**

When the dropped frame is the one carrying a layout area's content, the subscriber keeps its `Building layout…` base frame forever and its wait dies on its own timeout — with **nothing logged above `Debug` on either side**. This is the same visible failure the wrong-clock bug produced (see `SynchronizationStream.OwnerVersion`'s remarks), reached through arrival order instead of a bad version stamp.

## Evidence

`MESHWEAVER_MSG_TRACE=1` over a whole `MeshWeaver.Hosting.Orleans.Test` run, comparing each destination's `RouteMessage ENTER` order against its `MEMORY_STREAM` post order:

| | deliveries compared | destinations out of order | inverted pairs |
|---|---|---|---|
| **before** | 854 | 46 | **115** |
| **after** | 774 | 0 | **0** |

The other candidate reorder point — `OrleansRoutingService` dispatch → `RouteMessage ENTER` — measured **801 compared / 0 inversions**, so the pooled dispatch inside the grain was the only one.

This is what produced the "one random test times out per run, a different one each time" signature. Verified victims, all layout-area subscribes that never received their content:
- `OrleansBrokenNodeTypeAccessTest.Subscribe_ToLayoutAreaOf_NonCompilingNodeTypeInstance_SurfacesError_NotWedge`
- `OrleansMarkdownExportTest.SubHub_WithoutExplicitRegistration_ResolvesExportDocumentControlViaRegistryChain`
- `OrleansMarkdownExportTest.ExportPdfArea_RendersExportDocumentControl_ClientDeserializes`

A trace of the first one shows the request was never lost: the `SubscribeRequest` reached the grain, was `Processed`, the `SubscribeAck` went out, and **six `DataChangedEvent`s reached the client hub within 250 ms** — three of them posted in the exact reverse of the order the grain received them. Then 44 s of nothing until the test's own timeout.

## The fix

Stream-routed legs drain through a per-destination FIFO (`OrderedRouteDispatcher`):

- still **off the grain turn** (issue #1028) and still on the mesh's **drainable** routing `IIoPool`, so teardown can cancel + join it;
- one leg in flight **per destination**, in arrival order — the routing grain's turn (`[StatelessWorker(1)]`, non-reentrant) is the last point at which the send order is authoritative, which is why the FIFO is claimed there;
- destinations never wait on each other, and a destination's entry is released the moment its queue empties, so a silo that has served millions of short-lived `portal/{user}` addresses retains none of them;
- the per-node-grain branch (path resolution + grain hand-off) is **untouched**.

Head-of-line blocking per destination is the point, not a regression: a FIFO channel cannot overtake itself. It costs nothing on the healthy path (the post's only await is `IMemoryStreamQueueGrain.Enqueue`, already bounded by Orleans' 30 s response timeout under `StreamPostTimeout`), and a backlog is exactly what `ReportSaturation` already reports at `Critical`.

## Tests

`OrderedRouteDispatcherTest` pins the contract deterministically — no cluster, no timing luck:
- legs for one destination are subscribed in enqueue order, one at a time (the "second leg has not started" step is a bounded-absence assertion);
- a stalled destination does not hold up another;
- a drained destination releases its entry;
- **negative control**: the replaced shape (one `SubscribeThroughPool` per delivery) starts all three legs while none has completed — i.e. it cannot preserve any order.

## Verification

- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Hosting.Orleans.Test`, `MeshWeaver.Hosting.Cosmos.Test`, `Memex.Portal.Distributed`.
- `MeshWeaver.Hosting.Orleans.Test`, whole project in one process, `DOTNET_PROCESSOR_COUNT=4`:
  - **before**: 3 of 4 runs red;
  - **after**, under a controlled six-process CPU load that had reddened the pre-fix build: **4 of 4 green, plus 2 of 2 traced — 152/152 each.**

## Not claimed

Two other failures appeared only under the deliberately heavy artificial load and have different signatures — `OrleansMeshTests.HubWorksAfterDisposal` (a `DeliveryFailureException` from a disposing hub, 5 s) and `OrleansNodeChangePropagationTest.Delegation_NodeChanges_PropagateFromSubThread` (an assertion, not a timeout). They are separate defects; this PR does not address them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)