### PR TITLE
Stop routing through a silo that is already leaving the cluster

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -9,8 +9,10 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
+using MeshWeaver.Reflection;
 using MeshWeaver.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -63,6 +65,43 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     private readonly IIoPool ioPool;
     private volatile bool disposed;
 
+    /// <summary>
+    /// The host's own <see cref="IHostApplicationLifetime.ApplicationStopping"/> token — the
+    /// observable signal that this process has begun shutting down.
+    ///
+    /// <para>🚨 This is what makes the shutdown window ROUTABLE-OR-NOT decidable instead of
+    /// discovered by exception. The moment an Orleans silo begins graceful shutdown it leaves
+    /// <c>Active</c> in the membership oracle, and from that instant EVERY placement of
+    /// <see cref="IRoutingGrain"/> — a <c>[StatelessWorker(1)]</c> grain, placed through
+    /// <c>StatelessWorkerDirector</c> → <c>PlacementService.GetCompatibleSilos</c>, which
+    /// intersects with the ACTIVE silo set — throws
+    /// <c>OrleansException: No active nodes are compatible with grain routing</c>. The silo is
+    /// still running and still processing; it simply may no longer take new activations.</para>
+    ///
+    /// <para><b>Prod evidence (memex, 2026-08-10).</b> On all three pod shutdowns that day the
+    /// first such exception landed within HALF A SECOND of the host logging "Application is
+    /// shutting down..." — 11:44:31.341 → 11:44:31.750 on <c>…-wq7s8</c> — and then repeated
+    /// 52, 838 and 944 times respectively until the process exited. Every one of those was
+    /// (a) an Orleans-internal <c>Orleans.Messaging[100071]</c> error, because we asked for a
+    /// grain that could no longer be placed, and (b) a <see cref="ErrorType.Failed"/> — i.e.
+    /// TERMINAL — <see cref="DeliveryFailure"/> to the sender. The traffic was ordinary live
+    /// routing (activity <c>compile-state</c> heartbeats, node streams); nothing was wrong with
+    /// it except that the silo underneath was going away.</para>
+    ///
+    /// <para><see cref="IHostApplicationLifetime.ApplicationStopping"/> fires BEFORE the silo hosted service is stopped
+    /// (hosted services stop in reverse registration order, after the stopping handlers run), so
+    /// it is available strictly earlier than the condition it predicts. That ordering is what
+    /// makes this a readiness signal rather than a retry: we never attempt the placement we know
+    /// cannot succeed, so Orleans never logs 100071 and the sender is answered immediately with
+    /// the correct, RIDE-IT-OUT classification.</para>
+    /// </summary>
+    private readonly CancellationToken hostStopping;
+
+    /// <summary>
+    /// True once this process has begun shutting down — see <see cref="hostStopping"/>.
+    /// </summary>
+    private bool IsHostStopping => hostStopping.IsCancellationRequested;
+
     // Stream-teardown is bounded by Default (ProcessorCount); the op is a quick Orleans
     // UnsubscribeAsync, never a sustained fan-out.
     private const string StreamPoolName = "RoutingStream";
@@ -84,6 +123,11 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         this.logger = logger;
         ioPool = serviceProvider.GetService<IoPoolRegistry>()?.Get(StreamPoolName)
                  ?? IoPool.Unbounded;
+        // Optional by design: a non-host DI container (a bare mesh in a unit test) has no
+        // application lifetime, and then there is no shutdown window to detect — the token
+        // stays uncancelled and every routing decision below behaves exactly as before.
+        hostStopping = serviceProvider.GetService<IHostApplicationLifetime>()?.ApplicationStopping
+                       ?? CancellationToken.None;
     }
 
     /// <summary>
@@ -114,7 +158,46 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 return callback.Invoke(delivery, CancellationToken.None);
             }
 
