### PR TITLE
The installer started a teardown and handed back without waiting for it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-plugins-files-arrive-even-when-its-root-restarts.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-plugins-files-arrive-even-when-its-root-restarts.md
@@ -1,0 +1,42 @@
+---
+Name: A freshly installed plugin is ready the moment the install finishes
+Category: Fix
+Description: An install could hand back a package whose root was still restarting, so the first thing to open it got nothing — a page that never rendered, or files that were never written.
+Icon: CloudArrowUp
+Order: -20260810
+---
+
+# A freshly installed plugin is ready the moment the install finishes
+
+Installing a package could leave it in a state where the very next thing to touch
+it came away empty-handed. Two ways you might have seen it: a package that ships
+files — course videos, posters, images — installed without them, after a pause of
+about a minute and a note that its binaries were not being served. Or a freshly
+installed plugin's own page came up blank, showing none of the views the package
+brought with it.
+
+## What was happening
+
+Installing a package changes what kind of thing its root is, and the portal
+restarts that root so it picks up its new behaviour. The install did not wait for
+that restart. It started it, then handed back.
+
+So everything that came next — publishing the package's files, the first person to
+open one of its pages — could arrive while the root was still on its way down.
+Nothing was written, nothing rendered, and because the reply died with the
+restarting root, whatever was waiting waited out a full minute before giving up.
+Which side of that dead heat a machine landed on is why the same package could
+install perfectly on one portal and arrive half-empty on another.
+
+The restart was also happening too early to be useful. It ran before the package's
+own code had finished building, so the root that came back could not yet see what
+the package had brought — and, having come back once, it kept that empty view.
+
+## What changed
+
+The restart now happens once the package's code is ready, and the install waits for
+the root to come back before it finishes. It asks the root a question that can only
+be answered *after* the restart, so there is no window left to race.
+
+An install therefore hands back a package that is actually ready: its files are
+published, its pages render its own views, and the minute-long pause is gone.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -690,6 +690,20 @@ public static class PackageInstaller
     /// </summary>
     private static readonly TimeSpan RootTypeSettleTimeout = TimeSpan.FromSeconds(90);
 
+    /// <summary>How long one liveness probe of the root waits before it counts as "still down".</summary>
+    private static readonly TimeSpan RootPingTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Pause between liveness probes, so a fail-fast DeliveryFailure cannot spin the loop.</summary>
+    private static readonly TimeSpan RootPingRetryDelay = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Overall budget for the root to come back after its recycle, before the publish goes ahead
+    /// regardless. A recycle is milliseconds; this is the graceful sink for a wedged teardown, and
+    /// is deliberately far below the hub's own request timeout so a miss is diagnosable rather than
+    /// indistinguishable from the 60 s hang this wait exists to prevent.
+    /// </summary>
+    private static readonly TimeSpan RootReadyTimeout = TimeSpan.FromSeconds(20);
+
     /// <summary>
     /// The path of the NodeType <paramref name="root"/> declares, but ONLY when that type is one
     /// this very package installs — those are the only types that can still be carrying the
@@ -806,6 +820,89 @@ public static class PackageInstaller
     /// correctly. Deliberately NOT a wait: the installer runs on the mesh that is compiling, so
     /// holding here would trade a mis-binding for a stalled install.</para>
     /// </summary>
