### PR TITLE
A completion-memory read that reached no verdict was saved back as an empty history

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-editor-remembers-your-completion-choices.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-editor-remembers-your-completion-choices.md
@@ -1,0 +1,27 @@
+---
+Name: The editor no longer forgets which completions you prefer
+Category: Fix
+Description: The editor's memory of the suggestion you usually pick could be wiped down to your most recent choice when it could not be read back; it is now left untouched until it can be.
+Icon: Sparkle
+Order: -20260810
+---
+
+# The editor no longer forgets which completions you prefer
+
+The code editor learns from you. Each time you accept a suggestion it remembers the choice, so the
+next time the same list comes up the item you actually use is already highlighted — you press Enter
+instead of scrolling. That memory builds up over months of editing and is worth quite a lot by the
+time you notice it.
+
+It could be thrown away. Your history is stored alongside your settings, and the editor reads it
+once when you start working. If that read did not come back quickly enough — a busy moment, storage
+catching its breath — the editor concluded you had no history at all rather than that it had not
+managed to look. From then on it worked from an empty slate, and the moment you accepted your next
+suggestion it saved that single choice back in place of everything you had built up. Nothing failed
+and nothing was reported; the highlighting was simply worse than it used to be, and stayed that way.
+
+A read that does not come back is now treated as what it is — no answer, rather than an answer of
+"nothing" — and the editor will not save over a history it has not managed to read. It quietly tries
+again the next time you ask for completions, and until it succeeds it keeps your stored history
+untouched. Suggestions you accept in the meantime still get remembered for the rest of your session;
+they are written out once the earlier history is safely back in hand.

--- a/src/MeshWeaver.Graph/Configuration/CompletionMemoryStore.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompletionMemoryStore.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -25,35 +27,85 @@ namespace MeshWeaver.Graph.Configuration;
 /// <para><b>Never on the critical path.</b> Loading is a one-shot, empty-on-absent query behind a
 /// timeout; a user whose memory has not loaded (or cannot) simply gets no preselection. Nothing
 /// here can fail a completion request.</para>
