### PR TITLE
The last-admin guard is an expected boundary of the system-owned sweep, not a fault

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-wiring-a-git-sync-no-longer-reports-an-error-for-the-last-admin.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-wiring-a-git-sync-no-longer-reports-an-error-for-the-last-admin.md
@@ -1,0 +1,19 @@
+---
+Name: Wiring a Git sync no longer reports an error for the last admin
+Category: Fix
+Description: Making a space system-owned now keeps its last administrator deliberately instead of failing an impossible removal.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Wiring a Git sync no longer reports an error for the last admin
+
+When you wire a GitHub sync onto a space, the space becomes system-owned and existing
+write grants are retracted. If the only administrator of the space was among them, the
+platform correctly refused to remove the last admin — but the sweep reported that refusal
+as an error, as if something had gone wrong.
+
+The sweep now recognises this case up front: the space's last administrator is kept on
+purpose, the log states clearly what was kept and why, and no error is raised. If the
+space has other admins, everyone but the earliest-granted one is still retracted as
+before; once another admin exists, re-wiring the sync converges the rest.

--- a/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
+++ b/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh;
@@ -32,8 +33,16 @@ namespace MeshWeaver.GitSync;
 ///
 /// <para><b>What survives, deliberately:</b> <c>Viewer</c>/<c>Commenter</c> entitlements (a
 /// purchase, a redeemed coupon, an admin-issued grant — the only door into a gated plugin), every
-/// <c>Denied</c> assignment (that IS the gating), and <c>system-security</c> itself (the identity
-/// the importer writes under — retracting it would make the space unwritable by anything).</para>
+/// <c>Denied</c> assignment (that IS the gating), <c>system-security</c> itself (the identity
+/// the importer writes under — retracting it would make the space unwritable by anything), and
+/// the space's LAST administrator (#1120): the last-admin invariant
+/// (<c>SpaceAdminInvariantValidator</c> — "a space must always have at least one admin")
+/// outranks the sweep, so when no grant outside the doomed set still confers Admin, one admin
+/// grant is spared — the earliest-created, i.e. the space's original owner — and logged at
+/// Warning. The delete pipeline would refuse exactly that delete anyway; detecting it up front
+/// turns a guaranteed rejection (formerly a fail-level "FAILED to retract") into the expected,
+/// stated outcome. The spared grant converges like the rest of the sweep: the next time the
+/// sync is (re)wired after another admin exists, it is retracted.</para>
 ///
 /// <para>Best-effort by design (<c>FailsCreateOnError</c> stays false): a partition that cannot be
 /// swept must not block its own sync from being configured. Every retraction is logged at Warning
@@ -74,32 +83,80 @@ public sealed class SystemOwnedAccessRetractionHandler(
                     ? Observable.Return<IList<MeshNode>>([])
                     : persistence.ReadMany(paths, hub.JsonSerializerOptions).ToList();
             })
-            .SelectMany(RetractAll);
+            .SelectMany(grants => RetractAll(partition, grants));
     }
 
