### PR TITLE
A hub activated on the wrong NodeType now lets go of it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-picks-up-its-type-without-a-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-picks-up-its-type-without-a-restart.md
@@ -1,0 +1,29 @@
+---
+Name: A page picks up its type without a restart
+Category: Fix
+Description: When a node's type arrives or changes — a plugin finishing its install, an import landing, someone switching a node's type — the page now rebuilds itself on the new type instead of serving the old one until the portal is restarted.
+Icon: Sparkle
+Order: -20260810
+---
+
+# A page picks up its type without a restart
+
+Every node in the portal is backed by its own small server that decides, once, which pages and
+views the node offers. It makes that decision from the node's type at the moment it starts — and
+then it never looked again. If the node's type arrived or changed afterwards, the server kept
+handing out the pages it had chosen at the start, for as long as it stayed up.
+
+Most of the time that is invisible, because the type is set before anyone opens the node. It became
+visible when a plugin installed. Installing a plugin creates the space for it a moment before it
+writes the plugin's own root, so anything that touched the new space inside that gap — a background
+sync, a nav refresh, someone clicking the link early — started the server while the root still had
+no type. When the install then finished and gave the root its real type, the server did not notice:
+the plugin's own pages were simply missing, and the node showed only the generic pages every node
+has. Opening it again did not help, because "again" reached the same server. Only a portal restart
+cleared it.
+
+Now a node's server watches for its own type changing and rebuilds itself when it does. The next
+visit gets the right pages. This is a general fix rather than an install-specific one — the same
+thing happens when an import lands a typed row, when a repair changes a node's type, or when
+someone switches a node's type by hand — and it needs no action from anyone: the page that was
+showing the wrong thing simply starts showing the right thing.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
@@ -42,6 +42,14 @@ internal class MeshNodeHubFactory(
                         enriched.Path, enriched.NodeType);
                 }
 
