### PR TITLE
An instance can state what it runs — the combo reader

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-an-instance-can-state-what-it-runs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-an-instance-can-state-what-it-runs.md
@@ -1,0 +1,31 @@
+---
+Name: An installation can now state exactly what it is running
+Category: Feature
+Description: One read lists every module an installation carries, where it came from and the exact version it was last built from — the input a release check needs before an update is offered.
+Icon: Sparkle
+Order: -20260810
+---
+
+# An installation can now state exactly what it is running
+
+Before an update is offered to your installation, the safe question to ask is narrow and specific:
+does this new version work with **the modules this installation actually has, at the versions it
+actually has them**? Nobody can answer that centrally — a module that breaks on an installation
+nobody uses is not an incident, and the same break on yours is.
+
+Answering it needed something that did not exist: a single, reliable statement of what an
+installation is running. Modules arrive two different ways — most are kept in step with a repository,
+some are installed from the catalog — and each way records its version in its own place. Anything
+that looked at only one of them reported almost nothing on a real installation and, worse, reported
+it as a clean, empty result. That looks exactly like "nothing to check".
+
+Now one read returns the whole picture: every module, which repository or package it came from, and
+the exact commit or version it was last built from — both kinds folded into one list, so neither can
+go missing.
+
+It is also honest about what it does not know. A recorded version says where a module's content came
+from, not that nothing has been edited since — pages you write yourself are yours, and the answer
+says so rather than implying the two are identical. A module tracked only by a branch name is flagged
+too, because a branch moves and a check against it would not mean the same thing twice. And if any
+part of the picture could not be read, the result says it is incomplete instead of quietly coming
+back short.