+///
+/// <para><b>🚨 An unread history is NEVER an empty one.</b> This store persists by REPLACEMENT —
+/// one node whose Content is the whole memory — so anything it saves that is not grounded in a
+/// completed read of the stored node deletes whatever it did not read. A load that reached no
+/// verdict (timed out, faulted, no storage yet) therefore must not become a cached memory and must
+/// not authorise a save; the two invariants below are what keep that impossible:</para>
+/// <list type="bullet">
+///   <item><description><b>Indeterminate loads cache nothing.</b> The load marker is released so
+///     the viewer's NEXT completion request re-resolves through the same chain the success path
+///     takes — user-driven re-resolution, never a timer or a retry loop.</description></item>
+///   <item><description><b>Saves refuse an ungrounded memory</b> (<see cref="MemoryEntry.Loaded"/>).
+///     Defence in depth: even if a future edit reintroduced a cached fragment, the write cannot
+///     replace the user's stored history with it.</description></item>
+/// </list>
 /// </summary>
 internal sealed class CompletionMemoryStore : IDisposable
 {
     private static readonly TimeSpan SaveDebounce = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan LoadTimeout = TimeSpan.FromSeconds(15);
 
-    private readonly IMessageHub hub;
+    /// <summary>How long the query fold must be quiet before its state counts as the answer.</summary>
+    private static readonly TimeSpan LoadQuietWindow = TimeSpan.FromMilliseconds(500);
+
     private readonly ILogger logger;
-    private readonly ConcurrentDictionary<string, CompletionMemory> memories = new(StringComparer.Ordinal);
+    private readonly Func<AccessService?> accessService;
+    private readonly Func<JsonSerializerOptions> serializerOptions;
+    private readonly Func<string, IObservable<ImmutableList<MeshNode>>> loadNodes;
+    private readonly Func<MeshNode, IObservable<MeshNode>> saveNode;
+    private readonly IScheduler scheduler;
+
+    private readonly ConcurrentDictionary<string, MemoryEntry> memories = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, byte> loading = new(StringComparer.Ordinal);
     private readonly Subject<string> dirty = new();
     private readonly IDisposable saveSubscription;
+    private int disposed;
 
+    /// <summary>DI constructor: reads and writes the viewer's settings node through the mesh.</summary>
     public CompletionMemoryStore(IMessageHub hub, ILogger logger)
+        : this(
+            logger,
+            () => hub.ServiceProvider.GetService<AccessService>(),
+            () => hub.JsonSerializerOptions,
+            viewer => QueryStored(hub, viewer),
+            node => Persist(hub, node),
+            DefaultScheduler.Instance)
     {
-        this.hub = hub;
+    }
+
+    /// <summary>
+    /// Seam constructor (unit tests via InternalsVisibleTo): inject the load source, the save sink
+    /// and the time source directly — no hub, no mesh service required. The scheduler is what lets
+    /// the 15 s load timeout and the 10 s save debounce be exercised in virtual time.
+    /// </summary>
+    internal CompletionMemoryStore(
+        ILogger logger,
+        Func<AccessService?> accessService,
+        Func<JsonSerializerOptions> serializerOptions,
+        Func<string, IObservable<ImmutableList<MeshNode>>> loadNodes,
+        Func<MeshNode, IObservable<MeshNode>> saveNode,
+        IScheduler scheduler)
+    {
         this.logger = logger;
+        this.accessService = accessService;
+        this.serializerOptions = serializerOptions;
+        this.loadNodes = loadNodes;
+        this.saveNode = saveNode;
+        this.scheduler = scheduler;
         // One save per user per quiet window — the coalescing that keeps acceptance recording
         // from becoming a write storm.
         saveSubscription = dirty
             .GroupBy(viewer => viewer, StringComparer.Ordinal)
-            .SelectMany(group => group.Throttle(SaveDebounce))
+            .SelectMany(group => group.Throttle(SaveDebounce, scheduler))
             .Subscribe(Save, ex => logger.LogDebug(ex, "Completion memory save pipeline faulted"));
     }
 
     /// <summary>The signed-in viewer, or null when there is nobody to remember for.</summary>
     public string? Viewer()
     {
-        var access = hub.ServiceProvider.GetService<AccessService>();
+        var access = accessService();
         foreach (var candidate in new[] { access?.Context?.ObjectId, access?.CircuitContext?.ObjectId })
             if (!string.IsNullOrEmpty(candidate)
                 && candidate != WellKnownUsers.System
@@ -63,15 +115,19 @@ internal sealed class CompletionMemoryStore : IDisposable
     }
 
     /// <summary>
-    /// The viewer's memory as currently known in-process, kicking off a one-time load when it has
-    /// not been read yet. Returns empty (never blocks) until that load lands.
+    /// The viewer's memory as currently known in-process, kicking off a load when no load has yet
+    /// reached a verdict. Returns empty (never blocks) until that load lands.
+    ///
+    /// <para>This is also the RE-RESOLUTION point: a load that reached no verdict left nothing
+    /// cached, so the viewer's next completion request starts a fresh one. No timer, no retry
+    /// loop — the user's own next keystroke is the trigger.</para>
     /// </summary>
     public CompletionMemory For(string viewer)
     {
-        if (memories.TryGetValue(viewer, out var memory))
-            return memory;
-        BeginLoad(viewer);
-        return new CompletionMemory();
+        memories.TryGetValue(viewer, out var entry);
+        if (entry is not { Loaded: true })
+            BeginLoad(viewer);
+        return entry?.Memory ?? new CompletionMemory();
     }
 
     /// <summary>Records an acceptance and schedules the coalesced save. Never throws.</summary>
@@ -81,9 +137,12 @@ internal sealed class CompletionMemoryStore : IDisposable
         {
             memories.AddOrUpdate(
                 viewer,
-                _ => new CompletionMemory().Record(prefix, label, kind),
-                (_, existing) => existing.Record(prefix, label, kind));
-            dirty.OnNext(viewer);
+                _ => new MemoryEntry(new CompletionMemory().Record(prefix, label, kind), Loaded: false),
+                (_, existing) => existing with { Memory = existing.Memory.Record(prefix, label, kind) });
+            // An acceptance is also a reason to resolve the stored history: until a load reaches a
+            // verdict this acceptance is unsaveable (Save refuses an ungrounded memory).
+            BeginLoad(viewer);
+            MarkDirty(viewer);
         }
         catch (Exception ex)
         {
@@ -99,44 +158,98 @@ internal sealed class CompletionMemoryStore : IDisposable
         if (!loading.TryAdd(viewer, 0))
             return;
 
-        var mesh = hub.ServiceProvider.GetService<IMeshService>();
-        if (mesh is null)
+        Observable.Defer(() => loadNodes(viewer))
+            .Throttle(LoadQuietWindow, scheduler)
+            .Take(1)
+            .Timeout(LoadTimeout, scheduler)
+            .Select(nodes => LoadOutcome.Reached(
+                nodes.FirstOrDefault().ContentAs<CompletionMemory>(serializerOptions(), logger)))
+            // 🚨 A read that reached NO VERDICT is not the same answer as one that found nothing.
+            // Folding both into "empty" made a transient stall (busy mesh hub, slow storage, a
+            // partition mid-provision) look like "this user has no acceptance history" — and
+            // because that answer was CACHED, the next acceptance saved it back, replacing the
+            // user's real history with a single entry. Nothing errored; the history was just gone.
+            // Keep the two apart, exactly as the NodeType registration probe does (#1085).
+            .Catch<LoadOutcome, Exception>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "Completion memory load for {Viewer} reached no verdict ({ExceptionType}) — treating it "
+                    + "as INDETERMINATE, not empty. Nothing is cached and nothing is saved for this viewer "
+                    + "until a load succeeds; the next completion request re-resolves.",
+                    viewer, ex.GetType().Name);
+                return Observable.Return(LoadOutcome.Indeterminate);
+            })
+            .Subscribe(
+                outcome => Apply(viewer, outcome),
+                ex =>
+                {
+                    // Only reachable if Apply itself threw — the Catch above owns every upstream
+                    // fault. Release the marker so the viewer is not stuck without a memory.
+                    loading.TryRemove(viewer, out _);
+                    logger.LogDebug(ex, "Completion memory load failed for {Viewer}", viewer);
+                });
+    }
+
+    /// <summary>
+    /// Folds one load verdict into the in-process memory.
+    ///
+    /// <para>An INDETERMINATE verdict leaves the cache untouched and releases the load marker: the
+    /// viewer keeps whatever unsaveable acceptances they have accrued, and the next
+    /// <see cref="For"/> re-resolves.</para>
+    ///
+    /// <para>A REACHED verdict grounds the memory in stored history. Acceptances recorded while the
+    /// load was in flight are REPLAYED on top of what was read rather than replacing it — the old
+    /// <c>TryAdd</c> here silently discarded the loaded history whenever an acceptance had beaten
+    /// the load home, which is the same replacement-loss the timeout caused.</para>
+    /// </summary>
+    private void Apply(string viewer, LoadOutcome outcome)
+    {
+        if (!outcome.IsReached)
         {
-            memories.TryAdd(viewer, new CompletionMemory());
+            loading.TryRemove(viewer, out _);
             return;
         }
 
-        var path = PathFor(viewer);
-        // Empty-on-absent query — never a point read of a maybe-absent path (that is the probe
-        // this mesh fast-fails and logs as a defect).
-        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}"))
-            .Scan(ImmutableList<MeshNode>.Empty, (list, change) => change.ChangeType switch
-            {
-                QueryChangeType.Removed => ImmutableList<MeshNode>.Empty,
-                _ => change.Items.ToImmutableList(),
-            })
-            .Throttle(TimeSpan.FromMilliseconds(500))
-            .Take(1)
-            .Timeout(LoadTimeout)
-            .Catch(Observable.Return(ImmutableList<MeshNode>.Empty))
-            .Subscribe(
-                nodes =>
-                {
-                    var stored = nodes.FirstOrDefault()
-                        ?.ContentAs<CompletionMemory>(hub.JsonSerializerOptions);
-                    // A load must never clobber acceptances recorded while it was in flight.
-                    memories.TryAdd(viewer, stored ?? new CompletionMemory());
-                },
-                ex => logger.LogDebug(ex, "Completion memory load failed for {Viewer}", viewer));
+        var stored = outcome.Stored ?? new CompletionMemory();
+        var grounded = memories.AddOrUpdate(
+            viewer,
+            _ => new MemoryEntry(stored, Loaded: true),
+            (_, existing) => existing.Loaded
+                ? existing
+                : new MemoryEntry(Replay(stored, existing.Memory), Loaded: true));
+
+        // Acceptances made before the verdict landed were refused by the save guard. Now that the
+        // memory carries the stored history, let the coalescer persist the merged result.
+        if (!ReferenceEquals(grounded.Memory, stored))
+            MarkDirty(viewer);
     }
