### PR TITLE
Gate Orleans stream subscriptions on lifecycle readiness, not retry

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansConnectionExtensions.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansConnectionExtensions.cs
@@ -49,6 +49,9 @@ public static class OrleansConnectionExtensions
         // See Doc/Architecture/PartitionedPersistence.md.
         services.AddPartitionedInMemoryPersistence();
         services.TryAddSingleton<IRoutingService, OrleansRoutingService>();
+        // Deterministic streaming-readiness signal (cluster-client lifecycle → Active) that the
+        // routing service orders its Orleans stream subscriptions on — see OrleansStreamingReadiness.
+        services.AddOrleansStreamingReadiness();
         return services;
     }
 

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -296,21 +296,23 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         streams[address] = callback;
         OrleansRouteTrace.Write($"OrleansRoutingService.RegisterStream addr={address} streamName={address}");
 
-        // 🚨 Attach the Orleans memory-stream subscription on a bounded background retry. GetStreamProvider
-        // (Memory) throws (an NRE from deep in the Orleans stream runtime) when the silo/client stream
-        // provider is not yet started — the process-wide cache hub is created eagerly at silo startup and
-        // can lose the race with Orleans init. This subscribe USED to run synchronously here, so that throw
-        // propagated out of the cache hub's construction, KILLED the cache hub, and left every DataChanged
-        // Event deferred >30s → a silo-wide "deferred without opening init gates" storm that wedged the
-        // whole portal — with the real NullReferenceException swallowed into Autofac activation noise. Now
-        // the hub is always fully created (the local route above already routes in-process), and the cross-
-        // process subscription attaches as soon as the provider is ready. Each failure is surfaced (Error),
-        // and a hard failure past the deadline is loud (Critical) instead of a silent wedge.
+        // 🚨 Attach the Orleans memory-stream subscription once Orleans streaming is READY — never
+        // before. GetStream on a PersistentStreamProvider whose lifecycle Init has not yet run throws
+        // an NRE from deep inside the Orleans stream runtime (issue #1129): the process-wide cache/mesh
+        // hubs are created eagerly at silo startup and used to lose that race on every pod boot. This
+        // subscribe USED to run synchronously here, so that throw propagated out of the cache hub's
+        // construction, KILLED the cache hub, and left every DataChangedEvent deferred >30s → a
+        // silo-wide "deferred without opening init gates" storm that wedged the whole portal; a
+        // Task.Delay poll-retry loop then papered over the race (2 Error-level NRE logs per boot).
+        // Now the hub is always fully created (the local route above already routes in-process), and
+        // the cross-process attach is ORDERED on OrleansStreamingReadiness — completed at
+        // ServiceLifecycleStage.Active of the silo (or cluster-client) lifecycle, strictly after the
+        // stream provider's Init stage — so the first touch of the provider is valid by construction.
         var cts = new CancellationTokenSource();
-        var subscriptionTask = SubscribeWithRetryAsync(address, callback, cts.Token);
-        // Observe the task's terminal state so a fault is NEVER an unobserved-task exception (the retry
-        // RETURNS NULL — not a throw — when it gives up, so a fault here is genuinely unexpected). Accessing
-        // t.Exception marks it observed; this is trace-only, teardown still awaits the handle below.
+        var subscriptionTask = SubscribeWhenStreamingReadyAsync(address, callback, cts.Token);
+        // Observe the task's terminal state so a fault is NEVER an unobserved-task exception (the gated
+        // attach RETURNS NULL — not a throw — when it gives up, so a fault here is genuinely unexpected).
+        // Accessing t.Exception marks it observed; this is trace-only, teardown still awaits the handle below.
         subscriptionTask.ContinueWith(t =>
         {
             if (t.IsFaulted)
@@ -321,7 +323,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync DONE addr={address} subscribed={t.Result is not null}");
         }, TaskScheduler.Default);
 
-        // Synchronous to the caller: remove the local route immediately, cancel any in-flight retry, then
+        // Synchronous to the caller: remove the local route immediately, cancel a still-gated attach, then
         // bridge the genuinely-async Orleans UnsubscribeAsync onto the mesh IO pool (never inline on the
         // disposing hub/grain scheduler). Fire-and-forget on the pool — teardown is best-effort.
         return Disposable.Create(() =>
@@ -331,7 +333,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             ioPool.Invoke(async _ =>
                 {
                     StreamSubscriptionHandle<IMessageDelivery>? subscription = null;
-                    // The retry task may have been cancelled or given up (never subscribed) — then there is
+                    // The attach task may have been cancelled or given up (never subscribed) — then there is
                     // nothing to unsubscribe; a faulted/cancelled await here is expected, not an error.
                     try { subscription = await subscriptionTask.ConfigureAwait(false); }
                     catch (OperationCanceledException) { /* cancelled before it subscribed — nothing to tear down */ }
@@ -346,67 +348,80 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         });
     }
 
