### PR TITLE
A hub that was going down answered nobody, so every caller waited out its full minute

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -57,10 +57,31 @@ public static class ContentImportExtensions
         SyncFiles(contentService, request)
             .Subscribe(
                 count => hub.Post(ImportContentResponse.Ok(count), o => o.ResponseFor(delivery)),
-                ex => hub.Post(ImportContentResponse.Fail(ex.Message), o => o.ResponseFor(delivery)));
+                ex => hub.Post(FailureFor(delivery, ex), o => o.ResponseFor(delivery)));
 
         return delivery.Processed();
     }
+
+    /// <summary>
+    /// The answer to send when a sync failed.
+    ///
+    /// <para>🚨 A hub-disposal fault is TRANSIENT and must NOT be flattened into
+    /// <see cref="ImportContentResponse.Fail"/>. This hub is being recycled — the collection could
+    /// not even be created (<c>ContentCollection.CreateStream</c> cannot host its
+    /// <c>SynchronizationStream</c> once creation is frozen) — and the node is coming straight
+    /// back. Reported as an application failure, the caller can no longer tell "your request is
+    /// malformed" from "ask me again in a moment", so it gives up on work that would have
+    /// succeeded: the plugin installer declared a package's committed binaries lost and the assets
+    /// were never served (StaleStampRootBindingTest, the test that turned main red). Answering with
+    /// the typed <see cref="ErrorType.ShuttingDown"/> hands the caller the framework's own verdict
+    /// — "the address may reactivate; retry to get the authoritative answer" — which it can act on.
+    /// The reply still reaches the sender because <c>MessageService</c> forwards a correlated reply
+    /// through the live parent when this hub can no longer post it itself.</para>
+    /// </summary>
+    private static object FailureFor(IMessageDelivery delivery, Exception exception)
+        => HubDisposingException.IsHubDisposal(exception)
+            ? new DeliveryFailure(delivery, exception.Message) { ErrorType = ErrorType.ShuttingDown }
+            : ImportContentResponse.Fail(exception.Message);
 
     /// <summary>
     /// Writes each inline file under <c>TargetPath</c> (binary-safe — the bytes are streamed straight

--- a/src/MeshWeaver.ContentCollections/ContentService.cs
+++ b/src/MeshWeaver.ContentCollections/ContentService.cs
@@ -230,8 +230,30 @@ public class ContentService : IContentService
             CreateCollection(config)
                 .Catch((Exception ex) =>
                 {
-                    logger.LogWarning(ex, "Creating content collection '{Collection}' failed", name);
                     collections.TryRemove(name, out _);
+
+                    // 🚨 A hub-disposal fault is NOT "no such collection". The hub is being
+                    // recycled, so it cannot host the collection's SynchronizationStream right
+                    // now — but the collection is configured and the node is coming straight back.
+                    // Collapsing that into null made every caller report the terminal "Target
+                    // content collection 'content' not found", which is a lie the caller cannot
+                    // recover from: the plugin installer read it as a real failure and declared a
+                    // package's committed binaries lost rather than asking again a moment later
+                    // (StaleStampRootBindingTest, the test that turned main red — the trail was
+                    // "Creating content collection 'content' failed: HubDisposingException"
+                    // logged as a warning, then a not-found the caller acted on). Rethrow so the
+                    // TRANSIENT verdict survives to the messaging layer, which classifies it as
+                    // ErrorType.ShuttingDown; the cache entry is already evicted, so the next
+                    // access builds a fresh pipeline against the reactivated hub.
+                    if (HubDisposingException.IsHubDisposal(ex))
+                    {
+                        logger.LogDebug(ex,
+                            "Content collection '{Collection}' could not be created because its hub is "
+                            + "recycling — surfacing as transient, not as a missing collection", name);
+                        return Observable.Throw<ContentCollection?>(ex);
+                    }
+
+                    logger.LogWarning(ex, "Creating content collection '{Collection}' failed", name);
                     return Observable.Return<ContentCollection?>(null);
                 })
                 .Replay(1)

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -34,6 +34,16 @@ public sealed class StaleStreamStateException : InvalidOperationException
 /// </summary>
 public static class JsonSynchronizationStream
 {
+    /// <summary>
+    /// How many times one stream re-arms after the owner rejected its SubscribeRequest for being
+    /// mid-recycle. A recycle answers within milliseconds and the re-ask activates the fresh hub,
+    /// so the healthy case needs one; the bound exists purely so an owner stuck in a recycle LOOP
+    /// degrades to the pre-existing orphaned-stream behaviour rather than becoming a resubscribe
+    /// storm. It is not a budget to widen — if a stream needs more than this, the owner is
+    /// recycling pathologically and THAT is the bug.
+    /// </summary>
+    private const int MaxRecycleReArms = 3;
+
     // Mirror of MeshWeaver.Mesh.Security.WellKnownUsers.System — Data sits below
     // Mesh.Contract in the project graph and cannot reference it. Same literal
     // recognized by AccessService.ImpersonateAsSystem and PostgreSqlMeshQuery's
@@ -334,6 +344,16 @@ public static class JsonSynchronizationStream
         // by RouteStreamMessage); a DeliveryFailure / NotFound — the owner ADDRESS DOES NOT EXIST —
         // surfaces as OnError, so we fault subscribers and dispose the keep-alive so nothing
         // heartbeats/resubscribes a non-existent owner. Reactive end-to-end: no await.
+        //
+        // 🚨 Carries the "the owner rejected us because it is recycling" signal from the subscribe
+        // arm below to the re-arm wired further down (where Resubscribe is in scope).
+        //
+        // REPLAY, not a bare Subject. The rejection normally arrives long after both ends are
+        // wired, but a same-process owner can NACK inside the subscribe call itself — before this
+        // method reaches the re-arm — and a bare Subject drops an emission that has no subscriber
+        // yet. That would resurrect the orphaned stream in exactly the fast local case this fix
+        // exists for, and only sometimes: the classic invisible race.
+        var rejectedByRecycle = new System.Reactive.Subjects.ReplaySubject<string>(1);
         var observeSubscription = Observable
             .Using(
                 // Apply an explicit identity SCOPE for the post — do NOT rely on the ambient AsyncLocal
@@ -376,8 +396,18 @@ public static class JsonSynchronizationStream
                     {
                         logger.LogDebug(
                             "SubscribeRequest for stream {StreamId} rejected — owner {Owner} is shutting down "
-                            + "(recycle/restart in flight); keeping the stream alive for the resubscribe latch",
+                            + "(recycle/restart in flight); keeping the stream alive and re-arming",
                             reduced.StreamId, owner);
+                        // 🚨 …and RE-ARM, because the latch alone cannot recover this. The latch's
+                        // only trigger is a mesh change-feed event on the owner's path, and a pure
+                        // RECYCLE writes nothing — so a subscriber the recycle rejected waits for
+                        // an announce that never comes. That hole was invisible while this
+                        // rejection was silently swallowed (the sender just timed out and the
+                        // consumer tore down); once the owner started answering honestly, the
+                        // orphaned stream became the visible symptom — a freshly installed root
+                        // whose area never renders (StaleStampRootBindingTest, 120 s with the
+                        // client sitting idle after the NACK landed).
+                        rejectedByRecycle.OnNext("rejected our SubscribeRequest while shutting down");
                         return;
                     }
 
@@ -479,6 +509,36 @@ public static class JsonSynchronizationStream
                             });
                 }
             }
