### PR TITLE
The plugins gate blamed a compile break for a failure that compiled fine

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -784,6 +784,12 @@ jobs:
     # bar. The timeout is deliberately well below the shard job's 20 min — if the gate ever becomes
     # the long pole it should fail and be re-scoped, not silently stretch every PR.
     timeout-minutes: 12
+    # The failing CHECK and the node(s) it failed on, lifted verbatim from the tester's verdict
+    # line, so the required check downstream can name the real cause instead of guessing one.
+    # Empty whenever the gate died before producing a verdict (checkout fault, missing tester) —
+    # consumers must degrade to "see the job", never to an invented cause.
+    outputs:
+      failure: ${{ steps.gate.outputs.failure }}
     steps:
     - uses: actions/checkout@v6
       with: { fetch-depth: 1 }
@@ -829,6 +835,7 @@ jobs:
         ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
         fetch-depth: 1
     - name: "Compile + run the VITAL plugins against this PR"
+      id: gate
       env:
         # 🚨 The vital organs only — NOT the whole repo. This gate sits in the PR critical path,
         # so it buys the most breakage-detection per minute rather than maximum coverage:
@@ -865,7 +872,40 @@ jobs:
         # plugin-gate.allow is the plugins repo's known-debt ratchet: listed failures are
         # tolerated, NEW failures fail this PR. Same one-way contract the plugins CI uses, so the
         # two gates cannot disagree about what is acceptable.
-        time dotnet "$TESTER" "$STAGE" --allow "$STAGE/plugin-gate.allow"
+        #
+        # 🚨 The run is TEED, not swallowed: the log still streams to the job, and the copy is read
+        # afterwards for the tester's verdict line. `if !` (not `set +e`) so `set -e` stays armed
+        # for everything else, and PIPESTATUS[0] is the TESTER's code — tee always exits 0.
+        log="${RUNNER_TEMP:-/tmp}/plugin-gate.log"
+        status=0
+        if ! time dotnet "$TESTER" "$STAGE" --allow "$STAGE/plugin-gate.allow" 2>&1 | tee "$log"; then
+          status="${PIPESTATUS[0]}"
+          # tee always exits 0, so a non-zero pipeline with a zero head means tee itself failed.
+          if [ "$status" = "0" ]; then status=1; fi
+        fi
+        # The tester's verdict line IS the message — `GATE FAILED — tests: Store/Catalog — 1 new
+        # failure(s), …` (GateReport.FailedPrefix). Lifted verbatim: nothing here re-derives or
+        # re-words a cause, which is exactly how this job came to annotate a `tests` failure as
+        # "does not compile — a public API changed" and send investigators to diff public
+        # signatures that were fine (#1077).
+        verdict="$(grep -m1 -- '^GATE FAILED —' "$log" || true)"
+        # Multi-line-safe even though the verdict is one line: a bare KEY=VALUE with an unexpected
+        # newline would corrupt every later output in the file.
+        {
+          echo "failure<<GATE_EOF"
+          echo "$verdict"
+          echo "GATE_EOF"
+        } >> "$GITHUB_OUTPUT"
+        if [ "$status" != "0" ]; then
+          if [ -n "$verdict" ]; then
+            echo "::error::$verdict"
+          else
+            # No verdict = the gate died before judging anything (missing tester, install fault,
+            # crash). Say THAT — an unexplained failure is cheaper than a wrong explanation.
+            echo "::error::The plugins gate failed before it produced a verdict — no check was judged. See this job's log."
+          fi
+          exit "$status"
+        fi
 
   collect-results:
     name: "Consolidate test results"
@@ -1033,10 +1073,40 @@ jobs:
     # 🚨 `needs:` alone is NOT enough: this job runs with `if: always()`, so a failed dependency
     # does not fail it — it would report success while the plugins are broken, which is precisely
     # the silent-green failure the gate exists to end.
+    # 🚨 NAME THE PHASE THAT FAILED — never a guessed cause. The gate judges three checks per node
+    # (compile / render / tests) and its verdict line says which one failed on which node; this
+    # step relays that line verbatim. The message it replaced asserted ONE cause for all three:
+    #
+    #     "MeshWeaver.Plugins does not compile against this PR … A public API change here breaks
+    #      plugin node source that is Roslyn-compiled at runtime"
+    #
+    # …which is the most expensive wrong lead available. A public-API break here genuinely DOES
+    # break that repo — plugin node source is Roslyn-compiled from mesh content, so a repo-local
+    # `rg` can never prove a deletion safe (that is how `AddSkillSource` broke 8 NodeTypes). So the
+    # claim reads as authoritative and sends the investigator to diff public signatures. On
+    # 2026-08-10 it did exactly that for a `Store/Catalog` verdict of `compile=Ok render=ok
+    # tests=FAILED`, on PR #1043 whose whole diff was MessageService.cs plus two test files
+    # (issue #1077). Keep the API sentence CONDITIONAL on the phase actually being `compile`.
     - name: Fail if the plugin gate failed
       if: needs.plugin-gate.result == 'failure'
