### PR TITLE
fix(delete): recursive delete denies atomically up front — no more half-deleted subtrees on permission loss

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-recursive-delete-atomic-permission-denial.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-recursive-delete-atomic-permission-denial.md
@@ -1,0 +1,20 @@
+---
+Name: Recursive delete now refuses permission denials up front — never half-deletes a subtree
+Category: Fix
+Description: A recursive delete that hits a missing Delete permission is now refused atomically before anything is removed, with a clear "permission denied" answer instead of an unexpected error after a partial deletion.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Recursive delete now refuses permission denials up front — never half-deletes a subtree
+
+Deleting a folder tree you were not fully allowed to delete could previously remove part of
+the tree before stopping: the permission check for each node ran while the deletion was
+already underway, so dozens of nodes could be gone by the time the denial hit — and the error
+was reported as an unexpected failure rather than a permission problem.
+
+Recursive deletes now decide permissions for the whole subtree before touching anything. If
+you lack Delete on any node in the tree, nothing is deleted and you get a clear message naming
+the node you are not allowed to delete. A delete that was fully authorized when it started can
+also no longer trip over its own access records mid-way — it either refuses up front or
+completes fully.

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -243,11 +243,33 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
 
     /// <summary>
     /// Extracts the user ID from the validation context.
-    /// First checks explicit request identity (CreatedBy/UpdatedBy/DeletedBy),
-    /// then falls back to AccessContext (the logged-in user).
+    /// A recursive-delete cascade leg executed under the delivery-stamped SYSTEM
+    /// context acts as system; otherwise the explicit request identity
+    /// (CreatedBy/UpdatedBy/DeletedBy) is checked first, then the AccessContext
+    /// (the logged-in user).
     /// </summary>
     private static string? GetUserId(NodeValidationContext context)
     {
+        // 🚨 A CASCADE-LEG delete executed under the SYSTEM context acts as system, even
+        // though DeletedBy carries the original caller for the audit trail. The recursive
+        // delete authorizes the WHOLE subtree up front under the caller (root permission
+        // check + the [RequiresPermission(Delete)] gate on every descendant's pre-flight
+        // ValidateDeleteRequest) and then commits under the system identity — because the
+        // plan contains the subtree's own _Access grant satellites, and re-deriving the
+        // principal from DeletedBy here re-decided that authorization MID-COMMIT against
+        // state the cascade itself was deleting, aborting the subtree half-deleted
+        // (issue #1128, "partial-deleted=31"). BOTH signals are required:
+        //  • CascadeRootPath — only the subtree fan-out stamps it; and
+        //  • the SYSTEM AccessContext — carried on the DELIVERY by the fan-out's explicit
+        //    WithAccessContext stamp and threaded into this context by the delete handler.
+        // A leaked ambient "system-security" (the bootstrap-ImpersonateAsSystem AsyncLocal
+        // residue AccessControlPipeline.ResolveIdentity documents) has CascadeRootPath null
+        // and therefore never matches — DeletedBy/CreatedBy stay authoritative for every
+        // direct request, exactly as before (RlsIntegrationTests' DeletedBy shape).
+        if (context.Request is DeleteNodeRequest { CascadeRootPath: not null }
+            && context.AccessContext?.ObjectId == WellKnownUsers.System)
+            return WellKnownUsers.System;
+
         // Check explicit request identity first
         var requestUserId = context.Request switch
         {

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2142,7 +2142,7 @@ public static class MeshExtensions
                             return Observable.Empty<System.Reactive.Unit>();
                         }
 
-                        return RunDeletionValidatorsWithWarningsObs(hub, rootNode, capturedRequest)
+                        return RunDeletionValidatorsWithWarningsObs(hub, rootNode, capturedRequest, request.AccessContext)
                             .SelectMany(vresult =>
                             {
                                 if (vresult.Error is { Length: > 0 } err)
@@ -2214,12 +2214,30 @@ public static class MeshExtensions
                                         //     all-or-nothing failure.
                                         var preValidate = capturedRequest.Recursive
                                             ? PreValidateDescendantsObs(meshHub, path, collected.ToDelete, request.AccessContext, opts.Timeout, logger)
-                                            : Observable.Return<(string Path, string Error)?>(null);
+                                            : Observable.Return<(string Path, string Error, NodeDeletionRejectionReason Reason)?>(null);
 
                                         return preValidate.SelectMany(failure =>
                                         {
                                             if (failure is { } f)
                                             {
+                                                if (f.Reason == NodeDeletionRejectionReason.Unauthorized)
+                                                {
+                                                    // A permission denial on a descendant is an EXPECTED
+                                                    // outcome, refused atomically BEFORE any deletion —
+                                                    // name the real condition at Warning, and answer with
+                                                    // Unauthorized, not a generic validation failure
+                                                    // mislabelled "unexpected" (issue #1128).
+                                                    logger.LogWarning(
+                                                        "[DeleteNode] permission-denied path={Root} deniedAt={Path} — refused before any deletion: {Err}",
+                                                        path, f.Path, f.Error);
+                                                    PostFailed(
+                                                        f.Error,
+                                                        NodeDeletionRejectionReason.Unauthorized,
+                                                        [new LogMessage(f.Error, LogLevel.Error)],
+                                                        collected.ToDelete.ToImmutableList());
+                                                    return Observable.Empty<System.Reactive.Unit>();
+                                                }
+
                                                 logger.LogWarning(
                                                     "[DeleteNode] pre-validation failed path={Root} blockedBy={Path} err={Err}",
                                                     path, f.Path, f.Error);
@@ -2247,9 +2265,31 @@ public static class MeshExtensions
                                             "[DeleteNode] committing path={Path} count={Count}",
                                             path, collected.ToDelete.Count);
 
+                                        // 🚨 Execute the COMMIT under the SYSTEM identity, not the
+                                        // caller's. The authorization decision for the whole cascade
+                                        // was taken atomically ABOVE, before any mutation: the caller's
+                                        // Delete permission on the root (phase 2) plus the per-leaf
+                                        // [RequiresPermission(Delete)] delivery gate that every
+                                        // descendant's ValidateDeleteRequest just passed (pre-flight).
+                                        // Re-evaluating the CALLER's permission per-leaf DURING the
+                                        // commit was issue #1128: the plan contains the subtree's own
+                                        // `_Access` grant satellites, the bottom-up fan-out deletes
+                                        // them early, the caller's authorization evaporates MID-COMMIT,
+                                        // and the cascade aborted half-done ("partial-deleted=31" with
+                                        // no rollback) even though the caller was fully authorized when
+                                        // the operation was admitted. Decide once, up front, under the
+                                        // caller; execute the already-decided cascade under system.
+                                        // DeletedBy still carries the caller for the audit trail, and
+                                        // per-leaf validators still run at each leaf's own hub.
+                                        var executionContext = new AccessContext
+                                        {
+                                            ObjectId = WellKnownUsers.System,
+                                            Name = WellKnownUsers.System
+                                        };
+
                                         return DeleteSubtreeUntilDrained(
                                                 meshHub, storage, path, collected.ToDelete,
-                                                capturedRequest, request.AccessContext,
+                                                capturedRequest, executionContext,
                                                 recentlyDeleted, logger, collectedMessages)
                                             .Timeout(opts.Timeout)
                                             // 5. Post-deletion side effects for the ROOT node — e.g.
@@ -2377,8 +2417,25 @@ public static class MeshExtensions
                             _ => null,
                         }
                         : null;
-                    logger.LogError(ex, "[DeleteNode] {Kind} path={Path} partial-deleted={Partial}",
-                        isTimeout ? "timeout" : (isNotFound ? "not-found" : "unexpected"), path, partial.Count);
+                    // 🚨 Name the real condition (issue #1128): a permission denial is an
+                    // EXPECTED outcome, never an "unexpected" fail-level event. When it
+                    // arrives here with NOTHING deleted it is a plain Warning; when nodes
+                    // were already deleted before the denial, the subtree is left torn —
+                    // that partial mutation stays a LOUD error until the day it can no
+                    // longer happen (the commit now runs under the system identity after
+                    // up-front authorization, so this leg is a canary, not a code path).
+                    var isUnauthorized = dfxReason == NodeDeletionRejectionReason.Unauthorized;
+                    if (isUnauthorized && partial.Count > 0)
+                        logger.LogError(ex,
+                            "[DeleteNode] permission-denied MID-COMMIT path={Path} — {Partial} node(s) were "
+                            + "already deleted before the denial; the subtree is left partially deleted",
+                            path, partial.Count);
+                    else if (isUnauthorized)
+                        logger.LogWarning(
+                            "[DeleteNode] permission-denied path={Path}: {Reason}", path, ex.Message);
+                    else
+                        logger.LogError(ex, "[DeleteNode] {Kind} path={Path} partial-deleted={Partial}",
+                            isTimeout ? "timeout" : (isNotFound ? "not-found" : "unexpected"), path, partial.Count);
                     var failMsgs = collectedMessages.ToImmutable()
                         .Add(new LogMessage(
                             isNotFound ? $"Node not found at path '{path}'" : ex.Message,
@@ -2388,7 +2445,11 @@ public static class MeshExtensions
                             ? $"Delete of '{path}' exceeded {opts.Timeout.TotalSeconds:0}s timeout"
                             : (isNotFound
                                 ? $"Node not found at path '{path}'"
-                                : $"Unexpected error: {ex.Message}"),
+                                : (isUnauthorized
+                                    // Already legible ("Access denied: user 'x' lacks Delete
+                                    // permission on 'y'") — no "Unexpected error:" prefix.
+                                    ? ex.Message
+                                    : $"Unexpected error: {ex.Message}")),
                         isTimeout
                             ? NodeDeletionRejectionReason.Unknown
                             : (dfxReason
@@ -2725,12 +2786,23 @@ public static class MeshExtensions
     /// <summary>
     /// Bulk-atomic pre-flight: post <see cref="ValidateDeleteRequest"/> at every
     /// descendant address (root excluded — already validated by the caller) and
-    /// return the FIRST validator failure as <c>(Path, Error)</c>, or <c>null</c>
+    /// return the FIRST failure as <c>(Path, Error, Reason)</c>, or <c>null</c>
     /// if all descendants pass. Subscribed before any storage side effects fire,
     /// so a single failing descendant aborts the whole subtree delete with no
     /// partial state — sibling deletes that pass validation never run.
+    ///
+    /// <para>🚨 This pre-flight is ALSO the per-descendant PERMISSION check
+    /// (issue #1128): <see cref="ValidateDeleteRequest"/> carries the same
+    /// <c>[RequiresPermission(Delete)]</c> delivery gate as the leaf
+    /// <see cref="DeleteNodeRequest"/> fan-out, evaluated at each leaf's own hub
+    /// under the caller's <see cref="AccessContext"/>. An Unauthorized refusal
+    /// here is the atomic up-front denial — reported as
+    /// <see cref="NodeDeletionRejectionReason.Unauthorized"/> so callers see a
+    /// legible permission denial, never a partially deleted subtree. The commit
+    /// that follows a fully-granted pre-flight then runs under the system
+    /// identity, immune to the cascade deleting its own <c>_Access</c> grants.</para>
     /// </summary>
-    private static IObservable<(string Path, string Error)?> PreValidateDescendantsObs(
+    private static IObservable<(string Path, string Error, NodeDeletionRejectionReason Reason)?> PreValidateDescendantsObs(
         IMessageHub meshHub,
         string rootPath,
         ImmutableHashSet<string> allPaths,
@@ -2742,7 +2814,7 @@ public static class MeshExtensions
             .Where(p => !string.Equals(p, rootPath, StringComparison.OrdinalIgnoreCase))
             .ToArray();
         if (descendants.Length == 0)
-            return Observable.Return<(string, string)?>(null);
+            return Observable.Return<(string, string, NodeDeletionRejectionReason)?>(null);
 
         var perPath = descendants.Select(p => meshHub
             // 🚨 Stamp the caller's AccessContext on every ValidateDeleteRequest.
@@ -2761,14 +2833,28 @@ public static class MeshExtensions
             {
                 var resp = d.Message as ValidateDeleteResponse;
                 if (resp is null || resp.IsValid)
-                    return ((string, string)?)null;
-                return (p, resp.Errors[0]);
+                    return ((string, string, NodeDeletionRejectionReason)?)null;
+                return (p, resp.Errors[0], NodeDeletionRejectionReason.ValidationFailed);
             })
-            .Catch<(string, string)?, Exception>(ex =>
+            .Catch<(string, string, NodeDeletionRejectionReason)?, Exception>(ex =>
             {
+                // The [RequiresPermission(Delete)] gate on ValidateDeleteRequest refused
+                // this leaf for the CALLER — the atomic up-front permission denial. It is
+                // an expected outcome, decided before any deletion; classify it so the
+                // caller gets Unauthorized with the gate's legible message ("Access
+                // denied: user 'x' lacks Delete permission on 'y'"), not a fail-level
+                // "unexpected" report (issue #1128).
+                if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.Unauthorized })
+                {
+                    logger.LogDebug(
+                        "[DeleteNode] pre-flight permission denied {Path}: {Message}", p, ex.Message);
+                    return Observable.Return<(string, string, NodeDeletionRejectionReason)?>(
+                        (p, ex.Message, NodeDeletionRejectionReason.Unauthorized));
+                }
                 logger.LogWarning(ex,
                     "[DeleteNode] pre-validate descendant failed {Path}", p);
-                return Observable.Return<(string, string)?>((p, ex.Message));
+                return Observable.Return<(string, string, NodeDeletionRejectionReason)?>(
+                    (p, ex.Message, NodeDeletionRejectionReason.ValidationFailed));
             }));
 
         // Collect every descendant's outcome; emit the first non-null failure
@@ -3173,7 +3259,8 @@ public static class MeshExtensions
         RunDeletionValidatorsWithWarningsObs(
             IMessageHub hub,
             MeshNode node,
-            DeleteNodeRequest request)
+            DeleteNodeRequest request,
+            AccessContext? deliveryAccessContext = null)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var context = new NodeValidationContext
@@ -3181,7 +3268,14 @@ public static class MeshExtensions
             Operation = NodeOperation.Delete,
             Node = node,
             Request = request,
-            AccessContext = accessService?.Context ?? accessService?.CircuitContext,
+            // 🚨 The DELIVERY's AccessContext first — the ambient AsyncLocal does not
+            // survive the scheduler hops between handler entry and this call (the same
+            // reason the handler captures senderUserId at entry), and for a cascade-leg
+            // delete the delivery carries the explicit SYSTEM execution stamp that
+            // RlsNodeValidator's cascade bypass keys on (issue #1128). Falling back to
+            // the ambient context preserves the pre-existing behavior for callers that
+            // did not thread the delivery through.
+            AccessContext = deliveryAccessContext ?? accessService?.Context ?? accessService?.CircuitContext,
             // This runner validates the ROOT node of the delete. For a standalone delete the
             // cascade root is the request path itself; a leaf delete issued by the subtree
             // fan-out carries the ORIGINAL root so validators exempt space-teardown invariants

--- a/test/MeshWeaver.Hosting.Monolith.Test/RecursiveDeletePermissionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RecursiveDeletePermissionTest.cs
@@ -1,0 +1,162 @@
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic pins for issue #1128 — a recursive delete that hits a permission denial
+/// left the subtree HALF-DELETED (`[DeleteNode] unexpected path=Instances partial-deleted=31`)
+/// instead of being refused atomically up front. Two mechanisms are pinned:
+/// <list type="number">
+/// <item><description><b>Descendant denial is atomic and legible.</b> A caller who holds
+/// Delete on the subtree root but is DENIED on a descendant scope gets a structured
+/// <see cref="NodeDeletionRejectionReason.Unauthorized"/> response naming the denied path,
+/// decided by the pre-flight (<c>ValidateDeleteRequest</c>'s <c>[RequiresPermission(Delete)]</c>
+/// delivery gate) BEFORE any storage mutation — nothing is deleted, no DeliveryFailure
+/// escapes as an "unexpected" error.</description></item>
+/// <item><description><b>No mid-commit self-revocation.</b> The recursive-delete plan
+/// contains the subtree's own <c>_Access</c> grant satellites — the very nodes that
+/// authorize the caller. The bottom-up fan-out used to delete them early and then re-check
+/// the CALLER's permission at every remaining leaf, so the cascade revoked its own
+/// authorization and aborted half-done (the incident's <c>partial-deleted=31</c>). The
+/// commit of a fully-authorized cascade now runs under the system identity: it either
+/// refuses up front or completes fully.</description></item>
+/// </list>
+/// Post-delete assertions go against STORAGE (adapter reads / descendant enumeration, below
+/// the security layer), never the eventually-consistent query catalog.
+/// </summary>
+public class RecursiveDeletePermissionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Carol = "carol-1128";
+
+    private IMessageHub Client => _client ??= GetClient();
+    private IMessageHub? _client;
+
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    /// <summary>
+    /// No root-level Public→Admin — permission denials must be observable. The DevLogin
+    /// admin gets an explicit root grant via <see cref="SetupAccessRightsAsync"/>.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
+
+    protected override async Task SetupAccessRightsAsync()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService.CreateNode(AssignmentNodeFactory.UserRole(TestUsers.Admin.ObjectId, "Admin", null))
+            .Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>A dedicated client hub running under Carol's (non-admin) identity.</summary>
+    private IMessageHub CarolClient()
+    {
+        var client = GetClient();
+        client.ServiceProvider.GetRequiredService<AccessService>()
+            .SetCircuitContext(new AccessContext { ObjectId = Carol, Name = Carol, Roles = [] });
+        return client;
+    }
+
+    // ─── 1. Denied on a descendant → atomic, legible Unauthorized; NOTHING deleted ───
+
+    [Fact(Timeout = 30_000)]
+    public async Task RecursiveDelete_DeniedOnDescendant_RefusedAtomically_NothingDeleted()
+    {
+        var space = $"{TestPartition}/permspace";
+        await NodeFactory.CreateNode(new MeshNode("permspace", TestPartition)
+        { Name = "Space", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("keep", space)
+        { Name = "Keep", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("protected", space)
+        { Name = "Protected", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("inner", $"{space}/protected")
+        { Name = "Inner", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        // Carol: Admin on the space — but explicitly DENIED on the 'protected' descendant
+        // scope (the incident shape: Delete on `Instances`, denied on `Instances/Deployment`).
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(Carol, "Admin", space))
+            .Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(Carol, "Admin", $"{space}/protected", denied: true))
+            .Should().Within(30.Seconds()).Emit();
+
+        // Wait until both grants are visible to the live permission fold — the same fold
+        // every delivery gate reads — so the delete below races nothing.
+        await Mesh.GetEffectivePermissions(space, Carol)
+            .Should().Within(30.Seconds()).Match(p => p.HasFlag(Permission.Delete));
+        await Mesh.GetEffectivePermissions($"{space}/protected", Carol)
+            .Should().Within(30.Seconds()).Match(p => !p.HasFlag(Permission.Delete));
+
+        var response = (await CarolClient()
+            .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
+                o => o.WithTarget(new Address(space)))
+            .Should().Within(30.Seconds()).Emit()).Message;
+
+        // A structured response — NOT a DeliveryFailureException — with the real reason.
+        response.Success.Should().BeFalse(
+            "carol lacks Delete on a descendant, so the WHOLE recursive delete must be refused");
+        response.RejectionReason.Should().Be(NodeDeletionRejectionReason.Unauthorized,
+            $"a permission denial must surface as Unauthorized, got: {response.Error}");
+        response.Error.Should().Contain("lacks Delete permission",
+            "the denial must be legible, naming the missing permission");
+        response.Error.Should().Contain($"{space}/protected",
+            "the denial must name the denied path");
+
+        // ATOMIC: storage-authoritative — nothing was deleted before the denial.
+        var options = Client.JsonSerializerOptions;
+        (await Storage.Read(space, options).Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull("the root must survive a denied delete");
+        (await Storage.Read($"{space}/keep", options).Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull("no sibling may be deleted before the denial is decided");
+        (await Storage.Read($"{space}/protected", options).Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull("the denied node must survive");
+        (await Storage.Read($"{space}/protected/inner", options).Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull("descendants of the denied node must survive");
+    }
+
+    // ─── 2. Plan contains the caller's own _Access grant → completes fully ───
+
+    [Fact(Timeout = 30_000)]
+    public async Task RecursiveDelete_PlanContainsCallersOwnAccessGrant_CompletesFully()
+    {
+        var space = $"{TestPartition}/revospace";
+        await NodeFactory.CreateNode(new MeshNode("revospace", TestPartition)
+        { Name = "Space", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("a", space)
+        { Name = "A", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("b", $"{space}/a")
+        { Name = "B", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("deep", $"{space}/a/b")
+        { Name = "Deep", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        // Carol's ONLY Delete authorization lives INSIDE the subtree being deleted:
+        // {space}/_Access/… is part of the recursive-delete plan. Pre-#1128, the bottom-up
+        // fan-out deleted that grant mid-commit, every later per-leaf permission re-check
+        // denied the caller, and the operation aborted with part of the tree gone.
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(Carol, "Admin", space))
+            .Should().Within(30.Seconds()).Emit();
+        await Mesh.GetEffectivePermissions(space, Carol)
+            .Should().Within(30.Seconds()).Match(p => p.HasFlag(Permission.Delete));
+
+        var response = (await CarolClient()
+            .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
+                o => o.WithTarget(new Address(space)))
+            .Should().Within(30.Seconds()).Emit()).Message;
+
+        response.Success.Should().BeTrue(
+            "the cascade was fully authorized up front; deleting the caller's own _Access grant "
+            + $"mid-commit must not abort it half-done (issue #1128) — got: {response.Error}");
+
+        // AUTHORITATIVE: the whole subtree — grant satellite included — is gone.
+        var survivors = await Storage.ListDescendantPaths(space).Should().Within(30.Seconds()).Emit();
+        survivors.Should().BeEmpty(
+            $"an authorized recursive delete must drain the subtree; still present: {string.Join(", ", survivors)}");
+        (await Storage.Read(space, Client.JsonSerializerOptions).Should().Within(30.Seconds()).Emit())
+            .Should().BeNull("the root must be deleted");
+    }
+}


### PR DESCRIPTION
Fixes #1128

## What was happening

A recursive `DeleteNodeRequest` on `Instances` aborted with `DeliveryFailureException: Access denied: user 'rbuergi' lacks Delete permission on 'Instances/Deployment'` **after 31 descendants were already deleted**, and the handler logged the denial as `[DeleteNode] unexpected path=Instances partial-deleted=31`.

## Root cause — measured order

The pipeline already decides a lot before mutating (root permission check → root validators → plan → per-descendant `ValidateDeleteRequest` pre-flight, which carries the same `[RequiresPermission(Delete)]` gate). The defect is that the **commit re-takes the authorization decision per-leaf, mid-mutation, against state the cascade itself is deleting**:

1. The deletion plan (authoritative storage enumeration, incl. satellite tables) contains the subtree's own `_Access` grant nodes — the very rows that authorize the caller.
2. The bottom-up fan-out (`Observable.Merge` over sibling branches) deletes those grants early.
3. The caller's effective Delete permission evaporates mid-commit; the next per-leaf `DeleteNodeRequest` is refused — by the delivery gate and/or by `RlsNodeValidator`, which derives its principal from the `DeletedBy` audit field.
4. The cascade aborts half-done (no rollback — actor model), and the error branch labels an expected permission denial "unexpected".

The 31 deleted nodes were physically removed from storage; there is no recycle path in this pipeline (recovery only via version history / point-in-time restore where PG backs the partition).

## Fix — decide once up front (caller), execute the decided cascade (system)

- **Atomic up-front denial, legible**: an Unauthorized refusal in the per-descendant pre-flight now aborts the whole operation **before any mutation** with `NodeDeletionRejectionReason.Unauthorized` and the gate's message naming the denied path (previously mislabelled `ValidationFailed`).
- **Commit immune to self-revocation**: `DeleteSubtreeUntilDrained` stamps the SYSTEM `AccessContext` on the per-leaf deletes. `DeletedBy` still carries the caller for audit; per-leaf validators still run.
- **`RlsNodeValidator`**: a cascade leg (`CascadeRootPath` set — only the fan-out stamps it) executed under the **delivery-stamped** system context acts as system instead of re-deciding authorization from `DeletedBy` mid-commit. Both signals are required, so the leaked ambient `system-security` AsyncLocal residue never matches — `DeletedBy` stays authoritative for every direct request (RlsIntegrationTests' shape unchanged, all 23 green).
- **Diagnostics name the real condition**: permission denial → Warning `[DeleteNode] permission-denied path=…`; a denial arriving with partial deletions stays a LOUD error canary (`permission-denied MID-COMMIT … N node(s) already deleted`); the response passes the legible "Access denied …" message through without the "Unexpected error:" prefix.

## Test evidence

New `RecursiveDeletePermissionTest` (MonolithMeshTestBase + per-user `SetCircuitContext`):

- `RecursiveDelete_DeniedOnDescendant_RefusedAtomically_NothingDeleted` — caller holds Delete on the root but is denied on a descendant scope → structured Unauthorized response naming the denied path; storage-authoritative assert that **nothing** was deleted.
- `RecursiveDelete_PlanContainsCallersOwnAccessGrant_CompletesFully` — the incident mechanism (caller's only grant inside the subtree). **Red before the fix** with the exact incident signature (`[DeleteNode] unexpected path=… partial-deleted=2`, mid-commit denial), green after.

Regression: `DeleteNodeBehaviorTest` + `RecursiveDeleteAuthoritativeTest` (13/13), `RlsIntegrationTests` (23/23), `PartitionRootDeletionGuardTest` (13/13), `MeshNodeAuditingTest` (3/3). Touched projects build clean with `-c Release -warnaserror`.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