-            // 2. Background mesh dispatch via the routing grain. Path resolution
+            // 2. Shutdown window. The host has begun stopping, so the silo is leaving (or has
+            //    left) the ACTIVE silo set and IRoutingGrain can no longer be PLACED — the
+            //    dispatch below is guaranteed to throw "No active nodes are compatible with
+            //    grain routing". Answer the sender HERE instead: the failure is real (this
+            //    message is not being routed) but it is TRANSIENT, so it must carry
+            //    ErrorType.ShuttingDown, never the terminal ErrorType.Failed.
+            //
+            //    🚨 The classification is the functional half of this fix. Long-lived consumers
+            //    with their own recovery machinery — chiefly SynchronizationStream's keep-alive
+            //    + change-feed resubscribe latch, and JsonSynchronizationStream — key on
+            //    ShuttingDown to RIDE THE REJECT OUT; a terminal Failed makes them tear down
+            //    (CI 30003419841). The Monolith router already classifies its shutdown reject
+            //    this way (MonolithRoutingService.PostNotFound); the Orleans router did not, so
+            //    every pod shutdown NACKed hundreds of live subscriptions as permanently failed.
+            //
+            //    Not dispatching is also what removes the Orleans-internal
+            //    `Orleans.Messaging[100071] Failed to address message` error per attempt — that
+            //    log is emitted by Orleans when WE ask for an unplaceable grain, so it can only
+            //    be silenced by not asking.
+            if (IsHostStopping)
+            {
+                var shutdownMessage = $"Host is shutting down, cannot route to {address}";
+                OrleansRouteTrace.Write($"OrleansRoutingService.Deliver SHUTTING_DOWN addr={address} id={delivery.Id}");
+                logger.LogDebug("Orleans: {MessageType} → {Address} rejected as {ErrorType} — host is shutting down",
+                    delivery.Message?.GetType().Name, address, nameof(ErrorType.ShuttingDown));
+
+                // Same NACK-once contract as RoutingServiceBase.PostNotFound: never answer a
+                // DeliveryFailure (that loops) and never answer a [CanBeIgnored] message, but
+                // DO classify the returned delivery either way so whoever finishes it can.
+                var senderNacked = delivery.Message is not DeliveryFailure
+                                   && delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() != true;
+                if (senderNacked)
+                    SendDeliveryFailure(delivery, shutdownMessage, ErrorType.ShuttingDown);
+
+                return Observable.Return(senderNacked
+                    ? delivery.FailedAndNacked(shutdownMessage)
+                    : delivery.Failed(shutdownMessage, ErrorType.ShuttingDown));
+            }
+
+            // 3. Background mesh dispatch via the routing grain. Path resolution
             //    runs INSIDE the grain (silo-side) where the catalog is visible —
             //    on the client, MeshConfiguration.Nodes is empty. Fire-and-forget
             //    Subscribe — errors flow into SendDeliveryFailure inside the
@@ -127,9 +210,19 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 sub.Disposable = DispatchObservable(delivery, address)
                     .Catch<IMessageDelivery, Exception>(ex =>
                     {
-                        logger.LogError(ex, "Failed to deliver to {Address}", address);
-                        OrleansRouteTrace.Write($"OrleansRoutingService.Deliver DISPATCH_FAILED addr={address} id={delivery.Id} ex={ex.Message}");
-                        SendDeliveryFailure(delivery, $"Failed to deliver to {address}: {ex.Message}");
+                        // The stopping token can flip AFTER we dispatched — the placement then
+                        // fails for exactly the reason handled above, so classify it the same
+                        // way (transient, ride-it-out) and keep it out of the error log. An
+                        // expected shutdown artifact reported at Error is what auto-filed a
+                        // production incident for a process that was merely exiting.
+                        var shuttingDown = IsHostStopping;
+                        if (shuttingDown)
+                            logger.LogDebug(ex, "Failed to deliver to {Address} — host is shutting down", address);
+                        else
+                            logger.LogError(ex, "Failed to deliver to {Address}", address);
+                        OrleansRouteTrace.Write($"OrleansRoutingService.Deliver DISPATCH_FAILED addr={address} id={delivery.Id} shuttingDown={shuttingDown} ex={ex.Message}");
+                        SendDeliveryFailure(delivery, $"Failed to deliver to {address}: {ex.Message}",
+                            shuttingDown ? ErrorType.ShuttingDown : ErrorType.Failed);
                         return Observable.Empty<IMessageDelivery>();
                     })
                     .Finally(() =>
@@ -228,7 +321,13 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             });
     }
 