+      env:
+        # Empty when the gate produced no verdict (it died before judging), and — depending on how
+        # GitHub propagates a failed job's outputs — possibly empty even when it did. Both degrade
+        # to "see the job", which is true either way.
+        GATE_VERDICT: ${{ needs.plugin-gate.outputs.failure }}
       run: |
-        echo "::error::MeshWeaver.Plugins does not compile against this PR — see the 'Plugins compile against this PR' job. A public API change here breaks plugin node source that is Roslyn-compiled at runtime from the plugins repo."
+        set -uo pipefail
+        verdict="$(printf '%s' "${GATE_VERDICT}" | head -1)"
+        if [ -n "$verdict" ]; then
+          echo "::error::The plugins gate failed: ${verdict} — see the 'Plugins compile against this PR' job."
+        else
+          echo "::error::The plugins gate failed — see the 'Plugins compile against this PR' job for the failing check (compile / render / tests) and the node(s) it failed on."
+        fi
+        case "$verdict" in
+          *compile:*)
+            echo "::error::A failing 'compile' check means a public API change here broke plugin node source that is Roslyn-compiled at runtime from the plugins repo."
+            ;;
+        esac
         exit 1
 
     # ── …and a missing CI INPUT decides it too ──────────────────────────────────────────────

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -888,7 +888,7 @@ jobs:
         # re-words a cause, which is exactly how this job came to annotate a `tests` failure as
         # "does not compile — a public API changed" and send investigators to diff public
         # signatures that were fine (#1077).