--- a/src/MeshWeaver.PluginCatalog/InstanceCombo.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceCombo.cs
@@ -1,0 +1,308 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What THIS instance is actually running, as a single list: every module it carries, with where
+/// that module came from and the ref it was last materialised at.
+///
+/// <para><b>Why this type exists.</b> The candidate-release gate's unit of verification is the
+/// <b>combo</b> — a candidate image × the module versions THAT instance has installed — because no
+/// central set of dependents is the right set (a NodeType broken on a plugin nobody deployed is not
+/// an outage; broken on a plugin one portal installed, it is an outage for exactly that portal).
+/// Only the instance knows its own set, and this is the read that states it.</para>
+///
+/// <para><b>🚨 Two shapes, not one — and a reader that handles only one looks HEALTHY while
+/// returning nothing.</b> Modules reach an instance by two paths and each records its coordinate
+/// differently: per-Space <see cref="GitSyncCoordinate"><c>{Space}/_GitSync</c></see> entries (how
+/// most modules actually arrive) and <see cref="PackageCoordinate"><c>Plugins/{id}</c> install
+/// records</see>. Measured on memex 2026-08-10: <b>42 sync configs and ZERO install records</b> —
+/// so a Package-only reader reports an empty set there and reads as "nothing installed, all clear".
+/// <see cref="InstanceComboReader"/> folds both, which is the whole point of the type.</para>
+///
+/// <para><b>🚨 Every ref in here is PROVENANCE, never proof of identity.</b> See
+/// <see cref="ModuleCoordinate.ProvenanceRef"/>: it records what the module was last materialised
+/// FROM, not that the live mesh still matches it. In-mesh editing is always possible, so the honest
+/// claim is "this content came from that ref", never "the mesh equals that ref".</para>
+///
+/// <para>See <c>Doc/Architecture/CandidateReleaseProtocol</c>.</para>
+/// </summary>
+public sealed record InstanceCombo
+{
+    /// <summary>When this combo was read (UTC). A combo is a SNAPSHOT: a sync landing a second
+    /// later moves a ref, so a gate must record which read it verified.</summary>
+    public DateTimeOffset ReadAt { get; init; }
+
+    /// <summary>Every module this instance carries, ordered by <see cref="ModuleCoordinate.ModuleId"/>.
+    /// One entry per module even when a module arrived BOTH ways — both coordinates hang off the
+    /// single entry.</summary>
+    public ImmutableList<ModuleCoordinate> Modules { get; init; } = [];
+
+    /// <summary>
+    /// Modules a configured repo ships that this instance does NOT carry, read from the
+    /// <see cref="ModuleDiscovery"/> records when they exist. Empty when no discovery record does —
+    /// which is NOT the same as "there are none", and is why that case raises a
+    /// <see cref="Caveats">caveat</see>.
+    /// </summary>
+    public ImmutableList<ModuleGap> NotCarried { get; init; } = [];
+
+    /// <summary>
+    /// Everything that makes this answer less than a complete, exactly-reproducible statement:
+    /// a source that could not be read, an absent discovery record, a module pinned only to a
+    /// moving branch, and the standing provenance caveat.
+    ///
+    /// <para>🚨 A gate MUST surface these. The failure mode this whole type exists to prevent is a
+    /// partial answer that reads as a healthy one.</para>
+    /// </summary>
+    public ImmutableList<string> Caveats { get; init; } = [];
+
+    /// <summary>
+    /// False when a source query FAILED, so the module list is known to be short. Distinguishes
+    /// "this instance carries nothing" from "we could not find out" — the two answers a gate must
+    /// never conflate.
+    /// </summary>
+    public bool IsComplete { get; init; } = true;
+
+    /// <summary>
+    /// Whether every carried module names a ref that identifies an immutable tree, so the combo can
+    /// be re-assembled and get the same input twice. False when any module is pinned only to a
+    /// moving branch or to nothing at all — a run against those two is not repeatable and must not
+    /// be reported as though it were.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsReproducible =>
+        IsComplete && Modules.Count > 0 && Modules.All(m => m.Fidelity == RefFidelity.Exact);
+}
+
+/// <summary>
+/// One module of an instance's combo, folded from whichever of the two recording shapes carry it.
+/// The <see cref="ModuleId"/> is the mesh partition the module's content lives in — the id both
+/// shapes agree on, and what makes folding them possible at all.
+/// </summary>
+public sealed record ModuleCoordinate
+{
+    /// <summary>The module's mesh partition / Space id (<c>SocialMedia</c>, <c>Store</c>, …).</summary>
+    public string ModuleId { get; init; } = "";
+
+    /// <summary>The module's display name where one is recorded.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The <c>{Space}/_GitSync</c> coordinate, when the module arrived by repo import.</summary>
+    public GitSyncCoordinate? GitSync { get; init; }
+
+    /// <summary>The <c>Plugins/{id}</c> install-record coordinate, when the module was installed by
+    /// the package installer.</summary>
+    public PackageCoordinate? Package { get; init; }
+
+    /// <summary>Which shape(s) recorded this module.</summary>
+    [JsonIgnore]
+    public ModuleOrigin Origin => (GitSync, Package) switch
+    {
+        (not null, not null) => ModuleOrigin.Both,
+        (not null, null) => ModuleOrigin.GitSync,
+        (null, not null) => ModuleOrigin.PackageInstall,
+        _ => ModuleOrigin.None,
+    };
+
+    /// <summary>
+    /// The ref this module was last materialised FROM — the coordinate a gate checks out to
+    /// re-assemble the combo.
+    ///
+    /// <para>🚨 <b>PROVENANCE, not identity.</b> It answers "where did this content come from?",
+    /// never "is the live mesh byte-identical to this?". A node edited in-mesh after
+    /// <see cref="MaterializedAt"/> has diverged from this ref and nothing here says otherwise —
+    /// the mesh is authored as well as synced, so divergence is normal, not corruption. Treat a
+    /// combo run at this ref as "the recorded input", and treat a difference against the live mesh
+    /// as expected rather than as a failure.</para>
+    ///
+    /// <para>Preference order when both shapes recorded one: the install record's
+    /// <see cref="PackageCoordinate.ModuleVersion"/> (a hash of the MODULE's own files) beats the
+    /// sync entry's commit sha (whole-repo, so it moves when an unrelated module changes).</para>
+    /// </summary>
+    [JsonIgnore]
+    public string? ProvenanceRef =>
+        Coalesce(Package?.ModuleVersion)
+        ?? Coalesce(GitSync?.LastSyncCommitSha)
+        ?? Coalesce(Package?.InstalledFromRef)
+        ?? Coalesce(GitSync?.Branch);
+
+    /// <summary>Which record <see cref="ProvenanceRef"/> was taken from — so a caller resolving it
+    /// knows whether it holds a git commit, a content hash, or a branch name.</summary>
+    [JsonIgnore]
+    public ProvenanceKind ProvenanceKind =>
+        Coalesce(Package?.ModuleVersion) is not null ? ProvenanceKind.ModuleVersion
+        : Coalesce(GitSync?.LastSyncCommitSha) is not null ? ProvenanceKind.SyncedCommit
+        : Coalesce(Package?.InstalledFromRef) is not null ? ProvenanceKind.InstalledRef
+        : Coalesce(GitSync?.Branch) is not null ? ProvenanceKind.Branch
+        : ProvenanceKind.None;
+
+    /// <summary>
+    /// Whether <see cref="ProvenanceRef"/> identifies an immutable tree
+    /// (<see cref="RefFidelity.Exact"/>) or something that moves under it
+    /// (<see cref="RefFidelity.Moving"/>) — the difference between a combo two runs agree on and
+    /// one they do not.
+    /// </summary>
+    [JsonIgnore]
+    public RefFidelity Fidelity => ProvenanceKind switch
+    {
+        // A content hash over the module's own file set: equal hash ⇒ identical files.
+        ProvenanceKind.ModuleVersion => RefFidelity.Exact,
+        // A sha is exact; anything else recorded in these fields is a branch/tag that can move.
+        ProvenanceKind.SyncedCommit or ProvenanceKind.InstalledRef =>
+            LooksLikeCommitSha(ProvenanceRef) ? RefFidelity.Exact : RefFidelity.Moving,
+        ProvenanceKind.Branch => RefFidelity.Moving,
+        _ => RefFidelity.Unrecorded,
+    };
+
+    /// <summary>
+    /// When this module's content was last written INTO the mesh from <see cref="ProvenanceRef"/> —
+    /// the install time, else the sync's reconcile horizon. 🚨 The boundary the honesty note on
+    /// <see cref="ProvenanceRef"/> turns on: anything authored in-mesh after this moment is not in
+    /// the ref. Null when neither shape recorded a time.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset? MaterializedAt => Package?.InstalledAtUtc ?? GitSync?.LastSyncedAt;
+
+    /// <summary>The repository this module comes from, where a shape records one.</summary>
+    [JsonIgnore]
+    public string? RepositoryUrl => Coalesce(GitSync?.RepositoryUrl);
+
+    /// <summary>A 40- or 64-character hex string — a git commit sha. Anything else in a ref field is
+    /// a branch or tag, which moves.</summary>
+    private static bool LooksLikeCommitSha(string? value) =>
+        value is { Length: 40 or 64 } && value.All(char.IsAsciiHexDigit);
+
+    private static string? Coalesce(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}
+
+/// <summary>
+/// The <c>{Space}/_GitSync</c> coordinate — how MOST modules actually reach a real instance
+/// (<see cref="MeshWeaver.GitSync.GitHubSyncConfig"/> nodes; 42 of them on memex against zero
+/// install records).
+/// </summary>
+public sealed record GitSyncCoordinate
+{
+    /// <summary>The sync-config node's path (<c>{Space}/_GitSync</c>, or
+    /// <c>{Space}/_GitSync/{sourceId}</c> for an additional source) — where this coordinate was
+    /// read, so an operator can go look at it.</summary>
+    public string ConfigPath { get; init; } = "";
+
+    /// <summary>The repository the Space syncs from.</summary>
+    public string? RepositoryUrl { get; init; }
+
+    /// <summary>The branch it commits against. 🚨 A branch MOVES — on its own it is not a
+    /// coordinate; <see cref="LastSyncCommitSha"/> is.</summary>
+    public string? Branch { get; init; }
+
+    /// <summary>The module's folder inside the repo.</summary>
+    public string? Subdirectory { get; init; }
+
+    /// <summary>The commit this Space was last synced from — the exact coordinate.
+    /// 🚨 Provenance: see <see cref="ModuleCoordinate.ProvenanceRef"/>.</summary>
+    public string? LastSyncCommitSha { get; init; }
+
+    /// <summary>When mesh and repo were last reconciled. A node modified after this has diverged
+    /// from <see cref="LastSyncCommitSha"/>.</summary>
+    public DateTimeOffset? LastSyncedAt { get; init; }
+}
+
+/// <summary>The <c>Plugins/{id}</c> install-record coordinate — a
+/// <see cref="PackageManifest"/> written by <see cref="PackageInstaller"/>.</summary>
+public sealed record PackageCoordinate
+{
+    /// <summary>The install record's node path (<c>Plugins/{id}</c>).</summary>
+    public string RecordPath { get; init; } = "";
+
+    /// <summary>The package id — the record's id, which may differ from the partition it installed
+    /// into.</summary>
+    public string PackageId { get; init; } = "";
+
+    /// <summary>The package's display name, as the manifest recorded it.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The module's content version from its <c>manifest.lock</c> — a hash over the
+    /// module's own files, so it is exact AND does not move when a sibling module changes.</summary>
+    public string? ModuleVersion { get; init; }
+
+    /// <summary>The package's declared version string (whole-repo commit sha for a node repo).</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The git ref the install ran from (a commit or a branch).</summary>
+    public string? InstalledFromRef { get; init; }
+
+    /// <summary>When the package was installed (UTC).</summary>
+    public DateTimeOffset? InstalledAtUtc { get; init; }
+
+    /// <summary>The configured registry source the package came from.</summary>
+    public string? SourceName { get; init; }
+}
+
+/// <summary>A module a configured repo ships that this instance does NOT carry, as the last
+/// <see cref="ModuleDiscovery"/> scan recorded it. Present only where such a record exists.</summary>
+public sealed record ModuleGap
+{
+    /// <summary>The module id the repo ships it under.</summary>
+    public string ModuleId { get; init; } = "";
+
+    /// <summary>Its display name, where the scan recorded one.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The repo that ships it.</summary>
+    public string? RepositoryUrl { get; init; }
+
+    /// <summary>Why it is not here — discovered-but-not-synced, occupied, refused, failed, orphaned.</summary>
+    public ModuleDiscoveryStatus Status { get; init; }
+
+    /// <summary>The scan's speaking reason.</summary>
+    public string? Detail { get; init; }
+}
+
+/// <summary>Which of the two recording shapes carry a module.</summary>
+public enum ModuleOrigin
+{
+    /// <summary>Neither shape — never produced by the reader; the default guards a hand-built record.</summary>
+    None,
+
+    /// <summary>A <c>{Space}/_GitSync</c> entry: repo import. The production majority.</summary>
+    GitSync,
+
+    /// <summary>A <c>Plugins/{id}</c> install record written by the package installer.</summary>
+    PackageInstall,
+
+    /// <summary>Both — the module was installed AND is kept in sync from its repo.</summary>
+    Both,
+}
+
+/// <summary>Which record a <see cref="ModuleCoordinate.ProvenanceRef"/> came from.</summary>
+public enum ProvenanceKind
+{
+    /// <summary>Nothing pins this module: neither shape recorded a ref.</summary>
+    None,
+
+    /// <summary>A branch name off the sync entry, with no sync ever recorded. It MOVES.</summary>
+    Branch,
+
+    /// <summary>The sync entry's <c>lastSyncCommitSha</c> — the commit the Space was imported from.</summary>
+    SyncedCommit,
+
+    /// <summary>The install record's <c>installedFromRef</c> — a commit or a branch.</summary>
+    InstalledRef,
+
+    /// <summary>The install record's <c>moduleVersion</c> — a hash over the module's own files.</summary>
+    ModuleVersion,
+}
+
+/// <summary>Whether a ref identifies one immutable tree, or something that moves under it.</summary>
+public enum RefFidelity
+{
+    /// <summary>No ref at all — the module cannot be re-assembled from what is recorded.</summary>
+    Unrecorded,
+
+    /// <summary>A branch or tag: two runs of the same combo can resolve it to different content.</summary>
+    Moving,
+
+    /// <summary>A commit sha or a content hash: two runs resolve it identically.</summary>
+    Exact,
+}

--- a/src/MeshWeaver.PluginCatalog/InstanceComboReader.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceComboReader.cs
@@ -1,0 +1,339 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Reads THIS instance's combo — every module it carries, with its source and its pinned ref —
+/// folding the two shapes a module's coordinate is recorded in into one list.
+///
+/// <para><b>Why a reader is the first task.</b> The candidate-release gate verifies a candidate
+/// image against the module versions <i>that instance</i> installed, and an earlier reading of the
+/// problem said an instance could not state its combo. It can: the coordinate was never missing,
+/// it was in two shapes.</para>
+///
+/// <list type="table">
+///   <listheader><term>path</term><description>coordinate</description></listheader>
+///   <item>
+///     <term><c>{Space}/_GitSync</c> (<c>nodeType:GitHubSyncConfig</c>)</term>
+///     <description><c>repositoryUrl</c> + <c>branch</c> + <c>subdirectory</c> +
+///       <c>lastSyncCommitSha</c> — how MOST modules actually arrive.</description>
+///   </item>
+///   <item>
+///     <term><c>Plugins/{id}</c> (<c>nodeType:Package</c>)</term>
+///     <description><see cref="PackageManifest.ModuleVersion"/> — the installer's record.</description>
+///   </item>
+/// </list>
+///
+/// <para>🚨 <b>A reader that handled only the install records would report almost nothing on a real
+/// portal and look like a healthy empty set</b> — the same false-confidence failure in a new place.
+/// Measured on memex 2026-08-10: <b>42</b> sync configs, <b>ZERO</b> install records
+/// (<c>Plugins/*</c> holds only <c>_Policy</c>). That single fact is why folding is the feature.</para>
+///
+/// <para><b><see cref="ModuleDiscovery"/> is enrichment, never the set.</b> It records what a
+/// configured repo SHIPS — most of the module set, in one place — but it exists only where a source
+/// set <c>AutoDiscover</c>, and <c>Admin/_Discovery</c> is <b>empty on memex</b>. Its
+/// <see cref="ModuleDiscovery.GitRef"/> is also repo-wide and may be a branch name, which moves and
+/// so is not a coordinate. It therefore contributes <see cref="InstanceCombo.NotCarried"/> (modules
+/// the repo ships that this instance lacks) and each module's source name — never the module set
+/// itself, which comes from what the instance demonstrably HAS.</para>
+///
+/// <para><b>Reads as SYSTEM, deliberately.</b> A partial combo is exactly the failure this type
+/// exists to prevent, and neither the sync entries nor the install records are readable by an
+/// ordinary principal. 🚨 A caller that exposes this over any user-facing surface must gate on
+/// <c>hub.IsGlobalAdmin()</c> — the reader itself does not, because a gate running unattended has no
+/// principal at all.</para>
+///
+/// <para>Instance-scoped singleton (its lifetime is the mesh's — <c>Doc/Architecture/NoStaticState</c>),
+/// reactive end to end, no <c>async</c>/<c>await</c>. Cold: the queries run on Subscribe.</para>
+///
+/// <para>See <c>Doc/Architecture/CandidateReleaseProtocol</c>.</para>
+/// </summary>
+/// <param name="hub">The hub whose instance this reads.</param>
+/// <param name="logger">Diagnostics.</param>
+public sealed class InstanceComboReader(IMessageHub hub, ILogger<InstanceComboReader>? logger = null)
+{
+    /// <summary>How long a mesh-wide set query gets before it is reported as UNREADABLE. It is
+    /// never reported as empty — "this instance carries nothing" and "we could not find out" are
+    /// the two answers a gate must never conflate.</summary>
+    private static readonly TimeSpan QueryTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The standing honesty note, present whenever any module's ref came from a sync entry or an
+    /// install record — i.e. essentially always.
+    ///
+    /// <para>Gate diagnostics, deliberately NOT localized: the consumer is an unattended deploy
+    /// gate reading a machine report, the same call <see cref="DiscoveredModule.Detail"/> makes. A
+    /// UI that renders these localizes at the render site.</para>
+    /// </summary>
+    public const string ProvenanceCaveat =
+        "Every ref reported here is PROVENANCE: it records what a module was last materialised "
+        + "FROM, not that the live mesh is byte-identical to it. Content authored in the mesh after "
+        + "a module's materializedAt has diverged from its ref, and that is normal — the mesh is "
+        + "authored as well as synced.";
+
+    /// <summary>Raised when no <see cref="ModuleDiscovery"/> record exists, so the reader can only
+    /// see what this instance HAS and cannot tell whether a configured repo ships more.</summary>
+    public const string NoDiscoveryCaveat =
+        "No module-discovery record exists (Admin/_Discovery is empty — the case on memex), so "
+        + "modules a configured repo ships but this instance does NOT carry are invisible to this "
+        + "read. Turn on PluginCatalog:Sources:N:AutoDiscover to make that set visible.";
+
+    /// <summary>
+    /// This instance's combo. Cold — subscribe to run it.
+    ///
+    /// <para>Never faults on an unreadable source: a fault would tell a gate nothing about what it
+    /// DID manage to read. An unreadable source instead sets <see cref="InstanceCombo.IsComplete"/>
+    /// false and names itself in <see cref="InstanceCombo.Caveats"/>.</para>
+    /// </summary>
+    /// <returns>One emission carrying the instance's full combo, then completes.</returns>
+    public IObservable<InstanceCombo> Read()
+    {
+        var readAt = DateTimeOffset.UtcNow;
+        return Observable.Zip(
+            // Every {Space}/_GitSync and {Space}/_GitSync/{sourceId} on the instance.
+            QuerySet($"nodeType:{GitHubSyncService.ConfigNodeType}", "sync entries ({Space}/_GitSync)"),
+            // Every install record the package installer wrote.
+            QuerySet(
+                $"path:{PackageInstaller.InstalledPartition} scope:children "
+                + $"nodeType:{PackageInstaller.PackageNodeType}",
+                $"install records ({PackageInstaller.InstalledPartition}/*)"),
+            // Enrichment only — see the type remarks.
+            QuerySet($"nodeType:{ModuleDiscovery.NodeType}", "module-discovery records"),
+            (sync, installs, discovery) => Fold(readAt, sync, installs, discovery));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Reading
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// One set query, as SYSTEM. A SET query is the sanctioned use of <c>Query</c> (listing,
+    /// existence) — no single node's content is read through it, which is the CQRS rule this stays
+    /// on the right side of.
+    /// </summary>
+    private IObservable<SourceRead> QuerySet(string query, string what)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
+            .Take(1)
+            .Timeout(QueryTimeout)
+            .Select(change => new SourceRead(change.Items.ToImmutableList(), null))
+            .Catch((Exception exception) =>
+            {
+                logger?.LogWarning(exception,
+                    "[InstanceCombo] reading {What} ('{Query}') failed — the combo is reported as "
+                    + "INCOMPLETE rather than short.", what, query);
+                return Observable.Return(new SourceRead(
+                    [],
+                    $"Could not read {what}: {exception.Message}. This combo is INCOMPLETE — "
+                    + "modules recorded there are missing from it."));
+            });
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Folding the two shapes into one list
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private InstanceCombo Fold(
+        DateTimeOffset readAt, SourceRead sync, SourceRead installs, SourceRead discovery)
+    {
+        var caveats = ImmutableList.CreateBuilder<string>();
+        foreach (var failure in new[] { sync.Failure, installs.Failure, discovery.Failure })
+            if (failure is not null)
+                caveats.Add(failure);
+
+        var syncByModule = ReadSyncEntries(sync.Items);
+        var packagesByModule = ReadInstallRecords(installs.Items);
+        var records = ReadDiscoveryRecords(discovery.Items);
+
+        // The module SET is the union of what the instance demonstrably HAS. Discovery contributes
+        // names and gaps, never membership — it is absent on real portals.
+        var modules = syncByModule.Keys
+            .Concat(packagesByModule.Keys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .Select(id =>
+            {
+                syncByModule.TryGetValue(id, out var gitSync);
+                packagesByModule.TryGetValue(id, out var package);
+                return new ModuleCoordinate
+                {
+                    ModuleId = id,
+                    Name = NameOf(id, package, records),
+                    GitSync = gitSync,
+                    Package = package,
+                };
+            })
+            .ToImmutableList();
+
+        if (records.Count == 0)
+            caveats.Add(NoDiscoveryCaveat);
+        if (modules.Any(m => m.ProvenanceKind is not ProvenanceKind.None))
+            caveats.Add(ProvenanceCaveat);
+        foreach (var moving in modules.Where(m => m.Fidelity != RefFidelity.Exact))
+            caveats.Add(
+                $"'{moving.ModuleId}' is pinned only to {Describe(moving)} — two runs of this combo "
+                + "can resolve it to different content, so a green result does not pin a tree.");
+
+        return new InstanceCombo
+        {
+            ReadAt = readAt,
+            Modules = modules,
+            NotCarried = Gaps(records, syncByModule, packagesByModule),
+            Caveats = caveats.ToImmutable(),
+            IsComplete = sync.Failure is null && installs.Failure is null,
+        };
+    }
+
+    /// <summary>
+    /// The sync entries, keyed by the PARTITION they belong to. A Space's primary entry lives at
+    /// <c>{Space}/_GitSync</c> and each additional source at <c>{Space}/_GitSync/{sourceId}</c>;
+    /// both resolve to the owning partition through their namespace's first segment. The primary
+    /// wins when a Space has several — it is the one the module itself is imported through.
+    /// </summary>
+    private ImmutableDictionary<string, GitSyncCoordinate> ReadSyncEntries(
+        IReadOnlyList<MeshNode> nodes) =>
+        nodes
+            .Select(node => (
+                Module: AccessAssignmentGuard.PartitionOf(node.Namespace ?? ""),
+                Node: node,
+                Config: node.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger)))
+            .Where(x => x.Module.Length > 0 && x.Config is not null)
+            .GroupBy(x => x.Module, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableDictionary(
+                g => g.Key,
+                g =>
+                {
+                    var entries = g.ToImmutableList();
+                    // The PRIMARY entry ({Space}/_GitSync) is the one the module itself is imported
+                    // through; an additional source ({Space}/_GitSync/{sourceId}) mirrors a subtree.
+                    // Index rather than FirstOrDefault: these are value tuples, whose default is a
+                    // silently-empty entry rather than a null the ?? could catch.
+                    var index = entries.FindIndex(
+                        x => string.Equals(x.Node.Id, GitHubSyncService.ConfigId,
+                            StringComparison.OrdinalIgnoreCase));
+                    var primary = entries[index >= 0 ? index : 0];
+                    return new GitSyncCoordinate
+                    {
+                        ConfigPath = primary.Node.Path,
+                        RepositoryUrl = primary.Config!.RepositoryUrl,
+                        Branch = primary.Config.Branch,
+                        Subdirectory = primary.Config.Subdirectory,
+                        LastSyncCommitSha = primary.Config.LastSyncCommitSha,
+                        LastSyncedAt = primary.Config.LastSyncedAt,
+                    };
+                },
+                StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The install records, keyed by the partition each installed INTO — which is what a sync entry
+    /// keys on too, and so what makes folding the two shapes onto one module possible. The record's
+    /// own id is kept as <see cref="PackageCoordinate.PackageId"/>: it can differ from the
+    /// partition, and it is what the installer's APIs take.
+    /// </summary>
+    private ImmutableDictionary<string, PackageCoordinate> ReadInstallRecords(
+        IReadOnlyList<MeshNode> nodes) =>
+        nodes
+            .Select(node => (
+                Node: node,
+                Manifest: node.ContentAs<PackageManifest>(hub.JsonSerializerOptions, logger)))
+            .Where(x => x.Manifest is not null)
+            .Select(x => (
+                Module: string.IsNullOrWhiteSpace(x.Manifest!.TargetPartition)
+                    ? (string.IsNullOrWhiteSpace(x.Manifest.Id) ? x.Node.Id : x.Manifest.Id)
+                    : x.Manifest.TargetPartition!,
+                x.Node,
+                x.Manifest))
+            .Where(x => x.Module.Length > 0)
+            .GroupBy(x => x.Module, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableDictionary(
+                g => g.Key,
+                g =>
+                {
+                    var (_, node, manifest) = g.First();
+                    return new PackageCoordinate
+                    {
+                        RecordPath = node.Path,
+                        PackageId = string.IsNullOrWhiteSpace(manifest.Id) ? node.Id : manifest.Id,
+                        Name = manifest.Name,
+                        ModuleVersion = manifest.ModuleVersion,
+                        Version = manifest.Version,
+                        InstalledFromRef = manifest.InstalledFromRef,
+                        InstalledAtUtc = manifest.InstalledAtUtc,
+                        SourceName = manifest.Source,
+                    };
+                },
+                StringComparer.OrdinalIgnoreCase);
+
+    private ImmutableList<ModuleDiscovery> ReadDiscoveryRecords(IReadOnlyList<MeshNode> nodes) =>
+        nodes
+            .Select(node => node.ContentAs<ModuleDiscovery>(hub.JsonSerializerOptions, logger))
+            .Where(record => record is not null)
+            .Select(record => record!)
+            .ToImmutableList();
+
+    /// <summary>
+    /// What a configured repo ships that this instance does NOT carry — the honest counterpart to
+    /// the module list, and the only thing that lets a caller tell "the combo is the whole set" from
+    /// "the combo is what happens to be here". Empty (with a caveat) when no scan has ever run.
+    /// </summary>
+    private static ImmutableList<ModuleGap> Gaps(
+        ImmutableList<ModuleDiscovery> records,
+        ImmutableDictionary<string, GitSyncCoordinate> synced,
+        ImmutableDictionary<string, PackageCoordinate> installed) =>
+        records
+            .SelectMany(record => record.Modules.Select(module => (record, module)))
+            .Where(x => x.module.Status is not (ModuleDiscoveryStatus.Synced
+                or ModuleDiscoveryStatus.Installed))
+            // A scan can be older than the provisioning it reported — never contradict what the
+            // instance demonstrably carries right now.
+            .Where(x => !synced.ContainsKey(x.module.Id) && !installed.ContainsKey(x.module.Id))
+            .GroupBy(x => x.module.Id, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var (record, module) = g.First();
+                return new ModuleGap
+                {
+                    ModuleId = module.Id,
+                    Name = module.Name,
+                    RepositoryUrl = record.RepositoryUrl,
+                    Status = module.Status,
+                    Detail = module.Detail,
+                };
+            })
+            .ToImmutableList();
+
+    /// <summary>The module's display name: the install record's own, else whatever the last
+    /// discovery scan recorded for it, else none. A name is presentation — never an identity — so a
+    /// missing one is a null, never a fabricated fallback.</summary>
+    private static string? NameOf(
+        string moduleId, PackageCoordinate? package, ImmutableList<ModuleDiscovery> records) =>
+        string.IsNullOrWhiteSpace(package?.Name)
+            ? records
+                .SelectMany(record => record.Modules)
+                .FirstOrDefault(m => string.Equals(m.Id, moduleId, StringComparison.OrdinalIgnoreCase))
+                ?.Name
+            : package!.Name;
+
+    private static string Describe(ModuleCoordinate module) => module.Fidelity switch
+    {
+        RefFidelity.Moving => $"a moving ref ('{module.ProvenanceRef}')",
+        _ => "nothing — neither a sync entry nor an install record names a ref for it",
+    };
+
+    /// <summary>One source query's outcome: what it returned, or why it could not be read.
+    /// A failure is NEVER folded into an empty result.</summary>
+    private sealed record SourceRead(ImmutableList<MeshNode> Items, string? Failure);
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -82,7 +82,14 @@ public static class PluginCatalogConfigurationExtensions
                 // Same two-registration idiom: the IHostedService forward is what STARTS it.
                 .AddSingleton<ModuleDiscoveryService>()
                 .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
-                    sp => sp.GetRequiredService<ModuleDiscoveryService>()))
+                    sp => sp.GetRequiredService<ModuleDiscoveryService>())
+                // Reads this instance's COMBO — every module it carries with its source and pinned
+                // ref, folding the {Space}/_GitSync and Plugins/{id} shapes into one list. The input
+                // the candidate-release deploy gate verifies an image against
+                // (Doc/Architecture/CandidateReleaseProtocol). A plain singleton, NOT a hosted
+                // service: it is a pull-on-demand READER — it starts nothing, subscribes to nothing,
+                // and writes nothing, so it costs an instance that never calls it exactly nothing.
+                .AddSingleton<InstanceComboReader>())
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/MeshWeaver.PluginCatalog.Test/InstanceComboReaderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstanceComboReaderTest.cs
@@ -1,0 +1,427 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// THE COMBO READER — one read that states what an instance is actually running, so a deploy gate
+/// can verify that exact combination before shipping (<c>Doc/Architecture/CandidateReleaseProtocol</c>).
+///
+/// <para><b>The property under test is the FOLD.</b> A module's coordinate is recorded in two
+/// shapes — per-Space <c>{Space}/_GitSync</c> entries and <c>Plugins/{id}</c> install records — and
+/// a reader that handles only the install records returns almost nothing on a real portal <b>while
+/// looking like a healthy empty set</b>. Measured live on memex 2026-08-10: <b>42 sync configs</b>,
+/// and <c>Plugins/*</c> holding only <c>_Policy</c> — <b>zero install records</b>. So the headline
+/// test is the GitSync-only instance, not the installer one.</para>
+///
+/// <para>🚨 <b>The honesty property.</b> <c>lastSyncCommitSha</c> pins what the Space was last
+/// SYNCED FROM. Content authored in the mesh afterwards is not in that commit, and the reader must
+/// never imply otherwise — so it reports the ref as PROVENANCE and says so in the answer itself.
+/// <see cref="TheRefIsProvenance_NotAClaimThatTheMeshStillMatchesIt"/> pins that a post-sync edit
+/// does not move (or invalidate) the ref, and that the answer carries the caveat.</para>
+/// </summary>
+public class InstanceComboReaderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RepoUrl = "https://github.com/Systemorph/MeshWeaver.SocialMedia";
+
+    /// <summary>A real 40-hex commit sha — the shape a sync records, and the shape the reader must
+    /// grade as an EXACT coordinate.</summary>
+    private const string CommitSha = "d19534d605ed24c348178803bb1241744c39091b";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                return services;
+            });
+
+    private InstanceComboReader Reader =>
+        Mesh.ServiceProvider.GetRequiredService<InstanceComboReader>();
+
+    private GitHubSyncService Sync =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The shape that actually carries production
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE REGRESSION THIS TYPE EXISTS FOR. An instance whose modules ALL arrived through
+    /// <c>{Space}/_GitSync</c> — the memex shape, 42 configs against zero install records — must
+    /// report those modules, with their repo and their pinned commit. A Package-only reader answers
+    /// "0 modules" here and that reads as "nothing installed, all clear".
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AGitSyncOnlyInstance_ReportsItsModules_NotAnEmptySet()
+    {
+        await Provision("SocialMedia", "SocialMedia", CommitSha);
+        await Provision("LinkedIn", "LinkedIn", CommitSha);
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        combo.IsComplete.Should().BeTrue("both sources were readable");
+        combo.Modules.Select(m => m.ModuleId).Should().Contain(["LinkedIn", "SocialMedia"],
+            "these modules arrived the way modules ACTUALLY arrive — a reader that only knows "
+            + "install records reports nothing here and looks healthy doing it");
+
+        var social = combo.Modules.Single(m => m.ModuleId == "SocialMedia");
+        social.Origin.Should().Be(ModuleOrigin.GitSync);
+        social.GitSync.Should().NotBeNull();
+        social.GitSync!.RepositoryUrl.Should().Be(RepoUrl);
+        social.GitSync.Subdirectory.Should().Be("SocialMedia");
+        social.GitSync.Branch.Should().Be("main");
+        social.GitSync.LastSyncCommitSha.Should().Be(CommitSha);
+        social.GitSync.ConfigPath.Should().Be("SocialMedia/_GitSync",
+            "the answer must name WHERE it read the coordinate, so an operator can go look");
+
+        social.ProvenanceRef.Should().Be(CommitSha);
+        social.ProvenanceKind.Should().Be(ProvenanceKind.SyncedCommit);
+        social.Fidelity.Should().Be(RefFidelity.Exact, "a commit sha identifies one immutable tree");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The installer shape, and the fold
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The other shape: a real install through <see cref="PackageInstaller"/> writes
+    /// <c>Plugins/{id}</c>, and the combo reports its <c>ModuleVersion</c> — a hash over the
+    /// module's OWN files, which is why it outranks a whole-repo commit sha as a coordinate.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AnInstalledPackage_IsReportedWithItsModuleVersion()
+    {
+        await Install("data-analyst", moduleVersion: "mv-abc123");
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        var module = combo.Modules.Single(m => m.ModuleId == "data-analyst");
+        module.Origin.Should().Be(ModuleOrigin.PackageInstall);
+        module.Package.Should().NotBeNull();
+        module.Package!.RecordPath.Should().Be($"{PackageInstaller.InstalledPartition}/data-analyst");
+        module.Package.ModuleVersion.Should().Be("mv-abc123");
+        module.ProvenanceKind.Should().Be(ProvenanceKind.ModuleVersion);
+        module.Fidelity.Should().Be(RefFidelity.Exact,
+            "a content hash over the module's own files identifies its tree exactly");
+        module.MaterializedAt.Should().NotBeNull("an install records when it landed");
+    }
+
+    /// <summary>
+    /// BOTH shapes, folded into ONE list: a module that is installed AND kept in sync appears
+    /// exactly once, carrying both coordinates. Reporting it twice would double-count the combo;
+    /// dropping one coordinate would lose the repo the gate has to check out.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AModuleRecordedBothWays_AppearsOnce_CarryingBothCoordinates()
+    {
+        await Install("SocialMedia", moduleVersion: "mv-both");
+        // The installer already provisioned the partition — wire the sync entry onto it rather than
+        // re-creating a root that is there (CreateNode is create-only).
+        await Provision("SocialMedia", "SocialMedia", CommitSha, createSpace: false);
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        combo.Modules.Count(m => m.ModuleId == "SocialMedia").Should().Be(1,
+            "one module is one entry — folding the two shapes is the whole job");
+
+        var module = combo.Modules.Single(m => m.ModuleId == "SocialMedia");
+        module.Origin.Should().Be(ModuleOrigin.Both);
+        module.GitSync!.LastSyncCommitSha.Should().Be(CommitSha,
+            "the sync coordinate must survive the fold — it is what a gate checks out");
+        module.Package!.ModuleVersion.Should().Be("mv-both");
+        module.ProvenanceRef.Should().Be("mv-both",
+            "the module's own content hash outranks a whole-repo commit sha, which moves whenever "
+            + "an unrelated sibling module changes");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  🚨 Honesty
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <c>lastSyncCommitSha</c> is PROVENANCE. After content is authored in the mesh the Space no
+    /// longer matches the commit it was synced from — and the reader neither notices nor claims
+    /// otherwise. So the answer must SAY so rather than let a caller read the ref as an identity.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task TheRefIsProvenance_NotAClaimThatTheMeshStillMatchesIt()
+    {
+        await Provision("SocialMedia", "SocialMedia", CommitSha);
+
+        var before = await Reader.Read().Should().Within(120.Seconds()).Emit();
+        before.Caveats.Should().Contain(InstanceComboReader.ProvenanceCaveat,
+            "an answer that reports a sync sha must state, in the answer, that it records where the "
+            + "content CAME FROM — never that the live mesh is byte-identical to it");
+
+        var module = before.Modules.Single(m => m.ModuleId == "SocialMedia");
+        module.MaterializedAt.Should().NotBeNull(
+            "the drift boundary must be readable: anything authored after it is not in the ref");
+
+        // Author content in the mesh AFTER the sync — the normal case, since the mesh is authored
+        // as well as synced. Written as SYSTEM because wiring a _GitSync makes the partition
+        // repo-owned and retracts the human creator's grant (SystemOwnedAccessRetractionHandler) —
+        // that is the production shape, and not what this test is about.
+        await AsSystem(() => NodeFactory.CreateNode(new MeshNode("HandWritten", "SocialMedia")
+        {
+            NodeType = "Markdown",
+            Name = "Written here, after the sync",
+            State = MeshNodeState.Active,
+            Content = "# Not in that commit",
+        })).Timeout(60.Seconds()).ToTask();
+
+        var after = await Reader.Read().Should().Within(120.Seconds()).Emit();
+        after.Modules.Single(m => m.ModuleId == "SocialMedia").ProvenanceRef.Should().Be(CommitSha,
+            "the ref still records the last sync — it is provenance, and an in-mesh edit neither "
+            + "moves it nor is detected by it. That is exactly why it must never be read as identity");
+        after.Caveats.Should().Contain(InstanceComboReader.ProvenanceCaveat);
+    }
+
+    /// <summary>
+    /// A Space wired to a repo that has never synced is pinned to a BRANCH — which moves. Two runs
+    /// of that combo can resolve it to different content, so the answer must grade it
+    /// <see cref="RefFidelity.Moving"/>, refuse <see cref="InstanceCombo.IsReproducible"/>, and name
+    /// the module in a caveat. Silently treating a branch as a coordinate is how a gate reports
+    /// "verified" for something it cannot reproduce.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AModulePinnedOnlyToABranch_IsGradedMoving_AndBlocksReproducibility()
+    {
+        await Provision("Chess", "Chess", lastSyncCommitSha: null);
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        var module = combo.Modules.Single(m => m.ModuleId == "Chess");
+        module.ProvenanceKind.Should().Be(ProvenanceKind.Branch);
+        module.ProvenanceRef.Should().Be("main");
+        module.Fidelity.Should().Be(RefFidelity.Moving, "a branch is not a coordinate — it moves");
+
+        combo.IsReproducible.Should().BeFalse(
+            "one un-pinned module makes the whole combo unrepeatable, and a gate must be told");
+        combo.Caveats.Should().Contain(c => c.Contains("'Chess'") && c.Contains("moving"),
+            "the caveat must NAME the module, not just say something somewhere is unpinned");
+    }
+
+    /// <summary>
+    /// With no <see cref="ModuleDiscovery"/> record — <c>Admin/_Discovery</c> is empty on memex —
+    /// the reader can only see what this instance HAS. Modules a configured repo ships but this
+    /// instance lacks are invisible, and that limit has to be stated rather than passed off as a
+    /// complete set.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task WithNoDiscoveryRecord_TheAnswerSaysAbsentModulesAreInvisible()
+    {
+        await Provision("SocialMedia", "SocialMedia", CommitSha);
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        combo.NotCarried.Should().BeEmpty();
+        combo.Caveats.Should().Contain(InstanceComboReader.NoDiscoveryCaveat,
+            "an empty NotCarried must not be readable as 'the repo ships nothing else'");
+    }
+
+    /// <summary>
+    /// When a discovery scan HAS run, the modules it found and this instance does not carry come
+    /// back as <see cref="InstanceCombo.NotCarried"/> — so a gate can tell "this combo is the whole
+    /// set" from "this combo is what happens to be here". A module the instance demonstrably carries
+    /// is never reported as a gap, however stale the scan.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task WithADiscoveryRecord_ModulesTheRepoShipsButThisInstanceLacks_AreNamed()
+    {
+        await Provision("SocialMedia", "SocialMedia", CommitSha);
+        await WriteDiscoveryRecord();
+
+        var combo = await Reader.Read().Should().Within(120.Seconds()).Emit();
+
+        combo.NotCarried.Select(g => g.ModuleId).Should().Equal(["Planning"],
+            "Planning is shipped by the repo and absent here; SocialMedia is carried, so it is not "
+            + "a gap even though the scan predates nothing in particular");
+        combo.NotCarried.Single().Status.Should().Be(ModuleDiscoveryStatus.Discovered);
+        combo.NotCarried.Single().RepositoryUrl.Should().Be(RepoUrl);
+        combo.Caveats.Should().NotContain(InstanceComboReader.NoDiscoveryCaveat);
+
+        combo.Modules.Single(m => m.ModuleId == "SocialMedia").Name.Should().Be("Social Media",
+            "the discovery record is where a GitSync-only module's display name comes from");
+    }
+
+    /// <summary>
+    /// An instance that carries nothing reports an empty list — and is NOT reproducible, because
+    /// "no modules" is not a verified combo. The distinction that matters is against an UNREADABLE
+    /// source, which sets <see cref="InstanceCombo.IsComplete"/> false; an empty read leaves it
+    /// true.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AnInstanceCarryingNothing_IsCompleteButNotReproducible()
+    {
+        var combo = await Reader.Read().Should().Within(90.Seconds()).Emit();
+
+        combo.Modules.Should().BeEmpty();
+        combo.IsComplete.Should().BeTrue("both sources were readable — they were just empty");
+        combo.IsReproducible.Should().BeFalse(
+            "an empty combo verifies nothing; only IsComplete says the read succeeded");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Grading, without a mesh
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The fidelity grading is the gate's whole go/no-go, so it is pinned directly: a sha is exact,
+    /// a branch name in the same field is not, a module hash is exact, and nothing recorded is
+    /// <see cref="RefFidelity.Unrecorded"/> rather than optimistically "fine".
+    /// </summary>
+    [Theory]
+    [InlineData(CommitSha, null, ProvenanceKind.SyncedCommit, RefFidelity.Exact)]
+    [InlineData("main", null, ProvenanceKind.SyncedCommit, RefFidelity.Moving)]
+    [InlineData(null, "mv-abc", ProvenanceKind.ModuleVersion, RefFidelity.Exact)]
+    [InlineData(null, null, ProvenanceKind.None, RefFidelity.Unrecorded)]
+    public void FidelityGrading_TellsAnImmutableTreeFromAMovingOne(
+        string? syncedSha, string? moduleVersion, ProvenanceKind kind, RefFidelity fidelity)
+    {
+        var module = new ModuleCoordinate
+        {
+            ModuleId = "X",
+            GitSync = syncedSha is null ? null : new GitSyncCoordinate { LastSyncCommitSha = syncedSha },
+            Package = moduleVersion is null ? null : new PackageCoordinate { ModuleVersion = moduleVersion },
+        };
+
+        module.ProvenanceKind.Should().Be(kind);
+        module.Fidelity.Should().Be(fidelity);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Helpers — the REAL write paths, never a stand-in
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Provisions a module the way production does: a Space, its <c>_GitSync</c> entry through
+    /// <see cref="GitHubSyncService.SaveConfig"/>, and — when the module has actually synced — the
+    /// commit merged onto the config node exactly as <c>RecordLastSync</c> merges it.
+    /// </summary>
+    private async Task Provision(
+        string space, string subdirectory, string? lastSyncCommitSha, bool createSpace = true)
+    {
+        if (createSpace)
+            await NodeFactory.CreateNode(new MeshNode(space)
+            {
+                NodeType = GitHubSyncService.SpaceNodeType,
+                Name = space,
+                State = MeshNodeState.Active,
+                Content = new Space(),
+            }).Timeout(60.Seconds()).ToTask();
+
+        await Sync.SaveConfig(
+                space, RepoUrl, "main", subdirectory,
+                createBranchIfMissing: false, createRepoIfMissing: false,
+                direction: SyncDirection.ImportOnly)
+            .Timeout(60.Seconds()).ToTask();
+
+        if (lastSyncCommitSha is null)
+            return;
+
+        // The same two-field merge the sync operation performs when an import lands.
+        var now = DateTimeOffset.UtcNow;
+        await Mesh.GetWorkspace()
+            .GetMeshNodeStream(GitHubSyncService.ConfigPath(space))
+            .Update(node => node with
+            {
+                Content = (node.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)
+                           ?? new GitHubSyncConfig()) with
+                {
+                    LastSyncedAt = now,
+                    LastSyncCommitSha = lastSyncCommitSha,
+                },
+            })
+            .Timeout(60.Seconds()).ToTask();
+    }
+
+    /// <summary>Installs a package for real — <see cref="PackageInstaller"/> writes the
+    /// <c>Plugins/{id}</c> record this reader then reads.</summary>
+    private Task<InstallResult> Install(string id, string moduleVersion) =>
+        PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = id,
+                    Name = id,
+                    Kind = PackageKind.Content,
+                    TargetPartition = id,
+                    SourceFolder = id,
+                    Version = "1.0.0",
+                    ModuleVersion = moduleVersion,
+                },
+                [new PackageFile($"{id}/Doc.md", $"# {id}")],
+                "HEAD")
+            .FirstAsync().Timeout(120.Seconds()).ToTask();
+
+    /// <summary>
+    /// The record a <see cref="ModuleDiscoveryService"/> scan writes: the repo ships two modules,
+    /// one of which this instance carries.
+    /// </summary>
+    private async Task WriteDiscoveryRecord()
+    {
+        var path = ModuleDiscovery.PathFor(RepoUrl);
+        var slash = path.LastIndexOf('/');
+        var node = new MeshNode(path[(slash + 1)..], path[..slash])
+        {
+            NodeType = ModuleDiscovery.NodeType,
+            Name = "Modules of SocialMedia",
+            State = MeshNodeState.Active,
+            Content = new ModuleDiscovery
+            {
+                RepositoryUrl = RepoUrl,
+                SourceName = "plugins",
+                GitRef = "main",
+                LastScannedAt = DateTimeOffset.UtcNow,
+                Modules =
+                [
+                    new DiscoveredModule
+                    {
+                        Id = "SocialMedia",
+                        Name = "Social Media",
+                        Status = ModuleDiscoveryStatus.Synced,
+                    },
+                    new DiscoveredModule
+                    {
+                        Id = "Planning",
+                        Name = "Planning",
+                        Status = ModuleDiscoveryStatus.Discovered,
+                        Detail = "not on this instance",
+                    },
+                ],
+            },
+        };
+
+        await AsSystem(() => Mesh.Observe<CreateOrUpdateNodeResponse>(
+                new CreateOrUpdateNodeRequest(node)))
+            .FirstAsync().Timeout(60.Seconds()).ToTask();
+    }
+
+    /// <summary>Establishes System on the write's OWN subscribe — an ambient impersonation does not
+    /// survive a scheduler hop, which is exactly why production wraps every such write this way.</summary>
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> write)
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(() => accessService.ImpersonateAsSystem(), _ => write());
+    }
+}