+
+            // 🚨 THE UN-ANNOUNCED RECYCLE. The change-feed latch below is the recycled-owner
+            // detector, but it can only fire on a mesh change event for the owner's path — and a
+            // recycle IS NOT A WRITE. Recycle the owner while a SubscribeRequest is in flight and
+            // that subscriber is orphaned until something unrelated happens to write the node:
+            // no announce, no event, no recovery. The heartbeat cannot rescue it either — it is
+            // fire-and-forget and deliberately does not resubscribe.
+            //
+            // So the rejection itself is the event. The owner told us, in the same breath, both
+            // that it is going and that it is coming back ("the address may reactivate; retry to
+            // get the authoritative answer"), and by the time that verdict is produced the hub is
+            // already at RunLevel Dead — so the re-ask lands on a FRESH activation, which a
+            // SubscribeRequest creates on arrival.
+            //
+            // This is not the forbidden watchdog: nothing polls, nothing runs on a timer, and it
+            // fires only in response to an explicit typed rejection. It reuses Resubscribe, so it
+            // inherits the in-flight guard, ExpectResubscribeFull (the mirror must accept a
+            // re-snapshot stamped below its cached frame version) and the System impersonation.
+            // The re-ask asks for the CURRENT snapshot — it never re-asserts a cached frame, which
+            // is the #945 shape and the opposite of what this does. Bounded so that an owner stuck
+            // in a recycle LOOP degrades to the pre-existing "orphaned" behaviour instead of
+            // trading a stalled stream for a storm.
+            var recycleReArms = 0;
+            var recycleReArm = rejectedByRecycle
+                .Where(_ => Interlocked.Increment(ref recycleReArms) <= MaxRecycleReArms)
+                .Subscribe(
+                    reason => Resubscribe(reason),
+                    ex => logger.LogDebug(ex,
+                        "Stream {StreamId}: recycle re-arm stream faulted", reduced.StreamId));
+            reduced.RegisterForDisposal(recycleReArm);
 
             // 🚨 THE LOST INITIAL — and why the first heartbeat comes EARLY.
             //

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-restarting-node-answers-instead-of-going-quiet.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-restarting-node-answers-instead-of-going-quiet.md
@@ -1,0 +1,25 @@
+---
+Name: A restarting node answers instead of going quiet
+Category: Fix
+Description: Anything asked of a node while it restarted got no reply at all, so the caller waited a full minute for nothing.
+Icon: Sparkle
+Order: -20260810
+---
+
+# A restarting node answers instead of going quiet
+
+Nodes restart routinely — after their type is rebuilt, after a package is installed, after a
+recycle. Until now, anything you asked of a node during that short window simply vanished.
+The request was accepted, the node went down, and no reply of any kind came back. Whatever
+was waiting — a page opening, an install finishing, a save confirming — sat there for a full
+minute before giving up with a timeout that named nothing useful.
+
+The most visible casualty was installing a package that ships images or videos: its files are
+published into the node right as that node restarts, so the publish waited out the whole
+minute and then reported that the package's binaries were not being served. The package
+looked installed, but its pictures never appeared.
+
+A restarting node now always answers, immediately, and says which kind of answer it is: "I am
+coming back, ask again" rather than silence. Replies its own work already produced are
+delivered instead of being thrown away on the way out. And installing a package now waits for
+the node's restart to finish before publishing into it, so the files land the first time.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -309,11 +309,19 @@ public class MessageService : IMessageService
     /// (<see cref="ErrorType.NotFound"/>) depending on whether this address can still come back;
     /// see the two 🚨 paragraphs below for the fork and why it matters.
     ///
