### PR TITLE
Installing a plugin could pin its front page to the generic view

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-new-plugin-lands-with-its-own-pages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-new-plugin-lands-with-its-own-pages.md
@@ -1,0 +1,42 @@
+---
+Name: A new plugin lands with its own pages
+Category: Fix
+Description: A freshly installed plugin could open on a bare, generic page — none of its own views — until something recycled it. Its front page is now built only once the plugin's code is ready to serve it.
+Icon: AppsAddIn
+Order: -20260810
+---
+
+# A new plugin lands with its own pages
+
+Installing a plugin sometimes ended with an oddly empty result. The install
+reported success, every node was there, and the plugin's front page opened — but
+it was the generic node page, not the plugin's own. The Store's catalog, a
+course's landing view, a shop front: gone, replaced by the standard tabs every
+node has. Opening a page *inside* the plugin worked fine. Only the front page was
+wrong, and it stayed wrong until someone recycled it or the portal restarted.
+
+The cause was a matter of a few milliseconds.
+
+A plugin ships its own code, and that code is compiled here, on your portal,
+against the exact version of the platform you are running. A plugin repository
+also carries the result of the *last* compile someone did — which was against a
+different version, months ago, on a different machine. So the first thing your
+portal does with a newly installed plugin is rebuild it.
+
+Meanwhile the installer opens the plugin's front page once, on purpose, so the
+plugin is ready the moment you click on it. A page works out which code serves it
+exactly once, when it first opens, and then keeps that answer. Opening the front
+page while the rebuild had not started yet meant the page asked the question too
+early, got "no usable code here", and kept that answer for good — while the
+rebuild finished a few seconds later and changed nothing, because nobody asked
+again.
+
+Now the installer checks first. If the plugin's own code has not been rebuilt yet,
+it simply does not open the front page — because opening it is only a
+head start, while opening it too early is a wrong answer that sticks. The page is
+then built the first time someone actually visits, by which point the rebuild has
+long finished, and it gets the right answer the only time it asks. Installs never
+wait on a compile, so nothing gets slower.
+
+You should notice nothing except that a newly installed plugin now looks the way
+its author intended, first time.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1561,6 +1561,48 @@ public static class MeshDataSourceExtensions
             || (def.CompilationStatus != CompilationStatus.Compiling
                 && def.CompilationStatus != CompilationStatus.Pending));
 
+    /// <summary>
+    /// Holds a NodeType MeshNode stream until the type is settled AND is not advertising a build
+    /// the framework cannot load — i.e. until an INSTANCE activating against it can be given the
+    /// type's real configuration.
+    ///
+    /// <para>Stricter than <see cref="AwaitCompilationSettled"/> in exactly one way: a settled
+    /// <c>Ok</c> whose assembly coordinates are present but whose
+    /// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> does not match the live framework
+    /// (or whose bytes this process cannot resolve) is NOT accepted. That state is what a node repo
+    /// COMMITS — MeshWeaver.Plugins ships <c>Store/Catalog</c> with <c>compilationStatus: Ok</c> and
+    /// a July framework hash — and it is transient by construction: the per-NodeType hub's
+    /// framework-stale kickoff flips it to Pending and rebuilds. An instance enriched inside that
+    /// window binds ONCE to the fallback configuration and then serves only the generic areas
+    /// ("No renderer is registered for area <c>Tests</c> on hub <c>Store</c>").</para>
+    ///
+    /// <para>A type that never compiled at all (no assembly coordinates) and a type whose compile
+    /// genuinely FAILED both pass straight through — the assembly fields are only ever written by a
+    /// successful compile, so "nothing built" is a settled answer, not a stale build. Callers must
+    /// still bound the wait (a type that can never produce a loadable build would otherwise hold
+    /// forever) and degrade rather than fail.</para>
+    ///
+    /// <para>Non-NodeType nodes answer <c>true</c>, so this is safe to ask about any MeshNode.</para>
+    /// </summary>
+    /// <param name="node">The NodeType MeshNode to judge.</param>
+    /// <returns>False only while the node is mid-compile or is advertising an unloadable build.</returns>
+    public static bool HasLoadableBuild(this MeshNode? node)
+        => node?.Content is not NodeTypeDefinition def
+            || (def.CompilationStatus != CompilationStatus.Compiling
+                && def.CompilationStatus != CompilationStatus.Pending
+                && (string.IsNullOrEmpty(def.LatestAssemblyPath)
+                    || NodeTypeCompilationHelpers.HasUsableBuild(node, def)));
+
+    /// <summary>
+    /// Stream form of <see cref="HasLoadableBuild"/> — holds a NodeType MeshNode stream until the
+    /// type is settled and not advertising a build the framework cannot load. Callers must bound
+    /// the wait: a type that can never produce a loadable build would otherwise hold forever.
+    /// </summary>
+    /// <param name="source">The NodeType's MeshNode stream.</param>
+    /// <returns>The same stream, filtered to loadable-build emissions.</returns>
+    public static IObservable<MeshNode> AwaitLoadableBuild(this IObservable<MeshNode> source)
+        => source.Where(node => node.HasLoadableBuild());
+
     // StartCompile relocated to NodeTypeCompilationHelpers.RunCompile so the
     // per-NodeType-hub auto-watcher and the CreateReleaseRequest handler share
     // one body. The watcher fires on CompilationStatus = Pending; the handler

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -143,7 +143,7 @@ public static class PackageInstaller
                         nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, authorizingUserId: authorizingUserId))
