### PR TITLE
The boot plugin install no longer races the NodeType bake it depends on

### DIFF
--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -35,6 +35,23 @@ public static class ServiceDefaults
             http.AddServiceDiscovery();
         });
 
+        // Attributable resilience for the plugin-registry client (#1133/#1137). Every client
+        // otherwise shares the ONE unnamed defaults pipeline above, whose Polly events log
+        // Source: '-standard//…' with an empty operation key — the boot-time registry timeouts
+        // could not be attributed to any call path. Re-registering the named client the
+        // PluginCatalog consumer resolves (InstanceRegistrationClient.HttpClientName — the
+        // literal is duplicated here because ServiceDefaults deliberately does not reference
+        // MeshWeaver.PluginCatalog) swaps the shared default pipeline for its own standard one,
+        // so the same event now reads 'plugin-registry-standard//…'. Same policies, named.
+        // RemoveAllResilienceHandlers is [Experimental] (EXTEXP0001) — the pragma is the API's
+        // designed opt-in, and it is the ONLY way to override the defaults pipeline per client
+        // without stacking a second retry-inside-retry pipeline on top of it.
+#pragma warning disable EXTEXP0001
+        builder.Services.AddHttpClient("plugin-registry")
+            .RemoveAllResilienceHandlers()
+            .AddStandardResilienceHandler();
+#pragma warning restore EXTEXP0001
+
         builder.Services.AddRequestTimeouts();
         builder.Services.AddOutputCache();
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-default-plugins-survive-every-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-default-plugins-survive-every-restart.md
@@ -1,0 +1,36 @@
+---
+Name: Default plugins survive every restart
+Category: Fix
+Description: After an update, a portal could come back up with none of its standard plugins — and repeat that on every restart. The install now waits its turn and lands.
+Icon: BoxCheckmark
+Order: -20260810
+---
+
+# Default plugins survive every restart
+
+Every portal ships with a standard set of plugins — the agents, the store, the
+publishing tools, the collaboration features. They are installed automatically
+each time the portal starts, so an update can never leave you without them.
+
+Except that for a while, it could — and did. After an update, the portal came
+back up with none of them. Not one. And because the same thing happened on the
+next restart, and the next, it stayed that way: a running, healthy-looking
+portal with its entire standard plugin set missing.
+
+Two boot-time jobs were racing each other. When the portal starts on a new
+version, it rebuilds every piece of dynamically-compiled code it hosts — a
+sweep that takes several minutes. The plugin installer started at the same
+moment, and each plugin it tried to install needed exactly the thing the sweep
+had not gotten to yet: the plugin's own page type, freshly rebuilt. The
+installer waited its allotted half minute, gave up, moved to the next plugin,
+and lost the same race again — six times in a row, every boot.
+
+The installer now simply waits for the rebuild sweep to finish before it
+starts. On a portal that does not run the sweep, nothing changes — the install
+starts immediately, as it always has. On the portals that do, the plugins
+install a few minutes into the boot, once the ground they land on actually
+exists.
+
+As part of tracing this, the network calls the installer makes to the plugin
+registry now identify themselves in the logs, so a slow or failed download
+names its caller instead of appearing as an anonymous timeout.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -2,6 +2,7 @@ using System.Reactive.Linq;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -50,6 +51,11 @@ public sealed class DynamicTypePreWarmerHostedService(
 
     private void KickWarmup()
     {
+        // The bake barrier consumers sequence on (#1114) — settled at EVERY terminal of this
+        // method, including the early no-bake returns, so a waiter never waits on a bake that is
+        // not coming. Resolved (not required) for resilience; AddDynamicTypePreWarming registers it.
+        var bake = services.GetService<PreWarmCompletion>();
+
         // Config-gated, DEFAULT OFF — see the class doc. Read as a raw string (no Binder
         // dependency); anything but an explicit true stays lazy.
         var enabled = services.GetService<IConfiguration>()?[EnabledConfigKey];
@@ -58,6 +64,7 @@ public sealed class DynamicTypePreWarmerHostedService(
             logger.LogInformation(
                 "DynamicTypePreWarmer: disabled ({Key} != true) — dynamic NodeTypes compile lazily on first access",
                 EnabledConfigKey);
+            bake?.MarkSettled();
             return;
         }
 
@@ -65,6 +72,7 @@ public sealed class DynamicTypePreWarmerHostedService(
         if (mesh is null)
         {
             logger.LogDebug("DynamicTypePreWarmer: no mesh hub resolved — skipping startup warm-up");
+            bake?.MarkSettled();
             return;
         }
 
@@ -114,6 +122,9 @@ public sealed class DynamicTypePreWarmerHostedService(
                     // an un-provable bake must not become an outage. A genuine broken type is caught
                     // by MarkOutcome above, which is what the gate is actually for.
                     gate?.MarkComplete("warm-up stream faulted — gate released, lazy compile applies");
+                    // A fault is a terminal too: the sweep is over, the compile queue is no longer
+                    // saturated, and whoever sequenced on the bake may proceed (#1114).
+                    bake?.MarkSettled();
                 },
                 () =>
                 {
@@ -152,6 +163,13 @@ public sealed class DynamicTypePreWarmerHostedService(
                                 gate.Regressions.Count, NodeTypeBakeGateExtensions.EnabledConfigKey,
                                 gate.Detail, regressions);
                     }
+
+                    // The sweep ran to its end — regressed or not, the compile queue has drained
+                    // and per-node hub activations no longer park behind it. Release the boot
+                    // flows sequenced on the bake (#1114). On a Regressed+armed pod readiness
+                    // stays refused regardless; the default install proceeding is deliberate —
+                    // installs repair content, and the broken type is already terminal.
+                    bake?.MarkSettled();
                 });
     }
 
