### PR TITLE
A course's videos could vanish on install, and a page could wait forever

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-plugins-files-arrive-with-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-plugins-files-arrive-with-it.md
@@ -1,0 +1,40 @@
+---
+Name: A plugin's files arrive with it
+Category: Fix
+Description: Installing a course or plugin that ships videos, images or other files could hang for a minute and then quietly leave those files behind. They now travel with it.
+Icon: CloudArrowUp
+Order: -20260810
+---
+
+# A plugin's files arrive with it
+
+A course does not consist only of pages. It also carries the videos, posters and
+images those pages point at, and installing it is supposed to bring all of it.
+
+For most plugins it did. For one particular shape it did not: a plugin whose
+front page is built by code the plugin itself ships — a shop front, a catalog, a
+course landing view. Installing one of those could sit for a full minute doing
+nothing visible, finish reporting success, and leave every one of its files
+behind. The pages were there. The videos 404'd. The only sign anything had gone
+wrong was a line in the log.
+
+The two halves of the plugin were fighting each other. A plugin's code is
+rebuilt on your portal when it arrives, and while that rebuild is running the
+plugin's front page has no code to serve it yet. Publishing the files happens
+through that same front page — it is where the portal keeps a node's files — so
+the publish arrived while the page was still waiting for the rebuild. It waited
+with it. And if the rebuild finished without producing anything usable, because
+the plugin's code no longer compiles against this version of the platform, the
+page waited for a result that was never coming, forever. The file publish
+eventually gave up on its own clock, a minute later, and dropped what it was
+carrying.
+
+Two things changed. The publish now waits for the plugin's code to be ready
+before it goes through the front page, so on a healthy install it simply happens
+in the right order. And a page that is waiting on code which turns out never to
+arrive now stops waiting and says so, instead of hanging silently — so it opens
+with an explanation of what is wrong with the plugin, and the files are
+published either way.
+
+If you have ever installed a course and found its videos missing, that is the
+bug. Re-installing it now publishes them.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -523,11 +523,30 @@ internal static class NodeTypeEnrichmentHelpers
     ///     (the wedge that previously required a manual recycle).</item>
     /// </list></para>
     ///
-    /// <para>Reactive-only: an <c>Observable.Timer</c> gated by <c>TakeUntil</c> on the
-    /// in-flight signal, merged with <paramref name="settled"/>. The timer never emits
-    /// OnNext, so <c>Merge</c> forwards only the settled node (or the timer's OnError
-    /// when Phase A elapses). <paramref name="scheduler"/> is for deterministic
-    /// virtual-time tests; production uses the default scheduler.</para>
+    /// <para>🚨 The disarm is a LEVEL, not a one-shot edge — it lasts exactly as long as a
+    /// compile is actually running, and the budget RE-ARMS the moment the type leaves
+    /// Pending/Compiling without <paramref name="settled"/> accepting the result. It used to be
+    /// <c>TakeUntil(compileInFlight.Take(1))</c>, which cancelled the wall clock FOREVER on the
+    /// first in-flight emission. That is only sound when every terminal state satisfies
+    /// <paramref name="settled"/>. It does not for the framework-stale self-heal, whose
+    /// <see cref="IsRecompileSettled"/> accepts ONLY a genuinely usable build: a rebuild that ends
+    /// at <c>Error</c> — a node repo's committed stale stamp whose source no longer compiles — is
+    /// not an answer, no further compile is coming, and with the clock permanently disarmed
+    /// NOTHING bounded the wait. The per-instance hub's enrichment then never completed and never
+    /// faulted: its hub was never created, and every message routed to that node parked until the
+    /// SENDER's own timeout. Measured on the installer: a package whose root is typed by such a
+    /// NodeType stalled 60.3 s on its content publish (the mesh hub's RequestTimeout) and then
+    /// dropped the package's binaries. A wait that ends only at someone else's timeout is a silent
+    /// hang; re-arming turns it back into the graceful sink the caller can overlay.</para>
+    ///
+    /// <para>Reactive-only: the in-flight LEVEL selects either <c>Observable.Never</c> (disarmed)
+    /// or a fresh <c>Observable.Timer</c> (armed), flattened with <c>Switch</c> so only the
+    /// current one is live. <c>DistinctUntilChanged</c> is load-bearing: without it every
+    /// non-in-flight emission would restart the budget, and a chatty stream would never elapse —
+    /// the same silent hang by another route. <c>StartWith(false)</c> arms it at subscribe, so
+    /// Phase A is unchanged. The timer never emits OnNext, so <c>Merge</c> forwards only the
+    /// settled node. <paramref name="scheduler"/> is for deterministic virtual-time tests;
+    /// production uses the default scheduler.</para>
     /// </summary>
     internal static IObservable<MeshNode> WaitForCompileSettled(
         IObservable<MeshNode> typeStream,
@@ -536,23 +555,26 @@ internal static class NodeTypeEnrichmentHelpers
         Func<Exception> onNoProgress,
         System.Reactive.Concurrency.IScheduler? scheduler = null)
     {
+        var clock = scheduler ?? System.Reactive.Concurrency.Scheduler.Default;
+
         // A compile is genuinely in flight for this NodeType — its terminal write is
-        // guaranteed by RunCompile, so the wait is bounded by the compile FINISHING,
-        // not a wall clock. Observing it DISARMS the no-progress deadline.
-        var compileInFlight = typeStream
-            .Where(t => t?.Content is NodeTypeDefinition d
+        // guaranteed by RunCompile, so while that holds the wait is bounded by the compile
+        // FINISHING, not a wall clock.
+        var noProgressDeadline = typeStream
+            .Select(t => t?.Content is NodeTypeDefinition d
                 && d.CompilationStatus is CompilationStatus.Pending
                                        or CompilationStatus.Compiling)
-            .Take(1);
-
-        var noProgressDeadline = Observable
-            .Timer(noProgressBudget, scheduler ?? System.Reactive.Concurrency.Scheduler.Default)
-            .TakeUntil(compileInFlight)                 // disarm once a compile is running
+            .StartWith(false)                       // armed from subscribe (Phase A)
+            .DistinctUntilChanged()                 // only transitions restart/cancel the budget
+            .Select(inFlight => inFlight
+                ? Observable.Never<long>()          // disarmed while a compile runs
+                : Observable.Timer(noProgressBudget, clock))
+            .Switch()
             .SelectMany(_ => Observable.Throw<MeshNode>(onNoProgress()));
 
-        // The timer never emits OnNext (only OnError, or it completes empty once
-        // disarmed), so the only value flowing through Merge is the settled node.
-        // Take(1) then unsubscribes the still-armed timer on the happy path.
+        // The timer never emits OnNext (only OnError), so the only value flowing through
+        // Merge is the settled node. Take(1) then unsubscribes the still-armed timer on the
+        // happy path.
         return settled.Merge(noProgressDeadline).Take(1);
     }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -146,7 +146,7 @@ public static class PackageInstaller
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // …then the package's committed binaries, into the warmed root's content
                     // collection — the half of "publish" that merging used to leave undone (#848).
-                    .SelectMany(_ => SyncPackageContent(hub, partition, sourceFolder, files, logger))
+                    .SelectMany(_ => SyncPackageContent(hub, partition, sourceFolder, files, nodes, logger))
                     .SelectMany(_ => RunInstallHooks(hub, partition!, logger))
                     .Select(_ => result);
             });