+
+    /// <summary>
+    /// Replays in-flight acceptances onto the loaded history, oldest first, through
+    /// <see cref="CompletionMemory.Record"/> so its dedup and bound apply. Returns
+    /// <paramref name="stored"/> itself when there was nothing pending.
+    /// </summary>
+    private static CompletionMemory Replay(CompletionMemory stored, CompletionMemory pending) =>
+        pending.Entries
+            .OrderBy(e => e.Touch)
+            .Aggregate(stored, (acc, e) => acc.Record(e.Prefix, e.Label, e.Kind));
 
     private void Save(string viewer)
     {
-        if (!memories.TryGetValue(viewer, out var memory))
+        if (!memories.TryGetValue(viewer, out var entry))
             return;
-        var mesh = hub.ServiceProvider.GetService<IMeshService>();
-        if (mesh is null)
+
+        // 🚨 Defence in depth on a DATA-LOSS path. This save REPLACES the node's whole Content, so
+        // a memory that is not grounded in a completed read is missing everything that read would
+        // have returned — writing it would substitute an in-process fragment for the user's
+        // acceptance history. Skip; a later successful load merges and re-arms the save.
+        if (!entry.Loaded)
+        {
+            logger.LogDebug(
+                "Skipping completion memory save for {Viewer} — no load has reached a verdict, so this "
+                + "memory would overwrite stored history with an in-process fragment", viewer);
             return;
+        }
 
         var path = PathFor(viewer);
         var node = MeshNode.FromPath(path) with
@@ -145,18 +258,97 @@ internal sealed class CompletionMemoryStore : IDisposable
             NodeType = CompletionMemoryNodeType.NodeType,
             MainNode = viewer,
             State = MeshNodeState.Active,
-            Content = memory,
+            Content = entry.Memory,
         };