@@ -185,6 +203,12 @@ public static class PreWarmServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddDynamicTypePreWarming(this IServiceCollection services)
     {
+        // The bake barrier (#1114): boot flows that write through per-node hubs — the plugin
+        // default install foremost — resolve this and sequence themselves after the sweep, so
+        // they never race a post-roll recompile storm. Registered HERE, with the pre-warmer,
+        // because its absence is itself the signal: a host without the pre-warm has no bake to
+        // wait for, and consumers proceed immediately.
+        services.TryAddSingleton<PreWarmCompletion>();
         services.AddHostedService<DynamicTypePreWarmerHostedService>();
         return services;
     }

--- a/src/MeshWeaver.Hosting/PreWarmCompletion.cs
+++ b/src/MeshWeaver.Hosting/PreWarmCompletion.cs
@@ -1,0 +1,54 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// The boot bake's completion signal: emits once when this host's dynamic-NodeType pre-warm has
+/// SETTLED — ran to completion, faulted, or was disabled — and replays that emission to late
+/// subscribers. Registered by
+/// <see cref="PreWarmServiceCollectionExtensions.AddDynamicTypePreWarming"/>; a host that never
+/// registers the pre-warm has no instance, and consumers treat "absent" as "nothing to wait for".
+///
+/// <para>🚨 Why this exists (#1114): boot work that WRITES THROUGH per-node hubs must not race the
+/// bake. On a pre-warming host every framework roll leaves ~240 dynamic NodeTypes ABI-stale, and
+/// the sweep rebuilds them sequentially (~10 min measured across three production portals).
+/// While that queue drains, ANY touch of a node whose NodeType is dynamic parks its per-node hub
+/// activation on the type's rebuild (<c>NodeTypeEnrichmentHelpers</c>' framework-stale heal flips
+/// the stale-Ok stamp to Pending and waits — correctly — for the compile). A caller with its own
+/// bound, like the installer's cross-hub <c>stream.Update</c> and its 30 s initial-state wait,
+/// then aborts on every single package — which is exactly how every pod boot on the memex portal
+/// installed ZERO default plugins for months of restarts. The fix is ordering, not a bigger
+/// timeout: boot flows that activate per-node hubs sequence themselves after this signal.</para>
+///
+/// <para>The one-shot replay is an <see cref="AsyncSubject{T}"/>, the same idiom
+/// <c>InstanceAutoRegistrationService.Completed</c> uses: whoever subscribes after the bake
+/// settled proceeds immediately; whoever subscribes before waits without polling. Deliberately
+/// NOT settled on host shutdown — a consumer's own subscription teardown is what cancels its
+/// wait, and settling mid-shutdown would START the very work being torn down.</para>
+/// </summary>
+public sealed class PreWarmCompletion : IDisposable
+{
+    private readonly AsyncSubject<Unit> completed = new();
+
+    /// <summary>
+    /// Emits exactly once, when the bake has settled, and replays that emission to late
+    /// subscribers. Never emits on a host whose pre-warm hosted service was registered but not
+    /// started (the subscription is expected to be torn down with its owner).
+    /// </summary>
+    public IObservable<Unit> Completed => completed.AsObservable();
+
+    /// <summary>
+    /// The bake settled: the sweep completed, faulted (lazy compile still applies), or never
+    /// applied (pre-warm disabled, no mesh hub). Idempotent — a second call is a no-op.
+    /// </summary>
+    public void MarkSettled()
+    {
+        completed.OnNext(Unit.Default);
+        completed.OnCompleted();
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => completed.Dispose();
+}

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.AI;
+using MeshWeaver.Hosting;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -201,7 +202,26 @@ public sealed class InstanceAutoRegistrationService(
                 return Observable.Return(Unit.Default);
             });
 