-    // Attaches the Orleans memory-stream subscription for <paramref name="address"/>, retrying while the
-    // stream provider is not yet ready (bounded by a deadline). The delivery handler is identical to the
-    // former direct-subscribe path. Runs detached (never on a hub action-block / grain scheduler).
-    private async Task<StreamSubscriptionHandle<IMessageDelivery>?> SubscribeWithRetryAsync(
+    // How long to wait for the Orleans lifecycle to report streaming usable before giving up
+    // LOUDLY. This is not a retry budget — the gate below is deterministic ordering, not a poll.
+    // On a healthy boot the lifecycle reaches Active within seconds; a gate that never opens
+    // means silo/client startup itself is wedged (cf. the 2026-08-10 stalled-rollout window),
+    // and that must surface as a Critical, never a silent hang (wedges-to-zero).
+    private static readonly TimeSpan StreamingReadinessTimeout = TimeSpan.FromSeconds(120);
+
+    // Attaches the Orleans memory-stream subscription for <paramref name="address"/> once the
+    // Orleans lifecycle reports streaming usable — a deterministic ordering gate on
+    // OrleansStreamingReadiness (ServiceLifecycleStage.Active), NOT a retry loop. Touching
+    // GetStream earlier NREs out of the uninitialised PersistentStreamProvider (issue #1129);
+    // waiting for the lifecycle stage the provider itself participates in removes the race by
+    // construction. The delivery handler is identical to the former direct-subscribe path. Runs
+    // detached (never on a hub action-block / grain scheduler); RegisterStream's teardown awaits
+    // this task and unsubscribes whatever it produced.
+    private async Task<StreamSubscriptionHandle<IMessageDelivery>?> SubscribeWhenStreamingReadyAsync(
         Address address, AsyncDelivery callback, CancellationToken ct)
     {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(120);
-        for (var attempt = 1; ; attempt++)
+        try
         {
-            ct.ThrowIfCancellationRequested();
-            try
-            {
-                var stream = GetStreamProvider(StreamProviders.Memory)
-                    .GetStream<IMessageDelivery>(address.ToString());
-                var handle = await stream.SubscribeAsync((v, _) =>
-                {
-                    OrleansRouteTrace.Write($"OrleansRoutingService.STREAM_CALLBACK addr={address} msg={v.Message?.GetType().Name} id={v.Id}");
-                    // Orleans stream handlers must return Task; the AsyncDelivery callback is a cold
-                    // IObservable — Subscribe to run the delivery (the hub queues it), then signal Orleans
-                    // the message was accepted. 🚨 onError is mandatory: we return Task.CompletedTask below,
-                    // so Orleans considers the item accepted and nothing retries — a faulted delivery here
-                    // IS a lost message and must be loud, never an unobserved rethrow.
-                    callback.Invoke(v, CancellationToken.None).Subscribe(
-                        _ => { },
-                        ex =>
-                        {
-                            logger.LogError(ex,
-                                "Delivery callback faulted for {MessageType} ({Id}) on stream {Address} — message dropped",
-                                v.Message?.GetType().Name, v.Id, address);
-                            OrleansRouteTrace.Write(
-                                $"OrleansRoutingService.STREAM_CALLBACK FAULTED addr={address} msg={v.Message?.GetType().Name} id={v.Id} ex={ex.Message}");
-                        });
-                    return Task.CompletedTask;
-                }).ConfigureAwait(false);
+            // The readiness signal is an AsyncSubject the Orleans lifecycle completes at Active —
+            // the source observable IS the gate (no polling, no timer). Late subscribers get the
+            // completed signal replayed, so hubs registered after startup pass straight through.
+            await serviceProvider.GetRequiredService<OrleansStreamingReadiness>().Ready
+                .Timeout(StreamingReadinessTimeout)
+                .ToTask(ct)
+                .ConfigureAwait(false);
 
-                if (attempt > 1)
-                    logger.LogInformation(
-                        "Orleans '{Provider}' stream subscription attached for {Address} after {Attempts} attempt(s)",
-                        StreamProviders.Memory, address, attempt);
-                OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync OK addr={address} attempt={attempt}");
-                return handle;
-            }
-            catch (Exception ex) when (!ct.IsCancellationRequested)
+            var stream = GetStreamProvider(StreamProviders.Memory)
+                .GetStream<IMessageDelivery>(address.ToString());
+            var handle = await stream.SubscribeAsync((v, _) =>
             {
-                OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync RETRY addr={address} attempt={attempt} ex={ex.Message}");
-                if (DateTime.UtcNow > deadline)
-                {
-                    // Give up — surface loudly. The local route is still live, so in-process delivery keeps
-                    // working; only this hub's cross-process routing is degraded (never a silent silo wedge).
-                    logger.LogCritical(ex,
-                        "Orleans '{Provider}' stream provider never became ready for {Address} after {Attempts} attempts — cross-process routing for this hub is DISABLED (in-process routing remains active)",
-                        StreamProviders.Memory, address, attempt);
-                    return null; // give up WITHOUT faulting the task (no unobserved exception); local route stays live
-                }
-                // Surface the real cause on the first failure and periodically thereafter (not every tick).
-                if (attempt == 1 || attempt % 20 == 0)
-                    logger.LogError(ex,
-                        "Orleans '{Provider}' stream provider not ready for {Address} (attempt {Attempt}) — retrying; in-process routing is active meanwhile",
-                        StreamProviders.Memory, address, attempt);
-                await Task.Delay(TimeSpan.FromMilliseconds(Math.Min(1000, 50 * attempt)), ct).ConfigureAwait(false);
-            }
+                OrleansRouteTrace.Write($"OrleansRoutingService.STREAM_CALLBACK addr={address} msg={v.Message?.GetType().Name} id={v.Id}");
+                // Orleans stream handlers must return Task; the AsyncDelivery callback is a cold
+                // IObservable — Subscribe to run the delivery (the hub queues it), then signal Orleans
+                // the message was accepted. 🚨 onError is mandatory: we return Task.CompletedTask below,
+                // so Orleans considers the item accepted and nothing retries — a faulted delivery here
+                // IS a lost message and must be loud, never an unobserved rethrow.
+                callback.Invoke(v, CancellationToken.None).Subscribe(
+                    _ => { },
+                    ex =>
+                    {
+                        logger.LogError(ex,
+                            "Delivery callback faulted for {MessageType} ({Id}) on stream {Address} — message dropped",
+                            v.Message?.GetType().Name, v.Id, address);
+                        OrleansRouteTrace.Write(
+                            $"OrleansRoutingService.STREAM_CALLBACK FAULTED addr={address} msg={v.Message?.GetType().Name} id={v.Id} ex={ex.Message}");
+                    });
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+
+            OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync OK addr={address}");
+            logger.LogDebug("Orleans '{Provider}' stream subscription attached for {Address}",
+                StreamProviders.Memory, address);
+            return handle;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // RegisterStream's teardown cancelled the attach before the gate opened — expected,
+            // nothing to tear down. Propagate as cancellation so teardown's await sees Canceled.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Past the gate this is a genuine fault (or the gate itself never opened / is not
+            // registered) — surface it loudly ONCE and give up WITHOUT faulting the task (no
+            // unobserved exception, no retry into a broken state). The local route registered
+            // above stays live, so in-process delivery keeps working; only this hub's
+            // cross-process routing is degraded — never a silent silo wedge.
+            OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync FAILED addr={address} ex={ex.Message}");
+            logger.LogCritical(ex,
+                "Orleans '{Provider}' stream subscription could not be attached for {Address} — cross-process routing for this hub is DISABLED (in-process routing remains active)",
+                StreamProviders.Memory, address);
+            return null;
         }
     }
 

--- a/src/MeshWeaver.Connection.Orleans/OrleansStreamingReadiness.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansStreamingReadiness.cs
@@ -1,0 +1,97 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+
+namespace MeshWeaver.Connection.Orleans;
+
+/// <summary>
+/// Deterministic "Orleans streaming is usable" signal, completed when the hosting Orleans
+/// lifecycle — silo or cluster client, whichever this host runs — reaches
+/// <see cref="ServiceLifecycleStage.Active"/>.
+///
+/// <para>Why this exists (issue #1129): Orleans' <c>PersistentStreamProvider</c> initialises
+/// itself as a lifecycle participant at <c>StreamLifecycleOptions.InitStage</c>
+/// (<see cref="ServiceLifecycleStage.ApplicationServices"/> by default). Touching
+/// <c>GetStream</c> before that stage has run throws a <see cref="NullReferenceException"/>
+/// from deep inside the Orleans stream runtime (<c>PersistentStreamProvider.get_IsRewindable</c>
+/// — the provider instance exists, its state does not). The process-wide cache/mesh hubs are
+/// created eagerly at silo startup and used to lose exactly that race on every pod boot,
+/// which a poll-retry loop then papered over with two <c>Error</c>-level NRE logs per boot.</para>
+///
+/// <para>This signal replaces the poll: it observes the same lifecycle the stream provider
+/// participates in, at <see cref="ServiceLifecycleStage.Active"/> — a stage strictly AFTER the
+/// provider's init stage, and also after the silo has joined membership, so PubSub grain calls
+/// made while subscribing can be placed. Consumers order their first provider touch on
+/// <see cref="Ready"/> and the race is gone by construction — no retry, no timer.</para>
+///
+/// <para>Registered by <see cref="OrleansStreamingReadinessExtensions.AddOrleansStreamingReadiness"/>
+/// for both lifecycles; Orleans collects lifecycle participants from DI, so whichever lifecycle
+/// the host actually runs picks it up and the other registration is simply never resolved.</para>
+/// </summary>
+public sealed class OrleansStreamingReadiness :
+    ILifecycleParticipant<ISiloLifecycle>,
+    ILifecycleParticipant<IClusterClientLifecycle>,
+    ILifecycleObserver
+{
+    private readonly AsyncSubject<Unit> ready = new();
+
+    /// <summary>
+    /// Emits a single <see cref="Unit"/> and completes once the Orleans lifecycle has reached
+    /// <see cref="ServiceLifecycleStage.Active"/>. Backed by an <see cref="AsyncSubject{T}"/>,
+    /// so late subscribers get the completed signal replayed immediately.
+    /// </summary>
+    public IObservable<Unit> Ready => ready.AsObservable();
+
+    /// <summary>
+    /// Silo-side participation: observe the silo lifecycle at
+    /// <see cref="ServiceLifecycleStage.Active"/>.
+    /// </summary>
+    /// <param name="observer">The silo lifecycle to participate in.</param>
+    public void Participate(ISiloLifecycle observer) =>
+        observer.Subscribe(nameof(OrleansStreamingReadiness), ServiceLifecycleStage.Active, this);
+
+    /// <summary>
+    /// Client-side participation: observe the cluster-client lifecycle at
+    /// <see cref="ServiceLifecycleStage.Active"/>.
+    /// </summary>
+    /// <param name="observer">The cluster-client lifecycle to participate in.</param>
+    public void Participate(IClusterClientLifecycle observer) =>
+        observer.Subscribe(nameof(OrleansStreamingReadiness), ServiceLifecycleStage.Active, this);
+
+    Task ILifecycleObserver.OnStart(CancellationToken cancellationToken)
+    {
+        ready.OnNext(Unit.Default);
+        ready.OnCompleted();
+        return Task.CompletedTask;
+    }
+
+    Task ILifecycleObserver.OnStop(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// DI wiring for <see cref="OrleansStreamingReadiness"/>.
+/// </summary>
+public static class OrleansStreamingReadinessExtensions
+{
+    /// <summary>
+    /// Registers <see cref="OrleansStreamingReadiness"/> and exposes it to both the silo and the
+    /// cluster-client lifecycle (Orleans collects <see cref="ILifecycleParticipant{T}"/>
+    /// registrations from DI — whichever lifecycle this host runs picks the signal up).
+    /// Idempotent: a second call is a no-op.
+    /// </summary>
+    /// <param name="services">The service collection to add the readiness signal to.</param>
+    /// <returns>The same service collection for further chaining.</returns>
+    public static IServiceCollection AddOrleansStreamingReadiness(this IServiceCollection services)
+    {
+        if (services.Any(d => d.ServiceType == typeof(OrleansStreamingReadiness)))
+            return services;
+        services.AddSingleton<OrleansStreamingReadiness>();
+        services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(sp =>
+            sp.GetRequiredService<OrleansStreamingReadiness>());
+        services.AddSingleton<ILifecycleParticipant<IClusterClientLifecycle>>(sp =>
+            sp.GetRequiredService<OrleansStreamingReadiness>());
+        return services;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-quiet-portal-startup-no-more-phantom-errors.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-quiet-portal-startup-no-more-phantom-errors.md
@@ -1,0 +1,25 @@
+---
+Name: Portal startup no longer logs phantom errors
+Category: Fix
+Description: Every portal start logged internal errors from a race it always won anyway; startup is now ordered so the race cannot happen.
+Icon: PlugConnected
+Order: -20260810
+---
+
+# Portal startup no longer logs phantom errors
+
+Every time a portal started, two alarming-looking internal errors appeared in its logs —
+a low-level failure from the messaging engine, reported at error severity, on every
+single boot. The portal always recovered on its own within seconds, but the errors were
+real enough to trip automated monitoring and file incidents for starts that were, in
+fact, perfectly healthy.
+
+The cause was ordering: two core services came up eagerly and tried to attach to the
+cross-process messaging layer before that layer had finished initialising. A retry loop
+then quietly won the race a moment later — working, but by collision rather than by
+design.
+
+Startup is now properly ordered. The attachment waits for the messaging layer to
+announce it is ready and then connects exactly once — no race, no retry, and no phantom
+errors in the log. If the messaging layer genuinely never comes up, that is now reported
+loudly as the real problem it is, instead of being buried under routine noise.

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -115,6 +115,9 @@ public static class OrleansServerRegistryExtensions
         // Partition routing is the default (see OrleansConnectionExtensions for rationale).
         services.AddPartitionedInMemoryPersistence();
         services.TryAddSingleton<IRoutingService, OrleansRoutingService>();
+        // Deterministic streaming-readiness signal (silo lifecycle → Active) that the routing
+        // service orders its Orleans stream subscriptions on — see OrleansStreamingReadiness.
+        services.AddOrleansStreamingReadiness();
         // The root mesh hub's cross-silo REPLY stream (core#694 layer 2) — see
         // RootMeshHubReplyStreamService for the full story.
         services.AddRootMeshHubReplyStream();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansStreamingReadinessGateTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansStreamingReadinessGateTest.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the #1129 root fix: <c>OrleansRoutingService.RegisterStream</c> must NOT touch the
+/// Orleans stream provider before the Orleans lifecycle reports streaming usable
+/// (<see cref="OrleansStreamingReadiness"/>, completed at <c>ServiceLifecycleStage.Active</c>).
+/// <c>GetStream</c> on a <c>PersistentStreamProvider</c> whose lifecycle Init has not run yet
+/// NREs from deep inside Orleans — the eagerly-created cache/mesh hubs lost exactly that race
+/// on every memex pod boot (2 Error-level NREs per boot), papered over by a poll-retry loop.
+/// Deterministic unit test, no cluster: the stream provider is a recording probe — REACHING it
+/// is the observable, so both directions of the gate are assertable.
+/// </summary>
+public class OrleansStreamingReadinessGateTest
+{
+    private sealed class RecordingStreamProvider : IStreamProvider
+    {
+        private int getStreamCalls;
+        public int GetStreamCalls => Volatile.Read(ref getStreamCalls);
+        public string Name => StreamProviders.Memory;
+        public bool IsRewindable => false;
+
+        public IAsyncStream<T> GetStream<T>(StreamId streamId)
+        {
+            Interlocked.Increment(ref getStreamCalls);
+            // Any touch BEFORE readiness would have been the #1129 NRE; the gate must make this
+            // unreachable until the lifecycle observer has run. The throw keeps the fake minimal —
+            // the attach-success path is covered by the real-cluster routing tests.
+            throw new NotSupportedException("attach probe — reaching the provider is the assertion");
+        }
+    }
+
+    [Fact]
+    public async Task RegisterStream_TouchesStreamProvider_OnlyAfterLifecycleReportsReady()
+    {
+        var provider = new RecordingStreamProvider();
+        var readiness = new OrleansStreamingReadiness();
+        var services = new ServiceCollection();
+        services.AddSingleton(readiness);
+        services.AddKeyedSingleton<IStreamProvider>(StreamProviders.Memory, provider);
+        await using var sp = services.BuildServiceProvider();
+
+        // grainFactory is deliberately null — RegisterStream never places grains, so reaching it
+        // would throw and fail the test (the same probe technique as the shutdown-classification test).
+        using var routing = new OrleansRoutingService(
+            null!,
+            sp,
+            NullLogger<OrleansRoutingService>.Instance);
+
+        using var registration = routing.RegisterStream(
+            AddressExtensions.CreateMeshAddress("streaming-gate-test"),
+            (d, _) => Observable.Return(d));
+
+        // Negative control: the gate must HOLD while the lifecycle has not reported ready.
+        // (Sanctioned "confirm nothing happened" wait — there is no positive signal to filter for.)
+        await Task.Delay(500);
+        provider.GetStreamCalls.Should().Be(0,
+            "the stream provider must never be touched before the Orleans lifecycle reaches Active — " +
+            "that touch is the #1129 NRE");
+
+        // Open the gate exactly the way Orleans does: the lifecycle observer's OnStart at Active.
+        await ((ILifecycleObserver)readiness).OnStart(CancellationToken.None);
+
+        // The attach must now reach the provider (poll the recorded call, never a fixed sleep).
+        var calls = await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .Select(_ => provider.GetStreamCalls)
+            .Where(c => c > 0)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .ToTask();
+        calls.Should().Be(1, "after readiness the subscription attaches exactly once — no retry loop");
+    }
+}


### PR DESCRIPTION
## The defect

Every portal pod boot logged **two Error-level `NullReferenceException`s** from deep inside
Orleans — `PersistentStreamProvider.get_IsRewindable`, reached through
`OrleansRoutingService.SubscribeWithRetryAsync` → `GetStream`. On 2026-08-10 alone: 16
occurrences across 8 pod boots in `memex`, always "attempt 1", always ~0.5 s into the pod's
logged life (`cache/{id}` and `mesh/{id}` — the two process-wide hubs created eagerly at silo
startup).

The provider instance exists but its state is null because its lifecycle **Init has not run
yet**: `PersistentStreamProvider` initialises as an Orleans lifecycle participant at
`StreamLifecycleOptions.InitStage` (`ServiceLifecycleStage.ApplicationServices`). The
eagerly-created hubs raced that stage on every boot, and a `Task.Delay` poll-retry loop then
papered over the race — its own comment admitted the provider "can lose the race with Orleans
init". The loop *worked* (the issue's "no retry ever succeeds" inference is backwards — the
success line is `Information`, which the deployment's level filter drops before Loki, and
attempts 2–19 log nothing; zero attempt-20 lines and zero 120 s Criticals prove it healed
within ~10 s), but it worked **by collision, not by design**, and its attempt-1 `Error` log
auto-filed a production incident for every healthy start.

## The fix — ordering, not retry

`OrleansStreamingReadiness` participates in the **silo** and **cluster-client** lifecycles
(Orleans collects `ILifecycleParticipant<T>` registrations from DI; whichever lifecycle the
host runs picks it up) and completes an `AsyncSubject<Unit>` at
`ServiceLifecycleStage.Active` — strictly after the stream provider's Init stage, and after
membership join, so the PubSub grain calls made while subscribing can be placed.

`OrleansRoutingService.RegisterStream` now orders its **one-shot** subscribe on that signal:
the retry loop is deleted; the local (in-process) route still goes live immediately and
unconditionally. If the lifecycle never reaches Active (a wedged startup — cf. the 2026-08-10
stalled-rollout window), the 120 s give-up is a loud `Critical` (cross-process routing
disabled for that hub, in-process routing stays live) — never a silent wedge, and never a
retry into a broken state. Teardown semantics are unchanged (cancel → the pending gate is
abandoned; an attached handle is unsubscribed on the IO pool).

## Proof

`OrleansStreamingReadinessGateTest` — no cluster, deterministic: the stream provider is a
recording probe, so *reaching it* is the observable.

| | fix in | gate neutered | restored |
|---|---|---|---|
| provider untouched before lifecycle `OnStart(Active)` | pass | **FAIL** (probe reached) | pass |
| attaches exactly once after readiness | pass | — | pass |

Real-cluster tests stay green: `OrleansHostedHubRoutingTest`, `OrleansCrossSiloStreamProbeTest`
(4/4 passed). `MeshWeaver.Connection.Orleans`, `MeshWeaver.Hosting.Orleans`, the test project
and `Memex.Portal.Distributed` all build clean under `-c Release -warnaserror`.

## Relationship to #1152

Composes with #1152 (*Stop routing through a silo that is already leaving the cluster*): that
PR fixes the **shutdown** edge of the same file (`DeliverMessage` / grain placement /
`ErrorType` classification — issue #1107); this PR fixes the **startup** edge
(`RegisterStream` / stream subscription — issue #1129). The diffs touch disjoint regions of
`OrleansRoutingService.cs`; whichever merges second re-merges main first. Independent Loki
verification of #1152's analysis (all `No active nodes are compatible` occurrences confined to
pod-shutdown windows; the healthy pod's whole life clean) is on the ops report for #1107.

Fixes #1129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