-        mesh.CreateOrUpdateNode(node)
+        Observable.Defer(() => saveNode(node))
             .Take(1)
             .Subscribe(
                 _ => { },
                 ex => logger.LogDebug(ex, "Completion memory save failed for {Viewer}", viewer));
     }
 
+    /// <summary>
+    /// Nudges the save coalescer, tolerating the store being disposed underneath an in-flight
+    /// load — that is teardown, not a fault to hide.
+    /// </summary>
+    private void MarkDirty(string viewer)
+    {
+        if (Volatile.Read(ref disposed) != 0)
+            return;
+        try
+        {
+            dirty.OnNext(viewer);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced Dispose: there is no coalescer left to nudge, and nothing to persist into.
+        }
+    }
+
+    /// <summary>
+    /// The viewer's settings node as an empty-on-absent query fold — never a point read of a
+    /// maybe-absent path (that is the probe this mesh fast-fails and logs as a defect).
+    /// A missing <see cref="IMeshService"/> is an UNAVAILABLE read, not an empty one: it faults so
+    /// the chain classifies it INDETERMINATE and no save can be grounded on it.
+    /// </summary>
+    private static IObservable<ImmutableList<MeshNode>> QueryStored(IMessageHub hub, string viewer)
+    {
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Throw<ImmutableList<MeshNode>>(new InvalidOperationException(
+                "No IMeshService is registered — the completion memory cannot be read."));
+
+        return mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{PathFor(viewer)}"))
+            .Scan(ImmutableList<MeshNode>.Empty, (list, change) => change.ChangeType switch
+            {
+                QueryChangeType.Removed => ImmutableList<MeshNode>.Empty,
+                _ => change.Items.ToImmutableList(),
+            });
+    }
+
+    private static IObservable<MeshNode> Persist(IMessageHub hub, MeshNode node)
+    {
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        return mesh is null
+            ? Observable.Throw<MeshNode>(new InvalidOperationException(
+                "No IMeshService is registered — the completion memory cannot be saved."))
+            : mesh.CreateOrUpdateNode(node);
+    }
+
     public void Dispose()
     {
+        Interlocked.Exchange(ref disposed, 1);
         saveSubscription.Dispose();
         dirty.Dispose();
+    }
+
+    /// <summary>
+    /// The viewer's in-process memory plus the one fact that decides whether it may be persisted.
+    /// </summary>
+    /// <param name="Memory">The acceptance history as currently known in this process.</param>
+    /// <param name="Loaded">
+    /// True only when a load REACHED A VERDICT (found the node, or established that there is
+    /// nothing readable at that path) and this memory is built on top of it. False means the
+    /// entries here are whatever this process happened to observe — usable for preselection,
+    /// never safe to write back, because a write replaces the stored node wholesale.
+    /// </param>
+    private sealed record MemoryEntry(CompletionMemory Memory, bool Loaded);
+
+    /// <summary>
+    /// What ONE bounded read of the viewer's settings node established — the seam that keeps "we
+    /// could not find out" apart from "we found out, and there is nothing stored".
+    /// </summary>
+    /// <param name="IsReached">
+    /// True when the read completed. <paramref name="Stored"/> is then the history, or null for a
+    /// DEFINITIVE "nothing stored here". False means no verdict at all.
+    /// </param>
+    /// <param name="Stored">The stored history when one was read; null otherwise.</param>
+    private readonly record struct LoadOutcome(bool IsReached, CompletionMemory? Stored)
+    {
+        /// <summary>The read completed; <paramref name="stored"/> may be null for a definitive absence.</summary>
+        public static LoadOutcome Reached(CompletionMemory? stored) => new(true, stored);
+
+        /// <summary>The read reached no verdict — cache nothing, save nothing, re-resolve later.</summary>
+        public static LoadOutcome Indeterminate { get; } = new(false, null);
     }
 }