-    private void SendDeliveryFailure(IMessageDelivery delivery, string message)
+    /// <param name="delivery">The delivery that could not be routed.</param>
+    /// <param name="message">The failure message returned to the sender.</param>
+    /// <param name="errorType">How the sender should read the failure. <see cref="ErrorType.Failed"/>
+    /// is TERMINAL; pass <see cref="ErrorType.ShuttingDown"/> whenever the cause is this process
+    /// going away, so consumers with recovery machinery ride it out instead of tearing down.</param>
+    private void SendDeliveryFailure(IMessageDelivery delivery, string message,
+        ErrorType errorType = ErrorType.Failed)
     {
         try
         {
@@ -252,7 +351,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                     meshHub.Post(
                         new DeliveryFailure(delivery)
                         {
-                            ErrorType = ErrorType.Failed,
+                            ErrorType = errorType,
                             Message = message
                         },
                         o =>

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -184,13 +184,15 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 logger.LogDebug("Orleans: {MessageType} → {Address} rejected as {ErrorType} — host is shutting down",
                     delivery.Message?.GetType().Name, address, nameof(ErrorType.ShuttingDown));
 
-                // Same NACK-once contract as RoutingServiceBase.PostNotFound: never answer a
-                // DeliveryFailure (that loops) and never answer a [CanBeIgnored] message, but
+                // Same NACK-once contract as RoutingServiceBase.PostNotFound (see MayAnswer), but
                 // DO classify the returned delivery either way so whoever finishes it can.
-                var senderNacked = delivery.Message is not DeliveryFailure
-                                   && delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() != true;
-                if (senderNacked)
-                    SendDeliveryFailure(delivery, shutdownMessage, ErrorType.ShuttingDown);
+                //
+                // 🚨 senderNacked is the POST's verdict, not the permission to post. FailedAndNacked
+                // means "the sender has been answered" and suppresses downstream reporting, so
+                // claiming it when SendDeliveryFailure could not post (no mesh hub) would leave an
+                // Observe(...) caller waiting out its full budget with the failure recorded nowhere.
+                var senderNacked = MayAnswer(delivery)
+                                   && SendDeliveryFailure(delivery, shutdownMessage, ErrorType.ShuttingDown);
 
                 return Observable.Return(senderNacked
                     ? delivery.FailedAndNacked(shutdownMessage)
@@ -221,8 +223,16 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                         else
                             logger.LogError(ex, "Failed to deliver to {Address}", address);
                         OrleansRouteTrace.Write($"OrleansRoutingService.Deliver DISPATCH_FAILED addr={address} id={delivery.Id} shuttingDown={shuttingDown} ex={ex.Message}");
-                        SendDeliveryFailure(delivery, $"Failed to deliver to {address}: {ex.Message}",
-                            shuttingDown ? ErrorType.ShuttingDown : ErrorType.Failed);
+
+                        // 🚨 The same answer-once contract the shutdown branch above applies —
+                        // this path used to answer unconditionally. A DeliveryFailure answered
+                        // with a DeliveryFailure loops, and a [CanBeIgnored] control message has
+                        // no one waiting, so the NACK is pure added traffic. Both matter most
+                        // precisely here: dispatch fails in bulk while a silo is leaving, which is
+                        // when the mesh can least afford an answering storm.
+                        if (MayAnswer(delivery))
+                            SendDeliveryFailure(delivery, $"Failed to deliver to {address}: {ex.Message}",
+                                shuttingDown ? ErrorType.ShuttingDown : ErrorType.Failed);
                         return Observable.Empty<IMessageDelivery>();
                     })
                     .Finally(() =>
@@ -321,12 +331,37 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             });
     }
 
