### PR TITLE
A recycled hub's subscriber now re-probes instead of parking two minutes

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -41,6 +41,14 @@ public static class JsonSynchronizationStream
     private const string SystemUserId = "system-security";
 
     /// <summary>
+    /// Upper bound on NACK-triggered re-probes of a recycling owner (see the re-probe block in
+    /// <c>CreateExternalClient</c>). Six attempts at doubling backoff (500 ms … 8 s) cover ~24 s —
+    /// far beyond any recycle window — while keeping a permanently-rejecting owner from being
+    /// probed forever.
+    /// </summary>
+    private const int MaxRecycleReprobes = 6;
+
+    /// <summary>
     /// When the FIRST heartbeat fires on a fresh subscription. The rest keep the configured
     /// <see cref="SyncStreamOptions.HeartbeatInterval"/> cadence.
     ///
@@ -334,6 +342,21 @@ public static class JsonSynchronizationStream
         // by RouteStreamMessage); a DeliveryFailure / NotFound — the owner ADDRESS DOES NOT EXIST —
         // surfaces as OnError, so we fault subscribers and dispose the keep-alive so nothing
         // heartbeats/resubscribes a non-existent owner. Reactive end-to-end: no await.
+        // 🚨 Bounded re-probe for a TRANSIENT recycle reject — assigned below, where Resubscribe
+        // is defined (safe: a NACK response can only arrive through the hub's turn loop, strictly
+        // after this method finished wiring the stream). The ShuttingDown NACK's contract is
+        // explicit — "the address may reactivate (recycle / restart); retry to get the
+        // authoritative answer" — and the re-sent SubscribeRequest is ITSELF what reactivates a
+        // recycled owner (routing creates per-node hubs on demand), so no OTHER event is
+        // guaranteed to exist: a recycle whose reactivation lands no further node write produces
+        // no change-feed pulse, and the heartbeat is deliberately fire-and-forget. Measured in
+        // StaleStampRootBindingTest: with the NACK delivered but no re-probe, the ride-out sat
+        // out the caller's whole 120 s with a live keep-alive and nothing to fire the latch.
+        // This is NOT the 2026-06-08 watchdog shape: nothing runs on a schedule — each attempt
+        // is triggered by an explicit transient NACK, the count is bounded, and the change-feed
+        // latch stays the primary detector. Same protocol reaction as OrleansRoutingService's
+        // transient dispatch retry.
+        Action? reprobeOnRecycleNack = null;
         var observeSubscription = Observable
             .Using(
                 // Apply an explicit identity SCOPE for the post — do NOT rely on the ambient AsyncLocal
@@ -376,8 +399,12 @@ public static class JsonSynchronizationStream
                     {
                         logger.LogDebug(
                             "SubscribeRequest for stream {StreamId} rejected — owner {Owner} is shutting down "
-                            + "(recycle/restart in flight); keeping the stream alive for the resubscribe latch",
+                            + "(recycle/restart in flight); keeping the stream alive and re-probing",
                             reduced.StreamId, owner);
+                        // The change-feed latch only fires on a post-recycle WRITE; a recycle
+                        // whose reactivation writes nothing leaves it silent forever. The NACK
+                        // is the one guaranteed event, so it triggers the bounded re-probe.
+                        reprobeOnRecycleNack?.Invoke();
                         return;
                     }
 
@@ -476,9 +503,37 @@ public static class JsonSynchronizationStream
                                     "Stream {StreamId}: resubscribe failed.",
                                     reduced.StreamId);
                                 Interlocked.Exchange(ref resubscribing, 0);
+                                // A re-probe that itself raced the same recycle window gets the
+                                // same transient verdict — take the next bounded attempt.
+                                if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
+                                    reprobeOnRecycleNack?.Invoke();
                             });
                 }
             }
