### PR TITLE
Nothing on the incident said it already had a ticket, so every recurrence opened another

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -91,13 +91,48 @@ The lifecycle runs on the `Status` / `RequestedStatus` control-plane pair
 
 | `RequestedStatus` | Set by | The control plane does |
 |---|---|---|
-| `Triage` | ingest (first sighting, or a repeat of a `New`/`Failed` incident) | marks `Triaging`, starts a LogTriage thread with the incident as `MainNode` |
-| `File` | the triage agent | resolves the repository, opens the issue as the GitHub App, records `IssueUrl` |
-| `Comment` | ingest (repeat of a `Filed` incident, at most once per `CommentInterval`) | comments the recurrence; reopens the issue first if it had been closed |
+| `Triage` | ingest (first sighting, or a repeat of an un-ticketed `New`/`Failed` incident) | marks `Triaging`, starts a LogTriage thread with the incident as `MainNode` |
+| `File` | the triage agent | marks `Filing`, resolves the repository, opens the issue as the GitHub App, records `IssueNumber`/`IssueUrl` |
+| `Comment` | ingest (repeat of a ticketed incident, at most once per `CommentInterval`) | comments the recurrence; reopens the issue first if it had been closed |
 | `Suppress` | the triage agent, or an admin | marks `Suppressed` — occurrences keep counting, tickets stop |
 
 Because the state lives in the mesh, a portal restart mid-triage strands nothing: the node still
 says what it is waiting for and the next query emission picks it up.
+
+### One fault, one ticket — for the fault's whole life
+
+Deduplicating at the *fingerprint* is only half the promise. The other half is that the incident is
+**filed at most once**, and the control plane enforces it in two places.
+
+**The claim.** Every transition consumes `RequestedStatus` in a write against the incident's LIVE
+content, and that write lands *before* the GitHub call it guards (the
+claim-the-guard-before-the-mutation rule). A second work item for the same incident finds the
+request already cleared and stands down. Without it the only guards are in-process: the incident
+query is eventually consistent, so it re-emits the pre-write snapshot after the in-flight set has
+been released — which is how two issues were opened for one fault inside the same second on the
+watcher's first live run.
+
+**The issue link outranks the status.** `NextRequest` checks `IssueNumber` *before* the
+`New`/`Failed` retry rule, and a `File` request that arrives on an already-ticketed incident is
+granted as a `Comment` instead. Both close the same chain: a recurrence parks a ticketed incident at
+`Failed` (a comment that errored, or the stranded-triage reconcile marking it retryable), ingest
+re-triages it, the agent drafts again and asks to `File` — and a second issue appears. That chain
+filed `ROUTER_TRAFFIC` eight times in seven minutes.
+
+A recurrence is therefore always folded onto the ticket that exists:
+
+- One comment per `CommentInterval` (default 6 h), whatever asked for it — a `File` request landing
+  on a ticketed incident obeys the same bound a `Comment` request does, so a continuously-firing
+  fault cannot turn its own issue into a feed.
+- A **closed** issue is reopened first (`ReopenOnRecurrence`). A defect that returns after someone
+  closed its ticket is exactly what should notify.
+- A comment that lands writes the incident back to `Filed`, clearing a stale `Failed` — leaving it
+  is what let ingest re-triage a ticketed incident in the first place.
+
+The claim keys on `RequestedStatus`, never on the status, so the in-flight statuses (`Triaging`,
+`Filing`) are not dead ends: a crash between the claim and the write-back parks the incident there,
+and asking again — an admin in the incident view, or the stranded-triage reconcile below — is
+honoured.
 
 ### The one state nothing requests: `Triaging`
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-one-alert-per-fault-not-one-per-recurrence.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-one-alert-per-fault-not-one-per-recurrence.md
@@ -1,0 +1,45 @@
+---
+Name: One alert per fault, not one per recurrence
+Category: Fix
+Description: A recurring error opened a fresh ticket every few minutes. Recurrences now land on the ticket that already exists — reopening it if it had been closed.
+Icon: BellAlert
+Order: -20260810
+---
+
+# One alert per fault, not one per recurrence
+
+Automatic error ticketing had one job beyond noticing a problem: tell you about it
+**once**. It got the noticing right and the telling wrong. In its first live run it
+opened 37 tickets for about a dozen distinct faults. One error — a routing failure
+that fired 602 times in a quarter of an hour — was reported eight separate times in
+seven minutes. Every one of those was a notification in your inbox, and every one of
+them was about something you already knew.
+
+The count itself was never confused. All 602 sightings stayed a single incident, on a
+single record, with a single running total. What went wrong was the step after that.
+When the fault fired again, the incident was handed back for a fresh look, a fresh
+write-up came out of it, and the write-up was filed — without anyone checking whether
+this fault already had a ticket open. Nothing on the incident pointed back at the
+ticket it had produced, so nothing could tell the difference between "report this" and
+"report this again".
+
+A second, smaller version of the same gap produced pairs: two tickets for one fault,
+created in the same second. Two views of the same incident both read "ready to file"
+before either had a chance to record that it was filing.
+
+Both are closed now, by the same change. An incident **claims** the job before it does
+it — the record is marked first, so a second attempt finds the work already taken and
+stands down. And the incident now remembers its ticket. A fault that comes back is
+folded into the ticket it already has, as a short update saying how many times it has
+fired since the last one, at most once every six hours no matter how continuously the
+error is firing.
+
+Recurrence after a ticket was **closed** is treated as the news it is: the ticket is
+reopened and the update posted, rather than silently piling up under something marked
+done. A defect that returns after you fixed it is exactly the thing worth telling you
+about.
+
+Nothing is quieter than it should be. The first sighting of a new fault still opens a
+ticket immediately, still with the full evidence — the exact log lines, the counts, the
+pods it happened on. What changed is that the second, third and eighth sighting no
+longer look like new problems.

--- a/src/MeshWeaver.Observability/LogIncidentControlPlane.cs
+++ b/src/MeshWeaver.Observability/LogIncidentControlPlane.cs
@@ -193,27 +193,29 @@ public sealed class LogIncidentControlPlane : BackgroundService
         && incident.TriageThreadPath is { Length: > 0 };
 
     /// <summary>