-                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // …then the package's committed binaries, into the warmed root's content
                     // collection — the half of "publish" that merging used to leave undone (#848).
                     .SelectMany(_ => SyncPackageContent(hub, partition, sourceFolder, files, logger))
@@ -673,13 +673,51 @@ public static class PackageInstaller
             },
         };
 
+    /// <summary>
+    /// Budget for the single READ that decides whether a self-typed root may be warmed yet. This
+    /// is a snapshot of the type's current state, never a wait for a compile — the installer must
+    /// not hold on Roslyn (the compile activity it just kicked runs on the same mesh), so an
+    /// unanswered read simply means "don't warm this one".
+    /// </summary>
+    private static readonly TimeSpan RootTypeProbeTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Activates the roots this install just wrote, so a freshly installed package is not dark
+    /// until someone navigates to it.
+    ///
+    /// <para>🚨 Warming a root is not a read — it ACTIVATES its hub, and a hub's NodeType
+    /// enrichment binds ONCE for the hub's lifetime. So a root may only be warmed once its type
+    /// can actually produce a configuration. For a SELF-TYPED root (the Store shape: root
+    /// <c>Store</c> is nodeType <c>Store/Catalog</c>, defined by a child of the same package) the
+    /// type is, at this moment, still carrying the compile stamp the node repo COMMITTED —
+    /// <c>compilationStatus: Ok</c> with a months-old <c>compiledFrameworkVersion</c> and an
+    /// assembly this mesh has never seen. Warming into that state made the outcome a race between
+    /// the per-NodeType hub's framework-stale kickoff (which flips Pending, so enrichment WAITS for
+    /// the rebuild) and this activation (which, if it wins, snaps the stale <c>Ok</c>, spends the
+    /// single self-heal retry and can end on the silent defaults-only fallback). Measured margin on
+    /// a developer machine: 13 ms. A loaded CI runner loses it, and the root then serves only the
+    /// generic areas — "No renderer is registered for area <c>Tests</c> on hub <c>Store</c>", the
+    /// plugin gate's Store/Catalog RED (2026-07-29, recurred 2026-08-10 on three different PRs).
+    /// The recycle a few lines above exists precisely so the root re-activates against its FINAL
+    /// type; warming before that type is loadable defeated it.</para>
+    ///
+    /// <para>So: when a root is typed by a NodeType this very package installs, SKIP the warm
+    /// unless that type currently has a build an instance could load
+    /// (<see cref="MeshDataSourceExtensions.AwaitLoadableBuild"/>, read once, bounded by
+    /// <see cref="RootTypeProbeTimeout"/>). Skipping is the safe answer, and it is cheap: warming
+    /// is only an optimisation against "the root stays dark until something touches it", whereas a
+    /// warm into an unloadable type PINS the wrong configuration. The next real access — the gate's
+    /// render, a visitor, the next install — activates the root against the rebuilt type and binds
+    /// correctly. Deliberately NOT a wait: the installer runs on the mesh that is compiling, so
+    /// holding here would trade a mis-binding for a stalled install.</para>
+    /// </summary>
     private static IObservable<Unit> WarmInstalledRoots(
-        IMessageHub hub, IEnumerable<string> paths, ILogger? logger)
+        IMessageHub hub, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
     {
         var workspace = hub.GetWorkspace();
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var roots = paths
-            .Select(path => path.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
+        var roots = nodes
+            .Select(n => n.Path.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
             .Where(root => !string.IsNullOrWhiteSpace(root))
             .Select(root => root!)
             .Distinct(StringComparer.Ordinal)
@@ -687,14 +725,58 @@ public static class PackageInstaller
         if (roots.Length == 0)
             return Observable.Return(Unit.Default);
 
+        // The NodeTypes this package defines — only these can still be carrying the repo's
+        // committed stale stamp at this point in the install.
+        var inPackageTypes = nodes
+            .Where(n => n.Content is NodeTypeDefinition)
+            .Select(n => n.Path)
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // The root's DECLARED type, read off the nodes we just wrote — never off the mesh, since
+        // reading the root is the very activation this gate exists to defer.
+        string? DeclaredTypeOf(string root) => nodes
+            .FirstOrDefault(n => string.Equals(n.Path, root, StringComparison.Ordinal))?.NodeType;
+
+        // True when warming this root now cannot pin the wrong configuration: either its type is
+        // not one this package defines (nothing about to be rebuilt), or that type already has a
+        // build an instance could load. One bounded READ — never a wait for a compile.
+        IObservable<bool> MayWarm(string root)
+        {
+            var declaredType = DeclaredTypeOf(root);
+            if (string.IsNullOrEmpty(declaredType) || !inPackageTypes.Contains(declaredType))
+                return Observable.Return(true);
+            return workspace.GetMeshNodeStream(declaredType)
+                .Where(node => node is not null)
+                .Take(1)
+                .Timeout(RootTypeProbeTimeout)
+                .Select(node => node.HasLoadableBuild())
+                .Catch<bool, Exception>(_ => Observable.Return(false))
+                .Do(loadable =>
+                {
+                    if (!loadable)
+                        logger?.LogInformation(
+                            "[PackageInstaller] not warming root {Root}: its NodeType {Type} has no "
+                            + "build this framework can load yet (the repo's committed compile stamp "
+                            + "is being rebuilt). Warming now would bind the root to the fallback "
+                            + "configuration for its hub's lifetime; the first real access after the "
+                            + "rebuild binds it correctly.",
+                            root, declaredType);
+                });
+        }
+
         return roots
             .Select(root => Observable
                 .Using(
                     () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                    _ => workspace.GetMeshNodeStream(root)
-                        .Where(node => node is not null)
-                        .Take(1)
-                        .Timeout(WarmTimeout))
+                    _ => MayWarm(root)
+                        .SelectMany(mayWarm => mayWarm
+                            ? workspace.GetMeshNodeStream(root)
+                                .Where(node => node is not null)
+                                .Take(1)
+                                .Timeout(WarmTimeout)
+                                .Select(_ => true)
+                            : Observable.Return(false)))
+                .Where(warmed => warmed)
                 .Select(_ => root)
                 .Catch<string, Exception>(exception =>
                 {
@@ -942,7 +1024,7 @@ public static class PackageInstaller
                 }
                 return WriteInstalledRecord(
                         hub, manifest, installedFromRef, all.Length, authorizingUserId: authorizingUserId)
-                    .SelectMany(_ => WarmInstalledRoots(hub, all.Select(n => n.Path), logger))
+                    .SelectMany(_ => WarmInstalledRoots(hub, all, logger))
                     .Select(_ => result);
             });
     }
@@ -1551,7 +1633,7 @@ public static class PackageInstaller
                         logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
-                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // …then the package's committed binaries (course videos/posters) into the
                     // warmed root's content collection — the half of "publish" that merging used
                     // to leave undone (#848).
@@ -1741,7 +1823,7 @@ public static class PackageInstaller
                         logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef,
                         newManifest.Files.Count, newManifest, authorizingUserId))
