### PR TITLE
A scan that lost its load context bound the hub to nothing

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-no-longer-loses-its-views-to-a-rebuild-next-door.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-no-longer-loses-its-views-to-a-rebuild-next-door.md
@@ -1,0 +1,37 @@
+---
+Name: A page no longer loses its own views to a rebuild happening next door
+Category: Fix
+Description: A page could come up with only the generic menu — none of its own views — and stay that way, because it opened at the instant its code was being rebuilt.
+Icon: ArrowSync
+Order: -20260810
+---
+
+# A page no longer loses its own views to a rebuild happening next door
+
+A page whose behaviour comes from code you wrote could open showing only the
+generic node menu — none of the views that code defines — and reporting that the
+view you asked for could not be found. Reloading did not help. The page stayed
+that way until somebody restarted it by hand, even though the code it was missing
+had built perfectly well seconds earlier.
+
+## What was happening
+
+A page works out which code serves it exactly once, when it first opens. That
+lookup reads the compiled result of your code.
+
+Rebuilds swap that compiled result out. If a page happened to open in the instant a
+rebuild was swapping — and a rebuild can be triggered by something entirely
+unrelated to that page — the lookup found itself reading a result that was being
+retired underneath it. Instead of looking again at the current one, it gave up and
+reported that your code defines no views at all.
+
+That answer was then treated as the truth. The page bound itself to the generic
+defaults, and because the lookup only ever happens once, it kept them for as long
+as it stayed open.
+
+## What changed
+
+A lookup that finds itself reading a result being retired now simply looks again at
+the current one, which is what it should have done all along. The rebuild next door
+no longer costs a page its own views, and a page that opens during one comes up
+complete.

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -195,11 +195,51 @@ internal interface ICompilationCacheService
     NodeAssemblyLoadContext GetOrCreateLoadContextForPath(string nodeName, string dllPath);
 
     /// <summary>
+    /// Resolves a LIVE context for a scan and returns it already pinned — the atomic form of
+    /// "GetOrCreateLoadContext… then <see cref="NodeAssemblyLoadContext.Pin"/>".
+    /// <para>🚨 Resolve-then-Pin as two steps is a RACE, and losing it silently mis-binds a hub
+    /// for its whole lifetime. A concurrent recompile evicts the superseded context
+    /// (<c>EvictSupersededContexts</c> → <c>UnloadContext</c>) between the caller's resolve and
+    /// its pin, so the pin throws <see cref="ObjectDisposedException"/> on a reference that was
+    /// live one instruction earlier. <see cref="NodeAssemblyLoadContext.Pin"/> documents the
+    /// answer — "the caller must then re-resolve against the current context rather than scan a
+    /// doomed assembly" — but no caller implemented it, and the swallow downstream turned a
+    /// transient supersession into an authoritative EMPTY configuration list (issue #1151:
+    /// the freshly installed root hub bound the mesh defaults and served "Area not found" for
+    /// good, because a hub resolves its configuration exactly once, at activation).</para>
+    /// <para>Only this service can close that window: it owns the dictionary, so it is the only
+    /// component that can re-resolve. The loop terminates because the evictor removes the key
+    /// BEFORE disposing, so the next resolve constructs a fresh context.</para>
+    /// </summary>
+    PinnedScanContext PinForScan(string nodeName, string? dllPath);
+
+    /// <summary>
+    /// <see cref="PinForScan(string, string?)"/> for a release-keyed context.
+    /// </summary>
+    PinnedScanContext PinForScanOfRelease(NodeTypeRelease release, string releaseFolder);
+
+    /// <summary>
     /// Registers NuGet probing directories for a node. The node's AssemblyLoadContext
     /// consults these directories during Resolving events so transitive dependencies
     /// of resolved NuGet packages can be loaded at runtime.
     /// </summary>
     void RegisterProbingDirectories(string nodeName, System.Collections.Generic.IReadOnlyList<string> directories);