--- a/test/MeshWeaver.Graph.Test/CompletionMemoryLoadVerdictTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompletionMemoryLoadVerdictTest.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The DATA-LOSS contract for <see cref="CompletionMemoryStore"/>.
+///
+/// <para>The store persists by REPLACEMENT — one settings node whose Content is the whole
+/// acceptance history — so every save deletes whatever it did not put back. That makes one question
+/// load-bearing: <i>did a read actually establish what is stored?</i> A read that reached no verdict
+/// (timed out, faulted, no storage yet) must never be answered with "the user has no history",
+/// because that answer, once cached and saved, IS the deletion.</para>
+///
+/// <para>What used to happen: a 15 s load timeout was folded into an empty node list by a blanket
+/// <c>Catch(Observable.Return(Empty))</c>, cached as an empty memory that nothing ever reloaded, and
+/// the very next acceptance marked it dirty so the debounced save wrote that near-empty memory over
+/// the real history. Nothing threw and nothing logged a loss.</para>
+///
+/// <para>Everything here runs on a <see cref="HistoricalScheduler"/>: the 15 s load timeout and the
+/// 10 s save debounce are crossed in virtual time, so these are exact, not races.</para>
+/// </summary>
+public class CompletionMemoryLoadVerdictTest
+{
+    private const string Viewer = "alice";
+
+    /// <summary>An LSP completion kind — which one is irrelevant, only that it is stable.</summary>
+    private const int Kind = 2;
+
+    /// <summary>Three acceptances standing in for the user's real, already-stored history.</summary>
+    private static CompletionMemory StoredHistory() =>
+        new CompletionMemory()
+            .Record("St", "Stack", Kind)
+            .Record("Ma", "Markdown", Kind)
+            .Record("La", "LayoutGrid", Kind);
+
+    /// <summary>The query fold as it looks when the viewer's settings node IS stored.</summary>
+    private static ImmutableList<MeshNode> StoredNodes(CompletionMemory memory) =>
+        ImmutableList.Create(
+            MeshNode.FromPath(CompletionMemoryStore.PathFor(Viewer)) with
+            {
+                Name = "Completion memory",
+                NodeType = CompletionMemoryNodeType.NodeType,
+                Content = memory,
+            });
+
+    /// <summary>A live query that has answered "nothing here" and stays open (never completes).</summary>
+    private static IObservable<ImmutableList<MeshNode>> Answers(ImmutableList<MeshNode> nodes) =>
+        Observable.Return(nodes).Concat(Observable.Never<ImmutableList<MeshNode>>());
+
+    /// <summary>A read that never reaches a verdict — the shape a stalled backend produces.</summary>
+    private static IObservable<ImmutableList<MeshNode>> NeverAnswers() =>
+        Observable.Never<ImmutableList<MeshNode>>();
+
+    private sealed record Harness(CompletionMemoryStore Store, List<MeshNode> Saves, Func<int> LoadAttempts);
+
+    /// <summary>
+    /// Wires the store's seam constructor: <paramref name="loadForAttempt"/> receives the 0-based
+    /// load attempt (so a test can make the first read stall and a later one answer), and every save
+    /// is captured instead of hitting a mesh.
+    /// </summary>
+    private static Harness Build(
+        HistoricalScheduler scheduler,
+        Func<int, IObservable<ImmutableList<MeshNode>>> loadForAttempt)
+    {
+        var saves = new List<MeshNode>();
+        var attempts = 0;
+        var store = new CompletionMemoryStore(
+            NullLogger.Instance,
+            () => null,
+            () => new JsonSerializerOptions(),
+            _ => loadForAttempt(attempts++),
+            node =>
+            {
+                saves.Add(node);
+                return Observable.Return(node);
+            },
+            scheduler);
+        return new Harness(store, saves, () => attempts);
+    }
+
+    private static IReadOnlyList<string> SavedLabels(MeshNode node) =>
+        ((CompletionMemory)node.Content!).Entries.Select(e => e.Label).ToList();
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. A load that reaches no verdict, followed by an acceptance, must not
+    /// produce a save at all — the alternative is writing a one-entry memory over a history this
+    /// process never managed to read.
+    /// </summary>
+    [Fact]
+    public void LoadThatReachesNoVerdict_IsNeverPersistedOverStoredHistory()
+    {
+        var scheduler = new HistoricalScheduler();
+        var harness = Build(scheduler, _ => NeverAnswers());
+        using var store = harness.Store;
+
+        // A completion request kicks the load off. It never answers.
+        store.For(Viewer).Entries.Should().BeEmpty("nothing has been read yet");
+
+        // Past the 15 s load timeout.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(16));
+
+        // The user accepts one completion, then goes quiet past the 10 s save debounce.
+        store.Record(Viewer, "St", "Stack", Kind);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(11));
+
+        harness.Saves.Should().BeEmpty(
+            "a read that reached no verdict says NOTHING about what is stored, so a memory built on "
+            + "it must never be written back — that write would replace the user's whole acceptance "
+            + "history with this single acceptance");
+    }
+
+    /// <summary>
+    /// The same loss without any timeout: an acceptance that beats a HEALTHY load home. The old
+    /// <c>TryAdd</c> here kept the in-flight fragment and discarded the history it had just read;
+    /// the merge must go the other way — replay the fragment ON TOP of the stored history.
+    /// </summary>
+    [Fact]
+    public void AcceptanceRecordedWhileLoading_IsMergedOntoStoredHistory_NotSubstitutedForIt()
+    {
+        var scheduler = new HistoricalScheduler();
+        var source = new Subject<ImmutableList<MeshNode>>();
+        var harness = Build(scheduler, _ => source);
+        using var store = harness.Store;
+
+        store.For(Viewer);                              // load in flight
+        store.Record(Viewer, "Ne", "NewThing", Kind);   // acceptance beats it home
+
+        source.OnNext(StoredNodes(StoredHistory()));
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1));   // past the 500 ms quiet window
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(11));  // past the save debounce
+
+        var labels = SavedLabels(harness.Saves.Should().ContainSingle().Subject);
+        labels.Should().Contain("NewThing", "the in-flight acceptance must survive the load");
+        labels.Should().Contain("Stack", "the loaded history must survive the in-flight acceptance");
+        labels.Should().Contain("Markdown");
+        labels.Should().Contain("LayoutGrid");
+    }
+
+    /// <summary>
+    /// The guard must not silence a genuine first-time user: a read that DEFINITIVELY finds nothing
+    /// is a verdict, so their first acceptance is persisted normally.
+    /// </summary>
+    [Fact]
+    public void LoadThatDefinitivelyFindsNothing_StillPersists()
+    {
+        var scheduler = new HistoricalScheduler();
+        var harness = Build(scheduler, _ => Answers(ImmutableList<MeshNode>.Empty));
+        using var store = harness.Store;
+
+        store.For(Viewer);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1));   // verdict reached: nothing is stored
+
+        store.Record(Viewer, "St", "Stack", Kind);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(11));
+
+        SavedLabels(harness.Saves.Should().ContainSingle(
+                "a definitive absence is a verdict, so saving over it loses nothing").Subject)
+            .Should().Contain("Stack");
+    }
+
+    /// <summary>
+    /// Re-resolution is USER-DRIVEN, not a timer: after a no-verdict read the store caches nothing
+    /// and releases its load marker, so the viewer's next completion request runs a fresh load
+    /// through the same chain the success path takes — and once that one answers, saving is armed.
+    /// </summary>
+    [Fact]
+    public void AfterANoVerdictLoad_TheNextCompletionRequestReResolves_AndThenSaves()
+    {
+        var scheduler = new HistoricalScheduler();
+        var harness = Build(scheduler, attempt => attempt == 0
+            ? NeverAnswers()
+            : Answers(StoredNodes(StoredHistory())));
+        using var store = harness.Store;
+
+        store.For(Viewer);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(16));  // no verdict
+        harness.LoadAttempts().Should().Be(1);
+
+        store.For(Viewer);                              // the next completion request re-resolves
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1));
+        harness.LoadAttempts().Should().Be(2, "the stalled read left nothing cached to reuse");
+
+        store.Record(Viewer, "Ne", "NewThing", Kind);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(11));
+
+        var labels = SavedLabels(harness.Saves.Should().ContainSingle().Subject);
+        labels.Should().Contain("NewThing");
+        labels.Should().Contain("Stack", "the re-resolved load grounds the save in stored history");
+    }
+}