-                    .SelectMany(_ => WarmInstalledRoots(hub, nodes.Select(n => n.Path), logger))
+                    .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // A changed BINARY is a changed file like any other: manifest.lock hashes the
                     // `content/**` assets too, so a re-cut video is in `changedFiles` and an
                     // unchanged one never travels. This is what keeps the incremental path cheap

--- a/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
@@ -107,6 +107,103 @@ public class PluginGateRunnerTest(ITestOutputHelper output)
     private const string PricedThingNodeTypeJson =
         """{"$type":"MeshNode","id":"Thing","namespace":"Priced","path":"Priced/Thing","mainNode":"Priced/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
 
+    // ── the STORE shape: a SELF-TYPED root (root `Shop` is nodeType `Shop/Front`, defined by a
+    //    child of the same package) whose NodeType node ships a BAKED, STALE compile stamp —
+    //    `compilationStatus: Ok` plus assembly coordinates and a `compiledFrameworkVersion` from
+    //    a long-gone framework build. That is EXACTLY what MeshWeaver.Plugins commits (see
+    //    Store/Catalog/index.json), and it is the only shape whose Tests host is a node the
+    //    INSTALLER activates: PackageInstaller lands the root as a Space placeholder, retypes it,
+    //    recycles its hub and then WARMS it — i.e. the root's one-and-only NodeType enrichment
+    //    runs while the type is still framework-stale and its assembly is absent from this run's
+    //    store. Every other Tests host is created after the compiles and cannot see that window.
+    //    If enrichment binds the root to the defaults-only fallback there, the root serves the
+    //    generic areas and NOT the type's — "No renderer is registered for area `Tests` on hub
+    //    `Store`", the plugin gate's Store/Catalog RED (2026-07-29, recurred 2026-08-10). ──
+
+    private const string ShopIndexJson =
+        """{"$type":"MeshNode","id":"Shop","namespace":"","path":"Shop","mainNode":"Shop","name":"Shop","nodeType":"Shop/Front","state":"Active","content":{"$type":"FrontContent","intro":"hello"}}""";
+
+    private const string ShopFrontNodeTypeJson =
+        """{"$type":"MeshNode","id":"Front","namespace":"Shop","path":"Shop/Front","mainNode":"Shop/Front","name":"Front","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The shop front.","configuration":"config => config.WithContentType<FrontContent>().AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Tests\", FrontTestsArea.Tests))","includeGlobalTypes":true,"compilationStatus":"Ok","lastCompiledVersion":201,"latestAssemblyCollection":"local","latestAssemblyPath":"Shop_Front/v201-0123456789abcdef0123456789abcdef-aaaabbbbcccc.dll","compiledFrameworkVersion":"0123456789abcdef0123456789abcdef","latestReleasePath":"Shop/Front/Release/20260719130110-fHGetxbU"}}""";
+
+    private const string FrontContentSource =
+        """
+        public record FrontContent
+        {
+            public string? Intro { get; init; }
+
+            public int Answer() => 42;
+        }
+        """;
+
+    private const string FrontTestsArea =
+        """
+        using System;
+        using System.Reactive.Linq;
+        using MeshWeaver.Layout;
+        using MeshWeaver.Layout.Composition;
+
+        public static class FrontTestsArea
+        {
+            public static IObservable<UiControl?> Tests(LayoutAreaHost host, RenderingContext _)
+            {
+                var sb = new System.Text.StringBuilder("### Front tests\n\n| Test | Result |\n|---|---|\n");
+                var passed = 0;
+                try
+                {
+                    if (new FrontContent().Answer() != 42)
+                        throw new Exception("expected the answer to be 42");
+                    sb.Append("| Answer is 42 | ✅ pass |\n");
+                    passed++;
+                }
+                catch (Exception ex) { sb.Append($"| Answer is 42 | ❌ {ex.Message} |\n"); }
+                sb.Append($"\n**{passed}/1 passed.**");
+                return Observable.Return<UiControl?>(Controls.Markdown(sb.ToString()));
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The regression this pins: a package whose ROOT is typed by an in-package NodeType that
+    /// ships a stale compile stamp must still serve that type's areas once installed. The gate
+    /// runs the root's <c>Tests</c> area, which only exists in the type's compiled configuration
+    /// — so a root bound to the defaults-only fallback fails here with "Area not found", exactly
+    /// as Store/Catalog does when the race is lost on a loaded CI runner.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task SelfTypedRootWithStaleCompileStamp_ServesItsTypesAreas()
+    {
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Shop/index.json", ShopIndexJson);
+            WriteFile(root, "Shop/Front.json", ShopFrontNodeTypeJson);
+            WriteFile(root, "Shop/Front/Source/FrontContent.cs", FrontContentSource);
+            WriteFile(root, "Shop/Front/Test/FrontTestsArea.cs", FrontTestsArea);
+        });
+        try
+        {
+            var (report, log) = await RunGate(repo);
+
+            report.FatalError.Should().BeNull();
+            var shop = report.Packages.Single(p => p.Id == "Shop");
+            shop.InstallError.Should().BeNull($"the self-typed root must install; log:\n{log}");
+
+            var front = shop.NodeTypes.Single(t => t.Path == "Shop/Front");
+            front.Compile.Should().Be(CheckOutcome.Passed,
+                $"the shipped stale stamp must be rebuilt, not trusted; detail: {front.CompileDetail}");
+            front.TestsDetail.Should().NotContain("Area not found",
+                "the root hub must be bound to the type's compiled configuration, never to the "
+                + $"defaults-only fallback; log:\n{log}");
+            front.Tests.Should().Be(CheckOutcome.Passed,
+                $"the ROOT's Tests area must execute green; detail: {front.TestsDetail}");
+            report.ExitCode.Should().Be(0, $"all green must exit 0; log:\n{log}");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
     [Fact(Timeout = 300_000)]
     public async Task GoodPackage_CompilesRendersAndExecutesTestsGreen_ExitsZero()
     {

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -373,8 +373,16 @@ public static class PluginGateRunner
             services.AddLogging(logging =>
             {
                 logging.SetMinimumLevel(minLevel);
-                if (minLevel < LogLevel.Warning)
-                    logging.AddSimpleConsole(o => { o.SingleLine = true; o.TimestampFormat = "HH:mm:ss.fff "; });
+                // 🚨 ALWAYS attach the provider, including at the default Warning level. It used to
+                // be attached only when the level was turned DOWN (`minLevel < Warning`), so a gate
+                // run at its default verbosity emitted the report and NOTHING else — every
+                // framework Warning was written to a logger with no sinks. When the gate went RED
+                // on CI ("No renderer is registered for area `Tests` on hub `Store`", 2026-08-10)
+                // the run therefore carried zero evidence of WHY the instance was bound to the
+                // fallback config, and the failure could not be diagnosed from the job log at all.
+                // Warning volume is a handful of lines per run — the trace levels are still opt-in
+                // through MW_LOG_LEVEL.
+                logging.AddSimpleConsole(o => { o.SingleLine = true; o.TimestampFormat = "HH:mm:ss.fff "; });
                 foreach (var category in (Environment.GetEnvironmentVariable("MW_LOG_CATEGORIES") ?? "")
                          .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                     logging.AddFilter(category, minLevel);


### PR DESCRIPTION
## What the gate was reporting

Three unrelated PRs (#1082, #1054, `fix/honest-bake-gate-log`) went RED on the
plugin gate within 25 minutes, all with the identical message:

```
RED Store/Catalog: compile=Ok render=ok tests=FAILED
    **Area not found**
    No renderer is registered for area `Tests` on hub `Store`.
    Available named areas: `$Data`, `$Model`, `$Schema`, `AccessControl`, `Catalog`, … `Versions`
```

Every one of them passed on re-run. Across the last 40 CI runs the gate failed
3 times and passed 27 — including on `main` itself between the failures — so it
is **not** a main-side regression. The available-areas list is exactly
`AddDefaultLayoutAreas()` and nothing from the type's compiled configuration:
the `Store` hub was bound to the fallback config.

## Mechanism

`Store` is the **only** Tests host the INSTALLER activates. `PackageInstaller`
lands a self-typed root as a `Space` placeholder, retypes it, recycles its hub —
and then warms it. Warming is not a read: it activates the hub, and a hub
resolves which configuration serves it exactly once, for its lifetime.

At that moment `Store/Catalog` is still carrying the stamp the node repo
**commits**: `compilationStatus: Ok`, `compiledFrameworkVersion:
eec04a05…` (2026-07-19) and an assembly no fresh mesh has ever seen. Local trace,
13 ms apart:

```
13:01:01.878  Framework-stale kickoff: NodeType Store/Catalog … flipping CompilationStatus=Pending to rebuild
13:01:01.891  [PackageInstaller] warmed installed root Store
```

Kickoff first ⇒ enrichment sees Pending and waits for the rebuild (green).
Warm first ⇒ enrichment snaps the stale `Ok`, spends the single
`MaxRecompileAttempts` on the framework-stale self-heal, and can end on the
silent defaults-only fallback (red, for the hub's lifetime). A loaded 4-core
runner loses that race; this machine does not.

The symptom is documented verbatim in `PackageInstaller`'s own recycle comment
from 2026-07-29 — the recycle exists so the root re-activates against its FINAL
type, and warming before that type is loadable defeats it.

## The change

- **`PackageInstaller` no longer warms a root whose in-package NodeType has no
  loadable build yet.** Warming is only a head start against "the root stays dark
  until something touches it"; warming into an unloadable type pins the wrong
  answer permanently. Deliberately a **skip, not a wait** — the installer runs on
  the mesh that is compiling, so holding there would trade a mis-binding for a
  stalled install. The first real access after the rebuild binds correctly.
- **`MeshNode.HasLoadableBuild()` / `AwaitLoadableBuild()`** in `MeshDataSource` —
  "settled and not advertising a build this framework cannot load", the predicate
  the decision needs.
- **The gate stopped discarding its own evidence.** The harness set a minimum
  level of Warning but attached the console provider only when the level was
  turned DOWN, so every framework warning in a default run went to a logger with
  no sinks — which is why the CI failure carried no diagnosis at all.
- **New gate fixture** for the untested shape: a self-typed root whose NodeType
  ships a stale compile stamp must serve its type's areas (Store/Catalog→Store in
  miniature).

## Verification

- Gate run locally against current main + current plugins main, before and after:
  `[PASS] Store (96 node(s), 9 type(s))`, `Store/Catalog … 44/44 passed`, ALL GREEN.
- Could **not** reproduce the red locally: 8 runs on macOS (incl.
  `DOTNET_PROCESSOR_COUNT=2`), 7 in a Linux container at `--cpus 2` and `--cpus 4`.
  The race window is ~13 ms.
- `MeshWeaver.PluginTester.Test` 19/19; `MeshWeaver.PluginCatalog.Test` (installer
  tests) 13/13. `-c Release -warnaserror` clean on the touched projects.

## Residual, named rather than hidden

`SyncPackageContent` also touches the root and runs just after the warm, so a
package that ships content assets can still activate its root early. No package
in the gate does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)