-    private IObservable<Unit> RetractAll(IList<MeshNode> grants)
+    private IObservable<Unit> RetractAll(string partition, IList<MeshNode> grants)
     {
         // The SAME predicate the write boundary uses — one rule, two enforcement points, so a
         // grant that could not be created here can never survive here either.
-        var doomed = grants
-            .Where(n => AccessAssignmentGuard.IsForbiddenOnSystemOwned(
-                n, n.ContentAs<AccessAssignment>(hub.JsonSerializerOptions), systemOwned: true, out _))
-            .Select(n => n.Path)
+        var candidates = grants
+            .Select(n => (Node: n, Assignment: n.ContentAs<AccessAssignment>(hub.JsonSerializerOptions)))
+            .ToArray();
+
+        var doomed = candidates
+            .Where(c => AccessAssignmentGuard.IsForbiddenOnSystemOwned(
+                c.Node, c.Assignment, systemOwned: true, out _))
             .ToArray();
 
         if (doomed.Length == 0)
             return Observable.Return(Unit.Default);
 
+        // 🚨 The last-admin invariant OUTRANKS the sweep (#1120). SpaceAdminInvariantValidator
+        // refuses to delete a partition's last non-denied Admin assignment — a space must always
+        // keep at least one admin who can manage it (the System identity holds Permission.All
+        // WITHOUT an assignment node, so it does not count). Attempting that delete is therefore
+        // a guaranteed rejection: a known-valid guard outcome, not a fault. Detect it up front —
+        // when no grant OUTSIDE the doomed set still confers Admin, spare exactly one doomed
+        // admin grant (deterministically the earliest-created: the space's original owner) and
+        // retract the rest. The spared grant self-heals like the rest of the sweep: it is
+        // retracted the next time the sync is (re)wired once another admin exists.
+        var doomedPaths = doomed
+            .Select(c => c.Node.Path)
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+        var adminSurvives = candidates.Any(c =>
+            !doomedPaths.Contains(c.Node.Path)
+            && string.Equals(c.Node.NodeType, AccessAssignmentGuard.AccessAssignmentNodeType,
+                StringComparison.OrdinalIgnoreCase)
+            && AccessAssignmentGuard.GrantsAdmin(c.Assignment));
+
+        var spared = adminSurvives
+            ? default
+            : doomed
+                .Where(c => AccessAssignmentGuard.GrantsAdmin(c.Assignment))
+                .OrderBy(c => c.Node.CreatedDate)
+                .ThenBy(c => c.Node.Path, StringComparer.Ordinal)
+                .FirstOrDefault();
+
+        if (spared.Node is not null)
+        {
+            logger?.LogWarning(
+                "[SystemOwned] keeping '{Path}' — '{Subject}' is the last administrator of "
+                + "'{Partition}' and a space must always have at least one admin. The grant still "
+                + "confers write access to a system-owned space; it is retracted the next time the "
+                + "sync is wired once another admin exists.",
+                spared.Node.Path, spared.Assignment?.AccessObject ?? "?", partition);
+        }
+
+        var doomedList = doomed
+            .Select(c => c.Node.Path)
+            .Where(p => spared.Node is null
+                || !string.Equals(p, spared.Node.Path, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (doomedList.Length == 0)
+            return Observable.Return(Unit.Default);
+
         logger?.LogWarning(
             "[SystemOwned] retracting {Count} privileged grant(s) — the partition is now system-owned "
             + "and only {System} may write it: {Paths}",
-            doomed.Length, WellKnownUsers.System, string.Join(", ", doomed));
+            doomedList.Length, WellKnownUsers.System, string.Join(", ", doomedList));
 
         // Sequential (Concat, never Merge): these are node deletes into a partition that may have
         // been created seconds ago, and a fan-out of cold per-node hub activations is what crashes
         // writes into a fresh partition. Under System — the retraction is the platform's decision,
         // not the caller's, and the caller may hold no rights on the space at all.
-        return AsSystem(() => doomed
+        return AsSystem(() => doomedList
             .Select(path => meshService.DeleteNode(path)
                 .Take(1)
                 .Select(_ => Unit.Default)

--- a/src/MeshWeaver.Graph/Configuration/SpaceAdminInvariantValidator.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceAdminInvariantValidator.cs
@@ -147,8 +147,10 @@ public sealed class SpaceAdminInvariantValidator(IMessageHub hub, ILogger<SpaceA
 
     /// <summary>
     /// True when <paramref name="node"/>'s <see cref="AccessAssignment"/> content grants the
-    /// <c>Admin</c> role with <see cref="RoleAssignment.Denied"/> = false. Tolerates content
-    /// still carried as a <see cref="JsonElement"/> (source hub without the typed registry).
+    /// <c>Admin</c> role with <see cref="RoleAssignment.Denied"/> = false (the shared
+    /// <see cref="AccessAssignmentGuard.GrantsAdmin"/> predicate, so the system-owned sweep
+    /// counts admins the same way this invariant does). Tolerates content still carried as a
+    /// <see cref="JsonElement"/> (source hub without the typed registry).
     /// </summary>
     private bool GrantsAdmin(MeshNode? node)
     {
@@ -158,9 +160,7 @@ public sealed class SpaceAdminInvariantValidator(IMessageHub hub, ILogger<SpaceA
             JsonElement je => TryDeserialize(je),
             _ => null,
         };
-        return assignment?.Roles is { } roles
-            && roles.Any(r => !r.Denied
-                && string.Equals(r.Role, Role.Admin.Id, StringComparison.OrdinalIgnoreCase));
+        return AccessAssignmentGuard.GrantsAdmin(assignment);
     }
 
     private AccessAssignment? TryDeserialize(JsonElement je)

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -163,6 +163,19 @@ public static class AccessAssignmentGuard
     }
 
     /// <summary>
+    /// The assignment currently grants the non-denied <c>Admin</c> role — the predicate the
+    /// last-admin invariant counts (<c>SpaceAdminInvariantValidator</c>: "a space must always
+    /// have at least one admin") and that the system-owned sweep
+    /// (<c>SystemOwnedAccessRetractionHandler</c>) must therefore respect. One rule, two
+    /// enforcement points, so the sweep never attempts a delete the invariant is guaranteed
+    /// to refuse (#1120).
+    /// </summary>
+    public static bool GrantsAdmin(AccessAssignment? assignment)
+        => assignment?.Roles is { } roles
+           && roles.Any(r => !r.Denied
+               && string.Equals(r.Role, Role.Admin.Id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// 🚨 A SYSTEM-OWNED space grants nobody write access. A partition with a <c>_GitSync</c> is
     /// rewritten from its repo on every sync, so the ONLY identity that may write it is the one the
     /// importer runs as (<see cref="WellKnownUsers.System"/>). Any other Admin/Editor grant is an

--- a/test/MeshWeaver.GitSync.Test/SystemOwnedRetractionLastAdminTest.cs
+++ b/test/MeshWeaver.GitSync.Test/SystemOwnedRetractionLastAdminTest.cs
@@ -1,0 +1,176 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins #1120: when wiring a <c>_GitSync</c> makes a space system-owned, the
+/// <see cref="SystemOwnedAccessRetractionHandler"/> sweep must treat the last-admin invariant
+/// (<c>SpaceAdminInvariantValidator</c>: "a space must always have at least one admin") as an
+/// EXPECTED boundary, not a fault. Before the fix the handler attempted the delete anyway, the
+/// delete pipeline correctly refused it, and the guaranteed rejection surfaced as a fail-level
+/// "[SystemOwned] FAILED to retract" + <see cref="UnauthorizedAccessException"/> — the log
+/// incident that opened the issue.
+///
+/// <para>The pinned semantics: when no grant outside the doomed set still confers Admin, the
+/// sweep SPARES exactly one doomed admin grant (deterministically the earliest-created — the
+/// space's original owner), says so at Warning naming the spared path and the reason, attempts
+/// no delete the guard is guaranteed to refuse, logs nothing at Error, and reaches its normal
+/// terminal state. Every other doomed grant — including a NON-last admin — is still retracted,
+/// and a surviving System-identity admin assignment releases the whole doomed set.</para>
+/// </summary>
+public class SystemOwnedRetractionLastAdminTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    private const string LastAdminSpace = "LastAdminSpace";
+    private const string CoAdminSpace = "CoAdminSpace";
+    private const string SystemAdminSpace = "SystemAdminSpace";
+
+    /// <summary>Second administrator on <see cref="CoAdminSpace"/> — granted AFTER the space
+    /// create, so the creator's grant stays the earliest-created admin the sweep
+    /// deterministically spares.</summary>
+    private const string CoAdmin = "co-admin";
+
+    private const string RepoUrl = "https://github.com/test/system-owned-last-admin";
+
+    private readonly RetractionLogCapture capture = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(s =>
+            {
+                s.AddSingleton<ILoggerProvider>(capture);
+                return s;
+            });
+
+    /// <summary>Creates the space (the DevLogin creator receives the Admin grant via the Space
+    /// post-creation handler), PERSISTS any extra grants (the sweep lists the storage adapter, so
+    /// a builder-seeded config node would be invisible to it — grants must be real nodes, as in
+    /// production), and wires the GitHub sync, which fires the system-owned sweep.</summary>
+    private async Task ProvisionSyncedSpace(string space, params MeshNode[] extraGrants)
+    {
+        await Connect();
+        await CreateSpace(space);
+        foreach (var grant in extraGrants)
+            await NodeFactory.CreateNode(grant).Timeout(30.Seconds()).ToTask();
+        await Sync.SaveConfig(space, RepoUrl, "main", null, true, true)
+            .Timeout(30.Seconds()).ToTask();
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task LastAdmin_IsSparedWithWarning_NotAnError()
+    {
+        await ProvisionSyncedSpace(LastAdminSpace);
+
+        // The sweep reaches its graceful terminal state: a Warning names the spared grant and the
+        // reason. Before the fix no such record exists — the handler attempted the delete, the
+        // last-admin guard refused it, and the outcome was a fail-level "FAILED to retract".
+        await WaitForRetractionRecord(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("last administrator")
+            && e.Message.Contains($"{LastAdminSpace}/_Access/{UserId}_Access"));
+
+        // The grant is NOT removed — the invariant outranks the sweep; the space keeps its admin.
+        var kept = await ReadNode($"{LastAdminSpace}/_Access/{UserId}_Access")
+            .Timeout(10.Seconds()).ToTask();
+        Assert.NotNull(kept);
+
+        // An expected condition, never a fault: nothing from the handler at Error or above.
+        Assert.DoesNotContain(capture.Entries, e => e.Level >= LogLevel.Error);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task NonLastAdmin_IsStillRetracted_EarliestAdminSpared()
+    {
+        // Two admins: the space creator (earliest-created) and a later co-admin. The sweep
+        // retracts the co-admin's grant — a NON-last admin — and spares the earliest one
+        // (the space's original owner).
+        await ProvisionSyncedSpace(CoAdminSpace,
+            AssignmentNodeFactory.UserRole(CoAdmin, "Admin", CoAdminSpace));
+
+        await WaitForAbsent($"{CoAdminSpace}/_Access/{CoAdmin}_Access");
+
+        var kept = await ReadNode($"{CoAdminSpace}/_Access/{UserId}_Access")
+            .Timeout(10.Seconds()).ToTask();
+        Assert.NotNull(kept);
+
+        Assert.Contains(capture.Entries, e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("last administrator")
+            && e.Message.Contains($"{CoAdminSpace}/_Access/{UserId}_Access"));
+        Assert.DoesNotContain(capture.Entries, e => e.Level >= LogLevel.Error);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SystemAdminAssignment_ReleasesTheWholeDoomedSet()
+    {
+        // A System-identity admin assignment survives the sweep (the importer's own identity) and
+        // satisfies the last-admin invariant, so every human write grant is retracted — nothing
+        // is spared and no last-admin warning is emitted for this space.
+        await ProvisionSyncedSpace(SystemAdminSpace,
+            AssignmentNodeFactory.UserRole(WellKnownUsers.System, "Admin", SystemAdminSpace));
+
+        await WaitForAbsent($"{SystemAdminSpace}/_Access/{UserId}_Access");
+
+        var systemGrant = await ReadNode($"{SystemAdminSpace}/_Access/{WellKnownUsers.System}_Access")
+            .Timeout(10.Seconds()).ToTask();
+        Assert.NotNull(systemGrant);
+
+        Assert.DoesNotContain(capture.Entries, e =>
+            e.Message.Contains("last administrator") && e.Message.Contains(SystemAdminSpace));
+        Assert.DoesNotContain(capture.Entries, e => e.Level >= LogLevel.Error);
+    }
+
+    /// <summary>Polls until the node at <paramref name="path"/> is gone — the positive signal that
+    /// the sweep retracted the grant.</summary>
+    private async Task WaitForAbsent(string path) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode(path))
+            .Where(n => n is null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+    /// <summary>Polls the captured handler log until a record matches — the log capture is not an
+    /// observable source, so the sanctioned interval re-query stands in for a stream wait.</summary>
+    private async Task WaitForRetractionRecord(Func<RetractionLogCapture.Entry, bool> predicate) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .Where(_ => capture.Entries.Any(predicate))
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+    /// <summary>Captures every record the <see cref="SystemOwnedAccessRetractionHandler"/> logs
+    /// (instance-scoped — one per test, dies with the mesh).</summary>
+    private sealed class RetractionLogCapture : ILoggerProvider
+    {
+        public sealed record Entry(LogLevel Level, string Message);
+
+        private readonly ConcurrentQueue<Entry> entries = new();
+
+        public IReadOnlyCollection<Entry> Entries => entries;
+
+        public ILogger CreateLogger(string categoryName)
+            => categoryName == typeof(SystemOwnedAccessRetractionHandler).FullName
+                ? new Sink(entries)
+                : Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+
+        public void Dispose() { }
+
+        private sealed class Sink(ConcurrentQueue<Entry> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+                => sink.Enqueue(new Entry(logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1120

## Root cause

`SystemOwnedAccessRetractionHandler` (MeshWeaver.GitSync) computes its doomed set purely from `AccessAssignmentGuard.IsForbiddenOnSystemOwned` and then attempts `meshService.DeleteNode` on every doomed grant. When the doomed grant is the partition's **last non-denied Admin assignment**, `SpaceAdminInvariantValidator` correctly rejects the delete ("Cannot remove the last administrator … a space must always have at least one admin"), `MeshService.DeleteNode` surfaces the `ValidationFailed` rejection as an `UnauthorizedAccessException`, and the handler's blanket `Catch` logged the known-valid guard outcome as a fail-level `[SystemOwned] FAILED to retract` — the exact prod log line in the issue.

## Chosen semantics: skip-with-warning, computed up front

The invariant **outranks** the sweep. The sweep now spares exactly one doomed admin grant — deterministically the earliest-created (the space's original owner) — whenever no grant outside the doomed set still confers Admin (the System identity holds `Permission.All` *without* an assignment node, so it cannot count). It logs the spared path, subject and reason at **Warning**, attempts no delete the guard is guaranteed to refuse, and reaches its normal terminal state (no exception, no Error, no retry loop).

Why skip rather than defer/escalate: the sweep is best-effort and self-healing by design — re-wiring the sync after another admin exists retracts the spared grant, so deferral already exists structurally, and "exactly one admin remains" is precisely the terminal state the invariant demands (someone must still manage entitlements / unwire the sync on a system-owned space).

The admin predicate is shared as `AccessAssignmentGuard.GrantsAdmin` and reused by `SpaceAdminInvariantValidator` — one rule, two enforcement points, so the sweep and the guard can never drift on what counts as an admin.

## Test evidence (red before / green after)

New `SystemOwnedRetractionLastAdminTest` (test/MeshWeaver.GitSync.Test), run against the **unfixed** handler first:

- `LastAdmin_IsSparedWithWarning_NotAnError` — **red**: reproduced the exact incident (`FAILED to retract 'LastAdminSpace/_Access/Roland_Access'` at Error + `UnauthorizedAccessException: Cannot remove the last administrator`), no graceful warning.
- `NonLastAdmin_IsStillRetracted_EarliestAdminSpared` — **red**: no last-admin warning existed.
- After the fix: **3/3 green** — last admin kept + Warning naming path/subject/reason + nothing at Error; the non-last admin is still retracted (earliest spared); a System-identity admin assignment releases the whole doomed set.

Regressions: `SyncTriggerAuthorizationTest` 3/3 green, MeshWeaver.Security.Test (`SecurityServiceTests`/`UserAccessTests`/`ReservedPartitionMirrorTest`) 55/55 green. `dotnet build -c Release -warnaserror` clean for all touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5