-        subscriptions.Add(registered
+        // 🚨 Sequenced AFTER the host's boot bake, when one is registered (#1114). Both phases
+        // write through per-node hubs (phase 2 upserts every package's partition ROOT via the
+        // owning hub's stream), and on a pre-warming host a framework roll leaves every dynamic
+        // NodeType ABI-stale: activating such a root mid-bake parks its enrichment on the type's
+        // rebuild, which queues BEHIND the sweep's ~240 sequential compiles — far past the
+        // cross-hub Update's 30 s initial-state bound. The observed shape was every default
+        // package aborting with "no initial state arrived for '{package}' within 30s" on every
+        // pod boot, leaving the instance with no default plugins until the next boot re-ran the
+        // identical race. Waiting on the bake's one-shot completion signal is ordering on the
+        // actual precondition — no timer, no retry, replayed to late subscribers; a host without
+        // the pre-warm has no PreWarmCompletion registered and proceeds exactly as before.
+        var bakeSettled = hub.ServiceProvider.GetService<PreWarmCompletion>()?.Completed
+            ?? Observable.Return(Unit.Default);
+
+        subscriptions.Add(bakeSettled
+            .Take(1)
+            // Hop off whatever thread settled the bake (the sweep's completion callback, or the
+            // ApplicationStarted callback on a no-bake host) before the install chain runs.
+            .ObserveOn(TaskPoolScheduler.Default)
+            .SelectMany(_ => registered)
             .SelectMany(_ => InstallDefaults(options))
             // 🚨 SubscribeOn the thread pool, NOT the host-startup thread. The chain is synchronous
             // right up to its first genuinely-async leaf (an in-memory or already-cached source

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistrationClient.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistrationClient.cs
@@ -41,12 +41,23 @@ public static class InstanceRegistrationPayloads
 /// </summary>
 public sealed class InstanceRegistrationClient(IMessageHub hub)
 {
+    /// <summary>
+    /// The named <see cref="HttpClient"/> every plugin-registry HTTP call resolves (this client and
+    /// <see cref="RegistryPackageSource"/>). Hosts SHOULD give this name its own resilience pipeline
+    /// (<c>AddHttpClient(HttpClientName).RemoveAllResilienceHandlers().AddStandardResilienceHandler()</c>):
+    /// under Aspire-style <c>ConfigureHttpClientDefaults</c> every client shares ONE unnamed
+    /// pipeline, so a boot-time registry timeout logs <c>Source: '-standard//…'</c> with an empty
+    /// operation key and cannot be attributed to the registry call path (#1133/#1137). A named
+    /// pipeline makes the same event read <c>plugin-registry-standard//…</c>.
+    /// </summary>
+    public const string HttpClientName = "plugin-registry";
+
     private static readonly HttpClient SharedHttp = new();
 
     private readonly IIoPool _httpPool =
         hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
     private readonly HttpClient _http =
-        hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient("plugin-registry") ?? SharedHttp;
+        hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName) ?? SharedHttp;
 
     /// <summary>
     /// Registers this installation at <paramref name="registryUrl"/>. Cold; the call happens on

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -46,7 +46,8 @@ public sealed class RegistryPackageSource : IPackageSource
         _registryUrl = (registryUrl ?? "").TrimEnd('/');
         _token = (token ?? "").Trim();
         _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
-        _http = hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient("plugin-registry") ?? SharedHttp;
+        _http = hub.ServiceProvider.GetService<IHttpClientFactory>()
+            ?.CreateClient(InstanceRegistrationClient.HttpClientName) ?? SharedHttp;
     }
 
     private sealed record ListResponse(IReadOnlyList<PackageManifest>? Packages);

--- a/test/MeshWeaver.PluginCatalog.Test/DefaultInstallBakeOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DefaultInstallBakeOrderingTest.cs
@@ -1,0 +1,148 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 The #1114 ordering pin: on a host that BAKES its dynamic NodeTypes at boot (the
+/// <c>DynamicTypePreWarmer</c> sweep), the default install must sequence AFTER the bake — never
+/// race it.
+///
+/// <para>The production shape this pins: every self-update roll changes the framework hash, so
+/// every dynamic NodeType is ABI-stale and the sweep rebuilds all ~240 sequentially (~10 min).
+/// The boot install races that queue: each package's partition-ROOT upsert routes through the
+/// owning per-node hub, whose activation parks on the root type's framework-stale rebuild —
+/// queued behind the sweep — and the cross-hub <c>stream.Update</c> aborts at its 30 s
+/// initial-state bound: <c>"no initial state arrived for '{package}' within 30s"</c>, for EVERY
+/// default package (Agent, DataModelling, Edu, Essentials, Publish, Collaboration), on EVERY pod
+/// boot. The failed packages keep their stale install records, so the next boot re-runs the
+/// identical race — a portal permanently missing its platform plugins.</para>
+///
+/// <para>The contract: <see cref="PreWarmCompletion"/> (registered by
+/// <c>AddDynamicTypePreWarming</c>, settled by the sweep's every terminal) is the barrier, and
+/// <see cref="InstanceAutoRegistrationService"/> starts its boot pass only after it emits. A host
+/// without the pre-warm registers no barrier and proceeds exactly as before — which every other
+/// default-install test in this project exercises.</para>
+/// </summary>
+public class DefaultInstallBakeOrderingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly PreWarmCompletion preWarm = new();
+    private readonly ProbeSource probe = new(Source());
+
+    /// <summary>
+    /// Records whether the boot pass has LISTED packages yet — listing is the install phase's very
+    /// first touch of a source, so it flipping before the bake settles is the race, caught at its
+    /// first observable step rather than at the eventual timeout.
+    /// </summary>
+    private sealed class ProbeSource(IPackageSource inner) : IPackageSource
+    {
+        public volatile bool Listed;
+
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef)
+        {
+            Listed = true;
+            return inner.ListPackages(gitRef);
+        }
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef) =>
+            inner.FetchPackageFiles(package, gitRef);
+    }
+
+    // One pre-installed package — the platform-baseline shape the boot pass reconciles on every
+    // start (same repo idiom as PreInstalledPackageInstallTest, pared to the ordering concern).
+    private static readonly IReadOnlyList<RepoFile> Repo =
+    [
+        new("Seed/index.json",
+            """
+            {"$type":"MeshNode","id":"Seed","namespace":"","path":"Seed","mainNode":"Seed",
+             "name":"Seed","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Baseline package.",
+                        "preInstalled":true}}
+            """),
+        new("Seed/Doc.json",
+            """
+            {"$type":"MeshNode","id":"Doc","namespace":"Seed","path":"Seed/Doc",
+             "mainNode":"Seed/Doc","name":"Doc","nodeType":"Markdown","state":"Active",
+             "content":"# Seed"}
+            """),
+    ];
+
+    private static NodeRepoPackageSource Source()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-bake-ordering", Repo));
+        return new NodeRepoPackageSource(fetch, "https://github.com/acme/plugins");
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                // The host pre-warms: the bake barrier is registered UNSETTLED, exactly as
+                // AddDynamicTypePreWarming registers it before the sweep has run.
+                .AddSingleton(preWarm)
+                .AddSingleton<IPackageSource>(probe));
+
+    [Fact(Timeout = 180_000)]
+    public async Task BootInstall_WaitsForTheBake_ThenInstalls()
+    {
+        var installer = Mesh.ServiceProvider.GetRequiredService<InstanceAutoRegistrationService>();
+
+        // The boot pass WAS started (the test base starts every IHostedService with the mesh) —
+        // but the bake has not settled, so it must not advance past the barrier: no source
+        // listing, no completion. This is the sanctioned "wait to confirm nothing happened"
+        // negative (WritingTests.md): there is no positive signal to filter for, because on the
+        // gated ordering the chain is parked on the barrier's AsyncSubject and CANNOT produce
+        // one — the window can never red a correct build. On the pre-#1114 (ungated) code the
+        // chain reaches ListPackages within ~1 s of hosted-service start, so the poll fails FAST
+        // the moment the race is observed rather than sitting out the window.
+        var raced = await Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .Select(_ => probe.Listed)
+            .FirstAsync(listed => listed)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<bool, TimeoutException>(_ => Observable.Return(false))
+            .ToTask();
+        raced.Should().BeFalse(
+            "the default install must not even LIST packages before the bake settles — every "
+            + "root it would go on to write parks on a type rebuild queued behind the sweep");
+        // AsyncSubject replays synchronously on Subscribe, so this is a no-wait probe, not a sleep.
+        var completedEarly = false;
+        using (installer.Completed.Subscribe(_ => completedEarly = true))
+            completedEarly.Should().BeFalse(
+                "the default install must not finish before the bake settles");
+
+        // The bake reaches a terminal — the barrier opens and the already-subscribed boot pass
+        // proceeds on its own: no re-kick, no poll.
+        preWarm.MarkSettled();
+
+        var summary = await installer.Completed
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+
+        summary.Packages.Should().Contain("Seed");
+        summary.Failed.Should().Be(0);
+        probe.Listed.Should().BeTrue("once the bake settled, the pass must actually run");
+
+        // …and the gated pass still delivers: the install record and the content landed.
+        var record = await Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read($"{PackageInstaller.InstalledPartition}/Seed", Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        record.Should().NotBeNull(
+            "waiting for the bake must delay the baseline install, never lose it");
+    }
+}