+    /// <summary>
+    /// Recycles the retyped partition root and waits for it to come back — the ORDERED replacement
+    /// for the fire-and-forget <c>DisposeRequest</c> that used to be posted at write time.
+    ///
+    /// <para>🚨 Two things were wrong with posting it there, and they compound. It was MISTIMED:
+    /// the in-package NodeType still advertised the compile stamp the repo COMMITTED, so the
+    /// re-activation the recycle invites bound the fallback configuration for the new hub's
+    /// lifetime — exactly what #1101 stopped the warm from doing. And it OUTLIVED the install: the
+    /// teardown was still running when Install returned, so the next touch of the root — the
+    /// content publish, a client's <c>SubscribeRequest</c>, anything — landed mid-teardown and got
+    /// <c>HubDisposingException</c>. Both halves of <c>StaleStampRootBindingTest</c> are that
+    /// failure ("cannot create '/content/'" and "cannot create 'LayoutAreaReference { Area =
+    /// Tests }'"), and in both the reply died with the hub, so the caller waited out its full
+    /// request timeout for work that never happened.</para>
+    ///
+    /// <para>So the recycle now runs where it can do its job: after the type's rebuild has settled
+    /// (<see cref="MayPublishIntoRoot"/> is that wait, and it answers promptly for a type whose
+    /// rebuild produced nothing loadable — there is nothing worth rebinding to, so the recycle is
+    /// skipped), and it WAITS for the root to answer before the install proceeds. Called only when
+    /// the placeholder dance actually ran, i.e. when there is a placeholder binding to replace.</para>
+    /// </summary>
+    private static IObservable<Unit> SettleRetypedRoot(
+        IMessageHub hub, string? rootPath, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+            return Observable.Return(Unit.Default);
+
+        return MayPublishIntoRoot(hub, rootPath!, nodes, logger)
+            .SelectMany(rebindable =>
+            {
+                if (!rebindable)
+                {
+                    logger?.LogInformation(
+                        "[PackageInstaller] not recycling root {Root}: its in-package NodeType has no "
+                        + "build an instance could load, so a fresh hub would bind the fallback too. "
+                        + "The rebind watcher recycles it once the type compiles.", rootPath);
+                    return Observable.Return(Unit.Default);
+                }
+
+                hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
+                return WaitForRootReady(hub, rootPath!, logger);
+            });
+    }
+
+    /// <summary>
+    /// Waits until <paramref name="rootPath"/>'s hub answers a <see cref="PingRequest"/>.
+    ///
+    /// <para>Ordering is the whole primitive: the ping is enqueued on the root BEHIND any
+    /// <c>DisposeRequest</c> already in flight, so it cannot be answered by the hub that is going
+    /// away — only by the one that comes after, and answering it IS that re-activation. A rejected
+    /// or undelivered ping means the teardown is still running, so it retries. The
+    /// <see cref="RootReadyTimeout"/> is a graceful sink, never a wedge: a root that never answers
+    /// is logged and the install carries on.</para>
+    /// </summary>
+    private static IObservable<Unit> WaitForRootReady(
+        IMessageHub hub, string rootPath, ILogger? logger)
+    {
+        var address = new Address(rootPath);
+        return Observable.Defer(Probe)
+            .Repeat()
+            .Where(alive => alive)
+            .FirstAsync()
+            .Timeout(RootReadyTimeout)
+            .Select(_ => Unit.Default)
+            .Catch((Exception exception) =>
+            {
+                logger?.LogWarning(exception,
+                    "[PackageInstaller] root {Root} never answered after its recycle — continuing; "
+                    + "whatever touches it next may still land on a hub that is tearing down",
+                    rootPath);
+                return Observable.Return(Unit.Default);
+            });
+
+        IObservable<bool> Probe() =>
+            hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address))
+                .Take(1)
+                .Timeout(RootPingTimeout)
+                .Select(_ => true)
+                // The delay bounds the retry loop: a DeliveryFailure answers immediately, and
+                // re-subscribing on it with no pause would spin the hub for the whole budget.
+                .Catch<bool, Exception>(_ => Observable.Return(false).Delay(RootPingRetryDelay));
+    }
+
     private static IObservable<Unit> WarmInstalledRoots(
         IMessageHub hub, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
     {
@@ -940,7 +1037,13 @@ public static class PackageInstaller
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         return MayPublishIntoRoot(hub, rootPath!, nodes, logger)
             .SelectMany(mayPublish => mayPublish
-                ? Publish()
+                // The root must not be TEARING DOWN when the publish lands, or
+                // ContentService.CreateCollection throws HubDisposingException — no byte written —
+                // and the ImportContentResponse the handler still posts dies with the hub, so the
+                // caller waits out its whole 60 s request timeout for assets that never landed.
+                // SettleRetypedRoot has normally already done this; the probe costs one ping when
+                // the root is up, and covers the call sites that do not run it.
+                ? WaitForRootReady(hub, rootPath!, logger).SelectMany(_ => Publish())
                 : Observable.Return(0));
 
         IObservable<int> Publish() => ContentAssetMapper.ToContentSyncs(rootPath!, assets)
@@ -1702,12 +1805,24 @@ public static class PackageInstaller
                     // of intent; it is not load-bearing. If the symptom ever reappears, check all
                     // three: is the hub recycled, is the resolution for the bare root path serving
                     // a real node, and did the rebind watcher see the retype?
-                    .Select(rest =>
-                    {
-                        if (placeholderRoot is not null && root is not null)
-                            hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(root.Path)));
-                        return rest;
-                    })
+                    //
+                    // 🚨 …and it no longer happens HERE. A fire-and-forget teardown posted at write
+                    // time outlives the install and is a race handed to whoever touches the root
+                    // next — the installer's own content publish, a client's SubscribeRequest,
+                    // anything — which lands mid-teardown and gets HubDisposingException: no bytes
+                    // written, or an area that never renders, plus a caller left waiting on a reply
+                    // that died with the hub. Both halves of StaleStampRootBindingTest are exactly
+                    // that (red on main from 2026-08-10): "cannot create '/content/'" for the
+                    // package that ships assets, "cannot create 'LayoutAreaReference { Area =
+                    // Tests }'" for the one that does not.
+                    //
+                    // It is also MISTIMED here: at this point the in-package type still advertises
+                    // the compile stamp the repo COMMITTED, so the re-activation this recycle
+                    // invites would bind the fallback for the new hub's lifetime — the very thing
+                    // #1101 stopped the warm from doing. The recycle now runs once that type has a
+                    // build an instance can load, and WAITS for the root to come back. See
+                    // SettleRetypedRoot below.
+                    .Select(rest => rest)
                     // A placeholder's write is bookkeeping, not content — its FINAL retype in
                     // stage 2 is the root's one counted write (keeps Written ≤ node count).
                     .Select(rest => (IList<(string Path, bool Wrote)>)(placeholderRoot is null ? rootWrites : [])
@@ -1738,6 +1853,13 @@ public static class PackageInstaller
                         logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
+                    // The retyped root's recycle, moved here from the write stage and made ORDERED
+                    // (see the note there). Only now can it do its job: the in-package type has had
+                    // its rebuild, so the hub that comes back binds the package's own configuration
+                    // instead of the fallback — and the install no longer returns while a teardown
+                    // it started is still running.
+                    .SelectMany(_ => SettleRetypedRoot(
+                        hub, placeholderRoot is not null ? root?.Path : null, nodes, logger))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // …then the package's committed binaries (course videos/posters) into the
                     // warmed root's content collection — the half of "publish" that merging used


### PR DESCRIPTION
**This greens main.** `StaleStampRootBindingTest` has been red on main in *both* its cases since it
merged (#1146, 12:54 today) — the PR itself was green, on a merge-ref whose tree main had already
moved past. One defect, two victims, so this is one fix rather than two.

## The defect

`UpsertNodes` recycled the retyped partition root with a fire-and-forget `DisposeRequest` at write
time. That is wrong twice over, and the two compound.

**Mistimed.** At that point the in-package NodeType still advertises the compile stamp the node repo
*committed*, so the re-activation the recycle invites binds the **fallback** configuration for the
new hub's lifetime — precisely what #1101 stopped the warm from doing, arriving by the other door.

**Outlives the install.** `Install` returned while that teardown was still running, so the next touch
of the root landed mid-teardown and got `HubDisposingException`. Both red tests are exactly that, and
the log names them:

- `cannot create '/content/'` — the package that ships assets
- `cannot create 'LayoutAreaReference { Area = Tests }'` — the one that does not

In both, the handler's reply died with the hub, so the caller had nothing to wait for and burned its
full 60 s request timeout on work that never happened. Whether a package's files arrived came down to
which side of that dead heat the machine fell on — which is why the same package installed cleanly on
one portal and half-empty on another.

## The fix

The recycle moves to where it can do its job. `SettleRetypedRoot` waits for the in-package type's
rebuild (`MayPublishIntoRoot` is that wait, and it answers promptly when the rebuild produced nothing
loadable — nothing worth rebinding to, so the recycle is skipped and the rebind watcher takes it once
the type compiles), **then** posts the `DisposeRequest`, **then** waits for the root to answer.

A `PingRequest` is the whole primitive and **ordering** is why it works: it is enqueued on the root
*behind* the `DisposeRequest`, so it cannot be answered by the hub that is going away — only by the one
that comes after, and answering it *is* that re-activation. A rejected or undelivered ping means the
teardown is still running, so it retries; the budget is bounded and its `Timeout` is a graceful sink
that lets the install finish rather than wedging. `SyncPackageContent` keeps the same wait for the call
sites that do not run `SettleRetypedRoot` — one ping when the root is already up.

## Verification

- `MeshWeaver.PluginCatalog.Test` **236/236**, from 235/1.
- The suite drops from **3 m 17 s to 1 m 19 s** — the stalls it was absorbing were these 60 s timeouts.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean.

Ruled out along the way, so it does not get re-guessed: the no-content case is **not** the NodeType-ALC
eviction of #1148 — it fails identically with that fix applied.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)