### PR TITLE
A stray recycle killed the hub the install was still using

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1540,6 +1540,24 @@ public class MessageService : IMessageService
             && message is not ShutdownRequest and not DisposeRequest)
         {
             postFate?.Add($"POST_REFUSED_SHUTTING_DOWN runLevel={hub.RunLevel}", Address);
+            // 🚨 …and record it on the REQUEST's trail when the message being refused IS the answer
+            // to an awaited request. `postFate` keys on the RESPONSE delivery's own id, which nobody
+            // tracks, so without this the refusal is recorded nowhere and the request's trail ends
+            // at RESPONSE_POSTED — reading "the reply was lost between the responder and the
+            // requester", with no hint that the responder's own teardown is what ate it. That
+            // ambiguity cost a full investigation on #1151, where an install's SyncContentFilesRequest
+            // burned its whole 60 s RequestTimeout because the answering hub crossed
+            // DisposeHostedHubs between HANDLER_ENTER and the reply.
+            //
+            // Diagnostics only — the refusal itself is unchanged. Actually DELIVERING (or NACKing)
+            // a reply a disposing hub cannot post is the open defect, tracked separately: it has to
+            // go out through the live PARENT (our own Post re-enters this very gate), which is the
+            // NackThroughParent contract applied to a third path — one this guard, not the intake
+            // gate or the disposal drain, is responsible for.
+            if (correlatedRequestId is not null)
+                requestFates?.Find(correlatedRequestId.ToString())?.Add(
+                    $"RESPONSE_REFUSED_SHUTTING_DOWN type={message.GetType().Name} runLevel={hub.RunLevel}",
+                    Address);
             return ((IMessageDelivery)delivery).Failed("Hub is shutting down");
         }
 

--- a/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
+++ b/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
@@ -233,10 +233,9 @@ internal sealed class RequestFateLedger
             // shutdown ate the reply" is a strictly sharper answer than "it was lost in transit".
             if (Has("RESPONSE_REFUSED_SHUTTING_DOWN"))
                 return "the handler REPLIED but the responding hub was already past "
-                     + "DisposeHostedHubs, so its own teardown guard refused the post — nothing "
-                     + "reached the requester and nothing NACKed it, so the caller burns its whole "
-                     + "RequestTimeout. The responder is the one shutting down; look at what "
-                     + "recycled/deleted that address mid-handler, not at the requester.";
+                     + "DisposeHostedHubs, so its own teardown guard refused the post and the "
+                     + "caller burns its whole RequestTimeout un-NACKed — chase what "
+                     + "recycled/deleted the RESPONDER's address mid-handler, not the requester";
             if (Has("RESPONSE_POSTED"))
                 return "a reply WAS posted for this correlation and the callback is STILL pending — "
                      + "the reply was lost between the responder and the requester, so chase the "