@@ -682,6 +682,101 @@ public static class PackageInstaller
     private static readonly TimeSpan RootTypeProbeTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// Backstop for <see cref="MayPublishIntoRoot"/> — the wait before the CONTENT publish touches
+    /// a self-typed root. Unlike the warm's probe this genuinely waits for the in-package type's
+    /// rebuild, because the publish is the point of the step, not an optimisation. The wait ends
+    /// as soon as the type has a loadable build OR its rebuild has run and settled without one, so
+    /// this cap is only ever reached when the type never even starts compiling.
+    /// </summary>
+    private static readonly TimeSpan RootTypeSettleTimeout = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// The path of the NodeType <paramref name="root"/> declares, but ONLY when that type is one
+    /// this very package installs — those are the only types that can still be carrying the
+    /// compile stamp the node repo COMMITTED at this point in the install. Read off the nodes we
+    /// just wrote, never off the mesh: reading the root is the very activation these gates exist
+    /// to defer. Null means "nothing about to be rebuilt — touching this root is safe".
+    /// </summary>
+    private static string? InPackageTypeOf(string root, IReadOnlyCollection<MeshNode> nodes)
+    {
+        var declaredType = nodes
+            .FirstOrDefault(n => string.Equals(n.Path, root, StringComparison.Ordinal))?.NodeType;
+        if (string.IsNullOrEmpty(declaredType))
+            return null;
+        return nodes.Any(n => n.Content is NodeTypeDefinition
+                && string.Equals(n.Path, declaredType, StringComparison.OrdinalIgnoreCase))
+            ? declaredType
+            : null;
+    }
+
+    /// <summary>
+    /// Whether the CONTENT publish may touch <paramref name="rootPath"/> yet — the gate in front
+    /// of <see cref="SyncPackageContent"/>, and the second half of the warm's guard above.
+    ///
+    /// <para>🚨 The publish posts its <c>SyncContentFilesRequest</c> to the ROOT's address, and
+    /// routing a message to a node that has no hub yet ACTIVATES one
+    /// (<c>RoutingServiceBase.RouteImpl</c> → <c>CreateHub</c> →
+    /// <c>IMeshNodeHubFactory.ResolveHubConfiguration</c>). So the publish is a root-activating
+    /// touch exactly like the warm, running a few lines after it: the guard the warm gained is
+    /// bypassed the moment a package carries a single byte of <c>content/**</c>. Same door, same
+    /// mis-binding.</para>
+    ///
+    /// <para>Unlike the warm the publish is the POINT of the step, so this WAITS for the type's
+    /// rebuild rather than giving up on the first read — a healthy self-typed package publishes
+    /// normally, a fraction of a second later, into a root that then binds its own configuration.
+    /// The wait ends the moment the type has a loadable build, or the moment a rebuild has RUN and
+    /// settled without producing one (a committed stale stamp whose source no longer compiles).
+    /// </para>
+    ///
+    /// <para>In that second case the answer is <c>false</c> and the publish is SKIPPED — because
+    /// sending it is strictly worse than not sending it. Activating a root whose type is
+    /// ABI-stale-with-a-failed-rebuild parks the enrichment on its framework-stale heal for the
+    /// full slow-path budget, which is the same 60 s as the hub's request timeout: measured, the
+    /// install burned 60.9 s and the sync was abandoned at the sender, its files landing (or not)
+    /// on whichever side of that dead heat the machine happened to fall. A skip is deterministic,
+    /// immediate, and recoverable — the assets are published by the next install once the type
+    /// compiles, which for a package under auto-update is the very next poll. The log names the
+    /// type so the cause is the package's compile error, not a mystery 404.</para>
+    /// </summary>
+    private static IObservable<bool> MayPublishIntoRoot(
+        IMessageHub hub, string rootPath, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
+    {
+        var declaredType = InPackageTypeOf(rootPath, nodes);
+        if (declaredType is null)
+            return Observable.Return(true);
+
+        // Fold the type's stream into "has a compile been in flight since we started?" so a
+        // rebuild that ends WITHOUT a loadable build is recognised as a final answer instead of
+        // waited out to the cap.
+        return hub.GetWorkspace().GetMeshNodeStream(declaredType)
+            .Where(node => node is not null)
+            .Scan((Compiled: false, Loadable: false, Settled: false), (state, node) =>
+            {
+                var inFlight = node.Content is NodeTypeDefinition def
+                    && def.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling;
+                var compiled = state.Compiled || inFlight;
+                var loadable = node.HasLoadableBuild();
+                return (compiled, loadable, loadable || (compiled && !inFlight));
+            })
+            .Where(state => state.Settled)
+            .Take(1)
+            .Timeout(RootTypeSettleTimeout)
+            .Select(state => state.Loadable)
+            .Catch<bool, Exception>(_ => Observable.Return(false))
+            .Do(loadable =>
+            {
+                if (!loadable)
+                    logger?.LogWarning(
+                        "[PackageInstaller] not publishing content assets into root {Root}: its NodeType "
+                        + "{Type} has no build this framework can load, so the publish would activate the "
+                        + "root against a type that cannot configure it — a request that parks for the "
+                        + "whole slow-path budget and is then abandoned. Fix the type's compile error; the "
+                        + "next install publishes the assets.",
+                        rootPath, declaredType);
+            });
+    }
+
+    /// <summary>
     /// Activates the roots this install just wrote, so a freshly installed package is not dark
     /// until someone navigates to it.
     ///
@@ -725,25 +820,13 @@ public static class PackageInstaller
         if (roots.Length == 0)
             return Observable.Return(Unit.Default);
 
-        // The NodeTypes this package defines — only these can still be carrying the repo's
-        // committed stale stamp at this point in the install.
-        var inPackageTypes = nodes
-            .Where(n => n.Content is NodeTypeDefinition)
-            .Select(n => n.Path)
-            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // The root's DECLARED type, read off the nodes we just wrote — never off the mesh, since
-        // reading the root is the very activation this gate exists to defer.
-        string? DeclaredTypeOf(string root) => nodes
-            .FirstOrDefault(n => string.Equals(n.Path, root, StringComparison.Ordinal))?.NodeType;
-
         // True when warming this root now cannot pin the wrong configuration: either its type is
         // not one this package defines (nothing about to be rebuilt), or that type already has a
         // build an instance could load. One bounded READ — never a wait for a compile.
         IObservable<bool> MayWarm(string root)
         {
-            var declaredType = DeclaredTypeOf(root);
-            if (string.IsNullOrEmpty(declaredType) || !inPackageTypes.Contains(declaredType))
+            var declaredType = InPackageTypeOf(root, nodes);
+            if (declaredType is null)
                 return Observable.Return(true);
             return workspace.GetMeshNodeStream(declaredType)
                 .Where(node => node is not null)
@@ -830,10 +913,15 @@ public static class PackageInstaller
     /// collection mounted (tests, a minimal host) answers "collection not found", and by this point the
     /// nodes have already landed — throwing would leave the package half-written. The written count is
     /// logged so an incomplete publish is visible rather than silent.</para>
+    ///
+    /// <para>🚨 The post ACTIVATES the root's hub (see <see cref="MayPublishIntoRoot"/>), so it is
+    /// gated on the root's in-package NodeType having a build an instance can load — the same
+    /// condition the warm consults. Gating INSIDE this method rather than at its three call sites
+    /// is deliberate: a call site that forgot would silently reopen the door.</para>
     /// </summary>
     private static IObservable<int> SyncPackageContent(
         IMessageHub hub, string? rootPath, string? sourceFolder,
-        IReadOnlyList<PackageFile> files, ILogger? logger)
+        IReadOnlyList<PackageFile> files, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(rootPath))
             return Observable.Return(0);
@@ -850,7 +938,12 @@ public static class PackageInstaller
             return Observable.Return(0);
 
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        return ContentAssetMapper.ToContentSyncs(rootPath!, assets)
+        return MayPublishIntoRoot(hub, rootPath!, nodes, logger)
+            .SelectMany(mayPublish => mayPublish
+                ? Publish()
+                : Observable.Return(0));
+
+        IObservable<int> Publish() => ContentAssetMapper.ToContentSyncs(rootPath!, assets)
             // Impersonated per post, like every other installer write: the pipeline hops schedulers
             // and an ambient impersonation does not survive those hops (see Upsert).
             .Select(sync => Observable.Using(
@@ -1639,7 +1732,7 @@ public static class PackageInstaller
                     // to leave undone (#848).
                     .SelectMany(_ => SyncPackageContent(
                         hub, manifest.TargetPartition ?? manifest.Id,
-                        manifest.SourceFolder ?? manifest.Id, files, logger))
+                        manifest.SourceFolder ?? manifest.Id, files, nodes, logger))
                     .Select(_ => result);
             }));
             });