### PR DESCRIPTION
## The defect

`CompletionMemoryStore` persists by **replacement** — one settings node (`{userId}/_Settings/Completions`) whose `Content` is the user's whole completion-acceptance history — so every save deletes whatever it did not put back. That makes one question load-bearing: *did a read actually establish what is stored?*

The load pipeline ended in a blanket catch:

```csharp
.Timeout(LoadTimeout)                                             // 15 s
.Catch(Observable.Return(ImmutableList<MeshNode>.Empty))          // ← any fault ⇒ "empty"
.Subscribe(nodes => memories.TryAdd(viewer, stored ?? new CompletionMemory()));
```

which folded a read that reached **no verdict** into the same empty node list a genuinely absent node produces. The chain from there:

1. Timeout (or *any* query fault — the `Catch` swallowed all of them, which also made the `Subscribe` error handler dead code) → empty list.
2. Empty memory **cached** via `TryAdd`, while the `loading` marker was never released → nothing ever reloaded it.
3. The next `Record` marked the entry dirty.
4. Ten seconds later the debounced `Save` wrote that one-entry memory **over the user's real history**.

Nothing threw and nothing logged a loss. This is exactly what `NodeReadOutcome` warns about in its own message — *"this read reached no verdict … This is NOT 'not found'"* — honoured elsewhere in the codebase and violated here.

