### PR TITLE
A claim that never reached GitHub parked the incident in Filing forever

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -131,8 +131,17 @@ A recurrence is therefore always folded onto the ticket that exists:
 
 The claim keys on `RequestedStatus`, never on the status, so the in-flight statuses (`Triaging`,
 `Filing`) are not dead ends: a crash between the claim and the write-back parks the incident there,
-and asking again — an admin in the incident view, or the stranded-triage reconcile below — is
-honoured.
+and asking again is honoured. **Something has to do the asking**, though, and that differs by status:
+
+- `Triaging` — the stranded-triage reconcile below, which asks the thread whether the round is over.
+  Only the thread can tell "still running" from "died", so nothing may re-request on a timer.
+- `Filing` **with no `IssueNumber`** — the next recurrence re-requests `File` (`NextRequest`). The
+  claim was taken and nothing came back, and unlike `Triaging` there is no in-mesh authority to ask:
+  the only record of whether the issue was opened is GitHub. Re-asking is safe because the claim
+  itself is the guard — if the incident has since been ticketed, the request is granted as a
+  `Comment`, never as a second issue.
+- `Filing` **with** an `IssueNumber` is not in-flight at all: the write-back lands the link, so that
+  state is a completed file whose status simply settled, and the issue-link rule keeps it quiet.
 
 ### The one state nothing requests: `Triaging`
 

--- a/src/MeshWeaver.Observability/LogIncidentIngestService.cs
+++ b/src/MeshWeaver.Observability/LogIncidentIngestService.cs
@@ -181,6 +181,17 @@ public sealed class LogIncidentIngestService(
     /// and the agent's fresh draft then asked to <c>File</c> again. That chain is how
     /// <c>ROUTER_TRAFFIC</c> was filed EIGHT times in seven minutes on the watcher's first live run.
     /// Once an issue exists, a recurrence belongs on it, never in a new one.</para>
+    ///
+    /// <para>🚨 <b><c>Filing</c> without an issue is the one in-flight status that is re-asked.</b>
+    /// The claim writes <c>Filing</c> BEFORE the GitHub round-trip, so a portal that dies in that
+    /// window — or a write-back that fails — leaves the incident at <c>Filing</c> with no link.
+    /// Nothing else can move it: the claim keys on <c>RequestedStatus</c>, which is already
+    /// <c>None</c>; the stranded-triage reconcile only ever touches <c>Triaging</c>; and every rule
+    /// above needs either an issue or a different status. That is precisely the dead end
+    /// <c>Triaging</c> used to be — nineteen incidents accumulated there, invisible and un-ticketed —
+    /// only now in a status the repair does not cover. Asking again is safe BECAUSE of the claim:
+    /// a File request on an incident that has since been ticketed is redirected to the
+    /// rate-limited comment, never to a second issue.</para>
     /// </summary>
     private static LogIncidentRequest NextRequest(
         LogIncident incident, LogWatchOptions options, DateTimeOffset now) => incident switch
@@ -190,8 +201,11 @@ public sealed class LogIncidentIngestService(
             ? LogIncidentRequest.Comment
             : LogIncidentRequest.None,
         { Status: LogIncidentStatus.Filed } => LogIncidentRequest.None,
-        // New/Failed → (re)try triage. Triaging/Filing → leave the in-flight request alone.
+        // New/Failed → (re)try triage. Triaging → leave the in-flight round alone; the control
+        // plane reconciles it against the thread, the only authority on whether it is still running.
         { Status: LogIncidentStatus.New or LogIncidentStatus.Failed } => LogIncidentRequest.Triage,
+        // Filing with no link ⇒ the claim was taken and nothing came back. Re-ask.
+        { Status: LogIncidentStatus.Filing } => LogIncidentRequest.File,
         _ => incident.RequestedStatus,
     };
 

--- a/test/MeshWeaver.Observability.Test/LogIncidentMergeTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogIncidentMergeTest.cs
@@ -159,15 +159,49 @@ public class LogIncidentMergeTest
             .RequestedStatus.Should().Be(LogIncidentRequest.None,
                 "suppression is the operator's decision and outranks every other rule");
 
-    [Theory]
-    [InlineData(LogIncidentStatus.Triaging)]
-    [InlineData(LogIncidentStatus.Filing)]
-    public void Merge_LeavesInFlightWorkAlone(LogIncidentStatus status)
+    [Fact]
+    public void Merge_LeavesAnInFlightTriageAlone()
     {
-        var existing = Existing(status) with { RequestedStatus = LogIncidentRequest.None };
+        var existing = Existing(LogIncidentStatus.Triaging) with { RequestedStatus = LogIncidentRequest.None };
 
-        // Re-requesting mid-flight would start a second triage thread / file a second issue.
+        // Re-requesting mid-round would start a second triage thread. A round that DIED is not
+        // recovered here but by the control plane's reconcile against the thread node — the only
+        // authority on whether it is still running.
         LogIncidentIngestService.Merge(existing, Repeat(), Options)
+            .RequestedStatus.Should().Be(LogIncidentRequest.None);
+    }
+
+    [Fact]
+    public void Merge_ReAsksForAFilingIncidentThatNeverGotAnIssue()
+    {
+        var existing = Existing(LogIncidentStatus.Filing) with { RequestedStatus = LogIncidentRequest.None };
+
+        // 🚨 Filing is written by the CLAIM, before the GitHub round-trip. A portal that dies in
+        // that window leaves the incident here with no link — and nothing else can move it: the
+        // claim keys on RequestedStatus (already None), and the stranded-triage reconcile only
+        // touches Triaging. Left alone, this is the same permanent dead end Triaging used to be:
+        // occurrences keep counting and no ticket is ever opened.
+        LogIncidentIngestService.Merge(existing, Repeat(), Options)
+            .RequestedStatus.Should().Be(LogIncidentRequest.File,
+                "a claim that never produced a ticket must be re-asked, not stranded");
+    }
+
+    [Fact]
+    public void Merge_DoesNotReAskOnceTheFilingProducedItsIssue()
+    {
+        // The same status with the link present is a file that COMPLETED (the write-back lands the
+        // link before the status settles). Re-asking would be the duplicate this whole rule exists
+        // to prevent — the issue link outranks the status here too.
+        var ticketed = Existing(LogIncidentStatus.Filing) with
+        {
+            RequestedStatus = LogIncidentRequest.None,
+            IssueNumber = 1113,
+            Repository = "Systemorph/MeshWeaver",
+            LastCommentedAt = T0.AddMinutes(4),
+        };
+        var options = Options with { CommentInterval = TimeSpan.FromHours(6) };
+
+        LogIncidentIngestService.Merge(ticketed, Repeat(at: T0.AddMinutes(5)), options)
             .RequestedStatus.Should().Be(LogIncidentRequest.None);
     }
 }


