### PR TITLE
Correct bake cost to the measured ~2.4 s/type; re-derive the two budgets sized from the wrong constant

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -166,9 +166,11 @@
        • CONTINUOUS (default — CI pipeline and local dev): append a build number, e.g.
          3.0.0-rc1.ci.21901, so continuous packages are DISTINGUISHABLE from the release and a
          local-deploy build always carries a build number.
-       InformationalVersion always carries +build.<ticks> so NodeTypeCompilationHelpers.FrameworkVersion
-       is distinct every build (NodeType cache invalidation), released or continuous. A direct
-       -p:Version=… still overrides everything (escape hatch). -->
+       Under CIRun — released or continuous alike — InformationalVersion carries +build.<ticks> so
+       NodeTypeCompilationHelpers.FrameworkVersion is distinct every build (NodeType cache
+       invalidation); local builds keep it stable to preserve incremental. See the 🚨 note on the
+       InformationalVersion property below before touching that stamp. A direct -p:Version=… still
+       overrides everything (escape hatch). -->
   <PropertyGroup Condition="'$(Version)' == ''">
     <!-- Build number. CI (CIRun=true): seconds-since-midnight / 2 (~2s granularity) so continuous
          packages are distinguishable. LOCAL DEV: a STABLE 0 — a per-build number re-stamps
@@ -202,8 +204,30 @@
     <Version Condition="'$(PublicRelease)' == 'true'">$(PlatformVersion)</Version>
     <Version Condition="'$(PublicRelease)' != 'true'">$(PlatformVersion)$(_CiSep)ci.$(_CiBuildNumber)</Version>
     <!-- CI appends +build.<ticks> so each continuous build's InformationalVersion is unique; LOCAL