-    /// <para>Used by BOTH paths on which a hub going down abandons a delivery a sender is
-    /// awaiting: the intake gate (a message arriving after RunLevel flipped) and disposal
-    /// (a message already parked in the deferred queue behind a closed init gate). Both used
-    /// to vanish silently, leaving the sender's <c>hub.Observe(...)</c> to burn its full
+    /// <para>Used by EVERY path on which a hub going down abandons a delivery a sender is
+    /// awaiting: the intake gate (a message arriving after RunLevel flipped), disposal (a message
+    /// already parked in the deferred queue behind a closed init gate), and the two seams in
+    /// <c>HandleMessage</c> — a delivery accepted while the hub was healthy whose turn comes after
+    /// <c>ShutDown</c>, and a handler that faulted with <see cref="HubDisposingException"/>. All
+    /// four used to vanish silently, leaving the sender's <c>hub.Observe(...)</c> to burn its full
     /// request budget with nothing to show for it.</para>
+    ///
+    /// <para>🚨 The <c>HandleMessage</c> seams must come through HERE rather than through
+    /// <see cref="ReportFailure"/>: that one posts through this hub's own <see cref="Post"/> and
+    /// declines entirely once <c>RunLevel &gt;= DisposeHostedHubs</c>, which is exactly the state
+    /// a disposal-race NACK is computed in — so its answer was classified correctly and then
+    /// dropped on the floor.</para>
     ///
     /// <para>Gated to deliveries a caller can actually be awaiting:
     /// <list type="bullet">
@@ -354,24 +362,40 @@ public class MessageService : IMessageService
     ///   <item><c>MeshWeaver.Hosting.Monolith.Test.PostDeleteReadVerdictTest</c> — the end-to-end
     ///     #1029 repro: create → read → delete → read, which before the fix sat silent for the
     ///     reader's whole budget.</item>
+    ///   <item><c>MeshWeaver.Messaging.Hub.Test.DisposalRaceNackTest</c> — the two
+    ///     <c>HandleMessage</c> seams, both driven to <c>RunLevel=Dead</c> deterministically.</item>
     /// </list></para>
     /// </summary>
-    private void NackThroughParent(IMessageDelivery delivery, string reason)
+    /// <param name="delivery">The delivery being abandoned.</param>
+    /// <param name="reason">Why it was abandoned; becomes the transient NACK's message.</param>
+    /// <returns>
+    /// True when the sender has its answer — either a <see cref="DeliveryFailure"/> was posted
+    /// through the parent, or an authoritative one had already been posted for this delivery.
+    /// False when nothing could carry it (no live parent, or traffic nobody awaits), which is the
+    /// caller's cue to fall back to <see cref="ReportFailure"/> if it can still post.
+    /// </returns>
+    private bool NackThroughParent(IMessageDelivery delivery, string reason)
     {
         if (delivery.Message is not IRequest
             && !(delivery.Message is RawJson rawJson
                  && !rawJson.Content.Contains(nameof(DeliveryFailure), StringComparison.Ordinal)))
-            return;
+            return false;
         if (delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
-            return;
+            return false;
+        // The same "ONE request, ONE failure response" rule ReportFailure applies: an
+        // authoritative, typed DeliveryFailure has already been posted for this delivery, so a
+        // second one here would make the classification a coin toss for whichever arrives first.
+        // Reported as handled — the sender HAS its answer, which is what the caller is asking.
+        if (delivery.Properties.ContainsKey(FailureAlreadyReported))
+            return true;
         if (delivery.Sender is null || delivery.Sender.Equals(Address))
-            return;
+            return false;
         // No live parent ⇒ nothing can carry the NACK. At a full mesh teardown the parent is
         // itself past DisposeHostedHubs, so this correctly stays silent: every sender is going
         // away too. Only a TARGETED hub disposal (recycle, node delete) under a live parent
         // NACKs — exactly the case where a sender is still there to hear it.
         if (ParentHub is not { } parent || parent.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
-            return;
+            return false;
         // Gone for good (node deleted) ⇒ authoritative NotFound; anything else ⇒ transient.
         // The delete source tombstones every planned path SYNCHRONOUSLY, before its response
         // returns, so this lookup is already authoritative for a delivery that raced the teardown.
@@ -408,12 +432,14 @@ public class MessageService : IMessageService
             parent.Post(
                 new DeliveryFailure(delivery) { ErrorType = errorType, Message = message },
                 o => o.ResponseFor(delivery));
+            return true;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex,
                 "Failed to NACK {MessageType} (ID: {MessageId}) abandoned by shutting-down hub {Address}",
                 delivery.Message.GetType().Name, delivery.Id, Address);
+            return false;
         }
     }
 
@@ -1245,6 +1271,29 @@ public class MessageService : IMessageService
             var jsonMessage = JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions);
             logger.LogWarning("Hub {Address} is disposing. Not processing message {Message}", hub.Address, jsonMessage);
             fate?.Add($"NOT_PROCESSED_DISPOSING runLevel={hub.RunLevel}", Address);