### A second, timeout-free instance of the same loss

`memories.TryAdd(viewer, stored ?? new CompletionMemory())` on the **success** path carried the loss too. The comment claimed *"a load must never clobber acceptances recorded while it was in flight"*, but `TryAdd` fails when `Record` already created the entry — so the freshly-**loaded history was silently discarded** and the in-flight fragment saved over it. No timeout required: the load's own 500 ms quiet window is the race window, on every cold viewer.

## The fix

Classify the read instead of collapsing it — the shape #1085 used for the `Indeterminate` NodeType probe (fall through to the same reactive chain the success path takes):

- **`LoadOutcome`** separates a REACHED verdict (found, or definitively nothing stored) from an INDETERMINATE one. The `Catch` maps a fault/timeout to `Indeterminate` and logs it as such, rather than manufacturing an "empty" answer.
- **An indeterminate load caches nothing** and releases the `loading` marker, so the viewer's next completion request re-resolves through the same chain — **user-driven, not a timer, poller or retry loop**.
- **In-flight acceptances are replayed onto** what was read (through `CompletionMemory.Record`, so dedup and the entry bound still apply) instead of replacing it, and the merged result re-arms the save.
- **Defence in depth:** `Save` refuses any memory not grounded in a completed read (`MemoryEntry.Loaded`), so an ungrounded fragment cannot reach storage even if a future edit reintroduced one. A missing `IMeshService` now faults the read (→ indeterminate) rather than reading as "empty".