@@ -1830,7 +1923,7 @@ public static class PackageInstaller
                     // even for a course carrying tens of MB of video (#848).
                     .SelectMany(_ => SyncPackageContent(
                         hub, manifest.TargetPartition ?? manifest.Id,
-                        manifest.SourceFolder ?? manifest.Id, changedFiles, logger))
+                        manifest.SourceFolder ?? manifest.Id, changedFiles, nodes, logger))
                     .Select(_ => result);
             });
     }

--- a/test/MeshWeaver.Graph.Test/CompileWaitDoesNotTimeoutTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileWaitDoesNotTimeoutTest.cs
@@ -153,6 +153,106 @@ public class CompileWaitDoesNotTimeoutTest
     }
 
     /// <summary>
+    /// 🚨 The wedge the disarm left behind: a compile that RUNS and lands a terminal state the
+    /// caller's <c>settled</c> predicate REJECTS must re-arm the budget, never wait forever.
+    ///
+    /// <para>The framework-stale self-heal is exactly that caller: <c>IsRecompileSettled</c> with
+    /// <c>requireUsableBuild</c> accepts ONLY a genuinely usable build, so a rebuild that ends at
+    /// <c>Error</c> — a node repo's committed stale stamp whose source no longer compiles, the
+    /// Store/Catalog shape — is not an answer. The disarm was a one-shot edge
+    /// (<c>TakeUntil(compileInFlight.Take(1))</c>): once ONE Pending/Compiling emission was seen
+    /// the wall clock was cancelled for good, so after that rejected terminal NOTHING was left to
+    /// bound the wait. The per-instance hub's enrichment then never completed and never faulted —
+    /// every message routed to that node parked until the SENDER's own timeout, and the node's hub
+    /// was never created at all. Measured: a package install whose root is typed by such a NodeType
+    /// stalled 60.3 s on its content publish (the mesh hub's RequestTimeout) and then dropped the
+    /// package's binaries. A hang that only ends at someone else's timeout is the "wedges to zero"
+    /// violation — the wait must sink gracefully so the caller can overlay the diagnostic.</para>
+    ///
+    /// <para>Contrast <see cref="InFlightCompile_ThatFailsLate_SurfacesError_NotHang"/>: there the
+    /// predicate ACCEPTS Error, so the same sequence resolves as a value. The distinguishing input
+    /// is the predicate, which is why the disarm's one-shot shape hid this for so long.</para>
+    /// </summary>
+    [Fact]
+    public void InFlightCompile_LandingATerminalTheWaitRejects_ReArmsTheBudget()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        // The framework-stale heal's rule: ONLY a usable build settles. Error does not.
+        var settledUsableOnly = typeStream
+            .Where(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath))
+            .Take(1);
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, settledUsableOnly, Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        typeStream.OnNext(Node(CompilationStatus.Compiling));   // disarms the wall clock
+        scheduler.AdvanceBy(Budget.Ticks * 3);
+        Assert.Null(error);
+        Assert.Null(emitted);
+
+        // The compile FINISHES — at a terminal state this caller does not accept. No further
+        // compile is in flight, so nothing else is coming: the budget must run again.
+        typeStream.OnNext(Node(CompilationStatus.Error));
+        Assert.Null(error);                                     // budget re-armed, not yet elapsed
+
+        scheduler.AdvanceBy(Budget.Ticks + 1);
+
+        Assert.Null(emitted);
+        Assert.IsType<TimeoutException>(error);
+    }
+
+    /// <summary>
+    /// The re-arm must not shorten a LEGITIMATE second compile: a rejected terminal followed by a
+    /// fresh Pending disarms the clock again, and the eventual usable build still resolves the
+    /// wait however long it takes. Otherwise the fix above would trade a hang for the fresh-pod
+    /// mid-compile fault it exists to prevent.
+    /// </summary>
+    [Fact]
+    public void RejectedTerminal_ThenASecondCompile_DisarmsAgain_AndResolvesOnTheUsableBuild()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        var settledUsableOnly = typeStream
+            .Where(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath))
+            .Take(1);
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, settledUsableOnly, Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        typeStream.OnNext(Node(CompilationStatus.Compiling));
+        scheduler.AdvanceBy(Budget.Ticks * 2);
+        typeStream.OnNext(Node(CompilationStatus.Error));       // rejected → budget re-arms
+
+        // A second compile starts well inside the re-armed budget — disarm again.
+        scheduler.AdvanceBy(Budget.Ticks / 2);
+        typeStream.OnNext(Node(CompilationStatus.Pending));
+        scheduler.AdvanceBy(Budget.Ticks * 5);
+        Assert.Null(error);
+        Assert.Null(emitted);
+
+        var ok = Node(CompilationStatus.Ok, withAssembly: true);
+        typeStream.OnNext(ok);
+
+        Assert.Null(error);
+        Assert.Same(ok, emitted);
+    }
+
+    /// <summary>
     /// A NodeType that is already settled Ok at first observation resolves immediately
     /// — the wall-clock never even starts to matter.
     /// </summary>