+            // 🚨 ANSWER it — never just drop it. This is the FOURTH door into the silent-
+            // abandonment park, and the one neither #672 fix covers: the delivery was ACCEPTED
+            // while the hub was healthy (so ScheduleNotify's intake gate never saw it) and it sat
+            // in the MAIN queue, not the deferred one (so the disposal drain has no tracker to
+            // answer for it) — it simply arrived at its turn after RunLevel passed ShutDown.
+            // Returning it unchanged ends the pipeline with no response and no failure, so the
+            // sender's hub.Observe(...) burns its ENTIRE RequestTimeout in silence.
+            //
+            // Measured, main-red: StaleStampRootBindingTest (CI run 31390882509) — the plugin
+            // installer's SyncContentFilesRequest activated a package root's hub, the root was
+            // recycled 94 ms later, the request executed at runLevel=Dead and was dropped here.
+            // The installer waited the full 60 s and reported "the package's nodes are installed
+            // but its binaries are not being served"; the committed asset never landed.
+            //
+            // Through the PARENT, because our own Post would re-enter this service's shutdown
+            // gate and be dropped — the very reason NackThroughParent exists. It applies the
+            // tombstone fork itself (transient ShuttingDown for an address that may reactivate,
+            // authoritative NotFound for a deleted one) and skips traffic nobody awaits.
+            NackThroughParent(delivery,
+                $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — "
+                + $"{delivery.Message.GetType().Name} (id={delivery.Id}) was accepted before "
+                + "disposal began and its turn came too late to process. The address may "
+                + "reactivate (recycle / restart); retry to get the authoritative answer.");
             exec = Observable.Return(delivery);
         }
 
@@ -1304,11 +1353,12 @@ public class MessageService : IMessageService
                     // Debug line is evaluated even when Debug is off and was itself a hot-path
                     // regression (the LogText storm, core #608).
                     // 🚨 …UNLESS the address is gone for good. This is the SECOND door into the
-                    // #1029 park, and it is not the one NackThroughParent guards: there the hub
-                    // ABANDONS a delivery (intake gate / disposal drain); here it ACCEPTED one and
-                    // the handler then threw, because HostedHubsCollection is already frozen while
-                    // RunLevel still reads Started. Same tombstone, same verdict — an
-                    // accepted-then-faulted delivery is not more recoverable than an abandoned one.
+                    // #1029 park: on the other two the hub ABANDONS a delivery (intake gate /
+                    // disposal drain); here it ACCEPTED one and the handler then threw, because
+                    // HostedHubsCollection is already frozen while RunLevel can still read Started.
+                    // Same tombstone, same verdict — an accepted-then-faulted delivery is not more
+                    // recoverable than an abandoned one, so it takes the same NackThroughParent
+                    // route (see the 🚨 below for why routing it through ReportFailure lost it).
                     //
                     // Reporting it as transient is what kept #1029 alive after that fix: the
                     // consumer's sync stream rides ShuttingDown out waiting for a reactivation that
@@ -1323,19 +1373,37 @@ public class MessageService : IMessageService
                     // matches — it would re-classify this verdict as retryable even under
                     // ErrorType.NotFound. Both halves are pinned by
                     // DeletedAddressNackClassificationTest.
+                    // 🚨 THROUGH THE PARENT FIRST — and this is the whole reason the verdict above
+                    // was going missing. ReportFailure posts through OUR OWN hub, and it declines
+                    // to post at all once RunLevel >= DisposeHostedHubs ("recipients are likely
+                    // also disposing"). That gate is satisfied in precisely the situation this
+                    // branch exists for, so the NACK it so carefully classifies was computed,
+                    // logged, and then silently dropped — the sender heard nothing and burned its
+                    // whole RequestTimeout. Locally reproduced with StaleStampRootBindingTest: a
+                    // client SubscribeRequest reached LayoutAreaHost in the root's recycle window,
+                    // faulted with HubDisposingException, and the subscriber sat idle for 60 s.
+                    //
+                    // NackThroughParent is the primitive built for exactly this ("our own Post
+                    // would re-enter this service's shutdown gate and be dropped") and it applies
+                    // the SAME tombstone fork internally. ReportFailure stays as the fallback for
+                    // the cases it can still serve — a root hub with no parent, or a parent that
+                    // is itself past DisposeHostedHubs — so no caller loses an answer it used to
+                    // get, and nobody gets two (the "ONE request, ONE failure" rule).
                     if (IsAddressDeleted())
                     {
                         logger.LogDebug(e,
                             "{MessageType} (ID: {MessageId}) faulted in {Address} after {Duration}ms because the hub is tearing down, and the address is TOMBSTONED — NACKing as authoritative NotFound.",
                             messageTypeName, delivery.Id, Address, executionStopwatch.ElapsedMilliseconds);
-                        ReportFailure(delivery.Failed(DeletedAddressMessage), ErrorType.NotFound);
+                        if (!NackThroughParent(delivery, e.ToString()))
+                            ReportFailure(delivery.Failed(DeletedAddressMessage), ErrorType.NotFound);
                     }
                     else
                     {
                         logger.LogDebug(e,
                             "{MessageType} (ID: {MessageId}) raced hub disposal in {Address} after {Duration}ms — NACKing as transient (ShuttingDown).",
                             messageTypeName, delivery.Id, Address, executionStopwatch.ElapsedMilliseconds);
-                        ReportFailure(delivery.Failed(e.ToString()), ErrorType.ShuttingDown);
+                        if (!NackThroughParent(delivery, e.ToString()))
+                            ReportFailure(delivery.Failed(e.ToString()), ErrorType.ShuttingDown);
                     }
                 }
                 else
