### PR TITLE
Docs accuracy: fix false statements in GUI / DataMesh / AI docs and src doc comments

### DIFF
--- a/clients/react/src/controls/threadChat.tsx
+++ b/clients/react/src/controls/threadChat.tsx
@@ -113,7 +113,7 @@ function useMessageCells(
   return cells;
 }
 
-/** Agent/model options from the mesh (nodeType:Agent / nodeType:Model), when the ops expose search. */
+/** Agent/model options from the mesh (nodeType:Agent / nodeType:LanguageModel), when the ops expose search. */
 function useSearchOptions(ops: MeshOps | null, query: string): { path: string; name: string }[] {
   const [options, setOptions] = useState<{ path: string; name: string }[]>([]);
   useEffect(() => {
@@ -301,7 +301,7 @@ function lastSegment(path: string): string {
 /**
  * A read-only selection chip — the twin of Blazor's `.thread-chat-status-item`. Surfaces the
  * composer's bound harness/agent/model selection so the DEFAULT is visible even when there are no
- * mesh options to pick from (the `nodeType:Agent`/`nodeType:Model` search returned nothing, or the
+ * mesh options to pick from (the `nodeType:Agent`/`nodeType:LanguageModel` search returned nothing, or the
  * host exposes no `search`). Blazor's status row is likewise display-only (selection happens via the
  * /harness /agent /model slash-commands, which the React composer has no twin for yet).
  */
@@ -467,7 +467,7 @@ export function ThreadChatView({ control }: { control: UiControl }): ReactNode {
   const effectiveAgent = agent ?? str(composer.agentName);
   const effectiveModel = model ?? str(composer.modelName);
   const agentOptions = useSearchOptions(ops, "nodeType:Agent");
-  const modelOptions = useSearchOptions(ops, "nodeType:Model");
+  const modelOptions = useSearchOptions(ops, "nodeType:LanguageModel");
 
   // Auto-scroll to the latest bubble (Blazor's ChatMessageList behavior).
   const endRef = useRef<HTMLDivElement | null>(null);

--- a/clients/react/src/live/meshOps.tsx
+++ b/clients/react/src/live/meshOps.tsx
@@ -61,7 +61,7 @@ export interface MeshOps {
   submitMessage(threadPath: string, userText: string, opts?: ThreadSubmitOptions): Promise<string | null>;
   /** Field-level partial node update (RFC 7396) — control-plane flips like requestedStatus. */
   patch(path: string, fields: Record<string, unknown>): void;
-  /** Optional mesh query — when present it feeds the agent/model selectors (nodeType:Agent / nodeType:Model). */
+  /** Optional mesh query — when present it feeds the agent/model selectors (nodeType:Agent / nodeType:LanguageModel). */
   search?(query: string, basePath?: string, limit?: number): Promise<Record<string, unknown>[]>;
   /**
    * Optional streaming-final autocomplete snapshot (the one-shot AutocompleteRequest twin) — feeds

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -272,7 +272,7 @@ public class AgentChatClient : IAgentChat
     /// In-memory set of sub-thread paths currently in flight on this chat
     /// session. Maintained by <see cref="EmitDelegationEvent"/>: Dispatched
     /// adds, Terminal removes. Read by the cancel watcher in
-    /// <c>ThreadExecution.SetupCancellationWatcher</c> to propagate cancel
+    /// <c>ThreadExecution.InstallCancellationWatcher</c> to propagate cancel
     /// to sub-threads whose paths haven't yet been persisted onto
     /// <c>Thread.StreamingToolCalls[].DelegationPath</c>, and by the
     /// streaming-loop's stamp pass that walks unmatched
@@ -502,7 +502,7 @@ public class AgentChatClient : IAgentChat
     /// <see cref="GetStreamingResponseAsync(IReadOnlyCollection{ChatMessage}, CancellationToken)"/>
     /// path, so the streaming chat ships the same context/attachments the user set (contextPath +
     /// attachments) instead of dropping them and forcing the agent to Search for what was attached.
-    /// 🚨 It deliberately does NOT enumerate context children (no IMeshService.QueryAsync fan-out) —
+    /// 🚨 It deliberately does NOT enumerate context children (no IMeshService.Query fan-out) —
     /// that fan-out bridges back through hub messaging and can park the streaming task indefinitely
     /// ("Generating response…" forever). The agent's Search tool pulls children when it needs them.
     /// </summary>
@@ -528,7 +528,7 @@ public class AgentChatClient : IAgentChat
                 messageText.AppendLine("The current node already exists. To modify it, use Get then Update — do NOT Create it again.");
             messageText.AppendLine();
 
-            // 🚨 No await foreach over IMeshService.QueryAsync here.
+            // 🚨 No await foreach over IMeshService.Query here.
             // That used to enumerate children of the context path to inject
             // into the system prompt. The fan-out through IMeshQueryProvider
             // bridges back through hub messaging in a way that can park the
@@ -778,7 +778,7 @@ public class AgentChatClient : IAgentChat
         // Pure in-memory lookup against the synced agent cache.
         // 🚨 Callers MUST await `WhenInitialized` before calling here on a
         // cold path — this method does not gate, because the gate must run
-        // on a non-hub thread (Task.Run in ThreadExecution.ExecuteMessageAsync).
+        // on a non-hub thread (the Ai I/O pool invoke in ThreadExecution.ExecuteMessageAsync).
         // Awaiting WhenInitialized here would block the hub's ActionBlock if
         // GetResponseAsync runs on it.
         var agent = SelectAgent(messages.LastOrDefault());
@@ -1566,7 +1566,7 @@ public class AgentChatClient : IAgentChat
         // produced "No suitable agent" even though the dropdown showed 9 of
         // them. The synced query runs on the workspace of THIS hub (the thread
         // hub passed in via the ctor's service provider), not the _Exec child
-        // — _Exec is blocked by the streaming Task.Run.
+        // — _Exec is occupied by the streaming round.
         var workspace = hub.GetWorkspace();
         // The chatting user's home namespace — where a user drops their OWN agents, surfaced via the
         // namespace:{userHome} alternation in AgentPickerProjection.BuildAgentQuery. Skips system/hub

--- a/src/MeshWeaver.AI/AgentNodeType.cs
+++ b/src/MeshWeaver.AI/AgentNodeType.cs
@@ -70,7 +70,7 @@ public static class AgentNodeType
         // while Doc — which has no IStaticNodeProvider — imported 161/0). Gating only the storage
         // provider (the prior state) was the gap. The "Agent" NodeType definition itself stays via
         // AddMeshNodes(CreateMeshNode()) above, so the import's NodeType-existence check still
-        // resolves. See OrleansStaticRepoImportStaticBackedTest.
+        // resolves.
         builder.ConfigureServices(services =>
         {
             services.TryAddSingleton<BuiltInAgentProvider>();

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -20,7 +20,7 @@ namespace MeshWeaver.AI;
 /// combo boxes.
 ///
 /// <para>🚨 The chat view (<c>ThreadChatView.SubscribeToAgentNodes</c> +
-/// <c>OnSyncedAgentSnapshot</c>) calls these helpers directly. Tests in
+/// <c>OnAgentList</c>) calls these helpers directly. Tests in
 /// <c>AgentPickerProjectionTest</c> drive the same
 /// <see cref="MeshWeaver.Graph.SyncedQueryDataSourceExtensions.GetQuery(MeshWeaver.Data.IWorkspace, object, string[])"/>
 /// pipe with the strings <see cref="BuildAgentQueries"/> returns and run the
@@ -618,7 +618,7 @@ public static class AgentPickerProjection
 
     /// <summary>
     /// Projects the synced-query snapshot into the agent picker's bound list.
-    /// Same shape as <c>ThreadChatView.OnSyncedAgentSnapshot</c>:
+    /// Same shape as <c>ThreadChatView.OnAgentList</c>:
     /// Agent-typed nodes only; tolerates <see cref="JsonElement"/> Content
     /// when the receiving hub's typed registry doesn't have
     /// <see cref="AgentConfiguration"/> wired up; sorts by Order then Name.
@@ -671,7 +671,7 @@ public static class AgentPickerProjection
 
     /// <summary>
     /// Projects the synced-query snapshot into the model picker's bound list.
-    /// Mirrors <c>ThreadChatView.OnSyncedAgentSnapshot</c>'s LanguageModel
+    /// Mirrors <c>ThreadChatView.OnAgentList</c>'s LanguageModel
     /// branch (without the factory-baseline merge — that lives in the
     /// view's <c>RebuildAvailableModels</c>).
     /// </summary>

--- a/src/MeshWeaver.AI/Connect/ConnectModels.cs
+++ b/src/MeshWeaver.AI/Connect/ConnectModels.cs
@@ -93,8 +93,12 @@ public sealed class ConnectSession : IDisposable
 /// <see cref="CompleteConnect"/> drives it to completion — writing the pasted code to stdin
 /// (Claude, <see cref="RequiresPastedCode"/> <c>true</c>) or polling auth status (Copilot,
 /// <c>false</c>) — and emits the captured raw token exactly once. Both return cold observables;
-/// the session manager subscribes. <c>Observable.FromAsync</c> is used only at the subprocess /
-/// SDK boundary (per the "nothing async ever" rule).</para>
+/// the session manager subscribes. The subprocess / SDK boundary is carried by the
+/// <see cref="MeshWeaver.Mesh.Threading.IoPoolNames.Process"/> <c>IIoPool</c> —
+/// <c>Invoke</c> / <c>InvokeBlocking</c> for the async leaves only (spawn, stdin write, file read),
+/// with the scrape composed as an ordinary observable. <b>Never <c>Observable.FromAsync</c></b>,
+/// which is forbidden outside <c>IoPool</c>: it would run the prologue on the SUBSCRIBING thread
+/// and bound nothing. See ControlledIoPooling.md.</para>
 /// </summary>
 public interface IConnectStrategy
 {

--- a/src/MeshWeaver.AI/Connect/ConnectSessionManager.cs
+++ b/src/MeshWeaver.AI/Connect/ConnectSessionManager.cs
@@ -21,8 +21,9 @@ namespace MeshWeaver.AI.Connect;
 /// (<c>Kill(entireProcessTree: true)</c>).</para>
 ///
 /// <para>Reactive end-to-end: the strategies expose cold observables and this manager subscribes
-/// inline; the only <c>Task</c> bridge is inside the strategies, at the subprocess / SDK boundary
-/// (<c>Observable.FromAsync</c>).</para>
+/// inline; the only <c>Task</c> bridge is inside the strategies, at the subprocess / SDK boundary,
+/// and it runs on the <c>Process</c> <c>IIoPool</c> (<c>Invoke</c> / <c>InvokeBlocking</c>) —
+/// never <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>.</para>
 /// </summary>
 public sealed class ConnectSessionManager : IDisposable
 {

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -295,7 +295,7 @@ public class MeshOperations
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var caller = accessService?.Context ?? accessService?.CircuitContext;
 
-        // Single-node content read via GetDataRequest + MeshNodeReference + RegisterCallback.
+        // Single-node content read via GetDataRequest + MeshNodeReference + hub.Observe(...).
         // See Doc/Architecture/CqrsAndContentAccess.md — queries are for sets only.
         return TryResolveUnifiedPath(resolvedPath)
             .SelectMany(unified =>
@@ -1031,7 +1031,7 @@ public class MeshOperations
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "UpdateViaDataChange: Post/RegisterCallback failed for {Path}", node.Path);
+                logger.LogWarning(ex, "UpdateViaDataChange: Post/Observe failed for {Path}", node.Path);
                 Fail(ex);
             }
 
@@ -1104,7 +1104,7 @@ public class MeshOperations
         logger.LogInformation("Resolving Unified Path: address={Address}, remainder={Remainder}",
             addressPart, remainder);
 
-        // Fire the GetDataRequest and receive the response via RegisterCallback.
+        // Fire the GetDataRequest and receive the response via hub.Observe(...).
         // Observable.Create wraps the post/register pair so the caller can compose it
         // into the Get pipeline without ever awaiting — the callback completes the
         // observable from a non-hub thread. The outer Timeout enforces an upper
@@ -1956,7 +1956,7 @@ public class MeshOperations
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "PatchViaDataRequest: Post/RegisterCallback failed for {Path}", resolvedPath);
+                logger.LogWarning(ex, "PatchViaDataRequest: Post/Observe failed for {Path}", resolvedPath);
                 Fail(ex);
             }
 
@@ -2587,7 +2587,7 @@ public class MeshOperations
 
     /// <summary>
     /// Moves a node and its descendants to a new path. Posts <see cref="MoveNodeRequest"/>
-    /// and subscribes via <c>RegisterCallback</c> — no <c>AwaitResponse</c>, no <c>await</c>
+    /// and subscribes via <c>hub.Observe(...)</c> — no <c>await</c>
     /// on the hub scheduler.
     /// </summary>
     public IObservable<string> Move(string sourcePath, string targetPath)

--- a/src/MeshWeaver.AI/ModelDefinition.cs
+++ b/src/MeshWeaver.AI/ModelDefinition.cs
@@ -1,13 +1,14 @@
 namespace MeshWeaver.AI;
 
 /// <summary>
-/// Content shape for <c>nodeType:Model</c> mesh nodes — the
-/// bring-your-own-model surface. Mirrors the role
+/// Content shape for <c>nodeType:LanguageModel</c> mesh nodes
+/// (<see cref="LanguageModelNodeType.NodeType"/>) — the bring-your-own-model
+/// surface. Mirrors the role
 /// <see cref="AgentConfiguration"/> plays for <c>nodeType:Agent</c>: a
 /// mesh node carries everything <see cref="IChatClientFactory"/> needs to
 /// instantiate a chat client (endpoint, model id, auth reference). Discovery
 /// happens via the same workspace synced query that loads agents
-/// (<c>nodeType:Agent|Model</c>).
+/// (<c>nodeType:Agent|LanguageModel</c>).
 ///
 /// <para>Auth is handled by an <see cref="ApiKeySecretRef"/> — a path or
 /// key into a secret store rather than the literal credential — so a Model

--- a/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
@@ -14,9 +14,11 @@ namespace MeshWeaver.AI.Plugins;
 /// Agent plugin providing tools for adding comments and suggesting edits on
 /// Markdown documents via the collaborative editing infrastructure.
 ///
-/// Every method is await-free — reads are wrapped in <c>Observable.FromAsync</c> on
-/// the <see cref="TaskPoolScheduler"/> so blocking enumeration never touches the hub
-/// scheduler, and writes go through <c>hub.Post + hub.RegisterCallback</c> with a
+/// Every method is await-free — reads are moved onto the <see cref="TaskPoolScheduler"/>
+/// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
+/// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so blocking
+/// enumeration never touches the hub scheduler, and writes go through
+/// <c>hub.Observe(...).Subscribe(...)</c> with a
 /// <see cref="TaskCompletionSource{T}"/> bridging the off-hub callback thread back
 /// to the caller. See <c>Doc/Architecture/AsynchronousCalls</c> for the rationale:
 /// any <c>await</c> on a hub-backed operation from inside a plugin method will
@@ -65,9 +67,9 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
         var resolvedPath = MeshOperations.ResolvePath(resolvedInput);
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Read the document off the hub scheduler, then fan into Post + RegisterCallback.
+        // Read the document off the hub scheduler, then fan into hub.Observe(...).
         // No `await` anywhere — the subscription runs the read on TaskPoolScheduler and
-        // the write's callback fires on the response thread. Both resolve the TCS.
+        // the write's response arrives on the observe subscription. Both resolve the TCS.
         ops.Get(resolvedInput)
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
@@ -241,8 +243,8 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
     }
 
     /// <summary>
-    /// Posts a request via Post + RegisterCallback and resolves <paramref name="tcs"/>
-    /// from the callback. No <c>await</c>: the callback fires on a non-hub thread
+    /// Posts a request via <c>hub.Observe(...)</c> and resolves <paramref name="tcs"/>
+    /// from the subscription. No <c>await</c>: the response arrives on a non-hub thread
     /// when the response arrives. Routing failures surface as a user-actionable
     /// error pointing the agent back at the "use `path`, not `name`" rule.
     /// </summary>

--- a/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
@@ -110,7 +110,7 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         var resolvedPath = MeshOperations.ResolvePath(MeshOperations.ResolveContextPath(chat, nodePath));
         var address = new Address(resolvedPath);
 
-        // Post + RegisterCallback + TCS — never `await hub.RegisterCallback(..., ct)` from
+        // hub.Observe(...) + TCS — never `await` a hub response from
         // a plugin method: that blocks the hub scheduler. The callback fires on a non-hub
         // thread when the response arrives and resolves the TCS to unblock the caller.
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
@@ -16,8 +16,10 @@ namespace MeshWeaver.AI.Plugins;
 /// Plugin providing version history operations for AI agents. Wraps
 /// <see cref="IVersionQuery"/> to list versions, retrieve snapshots, and restore nodes.
 ///
-/// Every method is await-free: the async <see cref="IVersionQuery"/> reads are run
-/// on <see cref="TaskPoolScheduler"/> via <c>Observable.FromAsync</c> so they never
+/// Every method is await-free: <see cref="IVersionQuery"/> already returns
+/// <c>IObservable</c>, and those reads are moved onto <see cref="TaskPoolScheduler"/>
+/// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
+/// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so they never
 /// occupy the hub scheduler, and restores go through <c>IMeshService.UpdateNode</c>
 /// which is already reactive (<c>IObservable&lt;MeshNode&gt;</c>). A
 /// <see cref="TaskCompletionSource{T}"/> bridges the off-hub completions back to the

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -475,7 +475,7 @@ internal static class ThreadExecution
                     {
                         case ThreadExecutionStatus.Executing
                             when !string.IsNullOrEmpty(thread.ActiveMessageId):
-                            // Interrupted mid-round — the in-flight Task.Run is gone.
+                            // Interrupted mid-round — the in-flight pooled round is gone.
                             // 🚨 We STAY Executing and re-launch the streaming loop
                             // directly. We must NOT write Executing→StartingExecution:
                             // that is the exact inverse of the _Exec commit edge
@@ -1603,7 +1603,7 @@ internal static class ThreadExecution
                     var toolCallLog = ImmutableList<ToolCallEntry>.Empty;
                 var nodeChangeLog = ImmutableList<NodeChangeEntry>.Empty;
                 // toolCallLog + nodeChangeLog are mutated from 4 concurrent paths:
-                //   1. Streaming loop (Task.Run with await foreach over agent updates)
+                //   1. Streaming loop (pooled Ai I/O invoke, await foreach over agent updates)
                 //   2. FCC middleware (ChatClientAgentFactory's .Use(...) callback,
                 //      fires on FCC's invocation thread)
                 //   3. client.ForwardToolCall (alias for path 2 on test agents that
@@ -1871,14 +1871,15 @@ internal static class ThreadExecution
 
                 logger.LogInformation("[ThreadExec] STREAMING_START: threadPath={ThreadPath}, responsePath={ResponsePath}",
                     threadPath, responsePath);
-                // Run streaming on thread pool via Task.Run — the grain scheduler
+                // Streaming runs OFF the hub turn, on the bounded Ai I/O pool
+                // (IoPoolNames.Ai — see the aiPool.Invoke below). The grain scheduler
                 // stays FREE to process tool call responses, delegation callbacks, and
-                // workspace updates. Without this, tool calls deadlock: they await a
-                // response that needs the grain scheduler which is blocked by InvokeAsync.
+                // workspace updates. Without that offload, tool calls deadlock: they await
+                // a response that needs the grain scheduler the round is occupying.
                 //
-                // DelayDeactivation keeps the grain alive while the thread pool task runs.
-                // BeginAsyncOperation signals the grain keep-alive timer.
-                // After await Task.Run(...), execution returns to the grain scheduler.
+                // 🚨 NEVER Task.Run for this — an unbounded thread-pool hop whose
+                // continuations bounce back onto the grain scheduler is the pattern the
+                // I/O pool replaced; see the note at the aiPool.Invoke call site below.
                 //
                 // Reuse the CancellationTokenSource HandleSubmitMessage stored on the
                 // parent hub. Storing it here would be too late — a Stop click between
@@ -1888,9 +1889,9 @@ internal static class ThreadExecution
                 // HandleSubmitMessage), allocate a fresh one as a safety net.
                 var executionCts = parentHub.Get<CancellationTokenSource>()
                     ?? StoreNewCts(parentHub);
-                // Cancel Task.Run when the hub disposes (grain deactivation).
-                // Without this, OnDeactivateAsync waits up to 120s for the Task.Run
-                // that's stuck on an AI API call with no cancellation signal.
+                // Cancel the in-flight pooled round when the hub disposes (grain
+                // deactivation). Without this, teardown waits up to 120s for a round
+                // stuck on an AI API call with no cancellation signal.
                 // Guard against a disposal race: the round may already have completed and
                 // disposed its CTS (or another disposal path raced here), in which case
                 // Cancel() throws ObjectDisposedException — which, unhandled in

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -674,7 +674,7 @@ public static class ThreadLayoutAreas
 
     /// <summary>
     /// Walks <paramref name="messageIds"/>, requests each satellite ThreadMessage via
-    /// GetDataRequest (Post + RegisterCallback wrapped as an Observable), accumulates
+    /// GetDataRequest (posted and observed via <c>hub.Observe(...)</c>), accumulates
     /// their UpdatedNodes, and emits the aggregated list once all responses arrive.
     /// </summary>
     private static IObservable<ImmutableList<NodeChangeEntry>> CollectUpdatedNodes(

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -24,8 +24,8 @@ namespace MeshWeaver.AI;
 ///   batched ingestion keeps one output cell per round.
 /// - Pure helpers <see cref="FindUnprocessedUserMessages"/> and <see cref="PlanNextRound"/>
 ///   are the unit-testable core.
-/// - Hard rule: no await, no IMeshService.QueryAsync, no Query, no client
-///   SubmitMessageRequest. Only Hub.Post + RegisterCallback + workspace stream writes.
+/// - Hard rule: no await, no IMeshService.Query, no client
+///   SubmitMessageRequest. Only Hub.Post + hub.Observe(...) + workspace stream writes.
 /// </summary>
 internal static class ThreadSubmission
 {
@@ -447,7 +447,7 @@ internal static class ThreadSubmissionServer
     /// <para><b>NOT a stopgap for the lost-message defect.</b> That defect — the non-atomic
     /// owner-side <c>PatchDataRequest</c> apply that read a handler-time snapshot and committed a
     /// deferred FULL-NODE replace, clobbering a concurrent writer's just-added field — is FIXED at
-    /// the root in <c>DataExtensions.ApplyMeshNodePatchAtomic</c> (the merge now applies onto the
+    /// the root in <c>DataExtensions.ApplyMeshNodePatchInTurn</c> (the merge now applies onto the
     /// LIVE node in one primary-stream turn). See
     /// <c>CrossHubPatchAtomicityTest.ConcurrentCrossHubPatches_DoNotDropAQueuedMessage</c>.</para>
     ///
@@ -497,7 +497,7 @@ internal static class ThreadSubmissionServer
                 "[SubmissionWatcher] lost-message invariant restored for {ThreadPath}: {Ids} were in "
                 + "Messages+UserMessageIds but neither ingested nor pending — re-marking ingested "
                 + "(concurrent cross-mirror RFC 7396 array-replace on IngestedMessageIds; the "
-                + "owner-side full-replace clobber is fixed in DataExtensions.ApplyMeshNodePatchAtomic)",
+                + "owner-side full-replace clobber is fixed in DataExtensions.ApplyMeshNodePatchInTurn)",
                 threadHub.Address.Path, string.Join(",", ingestedMissing));
 
         threadHub.GetWorkspace().GetMeshNodeStream().Update(n =>
@@ -701,7 +701,7 @@ internal static class ThreadSubmissionServer
     /// <summary>
     /// Creates the output cell, writes the committed round to the thread node, and
     /// fires off agent execution on the _Exec hosted hub. Non-blocking — all
-    /// Hub.Post + RegisterCallback; the workspace write is a synchronous fire-and-forget.
+    /// Hub.Post + hub.Observe(...); the workspace write is a synchronous fire-and-forget.
     ///
     /// Step 0 (new): for each unprocessed user id present in <see cref="MeshThread.PendingUserMessages"/>,
     /// create the satellite ThreadMessage cell. The client only writes the thread node;
@@ -1179,7 +1179,7 @@ internal static class ThreadSubmissionServer
                 return;
             }
 
-            // Step 1: create the assistant output cell (CreateNodeRequest → RegisterCallback).
+            // Step 1: create the assistant output cell (CreateNodeRequest → hub.Observe(...)).
             // Status=Streaming until the streaming loop transitions it to Completed/Cancelled/Error.
             var responseCell = new MeshNode(responseMsgId, threadPath)
             {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1097,7 +1097,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         // double-submit of the same text within its debounce window.
 
         // No await in the click path — dispatch to Blazor render context and return void.
-        // All Hub operations use Post + RegisterCallback; all IMeshService operations
+        // All Hub operations use Post + hub.Observe(...); all IMeshService operations
         // use IObservable + Subscribe. No awaits on hub-backed calls anywhere in this chain.
         _ = InvokeAsync(SubmitMessageCore);
     }
@@ -2668,7 +2668,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         // Add as attachment chip if not already present (text stays in editor)
         if (!attachments.Any(a => a.Path.Equals(path, StringComparison.OrdinalIgnoreCase)))
         {
-            // Add the chip immediately with path-only label; resolve display name via Post/RegisterCallback.
+            // Add the chip immediately with path-only label; resolve display name via Post/Observe.
             attachments.Add(new AttachmentInfo(path, null, IsContext: false));
             RequestDisplayName(path, displayName => InvokeAsync(() =>
             {

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -757,7 +757,7 @@ public static class DataExtensions
             // Applying the patch is fire-and-forget relative to the handler —
             // the helper reads the stream reactively (.Take(1).Subscribe), merges,
             // and commits via workspace.RequestChange. The response is posted from
-            // inside the subscribe callback so the caller's RegisterCallback fires
+            // inside the subscribe callback so the caller's Observe subscription fires
             // AFTER the commit (otherwise a racing read sees pre-patch state).
             var applyPatch = typeof(DataExtensions)
                 .GetMethod(nameof(ApplyJsonMergePatchAndUpdate),
@@ -1264,7 +1264,7 @@ public static class DataExtensions
                     // which blocked the handler's action block; the reducer's
                     // emission then couldn't be processed by the same hub →
                     // deadlock under load. The post-commit response timing
-                    // is preserved (caller's RegisterCallback fires after the
+                    // is preserved (caller's Observe subscription fires after the
                     // commit lands, before any subsequent Get).
                     var postSub = stream
                         .Skip(1)

--- a/src/MeshWeaver.Documentation/Data/AI/ExecuteScript.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ExecuteScript.md
@@ -161,12 +161,15 @@ The kernel's script context exposes `Mesh`. Call `Mesh.ServiceProvider.GetRequir
 **2. Avoid `await` on hub-reachable services in hot paths.**
 Scripts run on the kernel's action block. `await meshService.CreateNodeAsync` inside a loop serialises the hub. Prefer `meshService.CreateNode(node).Subscribe(...)` — it returns `IObservable<MeshNode>`, not `Task<MeshNode>`.
 
-**3. Wrap external `Task`-returning primitives at the boundary with `Observable.FromAsync`.**
+**3. Push external `Task`-returning primitives onto an `IIoPool`.**
 For blob reads:
 ```csharp
-Observable.FromAsync(() => contentService.GetContentAsync(...)).Subscribe(...)
+var pool = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>().Get(IoPoolNames.Blob);
+pool.Invoke(ct => contentService.GetContentAsync(..., ct)).Subscribe(...);
 ```
-This keeps the kernel's action block free while the fetch runs on the task pool.
+The pool runs the call **off** the kernel's action block with `ConfigureAwait(false)`, and bounds how many such calls are in flight at once.
+
+> 🚨 **Never `Observable.FromAsync`.** It looks like the same thing and is not: a bare `FromAsync` runs the function's synchronous prologue on the **subscribing** thread — the kernel's action block, when you subscribe mid-script — and applies no concurrency bound at all. That is the deadlock-and-exhaustion class `IIoPool` exists to remove, which is why `Observable.FromAsync` is forbidden everywhere in `src/` outside `IoPool` itself. Use `Invoke` for a `Task<T>` leaf, `InvokeBlocking` for a sync-blocking or CPU leaf, `InvokeStream` for an `IAsyncEnumerable<T>`. See [Controlled IO Pooling](/Doc/Architecture/ControlledIoPooling).
 
 **4. Log liberally.**
 `Log.LogInformation(...)` / `LogWarning(...)` / `LogError(...)` append to the run's ActivityLog. Agents and users watching the log have no other window into what the script is doing — tell them.

--- a/src/MeshWeaver.Documentation/Data/AI/ModelProviderSettings.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ModelProviderSettings.md
@@ -111,7 +111,7 @@ The backend lives in `src/MeshWeaver.AI/Connect/`:
 **`IConnectStrategy`** — one implementation per CLI.
 - `ClaudeConnectStrategy`: spawns `claude` under the user's `CLAUDE_CONFIG_DIR`, probes the CLI (or its `.credentials.json`) for login status, and if absent runs `claude setup-token` (or `/login`), scrapes the auth URL, surfaces it, and captures the pasted code/token.
 - `CopilotConnectStrategy`: runs the Copilot SDK device-flow — surfaces the device URL + code, polls `GetAuthStatusAsync`.
-- Both reuse the subprocess shape from `MeshPlugin`/`KernelExecutor` (`RedirectStandardInput`); `Observable.FromAsync` is used only at the process boundary.
+- Both reuse the subprocess shape from `MeshPlugin`/`KernelExecutor` (`RedirectStandardInput`). The process boundary runs on the `Process` [`IIoPool`](/Doc/Architecture/ControlledIoPooling) — `InvokeBlocking` for the spawn, `Invoke` for the stdin write — carrying **only** the async leaves, with the auth-URL/token scrape composed as an ordinary observable. Never `Observable.FromAsync`, which is forbidden outside `IoPool`.
 
 **`ConnectSessionManager`** — a mesh-scoped singleton that holds the live `Process` between "show URL" and "paste code", keyed per user (instance `ConcurrentDictionary`, **never static**), with a 5-minute timeout that calls `Kill(entireProcessTree:true)`.
 

--- a/src/MeshWeaver.Documentation/Data/AI/ModelProviderSetup.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ModelProviderSetup.md
@@ -30,7 +30,7 @@ Two companion node types carry everything a chat-client factory needs:
 | Node type | Holds | Path shape |
 |---|---|---|
 | `ModelProvider` | credentials shared by its models — `Endpoint`, `ApiKey` (encrypted at rest), `Label`, the model-id list | `Provider/{Provider}` (platform) · `{user}/_Memex/{Provider}` (user) |
-| `LanguageModel` | one model — `Id`, `Provider`, `ProviderRef` (→ its provider node), `ModelTier`, `Description` | `{providerPath}/{modelId}` (nested under its provider) |
+| `LanguageModel` | one model — `Id`, `Provider`, `ProviderRef` (→ its provider node), `Tier`, `Description` | `{providerPath}/{modelId}` (nested under its provider) |
 
 The platform catalog lives in the top-level **`Provider`** partition — a DB-synced [NodeType catalog](/Doc/Architecture/NodeTypeCatalogs), exactly like `Agent` / `Skill` / `Harness`. A user's **own** providers live in their dotfile namespace `{user}/_Memex/…`. A `LanguageModel` is always **nested under its provider** and never stores a key; it points at its `ModelProvider` via `ProviderRef`, and the resolver follows that reference to fetch `Endpoint` + `ApiKey`.
 
@@ -116,7 +116,7 @@ This is exactly how the shared **Azure AI Foundry (Systemorph)** provider was cr
     "displayName": "DeepSeek V3 (High)",
     "provider": "AzureFoundry",
     "providerRef": "Systemorph/Provider/AzureFoundry",
-    "modelTier": "heavy",
+    "tier": "coding",
     "order": 1
   }
 }

--- a/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
@@ -45,7 +45,7 @@ MeshWeaver speaks to multiple LLM providers — Claude via Anthropic, GPT-class 
   <line x1="100" y1="90" x2="100" y2="258" stroke="currentColor" stroke-opacity=".4" stroke-width="1.5"/>
   <rect x="310" y="80" width="160" height="60" rx="10" fill="#43a047"/>
   <text x="390" y="105" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#fff">Agent Definition</text>
-  <text x="390" y="122" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#c8e6c9">PreferredModel / ModelTier</text>
+  <text x="390" y="122" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#c8e6c9">ModelTier</text>
   <rect x="310" y="170" width="160" height="60" rx="10" fill="#f57c00"/>
   <text x="390" y="195" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#fff">AgentChatClient</text>
   <text x="390" y="212" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#ffe0b2">GetFactoryForModel</text>
@@ -207,7 +207,7 @@ To wire in a new provider (a second Azure OpenAI deployment, a hosted local mode
 1. **Implement `IChatClientFactory`** and register it via DI (`services.AddAzureOpenAI(...)` or similar).
 2. **Bind its options** from a new section in `MemexConfiguration.cs` — endpoint and auth fields only, **not** model names.
 3. **Add Aspire parameters** in `memex/aspire/Memex.AppHost/Program.cs` for the endpoint (and a key, if it doesn't share `azure-foundry-key`).
-4. **Reference the new model** in agent definitions via `PreferredModel` or `ModelTier`.
+4. **Label the new model's node** with a `tier` (`ModelDefinition.Tier`), so agents reach it by declaring `modelTier` in their front matter. An agent names a tier, never a model id — there is no per-agent "preferred model" field.
 
 > **Do not hardcode model identifiers in framework code.** If you find yourself writing `"gpt-4o"` or `"claude-sonnet-4-5"` in a `.cs` file outside an agent definition, that is precisely the pattern this page exists to prevent.
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
@@ -171,14 +171,20 @@ Choose the right reference type for your query pattern:
 
 ## Unified Reference Paths
 
-Path-based references give a uniform addressing scheme across entity, content, and schema resources:
+Path-based references give a uniform addressing scheme across entity and content resources.
+The prefix is separated by a **colon**, and what follows it starts with the owning address —
+`{prefix}:{addressType}/{addressId}/…`. A path with no recognised colon prefix falls through to
+`area`, so a slash-separated `"data/TodoItems"` is parsed as an *area* reference, not data.
 
 ```csharp
-var todoRef       = "data:TodoItems/todo-1";   // specific entity
-var allTodosRef   = "data/TodoItems";           // entire collection
-var fileRef       = "content/uploads/doc.pdf";  // file content
-var schemaRef     = "schema/TodoItem";          // JSON schema
+var allTodosRef = "data:app/my-app/TodoItems";           // entire collection
+var todoRef     = "data:app/my-app/TodoItems/todo-1";    // specific entity
+var fileRef     = "content:app/my-app/uploads/doc.pdf";  // file content
+var areaRef     = "area:app/my-app/Dashboard";           // layout area
 ```
+
+The three recognised prefixes are `data:`, `area:` and `content:` (`ParseUnifiedPath`).
+There is no `schema:` prefix.
 
 ## Virtual Paths
 
@@ -448,12 +454,13 @@ var rows = new[]
     new { Type = "CollectionsReference", Purpose = "Multiple collections at once", Example = "new CollectionsReference(\"TodoItems\", \"Projects\")" },
 };
 
-var header = "<thead><tr><th>Reference Type</th><th>Purpose</th><th>Example</th></tr></thead>";
-var bodyRows = string.Join("", rows.Select(r =>
-    $"<tr><td><code>{r.Type}</code></td><td>{r.Purpose}</td><td><code>{r.Example}</code></td></tr>"));
-
-MeshWeaver.Layout.Controls.Html(
-    $"<table style='width:100%;border-collapse:collapse'>{header}<tbody>{bodyRows}</tbody></table>")
+MeshWeaver.Layout.Controls.DataGrid(rows)
+    .WithColumn(new MeshWeaver.Layout.DataGrid.PropertyColumnControl<string>
+        { Property = "type" }.WithTitle("Reference Type"))
+    .WithColumn(new MeshWeaver.Layout.DataGrid.PropertyColumnControl<string>
+        { Property = "purpose" }.WithTitle("Purpose"))
+    .WithColumn(new MeshWeaver.Layout.DataGrid.PropertyColumnControl<string>
+        { Property = "example" }.WithTitle("Example"))
 ```
 
 ---

--- a/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/CRUD.md
@@ -293,33 +293,30 @@ Deleting a **node** (as opposed to an entity in a collection) is a lifecycle ope
 
 # Data Validation
 
-Attach validators to enforce business rules before any change is applied. The workspace calls every registered validator and returns `DataValidationResult.Failed(...)` to the caller if any rule is violated.
+Attach validators to enforce business rules before any change is applied. The workspace calls every registered validator and returns `DataValidationResult.Invalid(...)` to the caller if any rule is violated.
 
 ```csharp
 public class TodoValidator : IDataValidator
 {
-    public List<DataOperation> SupportedOperations =>
+    // Reactive, never Task<T> — this runs on the hub.
+    public IReadOnlyCollection<DataOperation> SupportedOperations { get; } =
         [DataOperation.Create, DataOperation.Update];
 
-    public Task<DataValidationResult> ValidateAsync(
-        DataValidationContext context,
-        CancellationToken ct)
+    public IObservable<DataValidationResult> Validate(DataValidationContext context)
     {
         if (context.Entity is TodoItem todo && string.IsNullOrEmpty(todo.Title))
-            return Task.FromResult(
-                DataValidationResult.Failed("Title is required"));
+            return Observable.Return(
+                DataValidationResult.Invalid("Title is required"));
 
-        return Task.FromResult(DataValidationResult.Success());
+        return Observable.Return(DataValidationResult.Valid());
     }
 }
 ```
 
-Register validators in the data configuration:
+Register validators in DI — the workspace resolves every registered `IDataValidator`:
 
 ```csharp
-.AddData(data => data
-    .WithValidator<TodoValidator>()
-)
+services.AddScoped<IDataValidator, TodoValidator>();
 ```
 
 ---
@@ -336,9 +333,9 @@ Restrict operations based on user context. Access restrictions run before valida
         (action, context, accessCtx) =>
         {
             if (action == AccessAction.Read)
-                return Task.FromResult(true);          // anyone can read
+                return Observable.Return(true);          // anyone can read
 
-            return Task.FromResult(accessCtx.UserContext != null); // writes require login
+            return Observable.Return(accessCtx.UserContext != null); // writes require login
         },
         "RequireAuthForWrites"
     )
@@ -354,8 +351,8 @@ Restrict operations based on user context. Access restrictions run before valida
         {
             var todo = ctx as TodoItem;
             // Only the owner may modify their own todos
-            return Task.FromResult(
-                todo?.OwnerId == accessCtx.UserContext?.UserId
+            return Observable.Return(
+                todo?.OwnerId == accessCtx.UserContext?.ObjectId
             );
         }, "OwnerOnly")
     )
@@ -373,17 +370,18 @@ A complete data source setup showing multiple types, a virtual path, a validator
     .AddSource(src => src
         .WithType<TodoItem>(type => type
             .WithKey(todo => todo.Id)
-            .WithInitialData(async (ref, ct) =>
-                await LoadTodosFromDatabaseAsync(ct))
+            .WithInitialData(() => LoadTodos())
         )
         .WithType<Project>(type => type
             .WithKey(proj => proj.Id)
         )
     )
     .WithVirtualPath("Dashboard", ComputeDashboard)
-    .WithValidator<TodoValidator>()
     .WithAccessRestriction(RequireAuthentication, "Auth")
 )
+
+// Validators are registered in DI, not on the data configuration:
+services.AddScoped<IDataValidator, TodoValidator>();
 ```
 
 ---
@@ -430,7 +428,7 @@ sequenceDiagram
 ## Best Practices
 
 1. **Use typed observables** — prefer `GetObservable<T>()` over raw streams for compile-time safety.
-2. **Check the response** — inspect `DataChangeResponse.Error` for validation failures before assuming success.
+2. **Check the response** — inspect `DataChangeResponse.Status` (`Committed` / `Failed`) before assuming success; the detail is in `.Log`. Note a `Warning` status still COMMITS.
 3. **Batch related changes** — group inserts, updates, and deletes into a single `DataChangeRequest` for atomic delivery.
 4. **Register validators** — enforce data integrity at the data layer rather than in each call site.
 5. **Protect with access restrictions** — declare who may read or write each type alongside the type configuration.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/DataModeling.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/DataModeling.md
@@ -276,7 +276,7 @@ public string? Description { get; init; }
 
 | Parameter | Default | Purpose |
 |---|---|---|
-| `EditorHeight` | auto | Height of the edit pane |
+| `EditorHeight` | `300px` | Height of the edit pane |
 | `ShowPreview` | `true` | Show live preview alongside the editor |
 
 ### `[Dimension<T>]`

--- a/src/MeshWeaver.Documentation/Data/DataMesh/NodeOperations.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/NodeOperations.md
@@ -87,13 +87,10 @@ Export requires `Permission.Export`, which is granted to the **Editor** and **Ad
 
 ## Programmatic Export
 
-```csharp
-var exportService = hub.ServiceProvider.GetRequiredService<IMeshExportService>();
-var result = await exportService.ExportToDirectoryAsync("org/acme/project", outputDir);
-// result.NodesExported, result.PartitionsExported, result.Success
-```
-
-`IMeshExportService` uses `FileFormatParserRegistry` to select the appropriate serializer for each node based on its content type. Partition data (sub-paths like `Source`, `layoutAreas`) is exported as JSON.
+Export is driven from the **Export** node-menu action and the `ExportLayoutArea`; there is no
+`IMeshExportService`. The writer uses `FileFormatParserRegistry` to select the serializer for each
+node from its content type — partition data (sub-paths like `Source`, `layoutAreas`) is written as
+JSON.
 
 ## Export–Import Round Trip
 
@@ -117,18 +114,24 @@ Import reads files from a directory or ZIP and creates nodes in the mesh. Three 
 | **Upload File** | Single `.md`, `.json`, `.yaml`, `.csv`, or `.html` file |
 | **Upload Folder (ZIP)** | Directory structure or ZIP archive |
 
-The import service (`IMeshImportService`) uses `FileFormatParserRegistry` to parse each file into a `MeshNode` based on its extension.
+Import uses `FileFormatParserRegistry` to parse each file into a `MeshNode` based on its extension (`StaticRepoImporter` does the work).
 
 ## Programmatic Import
 
+Import is a request on the hub — observe it, never await it:
+
 ```csharp
-var importService = hub.ServiceProvider.GetRequiredService<IMeshImportService>();
-var result = await importService.ImportNodesAsync(
-    sourcePath: "/tmp/exported-data",
-    targetRootPath: "org/acme/project",
-    force: true,           // overwrite existing nodes
-    removeMissing: false); // don't delete nodes absent from source
+hub.Observe<ImportNodesResponse>(
+        new ImportNodesRequest("/tmp/exported-data", "org/acme/project") { Force = true })
+    .Subscribe(
+        response => logger.LogInformation(
+            "Imported {Nodes} nodes, skipped {Skipped}",
+            response.Message.NodesImported, response.Message.NodesSkipped),
+        ex => logger.LogWarning(ex, "Import failed"));
 ```
+
+`ImportNodesResponse` carries `NodesImported`, `PartitionsImported`, `NodesSkipped`,
+`PartitionsSkipped`, `NodesRemoved`, `Elapsed`, and `Error` (null on success).
 
 ---
 
@@ -148,12 +151,17 @@ Copy duplicates a node and all its descendants to a new namespace. The source no
 
 ## Programmatic Copy
 
+`CopyNodeTree` returns `IObservable<int>` (the node count) — subscribe, don't await:
+
 ```csharp
-var nodesCopied = await NodeCopyHelper.CopyNodeTreeAsync(
-    meshService, meshService, hub,
-    sourcePath: "org/acme",
-    targetNamespace: "org/backup",
-    force: false);
+NodeCopyHelper.CopyNodeTree(
+        meshService, meshService, hub,
+        sourcePath: "org/acme",
+        targetNamespace: "org/backup",
+        force: false)
+    .Subscribe(
+        nodesCopied => logger.LogInformation("Copied {Count} nodes", nodesCopied),
+        ex => logger.LogWarning(ex, "Copy failed"));
 ```
 
 ---

--- a/src/MeshWeaver.Documentation/Data/DataMesh/NugetPackages.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/NugetPackages.md
@@ -4,7 +4,7 @@ Category: Documentation
 Description: Load any NuGet package directly from an interactive markdown code cell using the #r "nuget:..." directive — no SDK, no restart.
 ---
 
-Interactive markdown in MeshWeaver is backed by a [.NET Interactive](https://github.com/dotnet/interactive) `CSharpKernel`. That gives every code cell the same package-management directive used by Polyglot Notebooks: `#r "nuget:PackageId, Version"`. MeshWeaver resolves the package in-process using `NuGet.Protocol`, `NuGet.Packaging`, and `NuGet.Resolver` — no .NET SDK, no MSBuild — adds its assemblies to the kernel's compilation references, and the package is usable immediately without restarting the portal.
+Interactive markdown in MeshWeaver is backed by a Roslyn scripting kernel (`Microsoft.CodeAnalysis.CSharp.Scripting`). It supports the same package-management directive Polyglot Notebooks made familiar: `#r "nuget:PackageId, Version"` — but the implementation is MeshWeaver's own, not .NET Interactive's. MeshWeaver resolves the package in-process using `NuGet.Protocol`, `NuGet.Packaging`, and `NuGet.Resolver` — no .NET SDK, no MSBuild — adds its assemblies to the kernel's compilation references, and the package is usable immediately without restarting the portal.
 
 ## Basic usage
 
@@ -18,12 +18,16 @@ using Humanizer;
 
 When MeshWeaver renders a cell like this, it:
 
-1. Submits the entire cell to the kernel as a single `SubmitCode` command.
-2. .NET Interactive's package-management extension sees the `#r "nuget"` directive, calls `api.nuget.org`, and restores the package and its transitive dependencies into the local NuGet cache.
-3. Adds every resolved assembly to the kernel's metadata references via `CSharpKernel.AddAssemblyReferences(...)`.
+1. Submits the entire cell to the kernel as a single `SubmitCodeRequest`.
+2. `NuGetDirectiveParser.Extract` strips the `#r "nuget"` directives from the source, and
+   `INuGetAssemblyResolver.ResolveAsync` calls `api.nuget.org` and restores the package and its
+   transitive dependencies into the local NuGet cache.
+3. Adds every resolved assembly to the kernel's script options
+   (`scriptOptions.AddReferences(...)`) and installs a runtime probe for the package's
+   probing directories.
 4. Compiles and runs the remaining code against the augmented reference set.
 
-The return value flows back as a `ReturnValueProduced` event and is rendered into the `--render` area.
+The return value is rendered into the `--render` area.
 <svg viewBox="0 0 760 200" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;" font-family="sans-serif" font-size="13">
   <defs>
     <marker id="np-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
@@ -40,9 +44,9 @@ The return value flows back as a `ReturnValueProduced` event and is rendered int
   <rect x="195" y="60" width="130" height="80" rx="10" fill="#1b3a2a" stroke="#43a047" stroke-width="1.5"/>
   <rect x="195" y="60" width="130" height="34" rx="10" fill="#43a047"/>
   <rect x="195" y="80" width="130" height="14" fill="#43a047"/>
-  <text x="260" y="82" text-anchor="middle" fill="#fff" font-weight="bold" font-size="13">CSharpKernel</text>
-  <text x="260" y="108" text-anchor="middle" fill="#cfd8dc" font-size="11">SubmitCode</text>
-  <text x="260" y="124" text-anchor="middle" fill="#cfd8dc" font-size="11">command</text>
+  <text x="260" y="82" text-anchor="middle" fill="#fff" font-weight="bold" font-size="13">Script Kernel</text>
+  <text x="260" y="108" text-anchor="middle" fill="#cfd8dc" font-size="11">SubmitCodeRequest</text>
+  <text x="260" y="124" text-anchor="middle" fill="#cfd8dc" font-size="11">Roslyn scripting</text>
   <rect x="375" y="60" width="150" height="80" rx="10" fill="#2a1e3a" stroke="#8e24aa" stroke-width="1.5"/>
   <rect x="375" y="60" width="150" height="34" rx="10" fill="#8e24aa"/>
   <rect x="375" y="80" width="150" height="14" fill="#8e24aa"/>
@@ -53,8 +57,8 @@ The return value flows back as a `ReturnValueProduced` event and is rendered int
   <rect x="565" y="60" width="175" height="34" rx="10" fill="#f57c00"/>
   <rect x="565" y="80" width="175" height="14" fill="#f57c00"/>
   <text x="652" y="82" text-anchor="middle" fill="#fff" font-weight="bold" font-size="13">Result</text>
-  <text x="652" y="108" text-anchor="middle" fill="#cfd8dc" font-size="11">AddAssemblyReferences</text>
-  <text x="652" y="124" text-anchor="middle" fill="#cfd8dc" font-size="11">ReturnValueProduced</text>
+  <text x="652" y="108" text-anchor="middle" fill="#cfd8dc" font-size="11">AddReferences</text>
+  <text x="652" y="124" text-anchor="middle" fill="#cfd8dc" font-size="11">rendered inline</text>
   <line x1="150" y1="100" x2="193" y2="100" stroke="#90a4ae" stroke-width="1.5" marker-end="url(#np-arrow)"/>
   <line x1="325" y1="100" x2="373" y2="100" stroke="#90a4ae" stroke-width="1.5" marker-end="url(#np-arrow)"/>
   <line x1="525" y1="100" x2="563" y2="100" stroke="#90a4ae" stroke-width="1.5" marker-end="url(#np-arrow)"/>
@@ -101,7 +105,7 @@ DateTime.UtcNow.AddMinutes(-5).Humanize()
 
 ## What happens on failure
 
-If the package ID is unknown, the version does not exist, or the kernel cannot reach `nuget.org`, the cell produces a `CommandFailed` event. The error is rendered inline — the author sees exactly what went wrong without tailing server logs:
+If the package ID is unknown, the version does not exist, or the kernel cannot reach `nuget.org`, the restore throws and the cell fails. The error is rendered inline — the author sees exactly what went wrong without tailing server logs:
 
 ```csharp
 #r "nuget:ThisPackageDoesNotExist, 1.0.0"

--- a/src/MeshWeaver.Documentation/Data/DataMesh/QuerySyntax.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/QuerySyntax.md
@@ -456,22 +456,27 @@ Add `scope:descendants` to go recursive.
 
 ---
 
-## The `SelectAsync` API
+## Reading a single node's fields
 
-The `SelectAsync` API retrieves a single property from a node at a known path without deserializing the full content blob. Use it when you only need one field and overhead matters.
+There is no `SelectAsync` API. To read fields off a node at a **known path**, take the node
+from its stream — that is the authoritative, live read; a query would go through the lagged
+read-side index and return stale content right after a write:
 
 ```csharp
-// Get the display name of a node
-var name = await meshQuery.SelectAsync<string>("Systemorph/Marketing", "Name");
-
-// Get the node type
-var nodeType = await meshQuery.SelectAsync<string>("ACME/Project", "NodeType");
-
-// Get the icon
-var icon = await meshQuery.SelectAsync<string>("ACME", "Icon");
+workspace.GetMeshNodeStream("Systemorph/Marketing")
+    .Where(node => node is not null)
+    .Take(1)
+    .Timeout(TimeSpan.FromSeconds(10))
+    .Subscribe(node =>
+    {
+        var name = node.Name;
+        var nodeType = node.NodeType;
+        var icon = node.Icon;
+    });
 ```
 
-Returns `default` if the node is not found or the property is null. Any property on `MeshNode` is valid: `Name`, `NodeType`, `Path`, `Icon`, `Description`, and so on.
+If you want a narrower payload out of a **set** query, use `select:` (below) — but note it
+drops `content`. See [CQRS — Queries vs. Content Access](/Doc/Architecture/CqrsAndContentAccess).
 
 ---
 
@@ -515,5 +520,5 @@ MeshWeaver.Layout.Controls.Markdown($"""
 2. **`namespace:X` means "folder X"** — returns immediate children by default; add `scope:descendants` to go deep.
 3. **Wildcards** — `*` matches anything; prefix, suffix, and contains patterns all work.
 4. **Select only what you need** — use `select:` to keep payloads small in large result sets.
-5. **`SelectAsync` for single properties** — when you know the path and need just one field, `SelectAsync` avoids full-node deserialization.
+5. **Known path ⇒ node stream, not a query** — `workspace.GetMeshNodeStream(path)` is authoritative and live; `QueryAsync(path:X)` is a stale-read bug.
 6. **Vector search** — free-floating text tokens (`laptop nodeType:Story`) trigger HNSW cosine-index search on Postgres backends when an `IEmbeddingProvider` is registered; structured-only queries stay on the regular SQL path.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SatelliteEntities.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SatelliteEntities.md
@@ -149,7 +149,7 @@ Replies to comments are nested as children of the comment node (e.g., `_Comment/
 
 In PostgreSQL, satellite entities are stored in **dedicated tables** within the same schema as their parent partition. This separation enables efficient index-based lookups — for example, "get all comments for this document" via the `main_node` column index.
 
-Configuration lives in `PartitionDefinition.StandardTableMappings`:
+Configuration lives in `SatelliteTableMapping.Defaults` (surfaced per partition by `PartitionDefinition.DefaultSegmentTableMappings()`):
 
 | Sub-Namespace | Table | Description |
 |---|---|---|
@@ -157,9 +157,14 @@ Configuration lives in `PartitionDefinition.StandardTableMappings`:
 | `_UserActivity` | `user_activities` | User access records |
 | `_Thread` | `threads` | Threads and thread messages |
 | `_Tracking` | `annotations` | Legacy track-change records (no longer written) |
-| `_Approval` | `approvals` | Approval records |
+| `_Approval` | `annotations` | Approval records |
 | `_Access` | `access` | Access assignments |
-| `_Comment` | `comments` | Comments and replies |
+| `_Comment` | `annotations` | Comments and replies |
+| `_ThreadMessage` | `threads` | Thread messages |
+| `_Notification` | `notifications` | Notifications |
+| `Source`, `Test` | `code` | Source and test code nodes (primary content, not satellites) |
+
+`_Comment`, `_Approval` and `_Tracking` deliberately **share** the `annotations` table — there is no `comments` or `approvals` table in any schema.
 
 Primary entities (where `MainNode == Path`, or where no satellite prefix matches) go to the `mesh_nodes` table.
 
@@ -171,11 +176,11 @@ var def = new PartitionDefinition
 {
     Namespace = "ACME",
     Schema = "acme",
-    TableMappings = PartitionDefinition.StandardTableMappings
+    TableMappings = PartitionDefinition.DefaultSegmentTableMappings()
 };
 
 def.ResolveTable("ACME/Projects/Alpha")                     // → "mesh_nodes"
-def.ResolveTable("ACME/Projects/Alpha/_Comment/c1")         // → "comments"
+def.ResolveTable("ACME/Projects/Alpha/_Comment/c1")         // → "annotations"
 def.ResolveTable("ACME/Projects/Alpha/_Access/Alice_Access") // → "access"
 def.ResolveTable("ACME/Projects/Alpha/_Activity/act1")       // → "activities"
 ```
@@ -193,7 +198,9 @@ var comment = new MeshNode("c1", "ACME/Docs/readme/_Comment")
     MainNode = "ACME/Docs/readme",
     Content = new { Author = "alice", Text = "This is really helpful!" }
 };
-await persistence.SaveNodeAsync(comment, options, ct);
+meshService.CreateNode(comment).Subscribe(
+    _ => { },
+    ex => logger.LogWarning(ex, "Failed to create comment"));
 ```
 
 The `MainNode` property drives three key behaviours:

--- a/src/MeshWeaver.Documentation/Data/DataMesh/Spaces.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/Spaces.md
@@ -130,12 +130,12 @@ on the **Space node's content** — you never create a second node for it.
 
 | Field (`content.…`) | Shows up as |
 |---|---|
-| `name` | The large title in the header. |
+| *(node `Name`)* | The large title in the header. This lives on the **MeshNode**, not in `content` — the `Space` content carries no `name`, so patching `content.name` silently does nothing. |
 | `description` | Sub-title under the name (one line, markdown allowed). |
 | `logo` | The 100×100 header image. An **`https://…` URL** *or* a file in the Space's `content` collection. Falls back to the node icon, then to initials. |
 | `body` | The main page content — **markdown**. This is your "overview text". |
 | `website`, `email`, `location` | Small linked stats in the header row. |
-| `icon` | Fluent icon name used where no logo is set (default `Building`). |
+| `icon` | A **renderable** value used where no logo is set — an image URL, an inline `<svg>`, or an emoji. Never a Fluent icon name: a bare name like `Building` cannot render as an image and shows as text or a broken image. Defaults to `/static/NodeTypeIcons/space.svg`. |
 
 The body is resolved as **`node.PreRenderedHtml` → `content.body` → default welcome
 text**. So to replace the generic starter text, just set `content.body`. Leaving it
@@ -157,7 +157,7 @@ Treat `content.body` as the front door. A strong one usually has:
 
 ### Embedding the namespace catalog (the search that expands by namespace)
 
-The catalog is the `Children` layout area: a mesh search in **namespace-tree** mode,
+The catalog is the `Search` layout area: a mesh search in **namespace-tree** mode,
 scoped to the Space's own partition, that lets you drill into sub-namespaces with
 lazy-loaded counts and a search box. It is **not** hard-wired into the page — it lives
 in the body as a **deletable `@@`-embed** (the default welcome page ships one), so the

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
@@ -257,7 +257,7 @@ Reads and writes go through the framework's data-layer messages.
 
 - `NodeFactory.CreateNode(node)` — create a source node.
 - `NodeFactory.UpdateNode(node)` — write at the source side.
-- `ReadNodeAsync(path)` — read a `MeshNode` via `GetDataRequest + MeshNodeReference` on a dedicated reader hub.
+- `ReadNode(path)` — read a `MeshNode` on a dedicated reader hub; returns `IObservable<MeshNode?>` (the old `ReadNodeAsync` was deleted).
 
 Verification follows an observe-until-condition rhythm (mirrors `ObservableQueryTests`). The synced collection stays subscribed the whole time — no `Take(1)`, no draining.
 
@@ -273,10 +273,12 @@ public async Task DataChangeRequestOnSubscriber_PropagatesToOwningHub()
     // Source-side state.
     await NodeFactory.CreateNode(MakeSubject("alpha", "Original"))
         .FirstAsync().ToTask(ct);
-    await Task.Delay(500, ct);                 // synced collection picks it up.
 
-    // Read the current value (standard data-layer read).
-    var current = await ReadNodeAsync(path);
+    // Wait for the CONDITION, never a fixed sleep: a Task.Delay races CI load —
+    // too short and it flakes, too long and it wastes the suite's budget.
+    var current = await ReadNode(path)
+        .Where(n => n is not null)
+        .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
 
     // Write at the SUBSCRIBER via DataChangeRequest. The subscriber's
     // synced data source routes the update through its cached per-node
@@ -285,11 +287,12 @@ public async Task DataChangeRequestOnSubscriber_PropagatesToOwningHub()
             new DataChangeRequest { Updates = [current! with { Name = "Updated" }] },
             o => o.WithTarget(new Address(SubscriberPath)))
         .FirstAsync().ToTask(ct);
-    await Task.Delay(500, ct);
 
-    // Source side reflects the write.
-    var reread = await ReadNodeAsync(path);
-    reread!.Name.Should().Be("Updated");
+    // Source side reflects the write — again, observe until the condition holds.
+    await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+        .SelectMany(_ => ReadNode(path))
+        .Where(n => n?.Name == "Updated")
+        .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
 }
 ```
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
@@ -107,19 +107,14 @@ public static VirtualDataSource WithMeshQuery(
     this VirtualDataSource ds,
     string query,
     string? collectionName = null);
-
-public static VirtualDataSource WithMeshQuery<T>(
-    this VirtualDataSource ds,
-    string query,
-    string? collectionName = null) where T : class;
 ```
 
 | Parameter | Description |
 |---|---|
 | `query` | Mesh query string in the standard syntax (see [Query Syntax](/Doc/DataMesh/QuerySyntax)). Common shapes: `namespace:X scope:subtree nodeType:Y`, `path:X`, `path:X scope:descendants`, `namespace:X scope:nextLevel` (the next populated level — graph navigation). |
-| `collectionName` | Workspace collection name. Defaults to `typeof(T).Name` (or `nameof(MeshNode)` on the non-generic overload). Required when the same `T` appears in multiple synced collections — for example, `Sources` and `Tests` both hold `MeshNode`. |
+| `collectionName` | Workspace collection name. Defaults to `nameof(MeshNode)`. Required when several synced collections would otherwise collide — for example, `Sources` and `Tests` both hold `MeshNode`. |
 
-The non-generic overload is the everyday case (a collection of `MeshNode`). The generic overload accepts a content type and projects via `OfType<T>` — useful when the query selects a single content shape.
+There is one overload, and it yields a collection of `MeshNode`. To work with a single content shape, filter on the node's `Content` when you read the collection.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/VirtualDataSources.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/VirtualDataSources.md
@@ -43,7 +43,7 @@ The infrastructure lives in `VirtualDataSource`, built on `VirtualTypeSource<T>`
 | Helper | Use when |
 |---|---|
 | `WithVirtualType<T>(...)` | General case — any `IObservable<IEnumerable<T>>` is fair game. |
-| `WithMeshQuery<T>(query)` | Most common case — a mesh-query result set kept live in the workspace. Documented in [Synced Query Data Source](/Doc/DataMesh/SyncedQueryDataSource). |
+| `WithMeshQuery(query)` | Most common case — a mesh-query result set kept live in the workspace. Documented in [Synced Query Data Source](/Doc/DataMesh/SyncedQueryDataSource). |
 
 ---
 
@@ -80,7 +80,7 @@ The stream provider receives the hub's `IWorkspace`, so it can compose with othe
 
 | Pattern | Stream provider expression |
 |---|---|
-| Mesh query mirror | `ws => provider.Query<T>(MeshQueryRequest.FromQuery(q), opts).Select(c => c.Items)` — or just `WithMeshQuery<T>(q)`. |
+| Mesh query mirror | `ws => provider.Query<T>(MeshQueryRequest.FromQuery(q), opts).Select(c => c.Items)` — or just `WithMeshQuery(q)`. |
 | Cross-hub subscription | `ws => ws.GetRemoteStream<TReduced, TRef>(siblingAddress, ref).Select(c => Project(c.Value))` |
 | Polled external API | `ws => Observable.Interval(TimeSpan.FromSeconds(30)).SelectMany(_ => httpPool.Invoke(ct => FetchFromGitHub(ct))).Select(items => (IEnumerable<T>)items)` — the fetch goes through an `IIoPool` (`IoPoolRegistry.Get(IoPoolNames.Http)`). **Never `Observable.FromAsync`**, which is forbidden outside `IoPool`: it runs the prologue on the subscribing thread and bounds nothing. |
 | Computed projection | `ws => ws.GetStream<RawA>().CombineLatest(ws.GetStream<RawB>(), Compose)` |
@@ -173,7 +173,7 @@ The snippet below renders a live summary of the available stream shapes so you c
 MeshWeaver.Layout.Controls.Markdown(@"
 | Pattern | Stream provider expression |
 |---|---|
-| Mesh query mirror | `WithMeshQuery<T>(query)` |
+| Mesh query mirror | `WithMeshQuery(query)` |
 | Cross-hub subscription | `workspace.GetRemoteStream<TReduced, TRef>(addr, ref)` |
 | Polled external API | `Observable.Interval(30s).SelectMany(_ => FetchAsync())` |
 | Computed projection | `GetStream<A>().CombineLatest(GetStream<B>(), Compose)` |
@@ -185,7 +185,7 @@ MeshWeaver.Layout.Controls.Markdown(@"
 
 ## Related
 
-- [Synced Query Data Source](/Doc/DataMesh/SyncedQueryDataSource) — `WithMeshQuery<T>`, the most common virtual-source shape.
+- [Synced Query Data Source](/Doc/DataMesh/SyncedQueryDataSource) — `WithMeshQuery`, the most common virtual-source shape.
 - [Data Configuration](/Doc/DataMesh/DataConfiguration) — broader data-source patterns (`AddSource`, `AddHubSource`, `WithInitialData`).
 - [Access Control](/Doc/Architecture/AccessControl) — the per-node-hub cache pattern in production use.
 - [CQRS & Content Access](/Doc/Architecture/CqrsAndContentAccess) — why query mirrors are preferred over re-querying on every read.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/VirtualDataSources.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/VirtualDataSources.md
@@ -82,7 +82,7 @@ The stream provider receives the hub's `IWorkspace`, so it can compose with othe
 |---|---|
 | Mesh query mirror | `ws => provider.Query<T>(MeshQueryRequest.FromQuery(q), opts).Select(c => c.Items)` — or just `WithMeshQuery<T>(q)`. |
 | Cross-hub subscription | `ws => ws.GetRemoteStream<TReduced, TRef>(siblingAddress, ref).Select(c => Project(c.Value))` |
-| Polled external API | `ws => Observable.Interval(TimeSpan.FromSeconds(30)).SelectMany(_ => Observable.FromAsync(FetchFromGitHub)).Select(items => (IEnumerable<T>)items)` |
+| Polled external API | `ws => Observable.Interval(TimeSpan.FromSeconds(30)).SelectMany(_ => httpPool.Invoke(ct => FetchFromGitHub(ct))).Select(items => (IEnumerable<T>)items)` — the fetch goes through an `IIoPool` (`IoPoolRegistry.Get(IoPoolNames.Http)`). **Never `Observable.FromAsync`**, which is forbidden outside `IoPool`: it runs the prologue on the subscribing thread and bounds nothing. |
 | Computed projection | `ws => ws.GetStream<RawA>().CombineLatest(ws.GetStream<RawB>(), Compose)` |
 | In-process event subject | `ws => myEventSubject.Scan(ImmutableList<T>.Empty, (acc, e) => acc.Add(e))` |
 

--- a/src/MeshWeaver.Documentation/Data/GUI/ContainerControl.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/ContainerControl.md
@@ -46,7 +46,7 @@ Every call to `WithView` appends a new named area to the container. The framewor
 |------------|-----------------|
 | Show fixed text, icons, or buttons | `WithView(UiControl?)` — pass a control directly |
 | Show content that re-renders when data changes | `WithView(IObservable<UiControl?>)` — pass a reactive stream |
-| Load data asynchronously before rendering | `WithView(async (host, ctx, ct) => …)` — pass an async function |
+| Load **non-mesh** data before rendering | `WithView(async (host, ctx, ct) => …)` — pass an async function. Never `await` hub-reachable work in it (mesh reads, permissions, other areas); route external I/O through an `IIoPool`. For mesh data, pass the path and bind — see [Data Binding](/Doc/GUI/DataBinding). |
 | Access the current data store at render time | `WithView((host, ctx, store) => …)` — pass a store function |
 | Pin content to a specific named slot | `WithView(control, "slotName")` — pass an area string |
 | Customise the slot with skins or options | `WithView(control, area => area.WithLabel("…"))` — pass an options lambda |

--- a/src/MeshWeaver.Documentation/Data/GUI/DataBinding.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/DataBinding.md
@@ -38,7 +38,7 @@ This is non-negotiable, for three reasons:
 | Side | Responsibility |
 |---|---|
 | **Backend layout area** | Build a `UiControl` tree. Pass *paths* (or `JsonPointerReference`s) into controls. Never call `meshQuery.QueryAsync(...)`, never `await` data, never `await PermissionHelper.GetEffectivePermissions(...)` (compose its `IObservable<Permission>` with `CombineLatest` instead). |
-| **GUI Blazor view (.razor.cs)** | Hold an `IMeshNodeStreamCache` field. In `BindData()`, subscribe via `_cache.GetStream(NodePath)` using `AddBinding(...)`. Write user edits back via `_cache.Update(NodePath, fn)`. |
+| **GUI Blazor view (.razor.cs)** | In `BindData()`, subscribe via `Hub.GetMeshNodeStream(NodePath)` using `AddBinding(...)`. Write user edits back via `Hub.GetMeshNodeStream(NodePath).Update(fn).Subscribe(...)`. |
 
 ---
 
@@ -59,14 +59,13 @@ The backend layout-area method **must not** be `async Task<UiControl>`. Return `
 
 ## GUI: subscribe via the cache, re-render on emission
 
-The canonical Blazor view template — all reads go through the process-wide `IMeshNodeStreamCache`. Multiple views on the same path share **one** upstream subscription; writes through `_cache.Update(path, fn)` are visible to every reader.
+The canonical Blazor view template. Reads and writes both go through `Hub.GetMeshNodeStream(path)`, which returns a `MeshNodeStreamHandle` backed by the process-wide `IMeshNodeStreamCache`. Multiple views on the same path share **one** upstream subscription; writes through the handle's `.Update(...)` are visible to every reader.
 
-> **Access-checked.** `cache.GetStream(path)` is gated by the current user's effective Read permission on the node. The cache asks the owning hub via `GetPermissionRequest`, caches the answer per `(path, userId)` for 30 s, and terminates the observable with `UnauthorizedAccessException` if Read is not granted. Subscribers should handle that error (toast, navigate to AccessDenied, render empty state) rather than letting it propagate. See [AccessContextPropagation.md](/Doc/Architecture/AccessContextPropagation).
+> **Access-checked.** The stream is gated by the current user's effective Read permission on the node. The cache asks the owning hub via `GetPermissionRequest`, caches the answer per `(path, userId)` for 30 s, and terminates the observable with `UnauthorizedAccessException` if Read is not granted. Subscribers should handle that error (toast, navigate to AccessDenied, render empty state) rather than letting it propagate. See [AccessContextPropagation.md](/Doc/Architecture/AccessContextPropagation).
 
 ```csharp
 public partial class MyView : BlazorView<MyControl, MyView>
 {
-    private IMeshNodeStreamCache? _cache;
     public string? Title { get; private set; }
     public string? ImageUrl { get; private set; }
 
@@ -79,11 +78,8 @@ public partial class MyView : BlazorView<MyControl, MyView>
 
         if (string.IsNullOrEmpty(NodePath)) return;
 
-        // 2. Resolve the cache — singleton on the mesh hub's service provider
-        _cache = Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-
-        // 3. Subscribe — every emission re-renders this component
-        AddBinding(_cache.GetStream(NodePath)
+        // 2. Subscribe — every emission re-renders this component
+        AddBinding(Hub.GetMeshNodeStream(NodePath)
             .Where(node => node is not null)
             .DistinctUntilChanged()
             .Subscribe(node =>
@@ -98,7 +94,8 @@ public partial class MyView : BlazorView<MyControl, MyView>
 
 Key points to remember:
 
-- `_cache` is a **field**, not a local. Writers call `_cache.Update(NodePath, fn)` to push edits; the cache routes through the same shared handle so the read subscription receives the echo.
+- **Go through `Hub.GetMeshNodeStream(path)`, not the raw cache.** The handle supplies the hub's `JsonSerializerOptions` for you, so `node.Content` arrives as its registered domain type. The bare `IMeshNodeStreamCache.GetStream(path)` / `Update(path, fn)` overloads **were deleted**: without options the cache hands back Content as a raw `JsonElement`, so `node.Content as MyType` is `null` and the consumer silently no-ops — the wedged-thread / never-dispatching-watcher bug class. If you do resolve `IMeshNodeStreamCache` directly, you must pass `Hub.JsonSerializerOptions` to every call.
+- Writers call `Hub.GetMeshNodeStream(NodePath).Update(fn).Subscribe(...)` to push edits; the write routes through the same shared handle, so the read subscription receives the echo. `Update` returns a **cold** observable — without `Subscribe` the write never happens.
 - `AddBinding(...)` registers the subscription with the base class — it auto-disposes on component teardown. The cache's upstream handle stays alive for the process.
 - **No `.Take(1)`** — that snapshots once and the view freezes. Stay subscribed for the lifetime of the component.
 - **Never** open `workspace.GetRemoteStream<MeshNode, MeshNodeReference>(addr, ...)` directly in a Blazor view. That bypasses the cache; writes through the cache won't be observed by views that went around it.
@@ -108,13 +105,13 @@ Key points to remember:
 
 ## Writing user edits back
 
-The same `_cache` is the write path. Its `Update` takes a `MeshNode → MeshNode` lambda and returns `IObservable<MeshNode>` — subscribe to observe completion or errors:
+The same handle is the write path. Its `Update` takes a `MeshNode → MeshNode` lambda and returns a **cold** `IObservable<MeshNode>` — the write only happens on `Subscribe`:
 
 ```csharp
 private void OnTitleChanged(string newTitle)
 {
-    if (_cache == null || string.IsNullOrEmpty(NodePath)) return;
-    _cache.Update(NodePath, current => current with { Name = newTitle })
+    if (string.IsNullOrEmpty(NodePath)) return;
+    Hub.GetMeshNodeStream(NodePath).Update(current => current with { Name = newTitle })
         .Subscribe(_ => { }, ex => Logger.LogWarning(ex,
             "Title update failed for {Path}", NodePath));
 }
@@ -123,7 +120,7 @@ private void OnTitleChanged(string newTitle)
 Because the write routes through the **same shared upstream handle** every reader is subscribed to:
 
 1. The owning hub applies the patch and persists.
-2. This view's `_cache.GetStream(NodePath)` subscription receives the echo and re-renders.
+2. This view's `Hub.GetMeshNodeStream(NodePath)` subscription receives the echo and re-renders.
 3. Every other GUI watching the same path sees the patch through their own subscription.
 
 No separate `DataChangeRequest` is needed for own-node edits inside a bound view.
@@ -204,13 +201,13 @@ Mechanics (so you know what's load-bearing):
 
 | ❌ Wrong | Why | ✅ Right |
 |---|---|---|
-| `await meshQuery.QueryAsync<MeshNode>($"path:{x}").FirstOrDefaultAsync()` in a layout area | Lagged index, deadlock-prone, freezes view | Pass path; GUI subscribes via `IMeshNodeStreamCache.GetStream(path)` |
+| `await meshQuery.QueryAsync<MeshNode>($"path:{x}").FirstOrDefaultAsync()` in a layout area | Lagged index, deadlock-prone, freezes view | Pass path; GUI subscribes via `Hub.GetMeshNodeStream(path)` |
 | `SelectMany(async nodes => await ...)` for data resolution | async lambda inside an observable chain — same deadlock surface | Pass paths; bind in GUI via the cache |
 | `MeshNodeThumbnailControl.FromNode(loadedNode, ...)` after a backend fetch | Concrete values frozen at render time | `new MeshNodeThumbnailControl { NodePath = path }` |
 | `.Take(1)` on a display stream | View stops updating after first emission | Stay subscribed for the lifetime of the component |
 | `await PermissionHelper.GetEffectivePermissions(...).FirstAsync()` in a layout area | Hub deadlock candidate | Compose the `IObservable<Permission>` via `CombineLatest`; bind permissions on the GUI side |
 | `try { ... } catch { /* swallowed */ }` around backend reads | Errors disappear, debugging impossible | Propagate via `OnError`; framework handles it |
-| `workspace.GetRemoteStream<MeshNode, MeshNodeReference>(addr, ...)` directly in a Blazor view | Opens a per-view upstream handle; bypasses `IMeshNodeStreamCache`; multiplies subscriptions; writes through the cache aren't observed | `Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>().GetStream(path)` — shared, write-coherent |
+| `workspace.GetRemoteStream<MeshNode, MeshNodeReference>(addr, ...)` directly in a Blazor view | Opens a per-view upstream handle; bypasses `IMeshNodeStreamCache`; multiplies subscriptions; writes through the cache aren't observed | `Hub.GetMeshNodeStream(path)` — shared, write-coherent |
 | `host.UpdateData(id, node.Content)` + `GetDataStream(id).Debounce().Subscribe(...GetMeshNodeStream(path).Update...)` to edit node content (a.k.a. `SetupAutoSave`) | Replicate-then-save: two stores drift, the save loop races the echo and clobbers unedited fields | `MeshNodeContentEditorControl.ForType(path, typeof(T))` — the GUI view binds to `GetMeshNodeStream(path)` and writes per-field via `.Update(...)`; no replica, no save subscription |
 | A "Save" button that reads `/data/{id}` and writes the node | The edit should already be on the node via the bound stream | Node-bound editor; edits persist on change through `GetMeshNodeStream(path).Update(...)` |
 
@@ -218,9 +215,9 @@ Mechanics (so you know what's load-bearing):
 
 ## Where to look for working examples
 
-- **`src/MeshWeaver.Blazor/Components/MeshNodeThumbnailView.razor`** — the minimal read-only reference: one `IMeshNodeStreamCache.GetStream(NodePath)` subscription.
-- **`src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs`** — read + write reference: cache subscription for the markdown body; `_cache.Update(BoundNodePath, fn)` to push edits.
-- **`src/MeshWeaver.Blazor/Components/MarkdownEditorView.razor`** — auto-save via `_cache.Update` from a debounced editor stream; canonical write-path pattern.
+- **`src/MeshWeaver.Blazor/Components/MeshNodeThumbnailView.razor`** — the minimal read-only reference: one `Hub.GetMeshNodeStream(NodePath)` subscription.
+- **`src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs`** — read + write reference: a node-stream subscription for the markdown body, and `.Update(fn)` on the same handle to push edits.
+- **`src/MeshWeaver.Blazor/Components/MarkdownEditorView.razor`** — auto-save via `.Update(fn)` on the node-stream handle from a debounced editor stream; canonical write-path pattern.
 - **`src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor.cs`** — multiple sub-fields (Text, ToolCalls, UpdatedNodes, Role) extracted from `node.Content` as `JsonElement` inside the cache `Subscribe(...)`.
 - **`src/MeshWeaver.Blazor/BlazorView.razor.cs`** — the base class. Key API: `AddBinding`, `DataBind<T>`, `BindData()` lifecycle.
 

--- a/src/MeshWeaver.Documentation/Data/GUI/LayoutAreas.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/LayoutAreas.md
@@ -226,16 +226,19 @@ Controls.Stack
 An editor that commits changes and redirects back to the Overview:
 
 ```csharp
-Controls.Button("Save").WithClickAction(async ctx =>
+Controls.Button("Save").WithClickAction(ctx =>
 {
-    // ... save logic ...
+    // ... save logic — compose it as an observable and Subscribe; never await here ...
     var viewHref = new LayoutAreaReference("Overview").ToHref(hubAddress);
     ctx.Host.UpdateArea(ctx.Area, new RedirectControl(viewHref));
+    return Task.CompletedTask;
 });
 
 var cancelHref = new LayoutAreaReference("Overview").ToHref(hubAddress);
 Controls.Button("Cancel").WithNavigateToHref(cancelHref);
 ```
+
+> 🚨 The handler is **synchronous** — `ctx => { …; return Task.CompletedTask; }`, never `async ctx =>`. An async click handler runs its continuation on the wrong scheduler and deadlocks the layout pump under load. Work that needs I/O is composed as an `IObservable<T>` and `.Subscribe(...)`d from inside the handler; the handler itself returns immediately. See [Observables](/Doc/GUI/Observables) and [Asynchronous Calls](/Doc/Architecture/AsynchronousCalls).
 
 ## Live Demo
 

--- a/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
@@ -154,7 +154,7 @@ private static IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> MoreActi
     ]);
 ```
 
-The built-in `DefaultMenuProvider` groups Create, Copy, Move, Import, Export, and Delete under the "Actions" parent using exactly this pattern.
+The built-in `DefaultNodeMenuProvider` (in `NodeMenuItemsExtensions`, registered alongside `DefaultMeshMenuProvider`) groups Create, Copy, Move, Import, Export, and Delete under the "Actions" parent using exactly this pattern.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/GUI/Observables.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/Observables.md
@@ -110,15 +110,19 @@ The header and button are never touched by the update cycle. Only the middle are
 
 # Loading Data First
 
-When you need to fetch data before producing a control, an `async` delegate runs once at render time and returns the result. The delegate is not a subscription — it fires exactly once:
+`ViewDefinition` is declared as `Task<UiControl?>`, so `WithView` does accept an `async` delegate that runs once at render time. The delegate is not a subscription — it fires exactly once:
 
 ```csharp
 Controls.Stack
     .WithView(async (host, ctx, ct) => {
-        var user = await LoadUserAsync(ct);
-        return Controls.Label($"Hello, {user.Name}");
+        var settings = await ioPool.Invoke(ct2 => LoadSettingsAsync(ct2)).ToTask(ct);
+        return Controls.Label($"Hello, {settings.Name}");
     })
 ```
+
+> 🚨 **The signature allows `await`; the hub does not forgive it.** Never await *hub-reachable* work here — a mesh read, a `QueryAsync`, a permission lookup, another layout area. That is a render running on the hub scheduler waiting for the hub, which is how layout areas deadlock or freeze at "awaiting first data". External I/O must go through an [`IIoPool`](/Doc/Architecture/ControlledIoPooling), never a bare `await` and never `Observable.FromAsync`.
+>
+> For anything that comes from the mesh — which is almost everything — **do not fetch at all**: pass the path and let the view bind, or use the observable overload in the next section. See [Data Binding](/Doc/GUI/DataBinding).
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/GUI/React/ThreadChat.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/ThreadChat.md
@@ -24,7 +24,7 @@ export interface MeshOps {
   submitMessage(threadPath: string, userText: string, opts?: ThreadSubmitOptions): Promise<string | null>;
   /** Field-level partial node update (RFC 7396) — control-plane flips like requestedStatus. */
   patch(path: string, fields: Record<string, unknown>): void;
-  /** Optional mesh query — feeds the agent/model selectors (nodeType:Agent / nodeType:Model). */
+  /** Optional mesh query — feeds the agent/model selectors (nodeType:Agent / nodeType:LanguageModel). */
   search?(query: string, basePath?: string, limit?: number): Promise<Record<string, unknown>[]>;
 }
 ```
@@ -71,7 +71,7 @@ const canSend = !!ops && text.trim().length > 0 && !isExecuting && (!!threadPath
 
 — disabled while the text is whitespace-only or the thread is executing. Enter sends, Shift+Enter inserts a newline.
 
-The **agent / model dropdowns** populate from the mesh when the ops expose `search` (`nodeType:Agent` / `nodeType:Model`); the selection defaults to the thread's embedded `composer` (the single source of the round's selection), and an explicit pick folds back into the composer on submit — so the choice sticks for the next round, in either frontend.
+The **agent / model dropdowns** populate from the mesh when the ops expose `search` (`nodeType:Agent` / `nodeType:LanguageModel`); the selection defaults to the thread's embedded `composer` (the single source of the round's selection), and an explicit pick folds back into the composer on submit — so the choice sticks for the next round, in either frontend.
 
 ## Rendering it
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-react-model-picker.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-react-model-picker.md
@@ -1,0 +1,17 @@
+---
+Name: Model picker works in the React frontend
+Category: Fix
+Description: The React chat model dropdown was always empty; it now lists the models your deployment offers.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Model picker works in the React frontend
+
+The model dropdown in the React chat never showed anything. It asked the mesh for
+a kind of node that does not exist, so the answer was always empty and the picker
+fell back to its "nothing to choose from" state — even on deployments with several
+models configured and working.
+
+It now asks for the same node type the main portal uses, so the dropdown lists the
+models available to you and remembers your pick for the next round.

--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -30,7 +30,7 @@ public static class CommentLayoutAreas
     ///   <item><b>Current-value shadows</b> (<see cref="Editing"/>, <see cref="Text"/>, …) — every
     ///     sub-view stream re-subscribed on a re-render starts with <c>.StartWith(shadow)</c>, because
     ///     the transient <c>/data</c> seed does NOT reliably replay to a second subscription (see the
-    ///     same defense in <c>EditorExtensions.BuildToggleableProperty</c>). Without the shadow the
+    ///     same defense in <c>EditorExtensions</c>' inline-edit toggles). Without the shadow the
     ///     re-rendered sub-view never emits and the PREVIOUSLY rendered content sticks — the
     ///     "comment only appears after a page refresh" bug.</item>
     /// </list>
@@ -282,7 +282,7 @@ public static class CommentLayoutAreas
 
                 // StartWith(shadow): a re-subscribed sub-view gets no reliable /data replay — it
                 // must default to the session's current state and then react (same defense as
-                // EditorExtensions.BuildToggleableProperty), or the re-rendered area never emits
+                // EditorExtensions' inline-edit toggles), or the re-rendered area never emits
                 // and the previously rendered (stale) content sticks until a refresh.
                 return h.Stream.GetDataStream<bool>(editStateId)
                     .StartWith(session.Editing)

--- a/src/MeshWeaver.Graph/Configuration/CodeQueryResolver.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeQueryResolver.cs
@@ -81,7 +81,7 @@ public static class CodeQueryResolver
     /// <summary>
     /// Expands one raw query entry from <see cref="NodeTypeDefinition.Sources"/> or
     /// <see cref="NodeTypeDefinition.Tests"/> into one-or-more concrete mesh query
-    /// strings ready for <c>IMeshService.QueryAsync&lt;MeshNode&gt;</c>. An optional
+    /// strings ready for <c>IMeshService.Query&lt;MeshNode&gt;</c>. An optional
     /// <c>name=</c> prefix is stripped first — the compiler ignores grouping.
     /// </summary>
     public static IEnumerable<string> Expand(string rawQuery, string selfPath)

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -623,7 +623,7 @@ internal static class NodeTypeCompilationHelpers
                 // WrapWithPerUserRls short-circuit — no CheckPermission, no
                 // self-call, no cycle. Observable.Using keeps the System scope
                 // alive for the LIVE subscription, not just the GetSources build
-                // call. Repro: OrleansSourcesWatcherDeadlockTest.
+                // call.
                 return Observable.Using(
                     () => accessService?.ImpersonateAsSystem()
                           ?? System.Reactive.Disposables.Disposable.Empty,

--- a/src/MeshWeaver.Graph/DeleteLayoutArea.cs
+++ b/src/MeshWeaver.Graph/DeleteLayoutArea.cs
@@ -168,7 +168,7 @@ public static class DeleteLayoutArea
     }
 
     /// <summary>
-    /// Kicks off the delete via Post + RegisterCallback — no <c>await</c>. Drives the progressId
+    /// Kicks off the delete via Post + <c>hub.Observe(...)</c> — no <c>await</c>. Drives the progressId
     /// data stream so the user sees "Deleting…" while the callback is pending, and "Deleted" /
     /// "Failed" once the response arrives. See Doc/Architecture/AsynchronousCalls.
     /// </summary>

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -497,7 +497,7 @@ public static class MeshNodeLayoutAreas
     /// Builds the right-aligned button row: Edit, Move, Copy, Delete, plus Configuration on
     /// NodeType nodes and a node-type Configuration link on instance nodes.
     /// All buttons use anchor-style navigation (no <c>await</c>); Delete routes through the
-    /// dedicated Delete area which uses Post + RegisterCallback with a progress indicator.
+    /// dedicated Delete area which uses Post + hub.Observe(...) with a progress indicator.
     /// </summary>
     private static UiControl BuildHeaderActionRow(
         LayoutAreaHost host, MeshNode? node, string nodePath, bool canEdit)

--- a/src/MeshWeaver.Graph/Security/UserPiiRedaction.cs
+++ b/src/MeshWeaver.Graph/Security/UserPiiRedaction.cs
@@ -25,7 +25,7 @@ namespace MeshWeaver.Graph.Security;
 /// value to every subscriber on a silo, so it cannot project per-reader. Redaction is therefore
 /// applied at the read surfaces that carry the caller's identity and actually expose the email:
 /// the MCP/agent single-node read (<c>MeshOperations.Get</c>) and the GUI visitor profile
-/// (<c>UserActivityLayoutAreas.BuildVisitorProfile</c>). Search/enumeration returns only a
+/// (the visitor-profile area in <c>UserActivityLayoutAreas</c>). Search/enumeration returns only a
 /// {path,name,nodeType,version,lastModified} projection and never carries the email.
 /// </para>
 /// </summary>

--- a/src/MeshWeaver.Hosting/Completion/ChatCompletionOrchestrator.cs
+++ b/src/MeshWeaver.Hosting/Completion/ChatCompletionOrchestrator.cs
@@ -14,7 +14,7 @@ namespace MeshWeaver.Hosting.Completion;
 /// Orchestrates chat autocomplete by blending multiple sources:
 /// <list type="bullet">
 ///   <item>Source A — AutocompleteRequest via hub Post+Observe to the current node hub (custom providers)</item>
-///   <item>Source B — IMeshService.QueryAsync with <c>path:current scope:subtree</c> (subtree search)</item>
+///   <item>Source B — IMeshService.Query with <c>path:current scope:subtree</c> (subtree search)</item>
 ///   <item>Source C — Adaptive broadening: partition-level fan-out when primary results are sparse</item>
 ///   <item>Partition list — when typing <c>@/</c> or <c>@/&lt;filter&gt;</c></item>
 ///   <item>Partition drill-down — when typing <c>@/Partition/</c></item>

--- a/src/MeshWeaver.Hosting/MeshService.cs
+++ b/src/MeshWeaver.Hosting/MeshService.cs
@@ -10,16 +10,16 @@ namespace MeshWeaver.Hosting;
 
 /// <summary>
 /// Scoped IMeshService implementation.
-/// Writes go through hub messaging (Post + RegisterCallback) — no direct persistence dependency.
+/// Writes go through hub messaging (<c>hub.Observe(request, …)</c>) — no direct persistence dependency.
 /// Reads go through MeshQuery (aggregated query providers).
 /// Identity is captured from AccessService and stamped on each delivery.
 ///
-/// The CRUD observables use <c>Observable.Create(observer =&gt; ...)</c> and signal all outcomes —
-/// success, handler rejection, and routing <see cref="DeliveryFailure"/> — via
-/// <c>observer.OnNext</c> / <c>observer.OnError</c>. <b>Never <see cref="Observable.FromAsync(System.Func{System.Threading.Tasks.Task})"/></b>
-/// (FromAsync wraps a Task and blocks a thread-pool thread), <b>never Task return types</b> on the
-/// public surface, <b>never <see cref="Task"/>.<see cref="Task.FromResult{TResult}(TResult)"/></b>
-/// inside callbacks (use the <see cref="SyncDelivery"/> overload of RegisterCallback instead).
+/// The CRUD observables use <c>Observable.Defer(...)</c> over <c>hub.Observe(request, …)</c>,
+/// composing outcomes with <c>.SelectMany</c> and surfacing handler rejection / routing
+/// <see cref="DeliveryFailure"/> as <c>Observable.Throw</c>.
+/// <b>Never <see cref="Observable.FromAsync(System.Func{System.Threading.Tasks.Task})"/></b>
+/// (forbidden outside <c>IoPool</c>: it runs the prologue on the subscribing thread and bounds
+/// nothing), and <b>never Task return types</b> on the public surface.
 /// See <c>Doc/Architecture/AsynchronousCalls</c>.
 ///
 /// Each call is bounded by <see cref="MeshOperationOptions.Timeout"/> so a lost/slow response

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -79,7 +79,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
         // filtering on the secured IMeshQueryProvider surface goes through
         // INodeValidator instead, which has no back-reference into the
         // synced-query path. GetEffectivePermissions-style filtering for
-        // non-MeshNode results is intentionally dropped — IMeshService.QueryAsync
+        // non-MeshNode results is intentionally dropped — IMeshService.Query
         // results are MeshNodes today, and any future non-MeshNode projection
         // should declare an INodeValidator if it needs gating.
         AccessService? accessService = null,

--- a/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
@@ -40,7 +40,7 @@ internal sealed class StoragePostCommitFlush(IMessageHub hub) : IPostCommitFlush
             .DefaultIfEmpty(true);
     }
 
-    // Feed-only publish for the MeshNode cross-hub ATOMIC apply (ApplyMeshNodePatchAtomic),
+    // Feed-only publish for the MeshNode cross-hub ATOMIC apply (ApplyMeshNodePatchInTurn),
     // which persists off-turn via DataSourceWithStorage.Synchronize and so must NOT call Flush
     // (that would double-write). The atomic path dropped the post-commit Flush to keep the ack
     // emit-onstart — but Flush was ALSO what published the Updated event that evicts the

--- a/src/MeshWeaver.Markdown.Export/Layout/ExportDocumentLayoutArea.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/ExportDocumentLayoutArea.cs
@@ -16,7 +16,7 @@ namespace MeshWeaver.Markdown.Export.Layout;
 /// Layout areas that render the export dialog for a markdown node.
 /// Two entry points: <c>ExportPdf</c> and <c>ExportDocx</c>. Both render the same
 /// <see cref="ExportDocumentControl"/>; the Blazor view decides the default format.
-/// Uses the reactive <c>GetDataRequest</c> + <c>RegisterCallback</c> pattern — never
+/// Uses the reactive <c>GetDataRequest</c> + <c>hub.Observe(...)</c> pattern — never
 /// <c>await</c> inside the hub — so it can't deadlock the message pump.
 /// </summary>
 [Browsable(false)]
@@ -52,7 +52,7 @@ public static class ExportDocumentLayoutArea
         var hubPath = host.Hub.Address.ToString();
 
         // Seed the observable with a partial control (SourcePath + DefaultFormat always known).
-        // The hub then fires a GetDataRequest via Post + RegisterCallback — NO await — and when
+        // The hub then fires a GetDataRequest via hub.Observe(...) — NO await — and when
         // the response arrives the observable emits an enriched control with NodeName set.
         var seed = (UiControl?)new ExportDocumentControl
         {

--- a/src/MeshWeaver.Markdown/MarkdownViewLogic.cs
+++ b/src/MeshWeaver.Markdown/MarkdownViewLogic.cs
@@ -304,15 +304,14 @@ public static class MarkdownViewLogic
     /// must reach the kernel sequentially so block #2's
     /// <c>scriptState.ContinueWithAsync</c> sees block #1's variable.
     /// <para>
-    /// The naive shape — <c>foreach Post</c> without waiting — relies on the
-    /// kernel's <c>executionLock</c> SemaphoreSlim to serialise execution and
-    /// hopes that the SemaphoreSlim acquires in arrival order. SemaphoreSlim
-    /// is FIFO under contention, but each <c>Hub.Observe</c> + <c>Subscribe</c>
-    /// pair runs on the calling hub's action block; the inner WaitAsync
-    /// continuations resume on the TaskPool, so the order in which the script
-    /// pipeline acquires the lock can interleave on a busy CI thread pool —
-    /// surfaced as block #2 reaching <c>CSharpScript.RunAsync</c> before
-    /// block #1 has stored <c>scriptState</c>, then failing with
+    /// The naive shape — <c>foreach Post</c> without waiting — leaves ordering to
+    /// whatever order the posts happen to reach the kernel. The kernel itself
+    /// serialises correctly: <c>KernelExecutor</c> runs submissions on a reactive
+    /// serial queue (<c>Subject</c> + <c>Concat</c>, which subscribes the next
+    /// submission only after the previous <c>Execute</c> completes and
+    /// <c>scriptState</c> is assigned). But that guarantees order of ARRIVAL, not
+    /// the order this pipeline intended, so posting without waiting can still let
+    /// block #2 arrive before block #1 — surfaced as
     /// <c>error CS0103: The name 'counter' does not exist in the current
     /// context</c>.
     /// </para>

--- a/src/MeshWeaver.Mesh.Contract/Services/IsolatedChangeFeed.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IsolatedChangeFeed.cs
@@ -28,7 +28,7 @@ namespace MeshWeaver.Mesh.Services;
 /// query silently stopped re-emitting after a create that completed successfully. The subscriber
 /// that throws is not hypothetical on any backend: every live synced query owns a
 /// <c>persistence.Changes → changeBuffer</c> pipeline, and one-shot queries
-/// (<c>IMeshService.QueryAsync</c>, autocomplete, path resolution) open and tear one down
+/// (<c>IMeshService.Query</c>, autocomplete, path resolution) open and tear one down
 /// constantly, so the disposal window is hit whenever a write lands during a teardown.</para>
 ///
 /// <para>So: deliver to a SNAPSHOT of the observers, isolate each one, and never let a throw from

--- a/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
@@ -55,10 +55,10 @@ public static class MessageHubExtensions
     /// <summary>
     /// Posts <paramref name="request"/> and observes the typed response.
     /// <para>
-    /// Pre-registers the callback BEFORE posting (via the framework's
-    /// <c>AwaitResponse(object, Func&lt;PostOptions,PostOptions&gt;, Func&lt;IMessageDelivery,object?&gt;, CancellationToken)</c>
-    /// primitive which uses <see cref="PostOptions.WithMessageId"/>) so a synchronously-handled
-    /// response can't slip through before the callback is registered. Emits exactly one
+    /// Registers the response subject BEFORE posting (<c>MessageHub.Observe</c> allocates the
+    /// message id, calls <c>GetOrAddResponseSubject(messageId, …)</c>, and only THEN posts with
+    /// <see cref="PostOptions.WithMessageId"/>) so a synchronously-handled response can't slip
+    /// through before the subject exists — an unmatched correlation id is DROPPED. Emits exactly one
     /// <see cref="IMessageDelivery{TResponse}"/> on the response, or <c>OnError</c> for
     /// <see cref="DeliveryFailureException"/> / <see cref="TimeoutException"/>.
     /// </para>


### PR DESCRIPTION
An audit of the **non-Architecture** documentation for statements that are **false**, fixed in place. `Data/Architecture/` is deliberately untouched (another agent owns it), and nothing is moved, split or merged (a third agent owns restructure).

Every claim below was checked against the code. Counts: **9 dangerous**, **9 wrong**, **17 dead references**, **1 real code bug**.

## 1. Would cause a defect if believed (9)

- **`AI/ExecuteScript.md` taught `Observable.FromAsync`** as the way to wrap a `Task`-returning primitive, claiming it "keeps the kernel's action block free". It is forbidden outside `IoPool` precisely because it runs the prologue on the **subscribing** thread — which for a script *is* the kernel's action block — and bounds nothing. `src/` has **zero** `FromAsync` call sites; every `.cs` occurrence is a comment warning against it.
- **`DataMesh/VirtualDataSources.md` taught it too**, as the recommended "Polled external API" stream provider — while its sibling `CallingPython.md` correctly lists it as forbidden.
- **`GUI/DataBinding.md`'s canonical Blazor template did not compile.** It called `_cache.GetStream(path)` / `_cache.Update(path, fn)`; both untyped overloads **were deleted** (`IMeshNodeStreamCache.cs:64,:76`), and the interface records why — without `JsonSerializerOptions` the cache returns raw `JsonElement`, `Content as MyType` is null, and the write silently no-ops. Rewritten to `Hub.GetMeshNodeStream(path)`, which is what the page's own cited reference does.
- **`GUI/LayoutAreas.md` showed `WithClickAction(async ctx => …)`** — banned, and contradicted by `GUI/Observables.md`, which marks the same shape ❌.
- **`GUI/Observables.md` + `ContainerControl.md` showed `await`-ing data inside a layout-area render.** The async `WithView` overload is real (`ViewDefinition` returns `Task<UiControl?>`), but awaiting hub-reachable work there is the deadlock class `DataBinding.md` already warns about. Kept the overload, scoped what may be awaited in it.
- **`DataMesh/CRUD.md`'s `IDataValidator` example** used `Task<…> ValidateAsync(ctx, ct)` + `List<>`; the interface is `IObservable<DataValidationResult> Validate(...)` + `IReadOnlyCollection<>`. Didn't compile, and taught `Task<T>` on a hub path.
- **`WithAccessRestriction` returned `Task.FromResult(...)`**; the delegate returns `IObservable<bool>`.
- **`DataMesh/Spaces.md` recommended the exact icon value the code calls broken** — "Fluent icon name … (default `Building`)", where `SpaceNodeType.cs:40` says it must be a RENDERABLE value and names a bare `"Building"` as the failure case.
- **`SyncedQueryDataSource.md`'s canonical test sketch used `Task.Delay(500)` twice** to wait for propagation — banned, and contradicted by the same page four lines above.

## 2. Behaviour described wrongly (9)

- Two doc comments (`Connect/ConnectModels.cs`, `Connect/ConnectSessionManager.cs`) and `AI/ModelProviderSettings.md` documented the CLI subprocess boundary as using `Observable.FromAsync`; `ClaudeConnectStrategy` uses the `Process` `IIoPool`.
- **`ThreadExecution.cs:1874-1892` explained at length a `Task.Run` design that does not exist** — "runs on thread pool via Task.Run", `DelayDeactivation`, "OnDeactivateAsync waits up to 120s". The round runs on the bounded Ai I/O pool, and 100 lines below the same file says "NEVER Task.Run". Four further sites repeated it as rationale.
- `MeshService.cs` claimed `Observable.Create` + `observer.OnNext/OnError`; it uses `Observable.Defer` over `hub.Observe`.
- `SatelliteEntities.md` routed `_Comment`→`comments` and `_Approval`→`approvals`; both route to **`annotations`**, and neither table exists in any DDL.
- `Spaces.md` listed `content.name` as the header title (the `Space` record has no `Name`; the patch silently no-ops) and named the catalog area `Children` when it is `Search`.
- `CRUD.md`'s unified-path examples don't parse (prefixes are colon-separated `data:`/`area:`/`content:`; there is no `schema:`), invented `delivery` overloads, and used `UserContext?.UserId` (it is `ObjectId`).
- `DataModeling.md` gave `EditorHeight` a default of "auto"; it is `"300px"`.
- **`NugetPackages.md` described a .NET Interactive `CSharpKernel`** — no such package reference exists anywhere; the kernel is `Microsoft.CodeAnalysis.CSharp.Scripting` and the `#r "nuget"` handling is MeshWeaver's own.
- `MarkdownViewLogic.cs` built a root-cause paragraph on the kernel's `executionLock` SemaphoreSlim and SemaphoreSlim FIFO semantics; that lock is gone — `KernelExecutor` uses a reactive Subject+Concat queue and says "This replaces a hand-woven SemaphoreSlim".

## 3. Dead references (17)

`RegisterCallback` (**18 comment sites** — zero declarations, zero call sites; two shipped the dead name into production log strings) · `AwaitResponse` cited as the primitive behind `hub.Observe` · `IMeshService.QueryAsync` (7) · `nodeType:Model` (the type is `LanguageModel`) · `PreferredModel` · `SelectAsync` (a whole section) · `IMeshExportService` / `IMeshImportService` · `CopyNodeTreeAsync` · `PartitionDefinition.StandardTableMappings` · generic `WithMeshQuery<T>` · `ReadNodeAsync` · `data.WithValidator<T>()` · `DataValidationResult.Failed/.Success` · `DataChangeResponse.Error` · `ApplyMeshNodePatchAtomic` · `OnSyncedAgentSnapshot` · `SetupCancellationWatcher`, plus `BuildToggleableProperty`, `BuildVisitorProfile`, and two comments whose only cited proof was a test that does not exist.

## 4. One real code bug, fixed at the root

`clients/react/src/controls/threadChat.tsx` queried `nodeType:Model` for the model dropdown. `nodeType:` compiles to exact equality (`LOWER(n.node_type) = @p`, `PostgreSqlSqlGenerator.cs:1085`) and no `Model` node type exists — so the React model picker **always returned empty**. The doc described the code accurately and the code was wrong, so rather than documenting the bug it now queries `nodeType:LanguageModel`, matching the Blazor picker. No test asserted the old string. Ships with a What's New entry (`Fix`, `-20260810`).

## 5. Verified accurate — left alone

- **`AI/ModelTiers.md`** (the new tiering page) checks out on every symbol: `RouterOrder = -10`, `ModelTierSource.None`, `ApplyStaleModelFallback`, `ResolveTierModel`, `SubstitutedFromModel`, `ModelTierNodeType.RootNamespace = "Provider/Tier"`, and the Auto-dispatches-on-the-agent's-tier rule.
- `DataBinding.md`'s other flagged claims — `.Take(1)` freezing a live binding, one-shared-handle-per-path, the access gate — are true.
- `ProviderConfiguration.md`'s fallback section: `ThreadMessage.ModelName`/`RequestedModelName`, the `MODEL_SUBSTITUTED`/`PROVIDER_REFUSED` warnings, and all four `chat.*` keys present in **both** `strings.en.json` and `strings.de.json`.
- `QuerySyntax.md` (every operator re-verified against `QueryParser.cs`), `CollaborativeEditing.md`, `InteractiveMarkdown.md`, `DataConfiguration.md`, `DataCubes.md`, `CallingPython.md`.
- `content/ai/Agent/` and `content/ai/Skill/` follow the format contract — front matter carries config, body is the instructions, no JSON-escaped instruction strings. `ToolsReference.md` / `CommentingReference.md` are intentionally `nodeType: Markdown` includes, not agents.
- `IoPoolOptions` defaults, `PostgreSqlPartitionStorageProvider`'s promise-cache doc, and the `MeshNodeStreamCache` "never a watchdog" comment all verified correct.

## Noted, not fixed

- **27 pages carry a body H1 duplicating their front-matter `Name`.** Uniform formatting across the doc set rather than a false statement — left for the restructure pass instead of a 27-file diff that would collide with it.
- **`AGENTS.md` itself carries two of the stale names** (`IMeshService.QueryAsync` in its Data Access table; `RegisterCallback` described as `[Obsolete]` rather than removed). Out of scope here, but it is the source that keeps regenerating them.
- **`SocialMedia/Post/Source/SocialMediaPostLayoutAreas.cs:122-162`** hand-builds a `<table>` string rendered via `Controls.Html`, with hard-coded English headers in a file that localizes elsewhere — a shipped sample teaching the banned pattern. Flagged rather than rewritten (it is a functional sample change, not a doc fix).
- **`CallingPython.md:101`** awaits `pool.InvokeBlocking(...)` inside a `--render` cell, contradicting the page's own rule table. Whether the scripting-kernel context makes that safe is a runtime question not settleable by reading; flagged rather than guessed.

## Verification

- `dotnet build src/MeshWeaver.Blazor.Portal -c Release -warnaserror` — clean (transitively covers Hosting, Data, Graph, AI, Mesh.Contract, Messaging.Hub, Blazor)
- `dotnet build src/MeshWeaver.Markdown.Export -c Release -warnaserror` — clean
- `dotnet build src/MeshWeaver.Documentation -c Release -warnaserror` — clean
- `DocumentationLinkIntegrityTest` — passed after every doc commit (real trx; note a first `--no-restore` run was a silent no-op and was re-run after restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)