--- a/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
@@ -1,0 +1,353 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The STORE shape, in the harness the framework's own suites use: a SELF-TYPED root (root
+/// <c>Shop</c> is nodeType <c>Shop/Front</c>, defined by a child of the same package) whose
+/// NodeType node ships the compile stamp a node repo COMMITS — <c>compilationStatus: Ok</c> with
+/// assembly coordinates and a <c>compiledFrameworkVersion</c> from a long-gone framework build.
+/// That build cannot be loaded here, so the type is rebuilt on install; the root's hub must end
+/// up bound to the REBUILT configuration and serve the type's own areas.
+///
+/// <para>A hub resolves which configuration serves it exactly ONCE, at activation. So every step
+/// of the install that TOUCHES the root is a chance to pin the pre-rebuild answer for the hub's
+/// lifetime, after which the root serves only the generic areas — "No renderer is registered for
+/// area <c>Tests</c>", the plugin gate's Store/Catalog RED. <see cref="PackageInstaller"/> has two
+/// such touches: the warm (guarded) and the CONTENT publish, which posts a
+/// <c>SyncContentFilesRequest</c> to the root's address and therefore activates its hub exactly
+/// as the warm does. The second fact below is that door.</para>
+/// </summary>
+public class StaleStampRootBindingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly TimeSpan StepTimeout = 120.Seconds();
+
+    // Two real Roslyn compiles' worth of budget (the install's rebuild, plus the render).
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(120);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(280);
+
+    private readonly string _contentRoot = Path.Combine(
+        Path.GetTempPath(), "StaleStampRootBindingTest", Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Mirrors the portal: the writable <c>content</c> collection is mounted once per partition,
+    /// on the ROOT (a single-segment node path). That is the only hub where the collection
+    /// resolves — and the reason the installer posts its content sync at the root.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureDefaultNodeHub(config =>
+            {
+                var nodePath = config.Address.ToString();
+                if (nodePath.Contains('/'))
+                    return config;
+                return config.AddContentCollection(_ => new ContentCollectionConfig
+                {
+                    Name = ContentCollectionsExtensions.DefaultCollectionName,
+                    SourceType = "FileSystem",
+                    BasePath = Path.Combine(_contentRoot, nodePath),
+                    IsEditable = true,
+                    IsStatic = true,
+                    ExposeInChildren = true,
+                });
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddData();
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (Directory.Exists(_contentRoot))
+        {
+            try { Directory.Delete(_contentRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    // ── the fixture, byte for byte the gate's (PluginGateRunnerTest's Shop/Front), so a
+    //    divergence between the two harnesses is a difference in the HOST, never in the input ──
+
+    // `@ID@` stands in for the package id so the JSON can stay a verbatim copy of the gate's
+    // fixture (raw-string interpolation cannot carry the trailing `}}` of a JSON object).
+    private static string IndexJson(string id) =>
+        """{"$type":"MeshNode","id":"@ID@","namespace":"","path":"@ID@","mainNode":"@ID@","name":"@ID@","nodeType":"@ID@/Front","state":"Active","content":{"$type":"FrontContent","intro":"hello"}}"""
+            .Replace("@ID@", id, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The committed STALE stamp: <c>Ok</c> plus assembly coordinates and a framework hash this
+    /// process has never produced. <c>HasUsableBuild</c> is false for it, so the per-NodeType hub
+    /// flips it to Pending and rebuilds — and anything that activates the root inside that window
+    /// binds against a type with no loadable build.
+    /// </summary>
+    private static string FrontNodeTypeJson(string id) =>
+        """{"$type":"MeshNode","id":"Front","namespace":"@ID@","path":"@ID@/Front","mainNode":"@ID@/Front","name":"Front","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The shop front.","configuration":"config => config.WithContentType<FrontContent>().AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Tests\", FrontTestsArea.Tests))","includeGlobalTypes":true,"compilationStatus":"Ok","lastCompiledVersion":201,"latestAssemblyCollection":"local","latestAssemblyPath":"@ID@_Front/v201-0123456789abcdef0123456789abcdef-aaaabbbbcccc.dll","compiledFrameworkVersion":"0123456789abcdef0123456789abcdef"}}"""
+            .Replace("@ID@", id, StringComparison.Ordinal);
+
+    private const string FrontContentSource =
+        """
+        public record FrontContent
+        {
+            public string? Intro { get; init; }
+
+            public int Answer() => 42;
+        }
+        """;
+
+    private const string FrontTestsArea =
+        """
+        using System;
+        using System.Reactive.Linq;
+        using MeshWeaver.Layout;
+        using MeshWeaver.Layout.Composition;
+
+        public static class FrontTestsArea
+        {
+            public static IObservable<UiControl?> Tests(LayoutAreaHost host, RenderingContext _)
+            {
+                var sb = new System.Text.StringBuilder("### Front tests\n\n| Test | Result |\n|---|---|\n");
+                var passed = 0;
+                try
+                {
+                    if (new FrontContent().Answer() != 42)
+                        throw new Exception("expected the answer to be 42");
+                    sb.Append("| Answer is 42 | PASS |\n");
+                    passed++;
+                }
+                catch (Exception ex) { sb.Append($"| Answer is 42 | FAIL {ex.Message} |\n"); }
+                sb.Append($"\n**{passed}/1 passed.**");
+                return Observable.Return<UiControl?>(Controls.Markdown(sb.ToString()));
+            }
+        }
+        """;
+
+    // Deliberately NOT valid UTF-8 — the shape RepoFileCodec gives a committed binary.
+    private static readonly byte[] PosterBytes =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0xC0, 0xDE];
+
+    private static IReadOnlyList<RepoFile> Files(string id, bool withContentAssets)
+    {
+        var files = new List<RepoFile>
+        {
+            new($"{id}/index.json", IndexJson(id)),
+            new($"{id}/Front.json", FrontNodeTypeJson(id)),
+            new($"{id}/Front/Source/FrontContent.cs", FrontContentSource),
+            new($"{id}/Front/Test/FrontTestsArea.cs", FrontTestsArea),
+        };
+        if (withContentAssets)
+            files.Add(new($"{id}/content/images/cover.png", "", PosterBytes));
+        return files;
+    }
+
+    /// <summary>
+    /// The shape #1101 fixed, pinned in the framework harness: no content assets, so the only
+    /// root-activating touch is the (now guarded) warm. The rebuild must SETTLE and the root must
+    /// serve its type's <c>Tests</c> area.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task StaleStampSelfTypedRoot_RootServesItsTypesArea()
+        => await InstallAndAssertRootServesItsTypesArea("ShopA", withContentAssets: false);
+
+    /// <summary>
+    /// 🚨 The residual door #1101 named but did not close: a package that ships CONTENT ASSETS.
+    /// <c>SyncPackageContent</c> runs immediately after the warm and posts a
+    /// <c>SyncContentFilesRequest</c> to the ROOT's address — and routing a message to a node
+    /// address that has no hub yet ACTIVATES one
+    /// (<c>MonolithRoutingService.RouteImpl</c> → <c>CreateHub</c> →
+    /// <c>IMeshNodeHubFactory.ResolveHubConfiguration</c>). So the guard the warm gained is
+    /// bypassed the moment the package carries a single byte of content, and the root binds
+    /// against the still-stale type exactly as before.
+    ///
+    /// <para>Both halves are asserted: the root serves its type's area AND the committed asset is
+    /// published (the fix must not buy the binding by dropping the content — that is issue #848
+    /// in reverse).</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task StaleStampSelfTypedRootShippingContent_RootServesItsTypesArea()
+    {
+        const string id = "ShopB";
+        await InstallAndAssertRootServesItsTypesArea(id, withContentAssets: true);
+
+        var cover = Path.Combine(_contentRoot, id, "images", "cover.png");
+        File.Exists(cover).Should().BeTrue(
+            $"the committed asset must still be published into the root's content collection ({cover})");
+        File.ReadAllBytes(cover).Should().Equal(PosterBytes);
+    }
+
+    /// <summary>
+    /// The same door in the shape that needs no race to expose it, and the whole reason the gate
+    /// is a WAIT with a verdict rather than a blind post: a package whose in-package NodeType can
+    /// never produce a loadable build. It ships the committed stale stamp AND source that no
+    /// longer compiles, so the rebuild ends at <c>Error</c> while the stale assembly coordinates
+    /// stay on the node — <c>HasLoadableBuild</c> is false for the rest of the run, deterministically.
+    ///
+    /// <para>Measured before the fix: the install ran <b>60.9 s</b> — the mesh hub's whole
+    /// RequestTimeout — and then reported "its binaries are not being served". The content sync
+    /// had activated the root; that activation's framework-stale heal waited for a usable build
+    /// that was never coming, with no bound at all (the root's hub was still absent 180 s later),
+    /// so the request was abandoned at the sender. Whether the bytes landed came down to which
+    /// side of that dead heat the machine fell on.</para>
+    ///
+    /// <para>What must hold now: the install does NOT spend a request timeout on a root it cannot
+    /// activate. It recognises that the type's rebuild has run and produced nothing loadable, and
+    /// skips the publish — measured at 393 ms against 60.9 s, and the assets are published by the
+    /// next install once the type compiles (for a package under auto-update, the next poll). The
+    /// healthy counterpart is <see cref="StaleStampSelfTypedRootShippingContent_RootServesItsTypesArea"/>,
+    /// which pins that a package whose type DOES rebuild publishes its assets and serves its own
+    /// areas — so the skip here is scoped to the broken case and cannot quietly become the norm.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task SelfTypedRootWhoseTypeNeverCompiles_SkipsThePublishPromptly()
+    {
+        const string id = "ShopC";
+        // The healthy fixture with ONE deliberate compile error in FrontContent: MissingHelper
+        // exists nowhere. Everything else — including the Tests area the configuration names — is
+        // intact, so the ONLY reason this type cannot produce a build is that error.
+        var broken = Files(id, withContentAssets: true)
+            .Select(f => f.Path.EndsWith("FrontContent.cs", StringComparison.Ordinal)
+                ? new RepoFile(f.Path,
+                    "public record FrontContent { public string? Intro => MissingHelper.Frobnicate(); "
+                    + "public int Answer() => 42; }")
+                : f)
+            .ToList();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await Install(id, broken);
+        var installMs = sw.ElapsedMilliseconds;
+        Output.WriteLine($"install of the broken package returned at +{installMs}ms");
+
+        var type = await Mesh.GetWorkspace().GetMeshNodeStream($"{id}/Front")
+            .Where(n => n?.Content is NodeTypeDefinition).FirstAsync().Timeout(StepTimeout).ToTask();
+        type.HasLoadableBuild().Should().BeFalse(
+            "the fixture is only meaningful while the type genuinely cannot produce a loadable "
+            + "build — if this flips, the test has stopped covering the deterministic window");
+
+        installMs.Should().BeLessThan(30_000,
+            "the install must not post into a root it cannot activate and then wait out the hub's "
+            + $"whole request timeout — it did exactly that before the fix (60.9 s); took {installMs}ms");
+    }
+
+    /// <summary>Installs the fixture package through the standard installer.</summary>
+    private async Task Install(string id, IReadOnlyList<RepoFile> files)
+    {
+        var source = new NodeRepoPackageSource(
+            (_, _, _, _) => Observable.Return(new RepoSnapshot($"commit-{id}", files)),
+            repoUrl: "local");
+        var manifest = new PackageManifest
+        {
+            Id = id,
+            Name = id,
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = id,
+            SourceFolder = id,
+            Version = $"commit-{id}",
+        };
+        var packageFiles = await source.FetchPackageFiles(manifest, "HEAD")
+            .FirstAsync().Timeout(StepTimeout).ToTask();
+        await PackageInstaller.Install(Mesh, manifest, packageFiles, "HEAD")
+            .FirstAsync().Timeout(StepTimeout).ToTask();
+    }
+
+    private async Task InstallAndAssertRootServesItsTypesArea(string id, bool withContentAssets)
+    {
+        var typePath = $"{id}/Front";
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        await Install(id, Files(id, withContentAssets));
+        Output.WriteLine($"install returned at +{sw.ElapsedMilliseconds}ms");
+
+        // 🚨 Only NOW subscribe to the type's stream. Subscribing to a path that does not exist
+        // yet resolves to a NotFound OnError, and the shared per-path handle replays that
+        // terminal to every later subscriber — a "diagnostic" that would fail the assertions it
+        // is meant to explain. The install has written every node by the time it returns.
+        using var diag = Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Subscribe(n => Output.WriteLine(
+                n?.Content is NodeTypeDefinition d
+                    ? $"[type +{sw.ElapsedMilliseconds}ms] v{n.Version} Status={d.CompilationStatus} "
+                      + $"fv='{d.CompiledFrameworkVersion}' asm='{d.LatestAssemblyPath}'"
+                      + (d.CompilationError is { Length: > 0 } e ? $" ERROR={e.Replace("\n", " | ")}" : "")
+                    : $"[type +{sw.ElapsedMilliseconds}ms] content={n?.Content?.GetType().Name ?? "null"}"));
+
+        // The committed stale stamp must be REBUILT, not trusted: a terminal status carrying a
+        // build this framework can actually load (HasLoadableBuild is exactly that predicate).
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(StepTimeout)
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && n.HasLoadableBuild());
+        Output.WriteLine($"rebuild settled at +{sw.ElapsedMilliseconds}ms");
+
+        // …and the ROOT's hub must be bound to that rebuilt configuration. Its `Tests` area only
+        // exists there, so a root left on the defaults-only fallback renders "Area not found".
+        var client = GetClient();
+        var reference = new LayoutAreaReference("Tests") { Id = "" };
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(id), reference);
+        try
+        {
+            var frame = await stream.Select(ci => ci.Value)
+                .Where(f => Strings(f).Any(s =>
+                    s.Contains("passed", StringComparison.Ordinal)
+                    || s.Contains("Area not found", StringComparison.Ordinal)
+                    || s.Contains("This area failed to render", StringComparison.Ordinal)))
+                .FirstAsync().Timeout(StepTimeout).ToTask();
+            var text = string.Join("\n---\n", Strings(frame));
+            Output.WriteLine($"Tests frame at +{sw.ElapsedMilliseconds}ms:\n{text}");
+            text.Should().NotContain("Area not found",
+                "the root's hub must bind to its type's REBUILT configuration, never to the "
+                + "defaults-only fallback pinned while the committed stamp was still stale");
+            text.Should().Contain("1/1 passed",
+                "the root must execute its type's own Tests area");
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+
+    private static IReadOnlyList<string> Strings(JsonElement element)
+    {
+        var strings = new List<string>();
+        Walk(element, strings);
+        return strings;
+
+        static void Walk(JsonElement node, List<string> into)
+        {
+            switch (node.ValueKind)
+            {
+                case JsonValueKind.String:
+                    if (node.GetString() is { Length: > 0 } s) into.Add(s);
+                    break;
+                case JsonValueKind.Object:
+                    foreach (var property in node.EnumerateObject()) Walk(property.Value, into);
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in node.EnumerateArray()) Walk(item, into);
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two follow-ups from #1101, which fixed the installer's WARM — it activated a freshly retyped root while the root's own NodeType was still advertising the compile stamp the node repo COMMITTED, and a hub binds its configuration exactly once.

## 1. The other door — `SyncPackageContent`

`SyncPackageContent` runs a few lines after the warm and posts its `SyncContentFilesRequest` to the **root's address**. Routing a message at a node with no hub ACTIVATES one (`RouteImpl` → `CreateHub` → `ResolveHubConfiguration`), so the publish is a root-activating touch exactly like the warm: the guard #1101 added is bypassed the moment a package carries one byte of `content/**`. No gate package ships content, which is why #1101 could name it and leave it.

Measured with a package whose type can never produce a loadable build (committed stale stamp + source that no longer compiles):

| | before | after |
|---|---|---|
| install duration | **60.9 s** (the mesh hub's whole RequestTimeout) | **408 ms** |
| content publish | "its binaries are not being served" | skipped, with the type named in the log |
| root's hub | still absent at **+180 s** | created |

## 2. Why it parked — the larger bug

`WaitForCompileSettled` disarmed its no-progress clock with `TakeUntil(compileInFlight.Take(1))` — a **one-shot edge**. That is sound only if every terminal state satisfies the caller's `settled` predicate. It does not for the framework-stale self-heal, whose `IsRecompileSettled(requireUsableBuild: true)` accepts ONLY a genuinely usable build. A rebuild ending at `Error` was therefore not an answer, no further compile was coming, and with the clock cancelled for good **nothing bounded the wait**: the enrichment never completed and never faulted, the node's hub was never created, and every message routed there parked until the *sender's* timeout.

The disarm is now a LEVEL, not an edge — it lasts exactly as long as a compile is running, and the budget re-arms when the type leaves Pending/Compiling without settling. `DistinctUntilChanged` is load-bearing: without it a chatty stream would reset the budget forever, the same silent hang by another route.

The installer then consults the same `HasLoadableBuild` the warm does, but as a **wait with a verdict**, because the publish is the point of the step rather than an optimisation: a healthy self-typed package publishes a fraction of a second later into a root that binds its own configuration; a type whose rebuild has RUN and produced nothing loadable is a final answer and the publish is skipped, going out on the next install once the type compiles. Gated inside `SyncPackageContent`, not at its three call sites, so a call site cannot reopen the door by forgetting.

## Tests, each seen failing first

- **`InFlightCompile_LandingATerminalTheWaitRejects_ReArmsTheBudget`** (virtual time) — on the unfixed code: `Expected: typeof(TimeoutException), Actual: null` after 4× the budget; the wait neither emitted nor faulted. `RejectedTerminal_ThenASecondCompile_DisarmsAgain` pins that the re-arm does not trade this hang for the fresh-pod mid-compile fault the disarm exists to prevent.
- **`SelfTypedRootWhoseTypeNeverCompiles_SkipsThePublishPromptly`** — 60.9 s → 408 ms.
- **`StaleStampSelfTypedRoot{,ShippingContent}_RootServesItsTypesArea`** — the stale-stamp rebuild shape #1101 had to drop, now green in `MonolithMeshTestBase`; the content-shipping variant is the door above and asserts both that the root serves its type's `Tests` area **and** that the asset is published, so the binding is never bought by dropping the bytes.

## On the harness question #1101 left open

A repro that "never settled" in `MonolithMeshTestBase` while the gate runner did the same work in ~1.6 s: **the hosts are not the difference.** A faithful port of the gate's fixture settles the rebuild in 320 ms and serves the root's `Tests` area in 480 ms (gate runner: 680 ms). What differs is **order** — `PluginGateRunner` waits for every NodeType to reach a terminal compile status *before* it renders anything, so it never activates an instance against a type advertising an unloadable build. A repro that touches the root (which is the whole assertion) activates it inside that window, and before this fix that activation could never complete.

## Verification

`dotnet build -c Release -warnaserror` clean on MeshWeaver.Graph, MeshWeaver.PluginCatalog, MeshWeaver.Documentation and the three test projects. Graph.Test 910/910, PluginCatalog.Test 230/230, PluginTester.Test 23/23, and the 31 enrichment-sensitive Hosting.Monolith tests (FrameworkStale / NodeTypeCompile / CompileLeaf / CodeEditRecompile / DynamicTypePreWarmer / CompileSourceSnapshotWedge / NodeTypeRelease) — all green, after merging current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)