-        verdict="$(grep -m1 -- '^GATE FAILED —' "$log" || true)"
+        verdict="$(grep -m1 -- '^GATE FAILED' "$log" || true)"
         # Multi-line-safe even though the verdict is one line: a bare KEY=VALUE with an unexpected
         # newline would corrupt every later output in the file.
         {

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -461,6 +461,20 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// BEFORE writing its root, so any routed touch inside that window fabricated the
     /// placeholder, and the fabrication outlived every later write.
     /// Repro: <c>PathResolutionCachePoisonTest.SynthesizedPartitionRoot_IsNotCached</c>.</para>
+    ///
+    /// <para>🚨 NOT cached is not the same as NOT pinned, and the difference is still open.
+    /// The identical symptom recurred on 2026-08-10 (gate run 31361446933) on a commit that
+    /// already carried the no-cache fix, listing exactly this default set again. Whoever routes
+    /// on a synthesized resolution ACTIVATES a hub, and that hub is pinned by address in
+    /// <c>Mesh.GetHostedHub</c> — an instance hub never re-reads its node's NodeType, so it keeps
+    /// serving the default configuration for the life of the process even though every later
+    /// RESOLUTION is now correct. The fabrication is no longer the thing that outlives the write;
+    /// the HUB it activated is. So when this symptom reappears, check THREE things: is the
+    /// resolution for the bare root path serving a real node, was the hub recycled after the root
+    /// was retyped (<c>PackageInstaller</c> posts a <c>DisposeRequest</c> — fire-and-forget, and
+    /// only when the placeholder dance ran), and is the live hub the one that was activated inside
+    /// the provisioning window? Issue #1077 carries the analysis; the plugin gate now prints WHICH
+    /// node hosted the failing area, which is what makes that third question answerable.</para>
     /// </summary>
     private IObservable<AddressResolution?> SynthesizePartitionRoot(string[] segments)
     {

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1512,9 +1512,22 @@ public static class PackageInstaller
                     // the same fabrication. Partition provisioning runs BEFORE the root write, so
                     // any routed touch inside that window fabricated it. Fixed at the source —
                     // synthesized resolutions are never cached, and a fill that lands after its
-                    // own invalidation is discarded (PathResolutionCachePoisonTest). If this
-                    // symptom ever reappears, check BOTH: is the hub recycled, and is the
-                    // resolution for the bare root path serving a real node?
+                    // own invalidation is discarded (PathResolutionCachePoisonTest).
+                    //
+                    // 🚨 …and it recurred AGAIN on 2026-08-10 (gate run 31361446933) on a commit
+                    // that already carried that fix, with the same available-areas list: exactly
+                    // ConfigureDefaultNodeHub's set (AddDefaultLayoutAreas + Invite), so the hub
+                    // was serving the mesh DEFAULT configuration — not Store/Catalog's, not even
+                    // the Space placeholder's. The residual is that a hub, once activated, is
+                    // pinned by address in Mesh.GetHostedHub and never re-reads its node's
+                    // NodeType: fixing the RESOLUTION does not un-pin the HUB the bad resolution
+                    // already activated. This Dispose is the only thing that does, and it is
+                    // fire-and-forget AND conditional on the placeholder dance having run. So when
+                    // the symptom reappears, check THREE things: is the resolution for the bare
+                    // root path serving a real node, did this recycle run, and is the live hub the
+                    // one activated inside the provisioning window? Issue #1077 carries the
+                    // analysis; the plugin gate now names the node that hosted the failing area,
+                    // which is what makes the third question answerable from CI alone.
                     .Select(rest =>
                     {
                         if (placeholderRoot is not null && root is not null)

--- a/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
@@ -1,0 +1,210 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The gate's verdict LINE, pinned against drift — because CI lifts it verbatim into the failure
+/// annotation on the PR (<c>.github/workflows/dotnet-test.yml</c>, the plugin-gate step greps
+/// <see cref="GateReport.FailedPrefix"/>).
+///
+/// <para>🚨 What these tests exist to prevent: a message that names a cause the report does not
+/// support. The gate judges three checks per node — compile, render, tests — and CI used to
+/// annotate ALL of them as <i>"MeshWeaver.Plugins does not compile against this PR … A public API
+/// change here breaks plugin node source"</i>. On 2026-08-10 that fired for a verdict of
+/// <c>Store/Catalog: compile=Ok render=ok tests=FAILED</c>: nothing failed to compile, and the
+/// annotation sent investigators to diff public signatures on a PR whose whole diff was
+/// <c>MessageService.cs</c> plus two test files (issue #1077). The wrong lead is expensive
+/// precisely because a public-API break here IS a real way to break that repo — so the claim reads
+/// as authoritative. Every assertion below is therefore two-sided: the line must name the check
+/// that failed AND must not name one that did not.</para>
+/// </summary>
+public class GateSummaryTest
+{
+    private static NodeTypeResult Type(string path, CheckOutcome compile, CheckOutcome render,
+        CheckOutcome tests) =>
+        new(path, path.Split('/')[0])
+        {
+            Compile = compile,
+            CompileDetail = compile == CheckOutcome.Failed ? "CS0103: name not found" : null,
+            Render = render,
+            RenderDetail = render == CheckOutcome.Failed ? "This area failed to render" : null,
+            Tests = tests,
+            TestsDetail = tests == CheckOutcome.Failed ? "**Area not found**" : null,
+        };
+
+    private static GateReport Report(params NodeTypeResult[] types) =>
+        new([new PackageResult(types.FirstOrDefault()?.Package ?? "Store")
+        {
+            NodeCount = 97,
+            NodeTypes = [.. types],
+        }]);
+
+    private static string Summarize(GateReport report, GateVerdict? verdict = null)
+    {
+        var output = new StringWriter();
+        report.WriteSummary(output, verdict);
+        return output.ToString();
+    }
+
+    private static string VerdictLine(string summary) =>
+        summary.ReplaceLineEndings("\n").Split('\n')
+            .Single(l => l.StartsWith(GateReport.FailedPrefix, StringComparison.Ordinal));
+
+    // ── the exact shape that misled: tests failed, compile was fine ───────────────────────────
+
+    [Fact]
+    public void TestsFailure_NamesTests_AndNeverCompile()
+    {
+        var report = Report(Type("Store/Catalog",
+            CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed));
+
+        var line = VerdictLine(Summarize(report));
+
+        Assert.Contains("tests: Store/Catalog", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("compile", line, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TestsFailure_WithAllowlist_NamesTests_AndNeverCompile()
+    {
+        // The armed path CI actually runs: --allow is always passed, so the verdict — not the raw
+        // report — decides. This is the line that was annotated as a compile break.
+        var report = Report(Type("Store/Catalog",
+            CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed));
+        var verdict = GateVerdict.Evaluate(report, GateAllowlist.Empty);
+
+        var line = VerdictLine(Summarize(report, verdict));
+
+        Assert.StartsWith(GateReport.FailedPrefix, line, StringComparison.Ordinal);
+        Assert.Contains("tests: Store/Catalog", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("compile", line, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1 new failure(s)", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompileFailure_NamesCompile()
+    {
+        var report = Report(Type("Store/Plugin",
+            CheckOutcome.Failed, CheckOutcome.Skipped, CheckOutcome.Skipped));
+
+        var line = VerdictLine(Summarize(report));
+
+        Assert.Contains("compile: Store/Plugin", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("tests:", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryFailingCheck_IsNamed_InPipelineOrder()
+    {
+        var report = Report(
+            Type("Store/Order", CheckOutcome.Failed, CheckOutcome.Skipped, CheckOutcome.Skipped),
+            Type("Store/Coupon", CheckOutcome.Passed, CheckOutcome.Failed, CheckOutcome.Skipped),
+            Type("Store/Catalog", CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed));
+
+        var line = VerdictLine(Summarize(report));
+
+        Assert.Contains("compile: Store/Order", line, StringComparison.Ordinal);
+        Assert.Contains("render: Store/Coupon", line, StringComparison.Ordinal);
+        Assert.Contains("tests: Store/Catalog", line, StringComparison.Ordinal);
+        Assert.True(line.IndexOf("compile:", StringComparison.Ordinal)
+                    < line.IndexOf("render:", StringComparison.Ordinal));
+        Assert.True(line.IndexOf("render:", StringComparison.Ordinal)
+                    < line.IndexOf("tests:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SameCheck_OnSeveralNodes_ListsThemAll()
+    {
+        var report = Report(
+            Type("Store/Catalog", CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed),
+            Type("Store/Plugin", CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed));
+
+        var line = VerdictLine(Summarize(report));
+
+        Assert.Contains("tests: Store/Catalog, Store/Plugin", line, StringComparison.Ordinal);
+    }
+
+    // ── the failures that are NOT a per-node check ────────────────────────────────────────────
+
+    [Fact]
+    public void FatalError_SaysFatal_NotAFailingCheck()
+    {
+        // A fatal error used to render as "GATE FAILED — 0 new failure(s), 0 stale allow
+        // entr(ies)" — a failing gate reporting nothing failing.
+        var report = new GateReport([]) { FatalError = "IOException: repo root not found\n at …" };
+        var verdict = GateVerdict.Evaluate(report, GateAllowlist.Empty);
+
+        var line = VerdictLine(Summarize(report, verdict));
+
+        Assert.Contains("fatal: IOException: repo root not found", line, StringComparison.Ordinal);
+        // Only the first line of the error — a stack trace would swallow the annotation.
+        Assert.DoesNotContain(" at …", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaleAllowEntry_IsNamedAsSuch_NotAsAFailingCheck()
+    {
+        var green = Report(Type("Store/Catalog",
+            CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Passed));
+        var verdict = GateVerdict.Evaluate(green, GateAllowlist.Parse(["Store/Catalog tests"]));
+
+        var line = VerdictLine(Summarize(green, verdict));
+
+        Assert.Contains("stale allow entr(ies): Store/Catalog tests", line, StringComparison.Ordinal);
+        Assert.Contains("0 new failure(s)", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void KnownDebt_IsNotNamed_ItDidNotFailTheRun()
+    {
+        // Debt is tolerated, so it is not what failed — naming it would send the investigator at
+        // an entry that is deliberately on the list.
+        var report = Report(
+            Type("Store/Catalog", CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed),
+            Type("Store/Plugin", CheckOutcome.Failed, CheckOutcome.Skipped, CheckOutcome.Skipped));
+        var verdict = GateVerdict.Evaluate(report, GateAllowlist.Parse(["Store/Catalog tests"]));
+
+        var line = VerdictLine(Summarize(report, verdict));
+
+        Assert.Contains("compile: Store/Plugin", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("Store/Catalog", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoRecordedFailure_SaysSo_RatherThanGuessing()
+    {
+        // Defensive: if the run fails with nothing recorded, the line must admit that rather than
+        // pick a phase. An unexplained failure is cheaper than a confidently wrong explanation.
+        var report = new GateReport([]) { FatalError = null };
+        var verdict = new GateVerdict([], [], [], []);
+
+        Assert.Equal("no failing check was recorded", GateVerdict.Headline(report, verdict));
+    }
+
+    // ── the Tests host: which node actually ran the area ──────────────────────────────────────
+
+    [Fact]
+    public void TestsHost_IsPrinted_SoAreaNotFoundIsDiagnosable()
+    {
+        // "No renderer is registered for area `Tests` on hub `Store`" is unreadable without
+        // knowing WHY the gate probed `Store`: a type's Tests area is served by instance hubs, so
+        // the host is either an instance already in the mesh or a probe the gate created — and
+        // only the first can carry a hub activated before the install finished.
+        var report = Report(Type("Store/Catalog",
+            CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed) with
+        {
+            TestsHost = "Store — an instance of Store/Catalog already in the mesh",
+        });
+
+        var summary = Summarize(report);
+
+        Assert.Contains("Tests host: Store — an instance of Store/Catalog already in the mesh",
+            summary, StringComparison.Ordinal);
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
@@ -192,19 +192,25 @@ public class GateSummaryTest
     [Fact]
     public void TestsHost_IsPrinted_SoAreaNotFoundIsDiagnosable()
     {
-        // "No renderer is registered for area `Tests` on hub `Store`" is unreadable without
-        // knowing WHY the gate probed `Store`: a type's Tests area is served by instance hubs, so
-        // the host is either an instance already in the mesh or a probe the gate created — and
-        // only the first can carry a hub activated before the install finished.
+        // "No renderer is registered for area `Tests` on hub `X`" is unreadable without knowing
+        // which node X was — a type's Tests area is served by INSTANCE hubs, never by the type
+        // node, so the hub named in the error is never the type under test. Reading the original
+        // failure without this line produced the wrong conclusion twice over: that the gate had
+        // probed a type path (it had not), and that the plugin was broken (it was not).
+        //
+        // The string is the shape PluginGateRunner.RenderGate actually emits for the probe host
+        // CreateTestsProbe returns — keep the two in step, or this documents a host that cannot
+        // occur.
         var report = Report(Type("Store/Catalog",
             CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Failed) with
         {
-            TestsHost = "Store — an instance of Store/Catalog already in the mesh",
+            TestsHost = "Store/Catalog/GateProbe — the probe instance the gate created for this check",
         });
 
         var summary = Summarize(report);
 
-        Assert.Contains("Tests host: Store — an instance of Store/Catalog already in the mesh",
+        Assert.Contains(
+            "Tests host: Store/Catalog/GateProbe — the probe instance the gate created for this check",
             summary, StringComparison.Ordinal);
     }
 }

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -116,6 +116,56 @@ public sealed record GateVerdict(
     /// the report carries that separately).</summary>
     public bool Success => NewFailures.Count == 0 && Stale.Count == 0;
 
+    /// <summary>
+    /// The one-line, phase-accurate account of WHY the run failed: which check (install /
+    /// idempotence / compile / render / tests) failed, on which scope(s) — plus a fatal error or
+    /// stale allow entries when those are what failed the run.
+    ///
+    /// <para>🚨 It names only what the report RECORDS. The message this replaced asserted a cause
+    /// ("does not compile — a public API changed") that the report frequently contradicted: the
+    /// 2026-08-10 <c>Store/Catalog</c> RED read <c>compile=Ok render=ok tests=FAILED</c> while CI
+    /// annotated it as a compile break, sending every investigator to diff public signatures that
+    /// were fine (issue #1077). A failure with no recorded failing check says exactly that rather
+    /// than guessing — an unexplained failure is cheaper than a confidently wrong explanation.</para>
+    /// </summary>
+    /// <param name="report">The run's report.</param>
+    /// <param name="verdict">The allowlist verdict, when one was applied — its NEW failures are
+    /// what failed the run; known debt did not.</param>
+    public static string Headline(GateReport report, GateVerdict? verdict = null)
+    {
+        var parts = new List<string>();
+        if (report.FatalError is not null)
+            parts.Add($"fatal: {FirstLine(report.FatalError)}");
+
+        var failures = verdict is not null
+            ? verdict.NewFailures
+            : Failures(report).ToList();
+        foreach (var check in CheckOrder)
+        {
+            var scopes = failures
+                .Where(f => string.Equals(f.Check, check, StringComparison.OrdinalIgnoreCase))
+                .Select(f => f.Scope)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (scopes.Count > 0)
+                parts.Add($"{check}: {string.Join(", ", scopes)}");
+        }
+
+        if (verdict is { Stale.Count: > 0 })
+            parts.Add($"stale allow entr(ies): {string.Join(", ", verdict.Stale)}");
+
+        return parts.Count > 0
+            ? string.Join("; ", parts)
+            : "no failing check was recorded";
+    }
+
+    /// <summary>The checks in pipeline order — the order <see cref="Headline"/> lists them in.</summary>
+    private static readonly string[] CheckOrder =
+        ["install", "idempotence", "compile", "render", "tests"];
+
+    private static string FirstLine(string text) =>
+        text.ReplaceLineEndings("\n").Split('\n')[0];
+
     private static IEnumerable<GateFailure> Failures(GateReport report)
     {
         foreach (var package in report.Packages)

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -41,6 +41,16 @@ public sealed record NodeTypeResult(string Path, string Package)
     /// <summary>The Tests verdict detail (the pass/fail summary, or the red rows).</summary>
     public string? TestsDetail { get; init; }
 
+    /// <summary>
+    /// WHICH node hosted the <c>Tests</c> run, and how the gate picked it — a shipped instance or
+    /// the throwaway probe it created. A type's <c>Tests</c> area is served by INSTANCE hubs, never
+    /// by the type node, so "Area not found" is only diagnosable together with the host: without
+    /// this line the 2026-08-10 <c>Store/Catalog</c> RED was read as "the probe landed on a type
+    /// path" when it had in fact landed on a correctly-typed shipped instance whose hub was serving
+    /// the mesh default configuration (issue #1077).
+    /// </summary>
+    public string? TestsHost { get; init; }
+
     /// <summary>True when no gate check failed.</summary>
     public bool Success =>
         Compile != CheckOutcome.Failed
@@ -117,13 +127,15 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
                     output.WriteLine(Indent(type.CompileDetail));
                 if (type.RenderDetail is not null)
                     output.WriteLine(Indent(type.RenderDetail));
+                if (type.TestsHost is not null)
+                    output.WriteLine(Indent($"Tests host: {type.TestsHost}"));
                 if (type.TestsDetail is not null)
                     output.WriteLine(Indent(type.TestsDetail));
             }
         }
         if (verdict is null)
         {
-            output.WriteLine(Success ? "ALL GREEN." : "GATE FAILED.");
+            output.WriteLine(Success ? "ALL GREEN." : $"{FailedPrefix} {GateVerdict.Headline(this)}.");
             return;
         }
         foreach (var entry in verdict.Stale)
@@ -135,8 +147,17 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
             ? verdict.KnownDebt.Count == 0
                 ? "ALL GREEN."
                 : $"GREEN — {verdict.KnownDebt.Count} known-debt failure(s) allowed (shrinking list)."
-            : $"GATE FAILED — {verdict.NewFailures.Count} new failure(s), {verdict.Stale.Count} stale allow entr(ies).");
+            : $"{FailedPrefix} {GateVerdict.Headline(this, verdict)} — " +
+              $"{verdict.NewFailures.Count} new failure(s), {verdict.Stale.Count} stale allow entr(ies).");
     }
+
+    /// <summary>
+    /// The stable prefix of the ONE line CI lifts verbatim into its failure annotation. The whole
+    /// line is the message — no parsing, so the annotation cannot drift out of step with the
+    /// verdict. Changing this literal changes the workflow's grep: keep the two in step
+    /// (<c>.github/workflows/dotnet-test.yml</c>, the plugin-gate step).
+    /// </summary>
+    public const string FailedPrefix = "GATE FAILED —";
 
     private static string Label(PackageResult package, GateVerdict? verdict)
     {

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -135,7 +135,7 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
         }
         if (verdict is null)
         {
-            output.WriteLine(Success ? "ALL GREEN." : $"{FailedPrefix} {GateVerdict.Headline(this)}.");
+            output.WriteLine(Success ? "ALL GREEN." : $"{FailedPrefix} — {GateVerdict.Headline(this)}");
             return;
         }
         foreach (var entry in verdict.Stale)
@@ -147,17 +147,19 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
             ? verdict.KnownDebt.Count == 0
                 ? "ALL GREEN."
                 : $"GREEN — {verdict.KnownDebt.Count} known-debt failure(s) allowed (shrinking list)."
-            : $"{FailedPrefix} {GateVerdict.Headline(this, verdict)} — " +
+            : $"{FailedPrefix} — {GateVerdict.Headline(this, verdict)} — " +
               $"{verdict.NewFailures.Count} new failure(s), {verdict.Stale.Count} stale allow entr(ies).");
     }
 
     /// <summary>
     /// The stable prefix of the ONE line CI lifts verbatim into its failure annotation. The whole
     /// line is the message — no parsing, so the annotation cannot drift out of step with the
-    /// verdict. Changing this literal changes the workflow's grep: keep the two in step
-    /// (<c>.github/workflows/dotnet-test.yml</c>, the plugin-gate step).
+    /// verdict. Deliberately ASCII: <c>.github/workflows/dotnet-test.yml</c> greps
+    /// <c>^GATE FAILED</c>, so re-punctuating the line cannot silently unhook the annotation and
+    /// leave CI back on a guessed cause. Changing this literal changes that grep — keep them in
+    /// step.
     /// </summary>
-    public const string FailedPrefix = "GATE FAILED —";
+    public const string FailedPrefix = "GATE FAILED";
 
     private static string Label(PackageResult package, GateVerdict? verdict)
     {

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -285,17 +285,42 @@ public static class PluginGateRunner
                 if (!type.DeclaresTestsArea)
                     return Observable.Return(afterRender with { Tests = CheckOutcome.Skipped });
                 return ResolveTestsHost(harness, type.Path)
-                    .SelectMany(hostPath => AreaProbe.ExecuteTestsArea(
-                        harness.Client, hostPath, options.RenderTimeout))
-                    .Catch((Exception ex) => Observable.Return(new AreaVerdict(
-                        CheckOutcome.Failed,
-                        $"could not execute Tests area: {ex.GetType().Name}: {ex.Message}")))
-                    .Select(tests => afterRender with
+                    // Bounded: the host lookup queries the (eventually consistent) index and may
+                    // create a node — both are message round-trips with no budget of their own, and
+                    // an unbounded wait here would spend the whole JOB timeout and report nothing.
+                    // Same budget as the render it feeds; a resolve is sub-second when it works.
+                    .Timeout(options.RenderTimeout)
+                    .Catch((TimeoutException _) => Observable.Return(new TestsHost(
+                        Path: null,
+                        Description: $"unresolved — no Tests host within " +
+                                     $"{options.RenderTimeout.TotalSeconds:F0}s (neither a shipped " +
+                                     $"instance of {type.Path} nor a created probe)")))
+                    .SelectMany(host => (host.Path is null
+                            ? Observable.Return(new AreaVerdict(
+                                CheckOutcome.Failed, "no host to execute the Tests area on"))
+                            : AreaProbe.ExecuteTestsArea(
+                                harness.Client, host.Path, options.RenderTimeout))
+                        .Catch((Exception ex) => Observable.Return(new AreaVerdict(
+                            CheckOutcome.Failed,
+                            $"could not execute Tests area: {ex.GetType().Name}: {ex.Message}")))
+                        .Select(tests => afterRender with
+                        {
+                            Tests = tests.Outcome,
+                            TestsDetail = tests.Detail,
+                            TestsHost = host.Description,
+                        }))
+                    .Catch((Exception ex) => Observable.Return(afterRender with
                     {
-                        Tests = tests.Outcome,
-                        TestsDetail = tests.Detail,
-                    });
+                        Tests = CheckOutcome.Failed,
+                        TestsDetail = $"could not resolve a Tests host: " +
+                                      $"{ex.GetType().Name}: {ex.Message}",
+                    }));
             });
+
+    /// <summary>The node whose hub runs a type's <c>Tests</c> area, and how the gate picked it.</summary>
+    /// <param name="Path">The host node's path; null when no host could be resolved.</param>
+    /// <param name="Description">The human-readable account printed in the report.</param>
+    private sealed record TestsHost(string? Path, string Description);
 
     /// <summary>
     /// The node whose hub serves the type's <c>Tests</c> area: the area is registered by the
@@ -303,8 +328,16 @@ public static class PluginGateRunner
     /// served by the NodeType editor). Prefers an instance the package ships; otherwise creates
     /// a throwaway probe instance under the type path (system-impersonated — the same footing
     /// as the install).
+    ///
+    /// <para>🚨 The two branches are NOT equivalent, so the report names which one ran. A shipped
+    /// instance can be a node whose hub was activated earlier in the install — e.g. a package ROOT
+    /// retyped to the package's own NodeType, activated while it was still the Space placeholder —
+    /// and an instance hub never re-binds its configuration, so it can serve only the framework's
+    /// default areas while the type's own are missing. A freshly created probe cannot be in that
+    /// state. That is the difference between the same commit's green and red gate runs, and
+    /// without the host in the report the RED reads as "the plugin is broken" (issue #1077).</para>
     /// </summary>
-    private static IObservable<string> ResolveTestsHost(GateMesh harness, string typePath)
+    private static IObservable<TestsHost> ResolveTestsHost(GateMesh harness, string typePath)
     {
         var meshService = harness.ServiceProvider.GetRequiredService<IMeshService>();
         return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{typePath}"))
@@ -316,7 +349,10 @@ public static class PluginGateRunner
                     .OrderBy(n => n.Path, StringComparer.Ordinal)
                     .FirstOrDefault();
                 if (shipped is not null)
-                    return Observable.Return(shipped.Path);
+                    return Observable.Return(new TestsHost(
+                        shipped.Path,
+                        $"{shipped.Path} — an instance of {typePath} already in the mesh " +
+                        $"({change.Items.Count} candidate(s)); its hub may predate this install"));
 
                 var probePath = $"{typePath}/GateProbe";
                 var probe = new MeshNode("GateProbe", typePath)
@@ -330,7 +366,10 @@ public static class PluginGateRunner
                 return Observable.Using(
                         () => access.ImpersonateAsSystem(),
                         _ => meshService.CreateNode(probe))
-                    .Select(created => created.Path);
+                    .Select(created => new TestsHost(
+                        created.Path,
+                        $"{created.Path} — a throwaway probe instance the gate created " +
+                        $"(no instance of {typePath} was visible)"));
             });
     }
 


### PR DESCRIPTION
Fixes #1077

## 1. The message named a cause the report contradicted

The gate judges three checks per NodeType — **compile**, **render**, **tests** — and its own log says which failed:

```
RED Store/Catalog: compile=Ok render=ok tests=FAILED
    **Area not found**
    No renderer is registered for area `Tests` on hub `Store`.
```

CI annotated that as *"MeshWeaver.Plugins does not compile against this PR … A public API change here breaks plugin node source that is Roslyn-compiled at runtime."* One message for all three checks, asserting a cause the report contradicts — and the **most expensive wrong lead available**, because it is plausible: a public-API break here genuinely does break that repo (plugin node source is Roslyn-compiled from mesh content, so a repo-local `rg` can never prove a deletion safe — that is how `AddSkillSource` broke 8 NodeTypes). So the claim reads as authoritative and the investigator goes to diff public signatures. It did exactly that on #1043, whose whole diff was `MessageService.cs` and two test files.

Now the tester emits one verdict line naming the failing check and the node(s):

```
GATE FAILED — tests: Store/Catalog — 1 new failure(s), 0 stale allow entr(ies).
```

CI lifts that line **verbatim** — it does not re-derive or re-word a cause — and the public-API sentence is kept, **conditional on the phase actually being `compile`**. Two failures previously reported as "0 new failure(s)" now name themselves: a fatal error says `fatal: …`, a stale allow entry says so. A run that fails with nothing recorded says `no failing check was recorded` rather than picking a phase.

`GateSummaryTest` pins each of these **two-sided**: the line must name the check that failed *and* must not name one that did not — a message that can drift back is the thing being fixed. CI's grep is anchored on `^GATE FAILED` (the `GateReport.FailedPrefix` constant, ASCII), so re-punctuating the line cannot silently unhook the annotation.

## 2. The `Store/Catalog` failure is a framework defect, not plugin rot — and not the probe path

The hypothesis in the issue (the probe landed on a *type* path, where "Area not found" is by design) does not hold. `Store` is the Store package's **root**, retyped to `Store/Catalog` by the installer — a correctly-typed instance. The evidence is the available-areas list the failure printed: item for item it is `ConfigureDefaultNodeHub`'s set — `AddDefaultLayoutAreas` (incl. `AddEducationLayoutAreas`' CourseNav/Learn/StartExercise/GoToMyCopy and `AddDomainLayoutAreas`' Catalog/Details/DataModel) plus Invite. **Not one area from `Store/Catalog`'s compiled configuration, and not the Space placeholder's either.** Hub `Store` was serving the mesh **default** configuration: the known partition-root defect (#1055, and 2026-07-29 before it).

It recurred on a commit that already carried #1055's fix (run `31361446933` at 06:18Z; #1055 merged 04:39Z). **NOT cached is not NOT pinned**: a hub is pinned by address in `Mesh.GetHostedHub` and never re-reads its node's NodeType, so fixing the *resolution* does not un-pin the hub a bad resolution already activated. The only thing that does is `PackageInstaller`'s `DisposeRequest` — fire-and-forget, and conditional on the placeholder dance having run. That residual is **not fixed here** (it needs a repro and a design decision, not a guess); it is written into both comment blocks that carry this ledger, which now ask three questions instead of two.

The gate now prints **which** node hosted the Tests run and how it was picked (an instance already in the mesh vs. a throwaway probe it created) — the two are not equivalent, and that difference is what separates the same commit's green and red runs. That line is what makes the third question answerable from CI alone. The host resolution is also **bounded** now: it queries the index and may create a node, neither with a budget of its own, so a wedge there spent the whole job timeout and reported nothing.

## Not done

No `continue-on-error`, no retry around the probe, no widened timeout, no allow-list entry for `Store/Catalog`. The gate still fails exactly when it failed before — it just says what failed.

## Verification

- `MeshWeaver.PluginTester.Test`: 28/28 pass (12 new).
- `mw-plugin-test` run end-to-end against an empty root: emits `GATE FAILED — fatal: …`, exit 1 — the line CI greps, produced by the real binary.
- `-c Release -warnaserror` clean: `MeshWeaver.PluginTester`, `MeshWeaver.PluginTester.Test`, `MeshWeaver.PluginCatalog`, `MeshWeaver.Hosting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)