### PR DESCRIPTION
## The boot default install raced the post-roll NodeType bake — and lost, for every package, on every boot

### Measured boot sequence (memex namespace, PreWarm + bake gate armed)

1. A self-update rolls the pod onto a new image (boot windows 01:10 / 07:10 / 11:45 on 2026-08-10 — three deploys, four replica sets). A new framework hash leaves **every dynamic NodeType ABI-stale**.
2. `InstanceAutoRegistrationService.StartAsync` kicks the `[DefaultInstall]` pass immediately — during host start, before `ApplicationStarted`.
3. At `ApplicationStarted` the `DynamicTypePreWarmer` bake begins rebuilding all ~240 stale types **sequentially, ~10 min** (the measurement in `AddNodeTypeBakeGate`'s own docs).
4. For each default package with real work, the installer upserts the package's **partition root** through `CreateOrUpdateNodeRequest`. The row exists, so the handler takes `ApplyUpdateViaStream` → `GetMeshNodeStream(root).Update(...)` — a cross-hub write that must **activate the root's per-node hub** and wait for its initial snapshot (30 s bound in `UpdateRemote`).
5. That activation's enrichment finds the root's dynamic NodeType carrying an **old-framework Ok stamp**, flips it Pending (the framework-stale self-heal, `TriggerRecompileAndRetry`), and waits for the rebuild — which queues on the Compile pool **behind the bake's sequential sweep**, far past 30 s.
6. `Update aborted: no initial state arrived for '{package}' within 30s` → `Inner UpdateNode faulted` → the package install fails and is stepped over. All six packages (Agent, Collaboration, DataModelling, Edu, Essentials, Publish) fail identically, ~74 s apart — exactly the 01:13–01:16 / 07:10–07:16 log windows in #1114.
7. The failed install never re-stamps the record's `ModuleVersion`, so the **next boot retries the same work under the same storm**. Nothing retries between boots, by design — the persistent "boots with no default plugins" degradation.

The exception's own cause (4) was close but one level up: the per-node hub didn't fail to *load* the node — it never finished *activating*, because activation correctly waits for the type's rebuild, and the boot-time install had no business racing that queue.

### The fix — ordering on the real precondition; no timers, no retries, no widened timeouts

- **`PreWarmCompletion`** (new, `MeshWeaver.Hosting`): a one-shot, replayed bake-completion signal (`AsyncSubject`, the same idiom as `InstanceAutoRegistrationService.Completed`). Registered by `AddDynamicTypePreWarming()`; settled at the sweep's **every** terminal — completed, faulted, disabled, or no mesh hub — so a waiter can never wait on a bake that isn't coming.
- **`InstanceAutoRegistrationService`** sequences its boot pass after that signal when one is registered. A host without the pre-warm (tests, plain hosts) has no `PreWarmCompletion` and proceeds exactly as before.
- **Not** the write pattern: the service does no create-then-update of its own — the "CreateNode → UpdateNode" in the exception text is the `CreateOrUpdateNodeRequest` handler's internal branching, and routing an update of an existing node through the owning per-node hub is the sanctioned single mutation surface. The ordering was the defect.

### Test

`DefaultInstallBakeOrderingTest` (MonolithMeshTestBase, real hosted-service boot pass): with an unsettled `PreWarmCompletion` registered, the pass must not even list packages; after `MarkSettled()` it proceeds and the baseline package installs. Red-before verified by neutralizing the gate (the ungated chain reaches `ListPackages` within ~1 s and the pin goes red); green-after on the fixed code. The 28 surrounding default-install tests stay green.

### Satellites — same flow, confirmed

- **#1137** (`TimeoutRejectedException` installing Store, 11:45:24): the plugin-registry HTTP fetch inside this same `[DefaultInstall]` boot pass. The registry client (`RegistryPackageSource` / `InstanceRegistrationClient`, named client `plugin-registry`) rides the **unnamed default** standard resilience pipeline from `ServiceDefaults.ConfigureHttpClientDefaults`; the 30 s is `Standard-TotalRequestTimeout`; the transport `SocketException(125)` is the deploy window (registry endpoints rolling at the same moment).
- **#1133** (Polly `OnTimeout`, `Source: '-standard//…'`, empty operation key): the timeout **events of those same calls** — the pipeline is named `-standard` because `ConfigureHttpClientDefaults` builds it on the unnamed default builder. Timestamps (01:10:16/28, 07:10:27/37, 11:45:04/16/24) all sit in the boot windows on the same pods; the 11:45 trio is two attempt timeouts plus the total-timeout that surfaced as #1137's single failure.
- Observability (in scope, not a band-aid): the `plugin-registry` named client now carries its **own** standard resilience pipeline (`ServiceDefaults`), so future events read `plugin-registry-standard//…` instead of an unattributable `-standard//…`. Sequencing the install after the bake also moves these calls out of the deploy window.

Fixes #1114
Fixes #1137
Fixes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