+}
+
+/// <summary>
+/// A load context together with the scan pin held on it: guaranteed live at the moment it was
+/// handed out, and kept un-unloadable until this handle is disposed. ALWAYS use in a
+/// <c>using</c> — the pin is what makes <c>Dispose</c>/<c>Unload</c> wait rather than tear the
+/// collectible LoaderAllocator out mid-metadata-resolution.
+/// </summary>
+internal readonly struct PinnedScanContext(NodeAssemblyLoadContext context, IDisposable pin)
+    : IDisposable
+{
+    /// <summary>The live, pinned context.</summary>
+    public NodeAssemblyLoadContext Context { get; } = context;
+
+    /// <summary>Releases the scan pin.</summary>
+    public void Dispose() => pin.Dispose();
 }
 
 /// <summary>
@@ -901,6 +941,58 @@ internal class CompilationCacheService(
             EvictSupersededContexts(nodeName, keepKey: dllPath);
 
         return ctx;
+    }
+
+    /// <summary>
+    /// How many times <see cref="PinForScan"/> re-resolves before giving up. One re-resolve is
+    /// enough for a single eviction; the extra attempts cover a burst of recompiles landing back
+    /// to back. Exhaustion rethrows, so a genuinely dying cache still surfaces rather than spins.
+    /// </summary>
+    private const int ScanPinReResolveAttempts = 3;
+
+    /// <inheritdoc />
+    public PinnedScanContext PinForScan(string nodeName, string? dllPath)
+        => PinResolved(
+            cacheKey: string.IsNullOrEmpty(dllPath) ? nodeName : dllPath!,
+            resolve: () => string.IsNullOrEmpty(dllPath)
+                ? GetOrCreateLoadContext(nodeName)
+                : GetOrCreateLoadContextForPath(nodeName, dllPath!));
+
+    /// <inheritdoc />
+    public PinnedScanContext PinForScanOfRelease(NodeTypeRelease release, string releaseFolder)
+        => PinResolved(
+            // Same key GetOrCreateLoadContextForRelease adds under.
+            cacheKey: release.Path,
+            resolve: () => GetOrCreateLoadContextForRelease(release, releaseFolder));
+
+    /// <summary>
+    /// Resolve → Pin as ONE operation, re-resolving when the context we resolved is already
+    /// unloading. See <see cref="ICompilationCacheService.PinForScan"/> for why two steps is a
+    /// race and why losing it is not survivable downstream.
+    /// </summary>
+    private PinnedScanContext PinResolved(string cacheKey, Func<NodeAssemblyLoadContext> resolve)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            var context = resolve();
+            try
+            {
+                return new PinnedScanContext(context, context.Pin());
+            }
+            catch (ObjectDisposedException) when (attempt < ScanPinReResolveAttempts)
+            {
+                // Drop THIS instance if it is still the dictionary's value. The evictor removes
+                // before it disposes, so normally the key is already gone and the next resolve
+                // builds a fresh context — but the remove-less order must not be able to hand the
+                // same doomed context back, or this loop would spin instead of terminate.
+                _loadContexts.TryRemove(
+                    new KeyValuePair<string, NodeAssemblyLoadContext>(cacheKey, context));
+                logger.LogDebug(
+                    "Scan pin lost the race with an eviction of {CacheKey} (attempt {Attempt}) — "
+                    + "re-resolving against the current context",
+                    cacheKey, attempt);
+            }
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1490,12 +1490,23 @@ internal class MeshNodeCompilationService(
                 // while we reflect over its assembly, or the scan faults with
                 // "TypeLoadException: could not load type '…MeshNodeProviderAttribute' … because the
                 // format is invalid" (the flaky Orleans dynamic-compilation race). The pin releases
-                // when this method returns; Dispose() drains pins before Unload(). Pin throws if the
-                // context is already unloading → the catch below records it as a load miss (retryable).
-                var context = assemblyLocation.StartsWith("memory://", StringComparison.Ordinal)
-                    ? cacheService.GetOrCreateLoadContext(nodeName)
-                    : cacheService.GetOrCreateLoadContextForPath(nodeName, assemblyLocation);
-                using var scanPin = context.Pin();
+                // when this method returns; Dispose() drains pins before Unload().
+                //
+                // 🚨 Resolve and pin as ONE operation (PinForScan), never as two statements. This
+                // used to resolve the context, then pin it — and an eviction landing in between
+                // (a concurrent recompile superseding this assembly) made the pin throw on a
+                // reference that was live one instruction earlier. The catch below then recorded
+                // an EMPTY configuration list, which the per-instance activation path reads as
+                // authoritative: the hub binds the mesh defaults and, because a hub resolves its
+                // configuration exactly once at activation, serves "Area not found" for its whole
+                // lifetime. That is #1151's residual — a freshly installed package's root left
+                // without its own type's areas by a recompile it merely ran next to.
+                using var pinned = cacheService.PinForScan(
+                    nodeName,
+                    assemblyLocation.StartsWith("memory://", StringComparison.Ordinal)
+                        ? null
+                        : assemblyLocation);
+                var context = pinned.Context;
                 var assembly = context.LoadNodeAssembly();
                 if (assembly == null)
                 {
@@ -2132,8 +2143,11 @@ internal class MeshNodeCompilationService(
             // PIN across load + the GetTypes/MeshNodeProviderAttribute scan below — same
             // unload-during-scan race as CompileResultFromAssembly (TypeLoadException 'format is
             // invalid'). Released when the method returns; Dispose() drains pins before Unload().
-            var context = cacheService.GetOrCreateLoadContextForRelease(release, releaseFolder);
-            using var scanPin = context.Pin();
+            // Resolve+pin is ONE operation for the reason spelled out there: an eviction landing
+            // between the two steps otherwise yields an empty configuration list that reads as
+            // authoritative (#1151).
+            using var pinned = cacheService.PinForScanOfRelease(release, releaseFolder);
+            var context = pinned.Context;
             var assembly = context.LoadNodeAssembly();
             if (assembly == null)
             {

--- a/test/MeshWeaver.Graph.Test/ScanPinSupersessionTest.cs
+++ b/test/MeshWeaver.Graph.Test/ScanPinSupersessionTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The resolve-then-pin race, and why losing it is not survivable downstream (issue #1151).
+///
+/// <para>Every scan of a dynamically compiled NodeType assembly (the <c>GetTypes</c> +
+/// <c>MeshNodeProviderAttribute</c> reflection that recovers a NodeType's
+/// <c>HubConfiguration</c>) has to hold a <see cref="NodeAssemblyLoadContext"/> pin, so a
+/// concurrent recompile cannot unload the collectible LoaderAllocator mid-metadata-resolution.
+/// The scan sites used to do that in TWO statements — resolve the context, then pin it — and a
+/// recompile landing in between disposes the very context the reader just resolved
+/// (<c>GetOrCreateLoadContextForPath</c> → <c>EvictSupersededContexts</c> →
+/// <c>UnloadContext</c>). The pin then throws on a reference that was live one instruction
+/// earlier.</para>
+///
+/// <para>That is a transient supersession, not a broken assembly, and
+/// <see cref="NodeAssemblyLoadContext.Pin"/> says so in its own contract: <i>"the caller must
+/// then re-resolve against the current context rather than scan a doomed assembly"</i>. No
+/// caller implemented it. The swallow downstream turned it into an EMPTY configuration list
+/// that the per-instance activation path reads as authoritative — the hub binds the mesh
+/// defaults, and because a hub resolves its configuration exactly once at activation it serves
+/// "Area not found" for its whole lifetime. On CI that is a freshly installed package whose
+/// root never serves its own type's areas, purely because a recompile ran next to it.</para>
+/// </summary>
+public sealed class ScanPinSupersessionTest : IDisposable
+{
+    private const string NodeName = "Shop_Front";
+
+    private readonly string _cacheDir;
+    private readonly CompilationCacheService _service;
+
+    public ScanPinSupersessionTest()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), $"scan-pin-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_cacheDir);
+        _service = new CompilationCacheService(
+            Options.Create(new CompilationCacheOptions
+            {
+                CacheDirectory = _cacheDir,
+                EnableCompilationCache = true,
+            }),
+            NullLogger<CompilationCacheService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { _service.Dispose(); } catch { /* idempotent */ }
+        try { Directory.Delete(_cacheDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// The production trigger, reproduced exactly: a second compile registers its own
+    /// path-keyed context, which evicts and DISPOSES the one a concurrent reader already
+    /// resolved. This is the state the reader is left holding — asserted here so the fix below
+    /// is pinned against a race that genuinely happens, not a hypothetical one.
+    /// </summary>
+    [Fact]
+    public void ARecompileDoomsTheContextAConcurrentReaderAlreadyResolved()
+    {
+        var first = EmitAssembly("v3");
+        var second = EmitAssembly("v8");
+
+        // The reader resolves — exactly what a per-instance hub activation does when it hydrates
+        // configurations from the NodeType's current LatestAssemblyPath.
+        var readersContext = _service.GetOrCreateLoadContextForPath(NodeName, first);
+        readersContext.IsDisposed.Should().BeFalse();
+
+        // …and the recompile lands, superseding it.
+        _service.GetOrCreateLoadContextForPath(NodeName, second);
+
+        readersContext.IsDisposed.Should().BeTrue(
+            "a fresh path-keyed context for the same NodeType evicts every superseded one — "
+            + "that eviction is what makes the reader's already-resolved reference doomed");
+        Assert.Throws<ObjectDisposedException>(() => readersContext.Pin());
+    }
+
+    /// <summary>
+    /// The contract: resolving and pinning as ONE operation survives the supersession above.
+    /// <c>PinForScan</c> re-resolves against the current context — the assembly still loads and
+    /// the scan still sees its types, so the hub binds its own configuration instead of the
+    /// mesh defaults.
+    /// </summary>
+    [Fact]
+    public void PinForScan_SurvivesARecompileSupersedingTheAssembly()
+    {
+        var first = EmitAssembly("v3");
+        var second = EmitAssembly("v8");
+
+        _service.GetOrCreateLoadContextForPath(NodeName, first);
+        _service.GetOrCreateLoadContextForPath(NodeName, second);   // evicts + disposes the first
+
+        // The reader now asks for the assembly the NodeType still points at. Resolve-then-pin
+        // would hand back the doomed context above; PinForScan must not.
+        using var pinned = _service.PinForScan(NodeName, first);
+
+        pinned.Context.IsDisposed.Should().BeFalse(
+            "a scan pin must never be handed a context that is already unloading");
+        pinned.Context.LoadNodeAssembly().Should().NotBeNull(
+            "the assembly on disk is intact — only the context that had loaded it was superseded");
+    }
+
+    /// <summary>
+    /// The harder ordering, and the reason the re-resolve terminates rather than spins: a
+    /// context that was disposed while STILL the dictionary's value must be replaced, not
+    /// returned again. Eviction removes before it disposes, so production does not reach this
+    /// state today — but the loop's termination must not depend on that.
+    /// </summary>
+    [Fact]
+    public void PinForScan_ReplacesADisposedContextLeftInTheCache()
+    {
+        var dll = EmitAssembly("v3");
+
+        var stale = _service.GetOrCreateLoadContextForPath(NodeName, dll);
+        stale.Dispose();                                   // disposed, key left in place
+        _service.GetOrCreateLoadContextForPath(NodeName, dll).Should().BeSameAs(stale,
+            "the cache still holds the disposed instance — this is the state under test");
+
+        using var pinned = _service.PinForScan(NodeName, dll);
+
+        pinned.Context.Should().NotBeSameAs(stale);
+        pinned.Context.IsDisposed.Should().BeFalse();
+        pinned.Context.LoadNodeAssembly().Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Emits a real, loadable assembly into its own release-shaped subdirectory, mirroring the
+    /// one-directory-per-compile layout <c>EmitToDiskWithRetry</c> produces (which is why each
+    /// recompile yields a NEW path key and evicts the previous one).
+    /// </summary>
+    private string EmitAssembly(string version)
+    {
+        var folder = Path.Combine(_cacheDir, $"{NodeName}_{version}");
+        Directory.CreateDirectory(folder);
+        var dllPath = Path.Combine(folder, $"{NodeName}.dll");
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: $"DynamicNode_{NodeName}_{version}",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(
+                "public sealed class FrontContent { public int Answer() => 42; }")],
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var result = compilation.Emit(dllPath);
+        result.Success.Should().BeTrue(
+            string.Join("; ", result.Diagnostics.Select(d => d.ToString())));
+        return dllPath;
+    }
+}


### PR DESCRIPTION
**Not a fix for the main red — that is gone (#1153).** This is a *third*, independent
failure mode on the same `StaleStampRootBindingTest` cluster, captured on CI and fixed at
its root. It is orthogonal to both #1153 (installer teardown outliving the install) and
#1163 (a raced subscribe parking on an un-re-probed `ShuttingDown` NACK).

## The evidence

CI run [31404522444](https://github.com/Systemorph/MeshWeaver/actions/runs/31404522444),
shard 4, commit `169672e1`. The test does **not** time out — it completes in **831 ms** and
fails the *content* assertion:

```
[type +609ms] v6  Status=Ok       asm='ShopA_Front/v3-93d7ee2d-694c899111a5.dll'
rebuild settled at +609ms
[type +642ms] v7  Status=Pending
[type +643ms] v9  Status=Compiling
[Warning] Failed to extract NodeTypeConfigurations from …/v3-93d7ee2d-694c899111a5.dll:
    Cannot scan an assembly whose context is unloading
    Object name: 'DynamicNode_ShopA_Front'
    at NodeAssemblyLoadContext.Pin()  … at MeshNodeCompilationService.CompileResultFromAssembly
[type +697ms] v10 Status=Ok       asm='ShopA_Front/v8-93d7ee2d-694c899111a5.dll'
Tests frame at +831ms:  … Area not found
    at StaleStampRootBindingTest.cs(319)  — NotContain("Area not found")
```

Note the two assembly names: `v3-93d7ee2d-694c899111a5` and `v8-93d7ee2d-694c899111a5` —
**same framework hash, same source hash**. A byte-identical recompile is what evicted the
load context out from under a concurrent reader.

## The defect

A per-instance hub activation hydrates its NodeType's `HubConfiguration` by reflecting over
the compiled assembly (`GetConfigurationsFromExistingAssembly` →
`CompileResultFromAssembly`). Both scan sites resolved the load context and pinned it as
**two statements**:

```csharp
var context = cacheService.GetOrCreateLoadContextForPath(nodeName, assemblyLocation);
using var scanPin = context.Pin();
```

A recompile landing in between registers its own path-keyed context, and
`EvictSupersededContexts` → `UnloadContext` disposes every superseded one — including the
reference the reader had *just* resolved. The pin then throws on a context that was live one
instruction earlier.

`Pin()` documents exactly what to do about that, in its own XML doc:

> Throws `ObjectDisposedException` if the context is already unloading — **the caller must
> then re-resolve against the current context** rather than scan a doomed assembly.

Neither caller implemented it. The `catch` below recorded an **empty configuration list**
instead, and the activation path reads that as authoritative: no matching configuration →
`ApplyEntry(…, hubConfig: null)` → the hub binds the mesh defaults. A hub resolves its
configuration exactly once, at activation, so the freshly installed root then serves
"Area not found" **for its whole lifetime** — from a rebuild it merely ran next to. The
neighbouring branch in `NodeTypeEnrichmentHelpers` already calls this outcome out by name as
"the silent default-config fallback … cached for the grain's lifetime".

## The fix

Resolve and pin become **one** operation, `ICompilationCacheService.PinForScan`. The cache
service owns it because it owns `_loadContexts` — it is the only component that *can*
re-resolve. Both scan sites go through it, so two readers racing each other's evictions
both converge instead of both failing.

It terminates rather than spins: the evictor removes the key **before** it disposes, so the
next resolve constructs a fresh context; the defensive `TryRemove` covers the remove-less
ordering so the loop can never be handed the same doomed context twice. Exhaustion rethrows,
so a genuinely dying cache still surfaces.

## Verification

- `ScanPinSupersessionTest` (new, deterministic, dependency-free) pins three facts: a
  recompile really does doom a concurrent reader's already-resolved context (the
  precondition, asserted so the fix is pinned against a race that happens); `PinForScan`
  survives it; and a disposed context left in the cache is replaced rather than returned.
  **3/3 in 346 ms.**
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph` + `MeshWeaver.Graph.Test`.
- `MeshWeaver.PluginCatalog.Test`, `DOTNET_PROCESSOR_COUNT=4`, Release — reported in full because
  one run was red and the number matters:

  | tree | result |
  |---|---|
  | #1159's tree + this fix | 236/236, 1 m 21 s |
  | `origin/main` (0e4cc931) + this fix | **235/1**, 2 m 1 s |
  | `origin/main` (0e4cc931) alone | 236/236, 1 m 22 s |

  The red is **`SelfTypedRootWhoseTypeNeverCompiles_SkipsThePublishPromptly`** — a different test
  from the one this PR is about — and it is the pre-existing installer flake, not this change:

  - **This change is not on that test's code path.** ShopC's type never compiles, so
    `assemblyLocation` is empty and `CompileAndGetConfigurations` takes the
    `BuildFailureDiagnostics` branch, never reaching `CompileResultFromAssembly`. Its
    `HasUsableBuild` is false (the committed stamp carries a stale framework hash), so the
    hydration path never calls `GetConfigurationsFromExistingAssembly` either, and nothing emits,
    so `LoadAndExtractConfigurationsFromReleaseAsync` never runs. **Neither of the two call sites
    this PR touches executes for that test.**
  - #1163 independently measured this class at **2 of 5 class runs red** on `origin/main + #1153`.
    A single green baseline run is exactly what a 3-in-5 green rate produces, so it exonerates
    nothing by itself — the mechanism argument above is the load-bearing one.
  - The failure's own shape puts it in the installer: the log goes silent from **+2.3 s** (the
    expected `CS0103` compile failure for `ShopC/Front`) to **+30.2 s**, then an Rx
    `TimeoutException: The operation has timed out.` surfaces at `Install`. 30 s is not the test's
    own bound (`StepTimeout` is 120 s) — `PackageInstaller` has several uncaught
    `.Timeout(TimeSpan.FromSeconds(30))` (lines 465, 561, 1544, 1680, 1702, 1965), one of which
    fired. Handed to the installer cluster rather than guessed at here.

## Triage discriminator for the next red of this test

Three modes, told apart on sight:

| Fails at | Signature | Owner |
|---|---|---|
| ~60 s, on the **install** | reply died with a hub torn down mid-handler | #1153 (merged) |
| ~120 s, on the **frame wait** | `TimeoutException`, subscribe parked on an un-re-probed `ShuttingDown` NACK | #1163 |
| **< 1 s**, at `StaleStampRootBindingTest.cs:319` | `NotContain("Area not found")` + log carries `Cannot scan an assembly whose context is unloading` | **this PR** |

#1163's re-probe does not cover this one: a re-probe reactivates the owner, but if that
reactivation's configuration lookup hits an unloading context again it binds the defaults
again and answers *promptly* with the wrong content. If anything the re-probe schedules the
reactivation closer to the rebuild, so the two changes are complementary.

## Named, deliberately deferred

- **`EvictSupersededContexts` ping-pong.** Two readers on different assembly paths of the
  same NodeType each evict the other on registration. Bounded and convergent with this fix,
  but it is avoidable churn (an ALC re-created and re-loaded per hydration of a superseded
  path). Not touched here — narrowing it would only make the race rarer, which is not a fix.
- **The redundant recompile itself.** The second compile had an identical framework hash
  *and* source hash; `CompiledSources` keys on `LastModifiedTicks`, not content. Skipping it
  would shrink this window, but again only rarer, not gone — a real source edit produces the
  same eviction.
- **The silent default-binding still has no self-heal.** With this fix the scan no longer
  fails for supersession, but a genuine reflection failure (missing dependency) still lands
  on `ApplyEntry(hubConfig: null)` with no overlay and no `WithOverlaySelfHeal`, unlike its
  sibling byte-resolution branch — which the sibling's own comment says is mandatory-gated.
  Getting that version gate subtly wrong hot-loops a recycle, so it is not being done
  alongside a fix that already stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