-         keeps it stable (= $(Version)) so AssemblyInfo isn't regenerated every build. ABI identity
-         is the Graph MVID now, not this string, so a stable local value is safe. -->
+         keeps it stable (= $(Version)) so AssemblyInfo isn't regenerated every build (a per-build
+         stamp regenerates AssemblyInfo.cs and destroys incremental builds — see _BuildNumber above).
+
+         🚨 THIS TICKS STAMP IS LOAD-BEARING ABI SAFETY, NOT COSMETICS. It is easy to read the MVID
+         switch as "the version string no longer affects ABI identity" and delete the stamp. It does
+         affect it: this attribute is compiled INTO every assembly, MeshWeaver.Graph included, so
+         under CIRun the ticks are exactly what makes Graph's MVID — and therefore
+         NodeTypeCompilationHelpers.FrameworkVersion — differ on every CI build. That is what forces
+         a full NodeType recompile on every deployed build.
+
+         Removing the stamp would make the MVID content-stable, and a content-stable MVID is NOT a
+         sufficient staleness signal, for two independent reasons:
+           • A NodeType's compile reference set is AppContext's TRUSTED_PLATFORM_ASSEMBLIES — EVERY
+             assembly in the image (MeshNodeCompilationService.GetDefaultReferences), not just
+             Graph's dependency closure. A breaking change in an assembly Graph never references is
+             still inside that reference set, and a stable Graph MVID would declare the stale
+             NodeType assemblies valid and LOAD them across it.
+           • AssemblyVersion is pinned at 3.0.0.0 (issue #143, below), so runtime assembly binding
+             will not catch the mismatch either — nothing else stands between a stale NodeType
+             assembly and being loaded.
+         So: anyone removing the ticks stamp MUST, in the SAME change, widen FrameworkVersion to
+         cover the WHOLE reference set (e.g. a hash over the TPA closure). Do not remove one without
+         the other. Cost/benefit of the current scheme: deploy/CHANGE-PROPAGATION.md#the-bake-tax
+         (a full bake is ~10 min on the largest mesh — measured, not the hours once assumed). -->
     <InformationalVersion Condition="'$(CIRun)' == 'true'">$(Version)+build.$([System.DateTime]::UtcNow.Ticks)</InformationalVersion>
     <InformationalVersion Condition="'$(CIRun)' != 'true'">$(Version)</InformationalVersion>
     <!-- 🔴 AssemblyVersion is STABLE (3.0.0.0) — it is the RUNTIME ASSEMBLY-BINDING identity, so it

--- a/deploy/CHANGE-PROPAGATION.md
+++ b/deploy/CHANGE-PROPAGATION.md
@@ -14,8 +14,9 @@ The short version:
 | **d. Downstream content** (`education`) | CI → GitSync → import | **~5-15 min** | no |
 
 > **Numbers marked *(measured)* are real observations, dated. Everything else is an estimate and
-> says so.** Do not quote an estimate as a fact — the spread on the core path in particular is wide
-> and nobody has timed a full bake on memex yet.
+> says so.** Do not quote an estimate as a fact. The bake figures below were estimates until
+> 2026-08-10, when production Loki was read across all three portals — and the estimate was **37x
+> too high** (see [the bake tax](#the-bake-tax)). Two deploy budgets had been sized from it.
 
 ---
 
@@ -54,13 +55,30 @@ older code would mint a higher `-ci.<n>` and roll installs backwards.
 > is enabled on any environment. If it ever needs cutting, the lever is publishing it on a schedule
 > or only on release tags — not trimming its references.
 
-### Not every core release invalidates the compile cache
+### Every core release invalidates the compile cache — plan for the bake on all of them
 
-The compile cache keys on **Graph's MVID** — a *content* identity, not a per-build stamp. It changes
-when `MeshWeaver.Graph`, or anything Graph depends on, is rebuilt with different content. A release
-that only touches, say, `MeshWeaver.Blazor.Portal` leaves Graph's bytes identical, so **every cached
-assembly stays valid and there is no bake at all**. Graph sits low in the stack, so this is common
-but far from universal — check whether your change reaches Graph before assuming the expensive path.
+This page used to claim the opposite: that a release touching only, say, `MeshWeaver.Blazor.Portal`
+leaves Graph's bytes identical, so "every cached assembly stays valid and there is no bake at all".
+**That is false, and it is false twice over.** Do not plan a release around it.
+
+The compile cache keys on **Graph's MVID** (`NodeTypeCompilationHelpers.FrameworkVersion` — the
+`MeshWeaver.Graph` module's content hash). Both halves of the old claim break down:
+
+1. **The MVID is not content-stable in CI.** `Directory.Build.props` stamps the
+   `InformationalVersion` property with `$([System.DateTime]::UtcNow.Ticks)` under `CIRun`, and that
+   attribute is compiled *into* every assembly — Graph included. So **Graph's MVID changes on every
+   CI build regardless of which source files the release touched**, and every cached assembly is
+   invalidated on every core release. That stamp is deliberate and load-bearing (see point 2); the
+   mistake was reasoning about the MVID as if it were a pure content hash of Graph's *source*.
+2. **Graph's dependency closure is not the ABI boundary anyway.** A NodeType compiles against
+   `AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")` — **every assembly in the image**, not just
+   what Graph references (`MeshNodeCompilationService.GetDefaultReferences`). So a breaking change
+   in an assembly Graph never references is still inside a NodeType's reference set, and a
+   content-stable Graph MVID would happily declare those stale assemblies valid and load them.
+
+Together: the ticks stamp is what keeps invalidation *conservative* over that wider reference set.
+**Budget every core release as a full bake** — which, at the real measured cost below, is minutes,
+not the hours this page used to imply.
 
 ---
 
@@ -114,18 +132,48 @@ framework — by design, for ABI safety (assemblies built against the old framew
 members whose signatures moved).
 
 **This cost is not new and the bake does not add it.** Without the bake it is paid *lazily*:
-unordered, on user requests, on a pod already serving, ~90s at a time in front of whoever arrives
+unordered, on user requests, on a pod already serving, ~2.4 s at a time in front of whoever arrives
 first. The bake moves the same work ahead of the rollout, where nobody is waiting.
+
+### The real cost: ~2.4 s per NodeType *(measured 2026-08-10)*
+
+Read from production Loki across **all three portals running the same image** — the per-type figure
+agrees to within 3% across a 10x spread in mesh size, which is what makes it trustworthy:
+
+| Portal | Types | Full warm-up (median) | Per type |
+|---|---|---|---|
+| **memex-cloud** | 237-241 | **567 s** (~9.5 min) | **~2.4 s** |
+| **memex** | 72-81 | **179 s** (~3 min) | **~2.3 s** |
+| **atioz** | 22-36 | **68 s** (~1 min) | **~2.3 s** |
+
+Other measurements, for context:
 
 | Observation | |
 |---|---|
-| 4 small Doc types, full bake | **7.8s** *(measured, local k3s, 2026-07-28)* |
-| `Store/Plugin` alone (~30 source files) | **92s** *(measured, memex)* |
-| memex full bake (60-100 types) | **not measured** |
+| Resident memory per compiled type | **~46 MiB** *(measured 2026-08-10)* |
+| `Store/Plugin` alone (~30 source files) | **92 s** *(measured, memex)* — an outlier, ~38x the median |
+| 4 small Doc types, full bake | **7.8 s** *(measured, local k3s, 2026-07-28)* |
 
-The honest range for a memex full bake is wide: extrapolating the *largest* type gives ~1.5-2.5 h,
-but the local types averaged ~2s each, so the real figure depends entirely on how many memex types
-resemble `Store/Plugin`. **Measure it on the first real run rather than trusting either end.**
+**A full bake on the largest production mesh is ~10 minutes.** Not the "~1.5-2.5 h" this page
+carried until 2026-08-10.
+
+> #### 🚨 How the old number went wrong, and what it cost
+>
+> The retired estimate was **"~90 s per NodeType"** — **37x** the measured ~2.4 s. It came from
+> extrapolating the single *largest* type (`Store/Plugin`, 92 s, ~30 source files) across the whole
+> mesh. The page even flagged the alternative — "the local types averaged ~2s each" — and that end
+> of the range turned out to be the right one.
+>
+> This was not a harmless doc error: **two production deploy budgets were sized from it** — the
+> startup-probe budget (10 × 1080 = 3 h) and the bake Job's `activeDeadlineSeconds` (14400 = 4 h).
+> A budget derived from a 37x-overstated constant does not fail loudly; it silently stops being a
+> detector. Every real bake finishes inside ~10 minutes, so the remaining 2h50m of that probe window
+> separated nothing: a wedged pod and a healthy one look identical for the rest of it. Both budgets
+> have been re-derived from the measured figure — 30 min and 1 h respectively, with the arithmetic
+> written next to each value in `deploy/helm/values.yaml`.
+>
+> The lesson worth keeping: **never extrapolate a population from its largest member**, and treat a
+> budget whose constant was never measured as unsized rather than generous.
 
 Properties that bound the damage:
 

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -269,7 +269,7 @@ reverts them):
 |---|---|
 | `config.memex_portal.PreWarm__DynamicTypes: "true"` | every new pod sweeps + compiles ALL dynamic NodeTypes at start (resumes from the shared `/data` cache — warm restarts are cheap) |
 | `config.memex_portal.PreWarm__GateReadiness: "true"` | `/health` stays red until the sweep is green; with `maxSurge 1 / maxUnavailable 0` a regressed type STALLS the rollout with the old image serving. **✅ ON.** It was tried 2026-08-02 and reverted the same day on 7 FALSE regressions — all cross-silo `SubscribeRequest` timeouts, not compile errors (#694 residue). The gate no longer reads "no answer" as "it broke": a `TimedOut` outcome is filed as *unevaluated* and can never gate, and that leniency now survives the cascade (a dependent of an unevaluated upstream is `UpstreamUnevaluated`, also non-gating). Only a `CompileError` — or an `UpstreamFailed` cascading from one — on a **previously-healthy** type stalls a roll |
-| `probes.startup: {periodSeconds: 10, failureThreshold: 1080}` | ⚠️ REQUIRED with the gate: a cold bake is ~90 s/type, sequential — the default 5 min budget kills the pod mid-bake forever. `progressDeadlineSeconds` is DERIVED from these two in the chart, so raising them can't leave it behind |
+| `probes.startup: {periodSeconds: 10, failureThreshold: 180}` (= 30 min) | ⚠️ REQUIRED with the gate: a cold bake is **~2.4 s/type**, sequential *(measured 2026-08-10, prod Loki, three portals)* — ~10 min on memex-cloud, the largest mesh — and the default 5 min budget kills the pod mid-bake forever. 30 min is that worst case plus a plain cold boot, x2. `progressDeadlineSeconds` is DERIVED from these two in the chart, so raising them can't leave it behind. **Was `1080` (3 h)** until 2026-08-10, sized from a "~90 s/type" estimate that was 37x too high — a window that long detected nothing |
 
 **🚨 Before you trust the gate, verify the namespace actually reads it.** The gate protects a
 portal through exactly two deployment facts, and on 2026-08-10 two of the three portals had drifted
@@ -312,7 +312,7 @@ kubectl -n <env> patch configmap memex-portal-config --type merge \
   -p '{"data":{"PreWarm__DynamicTypes":"true","PreWarm__GateReadiness":"false"}}'
 kubectl -n <env> patch deployment memex-portal-deployment --type json -p \
   '[{"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/periodSeconds","value":10},
-    {"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/failureThreshold","value":1080}]'
+    {"op":"replace","path":"/spec/template/spec/containers/0/startupProbe/failureThreshold","value":180}]'
 # the probe patch rolls the deployment; the new pod bakes behind the gate while the old serves
 ```
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -158,7 +158,7 @@ config:
     #
     # ⚠️ THREE prerequisites, all of which must be true in the LIVE namespace —
     # verify, do not assume, because two of the three portals had drifted:
-    #   1. probes.startup raised to cover a full COLD bake (below: 10 × 1080 = 3h).
+    #   1. probes.startup raised to cover a full COLD bake (below: 10 × 180 = 30 min).
     #      Without it Kubernetes kills the pod mid-bake, every time, forever.
     #   2. The startupProbe must actually EXIST and point at /health — that probe
     #      is the only thing that reads this gate. A namespace with no startupProbe
@@ -401,13 +401,28 @@ bake:
 
 # ⚠️ PAIRED with PreWarm__GateReadiness above: the gate holds /health red while
 # the pod bakes, and a cold bake (fresh framework identity, empty cache for it)
-# is ~90 s per NodeType, strictly sequential — 60-100 types needs HOURS. The
-# default budget (5 s × 60 = 5 min) kills the pod mid-bake, on every attempt,
-# forever. 10 s × 1080 = 3 h covers the real worst case.
+# is strictly sequential. The default budget (5 s × 60 = 5 min) kills the pod
+# mid-bake, on every attempt, forever.
+#
+# ⏱️ DERIVED from the MEASURED per-type cost, 2026-08-10 (production Loki, all
+# three portals on one image): ~2.4 s per NodeType, within 3% across a 10x
+# spread in mesh size — memex-cloud 237-241 types / 567 s, memex 72-81 / 179 s,
+# atioz 22-36 / 68 s.
+#
+#   memex-cloud (largest)  ~240 types x 2.4 s  ~= 570 s  (~10 min)
+#   + plain cold boot      schema provisioning + static import
+#   worst realistic startup                    ~= 870 s  (~15 min)
+#   x2 headroom             10 s x 180          = 1800 s (30 min)
+#
+# Covers ~750 types, 3x memex-cloud's current count, so growth has room.
+#
+# 🚨 Was 10 × 1080 = 3 h until 2026-08-10, sized from a "~90 s per NodeType"
+# estimate measurement showed to be 37x too high. A stuck bake now trips this in
+# 30 min instead of hiding inside a 3-hour window that detected nothing.
 probes:
   startup:
     periodSeconds: 10
-    failureThreshold: 1080
+    failureThreshold: 180
 
 # --- Ingress with cookie session affinity (Blazor Server is sticky) ---------
 # Blazor Server holds a per-circuit SignalR connection; without sticky sessions

--- a/deploy/helm/templates/memex-bake/job.yaml
+++ b/deploy/helm/templates/memex-bake/job.yaml
@@ -7,8 +7,9 @@
 # 🚨 WHY THIS EXISTS. Every image roll changes the framework identity (Graph's MVID), and that
 # identity is part of the assembly store's filename AND its lookup glob — so a new image misses the
 # whole compile cache BY DESIGN (ABI safety). Left to the portal, that guaranteed miss is paid
-# lazily, unordered, on user requests, after the pod is already serving: ~90 s of cold Roslyn per
-# NodeType on somebody's page load. Paid here it is paid once, on a container nobody is waiting for.
+# lazily, unordered, on user requests, after the pod is already serving: ~2.4 s of cold Roslyn per
+# NodeType on somebody's page load (measured 2026-08-10, production Loki, three portals). Paid here
+# it is paid once, on a container nobody is waiting for.
 #
 # 🚦 AND IT IS THE GATE. The job exits non-zero when a NodeType that USED TO compile no longer does,
 # so a broken type is discovered before any traffic moves. A type that was already broken beforehand
@@ -34,8 +35,10 @@ spec:
   # would be indistinguishable from a clean one. Fix the type and re-run the upgrade.
   backoffLimit: 0
   ttlSecondsAfterFinished: {{ .Values.bake.ttlSecondsAfterFinished }}
-  # A full cold bake is ~90 s per NodeType, strictly sequential. Sized generously: hitting this
-  # deadline kills the bake mid-flight and reports failure for work that was merely slow.
+  # A full cold bake is ~2.4 s per NodeType, strictly sequential (measured 2026-08-10) — ~10 min on
+  # the largest mesh we run. The default 3600 s is that worst case plus Job overhead, x4: hitting
+  # this deadline kills the bake mid-flight and reports failure for work that was merely slow, so
+  # the headroom is wide on purpose. Full derivation in values.yaml (bake.activeDeadlineSeconds).
   activeDeadlineSeconds: {{ .Values.bake.activeDeadlineSeconds }}
   template:
     metadata:

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -51,10 +51,11 @@ data:
   #    1. PreWarm__DynamicTypes must ALSO be true — the gate reads state only the sweep
   #       writes, so gate-without-sweep is permanently green. The portal logs that
   #       combination at Critical on startup.
-  #    2. A startupProbe ON /health with a budget covering a full COLD bake (~90 s per
-  #       NodeType, sequential). See probes.startup in values — turning the gate on without
-  #       raising it means Kubernetes kills the pod mid-bake, every time, forever. Nothing
-  #       else reads the gate: a namespace probing /alive or /healthz ignores it entirely.
+  #    2. A startupProbe ON /health with a budget covering a full COLD bake (~2.4 s per
+  #       NodeType, sequential, measured 2026-08-10 — ~10 min on the largest mesh we run).
+  #       See probes.startup in values — turning the gate on without raising it means
+  #       Kubernetes kills the pod mid-bake, every time, forever. Nothing else reads the
+  #       gate: a namespace probing /alive or /healthz ignores it entirely.
   #    3. strategy.maxUnavailable: 0 — the gate works by making the NEW pod refuse
   #       readiness, which protects nothing if the serving pod was already deleted.
   PreWarm__DynamicTypes: "{{ .Values.config.memex_portal.PreWarm__DynamicTypes }}"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -136,10 +136,12 @@ spec:
             # failing, readiness/liveness are suspended, so a slow boot is never flagged unhealthy.
             #
             # ⚠️ This budget is what bounds a NodeType BAKE (PreWarm__GateReadiness). A cold compile
-            # is ~90 s per NodeType and the sweep is strictly sequential, so a mesh with dozens of
-            # types needs HOURS here, not minutes. periodSeconds × failureThreshold is the ceiling:
-            # the default 5 × 60 = 5 minutes is right for a plain boot and far too small for a cold
-            # bake — turning the gate on without raising this kills the pod mid-bake, every time.
+            # is ~2.4 s per NodeType and the sweep is strictly sequential (measured 2026-08-10), so
+            # the largest mesh we run (~240 types) needs ~10 min of bake on top of a plain cold boot.
+            # periodSeconds × failureThreshold is the ceiling: the default 5 × 60 = 5 minutes is
+            # right for a plain boot and too small for a cold bake — turning the gate on without
+            # raising this kills the pod mid-bake, every time. Paired setting and full derivation:
+            # values.yaml (probes.startup) — 10 × 180 = 30 min.
             httpGet: { path: /health, port: 8080 }
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
@@ -261,7 +263,7 @@ spec:
   #
   # 🚨 The k8s DEFAULT IS 600s, and against this deployment that default is simply WRONG: the
   # startupProbe budget above is periodSeconds × failureThreshold, which managed envs set to
-  # 10 × 1080 = 3 HOURS to cover a cold NodeType bake. A legitimately-baking pod is therefore
+  # 10 × 180 = 30 MINUTES to cover a cold NodeType bake. A legitimately-baking pod is therefore
   # declared failed after 10 minutes — and `kubectl rollout status` reports a perfectly healthy
   # long bake as a failed rollout, which is exactly the signal an operator would act on by
   # rolling back the good image.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -157,10 +157,26 @@ migration:
 bake:
   enabled: false
   image: "ghcr.io/systemorph/memex-bake:latest"
-  # A cold bake is ~90 s per NodeType and strictly sequential — 60-100 types is 2-3 hours. This
-  # deadline kills the Job, so size it above the real worst case: tripping it reports a failure for
-  # work that was only slow, which is the one wrong answer a gate must not give.
-  activeDeadlineSeconds: 14400   # 4h
+  # ⏱️ DERIVED from the MEASURED per-type bake cost — do not adjust either number alone.
+  #
+  #   measured 2026-08-10 (production Loki, all three portals on one image): ~2.4 s per NodeType,
+  #   agreeing within 3% across a 10x spread in mesh size —
+  #     memex-cloud 237-241 types / 567 s   memex 72-81 / 179 s   atioz 22-36 / 68 s
+  #
+  #   largest production mesh   ~240 types x 2.4 s  ~= 570 s  (~10 min)
+  #   + Job overhead            image pull + wait-for-postgres init + process boot
+  #   worst realistic run                           ~= 15 min
+  #   x4 headroom                                    = 3600 s (1 h)
+  #
+  # Headroom is deliberately WIDER here than on the startup probe (30 min): tripping this deadline
+  # kills the Job and reports a FAILURE for work that was only slow, which is the one wrong answer a
+  # gate must not give. 1 h still covers ~1500 types — 6x the largest mesh we run — and a bake past
+  # an hour is stuck, not slow.
+  #
+  # 🚨 This was 14400 (4 h) until 2026-08-10, sized from a "~90 s per NodeType" estimate that
+  # measurement showed to be 37x too high. A deadline that generous is not a safety margin; it is an
+  # absent detector. See deploy/CHANGE-PROPAGATION.md#the-bake-tax.
+  activeDeadlineSeconds: 3600   # 1h
   ttlSecondsAfterFinished: 3600
 
 # ---- Startup probe budget ------------------------------------------------------------------------
@@ -169,10 +185,27 @@ bake:
 # provisioning + static import).
 #
 # ⚠️ If you enable config.memex_portal.PreWarm__GateReadiness, raise failureThreshold in the SAME
-# change. The bake compiles every dynamic NodeType sequentially at ~90 s each, so a mesh with 60-100
-# types needs 2-3 HOURS. Suggested paired setting: periodSeconds 10, failureThreshold 1080 (3h).
-# Under-budgeting here is not a slow rollout — it is a pod that is killed mid-bake and never
+# change — the gate holds /health red for the whole bake. Suggested paired setting:
+#   periodSeconds: 10, failureThreshold: 180   →  1800 s = 30 min
+#
+# ⏱️ DERIVED from the MEASURED per-type bake cost (2026-08-10, production Loki, three portals):
+#   ~2.4 s per NodeType, sequential — memex-cloud 237-241 types / 567 s, memex 72-81 / 179 s,
+#   atioz 22-36 / 68 s.
+#
+#   largest production mesh   ~240 types x 2.4 s  ~= 570 s   (~10 min)
+#   + plain cold boot         schema provisioning + static import (the ungated 5 min budget)
+#   worst realistic startup                       ~= 870 s   (~15 min)
+#   x2 headroom                                    = 1800 s  (30 min)
+#
+# 1800 s also covers ~750 types — 3x the largest mesh we run — so growth has room without another
+# resize. Under-budgeting here is not a slow rollout: it is a pod killed mid-bake that never
 # converges, on every single attempt.
+#
+# 🚨 The suggestion here was 10 x 1080 (3 h) until 2026-08-10, sized from a "~90 s per NodeType"
+# estimate that measurement showed to be 37x too high. The point of this budget is that a genuinely
+# STUCK bake is DETECTED, and at 3 h it could not be: every real bake finishes inside 10 min, so the
+# remaining 2h50m distinguished nothing — a wedged pod and a healthy one are indistinguishable for
+# the rest of that window. See deploy/CHANGE-PROPAGATION.md#the-bake-tax.
 probes:
   startup:
     periodSeconds: 5
@@ -312,9 +345,9 @@ config:
     #     deploy-time latency and a gateable signal, which is an operational trade a MANAGED
     #     env makes knowingly (see deploy/aks/values.aks.yaml, where both are "true").
     #   • The gate additionally needs a startupProbe on /health with a budget covering a full
-    #     cold bake (~90 s per type, sequential — HOURS on a real mesh) and
-    #     strategy.maxUnavailable:0. Defaulting it on with the chart's 5-minute startup
-    #     budget would kill every pod mid-bake, forever.
+    #     cold bake (~2.4 s per type, sequential — ~10 min on the largest mesh we run;
+    #     measured 2026-08-10) and strategy.maxUnavailable:0. Defaulting it on with the
+    #     chart's 5-minute startup budget would kill every pod mid-bake, forever.
     # An instance that wants the protection turns BOTH on and raises probes.startup in the
     # same change; progressDeadlineSeconds follows probes.startup automatically. See
     # config.yaml for what each key does.

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -149,9 +149,12 @@ public static class NodeTypeBakeGateExtensions
     /// service writes to it whether or not anything gates on it, so the diagnostics are always there.
     ///
     /// <para>⚠️ A host that gates readiness on this MUST raise its <c>startupProbe.failureThreshold</c>
-    /// to cover a full cold bake. A cold compile is ~90 s per NodeType and the sweep is strictly
-    /// sequential, so a mesh with dozens of types needs HOURS of startup budget. Left at the usual
-    /// default (60 × 5 s = 5 minutes) Kubernetes kills and restarts the pod mid-bake, forever.</para>
+    /// to cover a full cold bake. A cold compile is ~2.4 s per NodeType and the sweep is strictly
+    /// sequential (measured 2026-08-10 across three production portals), so the largest mesh we run
+    /// (~240 types) needs ~10 minutes of bake on top of a plain cold boot. Left at the usual default
+    /// (60 × 5 s = 5 minutes) Kubernetes kills and restarts the pod mid-bake, forever. The chart's
+    /// paired setting is 10 s × 180 = 30 minutes; see <c>deploy/helm/values.yaml</c>
+    /// (<c>probes.startup</c>) for the derivation.</para>
     /// </summary>
     public static IServiceCollection AddNodeTypeBakeGate(this IServiceCollection services)
     {


### PR DESCRIPTION
## The measured fact

The docs carried **"~90 s per NodeType"** for a cold NodeType bake. Production Loki, read 2026-08-10 across **all three portals running the same image**, measures **~2.4 s per type** — the documented figure was **37x too high**.

| Portal | Types | Full warm-up (median) | Per type |
|---|---|---|---|
| memex-cloud | 237-241 | 567 s (~9.5 min) | ~2.4 s |
| memex | 72-81 | 179 s (~3 min) | ~2.3 s |
| atioz | 22-36 | 68 s (~1 min) | ~2.3 s |

Agreement within 3% across a 10x spread in mesh size is what makes it trustworthy. **A full bake on the largest mesh is ~10 minutes, not the "1.5-2.5 h" the page claimed.** Also recorded: ~46 MiB resident per compiled type.

The old number came from extrapolating the single *largest* type (`Store/Plugin`, 92 s) across the whole mesh. The page had even flagged the alternative — "the local types averaged ~2s each" — and that end was the right one.

## 🚨 Two production budgets were sized from the wrong constant

Neither was a safety margin; at those magnitudes they had **stopped being detectors**. Every real bake finishes inside ~10 min, so the rest of the window does not separate a wedged pod from a healthy one.

| Budget | Before | After | Derivation |
|---|---|---|---|
| `probes.startup` | `10 × 1080` = **3 h** | `10 × 180` = **30 min** | 240 types × 2.4 s ≈ 570 s, + plain cold boot ≈ 870 s, ×2 headroom. Covers ~750 types (3x the largest mesh) |
| `bake.activeDeadlineSeconds` | `14400` = **4 h** | `3600` = **1 h** | Same 570 s + Job overhead (pull, wait-for-postgres, boot) ≈ 15 min, ×4. Covers ~1500 types |

Headroom is deliberately **wider on the Job** than on the probe: tripping `activeDeadlineSeconds` kills the Job and reports a **failure for work that was only slow**, which is the one wrong answer a gate must not give. The probe's job is the opposite — detect a stuck bake in minutes.

The arithmetic is written next to each value so neither can be re-tuned without its derivation travelling with it.

## "A Blazor.Portal-only release means no bake at all" — false twice over

`CHANGE-PROPAGATION.md` claimed a release that leaves Graph's bytes identical skips the bake entirely. Both halves break down:

1. **The MVID is not content-stable in CI.** `Directory.Build.props` stamps `InformationalVersion` with `UtcNow.Ticks` under `CIRun`, and that attribute compiles *into* every assembly, Graph included — so **Graph's MVID changes on every CI build regardless of which source the release touched**.
2. **Graph's dependency closure is not the ABI boundary anyway.** A NodeType compiles against `TRUSTED_PLATFORM_ASSEMBLIES` — *every assembly in the image* (`MeshNodeCompilationService.GetDefaultReferences`), not what Graph references.

Corrected to: **budget every core release as a full bake** — which, at the real cost, is minutes.

## The ticks stamp is load-bearing ABI safety, not a build stamp

`Directory.Build.props`' comment *"ABI identity is the Graph MVID now, not this string"* invited exactly the wrong conclusion — that the stamp is cosmetic and removable. Replaced with the real reasoning plus a 🚨 warning: **anyone removing the ticks stamp must widen `FrameworkVersion` to cover the whole reference set in the same change.** With `AssemblyVersion` pinned at `3.0.0.0` (issue #143), a content-stable MVID would declare stale NodeType assemblies valid and **load them** across a breaking change in an assembly Graph does not reference — and runtime assembly binding would not catch it either.

The neighbouring comment at the version-channel block was accurate on the causal link; it is only tightened to say *under `CIRun`* (local builds keep it stable to preserve incremental).

## Verification

- `helm template` + `helm lint` — renders clean for **both** the default values and the AKS overlay; `progressDeadlineSeconds` derives correctly (900 s default, **2400 s** on AKS).
- `DocumentationLinkIntegrityTest` — **passed** 1/1.
- `dotnet build -c Release -warnaserror` on `MeshWeaver.Hosting` (the one compiled file touched) — **0 warnings, 0 errors**, re-run after merging current `main`.

No What's New entry: nothing here is user-noticeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)