**The 15 s timeout is unchanged** — widening it would only narrow the window on a defect that still loses data.

## Verification

`CompletionMemoryLoadVerdictTest` pins four behaviours on a `HistoricalScheduler`, so the 15 s load timeout and 10 s save debounce are crossed in **virtual time** — no wall-clock waits, no `Task.Delay` (whole class runs in 48 ms).

Against the old semantics **3 of 4 fail**:

| Test | Pre-fix failure |
|---|---|
| `LoadThatReachesNoVerdict_IsNeverPersistedOverStoredHistory` | `Expected collection to be empty …, but found 1 item(s).` |
| `AcceptanceRecordedWhileLoading_IsMergedOntoStoredHistory_NotSubstitutedForIt` | ``Expected collection {"NewThing"} to contain "Stack"`` — the saved memory held only the in-flight acceptance; the whole stored history was gone |
| `AfterANoVerdictLoad_TheNextCompletionRequestReResolves_AndThenSaves` | `Expected value to be 2 …, but found 1.` (no re-resolution ever happened) |
| `LoadThatDefinitivelyFindsNothing_StillPersists` | passes before and after — the no-regression guard that the new guard does not mute a genuine first-time user |

- `dotnet build -c Release -warnaserror`: `MeshWeaver.Graph`, `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation`, `MeshWeaver.Documentation.Test` — all green (built one project at a time; multiple `.csproj` args are an MSB1008 no-op).
- `MeshWeaver.Graph.Test` **893/893**, `MeshWeaver.Documentation.Test` **20/20**.
- Merged current `main` (`a7205d387`, #1087) before pushing.

What's New entry included (`Category: Fix` — losing a user's history is user-noticeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)