-                return enriched;
+                // 🚨 The binding above is made ONCE and then PINNED by address: routing
+                // short-circuits on GetHostedHub for an already-hosted address and never resolves
+                // the path again, so nothing re-reads the NodeType for the hub's whole lifetime.
+                // Arm the rebind watcher HERE — the single funnel every activation path (Monolith
+                // routing AND MessageHubGrain) goes through — so a node that acquires or changes
+                // its type recycles its hub instead of serving the wrong configuration forever
+                // (issue #1104). See NodeTypeRebindWatcher for why the mesh change feed, not the
+                // hub's own node stream, is the signal.
+                return NodeTypeRebindWatcher.WithNodeTypeRebind(enriched, meshHub, logger);
             });
 }

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -1,0 +1,149 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Un-pins a per-node hub whose node's <see cref="MeshNode.NodeType"/> changed after the hub was
+/// activated — the fix for issue #1104, <i>"a hub activated on the wrong NodeType stays wrong"</i>.
+///
+/// <para><b>The defect.</b> A per-node hub binds its <c>HubConfiguration</c> from its node's
+/// NodeType EXACTLY ONCE, during activation, and is then PINNED by address in
+/// <c>HostedHubsCollection</c>. Routing short-circuits on <c>Mesh.GetHostedHub(…, Never)</c> for an
+/// already-hosted address, so a hosted hub never resolves its path again and nothing ever re-reads
+/// its NodeType. If the node acquires — or changes — its type while the hub is alive, the hub keeps
+/// serving the configuration it was born with for the rest of its lifetime.</para>
+///
+/// <para><b>Why it bites.</b> A partition's schema is provisioned BEFORE its root node is written,
+/// and <c>PathResolutionService.SynthesizePartitionRoot</c> fabricates a NodeType-less placeholder
+/// so a bare partition path can still answer inside that window. Any routed touch there activates
+/// the root's hub against the mesh <c>DefaultNodeHubConfiguration</c>; the installer's later retype
+/// changes the row and the hub is none the wiser. That is the plugin gate's <c>Store/Catalog</c>
+/// RED — "No renderer is registered for area <c>Tests</c> on hub <c>Store</c>", listing item for
+/// item the framework defaults and not one area of the installed package.</para>
+///
+/// <para><b>Why fixing resolution was not enough.</b> #1055 stopped the fabricated placeholder from
+/// being CACHED, and #815's installer posts a <see cref="DisposeRequest"/> after the retype. Both
+/// are necessary; neither is sufficient. <i>Not cached is not not-pinned</i>: repairing the
+/// resolution path cannot help a hub a bad resolution has ALREADY activated, and the installer's
+/// recycle is fire-and-forget, conditional on the placeholder dance having run, and unavailable to
+/// every other writer that retypes a node (an import, a repair migration, a user). The guarantee
+/// has to live in the framework, at the hub.</para>
+///
+/// <para><b>The mechanism.</b> Every activation arms a watcher on the instance hub (the same
+/// <c>WithInitialization</c> + self-<see cref="DisposeRequest"/> idiom as
+/// <c>NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal</c> and <c>RecycleLayoutArea</c>). It observes
+/// <see cref="IMeshChangeFeed"/> for THIS node's path and recycles the hub the first time an event
+/// reports a NodeType different from the one the configuration was bound from. The hub tears down,
+/// the next access re-activates it, and enrichment binds the node's real type.</para>
+///
+/// <para>🚨 <b>The change feed, never the hub's own node stream.</b> Both would see the retype, but
+/// only the feed sees it POST-COMMIT: <c>StorageAdapterChangeFeedExtensions</c> publishes
+/// Created/Updated strictly after the storage adapter's write emits. Recycling off the hub's own
+/// in-memory commit would race its debounced persist — the re-activation reads the node back
+/// through routing, i.e. through storage, so it would resurrect the PRE-retype node and the fresh
+/// hub would bind the wrong type again (silently, and with the old row now authoritative). That is
+/// the same hazard <c>PackageInstaller.RootRetypePersisted</c> exists for. Using the feed makes the
+/// ordering airtight for free — it is the very event that invalidates
+/// <c>PathResolutionService</c>'s resolution cache, so by the time we recycle, the resolver the
+/// re-activation will consult has already been swept.</para>
+///
+/// <para><b>Blast radius.</b> Disposing a live hub is not free — in-flight subscriptions are torn
+/// down and clients re-subscribe — so the watcher fires only on a genuine change of THIS node's
+/// type, and only once (<c>Take(1)</c>); after the recycle the new hub's baseline IS the new type,
+/// so the predicate cannot re-fire and there is no recycle loop. Content writes, satellite writes,
+/// and writes to other paths are all no-ops for it. Arming costs one filtered subscription on the
+/// process-wide feed subject — no per-hub upstream stream, no poll, no timer.</para>
+/// </summary>
+internal static class NodeTypeRebindWatcher
+{
+    /// <summary>
+    /// Wraps <paramref name="enriched"/>'s HubConfiguration so the hub it activates arms the
+    /// rebind watcher. The baseline is <paramref name="enriched"/>'s own NodeType — the type the
+    /// configuration about to be applied was resolved from.
+    /// </summary>
+    public static MeshNode WithNodeTypeRebind(
+        MeshNode enriched, IMessageHub meshHub, ILogger? logger)
+    {
+        var baseConfig = enriched.HubConfiguration;
+        var path = enriched.Path;
+        var boundNodeType = enriched.NodeType;
+        return enriched with
+        {
+            HubConfiguration = config =>
+                (baseConfig is null ? config : baseConfig(config))
+                    .WithInitialization(instanceHub =>
+                    {
+                        // Fire-and-forget by design: a watcher that cannot be armed must never
+                        // fault hub initialization. Worst case is the pre-fix world (the hub stays
+                        // on its activation-time type until someone recycles it), never a dead hub.
+                        try
+                        {
+                            var feed = meshHub.ServiceProvider.GetService<IMeshChangeFeed>();
+                            if (feed is null)
+                                return;
+                            instanceHub.RegisterForDisposal(
+                                Arm(feed, instanceHub, path, boundNodeType, logger));
+                        }
+                        catch (Exception ex)
+                        {
+                            logger?.LogWarning(ex,
+                                "NodeType rebind: could not arm the watcher for '{Path}' (bound NodeType '{NodeType}')",
+                                path, boundNodeType ?? "(none)");
+                        }
+                    })
+        };
+    }
+
+    /// <summary>
+    /// Watcher core, split out so the firing contract is testable without building a hub
+    /// (exactly as <c>ArmOverlaySelfHeal</c> is). Posts at most ONE self-<see cref="DisposeRequest"/>.
+    /// </summary>
+    public static IDisposable Arm(
+        IMeshChangeFeed feed,
+        IMessageHub instanceHub,
+        string path,
+        string? boundNodeType,
+        ILogger? logger)
+        => Observable.Create<MeshChangeEvent>(observer => feed.Subscribe(observer.OnNext))
+            .Where(change => RequiresRebind(change, path, boundNodeType))
+            .Take(1)
+            .Subscribe(
+                change =>
+                {
+                    // A hub already tearing down needs no recycle, and posting to it would only
+                    // add a delivery the disposal has to drain.
+                    if (instanceHub.IsDisposing)
+                        return;
+                    logger?.LogInformation(
+                        "NodeType rebind: node '{Path}' is now typed '{NewNodeType}' but its hub activated on "
+                        + "'{BoundNodeType}' — recycling so the next access binds the real type",
+                        path, change.NodeType ?? "(none)", boundNodeType ?? "(none)");
+                    instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                },
+                ex => logger?.LogWarning(ex,
+                    "NodeType rebind watcher for '{Path}' faulted — the hub keeps its activation-time "
+                    + "configuration until it is recycled", path));
+
+    /// <summary>
+    /// The firing predicate: a post-commit Created/Updated event for THIS node whose NodeType is
+    /// not the one the hub bound.
+    ///
+    /// <para>Deletes are excluded — a deleted node's hub is torn down by the delete path itself,
+    /// and a <see cref="MeshChangeKind.Deleted"/> event carries no authoritative type. The
+    /// comparison is case-INSENSITIVE because enrichment resolves NodeType paths that way
+    /// (<c>FindStaticNode</c> / the static-provider lookup), so a case-only difference would
+    /// recycle a hub onto the identical configuration.</para>
+    /// </summary>
+    public static bool RequiresRebind(MeshChangeEvent change, string path, string? boundNodeType)
+        => change.Kind is MeshChangeKind.Created or MeshChangeKind.Updated
+            && string.Equals(change.Path, path, StringComparison.Ordinal)
+            && !string.Equals(
+                change.NodeType ?? string.Empty,
+                boundNodeType ?? string.Empty,
+                StringComparison.OrdinalIgnoreCase);
+}

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -115,15 +115,31 @@ internal static class NodeTypeRebindWatcher
             .Subscribe(
                 change =>
                 {
-                    // A hub already tearing down needs no recycle, and posting to it would only
-                    // add a delivery the disposal has to drain.
-                    if (instanceHub.IsDisposing)
-                        return;
-                    logger?.LogInformation(
-                        "NodeType rebind: node '{Path}' is now typed '{NewNodeType}' but its hub activated on "
-                        + "'{BoundNodeType}' — recycling so the next access binds the real type",
-                        path, change.NodeType ?? "(none)", boundNodeType ?? "(none)");
-                    instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                    // 🚨 The handler runs SYNCHRONOUSLY on the PUBLISHER's thread — inside the
+                    // storage write's post-commit Do (StorageAdapterChangeFeedExtensions). A throw
+                    // here would propagate INTO that write and fail an unrelated caller's save, so
+                    // this recycle can never be allowed to escape. It is cheap and non-blocking:
+                    // Post enqueues onto the target's action block, and DisposeRequest is
+                    // [SystemMessage]/[CanBeIgnored], so it needs no AccessContext on a thread that
+                    // carries none.
+                    try
+                    {
+                        // A hub already tearing down needs no recycle, and posting to it would only
+                        // add a delivery the disposal has to drain.
+                        if (instanceHub.IsDisposing)
+                            return;
+                        logger?.LogInformation(
+                            "NodeType rebind: node '{Path}' is now typed '{NewNodeType}' but its hub activated on "
+                            + "'{BoundNodeType}' — recycling so the next access binds the real type",
+                            path, change.NodeType ?? "(none)", boundNodeType ?? "(none)");
+                        instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(ex,
+                            "NodeType rebind: recycling '{Path}' after its retype failed — the hub keeps its "
+                            + "activation-time configuration until it is recycled", path);
+                    }
                 },
                 ex => logger?.LogWarning(ex,
                     "NodeType rebind watcher for '{Path}' faulted — the hub keeps its activation-time "

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -57,7 +57,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// type, and only once (<c>Take(1)</c>); after the recycle the new hub's baseline IS the new type,
 /// so the predicate cannot re-fire and there is no recycle loop. Content writes, satellite writes,
 /// and writes to other paths are all no-ops for it. Arming costs one filtered subscription on the
-/// process-wide feed subject — no per-hub upstream stream, no poll, no timer.
+/// process-wide feed subject — no per-hub upstream stream, no poll, no timer.</para>
 ///
 /// <para><b>The fan-out cost, chosen deliberately.</b> One subscription per live hub means each
 /// published change walks every armed watcher: an enum compare and an ordinal path compare that
@@ -66,7 +66,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// "deliberate: change events are rare relative to resolutions"), and it buys the simplicity of
 /// having NO shared registry — no mesh-scoped path→watcher map to keep in step with hub lifetimes,
 /// nothing to leak when a hub dies without unregistering. If the feed ever becomes hot enough for
-/// this to matter, the fix is a keyed feed, not a cache here.</para></para>
+/// this to matter, the fix is a keyed feed, not a cache here.</para>
 /// </summary>
 internal static class NodeTypeRebindWatcher
 {

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -79,12 +79,23 @@ internal static class NodeTypeRebindWatcher
         MeshNode enriched, IMessageHub meshHub, ILogger? logger)
     {
         var baseConfig = enriched.HubConfiguration;
+        // 🚨 A NULL HubConfiguration MUST SURVIVE. Both activation sites branch on it to activate
+        // the fail-fast NACK-FALLBACK hub — a hub whose UnhandledMessageNack answers every message
+        // with a typed DeliveryFailure naming the node type, and which DeactivateOnIdle's so the
+        // next access retries. Wrapping here would make it non-null unconditionally, killing that
+        // branch and swapping fail-fast for a bare hub that Ignores typed requests: the PARK class
+        // (senders wait out their whole budget instead of getting a diagnostic). That is the exact
+        // rule NodeTypeEnrichmentHelpers.ApplyStreamResult already states for its own wrap — "only
+        // wrap when a hub configuration will actually be composed". Nothing is lost: a hub with no
+        // configuration at all already retries on the next access, so it is never pinned.
+        if (baseConfig is null)
+            return enriched;
         var path = enriched.Path;
         var boundNodeType = enriched.NodeType;
         return enriched with
         {
             HubConfiguration = config =>
-                (baseConfig is null ? config : baseConfig(config))
+                baseConfig(config)
                     .WithInitialization(instanceHub =>
                     {
                         // Fire-and-forget by design: a watcher that cannot be armed must never

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -57,7 +57,16 @@ namespace MeshWeaver.Graph.Configuration;
 /// type, and only once (<c>Take(1)</c>); after the recycle the new hub's baseline IS the new type,
 /// so the predicate cannot re-fire and there is no recycle loop. Content writes, satellite writes,
 /// and writes to other paths are all no-ops for it. Arming costs one filtered subscription on the
-/// process-wide feed subject — no per-hub upstream stream, no poll, no timer.</para>
+/// process-wide feed subject — no per-hub upstream stream, no poll, no timer.
+///
+/// <para><b>The fan-out cost, chosen deliberately.</b> One subscription per live hub means each
+/// published change walks every armed watcher: an enum compare and an ordinal path compare that
+/// fails on the first character for all but one of them. That is the same trade
+/// <c>PathResolutionService.OnMeshChange</c> already makes (a full-dictionary sweep per event,
+/// "deliberate: change events are rare relative to resolutions"), and it buys the simplicity of
+/// having NO shared registry — no mesh-scoped path→watcher map to keep in step with hub lifetimes,
+/// nothing to leak when a hub dies without unregistering. If the feed ever becomes hot enough for
+/// this to matter, the fix is a keyed feed, not a cache here.</para></para>
 /// </summary>
 internal static class NodeTypeRebindWatcher
 {

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -461,6 +461,17 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// BEFORE writing its root, so any routed touch inside that window fabricated the
     /// placeholder, and the fabrication outlived every later write.
     /// Repro: <c>PathResolutionCachePoisonTest.SynthesizedPartitionRoot_IsNotCached</c>.</para>
+    ///
+    /// <para>🚨 <b>Not caching it is necessary, not sufficient — and that is now covered.</b> The
+    /// same symptom recurred on a build that already carried the no-cache fix (#1104), because a
+    /// hub the fabrication had ALREADY activated stays pinned: <c>Mesh.GetHostedHub</c> is keyed
+    /// by address, routing short-circuits on it for a hosted address, and the hub never re-reads
+    /// its NodeType. <i>Not cached is not not-pinned.</i> Repairing resolution can only help the
+    /// NEXT activation. The un-pin is the framework's job and lives in
+    /// <c>NodeTypeRebindWatcher</c>: every activation watches the mesh change feed for its own
+    /// path and recycles the hub the first time the node reports a different NodeType. So the two
+    /// halves are: this method must not PIN a fabrication (here), and a hub bound to one must be
+    /// able to LET GO of it (there).</para>
     /// </summary>
     private IObservable<AddressResolution?> SynthesizePartitionRoot(string[] segments)
     {

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1594,9 +1594,21 @@ public static class PackageInstaller
                     // the same fabrication. Partition provisioning runs BEFORE the root write, so
                     // any routed touch inside that window fabricated it. Fixed at the source —
                     // synthesized resolutions are never cached, and a fill that lands after its
-                    // own invalidation is discarded (PathResolutionCachePoisonTest). If this
-                    // symptom ever reappears, check BOTH: is the hub recycled, and is the
-                    // resolution for the bare root path serving a real node?
+                    // own invalidation is discarded (PathResolutionCachePoisonTest).
+                    //
+                    // 🚨 …and it recurred AGAIN on a build carrying that fix (#1104), because
+                    // fixing RESOLUTION cannot help a hub a bad resolution has ALREADY activated:
+                    // GetHostedHub pins by address and the hub never re-reads its NodeType. That
+                    // is why this Post is no longer where the guarantee lives. It is fire-and-
+                    // forget, conditional on the placeholder dance having run, and available to
+                    // nobody but this installer — while ANY writer can retype a node. The
+                    // framework now un-pins on its own: every activation arms
+                    // NodeTypeRebindWatcher, which recycles the hub the first time the mesh change
+                    // feed reports a different NodeType for its path. This Post stays as the fast
+                    // path (it recycles immediately rather than on the feed hop) and as the marker
+                    // of intent; it is not load-bearing. If the symptom ever reappears, check all
+                    // three: is the hub recycled, is the resolution for the bare root path serving
+                    // a real node, and did the rebind watcher see the retype?
                     .Select(rest =>
                     {
                         if (placeholderRoot is not null && root is not null)

--- a/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for the NodeType rebind watcher
+/// (<see cref="NodeTypeRebindWatcher"/>) — the fix for issue #1104, where a hub activated
+/// against a node with the WRONG (or no) NodeType kept the configuration it was born with for
+/// its whole lifetime, because a hosted hub is pinned by address and routing never resolves its
+/// path again.
+///
+/// <para>The contract pinned here:</para>
+/// <list type="bullet">
+///   <item>A post-commit Created/Updated for THIS node carrying a DIFFERENT NodeType posts a
+///     self-<see cref="DisposeRequest"/> — the <c>RecycleLayoutArea</c> idiom — targeting the
+///     instance hub's OWN address.</item>
+///   <item>Exactly ONCE: a second qualifying event never posts a second recycle, so a flapping
+///     writer cannot turn the watcher into a recycle storm.</item>
+///   <item>Events for OTHER paths (a satellite, a sibling, a child) and events that carry the
+///     SAME type (every ordinary content write) are ignored — those are the overwhelming
+///     majority, and recycling on them would tear down live hubs for nothing.</item>
+///   <item><see cref="MeshChangeKind.Deleted"/> never fires: the delete path tears the hub down
+///     itself and the event carries no authoritative type.</item>
+///   <item>Disposing the watcher (the hub's <c>RegisterForDisposal</c> hook) stops it — no post
+///     after teardown.</item>
+/// </list>
+/// </summary>
+public class NodeTypeRebindWatcherTest
+{
+    private const string InstancePath = "Store";
+    private const string BoundType = "Space";
+    private const string RealType = "Store/Catalog";
+
+    /// <summary>
+    /// A hand-rolled feed: the production <see cref="InProcessMeshChangeFeed"/> is a HOT subject
+    /// with no replay, and that property is load-bearing (a freshly-armed watcher must never see
+    /// the state it was armed on — the replay-and-recycle hot loop that forced the overlay
+    /// watcher's version gate). This stand-in has the same shape.
+    /// </summary>
+    private sealed class TestChangeFeed : IMeshChangeFeed
+    {
+        private readonly List<Action<MeshChangeEvent>> handlers = [];
+        public void Publish(MeshChangeEvent change)
+        {
+            foreach (var handler in handlers.ToArray())
+                handler(change);
+        }
+        public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
+        {
+            void Wrapped(MeshChangeEvent e)
+            {
+                if (filter is null || e.Kind == filter)
+                    handler(e);
+            }
+            handlers.Add(Wrapped);
+            return System.Reactive.Disposables.Disposable.Create(() => handlers.Remove(Wrapped));
+        }
+    }
+
+    private static IMessageHub BuildInstanceHub(out Func<Func<PostOptions, PostOptions>?> capturedOptions)
+    {
+        var hub = Substitute.For<IMessageHub>();
+        hub.Address.Returns(new Address(InstancePath));
+        hub.IsDisposing.Returns(false);
+        Func<PostOptions, PostOptions>? captured = null;
+        // Configure() records the Post spec WITHOUT running NSubstitute's auto-value provider —
+        // IMessageDelivery carries an INTERNAL member, so auto-substituting Post's return type
+        // throws TypeLoadException at proxy generation (same reason as OverlaySelfHealWatcherTest).
+        hub.Configure()
+            .Post(Arg.Any<DisposeRequest>(),
+                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
+            .Returns((IMessageDelivery<DisposeRequest>?)null);
+        capturedOptions = () => captured;
+        return hub;
+    }
+
+    private static MeshChangeEvent Change(
+        string path, string? nodeType, MeshChangeKind kind = MeshChangeKind.Updated)
+        => new("", path.Split('/')[^1], path, kind, nodeType, 1, DateTimeOffset.UtcNow);
+
+    private static void AssertNoDispose(IMessageHub hub) =>
+        hub.DidNotReceive().Post(
+            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+
+    private static void AssertDisposedExactlyOnce(IMessageHub hub) =>
+        hub.Received(1).Post(
+            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+
+    [Fact]
+    public void RetypeOfThisNode_RecyclesTheHub_ExactlyOnce()
+    {
+        var hub = BuildInstanceHub(out var capturedOptions);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
+
+        // Ordinary content writes republish the node with its type unchanged — by far the common
+        // case, and recycling on them would tear down a live hub on every save.
+        feed.Publish(Change(InstancePath, BoundType));
+        AssertNoDispose(hub);
+
+        // A write to a satellite / sibling / child is not this node.
+        feed.Publish(Change($"{InstancePath}/_Access/grant", "AccessAssignment"));
+        feed.Publish(Change("Store2", RealType));
+        AssertNoDispose(hub);
+
+        // THE signal: this node is now a different type from the one the hub bound.
+        feed.Publish(Change(InstancePath, RealType));
+        AssertDisposedExactlyOnce(hub);
+
+        // The post targets the instance's OWN address (the RecycleLayoutArea idiom). Derive the
+        // expectation from the SAME base options so the auto-generated MessageId does not perturb
+        // record equality.
+        var options = capturedOptions();
+        options.Should().NotBeNull("the DisposeRequest must be posted with explicit options");
+        var baseOptions = new PostOptions(new Address("sender"));
+        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
+            "the rebind recycle must target the instance hub's own address");
+
+        // Take(1): a flapping writer can never turn this into a recycle storm.
+        feed.Publish(Change(InstancePath, "Store/Plugin"));
+        feed.Publish(Change(InstancePath, RealType));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// #1104's own shape: the hub activated on a node that had NO type at all (the fabricated
+    /// partition-root placeholder, or the row inside the install window), so it bound the mesh
+    /// DEFAULT configuration. The arrival of the real type is the signal.
+    /// </summary>
+    [Fact]
+    public void TypeArrivingOnATypelessNode_RecyclesTheHub()
+    {
+        var hub = BuildInstanceHub(out _);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(
+            feed, hub, InstancePath, boundNodeType: null, logger: null);
+
+        // Still type-less — nothing has changed for the binding.
+        feed.Publish(Change(InstancePath, null));
+        feed.Publish(Change(InstancePath, ""));
+        AssertNoDispose(hub);
+
+        feed.Publish(Change(InstancePath, RealType, MeshChangeKind.Created));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// Enrichment resolves NodeType paths case-insensitively (the static-provider lookup /
+    /// <c>FindStaticNode</c>), so a case-only difference would recycle a hub onto the byte-identical
+    /// configuration — churn for nothing.
+    /// </summary>
+    [Fact]
+    public void CaseOnlyDifference_IsNotARebind()
+    {
+        var hub = BuildInstanceHub(out _);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, RealType, logger: null);
+
+        feed.Publish(Change(InstancePath, RealType.ToUpperInvariant()));
+        AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// A delete tears the hub down through the delete path itself, and the event carries no
+    /// authoritative type — recycling on it would race that teardown for no gain.
+    /// </summary>
+    [Fact]
+    public void Delete_NeverRecycles()
+    {
+        var hub = BuildInstanceHub(out _);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
+
+        feed.Publish(Change(InstancePath, nodeType: null, MeshChangeKind.Deleted));
+        AssertNoDispose(hub);
+    }
+
+    [Fact]
+    public void DisposingHub_StopsTheWatcher()
+    {
+        var hub = BuildInstanceHub(out _);
+        var feed = new TestChangeFeed();
+        var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
+
+        // The hub's RegisterForDisposal hook: tearing the hub down disposes the watcher, so a
+        // late retype must not post to a dead address.
+        watcher.Dispose();
+        feed.Publish(Change(InstancePath, RealType));
+        AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// A hub already tearing down needs no recycle, and posting to it only adds a delivery its
+    /// disposal has to drain.
+    /// </summary>
+    [Fact]
+    public void HubAlreadyDisposing_IsNotPosted()
+    {
+        var hub = BuildInstanceHub(out _);
+        hub.IsDisposing.Returns(true);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
+
+        feed.Publish(Change(InstancePath, RealType));
+        AssertNoDispose(hub);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using NSubstitute;
@@ -180,6 +181,53 @@ public class NodeTypeRebindWatcherTest
 
         feed.Publish(Change(InstancePath, nodeType: null, MeshChangeKind.Deleted));
         AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// 🚨 A null HubConfiguration must SURVIVE the wrap. Both activation sites
+    /// (<c>MonolithRoutingService.CreateHub</c>, <c>MessageHubGrain</c>) branch on it to activate
+    /// the fail-fast NACK-fallback hub, which answers every message with a typed DeliveryFailure
+    /// naming the node type and DeactivateOnIdle's so the next access retries. Making it non-null
+    /// unconditionally would kill that branch and swap fail-fast for a bare hub that Ignores typed
+    /// requests — the park class, where senders wait out their whole budget instead of getting a
+    /// diagnostic. Same rule <c>NodeTypeEnrichmentHelpers.ApplyStreamResult</c> states for its wrap.
+    /// </summary>
+    [Fact]
+    public void NullHubConfiguration_IsLeftNull()
+    {
+        var meshHub = Substitute.For<IMessageHub>();
+        var node = new MeshNode("Catalog", "Store") { NodeType = "Store/Catalog" };
+        node.HubConfiguration.Should().BeNull("precondition: the wrap's input has no configuration");
+
+        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, meshHub, logger: null);
+
+        wrapped.HubConfiguration.Should().BeNull(
+            "the fail-fast NACK-fallback branch keys on a null HubConfiguration — a hub with no "
+            + "configuration at all already retries on the next access, so it was never pinned");
+        wrapped.Should().BeSameAs(node, "there is nothing to wrap, so the node passes through");
+    }
+
+    /// <summary>
+    /// The ordinary case: a node that DOES carry a configuration keeps it (composed), so the wrap
+    /// never replaces the type's own areas — it only appends the watcher's initialization.
+    /// </summary>
+    [Fact]
+    public void NonNullHubConfiguration_IsComposedNotReplaced()
+    {
+        var meshHub = Substitute.For<IMessageHub>();
+        var applied = 0;
+        var node = new MeshNode("Catalog", "Store")
+        {
+            NodeType = "Store/Catalog",
+            HubConfiguration = c => { applied++; return c; }
+        };
+
+        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, meshHub, logger: null);
+
+        wrapped.HubConfiguration.Should().NotBeNull().And.NotBeSameAs(node.HubConfiguration);
+        wrapped.HubConfiguration!(new MessageHubConfiguration(
+            Substitute.For<IServiceProvider>(), new Address("Store")));
+        applied.Should().Be(1, "the node's own configuration must still be applied");
     }
 
     [Fact]

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Repro for issue #1104 — <b>a hub activated on the wrong NodeType stays wrong</b>.
+///
+/// <para>A per-node hub binds its <c>HubConfiguration</c> from the node's NodeType EXACTLY ONCE,
+/// at activation, and is then PINNED by address in <c>HostedHubsCollection</c>. Nothing re-reads
+/// the NodeType afterwards, so if the node's type ARRIVES or CHANGES while the hub is alive, the
+/// hub keeps serving the configuration it was born with — the mesh DEFAULT configuration when the
+/// node had no type at activation — for the rest of its lifetime.</para>
+///
+/// <para>That is the plugin gate's <c>Store/Catalog</c> RED: "No renderer is registered for area
+/// <c>Tests</c> on hub <c>Store</c>", whose available-areas list was item-for-item
+/// <c>ConfigureDefaultNodeHub</c>'s set and contained not one area from the installed package's
+/// configuration. The install provisions the partition BEFORE writing the root, so any routed
+/// touch inside that window activates the root's hub against a type-less node; the later retype
+/// changes the row and nothing recycles the hub. Fixing the RESOLUTION path (#1055 — a synthesized
+/// partition root is no longer CACHED) cannot help a hub a bad resolution has ALREADY activated:
+/// not cached is not not-pinned.</para>
+///
+/// <para>The test reproduces the mechanism WITHOUT the installer and without Roslyn: a node is
+/// created with no NodeType, its hub is activated (Ping), the node is then retyped to a static
+/// NodeType that declares a distinctive layout area, and the area is rendered through the layout
+/// client — the exact path the GUI drives. Before the fix the hub still serves the mesh default,
+/// the marker area does not exist on it, and the render never produces the marker control.</para>
+/// </summary>
+public class NodeTypeRebindTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string MarkerTypePath = "type/RebindMarker";
+    private const string MarkerArea = "RebindMarkerArea";
+    private const string Marker = "REBOUND_ON_THE_REAL_NODETYPE";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            // A STATIC NodeType (no Roslyn, no compile lifecycle) whose configuration declares
+            // one distinctive area. Its presence on the instance hub is the unambiguous proof
+            // that the hub bound THIS type rather than the mesh default.
+            .AddMeshNodes(MeshNode.FromPath(MarkerTypePath) with
+            {
+                Name = "RebindMarker",
+                State = MeshNodeState.Active,
+                HubConfiguration = config => config.AddLayout(layout =>
+                    layout.WithView(ctx => ctx.Area == MarkerArea,
+                        (_, _) => Controls.Html(Marker)))
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    [Fact(Timeout = 120_000)]
+    public async Task NodeTypeArrivesAfterActivation_HubRebindsToIt()
+    {
+        var instancePath = $"type/Rebind{Guid.NewGuid():N}";
+
+        // 1. A node with NO NodeType — the shape a freshly-provisioned partition root has
+        //    inside the install window, and the shape PathResolutionService's synthesized
+        //    placeholder always has.
+        await MeshService.CreateNode(MeshNode.FromPath(instancePath) with
+        {
+            Name = "Rebind",
+            State = MeshNodeState.Active,
+        }).Should().Emit();
+
+        // 2. ACTIVATE its hub while it is still type-less. Ping is answered by every hub, so
+        //    the response is proof the hub exists — and from here on it is PINNED by address:
+        //    routing short-circuits on GetHostedHub and never resolves the path again.
+        await Mesh.Observe(new PingRequest(), o => o.WithTarget(new Address(instancePath)))
+            .Should().Within(60.Seconds()).Emit();
+        Output.WriteLine($"Activated {instancePath} while it had no NodeType.");
+
+        // 3. The node acquires its real type — the installer's retype, a user changing a
+        //    node's type, a repo import landing the typed row.
+        await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Update(node => node with { NodeType = MarkerTypePath })
+            .Should().Emit();
+        await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n.NodeType == MarkerTypePath);
+        Output.WriteLine($"Retyped {instancePath} to {MarkerTypePath}.");
+
+        // 4. The hub MUST now serve the type's area. Before the fix it still serves the mesh
+        //    default configuration it was born with, the area is not registered on it, and this
+        //    render never yields the marker — "No renderer is registered for area
+        //    '{MarkerArea}' on hub '{instancePath}'".
+        var client = GetClient();
+        var reference = new LayoutAreaReference(MarkerArea);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(instancePath), reference);
+
+        var control = await stream
+            .GetControlStream(reference.Area!)
+            .Should().Within(90.Seconds())
+            .Match(c => c is HtmlControl h && h.Data?.ToString()?.Contains(Marker) == true);
+
+        control.Should().BeOfType<HtmlControl>(
+            "the hub must rebind to the node's real NodeType once it arrives, instead of "
+            + "staying pinned on the mesh default configuration it activated with")
+            .Which.Data!.ToString().Should().Contain(Marker);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
@@ -4,9 +4,11 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -45,61 +47,104 @@ public class NodeTypeRebindTest(ITestOutputHelper output) : MonolithMeshTestBase
     private const string MarkerArea = "RebindMarkerArea";
     private const string Marker = "REBOUND_ON_THE_REAL_NODETYPE";
 
+    private const string OtherTypePath = "type/RebindOther";
+    private const string OtherArea = "RebindOtherArea";
+
+    // The happy path is fast (the recycle is one change-feed hop), but a REGRESSION here is a
+    // wait that runs out — so the per-test watchdogs must outlast the render budget below, or the
+    // failure reads as a harness abort instead of the assertion it is.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(90);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(180);
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             .AddGraph()
-            // A STATIC NodeType (no Roslyn, no compile lifecycle) whose configuration declares
-            // one distinctive area. Its presence on the instance hub is the unambiguous proof
-            // that the hub bound THIS type rather than the mesh default.
+            // STATIC NodeTypes (no Roslyn, no compile lifecycle) whose configurations each declare
+            // one distinctive area. The marker area's presence on the instance hub is the
+            // unambiguous proof that the hub bound THAT type rather than the mesh default (or the
+            // type it activated with).
             .AddMeshNodes(MeshNode.FromPath(MarkerTypePath) with
             {
                 Name = "RebindMarker",
                 State = MeshNodeState.Active,
                 HubConfiguration = config => config.AddLayout(layout =>
-                    layout.WithView(ctx => ctx.Area == MarkerArea,
-                        (_, _) => Controls.Html(Marker)))
+                    layout.WithView(MarkerArea, RenderMarker))
+            })
+            .AddMeshNodes(MeshNode.FromPath(OtherTypePath) with
+            {
+                Name = "RebindOther",
+                State = MeshNodeState.Active,
+                HubConfiguration = config => config.AddLayout(layout =>
+                    layout.WithView(OtherArea, RenderOther))
             });
+
+    // NAMED areas (not predicate views) on purpose: a named area shows up in the "Available named
+    // areas" list the layout host prints when an area is missing, so a red run reproduces the
+    // issue's decisive evidence verbatim — the list is item for item ConfigureDefaultNodeHub's set,
+    // with not one area of the type the node actually carries.
+    private static IObservable<UiControl?> RenderMarker(LayoutAreaHost host, RenderingContext ctx)
+        => Observable.Return<UiControl?>(Controls.Html(Marker));
+
+    private static IObservable<UiControl?> RenderOther(LayoutAreaHost host, RenderingContext ctx)
+        => Observable.Return<UiControl?>(Controls.Html("the type this hub activated with"));
 
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
         => base.ConfigureClient(configuration).AddLayoutClient(d => d);
 
     private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
+    /// <summary>
+    /// #1104's exact shape: the hub activates against a node with NO NodeType — what a
+    /// freshly-provisioned partition root looks like inside the install window, and what
+    /// <c>PathResolutionService.SynthesizePartitionRoot</c>'s fabricated placeholder always is —
+    /// so it binds the mesh DEFAULT configuration. The type then arrives.
+    /// </summary>
     [Fact(Timeout = 120_000)]
-    public async Task NodeTypeArrivesAfterActivation_HubRebindsToIt()
+    public Task NodeTypeArrivesAfterActivation_HubRebindsToIt()
+        => AssertRebinds(activationNodeType: null);
+
+    /// <summary>
+    /// The installer's placeholder dance, generalised: the hub activates on one type and the node
+    /// is retyped to another. Same pin, same consequence — the hub serves the FIRST type's areas
+    /// forever. (In the Store's case type #1 is the <c>Space</c> placeholder written before the
+    /// package's own type has compiled.)
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public Task NodeTypeChangedAfterActivation_HubRebindsToIt()
+        => AssertRebinds(activationNodeType: OtherTypePath);
+
+    private async Task AssertRebinds(string? activationNodeType)
     {
         var instancePath = $"type/Rebind{Guid.NewGuid():N}";
 
-        // 1. A node with NO NodeType — the shape a freshly-provisioned partition root has
-        //    inside the install window, and the shape PathResolutionService's synthesized
-        //    placeholder always has.
+        // 1. The node as it looks at activation time. Content is required (a node with neither
+        //    NodeType nor Content is rejected), the NodeType is the variable under test.
         await MeshService.CreateNode(MeshNode.FromPath(instancePath) with
         {
             Name = "Rebind",
+            NodeType = activationNodeType,
             State = MeshNodeState.Active,
+            Content = JsonSerializer.SerializeToElement(new { title = "instance" }),
         }).Should().Emit();
 
-        // 2. ACTIVATE its hub while it is still type-less. Ping is answered by every hub, so
-        //    the response is proof the hub exists — and from here on it is PINNED by address:
-        //    routing short-circuits on GetHostedHub and never resolves the path again.
+        // 2. ACTIVATE its hub in that state. Ping is answered by every hub, so the response is
+        //    proof the hub exists — and from here on it is PINNED by address: routing
+        //    short-circuits on GetHostedHub and never resolves the path again.
         await Mesh.Observe(new PingRequest(), o => o.WithTarget(new Address(instancePath)))
             .Should().Within(60.Seconds()).Emit();
-        Output.WriteLine($"Activated {instancePath} while it had no NodeType.");
+        Output.WriteLine(
+            $"Activated {instancePath} as NodeType '{activationNodeType ?? "(none)"}'.");
 
-        // 3. The node acquires its real type — the installer's retype, a user changing a
-        //    node's type, a repo import landing the typed row.
+        // 3. The node acquires its real type — the installer's retype, a user changing a node's
+        //    type, a repo import landing the typed row.
         await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
             .Update(node => node with { NodeType = MarkerTypePath })
             .Should().Emit();
-        await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
-            .Should().Within(30.Seconds())
-            .Match(n => n.NodeType == MarkerTypePath);
         Output.WriteLine($"Retyped {instancePath} to {MarkerTypePath}.");
 
-        // 4. The hub MUST now serve the type's area. Before the fix it still serves the mesh
-        //    default configuration it was born with, the area is not registered on it, and this
-        //    render never yields the marker — "No renderer is registered for area
-        //    '{MarkerArea}' on hub '{instancePath}'".
+        // 4. The hub MUST now serve the type's area. Before the fix it still serves whatever it
+        //    was born with, the area is not registered on it, and this render never yields the
+        //    marker — "No renderer is registered for area '{MarkerArea}' on hub '{instancePath}'".
         var client = GetClient();
         var reference = new LayoutAreaReference(MarkerArea);
         var stream = client.GetWorkspace()
@@ -107,12 +152,18 @@ public class NodeTypeRebindTest(ITestOutputHelper output) : MonolithMeshTestBase
 
         var control = await stream
             .GetControlStream(reference.Area!)
-            .Should().Within(90.Seconds())
+            .Should().Within(60.Seconds())
             .Match(c => c is HtmlControl h && h.Data?.ToString()?.Contains(Marker) == true);
 
         control.Should().BeOfType<HtmlControl>(
             "the hub must rebind to the node's real NodeType once it arrives, instead of "
-            + "staying pinned on the mesh default configuration it activated with")
+            + "staying pinned on the configuration it activated with")
             .Which.Data!.ToString().Should().Contain(Marker);
+
+        // Asserted LAST, so a red run is never ambiguous about which half broke: by now the retype
+        // has demonstrably reached the hub, and this confirms it is what the mesh reads back too.
+        await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n.NodeType == MarkerTypePath);
     }
 }


### PR DESCRIPTION
Fixes #1104

## The defect, pinned

A per-node hub binds its `HubConfiguration` from its node's NodeType **exactly once**, during
activation, and is then pinned by address in `HostedHubsCollection`. `RoutingServiceBase.RouteInMesh`
short-circuits on `Mesh.GetHostedHub(address, Never)` for an already-hosted address, so a live hub
**never resolves its path again** and nothing re-reads its NodeType. A node that acquires — or
changes — its type while its hub is alive keeps serving the configuration it was born with, which
for a type-less node is the mesh `DefaultNodeHubConfiguration`.

The repro (`NodeTypeRebindTest`, `test/MeshWeaver.Hosting.Monolith.Test`) reproduces the issue's
decisive evidence **deterministically**, with neither the installer nor Roslyn: create a node,
activate its hub with `PingRequest`, retype the node, render an area the new type declares. With the
fix reverted:

```
No renderer is registered for area `RebindMarkerArea` on hub `type/Rebindcffe8718…`.
Available named areas: `$Data`, `$Model`, `$Schema`, `AccessControl`, `Catalog`, `Chat`, `Copy`,
`CourseNav`, `Create`, `Data`, `DataModel`, `Delete`, `Details`, `Edit`, `Export`, `Files`,
`GoToMyCopy`, `Groups`, `ImportMeshNodes`, `Invite`, `LayoutAreas`, `Learn`, `Move`, `NodeTypes`,
`Overview`, `Pin`, `PinnedThumbnail`, `Recycle`, `Search`, `Settings`, `StartExercise`, `StopSync`,
`Threads`, `Thumbnail`, `Unpin`, `VersionDiff`, `Versions`
```

— item for item `ConfigureDefaultNodeHub`'s set, with not one area of the type the node carries.
That is the plugin gate's `Store/Catalog` RED, in a unit-of-work you can run in five seconds. Both
variants fail (type-less → typed, and type A → type B), so the pin is general, not install-specific.

## Why #1055 did not close it

**Not cached is not not-pinned.** #1055 stopped `PathResolutionService` from *caching* the
fabricated partition-root placeholder, and `PackageInstaller` posts a `DisposeRequest` after its
retype. Both are necessary; neither is sufficient. Repairing resolution can only help the *next*
activation — it does nothing for a hub a bad resolution has **already** activated. And the
installer's recycle is fire-and-forget, conditional on the placeholder dance having run, and
available to no other writer, while *any* writer can retype a node (an import, a repair migration, a
user).

## The design, and the alternatives weighed

The un-pin belongs **at the hub**, driven by an event:

- **Not in `GetHostedHub`.** It is address-keyed and knows nothing about nodes; making it
  NodeType-aware would mean a path resolution per lookup — reinstating exactly the hot-path cost
  the `RouteInMesh` short-circuit exists to avoid (`Monitor.Enter_Slowpath ← GetHub ←
  RouteStreamMessage`, two prod incidents).
- **Not "re-read the NodeType at activation".** Activation already reads the resolution's node, and
  post-#1055 that is not a cached fabrication. The problem is not the *first* read; it is that there
  is no *later* activation.
- **Not "make the installer's recycle reliable".** That fixes one writer of many, and leaves the
  framework without the guarantee.

So: `MeshNodeHubFactory.ResolveHubConfiguration` — the single funnel every activation path (Monolith
routing **and** `MessageHubGrain`) goes through — wraps the resolved configuration with a
`WithInitialization` that arms `NodeTypeRebindWatcher` on the instance hub. It is the same
`WithInitialization` + self-`DisposeRequest` idiom as `NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal`
and `RecycleLayoutArea`.

**The signal is `IMeshChangeFeed`, not the hub's own node stream** — the load-bearing choice. Both
see the retype, but only the feed sees it **post-commit**: `StorageAdapterChangeFeedExtensions`
publishes Created/Updated strictly after the storage adapter's write emits. Recycling off the hub's
in-memory commit would race its debounced persist, and since re-activation reads the node back
through routing (i.e. through storage), the fresh hub would resurrect the **pre-retype** node and
bind the wrong type again — silently, with the stale row now authoritative. That is the hazard
`PackageInstaller.RootRetypePersisted` already exists for. Using the feed makes the ordering airtight
for free: it is the very event that sweeps `PathResolutionService`'s resolution cache, so by the time
we recycle, the resolver the re-activation will consult has already been invalidated.

## Blast radius

Disposing a live hub is not free — in-flight subscriptions are torn down and clients re-subscribe —
so the watcher is deliberately narrow:

- Fires only on a **genuine change of this node's own type**. Ordinary content writes (the
  overwhelming majority) republish the node with its type unchanged and are no-ops; so are writes to
  satellites, children and siblings.
- Fires **once** (`Take(1)`). After the recycle the new hub's baseline *is* the new type, so the
  predicate cannot re-fire — there is no recycle loop, and a flapping writer cannot make one.
- `Deleted` never fires (the delete path tears the hub down itself and the event carries no
  authoritative type); a case-only difference never fires (enrichment resolves type paths
  case-insensitively, so it would be churn onto the identical configuration).
- The feed is a **hot** subject with no replay, so a freshly-armed watcher structurally cannot fire
  on the state it was armed on — the replay-and-recycle hot loop that forced the overlay watcher's
  version gate cannot occur here.
- Arming costs one filtered subscription on the process-wide feed subject. No per-hub upstream
  stream, no poll, no timer.
- The handler runs synchronously on the publisher's thread (inside the storage write's post-commit
  `Do`), so the recycle is wrapped: a fault there could otherwise fail an unrelated caller's save.
  `DisposeRequest` is `[SystemMessage]`/`[CanBeIgnored]`, so it needs no `AccessContext` on a thread
  that carries none.

`PackageInstaller`'s `DisposeRequest` stays — it recycles immediately rather than on the feed hop —
but it is no longer load-bearing, and its comment ledger now says so.

## Verification

| | result |
|---|---|
| `NodeTypeRebindTest` (2 integration tests), **fix reverted** | **2 failed**, 120.9 s of timeouts, the area list above |
| `NodeTypeRebindTest`, fix restored | **2 passed**, 5.0 s |
| `NodeTypeRebindWatcherTest` (8 unit tests, firing contract) | 8 passed |
| `MeshWeaver.Graph.Test` (full) | 907 passed, 0 failed |
| `MeshWeaver.PluginCatalog.Test` (full) | 227 passed, 0 failed |
| `MeshWeaver.Hosting.Monolith.Test` (full) | 527 passed, 0 failed (4 macOS-only ClrMD skips) |

One review catch worth calling out, because it is the kind of wrap that has bitten this codebase
before: the watcher **must leave a null `HubConfiguration` null**. Both activation sites branch on it
to activate the fail-fast NACK-fallback hub (a typed `DeliveryFailure` naming the node type, plus
`DeactivateOnIdle`); wrapping unconditionally would have killed that branch and swapped fail-fast for
a bare hub that Ignores typed requests — the park class. `NodeTypeEnrichmentHelpers.ApplyStreamResult`
states the same rule for its own wrap. Pinned by `NullHubConfiguration_IsLeftNull`.

Comment ledgers updated at both sites the issue names: `PathResolutionService.SynthesizePartitionRoot`
(not pinning a fabrication is one half; letting go of one is the other) and `PackageInstaller` (why
its Post is now a fast path and not the guarantee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