### PR DESCRIPTION
Follow-up to #1144 / #1147. Not a duplicate of the idempotency fix — it closes the dead end that fix introduced.

## What is failing

#1147 made `Filing` a **written** status: the claim stamps it before the GitHub round-trip so a second work item can tell a mid-file incident from a mid-triage one. That closed the duplicate correctly. It also created a state nothing can leave.

When the claim is taken and nothing comes back — the portal dies in that window, or the write-back itself fails — the incident is left at:

```
Status = Filing,  RequestedStatus = None,  IssueNumber = null
```

and every exit is closed:

| Candidate | Why it does not fire |
|---|---|
| the claim | keys on `RequestedStatus`, which the claim itself already cleared to `None` |
| `NeedsTriageReconcile` | requires `Status == Triaging`; `Filing` is not covered |
| `NextRequest` → `{ IssueNumber: not null }` | there is no link |
| `NextRequest` → `New or Failed` | the status is `Filing` |
| `NextRequest` → `_` | returns `RequestedStatus`, i.e. `None` |

So the incident counts occurrences forever and is never ticketed — invisible and un-ticketed, which is exactly what `Triaging` used to do before #1094 (nineteen incidents accumulated that way on memex.systemorph.com), now in a status the repair does not cover. `LogIncidentControlPlane.InFlightStatus`'s doc comment already claims this case is recoverable "via the stranded-triage reconcile" — for `File` it is not, because that reconcile only reads `Triaging`.

## The fix

A recurrence re-asks for `File` when the incident is `Filing` **with no issue link**.

```csharp
// Filing with no link ⇒ the claim was taken and nothing came back. Re-ask.
{ Status: LogIncidentStatus.Filing } => LogIncidentRequest.File,
```

It sits *below* `{ IssueNumber: not null }`, so it only ever fires for an incident that has no ticket. And re-asking is safe **because of** #1147's claim: a `File` request arriving on an incident that has since been ticketed is granted as a rate-limited `Comment`, never as a second issue. `Filing` **with** a link is not in-flight at all — the write-back lands the link before the status settles — so the issue-link rule keeps it quiet.

No timer, no watchdog, no retry loop: the trigger is the same recurrence report that already drives every other transition.

## Pinned

`LogIncidentMergeTest`:

- `Merge_ReAsksForAFilingIncidentThatNeverGotAnIssue` — the strand is re-asked.
- `Merge_DoesNotReAskOnceTheFilingProducedItsIssue` — the same status **with** a link stays quiet.
- `Merge_LeavesAnInFlightTriageAlone` — replaces the `[Theory]` half that asserted `Filing` must be left alone (that assertion is what described the dead end). `Triaging` is unchanged: only the thread can tell "still running" from "died", so nothing may re-request there.

Negative control: removing only the new arm turns `Merge_ReAsksForAFilingIncidentThatNeverGotAnIssue` red — `Expected value to be File …, but found None`. Restored, all 106 tests in `MeshWeaver.Observability.Test` pass; `MeshWeaver.Observability` and the test project build clean at `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)