--- a/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
+++ b/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
@@ -228,6 +228,15 @@ internal sealed class RequestFateLedger
         {
             bool Has(string token) => snapshot.Any(s => s.StartsWith(token, StringComparison.Ordinal));
 
+            // Ahead of RESPONSE_POSTED on purpose: a refused reply always carries BOTH stages (the
+            // post is recorded, then the teardown guard refuses it), and "the responder's own
+            // shutdown ate the reply" is a strictly sharper answer than "it was lost in transit".
+            if (Has("RESPONSE_REFUSED_SHUTTING_DOWN"))
+                return "the handler REPLIED but the responding hub was already past "
+                     + "DisposeHostedHubs, so its own teardown guard refused the post — nothing "
+                     + "reached the requester and nothing NACKed it, so the caller burns its whole "
+                     + "RequestTimeout. The responder is the one shutting down; look at what "
+                     + "recycled/deleted that address mid-handler, not at the requester.";
             if (Has("RESPONSE_POSTED"))
                 return "a reply WAS posted for this correlation and the callback is STILL pending — "
                      + "the reply was lost between the responder and the requester, so chase the "

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1668,46 +1668,47 @@ public static class PackageInstaller
                     .SelectMany(rest => RootRetypeReconciled()
                         .SelectMany(_ => RootRetypePersisted())
                         .Select(_ => rest))
-                    // 🚨 RECYCLE the retyped root's hub. It was ACTIVATED as the Space placeholder
-                    // (RootRetypeReconciled reads the stream, and readers race the install anyway),
-                    // so the live hub instance still carries the placeholder's configuration — the
-                    // default areas, none of the package type's. Nothing re-activates it: the node's
-                    // stored type changed but the hub does not watch its own NodeType. The symptom
-                    // is a freshly installed package whose ROOT renders without its type's areas
-                    // ("No renderer is registered for area Tests on hub Store" — the plugin gate's
-                    // Store/Catalog RED, 2026-07-29; same family as the freshly-provisioned-Store-
-                    // is-invisible incident) until someone manually recycles it. Dispose is the
-                    // recycle idiom (RecycleLayoutArea): fire-and-forget, next access re-activates
-                    // with the final type. Only when the placeholder dance actually ran.
+                    // 🚨 NO RECYCLE IS POSTED HERE — deliberately, and this is load-bearing.
                     //
-                    // 🚨 This recycle is NECESSARY but was not SUFFICIENT: the identical symptom
-                    // recurred 2026-08-09 because PathResolutionService PINNED a fabricated
-                    // partition-root placeholder (no NodeType → the root's hub binds the mesh
-                    // DEFAULT configuration), so every re-activation after this Dispose re-read
-                    // the same fabrication. Partition provisioning runs BEFORE the root write, so
-                    // any routed touch inside that window fabricated it. Fixed at the source —
-                    // synthesized resolutions are never cached, and a fill that lands after its
-                    // own invalidation is discarded (PathResolutionCachePoisonTest).
+                    // The retyped root's hub DOES have to be un-pinned: it was ACTIVATED as the
+                    // Space placeholder, so the live instance still carries the placeholder's
+                    // configuration — the default areas, none of the package type's ("No renderer is
+                    // registered for area Tests on hub Store", the plugin gate's Store/Catalog RED,
+                    // 2026-07-29). The installer used to do that itself with a fire-and-forget
+                    // `hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(root.Path)))`.
                     //
-                    // 🚨 …and it recurred AGAIN on a build carrying that fix (#1104), because
-                    // fixing RESOLUTION cannot help a hub a bad resolution has ALREADY activated:
-                    // GetHostedHub pins by address and the hub never re-reads its NodeType. That
-                    // is why this Post is no longer where the guarantee lives. It is fire-and-
-                    // forget, conditional on the placeholder dance having run, and available to
-                    // nobody but this installer — while ANY writer can retype a node. The
-                    // framework now un-pins on its own: every activation arms
-                    // NodeTypeRebindWatcher, which recycles the hub the first time the mesh change
-                    // feed reports a different NodeType for its path. This Post stays as the fast
-                    // path (it recycles immediately rather than on the feed hop) and as the marker
-                    // of intent; it is not load-bearing. If the symptom ever reappears, check all
-                    // three: is the hub recycled, is the resolution for the bare root path serving
-                    // a real node, and did the rebind watcher see the retype?
-                    .Select(rest =>
-                    {
-                        if (placeholderRoot is not null && root is not null)
-                            hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(root.Path)));
-                        return rest;
-                    })
+                    // Since #1104 the FRAMEWORK owns that guarantee and owns it better:
+                    // NodeTypeRebindWatcher is armed on every activation and recycles the hub the
+                    // first time the mesh change feed reports a NodeType different from the one the
+                    // instance bound. Two properties matter here — it fires on the POST-COMMIT feed
+                    // event (so it cannot race the debounced persist), and it posts to its OWN
+                    // instance (`instanceHub.Post(…, WithTarget(instanceHub.Address))`), so the
+                    // signal can only ever kill the mis-bound instance that armed it.
+                    //
+                    // 🚨 The installer's copy had NEITHER property, and that is what made it a
+                    // defect rather than a redundant fast path (issue #1151). It is ADDRESSED, not
+                    // instance-scoped: routing resolves the address at DELIVERY time, so it disposes
+                    // whichever instance happens to be live when it lands — and it lands late,
+                    // because it queues behind the recycle the watcher already started. The install
+                    // then keeps touching that same address (WarmInstalledRoots, and
+                    // SyncPackageContent's SyncContentFilesRequest, both of which ACTIVATE the root),
+                    // so the stray Dispose tears down the FRESH, correctly-bound instance in the
+                    // middle of the handler serving the install's own content publish.
+                    //
+                    // Measured on StaleStampRootBindingTest's ShopB fixture: two ShopB disposals
+                    // 426 ms apart — the watcher's at +2 ms after the retype, this one at +428 ms,
+                    // landing on the instance activated by the content sync 105 ms earlier. The
+                    // handler faulted with HubDisposingException ("cannot create '/content/'"),
+                    // answered ImportContentResponse.Fail — and that reply never left the disposing
+                    // hub, so the installer burned its whole 60 s RequestTimeout and published
+                    // 0/1 assets. Deleting the stray Dispose removes the only recycle signal in the
+                    // install that can reach an instance other than the one it means.
+                    //
+                    // If the mis-binding symptom ever reappears, check all three: is the hub
+                    // recycled (the watcher logs "NodeType rebind: node '…' is now typed …"), is the
+                    // resolution for the bare root path serving a real node, and did the rebind
+                    // watcher see the retype?
+                    //
                     // A placeholder's write is bookkeeping, not content — its FINAL retype in
                     // stage 2 is the root's one counted write (keeps Written ≤ node count).
                     .Select(rest => (IList<(string Path, bool Wrote)>)(placeholderRoot is null ? rootWrites : [])


### PR DESCRIPTION
Fixes #1151. **main is red on this** — `StaleStampRootBindingTest` fails on main's own runs at `09cd35739` and `269dcbc76`, and reproduces locally.

## What was wrong

`PackageInstaller` posted a fire-and-forget `DisposeRequest` to un-pin the retyped root's hub. That hub genuinely does need un-pinning — it was activated as the Space placeholder, so the live instance still carried the placeholder's configuration (default areas, none of the package type's).

But the installer's recycle was **addressed, not instance-scoped**. Routing resolves the address at *delivery* time, so it disposes whichever instance happens to be live when it lands — and it lands **late**, queued behind the recycle the framework watcher already started. The install then keeps touching that same address (`WarmInstalledRoots`, and `SyncPackageContent`'s `SyncContentFilesRequest`, both of which ACTIVATE the root), so the stray `Dispose` tore down the **fresh, correctly-bound** instance in the middle of the handler serving the install's own content publish.

Measured on `StaleStampRootBindingTest`'s ShopB fixture: **two ShopB disposals 426 ms apart** — the watcher's at +2 ms after the retype, the stray one at +428 ms, landing on the instance the content sync had activated 105 ms earlier. The handler faulted with `HubDisposingException` ("cannot create '/content/'"), answered `ImportContentResponse.Fail` — and **that reply never left the disposing hub**, so the installer burned its whole 60 s `RequestTimeout` and published 0/1 assets.

## Why deleting it is safe now

Since **#1104** the framework owns this guarantee, and owns it better. `NodeTypeRebindWatcher` is armed on every activation and recycles the hub the first time the mesh change feed reports a NodeType different from the one the instance bound. Two properties matter:

- it fires on the **post-commit** feed event, so it cannot race the debounced persist;
- it posts to its **own instance** (`instanceHub.Post(…, WithTarget(instanceHub.Address))`), so the signal can only ever kill the mis-bound instance that armed it.

The installer's copy had **neither** property. That is what made it a defect rather than a redundant fast path.

## Also: the diagnostic that made this cost a whole investigation

`postFate` keys on the **response** delivery's own id, which nobody tracks — so a reply refused by the responder's teardown guard was recorded nowhere, and the request's trail ended at `RESPONSE_POSTED`, reading *"the reply was lost between responder and requester"* with no hint that the responder's own shutdown ate it.

The refusal is now recorded on the **request's** trail (`RESPONSE_REFUSED_SHUTTING_DOWN`), and `RequestFateLedger` reports that verdict ahead of `RESPONSE_POSTED` — a refused reply always carries both stages, and "the responder's own shutdown ate the reply" is strictly sharper than "lost in transit". Diagnostics only; the refusal behaviour is unchanged.

**Left open deliberately, and named in the code:** actually delivering (or NACKing) a reply a disposing hub cannot post. That has to go out through the live **parent** — our own `Post` re-enters the very gate that refused it — which is the `NackThroughParent` contract applied to a third path. Own change, own blast-radius review.

## Verification

| | result |
|---|---|
| Fix applied | **3 passed, 0 failed — 9 s** |
| **Negative control** (revert only `PackageInstaller.cs`) | **1 failed, 2 passed — 2 m 7 s** |
| Restored | 3 passed, 9 s |

The duration is itself the signature: the failing run burns the full 60 s `RequestTimeout`. `MeshWeaver.PluginCatalog` builds clean under `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)