@@ -1539,6 +1607,43 @@ public class MessageService : IMessageService
         if (hub.RunLevel >= MessageHubRunLevel.DisposeHostedHubs
             && message is not ShutdownRequest and not DisposeRequest)
         {
+            // 🚨 …EXCEPT an ANSWER somebody is awaiting. A message carrying RequestId IS the reply
+            // to a pending hub.Observe(...) callback, and refusing it here strands that caller for
+            // its ENTIRE RequestTimeout — the handler ran, produced a verdict, and the verdict died
+            // on the way out. That is the third seam of the same defect the two NackThroughParent
+            // sites above close, and it is the one the fate ledger calls out by name: "a reply WAS
+            // posted for this correlation and the callback is STILL pending — the reply was lost
+            // between the responder and the requester."
+            //
+            // Measured, main-red: StaleStampRootBindingTest — the plugin installer's
+            // SyncContentFilesRequest was HANDLED by the recycling root (HANDLER_ENTER +55ms,
+            // RESPONSE_POSTED +70ms, HANDLER_EXIT Processed +70ms) and the installer still waited
+            // the full 60 s, because that ImportContentResponse was refused right here.
+            //
+            // Hand it to the PARENT, which is alive and is already the carrier for every other
+            // thing a disposing hub still has to say (NackThroughParent). Scoped to correlated
+            // replies only: fire-and-forget traffic from a teardown keeps the historical refusal,
+            // so this cannot resurrect the ObjectDisposedException/storm class the guard exists
+            // for — nobody is waiting on those.
+            if (correlatedRequestId is not null
+                && ParentHub is { } replyParent
+                && replyParent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+            {
+                try
+                {
+                    replyParent.Post(message, _ => opt);
+                    postFate?.Add($"REPLY_FORWARDED_THROUGH_PARENT runLevel={hub.RunLevel}", Address);
+                    return delivery;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex,
+                        "Could not forward the reply {MessageType} (ID: {MessageId}) for request {RequestId} "
+                        + "through the parent of shutting-down hub {Address}",
+                        message!.GetType().Name, delivery.Id, correlatedRequestId, Address);
+                }
+            }
+
             postFate?.Add($"POST_REFUSED_SHUTTING_DOWN runLevel={hub.RunLevel}", Address);
             return ((IMessageDelivery)delivery).Failed("Hub is shutting down");
         }

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -710,6 +710,111 @@ public static class PackageInstaller
     }
 
     /// <summary>