### PR DESCRIPTION
Task 1 of the [Candidate Release Protocol](https://github.com/Systemorph/MeshWeaver/pull/1048)'s instance gate: before anything is verified, the instance must be able to **state its combo** — every module it carries, with its source and pinned ref. `InstanceComboReader` is that read.

## Two shapes, folded

| path | node | coordinate |
|---|---|---|
| GitSync / repo import | `{Space}/_GitSync` | `repositoryUrl` + `branch` + `subdirectory` + **`lastSyncCommitSha`** |
| PackageInstaller | `Plugins/{id}` | `PackageManifest.ModuleVersion` |

A reader that handles only one **looks healthy while returning nothing**: measured on memex, 42 sync configs and *zero* install records — a Package-only reader reports "nothing installed, all clear" on the portal with the most modules. That failure mode is why the fold is the whole point.

## Honesty is in the type

- **Every ref is provenance, never identity.** It records what the module was last materialised *from*; in-mesh editing is normal, so the honest claim is "came from that ref", never "equals that ref". The API says so (`ProvenanceRef`, `MaterializedAt`).
- **`IsComplete`** distinguishes "carries nothing" from "could not find out" — a failed source query becomes a named caveat, not a silently shorter list.
- **`RefFidelity`** separates a sha/content-hash (`Exact`) from a branch (`Moving`) from nothing (`Unrecorded`); **`IsReproducible`** is the conjunction a gate can act on.
- `ModuleDiscovery` records enrich (`NotCarried`) but never define the carried set — their `GitRef` may be a branch name, and a branch is not a coordinate.

## Shape

Plain singleton — a pull-on-demand reader that starts nothing, subscribes to nothing, writes nothing. Reactive end-to-end; three set queries (the sanctioned `Query` use), run as System, zipped, failure → explicit caveat.

12 tests · `MeshWeaver.PluginCatalog` builds clean under `-c Release -p:CIRun=true -warnaserror`.

Groundwork by a prior session that hit its limit mid-flight; verified, committed and shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPQKMhQDpitUzsW1MqTVhH