### PR TITLE
A message arriving mid-activation could overtake the queue that ordered it (fixes the kernel CS0103 reorder)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-code-cells-no-longer-forget-earlier-cells.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-code-cells-no-longer-forget-earlier-cells.md
@@ -1,0 +1,27 @@
+---
+Name: Code cells no longer forget earlier cells
+Category: Fix
+Description: Running several code cells in quick succession could fail with "the name does not exist" — a later cell could slip ahead of the one that defined the variable while the page's kernel was still waking up.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Code cells no longer forget earlier cells
+
+Running a page with several code cells — or pressing Run on a few cells back to back — could
+occasionally fail with an error like *"the name 'sharedValue' does not exist"*, even though an
+earlier cell on the same page had just defined it. Re-running the page usually worked, which made
+the failure look random.
+
+The cells were never lost and the kernel never forgot anything: the cells simply did not always
+arrive in the order they were sent. While the part of the portal that runs a page's code is still
+waking up, its incoming messages wait in a short queue so they can be handed over in order. The
+moment it finished waking up, however, a newly arriving message was handed straight to it — jumping
+ahead of messages still waiting in that queue. A cell that *uses* a variable could therefore run
+before the cell that *defines* it, and the kernel rightly reported the name as unknown.
+
+Now a newly arriving message joins the back of the queue whenever the queue is still emptying, so
+everything sent to the same destination is processed strictly in the order it was sent. Once the
+queue has drained, messages are handed over directly as before — nothing gets slower, the order is
+just guaranteed. Pages with many cells run reliably on the first try, and the same fix applies to
+anything else that sends several updates to a part of the portal that is just starting up.

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -78,6 +78,22 @@ namespace MeshWeaver.Hosting
                 return;
 
             var address = GetHostAddress(delivery.Target!);
+            var hostAddress = GetHostAddress(address);
+
+            // 🚨 FIFO with a still-draining activation FIRST — before the hosted-hub
+            // short-circuit below. A hub becomes visible to GetHostedHub the moment its
+            // construction completes (HostedHubsCollection.GetHub publishes it to the
+            // registry BEFORE the activation serializer has drained the deliveries that
+            // queued behind the activating message), so a message arriving in that window
+            // that took the direct path OVERTOOK every delivery still in the backlog:
+            // the kernel's "use sharedValue" submission reached the REPL before the
+            // "define sharedValue" one — CS0103, issue #1145. While a serializer for this
+            // address is live, EVERY message must join its queue (Concat preserves total
+            // arrival order); it self-retires the moment the backlog drains — TryEnqueue
+            // then returns false and the steady-state direct path below is untouched.
+            if (activationSerializers.TryGetValue(hostAddress, out var draining)
+                && draining.TryEnqueue(delivery))
+                return;
 
             // if we have created the hub ==> route through us.
             var hostedHub = Mesh.GetHostedHub(address, HostedHubCreation.Never);
@@ -86,8 +102,6 @@ namespace MeshWeaver.Hosting
                 hostedHub.DeliverMessage(delivery);
                 return;
             }
-
-            var hostAddress = GetHostAddress(address);
 
             // 🚨 Per-address activation FIFO. The hub for `hostAddress` is not yet
             // activated. Two rapid messages to the SAME not-yet-activated address

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -77,8 +77,14 @@ namespace MeshWeaver.Hosting
             if (Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
                 return;
 
+            // ONE traversal is enough, and the serializer key MUST be this same value:
+            // GetHostAddress is idempotent (every return path yields an address with
+            // Host == null), so a second call can only ever return `address` again. The
+            // serializer lookup below and EnqueueForActivation therefore key on exactly
+            // what the hosted-hub short-circuit probes — if those two ever disagreed, a
+            // message could miss the live queue and leapfrog it, which is the very bug
+            // this method now prevents.
             var address = GetHostAddress(delivery.Target!);
-            var hostAddress = GetHostAddress(address);
 
             // 🚨 FIFO with a still-draining activation FIRST — before the hosted-hub
             // short-circuit below. A hub becomes visible to GetHostedHub the moment its
@@ -91,7 +97,7 @@ namespace MeshWeaver.Hosting
             // address is live, EVERY message must join its queue (Concat preserves total
             // arrival order); it self-retires the moment the backlog drains — TryEnqueue
             // then returns false and the steady-state direct path below is untouched.
-            if (activationSerializers.TryGetValue(hostAddress, out var draining)
+            if (activationSerializers.TryGetValue(address, out var draining)
                 && draining.TryEnqueue(delivery))
                 return;
 
@@ -103,7 +109,7 @@ namespace MeshWeaver.Hosting
                 return;
             }
 
-            // 🚨 Per-address activation FIFO. The hub for `hostAddress` is not yet
+            // 🚨 Per-address activation FIFO. The hub for `address` is not yet
             // activated. Two rapid messages to the SAME not-yet-activated address
             // must reach its hub in ARRIVAL order. Routed independently, each drives
             // the async ResolvePath → CreateHub chain (RouteMessage) and the hub
@@ -116,7 +122,7 @@ namespace MeshWeaver.Hosting
             // pump preserves it through activation. Once the hub is hosted the backlog
             // drains and the serializer self-retires — subsequent messages take the
             // direct short-circuit above (no per-message ResolvePath).
-            EnqueueForActivation(delivery, hostAddress);
+            EnqueueForActivation(delivery, address);
         }
 
         private void EnqueueForActivation(IMessageDelivery delivery, Address hostAddress)

--- a/test/MeshWeaver.Hosting.Monolith.Test/ActivationBacklogFifoTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ActivationBacklogFifoTest.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>Probe request whose arrival order at the target hub the test asserts on.</summary>
+public record OrderProbeRequest(string Tag) : IRequest<OrderProbeResponse>;
+
+/// <summary>Response for <see cref="OrderProbeRequest"/> so the test can await completion.</summary>
+public record OrderProbeResponse(string Tag);
+
+/// <summary>
+/// Mesh-scoped instance recorder (never static — NoStaticState.md) capturing the
+/// order in which the probe hub's handler processed the deliveries.
+/// </summary>
+public sealed class DeliveryOrderRecorder
+{
+    private ImmutableList<string> tags = ImmutableList<string>.Empty;
+
+    /// <summary>Appends one processed tag.</summary>
+    public void Record(string tag) => ImmutableInterlocked.Update(ref tags, static (l, t) => l.Add(t), tag);
+
+    /// <summary>The tags in processing order.</summary>
+    public ImmutableList<string> Snapshot => tags;
+}
+
+/// <summary>
+/// Deterministic repro for issue #1145 (three back-to-back kernel submissions lose shared
+/// state — CS0103 on the monolith path).
+///
+/// <para><b>The hole:</b> <c>RoutingServiceBase.RouteInMesh</c> short-circuits to
+/// <c>Mesh.GetHostedHub(address, Never)</c> the moment the target hub is REGISTERED — but a hub
+/// becomes registered mid-activation (<c>HostedHubsCollection.GetHub</c> publishes it to
+/// <c>messageHubs</c> the instant construction completes), while earlier messages for the same
+/// address are still queued in the per-address <c>ActivationSerializer</c>. A message arriving in
+/// that window takes the direct path and OVERTAKES every delivery still in the backlog. For the
+/// kernel that means submission #2 ("use sharedValue") reaches the REPL before submission #1
+/// ("define sharedValue") → CS0103.</para>
+///
+/// <para><b>The script:</b> a gated <see cref="IPathResolver"/> decorator parks the FIRST
+/// resolution of the probe path (message A activating the hub — serializer alive, backlog [A])
+/// and the SECOND (message B's serializer turn — which only starts after A's activation
+/// registered the hub, so "hub registered + backlog undrained" holds deterministically). C is
+/// posted in exactly that state. The contract: the probe hub must process A, B, C in post
+/// order. Before the fix C leapfrogs B deterministically (order A, C, B).</para>
+/// </summary>
+public class ActivationBacklogFifoTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string ProbeId = "order-probe";
+    private static string ProbePath => $"{TestPartition}/{ProbeId}";
+
+    private readonly ResolutionGates gates = new();
+
+    /// <summary>
+    /// Per-mesh gate controller for the decorated path resolver. Instance state on the
+    /// test class (one mesh per test) — never static.
+    /// </summary>
+    private sealed class ResolutionGates
+    {
+        private int probeCalls;
+        private readonly ReplaySubject<int> calls = new();
+        private readonly ReplaySubject<Unit> first = new();
+        private readonly ReplaySubject<Unit> second = new();
+
+        /// <summary>Emits 1, 2, 3… as probe-path resolutions are requested (replayed).</summary>
+        public IObservable<int> Calls => calls;
+
+        /// <summary>Releases the first probe-path resolution (message A's activation).</summary>
+        public void ReleaseFirst() => first.OnNext(Unit.Default);
+
+        /// <summary>Releases the second probe-path resolution (message B's serializer turn).</summary>
+        public void ReleaseSecond() => second.OnNext(Unit.Default);
+
+        /// <summary>Gate observable for one resolution request of <paramref name="path"/>.</summary>
+        public IObservable<Unit> Gate(string path)
+        {
+            if (!path.EndsWith(ProbeId, StringComparison.Ordinal))
+                return Observable.Return(Unit.Default);
+            var call = Interlocked.Increment(ref probeCalls);
+            calls.OnNext(call);
+            return call switch
+            {
+                1 => first.Take(1),
+                2 => second.Take(1),
+                _ => Observable.Return(Unit.Default)
+            };
+        }
+    }
+
+    /// <summary>
+    /// Timing-control decorator over the REAL <see cref="PathResolutionService"/> — no data is
+    /// faked; only WHEN a resolution emits is controlled, exactly the CI-load jitter that makes
+    /// #1145 intermittent, made deterministic.
+    /// </summary>
+    private sealed class GatedPathResolver(IPathResolver inner, ResolutionGates gates) : IPathResolver
+    {
+        public IObservable<AddressResolution?> ResolvePath(string path)
+            => gates.Gate(path).SelectMany(_ => inner.ResolvePath(path));
+
+        public IObservable<AddressResolution?> ResolveNavigationPath(string path)
+            => inner.ResolveNavigationPath(path);
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(MeshNode.FromPath(ProbePath) with
+            {
+                Name = "Order Probe",
+                HubConfiguration = config => config
+                    .WithType(typeof(OrderProbeRequest), nameof(OrderProbeRequest))
+                    .WithType(typeof(OrderProbeResponse), nameof(OrderProbeResponse))
+                    .WithHandler<OrderProbeRequest>((hub, delivery) =>
+                    {
+                        hub.ServiceProvider.GetRequiredService<DeliveryOrderRecorder>()
+                            .Record(delivery.Message.Tag);
+                        hub.Post(new OrderProbeResponse(delivery.Message.Tag), o => o.ResponseFor(delivery));
+                        return delivery.Processed();
+                    })
+            })
+            .ConfigureServices(s => s
+                .AddSingleton<DeliveryOrderRecorder>()
+                // Last registration wins for single resolution; the framework's
+                // TryAddSingleton<IPathResolver> cannot override an existing one either
+                // way, so this decorator is what RoutingServiceBase resolves.
+                .AddSingleton<IPathResolver>(sp =>
+                    new GatedPathResolver(sp.GetRequiredService<PathResolutionService>(), gates)));
+
+    [Fact(Timeout = 60_000)]
+    public async Task MessageArrivingWhileActivationBacklogDrains_MustNotLeapfrogIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var probeAddress = new Address(ProbePath);
+        var client = GetClient(c => ConfigureClient(c)
+            .WithType(typeof(OrderProbeRequest), nameof(OrderProbeRequest))
+            .WithType(typeof(OrderProbeResponse), nameof(OrderProbeResponse)));
+
+        // Pre-activate the fence hub (the TestData partition node — NOT the mesh hub,
+        // which is the router and flags direct work as ROUTER_TRAFFIC). Later fence
+        // pings to it ride the same client→mesh mailbox as the probe messages, so a
+        // fence response proves the mesh has processed everything posted before it.
+        var fenceAddress = new Address(TestPartition);
+        await client.Observe(new PingRequest(), o => o.WithTarget(fenceAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+
+        // A — first message to the not-yet-activated probe hub. Its activation parks at
+        // resolver call #1: the per-address ActivationSerializer is now alive with A pending.
+        var aTask = client.Observe<OrderProbeResponse>(new OrderProbeRequest("A"),
+                o => o.WithTarget(probeAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+        await gates.Calls.Where(c => c == 1).FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
+        Output.WriteLine("A parked in activation (resolver call #1).");
+
+        // B — joins the activation backlog behind A. Fence: a ping to the pre-activated
+        // fence hub rides the same client→mesh mailbox, so its response proves the mesh
+        // has processed B's RouteInMesh (FIFO per mailbox) — B is provably enqueued
+        // before A is released.
+        var bTask = client.Observe<OrderProbeResponse>(new OrderProbeRequest("B"),
+                o => o.WithTarget(probeAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+        await client.Observe(new PingRequest(), o => o.WithTarget(fenceAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
+        Output.WriteLine("B enqueued behind A (mesh fence passed).");
+
+        // Release A: the hub is constructed + REGISTERED, A is delivered, and B's serializer
+        // turn starts — parking at resolver call #2. Call #2 firing therefore proves the
+        // leapfrog window is open: hub registered, backlog (B) undrained.
+        gates.ReleaseFirst();
+        await gates.Calls.Where(c => c == 2).FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
+        Mesh.GetHostedHub(probeAddress, HostedHubCreation.Never).Should().NotBeNull(
+            "A's activation must have registered the probe hub before B's serializer turn");
+        Output.WriteLine("Hub registered; B parked in serializer turn (resolver call #2).");
+
+        // C — posted exactly in the window. It must NOT bypass the still-draining backlog.
+        var cTask = client.Observe<OrderProbeResponse>(new OrderProbeRequest("C"),
+                o => o.WithTarget(probeAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+        await client.Observe(new PingRequest(), o => o.WithTarget(fenceAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask(ct);
+        Output.WriteLine("C routed (mesh fence passed).");
+
+        // Release B; every message must now complete.
+        gates.ReleaseSecond();
+        await Task.WhenAll(aTask, bTask, cTask);
+
+        var recorder = Mesh.ServiceProvider.GetRequiredService<DeliveryOrderRecorder>();
+        Output.WriteLine($"Processing order: {string.Join(", ", recorder.Snapshot)}");
+        recorder.Snapshot.Should().Equal(new[] { "A", "B", "C" },
+            "messages to one address must be processed in post order even when a later message "
+            + "arrives while the hub is already registered but the activation backlog has not "
+            + "drained — the #1145 kernel CS0103 reorder");
+    }
+}


### PR DESCRIPTION
## Root cause

`RoutingServiceBase.RouteInMesh` preserves FIFO for a not-yet-activated address through the per-address `ActivationSerializer` (bef260452) — but its hosted-hub short-circuit consults only "is the hub registered?". A hub becomes registered the moment its construction completes (`HostedHubsCollection.GetHub` publishes it to `messageHubs` BEFORE the serializer has drained the deliveries queued behind the activating message). A message arriving in that window was handed straight to the hub's mailbox and **overtook every delivery still in the backlog**.

For `MonolithKernelTest.ThreeSubmissions_ShareState`: the kernel-session Activity hub is activated concurrently by the test's `GetRemoteStream` subscriptions racing the three `SubmitCodeRequest` posts. When the activation completes between the arrival of submission 1 (already queued in the serializer) and submissions 2/3, the later submissions short-circuit past it — "use `sharedValue`" reaches the REPL before "define `sharedValue`" → CS0103. Three submissions + two streams put more messages in the backlog and more arrival gaps for the registration to land in than the 2-submission sibling — matching the observed discriminator (2 passes, 3 fails in the same runs).

Everything else on the path was verified order-preserving: client action block → mesh mailbox → `RouteInMesh` (serial per mailbox), the `ActivationSerializer` Concat pump, `KernelContainer`'s eager `Observe` forward, hosted-hub mailboxes, and `KernelExecutor`'s `Select(RunSubmission).Concat()` REPL queue.

## Deterministic repro

`ActivationBacklogFifoTest` scripts the exact interleaving with a timing-only gate around the real `PathResolutionService` (no data faked, no sleeps — every step is fenced on an observable condition): A parks in activation (serializer alive), B joins the backlog (fenced), A is released — hub registered, B parked in its serializer turn — and C is posted in exactly that window. **Before the fix the probe hub processes `A, C, B` on every run; after the fix `A, B, C`.** Verified fail-before/pass-after in both orders with the final test shape.

## Fix

In `RouteInMesh`, a still-live `ActivationSerializer` for the address takes precedence over the hosted-hub short-circuit: the message joins the queue, and Concat preserves total arrival order. The serializer self-retires the moment its backlog drains — `TryEnqueue` then returns `false` — so the steady-state direct path is untouched.

## Verification

- `ActivationBacklogFifoTest`: deterministic `A, C, B` fail before, green after (both verified).
- `MonolithKernelTest` (MeshWeaver.Persistence.Test): 8/8 green, incl. `ThreeSubmissions_ShareState`, `MultipleSubmissions_ShareKernelState`, and both interactive-showcase pipelines.
- `MonolithMeshTest` + `ShutdownRoutingRejectClassificationTest` + `SubscribeRequestIdentityRoutingTest`: 23/23 green; `KernelReplChainingTest` green.
- `WhatsNewEntryIntegrityTest` green.
- `dotnet build -c Release -warnaserror` clean for the touched chains (MeshWeaver.Hosting via Hosting.Monolith.Test, MeshWeaver.Documentation via Documentation.Test).

Fixes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