+    /// <summary>
+    /// Whether a NACK may be sent for <paramref name="delivery"/> AT ALL — the routing layer's
+    /// answer-once contract, stated in one place so every path that gives up on a delivery
+    /// applies it identically (the same contract as <c>RoutingServiceBase.PostNotFound</c>).
+    ///
+    /// <para>Never answer a <see cref="DeliveryFailure"/>: the answer is itself a
+    /// <see cref="DeliveryFailure"/>, so answering one loops. Never answer a
+    /// <see cref="CanBeIgnoredAttribute"/> message: nobody is awaiting it, so the NACK is pure
+    /// added traffic — and it is added at exactly the worst moment, since the paths that give up
+    /// are shutdown and dispatch failure, when the volume of control messages is highest and the
+    /// process has least capacity. That is how a teardown turns into a failure storm.</para>
+    /// </summary>
+    private static bool MayAnswer(IMessageDelivery delivery) =>
+        delivery.Message is not DeliveryFailure
+        && delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() != true;
+
     /// <param name="delivery">The delivery that could not be routed.</param>
     /// <param name="message">The failure message returned to the sender.</param>
     /// <param name="errorType">How the sender should read the failure. <see cref="ErrorType.Failed"/>
     /// is TERMINAL; pass <see cref="ErrorType.ShuttingDown"/> whenever the cause is this process
     /// going away, so consumers with recovery machinery ride it out instead of tearing down.</param>
-    private void SendDeliveryFailure(IMessageDelivery delivery, string message,
+    /// <returns>
+    /// 🚨 <c>true</c> only when the NACK was actually POSTED. The caller stamps the returned
+    /// delivery <c>FailedAndNacked</c> on the strength of this, and that state tells everyone
+    /// downstream "the sender has been answered, stop reporting" — so returning <c>true</c>
+    /// without having posted converts a routing failure into a silent one, and the
+    /// <c>hub.Observe(...)</c> caller waits out its whole request budget with nothing to show.
+    /// The mesh hub is genuinely absent in some hosts (a routing service built without one), which
+    /// is why this cannot be assumed.
+    /// </returns>
+    private bool SendDeliveryFailure(IMessageDelivery delivery, string message,
         ErrorType errorType = ErrorType.Failed)
     {
         try
@@ -343,30 +378,41 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // (feedback_access_context_always_set). We never invent a user here; we either
             // pass through the failed delivery's own AccessContext or use System.
             var meshHub = serviceProvider.GetService<IMessageHub>();
-            if (meshHub != null)
+            if (meshHub == null)
             {
-                var failureAccess = serviceProvider.GetService<AccessService>();
-                using (delivery.AccessContext is null ? failureAccess?.ImpersonateAsSystem() : null)
-                {
-                    meshHub.Post(
-                        new DeliveryFailure(delivery)
-                        {
-                            ErrorType = errorType,
-                            Message = message
-                        },
-                        o =>
-                        {
-                            o = o.WithTarget(delivery.Sender).WithRequestIdFrom(delivery);
-                            return delivery.AccessContext is not null
-                                ? o.WithAccessContext(delivery.AccessContext)
-                                : o;
-                        });
-                }
+                // No hub to post through: say so rather than letting the caller record a NACK
+                // that was never sent. Warning, not Debug — a sender is about to hang.
+                logger.LogWarning(
+                    "Cannot NACK {MessageType} → {Sender}: no IMessageHub is registered, so the "
+                    + "sender will not be told the delivery failed ({Message})",
+                    delivery.Message?.GetType().Name, delivery.Sender, message);
+                return false;
             }
+
+            var failureAccess = serviceProvider.GetService<AccessService>();
+            using (delivery.AccessContext is null ? failureAccess?.ImpersonateAsSystem() : null)
+            {
+                meshHub.Post(
+                    new DeliveryFailure(delivery)
+                    {
+                        ErrorType = errorType,
+                        Message = message
+                    },
+                    o =>
+                    {
+                        o = o.WithTarget(delivery.Sender).WithRequestIdFrom(delivery);
+                        return delivery.AccessContext is not null
+                            ? o.WithAccessContext(delivery.AccessContext)
+                            : o;
+                    });
+            }
+
+            return true;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to send delivery failure for {MessageId}", delivery.Id);
+            return false;
         }
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-open-pages-survive-a-portal-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-open-pages-survive-a-portal-restart.md
@@ -1,0 +1,37 @@
+---
+Name: Open pages survive a portal restart
+Category: Fix
+Description: A page you had open while the portal was updating could be told its data was permanently gone, when the portal was only restarting. It is now told the truth, and reconnects.
+Icon: ArrowSync
+Order: -20260810
+---
+
+# Open pages survive a portal restart
+
+The portal updates itself, and every update restarts it. That restart is meant to
+be something you barely notice: your open pages lose their connection for a
+moment, wait, and pick up where they left off.
+
+What actually happened was that some of them gave up instead.
+
+As the portal shuts down it keeps working for a few hundred milliseconds — long
+enough to still be handling live traffic while the machinery underneath it has
+already started to leave. Anything it tried to deliver in that window failed, which
+is expected and harmless. The problem was what it said about the failure. It
+reported it as permanent: *this could not be delivered*, full stop, with nothing to
+suggest trying again.
+
+A page that is watching data for you reacts to that exactly as it reads. A
+temporary interruption is something to sit out; a permanent failure is something to
+stop watching. So a view told the second thing tore itself down, and stayed down
+after the portal came back — until you reloaded it by hand. During a rolling update
+this could happen to hundreds of open views at once, none of which had anything
+wrong with them.
+
+Now the portal recognises its own shutdown and says so. The message that goes back
+is the one that already exists for exactly this situation — *temporarily
+unavailable* — and every view that knows how to wait, waits, and reconnects when the
+new instance is serving.
+
+You do not need to do anything. The next time your portal updates, a page you left
+open should still be showing live data afterwards.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansRoutingShutdownClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansRoutingShutdownClassificationTest.cs
@@ -1,0 +1,128 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the prod 2026-08-10 memex pod-shutdown burst (issue #1107).
+///
+/// <para><b>Trigger.</b> A silo that has begun graceful shutdown has already left the ACTIVE
+/// silo set. <c>IRoutingGrain</c> is <c>[StatelessWorker(1)]</c>, so it is placed through
+/// <c>StatelessWorkerDirector</c> → <c>PlacementService.GetCompatibleSilos</c>, which
+/// intersects candidates with the active silos — from that instant every placement throws
+/// <c>OrleansException: No active nodes are compatible with grain routing</c>, while the mesh
+/// hubs are still alive and still routing ordinary live traffic at it. Loki put the first such
+/// exception 409 ms after the host logged "Application is shutting down..." (11:44:31.341 →
+/// 11:44:31.750), and the bursts reached 944 occurrences on a single dying pod while a healthy
+/// pod logged ZERO in its entire 2 h life.</para>
+///
+/// <para><b>Invariant.</b> Once the host is stopping the router does not attempt a placement it
+/// knows cannot succeed, and the sender is answered with the TRANSIENT
+/// <see cref="ErrorType.ShuttingDown"/> — never the terminal <see cref="ErrorType.Failed"/>.
+/// The classification is the functional half: <c>SynchronizationStream</c>'s keep-alive +
+/// resubscribe latch and <c>JsonSynchronizationStream</c> ride <c>ShuttingDown</c> out and tear
+/// down on a terminal verdict (CI 30003419841).</para>
+///
+/// <para><b>No cluster, no mocks, no timing.</b> The stopping signal is a REAL
+/// <see cref="IHostApplicationLifetime"/> from a real host, cancelled through the same
+/// <see cref="IHostApplicationLifetime.StopApplication"/> the runtime calls on SIGTERM. The
+/// receiving hub is a REAL <see cref="IMessageHub"/> sitting at the sender's address, so the
+/// NACK asserted below is the actual <see cref="DeliveryFailure"/> the router posts.
+/// <see cref="IGrainFactory"/> is deliberately <c>null</c> — it is the PROBE: reaching grain
+/// placement is observable as the throw it raises, so "did not touch the grain" and "did touch
+/// the grain" are both directly assertable.</para>
+/// </summary>
+public class OrleansRoutingShutdownClassificationTest : TestBase
+{
+    private static readonly Address SenderAddress = new("portal", "shutdown-test-sender");
+    private static readonly Address TargetAddress = new("SomeNamespace", "SomeNode");
+
+    private readonly TaskCompletionSource<DeliveryFailure> nack = new();
+    private readonly IHostApplicationLifetime lifetime;
+
+    public OrleansRoutingShutdownClassificationTest(ITestOutputHelper output) : base(output)
+    {
+        // A real host purely for its real ApplicationLifetime — the concrete type the runtime
+        // cancels on shutdown. Nothing is started; StopApplication fires ApplicationStopping
+        // regardless, and that token is the signal under test.
+        lifetime = new HostBuilder().Build().Services.GetRequiredService<IHostApplicationLifetime>();
+        Services.AddSingleton(lifetime);
+        Services.AddSingleton<AccessService>();
+        // The hub sits AT the sender address, so the DeliveryFailure the router posts back to
+        // delivery.Sender lands on this handler — the real NACK, not a stand-in.
+        Services.AddSingleton<IMessageHub>(sp => sp.CreateMessageHub(SenderAddress, conf => conf
+            .WithHandler<DeliveryFailure>((_, d) => { nack.TrySetResult(d.Message); return d.Processed(); })
+            .WithPostingIdentity(PostingIdentity.System)));
+    }
+
+    private OrleansRoutingService CreateRouter() =>
+        // grainFactory: null is the probe — see the class remarks.
+        new(null!, ServiceProvider, ServiceProvider.GetRequiredService<ILogger<OrleansRoutingService>>());
+
+    private static IMessageDelivery NewDelivery() =>
+        new MessageDelivery<string>(SenderAddress, TargetAddress, "payload", JsonSerializerOptions.Default);
+
+    /// <summary>
+    /// The regression itself. While the host is stopping the sender must be NACKed with the
+    /// transient <see cref="ErrorType.ShuttingDown"/>; a terminal <see cref="ErrorType.Failed"/>
+    /// is what tears down the sync streams' resubscribe latch.
+    /// </summary>
+    [Fact]
+    public async Task HostStopping_SenderIsNackedAsShuttingDown_NotFailed()
+    {
+        var routing = CreateRouter();
+        lifetime.StopApplication();
+
+        await routing.DeliverMessage(NewDelivery()).FirstAsync().ToTask();
+
+        var failure = await nack.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // A reject caused by THIS process going away is transient: consumers with recovery
+        // machinery ride ShuttingDown out, and tear down on the terminal Failed the Orleans
+        // router used to send.
+        Assert.Equal(ErrorType.ShuttingDown, failure.ErrorType);
+    }
+
+    /// <summary>
+    /// The router must not attempt a placement it knows cannot succeed: that attempt is what makes
+    /// Orleans log its own <c>Orleans.Messaging[100071]</c> error per message, which is the bulk of
+    /// the 894 lines that auto-filed the incident. With the null grain factory as the probe,
+    /// "never reached placement" is observable as the absence of its throw.
+    /// </summary>
+    [Fact]
+    public async Task HostStopping_DoesNotReachGrainPlacement()
+    {
+        var routing = CreateRouter();
+        lifetime.StopApplication();
+
+        var result = await routing.DeliverMessage(NewDelivery()).FirstAsync().ToTask();
+
+        Assert.Equal(MessageDeliveryState.Failed, result.State);
+        // This path posts its own DeliveryFailure, so it must declare that — otherwise whoever
+        // finishes the delivery NACKs the sender a second time and a shutdown burst doubles.
+        Assert.True(result.SenderWasNacked);
+    }
+
+    /// <summary>
+    /// The control for the guard above: with the host RUNNING the very same delivery still goes to
+    /// grain placement, so the short-circuit is scoped to the shutdown window and is not quietly
+    /// swallowing ordinary routing. Reaching placement is observable as the null probe's throw.
+    /// </summary>
+    [Fact]
+    public async Task HostRunning_StillReachesGrainPlacement()
+    {
+        var routing = CreateRouter();
+
+        // With the host running the router must still place IRoutingGrain — the null factory is
+        // the probe that proves placement was reached.
+        await Assert.ThrowsAsync<NullReferenceException>(
+            () => routing.DeliverMessage(NewDelivery()).FirstAsync().ToTask());
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansRoutingShutdownClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansRoutingShutdownClassificationTest.cs
@@ -45,7 +45,12 @@ public class OrleansRoutingShutdownClassificationTest : TestBase
     private static readonly Address SenderAddress = new("portal", "shutdown-test-sender");
     private static readonly Address TargetAddress = new("SomeNamespace", "SomeNode");
 
-    private readonly TaskCompletionSource<DeliveryFailure> nack = new();
+    // RunContinuationsAsynchronously: without it, everything awaiting this TCS resumes INLINE on
+    // whatever thread completed it — here the hub's message-handling thread — so the awaiting test
+    // body would run on the single-threaded action block it is still driving. Same reason as
+    // OrleansCrossSiloStreamProbeTest.cs:53.
+    private readonly TaskCompletionSource<DeliveryFailure> nack =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly IHostApplicationLifetime lifetime;
 
     public OrleansRoutingShutdownClassificationTest(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
## The cluster is not one defect

Four log-watcher incidents (#1107, #1113, #1129, #1114) were filed as one Orleans
startup-ordering problem. They are not one problem, and **#1107 is not a startup
problem at all** — it is a *shutdown* problem. Evidence first, because #1129's body
explicitly asserts it shares a root cause with #1107, and that is disproven below.

**#1107 fires only while a pod is dying.** Loki, `namespace="memex"`, 2026-08-09 20:00 →
2026-08-10 13:50 — every occurrence of `No active nodes are compatible` on each pod falls
inside a *single* 15-minute bucket:

| pod | occurrences | `Application is shutting down...` | first routing error |
|---|---|---|---|
| `…-7f65668566-qdk6j` | 838 | 01:08:40.879 | 01:08:41 |
| `…-84855f7679-z4rsp` | 944 | 07:08:52.010 | 07:09:0x |
| `…-575dc48bfb-wq7s8` | 52 | **11:44:31.341** | **11:44:31.750** |

409 ms after the host announces shutdown, and then continuously until the process exits.
The healthy pod that replaced them (`…-85ddbf6c7f-p4t4b`) logged **zero** in its whole
2 h life — while logging the #1129 stream-provider NRE twice, at boot. Two incidents at
opposite ends of the process lifecycle cannot be the same defect.

## What #1107 actually is

`IRoutingGrain` is `[StatelessWorker(1)]`, so it is placed through
`StatelessWorkerDirector` → `PlacementService.GetCompatibleSilos`, which intersects the
candidates with the **ACTIVE** silo set. A silo that has begun graceful shutdown has
already left `Active`, so from that instant every placement throws — while the mesh hubs,
still alive, keep routing ordinary live traffic at it (activity `compile-state`
heartbeats, node streams). Nothing was misregistered; the grain simply could no longer be
*placed*.

Two things were wrong with what followed:

1. **The classification was terminal.** `OrleansRoutingService` stamped
   `ErrorType.Failed`. `SynchronizationStream` and `JsonSynchronizationStream` key on
   `ErrorType.ShuttingDown` to ride a reject out and **tear down on a terminal verdict**
   (CI 30003419841). `MonolithRoutingService.PostNotFound` has classified its shutdown
   reject correctly for a while — the Orleans router never did. So every rolling update
   NACKed live subscriptions as permanently failed.
2. **We kept asking for a grain that could not be placed**, and Orleans logged its own
   `Orleans.Messaging[100071]` error per attempt — the bulk of the 894 lines that filed
   the incident.

## The fix — ordering, not retry

Take the host's own `IHostApplicationLifetime.ApplicationStopping` token. It fires
*before* the silo hosted service stops (hosted services stop in reverse order, after the
stopping handlers run), so it is strictly earlier than the condition it predicts — the
409 ms above is that margin, measured. Once stopping, the router does not attempt the
placement it knows cannot succeed, and answers the sender immediately with
`ErrorType.ShuttingDown`.

No retry, no timeout, no watchdog: the failure still reaches the sender, it just stops
lying about being permanent. The NACK-once contract (never answer a `DeliveryFailure`,
never a `[CanBeIgnored]`) mirrors `RoutingServiceBase.PostNotFound`. The `Error` → `Debug`
move on this path is deliberate and permanent — a process that is exiting is not an error,
and reporting it as one is what filed a production incident for an orderly shutdown.

## Test + negative control

`OrleansRoutingShutdownClassificationTest` — 3 assertions, **no cluster**, 295 ms. Real
`IHostApplicationLifetime` cancelled via the same `StopApplication` the runtime calls on
SIGTERM; real `IMessageHub` at the sender's address, so the assertion reads the actual
`DeliveryFailure`. `IGrainFactory` is deliberately `null` — the **probe**: reaching
placement is observable as the throw it raises, so both directions are assertable.

Negative control (neuter only `IsHostStopping`, nothing else):

| | fix in | fix neutered | restored |
|---|---|---|---|
| `HostStopping_SenderIsNackedAsShuttingDown_NotFailed` | pass | **FAIL** | pass |
| `HostStopping_DoesNotReachGrainPlacement` | pass | **FAIL** | pass |
| `HostRunning_StillReachesGrainPlacement` | pass | pass | pass |

The control still passing while neutered is the point — it proves it is not riding on the
fix, and that a short-circuit which swallowed *all* routing would not pass.

`OrleansHostedHubRoutingTest` (real cluster) passes. `MeshWeaver.Connection.Orleans`,
`MeshWeaver.Hosting.Orleans` and `Memex.Portal.Distributed` all build clean under
`-c Release -warnaserror`.

## The other three — separate, deferred, with evidence

- **#1129** (Memory stream provider NRE) — *startup*. Exactly 2 per pod boot
  (`cache/{id}`, `mesh/{id}`), ~0.5 s into the pod's logged life, on a pod with **zero**
  routing-grain errors. The retry logs at `Error` on attempt 1 and then only every 20th
  attempt; neither an attempt-20 line nor the 120 s `Critical` give-up appears anywhere, and
  `Error` demonstrably reaches Loki (that is how attempt 1 is visible) — so the loop exits
  before attempt 20, i.e. within ~10 s. The issue's inference that "every occurrence is
  attempt 1 … meaning no retry ever succeeds" is exactly backwards, and its claim of a
  shared root cause with #1107 is disproven by the window alone. (The success line is
  `Information`, which this deployment's level filter drops before Loki, so the precise
  attempt is not recoverable from logs.)
  Real defect underneath: `RegisterStream` subscribes before the Orleans stream provider is
  initialised, and papers over it with a `Task.Delay` retry loop that its own comment admits
  is a workaround. Root-cause fix is to order the subscription on the silo streaming
  lifecycle — a separate change on the silo side, not folded in here.
- **#1114** (`InstanceAutoRegistrationService` 30 s initial-state timeouts) — *startup*, in
  the plugin auto-install path, and only partial on a healthy boot (1 of 7 packages on
  `p4t4b`, vs 6 on the earlier pods). Carries a second, distinct defect visible in the same
  window: `NodeType 'DefaultInstallLedger' is not registered`, so the ledger write fails
  independently of any timeout.
- **#1113** (`ROUTER_TRAFFIC`) — neither window: 223 occurrences on the *healthy* pod in
  2 h, continuous. A topology guard firing on live traffic. One shape of it is a direct
  consequence of routing failures (`DeliveryFailure has the mesh hub as target`) and should
  quieten with this PR; the majority (`RawJson has the mesh hub as sender`) is independent.

Fixes #1107. Refs #1129, #1114, #1113.