+    /// Runs one transition exactly as the work queue does — the seam the idempotency tests drive,
+    /// so they exercise the real claim + write path rather than a re-implementation of it.
+    /// </summary>
+    internal IObservable<Unit> RunRequest(string path, LogIncident incident, LogIncidentRequest request)
+        => Run(new LogIncidentWork(path, incident, request));
+
+    /// <summary>
     /// Performs one transition. Always completes — a failure is written onto the incident as
     /// <see cref="LogIncidentStatus.Failed"/> rather than left to fault the work loop, so one bad
     /// incident can never stop the others (AGENTS.md → "Wedges to zero").
+    ///
+    /// <para>Every transition CLAIMS the request first and then acts on what the claim granted —
+    /// never on <c>work.Incident</c>, which is the query snapshot that produced this work item and
+    /// is stale by the time it runs.</para>
     /// </summary>
     private IObservable<Unit> Run(LogIncidentWork work)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         return Observable.Using(
                 () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                _ => work.Reconcile ? ReconcileTriaging(work) : work.Request switch
-                {
-                    LogIncidentRequest.Triage => Triage(work),
-                    LogIncidentRequest.File => Apply(work, filer.File(work.Incident)),
-                    LogIncidentRequest.Comment => Apply(work, filer.Comment(work.Incident)),
-                    LogIncidentRequest.Suppress => Apply(work, Observable.Return(work.Incident with
-                    {
-                        Status = LogIncidentStatus.Suppressed,
-                        RequestedStatus = LogIncidentRequest.None,
-                    })),
-                    _ => Observable.Return(Unit.Default),
-                })
+                _ => work.Reconcile
+                    ? ReconcileTriaging(work)
+                    : Claim(work).SelectMany(claim => Perform(work.Path, claim)))
             .Catch((Exception ex) =>
             {
                 logger?.LogWarning(ex, "Incident {Fingerprint}: {Request} failed",
@@ -235,28 +237,138 @@ public sealed class LogIncidentControlPlane : BackgroundService
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    //  The claim — what makes a transition happen at most once
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Consumes the request on the LIVE node and emits what this worker actually won.
+    ///
+    /// <para>🚨 The claim is a WRITE, and it lands BEFORE the outward mutation it guards — the
+    /// claim-the-guard-before-the-mutation rule (#826). Everything downstream keys off that write
+    /// having COMPLETED, so a second work item for the same incident finds the request already
+    /// consumed and stands down. Without it, the queue's guards are all in-process: the live query
+    /// is eventually consistent and re-emits the pre-write snapshot after
+    /// <see cref="inFlight"/> has been released, which is how #1124/#1125 and #1111/#1112 were each
+    /// opened twice inside one second.</para>
+    /// </summary>
+    private IObservable<LogIncidentClaim> Claim(LogIncidentWork work)
+    {
+        // Declined until the update lambda says otherwise: content that cannot be read never
+        // reaches the lambda (UpdateIncident skips it), and "we did not win" is the only safe
+        // reading of that. Assigned inside the lambda — which runs, on the node's serialised write
+        // queue, before this write completes — and read afterwards, exactly as the ingest path's
+        // fold captures its merged result.
+        var claim = new LogIncidentClaim(LogIncidentRequest.None, work.Incident);
+        return Write(work.Path, current => (claim = ClaimRequest(current, work.Request, options)).Incident)
+            .Select(_ =>
+            {
+                if (claim.Granted != work.Request)
+                    logger?.LogInformation(
+                        "Incident {Fingerprint}: {Request} resolved to {Granted} — the incident is "
+                        + "{Status} and carries issue {IssueNumber}",
+                        work.Incident.Fingerprint, work.Request, claim.Granted,
+                        claim.Incident.Status, claim.Incident.IssueNumber);
+                return claim;
+            });
+    }
+
+    /// <summary>
+    /// The rule that makes filing idempotent, applied to the incident's LIVE content at write time.
+    /// Pure, so the whole policy is testable without a mesh.
+    ///
+    /// <para>Two things can take a request away between the query emission that queued the work and
+    /// the moment it runs: another worker (or another replica) consuming it, and the incident having
+    /// been ticketed already. Both mean the same thing — do not perform this operation again.</para>
+    /// </summary>
+    /// <param name="current">The incident as it is at write time.</param>
+    /// <param name="request">What the work item was queued for.</param>
+    /// <param name="options">The recurrence policy (the comment rate limit).</param>
+    /// <returns>What this worker may perform, and the content the claim writes.</returns>
+    internal static LogIncidentClaim ClaimRequest(
+        LogIncident current, LogIncidentRequest request, LogWatchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Nothing left to consume — someone else already took this request.
+        if (request == LogIncidentRequest.None || current.RequestedStatus != request)
+            return new LogIncidentClaim(LogIncidentRequest.None, current);
+
+        // 🚨 Already ticketed ⇒ a File request can only mean "this fault came back". It belongs on
+        // the issue that exists, under the SAME rate limit a recurrence comment obeys — never in a
+        // second issue. A recurrence on a CLOSED issue reopens it (LogIncidentFiler.Comment): a
+        // defect that returns after someone closed its ticket is exactly what should notify.
+        if (request == LogIncidentRequest.File && current.IssueNumber is not null)
+            return new LogIncidentClaim(
+                LogIncidentIngestService.CommentDue(current, options, current.LastSeen)
+                    ? LogIncidentRequest.Comment
+                    : LogIncidentRequest.None,
+                current with
+                {
+                    Status = LogIncidentStatus.Filed,
+                    RequestedStatus = LogIncidentRequest.None,
+                    Error = null,
+                });
+
+        return new LogIncidentClaim(request, current with
+        {
+            Status = InFlightStatus(request) ?? current.Status,
+            RequestedStatus = LogIncidentRequest.None,
+            Error = null,
+        });
+    }
+
+    /// <summary>
+    /// The status that says "this transition is running", or null for a request whose operation
+    /// writes its own terminal status (<c>Comment</c> stays <c>Filed</c>, <c>Suppress</c> becomes
+    /// <c>Suppressed</c> when it lands).
+    ///
+    /// <para>A crash between the claim and the write-back parks the incident in the in-flight
+    /// status. That is recoverable and NOT a new dead end: the claim keys on
+    /// <see cref="LogIncident.RequestedStatus"/>, never on the status, so asking again — an admin in
+    /// the incident view, or the ingest path's retry rule for <c>Triaging</c> via the stranded-triage
+    /// reconcile — is honoured.</para>
+    /// </summary>
+    private static LogIncidentStatus? InFlightStatus(LogIncidentRequest request) => request switch
+    {
+        LogIncidentRequest.Triage => LogIncidentStatus.Triaging,
+        LogIncidentRequest.File => LogIncidentStatus.Filing,
+        _ => null,
+    };
+
+    /// <summary>Performs what the claim granted, against the content the claim wrote.</summary>
+    private IObservable<Unit> Perform(string path, LogIncidentClaim claim) => claim.Granted switch
+    {
+        LogIncidentRequest.Triage => Triage(path, claim.Incident),
+        LogIncidentRequest.File => Apply(path, filer.File(claim.Incident)),
+        LogIncidentRequest.Comment => Apply(path, filer.Comment(claim.Incident)),
+        LogIncidentRequest.Suppress => Apply(path, Observable.Return(claim.Incident with
+        {
+            Status = LogIncidentStatus.Suppressed,
+            RequestedStatus = LogIncidentRequest.None,
+        })),
+        // Nothing granted: the claim write already recorded whatever bookkeeping it owed.
+        _ => Observable.Return(Unit.Default),
+    };
+
+    // ══════════════════════════════════════════════════════════════════════════
     //  Triage
     // ══════════════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Hands the incident to the triage agent. Marks the node <see cref="LogIncidentStatus.Triaging"/>
-    /// FIRST and only then starts the thread: the status write is what stops the next query
-    /// emission from starting a second thread for the same fault.
+    /// Hands the incident to the triage agent. The claim has already marked the node
+    /// <see cref="LogIncidentStatus.Triaging"/> and cleared the request — that write is what stops
+    /// the next query emission from starting a second thread for the same fault.
     ///
     /// <para>The agent is given the incident as its <c>MainNode</c>, so it reads the evidence from
     /// the node itself rather than from a prompt-stuffed copy, and writes its draft back to the
     /// same node. The thread path is recorded so the reasoning behind a ticket stays reachable.</para>
     /// </summary>
-    private IObservable<Unit> Triage(LogIncidentWork work)
+    private IObservable<Unit> Triage(string path, LogIncident incident)
     {
-        var fingerprint = work.Incident.Fingerprint;
+        var fingerprint = incident.Fingerprint;
 
-        return Write(work.Path, current => current with
-        {
-            Status = LogIncidentStatus.Triaging,
-            RequestedStatus = LogIncidentRequest.None,
-            Error = null,
-        }).Select(_ =>
+        return Observable.Defer(() =>
         {
             // 🚨 The thread hangs off the INCIDENT node, not the satellite namespace. Passing
             // `Admin/_LogIncident` here failed every triage in production with "No node found at
@@ -265,12 +377,12 @@ public sealed class LogIncidentControlPlane : BackgroundService
             // level). The incident IS the owner, so its thread lands at {incidentPath}/_Thread/{id}
             // and stays reachable from the ticket.
             hub.StartThread(
-                namespacePath: work.Path,
-                userText: Prompt(work.Incident),
+                namespacePath: path,
+                userText: Prompt(incident),
                 agentName: options.TriageAgent,
-                contextPath: work.Path,
-                mainNode: work.Path,
-                onCreated: thread => Write(work.Path, current =>
+                contextPath: path,
+                mainNode: path,
+                onCreated: thread => Write(path, current =>
                         current with { TriageThreadPath = thread.Path })
                     .Subscribe(
                         _ => { },
@@ -280,7 +392,7 @@ public sealed class LogIncidentControlPlane : BackgroundService
                 {
                     logger?.LogWarning("Incident {Fingerprint}: triage thread failed to start — {Error}",
                         fingerprint, error);
-                    Write(work.Path, current => current with
+                    Write(path, current => current with
                     {
                         Status = LogIncidentStatus.Failed,
                         Error = error,
@@ -289,7 +401,7 @@ public sealed class LogIncidentControlPlane : BackgroundService
                         ex => logger?.LogWarning(ex, "Incident {Fingerprint}: could not record the triage failure",
                             fingerprint));
                 });
-            return Unit.Default;
+            return Observable.Return(Unit.Default);
         });
     }
 
@@ -405,8 +517,8 @@ public sealed class LogIncidentControlPlane : BackgroundService
     /// (occurrences, pods, samples — during an active incident, constantly). Projecting only the
     /// fields the filer owns keeps both writers correct.</para>
     /// </summary>
-    private IObservable<Unit> Apply(LogIncidentWork work, IObservable<LogIncident> operation) =>
-        operation.SelectMany(filed => Write(work.Path, current => current with
+    private IObservable<Unit> Apply(string path, IObservable<LogIncident> operation) =>
+        operation.SelectMany(filed => Write(path, current => current with
         {
             Status = filed.Status,
             RequestedStatus = filed.RequestedStatus,
@@ -427,3 +539,16 @@ public sealed class LogIncidentControlPlane : BackgroundService
             .FirstAsync()
             .Select(_ => Unit.Default);
 }
+
+/// <summary>
+/// The outcome of consuming an incident's <see cref="LogIncident.RequestedStatus"/>.
+/// </summary>
+/// <param name="Granted">What this worker may actually perform — never simply the request echoed
+/// back. <see cref="LogIncidentRequest.None"/> means "stand down": another worker already took it,
+/// or the incident is ticketed and the recurrence is inside the comment window. A
+/// <see cref="LogIncidentRequest.File"/> on an already-ticketed incident is granted as a
+/// <see cref="LogIncidentRequest.Comment"/>, which is what makes filing idempotent.</param>
+/// <param name="Incident">The content the claim writes: the request cleared and the in-flight
+/// status stamped on a grant, unchanged when nothing was granted (so a declined claim emits an
+/// empty patch and costs nothing).</param>
+internal sealed record LogIncidentClaim(LogIncidentRequest Granted, LogIncident Incident);

--- a/src/MeshWeaver.Observability/LogIncidentFiler.cs
+++ b/src/MeshWeaver.Observability/LogIncidentFiler.cs
@@ -130,6 +130,11 @@ public sealed class LogIncidentFiler(
                     incident.Fingerprint, incident.Repository, number, reopened ? " (reopened)" : "");
                 return incident with
                 {
+                    // A comment that lands PROVES the issue exists and is current, so the incident
+                    // is Filed — even if it had been parked at Failed by an earlier error. Leaving
+                    // a stale Failed here is what let the ingest path re-triage a ticketed incident
+                    // and open a duplicate.
+                    Status = LogIncidentStatus.Filed,
                     RequestedStatus = LogIncidentRequest.None,
                     LastCommentedAt = incident.LastSeen,
                     OccurrencesAtLastComment = incident.Occurrences,

--- a/src/MeshWeaver.Observability/LogIncidentIngestService.cs
+++ b/src/MeshWeaver.Observability/LogIncidentIngestService.cs
@@ -170,22 +170,37 @@ public sealed class LogIncidentIngestService(
 
     /// <summary>
     /// What a recurrence should ask for. Suppressed incidents ask for nothing (that is the point of
-    /// suppressing); a filed incident asks for a comment at most once per
-    /// <see cref="LogWatchOptions.CommentInterval"/>; an incident whose triage never completed is
-    /// re-requested so a portal restart mid-triage cannot strand it forever.
+    /// suppressing); an incident that already has an issue folds the recurrence into it, at most
+    /// once per <see cref="LogWatchOptions.CommentInterval"/>; an incident whose triage never
+    /// completed is re-requested so a portal restart mid-triage cannot strand it forever.
+    ///
+    /// <para>🚨 <b>The issue link outranks the status.</b> The check on
+    /// <see cref="LogIncident.IssueNumber"/> comes before the <c>New</c>/<c>Failed</c> retry rule
+    /// deliberately: a ticketed incident that later goes <c>Failed</c> — a recurrence comment that
+    /// errored, or the stranded-triage reconcile marking it retryable — used to re-enter triage,
+    /// and the agent's fresh draft then asked to <c>File</c> again. That chain is how
+    /// <c>ROUTER_TRAFFIC</c> was filed EIGHT times in seven minutes on the watcher's first live run.
+    /// Once an issue exists, a recurrence belongs on it, never in a new one.</para>
     /// </summary>
     private static LogIncidentRequest NextRequest(
-        LogIncident incident, LogWatchOptions options, DateTimeOffset now) => incident.Status switch
+        LogIncident incident, LogWatchOptions options, DateTimeOffset now) => incident switch
     {
-        LogIncidentStatus.Suppressed => LogIncidentRequest.None,
-        LogIncidentStatus.Filed when CommentDue(incident, options, now) => LogIncidentRequest.Comment,
-        LogIncidentStatus.Filed => LogIncidentRequest.None,
+        { Status: LogIncidentStatus.Suppressed } => LogIncidentRequest.None,
+        { IssueNumber: not null } => CommentDue(incident, options, now)
+            ? LogIncidentRequest.Comment
+            : LogIncidentRequest.None,
+        { Status: LogIncidentStatus.Filed } => LogIncidentRequest.None,
         // New/Failed → (re)try triage. Triaging/Filing → leave the in-flight request alone.
-        LogIncidentStatus.New or LogIncidentStatus.Failed => LogIncidentRequest.Triage,
+        { Status: LogIncidentStatus.New or LogIncidentStatus.Failed } => LogIncidentRequest.Triage,
         _ => incident.RequestedStatus,
     };
 
-    private static bool CommentDue(LogIncident incident, LogWatchOptions options, DateTimeOffset now) =>
+    /// <summary>
+    /// Whether this incident may speak on its issue again. The ONE rate limit on recurrence noise —
+    /// the control plane's claim reads it too, so a <c>File</c> request that arrives on an
+    /// already-ticketed incident is bounded by exactly the same window as a <c>Comment</c> request.
+    /// </summary>
+    internal static bool CommentDue(LogIncident incident, LogWatchOptions options, DateTimeOffset now) =>
         incident.LastCommentedAt is not { } last || now - last >= options.CommentInterval;
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/test/MeshWeaver.Observability.Test/LogIncidentFilingIdempotencyTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogIncidentFilingIdempotencyTest.cs
@@ -1,0 +1,471 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// <b>One fault, one ticket — for the whole life of the fault, not just its first sighting.</b>
+///
+/// <para>The watcher's first live run (2026-08-10 12:03–12:17Z) opened 37 issues for ~12 defects.
+/// The fingerprint held perfectly — 602 occurrences of <c>ROUTER_TRAFFIC</c> stayed ONE incident —
+/// but the FILING duplicated, two ways, and these tests pin both:</para>
+/// <list type="number">
+///   <item><description><b>Re-filing on recurrence.</b> A recurrence parked the incident at
+///   <c>Failed</c>, the ingest path re-triaged it, the agent drafted again and asked to
+///   <c>File</c>, and nothing looked at the issue that already existed —
+///   <c>ROUTER_TRAFFIC</c> was filed eight times in seven minutes.</description></item>
+///   <item><description><b>Same-second doubles.</b> #1124/#1125 and #1111/#1112 were each opened
+///   within one second: the live incident query is eventually consistent and re-emits the
+///   pre-write snapshot, so two work items carried one <c>File</c> request and neither claimed the
+///   incident before opening the issue.</description></item>
+/// </list>
+///
+/// <para>Every timing here comes from the incident's own <c>LastSeen</c> — the same clock the
+/// recurrence policy reads — so there is no wall-clock dependency, no sleep and no scheduler to
+/// pump: the comment window is crossed by moving the data, not by waiting.</para>
+///
+/// <para>The mesh registers <c>AddLogWatch()</c> with NO destination configured, so the
+/// DI-hosted control plane logs "idle" and never subscribes to the incident query. The plane under
+/// test is constructed here with its own options and a fake GitHub, and driven one work item at a
+/// time through <c>RunRequest</c> — exactly what the queue does, minus the emission timing that
+/// cannot be reproduced on demand.</para>
+/// </summary>
+public class LogIncidentFilingIdempotencyTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Fingerprint = "routertraffic0001";
+    private static readonly string IncidentPath = LogIncidentNodeType.IncidentPath(Fingerprint);
+    private static readonly DateTimeOffset T0 = new(2026, 8, 10, 12, 3, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(60);
+
+    /// <summary>The deployment policy the plane under test runs with.</summary>
+    private static readonly LogWatchOptions Policy = new()
+    {
+        DefaultRepository = "Systemorph/MeshWeaver",
+        CommentInterval = TimeSpan.FromHours(6),
+        ReopenOnRecurrence = true,
+    };
+
+    private readonly FakeIssueApi github = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddLogWatch();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The two duplication mechanisms
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact(Timeout = 120_000)]
+    public async Task TwoFileRequestsForOneIncident_OpenExactlyOneIssue()
+    {
+        // ONE snapshot, TWO work items — the same-second double, verbatim: the query re-emitted the
+        // pre-write state after the in-process guard had been released.
+        var stale = await Drafted();
+        var plane = ControlPlane();
+
+        await plane.RunRequest(IncidentPath, stale, LogIncidentRequest.File).Timeout(Bound).ToTask();
+        await plane.RunRequest(IncidentPath, stale, LogIncidentRequest.File).Timeout(Bound).ToTask();
+
+        github.Created.Should().Be(1,
+            "the second work item carries a request the first already consumed — the claim is taken "
+            + "on the live node BEFORE the issue is opened, so only one worker can file");
+        github.Comments.Should().Be(0, "nothing recurred — the second request was a duplicate, not news");
+
+        var incident = await Read(i => i.Status == LogIncidentStatus.Filed);
+        incident.IssueNumber.Should().Be(1);
+        incident.IssueUrl.Should().NotBeNull("the issue link is what every later recurrence keys off");
+        incident.Repository.Should().Be("Systemorph/MeshWeaver");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ARecurrenceAskingToFileAgain_LandsOnTheExistingIssue()
+    {
+        await FileOnce();
+
+        // The production chain, verbatim: the fault comes back, the incident is parked at Failed
+        // (a comment that errored, or the stranded-triage reconcile), the ingest path re-triages,
+        // and the agent's fresh draft asks to File again.
+        var recurred = await Recur(current => current with
+        {
+            Status = LogIncidentStatus.Failed,
+            Error = "Triage finished without a draft.",
+            RequestedStatus = LogIncidentRequest.File,
+            Occurrences = 602,
+            LastSeen = T0.AddMinutes(10),
+        }, until: i => i.RequestedStatus == LogIncidentRequest.File);
+
+        await ControlPlane().RunRequest(IncidentPath, recurred, LogIncidentRequest.File)
+            .Timeout(Bound).ToTask();
+
+        github.Created.Should().Be(1,
+            "a fault that comes back belongs on the ticket it already has — this is the eight-issues-"
+            + "in-seven-minutes chain, and the issue link now outranks the status");
+        github.Comments.Should().Be(1, "the recurrence is reported once, on the existing issue");
+        github.LastComment.Should().Contain("602", "the comment carries the new occurrence count");
+
+        var incident = await Read(i => i.LastCommentedAt is not null);
+        incident.IssueNumber.Should().Be(1);
+        incident.Status.Should().Be(LogIncidentStatus.Filed,
+            "a comment that lands proves the issue exists — the stale Failed is what re-triaged it");
+        incident.Error.Should().BeNull();
+        incident.OccurrencesAtLastComment.Should().Be(602);
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task AFurtherRecurrenceInsideTheCommentWindow_SaysNothingAtAll()
+    {
+        await FileOnce();
+        var first = await Recur(current => current with
+        {
+            RequestedStatus = LogIncidentRequest.File,
+            Occurrences = 602,
+            LastSeen = T0.AddMinutes(10),
+        }, until: i => i.RequestedStatus == LogIncidentRequest.File);
+        await ControlPlane().RunRequest(IncidentPath, first, LogIncidentRequest.File)
+            .Timeout(Bound).ToTask();
+        await Read(i => i.LastCommentedAt is not null);
+
+        // Twenty minutes later, still firing. The comment window is six hours.
+        var again = await Recur(current => current with
+        {
+            RequestedStatus = LogIncidentRequest.File,
+            Occurrences = 1200,
+            LastSeen = T0.AddMinutes(30),
+        }, until: i => i.RequestedStatus == LogIncidentRequest.File);
+        await ControlPlane().RunRequest(IncidentPath, again, LogIncidentRequest.File)
+            .Timeout(Bound).ToTask();
+
+        github.Created.Should().Be(1);
+        github.Comments.Should().Be(1,
+            "a continuously-firing fault gets ONE update per CommentInterval, whatever asked for it — "
+            + "a File request that arrives on a ticketed incident obeys the same bound as a Comment");
+
+        var incident = await Read(i => i.RequestedStatus == LogIncidentRequest.None);
+        incident.Status.Should().Be(LogIncidentStatus.Filed, "silence is not failure");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ARecurrenceAfterTheIssueWasClosed_ReopensIt()
+    {
+        await FileOnce();
+        github.Close(1);
+
+        var recurred = await Recur(current => current with
+        {
+            RequestedStatus = LogIncidentRequest.Comment,
+            Occurrences = 900,
+            LastSeen = T0.AddHours(9),
+        }, until: i => i.RequestedStatus == LogIncidentRequest.Comment);
+
+        await ControlPlane().RunRequest(IncidentPath, recurred, LogIncidentRequest.Comment)
+            .Timeout(Bound).ToTask();
+
+        github.Created.Should().Be(1, "a regression re-surfaces on the original ticket");
+        github.State(1).Should().Be(GitHubIssueState.Open,
+            "a defect that returns after someone closed its ticket is exactly what should notify");
+        github.Comments.Should().Be(1);
+        github.LastComment.Should().Contain("Reopened");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The claim rule itself (no mesh — the whole policy is pure)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void AConsumedRequest_IsNeverPerformedTwice()
+    {
+        // What the second work item of a same-second double sees once the first has claimed.
+        var claimed = new LogIncident { Fingerprint = Fingerprint, RequestedStatus = LogIncidentRequest.None };
+
+        LogIncidentControlPlane.ClaimRequest(claimed, LogIncidentRequest.File, Policy)
+            .Granted.Should().Be(LogIncidentRequest.None);
+        LogIncidentControlPlane.ClaimRequest(claimed, LogIncidentRequest.Triage, Policy)
+            .Granted.Should().Be(LogIncidentRequest.None,
+                "a duplicated Triage starts a second agent round — the same defect, paid for in model budget");
+    }
+
+    [Fact]
+    public void AGrantedClaim_StampsTheInFlightStatusAndClearsTheRequest()
+    {
+        var claim = LogIncidentControlPlane.ClaimRequest(
+            new LogIncident { RequestedStatus = LogIncidentRequest.File, Error = "an earlier failure" },
+            LogIncidentRequest.File, Policy);
+
+        claim.Granted.Should().Be(LogIncidentRequest.File);
+        claim.Incident.Status.Should().Be(LogIncidentStatus.Filing);
+        claim.Incident.RequestedStatus.Should().Be(LogIncidentRequest.None,
+            "clearing the request IS the claim — it is what a second worker reads");
+        claim.Incident.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void AFileRequestOnATicketedIncident_IsGrantedAsAComment()
+    {
+        var ticketed = new LogIncident
+        {
+            Status = LogIncidentStatus.Failed,
+            RequestedStatus = LogIncidentRequest.File,
+            IssueNumber = 1113,
+            Repository = "Systemorph/MeshWeaver",
+            LastSeen = T0,
+        };
+
+        var claim = LogIncidentControlPlane.ClaimRequest(ticketed, LogIncidentRequest.File, Policy);
+
+        claim.Granted.Should().Be(LogIncidentRequest.Comment);
+        claim.Incident.Status.Should().Be(LogIncidentStatus.Filed);
+        claim.Incident.IssueNumber.Should().Be(1113, "the claim never drops the link it is protecting");
+    }
+
+    [Fact]
+    public void AFileRequestInsideTheCommentWindow_IsGrantedNothing()
+        => LogIncidentControlPlane.ClaimRequest(
+                new LogIncident
+                {
+                    Status = LogIncidentStatus.Filed,
+                    RequestedStatus = LogIncidentRequest.File,
+                    IssueNumber = 1113,
+                    LastCommentedAt = T0,
+                    LastSeen = T0.AddMinutes(5),
+                },
+                LogIncidentRequest.File, Policy)
+            .Granted.Should().Be(LogIncidentRequest.None,
+                "a fault firing continuously must not turn its own issue into a feed");
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Harness
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>The plane under test: its own policy, its own filer, its own fake GitHub.</summary>
+    private LogIncidentControlPlane ControlPlane()
+    {
+        var options = Options.Create(Policy);
+        return new LogIncidentControlPlane(Mesh, new LogIncidentFiler(github, AppTokens(), options), options);
+    }
+
+    /// <summary>
+    /// A REAL <see cref="GitHubAppTokenService"/> against a fake GitHub App API — the filer refuses
+    /// to run without the App identity, and faking the identity rather than the service keeps the
+    /// production credential path in the test.
+    /// </summary>
+    private GitHubAppTokenService AppTokens() => new(
+        Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>(),
+        Options.Create(new GitHubAppOptions
+        {
+            ClientId = "Iv23liLogWatchApp",
+            PrivateKey = FakeGitHubApp.TestKeyPem,
+            InstallationOwner = "Systemorph",
+        }),
+        logger: null,
+        httpClient: new HttpClient(new FakeGitHubApp.Handler()));
+
+    private LogIncidentIngestService Ingest() => new(Mesh, Options.Create(Policy));
+
+    /// <summary>The incident as it stands when triage has produced a draft and asked to file.</summary>
+    private async Task<LogIncident> Drafted()
+    {
+        await Ingest().Report(new LogIncidentReport
+        {
+            Fingerprint = Fingerprint,
+            Category = "MeshWeaver.Connection.Orleans.OrleansRoutingService",
+            Severity = LogSeverity.Error,
+            NormalizedMessage = "Router traffic to {address} failed",
+            Namespace = "memex",
+            Pods = ImmutableList.Create("memex-portal-0"),
+            Occurrences = 40,
+            FirstSeen = T0,
+            LastSeen = T0,
+            Samples = ImmutableList.Create(new LogSample(T0, "memex-portal-0", "fail: routing")),
+        }).FirstAsync().Timeout(Bound).ToTask();
+
+        await Mesh.UpdateIncident(IncidentPath, current => current with
+        {
+            Status = LogIncidentStatus.Triaging,
+            RequestedStatus = LogIncidentRequest.File,
+            Draft = new LogIncidentDraft
+            {
+                Title = "Orleans router drops traffic to unreachable silos",
+                Body = "The routing service retries a dead silo forever.",
+            },
+        }).FirstAsync().Timeout(Bound).ToTask();
+
+        return await Read(i => i.RequestedStatus == LogIncidentRequest.File);
+    }
+
+    /// <summary>Files the incident once — the starting point every recurrence test builds on.</summary>
+    private async Task FileOnce()
+    {
+        var drafted = await Drafted();
+        await ControlPlane().RunRequest(IncidentPath, drafted, LogIncidentRequest.File)
+            .Timeout(Bound).ToTask();
+        await Read(i => i is { Status: LogIncidentStatus.Filed, IssueNumber: not null });
+    }
+
+    /// <summary>Applies a recurrence to the live incident and reads back the settled state.</summary>
+    private async Task<LogIncident> Recur(
+        Func<LogIncident, LogIncident> recurrence, Func<LogIncident, bool> until)
+    {
+        await Mesh.UpdateIncident(IncidentPath, recurrence).FirstAsync().Timeout(Bound).ToTask();
+        return await Read(until);
+    }
+
+    /// <summary>
+    /// The incident's live content, once it satisfies <paramref name="until"/>. Never a bare
+    /// <c>Take(1)</c> after a write — the first emission off a shared handle can still be the
+    /// pre-write snapshot.
+    /// </summary>
+    private Task<LogIncident> Read(Func<LogIncident, bool> until) =>
+        Mesh.GetWorkspace().GetMeshNodeStream(IncidentPath)
+            .Where(node => node is not null)
+            .Select(node => node.ContentAs<LogIncident>(Mesh.JsonSerializerOptions))
+            .Where(incident => incident is not null && until(incident))
+            .Select(incident => incident!)
+            .FirstAsync()
+            .Timeout(Bound)
+            .ToTask();
+}
+
+/// <summary>
+/// In-memory GitHub issue API. Counts what was actually opened, commented and reopened — the
+/// numbers the duplicate-notification defect is measured in. No network, no statics, no clock.
+/// </summary>
+internal sealed class FakeIssueApi : IGitHubRepoClient
+{
+    private readonly object gate = new();
+    private readonly Dictionary<int, GitHubIssue> issues = new();
+    private int next;
+    private int comments;
+    private string? lastComment;
+
+    /// <summary>How many issues were opened.</summary>
+    public int Created { get { lock (gate) return issues.Count; } }
+
+    /// <summary>How many comments were posted, across all issues.</summary>
+    public int Comments { get { lock (gate) return comments; } }
+
+    /// <summary>The body of the most recent comment.</summary>
+    public string? LastComment { get { lock (gate) return lastComment; } }
+
+    /// <summary>The current state of an issue.</summary>
+    public GitHubIssueState State(int number) { lock (gate) return issues[number].State; }
+
+    /// <summary>Closes an issue, as a human would after fixing the defect.</summary>
+    public void Close(int number)
+    {
+        lock (gate) issues[number] = issues[number] with { State = GitHubIssueState.Closed };
+    }
+
+    public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request)
+        => Observable.Defer(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            lock (gate)
+            {
+                var number = ++next;
+                var issue = new GitHubIssue
+                {
+                    Number = number,
+                    Title = request.Title,
+                    Body = request.Body,
+                    State = GitHubIssueState.Open,
+                    Labels = request.Labels,
+                    Url = $"{request.RepositoryUrl}/issues/{number}",
+                };
+                issues[number] = issue;
+                return Observable.Return(issue);
+            }
+        });
+
+    public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+        => Observable.Defer(() =>
+        {
+            lock (gate) return Observable.Return(issues[number]);
+        });
+
+    public IObservable<GitHubIssue> SetIssueState(
+        string repositoryUrl, int number, GitHubIssueState state, string accessToken)
+        => Observable.Defer(() =>
+        {
+            lock (gate)
+            {
+                var issue = issues[number] with { State = state };
+                issues[number] = issue;
+                return Observable.Return(issue);
+            }
+        });
+
+    public IObservable<GitHubIssueComment> CommentIssue(
+        string repositoryUrl, int number, string body, string accessToken)
+        => Observable.Defer(() =>
+        {
+            lock (gate)
+            {
+                comments++;
+                lastComment = body;
+                return Observable.Return(new GitHubIssueComment(comments, "meshweaver[bot]", body, null, null));
+            }
+        });
+
+    public IObservable<RepoSnapshot> Fetch(
+        string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        => throw new NotSupportedException();
+    public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => throw new NotSupportedException();
+    public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request) => throw new NotSupportedException();
+    public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request) => throw new NotSupportedException();
+    public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(string repositoryUrl, int number, string accessToken) => throw new NotSupportedException();
+    public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(string repositoryUrl, GitHubIssueState? state, string accessToken) => throw new NotSupportedException();
+    public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(string repositoryUrl, PullRequestStatus? state, string accessToken) => throw new NotSupportedException();
+    public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(string repositoryUrl, int number, string accessToken) => throw new NotSupportedException();
+    public IObservable<GitHubIssueComment> CommentPullRequest(string repositoryUrl, int number, string body, string accessToken) => throw new NotSupportedException();
+    public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request) => throw new NotSupportedException();
+}
+
+/// <summary>The GitHub App API a real <see cref="GitHubAppTokenService"/> mints its token against.</summary>
+internal static class FakeGitHubApp
+{
+    /// <summary>A throwaway RSA key for the App JWT signature.</summary>
+    public static readonly string TestKeyPem = CreateKey();
+
+    private static string CreateKey()
+    {
+        using var rsa = RSA.Create(2048);
+        return rsa.ExportRSAPrivateKeyPem();
+    }
+
+    /// <summary>Installation discovery + token minting, offline and deterministic.</summary>
+    public sealed class Handler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            var path = request.RequestUri!.AbsolutePath;
+            if (request.Method == HttpMethod.Get && path == "/app/installations")
+                return Task.FromResult(Json("""[{"id": 42, "account": {"login": "Systemorph"}}]"""));
+            if (request.Method == HttpMethod.Post && path.EndsWith("/access_tokens", StringComparison.Ordinal))
+            {
+                var expires = DateTimeOffset.UtcNow.AddHours(1).ToString("o");
+                return Task.FromResult(Json($$"""{"token": "ghs_logwatch_token", "expires_at": "{{expires}}"}"""));
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"unexpected {request.Method} {path}"),
+            });
+        }
+
+        private static HttpResponseMessage Json(string body) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+    }
+}

--- a/test/MeshWeaver.Observability.Test/LogIncidentMergeTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogIncidentMergeTest.cs
@@ -25,6 +25,12 @@ public class LogIncidentMergeTest
         Status = status,
         Samples = ImmutableList.Create(new LogSample(T0, "pod-a", "old line")),
         Pods = ImmutableList.Create("pod-a"),
+        // A Filed incident ALWAYS carries its issue — the filer writes the status and the link in
+        // one go, and the link is what a recurrence is folded onto. A fixture that files without
+        // one describes a state the system cannot reach, and would have the recurrence ask for a
+        // comment on an issue that does not exist.
+        IssueNumber = status == LogIncidentStatus.Filed ? 1113 : null,
+        Repository = status == LogIncidentStatus.Filed ? "Systemorph/MeshWeaver" : null,
     };
 
     private static LogIncidentReport Repeat(
@@ -124,6 +130,34 @@ public class LogIncidentMergeTest
         // A portal restart mid-triage, or a transient triage failure, must not strand the incident.
         => LogIncidentIngestService.Merge(Existing(status), Repeat(), Options)
             .RequestedStatus.Should().Be(LogIncidentRequest.Triage);
+
+    [Theory]
+    [InlineData(LogIncidentStatus.New)]
+    [InlineData(LogIncidentStatus.Failed)]
+    [InlineData(LogIncidentStatus.Triaging)]
+    public void Merge_NeverReTriagesAnIncidentThatAlreadyHasAnIssue(LogIncidentStatus status)
+    {
+        // 🚨 The issue link outranks the status. A ticketed incident that later reads Failed — a
+        // recurrence comment that errored, or the stranded-triage reconcile marking it retryable —
+        // used to re-enter triage, and the agent's fresh draft then asked to File again. That chain
+        // filed ROUTER_TRAFFIC eight times in seven minutes on the watcher's first live run.
+        var ticketed = Existing(status) with
+        {
+            IssueNumber = 1113,
+            Repository = "Systemorph/MeshWeaver",
+        };
+
+        LogIncidentIngestService.Merge(ticketed, Repeat(), Options).RequestedStatus
+            .Should().Be(LogIncidentRequest.Comment,
+                "a fault that comes back belongs on the ticket it already has");
+    }
+
+    [Fact]
+    public void Merge_KeepsASuppressedIncidentQuietEvenWhenItWasTicketed()
+        => LogIncidentIngestService.Merge(
+                Existing(LogIncidentStatus.Suppressed) with { IssueNumber = 1113 }, Repeat(), Options)
+            .RequestedStatus.Should().Be(LogIncidentRequest.None,
+                "suppression is the operator's decision and outranks every other rule");
 
     [Theory]
     [InlineData(LogIncidentStatus.Triaging)]


### PR DESCRIPTION
Fixes #1144. The alerting rollout is blocked on this — the watcher is scaled to 0 replicas until it lands.

## What was wrong

The watcher's first live run filed **37 issues for ~12 defects**. The fingerprint held perfectly (602 occurrences of `ROUTER_TRAFFIC` stayed ONE incident), so the duplication was entirely in the **filing** — two mechanisms:

1. **Re-filing on recurrence.** A recurrence parked a *ticketed* incident at `Failed` (a comment that errored, or #1094's stranded-triage reconcile marking it retryable). `NextRequest` re-triaged it because it looked only at `Status`; the agent drafted again and asked to `File`; and the File path never looked at `IssueNumber`. `ROUTER_TRAFFIC` was filed **eight times in seven minutes**.
2. **Same-second doubles** (#1124/#1125, #1111/#1112). Every guard on the File path was in-process. The incident query is eventually consistent and re-emits the pre-write snapshot *after* the `inFlight` set has been released, so two work items carried one `File` request — and neither claimed the incident before opening the issue.

## The fix

**The claim.** Every transition now consumes `RequestedStatus` in a write against the incident's LIVE content, and that write lands **before** the GitHub call it guards (#826's claim-the-guard-before-the-mutation, off the completed write). A second work item finds the request cleared and stands down. The operation then runs on the content the *claim* wrote — not the stale query snapshot the work item was queued with, which also stops the issue body being built from out-of-date counts.

```
ClaimRequest(current, request, options)
  current.RequestedStatus != request        -> Granted None   (already consumed)
  File && current.IssueNumber is not null   -> Granted Comment (or None inside the window)
  otherwise                                 -> Granted request, stamp Triaging/Filing, clear the request
```

**The issue link outranks the status.** `NextRequest` checks `IssueNumber` *before* the `New`/`Failed` retry rule, so a ticketed incident never re-enters triage whatever its status says.

**The recurrence design.** A `File` request arriving on a ticketed incident is granted as a `Comment` — folded onto the issue that exists, under the **same** rate limit a `Comment` request already obeyed (`CommentInterval`, 6 h default), reusing the existing bound rather than inventing a second one. A **closed** issue is reopened first: a defect that returns after someone closed its ticket is exactly what should notify. A comment that lands also writes the incident back to `Filed`, clearing the stale `Failed` that started the re-triage chain in the first place.

The claim keys on `RequestedStatus`, never on `Status`, so the in-flight statuses (`Triaging`, `Filing`) are not new dead ends: a crash between claim and write-back parks the incident there, and asking again — an admin, or the stranded-triage reconcile — is honoured.

## Verification

All four regressions were **seen failing against the pre-fix code first** (HEAD + the 3-line `RunRequest` test seam, nothing else):

| Test | Pre-fix failure |
|---|---|
| `TwoFileRequestsForOneIncident_OpenExactlyOneIssue` | `Expected value to be 1 …, but found 2` |
| `ARecurrenceAskingToFileAgain_LandsOnTheExistingIssue` | `Expected value to be 1 …, but found 2` |
| `AFurtherRecurrenceInsideTheCommentWindow_SaysNothingAtAll` | `System.TimeoutException` — filing never wrote `LastCommentedAt`, so the incident never settled |
| `Merge_NeverReTriagesAnIncidentThatAlreadyHasAnIssue` (New/Failed/Triaging) | `Expected value to be Comment …, but found Triage` / `found None` |

`ARecurrenceAfterTheIssueWasClosed_ReopensIt` **passed pre-fix** — that path was already correct and is now pinned so it cannot regress.

The integration tests drive the real control plane against a real mesh (`MonolithMeshTestBase`), through the real claim + `stream.Update` write path, with a fake GitHub issue API and a **real** `GitHubAppTokenService` against a fake App endpoint. Every timing comes from the incident's own `LastSeen` — the clock the recurrence policy actually reads — so there is no wall clock, no sleep and no scheduler to pump.

- `MeshWeaver.Observability.Test`: **105 passed, 0 failed** (93 pre-existing + 12 new).
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest`: 2 passed.
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Observability`, `MeshWeaver.Observability.Test` and `MeshWeaver.Documentation`.

The `Filed` fixture in `LogIncidentMergeTest` now carries the issue it always has in production — a `Filed` incident without one describes a state the system cannot reach, and would ask for a comment on an issue that does not exist.

Docs: `LogWatchTriage.md` gains a "One fault, one ticket — for the fault's whole life" section; What's New entry `Category: Fix` (duplicate alert notifications are user-noticeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