+    /// How many times the content publish re-asks a root that answered "I am recycling". Two
+    /// recycles can hit one install (the installer's own and the framework's rebind watcher), so
+    /// this only has to outlast those; it is a guard against an unforeseen recycle LOOP, never a
+    /// budget to be widened. Each re-ask is gated on an observed teardown completing, so the
+    /// attempts cannot spin.
+    /// </summary>
+    private const int RootRecycleReAsks = 4;
+
+    /// <summary>
+    /// Whether a publish failure is the framework's TRANSIENT recycle verdict — the node is
+    /// coming back and the honest response is to ask again — rather than a real failure.
+    /// Typed on <see cref="ErrorType.ShuttingDown"/> / <see cref="HubDisposingException"/>, never
+    /// on message text, so an application error can never be mistaken for a recycle.
+    /// </summary>
+    private static bool IsRootRecycling(Exception exception)
+    {
+        for (var e = exception; e is not null; e = e.InnerException)
+        {
+            if (e is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
+                return true;
+            if (HubDisposingException.IsHubDisposal(e))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Completes once the teardown that just rejected a publish has finished, so the re-ask lands
+    /// on a fresh activation instead of racing the same dying instance. Event-driven: it observes
+    /// that hub instance's <see cref="IMessageHub.DisposalCompleted"/>. When nothing is there to
+    /// wait for — no local instance, or one that is not disposing (the recycle already finished,
+    /// or the hub lives on another silo) — the re-ask proceeds immediately.
+    /// </summary>
+    private static IObservable<Unit> RootTeardownSettled(IMessageHub hub, string rootPath)
+    {
+        var live = hub.GetHostedHub(new Address(rootPath), HostedHubCreation.Never);
+        if (live is null || !live.IsDisposing)
+            return Observable.Return(Unit.Default);
+        return live.DisposalCompleted
+            .Take(1)
+            .Timeout(RootRecycleTimeout)
+            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+            .DefaultIfEmpty(Unit.Default);
+    }
+
+    /// <summary>
+    /// How long the install waits for a root recycle it issued to actually finish. Generous
+    /// because it is only ever reached when a hub's teardown itself wedges; the normal case
+    /// completes in a few milliseconds and the wait ends the instant it does.
+    /// </summary>
+    private static readonly TimeSpan RootRecycleTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Recycles the retyped root's hub — and WAITS for that teardown to complete before the
+    /// install goes on to touch the root again.
+    ///
+    /// <para>🚨 The wait is the point. This recycle used to be fire-and-forget, so the install's
+    /// very next steps — the warm, then the CONTENT publish — raced the teardown they had just
+    /// asked for. Both of them ACTIVATE the root (routing a message to a node address creates its
+    /// hub), so a package with content assets reliably posted its
+    /// <c>SyncContentFilesRequest</c> into a hub that the queued <c>DisposeRequest</c> then tore
+    /// down underneath it, mid-activation. Measured on CI (run 31390882509, the merge that turned
+    /// main red): the sync reached the root at <c>runLevel=Starting</c> and was dead 94 ms later,
+    /// the installer burned the full 60 s hub timeout, and the committed asset never landed —
+    /// "the package's nodes are installed but its binaries are not being served". The sibling
+    /// symptom is the caller's: <c>Install</c> returned while the recycle was still in flight, so
+    /// a render of the freshly installed root raced the same teardown.</para>
+    ///
+    /// <para>Sequenced, not retried: we take the live instance BEFORE posting and then observe
+    /// its own <see cref="IMessageHub.DisposalCompleted"/>, so the install resumes exactly when
+    /// the old hub is gone and the next touch activates the FINAL one. Nothing to poll, nothing
+    /// to sleep. When there is no local instance (nothing was ever activated, or the hub lives on
+    /// another silo) the post stays fire-and-forget as before — there is no teardown here to wait
+    /// for. A timeout degrades to the old behaviour rather than failing the install: the package's
+    /// nodes are already written by this point.</para>
+    /// </summary>
+    private static IObservable<Unit> RecycleRoot(IMessageHub hub, string? rootPath, ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+            return Observable.Return(Unit.Default);
+
+        var address = new Address(rootPath!);
+        // Captured BEFORE the post: after it, the address may already resolve to nothing (or, in
+        // a later round, to the replacement) and we would wait on the wrong instance — or on none.
+        var live = hub.GetHostedHub(address, HostedHubCreation.Never);
+        hub.Post(new DisposeRequest(), o => o.WithTarget(address));
+        if (live is null)
+            return Observable.Return(Unit.Default);
+
+        return live.DisposalCompleted
+            .Take(1)
+            .Timeout(RootRecycleTimeout)
+            .Catch<Unit, Exception>(exception =>
+            {
+                logger?.LogWarning(exception,
+                    "[PackageInstaller] the recycle of root {Root} did not complete in {Timeout}; "
+                    + "continuing — the warm and the content publish may race its teardown",
+                    rootPath, RootRecycleTimeout);
+                return Observable.Return(Unit.Default);
+            })
+            .DefaultIfEmpty(Unit.Default);
+    }
+
+    /// <summary>
     /// Whether the CONTENT publish may touch <paramref name="rootPath"/> yet — the gate in front
     /// of <see cref="SyncPackageContent"/>, and the second half of the warm's guard above.
     ///
@@ -957,6 +1062,24 @@ public static class PackageInstaller
                     ? response.FilesImported
                     : throw new InvalidOperationException(
                         response.Error ?? "content sync failed without an error message"))
+                // 🚨 "The address may reactivate (recycle / restart); retry to get the
+                // authoritative answer" is not advice — it is the framework's TRANSIENT verdict,
+                // and this is the one consumer that used to throw it away and declare the
+                // package's binaries lost. A root is recycled TWICE during an install: once by
+                // the installer itself (now sequenced, see RecycleRoot) and once by the framework's
+                // NodeTypeRebindWatcher when the change feed reports the retype — that second one
+                // belongs to nobody and is what this publish lands in.
+                //
+                // Not a blind retry, and nothing to sleep on: the re-ask waits for the exact
+                // teardown that rejected it (that hub instance's own DisposalCompleted) and then
+                // asks the address again, which activates the FINAL hub. Only a typed transient
+                // is re-asked — an application failure, a bad path, a missing collection all still
+                // fail on the first answer, so a genuinely broken publish cannot hide in a loop.
+                .RetryWhen(faults => faults
+                    .Select((fault, attempt) => (fault, attempt))
+                    .SelectMany(f => IsRootRecycling(f.fault) && f.attempt < RootRecycleReAsks
+                        ? RootTeardownSettled(hub, sync.NodePath)
+                        : Observable.Throw<Unit>(f.fault)))
                 .Catch<int, Exception>(exception =>
                 {
                     logger?.LogWarning(exception,
@@ -1702,12 +1825,9 @@ public static class PackageInstaller
                     // of intent; it is not load-bearing. If the symptom ever reappears, check all
                     // three: is the hub recycled, is the resolution for the bare root path serving
                     // a real node, and did the rebind watcher see the retype?
-                    .Select(rest =>
-                    {
-                        if (placeholderRoot is not null && root is not null)
-                            hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(root.Path)));
-                        return rest;
-                    })
+                    .SelectMany(rest => RecycleRoot(
+                            hub, placeholderRoot is not null ? root?.Path : null, logger)
+                        .Select(_ => rest))
                     // A placeholder's write is bookkeeping, not content — its FINAL retype in
                     // stage 2 is the root's one counted write (keeps Written ≤ node count).
                     .Select(rest => (IList<(string Path, bool Wrote)>)(placeholderRoot is null ? rootWrites : [])

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The FOURTH door into the silent-abandonment park (#672 closed two, #1029 a third): a delivery
+/// the hub ACCEPTED — it was already in the main turn queue, never deferred — that only reaches
+/// the handler seam once disposal has advanced. Both outcomes at that seam used to answer nobody,
+/// so the sender's <c>hub.Observe(...)</c> burned its entire 60 s request budget in silence.
+///
+/// <para><b>Why the earlier fixes do not cover it.</b> <c>ScheduleNotify</c>'s intake gate NACKs a
+/// message that ARRIVES after <c>RunLevel</c> flipped, and the disposal drain NACKs whatever is
+/// still parked in <c>deferredDeliveries</c>. This delivery is neither: it was accepted while the
+/// hub was healthy and it is in the MAIN queue, so the intake gate never saw it and the deferred
+/// drain finds nothing to answer for it.</para>
+///
+/// <para><b>Field evidence.</b> <c>StaleStampRootBindingTest</c> on CI (run 31390882509, the merge
+/// that turned main red): the installer's <c>SyncContentFilesRequest</c> activated the package
+/// root's hub, the root was recycled ~94 ms later, and the request executed at
+/// <c>runLevel=Dead</c> — <c>NOT_PROCESSED_DISPOSING</c>, no NACK. The installer waited the full
+/// 60 s hub timeout and then reported "the package's nodes are installed but its binaries are not
+/// being served". The same test locally shows the other half: a client <c>SubscribeRequest</c>
+/// reaching <c>LayoutAreaHost</c> in the recycle window faults with <c>HubDisposingException</c>,
+/// and the sender still hears nothing.</para>
+///
+/// <para><b>The contract pinned here.</b> Both outcomes must NACK through the PARENT hub with the
+/// TRANSIENT <see cref="ErrorType.ShuttingDown"/> — through the parent because the disposing hub's
+/// own <c>Post</c> re-enters <c>ReportFailure</c>'s "don't post during shutdown" gate
+/// (<c>RunLevel &gt;= DisposeHostedHubs</c>) and is dropped, which is precisely how the disposal
+/// branch's NACK went missing while looking correct in the source.</para>
+/// </summary>
+public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record RaceRequest : IRequest<RaceResponse>;
+
+    private record RaceResponse;
+
+    private record FaultingRequest : IRequest<RaceResponse>;
+
+    private record Blocker;
+
+    private static readonly Address VictimAddress = new("disposal-race", "1");
+
+    private static readonly Address FaultingAddress = new("disposal-race-fault", "1");
+
+    /// <summary>
+    /// Door one: the delivery reaches <c>HandleMessage</c> with the hub already past
+    /// <c>ShutDown</c>, so no handler is entered at all (<c>NOT_PROCESSED_DISPOSING</c>). It used
+    /// to be returned unchanged — abandoned without a word to the sender.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AcceptedRequest_IsNacked_WhenTheHubGoesDownBeforeItsTurnRuns()
+        => await RunRace(VictimAddress, faulting: false);
+
+    /// <summary>
+    /// Door two: the delivery DOES reach its handler, which cannot complete because the hub is
+    /// tearing down (<see cref="HubDisposingException"/> — the production shape is
+    /// <c>LayoutAreaHost</c> failing to build its <c>SynchronizationStream</c>). The branch that
+    /// classifies this as transient posted its NACK through <c>ReportFailure</c>, whose own
+    /// shutdown gate then swallowed it — the classification was right and the answer never left
+    /// the hub.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FaultingRequest_IsNacked_WhenTheHandlerRacesDisposal()
+        => await RunRace(FaultingAddress, faulting: true);
+
+    private async Task RunRace(Address victimAddress, bool faulting)
+    {
+        using var handlerEntered = new ManualResetEventSlim(false);
+        using var releaseHandler = new ManualResetEventSlim(false);
+
+        var host = GetHost();
+        var victim = host.GetHostedHub(victimAddress, c => c
+            .WithTypes(typeof(RaceRequest), typeof(FaultingRequest), typeof(RaceResponse), typeof(Blocker))
+            // Deliberately ignores cancellation: keeps the victim's single-threaded action block
+            // busy so the ShutdownRequest posted by Dispose() cannot be processed. Disposal then
+            // completes out of band (the disposal watchdog), which is what lets RunLevel advance
+            // while our request is still sitting in the main queue — the production interleaving,
+            // made deterministic.
+            .WithHandler<Blocker>((_, d) =>
+            {
+                handlerEntered.Set();
+                releaseHandler.Wait(TimeSpan.FromSeconds(60));
+                return d.Processed();
+            })
+            // Both handlers WOULD answer / would be entered, so a pass can only come from the
+            // NACK — never from the request quietly being served after all.
+            .WithHandler<RaceRequest>((h, d) =>
+            {
+                h.Post(new RaceResponse(), o => o.ResponseFor(d));
+                return d.Processed();
+            })
+            .WithHandler<FaultingRequest>((h, _) =>
+                throw new HubDisposingException(h.Address, "area/Overview")));
+        victim.Should().NotBeNull();
+
+        try
+        {
+            // 1. Stall the victim's turn loop.
+            host.Post(new Blocker(), o => o.WithTarget(victimAddress));
+            handlerEntered.Wait(TimeSpan.FromSeconds(20)).Should().BeTrue(
+                "the blocker handler must be holding the victim's action block");
+
+            // 2. Accepted while the hub is healthy, so it lands in the MAIN queue behind the
+            //    stall — not in the deferred queue the #672 drain answers for.
+            IRequest<RaceResponse> request = faulting ? new FaultingRequest() : new RaceRequest();
+            var response = host
+                .Observe<RaceResponse>(request, o => o.WithTarget(victimAddress))
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+
+            // 3. Dispose. The phase machine is starved behind the stall, so the disposal watchdog
+            //    tears the hub down out of band and RunLevel reaches Dead with our request still
+            //    queued. Polls the public RunLevel rather than sleeping a fixed budget.
+            victim!.Dispose();
+            await WaitUntil(() => victim.RunLevel >= MessageHubRunLevel.ShutDown,
+                "the victim must reach ShutDown while the request is still queued");
+            Output.WriteLine($"victim RunLevel at release: {victim.RunLevel}");
+
+            // 4. Let the turn loop reach our request.
+            releaseHandler.Set();
+
+            // WITHOUT the fix this task never completes and the [Fact] timeout fires with no
+            // explanation — exactly the production symptom (an install that spins for 60 s, a
+            // page that never renders).
+            var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => response);
+            failure.Failure.Should().NotBeNull();
+            Output.WriteLine(
+                $"NACK: errorType={failure.Failure!.ErrorType} message={failure.Failure.Message}");
+
+            // TRANSIENT: a recycled address reactivates, so the sender must read "ask again",
+            // never "gone". SynchronizationStream's resubscribe latch keys off exactly this.
+            failure.Failure.ErrorType.Should().Be(ErrorType.ShuttingDown,
+                "the address may reactivate (recycle / restart), so a terminal classification "
+                + "would kill the consumer's rehydrate path");
+            failure.Failure.Message.Should().Contain("shutting down",
+                "the transient classifiers (MeshNodeStreamCache.IsTransientOwnerFailure, "
+                + "AreaErrorClassifier.IsTransientHubFailure) match this phrase when the typed "
+                + "failure has been flattened into a DeliveryFailureException message");
+        }
+        finally
+        {
+            releaseHandler.Set();
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> condition, string because)
+    {
+        for (var i = 0; i < 400; i++)
+        {
+            if (condition())
+                return;
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"Timed out waiting: {because}");
+    }
+}


### PR DESCRIPTION
## Main is red

`StaleStampRootBindingTest.StaleStampSelfTypedRootShippingContent_RootServesItsTypesArea`, run 31390882509 (the #1147 merge):

```
AssertionException : Expected value to be true because the committed asset must still be
published into the root's content collection (…/ShopB/images/cover.png), but found False.
[PackageInstaller] publishing 1 content asset(s) to ShopB failed — the package's nodes are
  installed but its binaries are not being served
  System.TimeoutException: No response received in hub mesh/… within 00:01:00 for request
  SyncContentFilesRequest → target ShopB.
install returned at +60701ms
```

**Not a #1147 interaction** — `git log 09cd35739..269dcbc76` is #1147 plus one commit, touching only `MeshWeaver.Observability` and docs. The test is genuinely racy: on `origin/main`, under `DOTNET_PROCESSOR_COUNT=4` in bulk, **the class failed in 4/4 runs**. #1146's single green was luck.

## Root cause, in two halves

The fate ledger names the first: `ROUTED onTarget=True state=Submitted@ShopB(+87ms) → NOT_PROCESSED_DISPOSING runLevel=Dead@ShopB(+94ms)`. A root hub is recycled during install, and **a hub that is tearing down answers nobody.** Three seams in `MessageService`, all silent:

1. **A delivery the hub ACCEPTED whose turn comes after `ShutDown`** was returned unchanged. Neither existing NACK covers it — the intake gate never saw it, and it is in the main queue, not the deferred one the #672 drain answers for.
2. **The `HubDisposingException` branch** posted its correctly-classified transient through `ReportFailure`, which **declines to post once `RunLevel >= DisposeHostedHubs`** — precisely the state that branch exists for. Computed, logged, dropped.
3. **An outbound REPLY** was refused by `PostImpl`'s teardown guard, so a handler that ran and posted its answer still stranded the caller — *"a reply WAS posted for this correlation and the callback is STILL pending."*

All three now go through the **live parent**. That killed the 60 s park — and immediately exposed the second half: the honest *"I am recycling, ask again"* verdict was being delivered to consumers that all read it as **permanent failure**, so the fast correct answer lost the same work the silence did, just sooner. (Both variants failed on the first CI run of this branch — that is this bug, not a regression.)

4. **`SynchronizationStream`** kept a rejected subscribe alive and waited for the change-feed latch — but **a recycle is not a write**, so no mesh change event is ever published and the latch's only trigger never fires. The subscriber is orphaned until something unrelated writes the node. The rejection itself is now the event: it re-arms through the **existing** `Resubscribe` (in-flight guard, `ExpectResubscribeFull`, System impersonation), bounded so a recycle loop degrades to today's orphaned stream rather than a storm. The re-ask fetches the **current** snapshot — it never re-asserts a cached frame (the #945 shape).
5. **`ContentService`** collapsed a `HubDisposingException` into a null collection, so callers got the terminal *"Target content collection 'content' not found"* for a hub that was merely restarting. It rethrows the transient; the cache entry is evicted either way.
6. **The content-sync handler** flattened the same fault into an application-level `ImportContentResponse.Fail`, indistinguishable from a real error. It answers with the typed `ErrorType.ShuttingDown`.
7. **`PackageInstaller`**: the root recycle was fire-and-forget, so the install's own warm and content publish raced the teardown they had just asked for — now sequenced on that instance's `DisposalCompleted`. And the publish re-asks on the typed transient, gated on the rejecting instance's `DisposalCompleted`. **Only** the typed transient — an application failure still fails on the first answer.

## Evidence

| | before | after |
|---|---|---|
| PluginCatalog.Test, bulk, `DOTNET_PROCESSOR_COUNT=4` | **4/4 and 5/5 runs red** | **green** |
| `StaleStampRootBindingTest` | a 60 s park + a 120 s one | **3/3 in 6 s** |
| installer content publish | `install returned at +60701ms` | `+289ms` |
| `DisposalRaceNackTest` (new) | both seams fail with the exact CI signature | 2/2 pass, 2 min → 16 s |
| `MeshWeaver.Messaging.Hub.Test` | — | **175/175** |
| `MeshWeaver.Data.Test` | — | **305/305** |

`dotnet build -c Release -warnaserror` clean on every touched project.

Same family as today's memex-cloud production wedge (a `DeliverMessage` executing 37+ min with `NumRunning=147` behind it): a recycle mid-request orphaning in-flight deliveries.

## Note

Main is red, so **this PR's own shard result is the proof** — see the `MeshWeaver.PluginCatalog.Test` shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)