+
+            // The bounded transient-NACK re-probe (see the declaration above the initial
+            // SubscribeRequest for the full rationale). Backoff doubles from 500 ms and caps at
+            // 8 s; MaxRecycleReprobes attempts cover ~24 s — far beyond any recycle window —
+            // after which recovery is left to the change-feed latch, exactly as before.
+            var recycleReprobes = 0;
+            reprobeOnRecycleNack = () =>
+            {
+                var attempt = Interlocked.Increment(ref recycleReprobes);
+                if (attempt > MaxRecycleReprobes)
+                {
+                    logger.LogWarning(
+                        "Stream {StreamId}: owner {Owner} still rejecting as shutting down after "
+                        + "{Attempts} re-probes — leaving recovery to the change-feed latch.",
+                        reduced.StreamId, owner, MaxRecycleReprobes);
+                    return;
+                }
+                var delay = TimeSpan.FromMilliseconds(Math.Min(500 * Math.Pow(2, attempt - 1), 8000));
+                // On keepAlive: a terminal NotFound (or stream teardown) disposes keepAlive,
+                // which cancels a pending re-probe — never probe an owner that is gone for good.
+                keepAlive.Add(Observable.Timer(delay).Subscribe(_ => Resubscribe(
+                    $"rejected the subscribe as shutting down (recycle in flight) — "
+                    + $"re-probe {attempt}/{MaxRecycleReprobes}")));
+            };
 
             // 🚨 THE LOST INITIAL — and why the first heartbeat comes EARLY.
             //

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-no-longer-waits-in-the-dark.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-no-longer-waits-in-the-dark.md
@@ -1,0 +1,20 @@
+---
+Name: A page no longer waits two minutes in the dark when its node restarts
+Category: Fix
+Description: Opening a page at the exact moment its node was restarting could leave it dark for two minutes. The page now notices and reconnects by itself within a second or two.
+Icon: ArrowSync
+Order: -20260810
+---
+
+# A page no longer waits two minutes in the dark when its node restarts
+
+Nodes restart routinely — right after a plugin install, after their code is
+rebuilt, after a recycle. A page opened in exactly that moment used to connect
+to the node that was on its way down, and then simply wait: nothing rendered,
+no error, no retry, until the page gave up minutes later.
+
+The restarting node already sends an honest answer — "I am coming back, ask
+again" — but the page never acted on it. It now does: on that answer it re-asks
+after a short pause, and the re-ask itself is what brings the fresh node up. A
+page caught in a restart window therefore comes alive within a second or two
+instead of sitting dark.


### PR DESCRIPTION
**Stacked on #1153** (base = `fix/installer-publish-after-recycle`; GitHub retargets to `main` when #1153 merges). Completes the fix for the `StaleStampRootBindingTest` red on main (#1146 merge; runs [31390266052](https://github.com/Systemorph/MeshWeaver/actions/runs/31390266052) / [31390882509](https://github.com/Systemorph/MeshWeaver/actions/runs/31390882509)).

## The residual race #1153 leaves

#1153 correctly sequences the **installer's own** recycle — but the **independent** post-install rebind recycle (~50 ms after `Install` returns, when the rebuilt build lands) can still race a client's `SubscribeRequest`. Measured on `origin/main + #1153` under `DOTNET_PROCESSOR_COUNT=4`: **2 of 5 class runs red**, both `StaleStampSelfTypedRoot_RootServesItsTypesArea` at ~2 m 6 s — the client parked its full 120 s frame wait.

The mechanism: the owner answers the raced subscribe with the framework's transient verdict — `ErrorType.ShuttingDown`, *"the address may reactivate (recycle / restart); retry to get the authoritative answer"* — and `JsonSynchronizationStream` **kept the stream alive but never asked again**. Its recovery is change-feed-driven, and a recycle whose reactivation lands no further node write produces **no change-feed pulse**; the heartbeat is deliberately fire-and-forget. So the ride-out had no trigger, ever. (This is also the failure mode of #1154's own shard-4 CI: with the NACK delivered, the no-content variant still died at the 120 s frame wait.)

## The fix

Act on the NACK: a **bounded re-probe** — 6 attempts, 500 ms doubling to 8 s — re-sends the `SubscribeRequest`, and the re-ask itself is what reactivates the recycled owner (routing creates per-node hubs on demand). Not a watchdog: nothing runs on a schedule; each attempt is triggered by an explicit transient NACK, the count is bounded, a terminal NotFound still tears the keep-alive down, and the change-feed latch remains the primary detector. Same protocol reaction as `OrleansRoutingService`'s transient dispatch retry and the NACK's own contract text.

## Relationship to #1154

#1154's MessageService seams (NACK-through-parent for accepted-then-orphaned deliveries, reply forwarding) are the complementary **protocol** half — they make every disposal race answer fast and classified, for all recycle sources. Independently corroborated here: an equivalent deterministic pin (both doors driven to `runLevel=Dead`) was red 2/2 on unfixed code (60 s parks) and green 2/2 with the seams. But the seams alone don't recover the subscriber — the delivered verdict still needs a consumer that re-asks, which is this PR. Note #1153 and #1154 conflict on `PackageInstaller.cs`; this PR touches neither side of that conflict.

## Evidence

- **#1153 alone:** 3/5 class runs green (failures: 120 s client park, install itself healthy at ~500 ms).
- **#1153 + this:** **10/10 consecutive class runs green**, 6–9 s per run, `DOTNET_PROCESSOR_COUNT=4`, Release.
- No new deterministic test is included: pinning "recycle-without-write → re-probe within backoff" needs a harness for a write-less reactivation window; the 10/10 vs 3/5 measurement above is the verification. (The protocol-level pin lives in #1154's `DisposalRaceNackTest`.)
- `dotnet build src/MeshWeaver.Data -c Release -warnaserror` clean.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
