### PR TITLE
Background services ran their work on the mesh router — issue it off-router

### DIFF
--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
@@ -59,7 +59,10 @@ public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
 
         // Cold: the side effect runs on Subscribe (driven by ContentIndexingService.WriteDocumentBranch).
         // FirstAsync() completes after the single response; map to Unit per the IDocumentSink contract.
-        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+        // Off-router issuing: the indexing pipeline can hold the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
+        return hub.NodeOperationIssuingHub()
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
             .FirstAsync()
             .SelectMany(delivery =>
             {

--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -284,7 +284,12 @@ public sealed class ContentImportBuilder
         // Typed request-response: pre-registers the response callback by message-id BEFORE posting
         // (canonical hub.Observe<TResponse> idiom) — no manual Post returning a nullable delivery.
         // Wrapped in Defer so the post still happens on Subscribe (cold), as before.
-        return Observable.Defer(() => _hub
+        // 🚨 Issued off the router: mesh-singleton callers (the plugin default-install seed) hold
+        // the DI root mesh hub, and an ImportContentRequest posted there addresses its response
+        // straight back at mesh/{id} — the production ROUTER_TRAFFIC line "ImportContentResponse
+        // has the mesh hub as target (sender: Agent…)". NodeOperationIssuingHub is a no-op for
+        // every non-router hub, so node/import/portal-hub callers are unchanged.
+        return Observable.Defer(() => _hub.NodeOperationIssuingHub()
             .Observe(request, o => o.WithTarget(address))
             .Select(d => d.Message)
             .Take(1));
@@ -368,7 +373,9 @@ public sealed class SyncContentFilesBuilder
             SourceOwnedPaths = _sourceOwnedPaths,
         };
         var address = new Address(_nodePath);
-        return Observable.Defer(() => _hub
+        // Off-router issuing, same reason as ContentImportBuilder.Post: the router must be neither
+        // end of the request/response pair (ROUTER_TRAFFIC); a non-router hub gets itself back.
+        return Observable.Defer(() => _hub.NodeOperationIssuingHub()
             .Observe(request, o => o.WithTarget(address))
             .Select(d => d.Message)
             .Take(1));

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-router-stays-a-router.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-router-stays-a-router.md
@@ -1,0 +1,19 @@
+---
+Name: Background services no longer run their work on the mesh router
+Category: Fix
+Description: Plugin installs, log-incident filing and one-shot node reads now run on a dedicated work hub instead of the mesh router, keeping routing responsive and removing a steady stream of router-traffic error logs.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Background services no longer run their work on the mesh router
+
+The mesh router's only job is to route messages — but several background services (the plugin
+default-install seed, log-incident filing, GitHub sync writes, and one-shot node reads) were
+issuing their work directly on it. Every such operation competed with routing itself and produced
+a steady stream of router-traffic error logs (hundreds per day on a busy portal).
+
+All of these now issue their work on the dedicated off-router work hub, so routing stays
+responsive under load and the error stream disappears. The router-traffic detector also no longer
+flags the router's own undeliverable-message notices, so the remaining reports point at genuine
+problems only.

--- a/src/MeshWeaver.GitSync/GitHubCredentialService.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredentialService.cs
@@ -70,7 +70,10 @@ public sealed class GitHubCredentialService(IMeshService meshService, IMessageHu
         logger?.LogInformation("Saving GitHub credential for {User} (login={Login}, keyFp={Fp})",
             userId, gitHubLogin, Fingerprint(token.AccessToken));
 
-        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+        // Off-router issuing: this service holds the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
+        return hub.NodeOperationIssuingHub()
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
             .FirstAsync()
             .Select(d => d.Message)
             .SelectMany(resp => resp.Success

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -840,7 +840,9 @@ public sealed class GitHubSyncService
         };
         // Carry the caller's identity (captured in UpdateConfig before the async ReadConfig hop) on
         // the create — otherwise RLS denies Create on {space}/_GitSync when the AsyncLocal is gone.
-        return hub.Observe<CreateOrUpdateNodeResponse>(
+        // Off-router issuing (NodeOperationIssuingHub): the DI root mesh hub must be neither end
+        // of the exchange, nor execute the target-less request (ROUTER_TRAFFIC).
+        return hub.NodeOperationIssuingHub().Observe<CreateOrUpdateNodeResponse>(
                 new CreateOrUpdateNodeRequest(node),
                 o => ctx is null ? o : o.WithAccessContext(ctx))
             .FirstAsync()

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -420,9 +420,12 @@ public sealed class GitHubWebhookProcessor
             repoUrl, completion.Branch, headSha, completion.WorkflowName, completion.RunNumber, path);
 
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // Off-router issuing: the webhook processor holds the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
-                _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
+                _ => hub.NodeOperationIssuingHub()
+                    .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
             .SelectMany(d =>
             {
                 if (!d.Message.Success)
@@ -490,9 +493,11 @@ public sealed class GitHubWebhookProcessor
                 Content = merged,
             };
             var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+            // Off-router issuing — same reason as RecordBuildCompletion above.
             return Observable.Using(
                     () => accessService.ImpersonateAsSystem(),
-                    _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
+                    _ => hub.NodeOperationIssuingHub()
+                        .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
                 .SelectMany(d => d.Message.Success
                     ? Observable.Return(d.Message.Node ?? node)
                     : Observable.Throw<MeshNode>(new InvalidOperationException(

--- a/src/MeshWeaver.GitSync/IssueService.cs
+++ b/src/MeshWeaver.GitSync/IssueService.cs
@@ -184,7 +184,10 @@ public sealed class IssueService
         // The write runs as the calling user: AccessContext is an AsyncLocal that ExecutionContext
         // carries across the IoPool's ConfigureAwait(false) hops, so it is still set here even after
         // the repoClient round-trip. Return the server-reconciled node (version/normalization) on success.
-        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+        // Off-router issuing: this service holds the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
+        return hub.NodeOperationIssuingHub()
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
             .FirstAsync()
             .Select(d => d.Message)
             .SelectMany(resp => resp.Success

--- a/src/MeshWeaver.Hosting/MeshService.cs
+++ b/src/MeshWeaver.Hosting/MeshService.cs
@@ -67,10 +67,7 @@ internal sealed class MeshService(
     /// this scoped service's lifetime.</para>
     /// </summary>
     private IMessageHub? _issuingHub;
-    private IMessageHub IssuingHub => _issuingHub ??=
-        string.Equals(hub.Address.Type, AddressExtensions.MeshType, StringComparison.Ordinal)
-            ? hub.NodeOperationExecutionHub() ?? hub
-            : hub;
+    private IMessageHub IssuingHub => _issuingHub ??= hub.NodeOperationIssuingHub();
 
     /// <summary>
     /// Per-call timeout ceiling. Every CRUD observable is bounded by this so a lost response

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -463,9 +463,12 @@ public sealed class InstanceSyncWorker : IDisposable
     private IObservable<MeshNode> ApplyLocal(MeshNode payload)
     {
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // Off-router issuing: this worker holds the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
-                _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(payload)).FirstAsync())
+                _ => hub.NodeOperationIssuingHub()
+                    .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(payload)).FirstAsync())
             .SelectMany(d => d.Message.Success
                 ? Observable.Return(d.Message.Node!)
                 : Observable.Throw<MeshNode>(new InvalidOperationException(

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -320,6 +320,39 @@ public static class MeshExtensions
         => hub.NodeOperationExecutionHub()?.Address ?? hub.GetMeshHub().Address;
 
     /// <summary>
+    /// The hub a node-operation request/response exchange should be ISSUED ON. The caller's own hub
+    /// — except when that hub is the ROOT MESH HUB, the mesh's ROUTER: a request posted there makes
+    /// the router an END of the delivery in both directions (the request goes out stamped
+    /// <c>Sender = mesh/{id}</c> and its response is addressed straight back at <c>mesh/{id}</c>),
+    /// which is exactly what the <c>ROUTER_TRAFFIC</c> detector reports — and, for a target-less
+    /// request, EXECUTES the work on the router's single-threaded action block, starving the
+    /// routing it exists to do.
+    ///
+    /// <para>This is the one shared seam for every mesh-singleton service that takes the DI-injected
+    /// <see cref="IMessageHub"/> (which in the mesh's root container IS the router) and issues
+    /// request/response work on it: the plugin-catalog boot services, the log-incident ingest, the
+    /// content importers, one-shot <c>GetMeshNode</c> reads. They all hop onto
+    /// <see cref="NodeOperationExecutionHub"/> — the mesh's dedicated off-router execution hub,
+    /// routing-registered so responses land on it cross-silo, sharing the mesh's type registry and
+    /// permission evaluator. For any hub that is NOT the router this returns the hub unchanged, so
+    /// portal/session/import-hub callers keep their identity byte-for-byte.</para>
+    ///
+    /// <para>Identity is unaffected: the ambient <c>AccessService</c> is the mesh-wide singleton
+    /// every hosted hub's provider chains to, so an <c>ImpersonateAsSystem</c> (or any ambient
+    /// context) active at Subscribe time is read identically by this hub's post pipeline.</para>
+    ///
+    /// <para>Falls back to the hub itself only while the mesh is tearing down
+    /// (<see cref="NodeOperationExecutionHub"/> returns <c>null</c>) — the historical behaviour, at
+    /// a point where the operation is being dropped anyway.</para>
+    /// </summary>
+    /// <param name="hub">The hub the caller holds — returned unchanged unless it is the root mesh hub.</param>
+    /// <returns>The off-router issuing hub.</returns>
+    public static IMessageHub NodeOperationIssuingHub(this IMessageHub hub) =>
+        string.Equals(hub.Address.Type, AddressExtensions.MeshType, StringComparison.Ordinal)
+            ? hub.NodeOperationExecutionHub() ?? hub
+            : hub;
+
+    /// <summary>
     /// Registers handlers for mesh node operations. Idempotent — calling twice on the
     /// same configuration is a no-op on the second call. Without this guard, every
     /// extra call would add a duplicate set of handlers; each delivery would invoke

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1432,7 +1432,9 @@ public static class MeshNodeStreamExtensions
     /// subscribed (no <c>.Take(1)</c>). See <c>Doc/Architecture/AsynchronousCalls.md</c>.
     /// </para>
     /// </summary>
-    /// <param name="hub">The hub that posts the read.</param>
+    /// <param name="hub">The hub the caller holds. When it is the ROOT MESH HUB (the router), the
+    /// read is issued on <see cref="MeshExtensions.NodeOperationIssuingHub"/> instead — the router
+    /// must be neither end of a delivery (ROUTER_TRAFFIC).</param>
     /// <param name="path">The mesh path to read.</param>
     /// <param name="timeout">Wall-clock budget for the read; defaults to 10 seconds.</param>
     /// <param name="onTimeout">
@@ -1447,6 +1449,16 @@ public static class MeshNodeStreamExtensions
         ReadTimeoutBehavior onTimeout = ReadTimeoutBehavior.Throw)
         => Observable.Create<MeshNode?>(observer =>
         {
+            // 🚨 Never issue the read on the ROOT MESH HUB — the router. Mesh-singleton services
+            // (plugin-catalog boot, log-incident ingest, credential resolvers) hold the DI-injected
+            // root hub, and a GetDataRequest posted there makes the router an END of the delivery in
+            // both directions: the request reaches the per-node hub stamped Sender = mesh/{id}, and
+            // the GetDataResponse (or, for a missing node, the DeliveryFailure) is addressed straight
+            // back at mesh/{id} — both exactly what the ROUTER_TRAFFIC detector reports (production
+            // 2026-08: "GetDataResponse has the mesh hub as target (sender: Hosting/_Access/…)" /
+            // "DeliveryFailure … (sender: Plugins/_DefaultInstallLedger)"). Same seam MeshService
+            // uses for CRUD; a non-router caller gets itself back, unchanged.
+            var issuingHub = hub.NodeOperationIssuingHub();
             var budget = timeout ?? TimeSpan.FromSeconds(10);
             var started = Stopwatch.StartNew();
             var cts = new CancellationTokenSource(budget);
@@ -1489,7 +1501,9 @@ public static class MeshNodeStreamExtensions
                 if (Volatile.Read(ref emitted) != 0) return;
                 var elapsed = started.Elapsed;
                 string diagnostics;
-                try { diagnostics = hub.GetPendingRequestDiagnostics(); }
+                // The pending-request snapshot must come from the ISSUING hub — that is where our
+                // GetDataRequest's callback is registered and where a lost reply shows as pending.
+                try { diagnostics = issuingHub.GetPendingRequestDiagnostics(); }
                 catch (Exception diagEx) { diagnostics = $"<diagnostics unavailable: {diagEx.GetType().Name}>"; }
                 // …and the OWNER's state, which is what actually decides the verdict. The reader's
                 // snapshot alone proves only that the reader is innocent (idle queues + our request
@@ -1550,7 +1564,7 @@ public static class MeshNodeStreamExtensions
                 // reply was dropped and this read hung to its timeout. That was the intermittent bulk flake
                 // in WorkspaceCacheEvictionTest (ReadNode -> GetMeshNode), proven deterministically by
                 // GetMeshNode_WarmOwner_DropsResponse_WhenSubjectRegisteredAfterPost.
-                innerSubscription = hub
+                innerSubscription = issuingHub
                     .Observe<GetDataResponse>(
                         new GetDataRequest(new MeshNodeReference()),
                         o => o.WithTarget(new Address(path)))

--- a/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
+++ b/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
@@ -37,7 +37,7 @@ public static class RouterTrafficRule
     /// arrives packed as <c>RawJson</c>), so the correlation marker is the structural signal.</param>
     /// <returns><c>"target"</c>, <c>"sender"</c>, <c>"sender AND target"</c>, or <c>null</c>.</returns>
     public static string? RoleOf(string? targetAddressType, string? senderAddressType, object? message,
-        bool isResponse = false)
+        bool isResponse)
     {
         // Heartbeats ARE the router's own job — routing liveness, not work. Type check, not a name
         // match: a rename must not silently turn this exclusion off.
@@ -61,4 +61,16 @@ public static class RouterTrafficRule
             _ => null,
         };
     }
+
+    /// <summary>
+    /// Binary-compatible 3-argument form — the pre-<c>isResponse</c> public signature, kept so
+    /// assemblies compiled against it keep resolving (this is a shipped Contract package).
+    /// Treats the delivery as a non-response, i.e. applies no NACK exclusion.
+    /// </summary>
+    /// <param name="targetAddressType">Address type of the delivery's TARGET.</param>
+    /// <param name="senderAddressType">Address type of the sender, if any.</param>
+    /// <param name="message">The message being delivered.</param>
+    /// <returns><c>"target"</c>, <c>"sender"</c>, <c>"sender AND target"</c>, or <c>null</c>.</returns>
+    public static string? RoleOf(string? targetAddressType, string? senderAddressType, object? message)
+        => RoleOf(targetAddressType, senderAddressType, message, isResponse: false);
 }

--- a/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
+++ b/src/MeshWeaver.Messaging.Contract/RouterTrafficRule.cs
@@ -27,8 +27,17 @@ public static class RouterTrafficRule
     /// </param>
     /// <param name="senderAddressType">Address type of the sender, if any.</param>
     /// <param name="message">The message being delivered.</param>
+    /// <param name="isResponse">Whether the delivery ANSWERS a request (it carries a request-id
+    /// correlation). A response the router posts is routing's own duty — the undeliverable-mail
+    /// NACK (<c>RoutingServiceBase.PostNotFound</c> / <c>NackRouteFailure</c> post their
+    /// <c>DeliveryFailure</c> from the mesh hub via <c>ResponseFor</c>, so its sender is honestly
+    /// <c>mesh/{id}</c>) — not work, and reporting it trains people to mute the channel. Coverage
+    /// is not lost: real work SENT TO the router is still reported at request time via the
+    /// <c>"target"</c> role, and the payload type is opaque at the detector anyway (a routed NACK
+    /// arrives packed as <c>RawJson</c>), so the correlation marker is the structural signal.</param>
     /// <returns><c>"target"</c>, <c>"sender"</c>, <c>"sender AND target"</c>, or <c>null</c>.</returns>
-    public static string? RoleOf(string? targetAddressType, string? senderAddressType, object? message)
+    public static string? RoleOf(string? targetAddressType, string? senderAddressType, object? message,
+        bool isResponse = false)
     {
         // Heartbeats ARE the router's own job — routing liveness, not work. Type check, not a name
         // match: a rename must not silently turn this exclusion off.
@@ -37,6 +46,12 @@ public static class RouterTrafficRule
 
         var targetIsRouter = string.Equals(targetAddressType, AddressExtensions.MeshType, StringComparison.Ordinal);
         var senderIsRouter = string.Equals(senderAddressType, AddressExtensions.MeshType, StringComparison.Ordinal);
+
+        // The router ANSWERING (and not also being the target) is the routing NACK — its own job.
+        // A response ADDRESSED AT the router still reports: it proves the router issued a request,
+        // which is the violation the issuing seam (NodeOperationIssuingHub) exists to remove.
+        if (senderIsRouter && !targetIsRouter && isResponse)
+            return null;
 
         return (targetIsRouter, senderIsRouter) switch
         {

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1278,7 +1278,11 @@ public sealed class MessageHub : IMessageHub
     {
         // The rule itself is a pure predicate — see RouterTrafficRule, where it is unit-tested.
         // Target = where the delivery is ADDRESSED, not where it is currently being handled.
-        var role = RouterTrafficRule.RoleOf(delivery.Target?.Type, delivery.Sender?.Type, delivery.Message);
+        // isResponse: the RequestId correlation marks a delivery that ANSWERS a request — the shape
+        // of the routing layer's own undeliverable-mail NACK, which posts from the mesh hub via
+        // ResponseFor (see RouterTrafficRule.RoleOf's isResponse doc).
+        var role = RouterTrafficRule.RoleOf(delivery.Target?.Type, delivery.Sender?.Type, delivery.Message,
+            delivery.Properties.ContainsKey(PostOptions.RequestId));
         if (role is null)
             return;
 

--- a/src/MeshWeaver.Observability/LogIncidentIngestService.cs
+++ b/src/MeshWeaver.Observability/LogIncidentIngestService.cs
@@ -105,7 +105,12 @@ public sealed class LogIncidentIngestService(
             "Red log first sighting {Fingerprint} in {Category} ({Occurrences} line(s)) — opening incident",
             report.Fingerprint, report.Category, report.Occurrences);
 
-        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+        // 🚨 Issued off the router: this service holds the DI root mesh hub, and a target-less
+        // CreateOrUpdateNodeRequest posted there EXECUTES on the router's action block and stamps
+        // mesh/{id} on both ends of the exchange (ROUTER_TRAFFIC — the very detector whose reports
+        // this service ingests). NodeOperationIssuingHub is the shared off-router seam.
+        return hub.NodeOperationIssuingHub()
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
             .FirstAsync()
             .Select(d => d.Message)
             .SelectMany(response => response.Success

--- a/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
@@ -752,7 +752,10 @@ public sealed class ModuleDiscoveryService : IHostedService, IDisposable
             State = MeshNodeState.Active,
             Content = record,
         };
-        return AsSystem(() => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)))
+        // Off-router issuing: this hosted service holds the DI root mesh hub — a target-less
+        // CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
+        return AsSystem(() => hub.NodeOperationIssuingHub()
+                .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)))
             .FirstAsync()
             .Select(delivery => delivery.Message)
             .SelectMany(response => response.Success

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1035,10 +1035,13 @@ public static class PackageInstaller
             };
             // System-impersonated like every installer write (Using — see Upsert): this runs after
             // barrier scheduler hops, where no ambient context survives.
+            // Off-router issuing: the boot default-install runs with the DI root mesh hub — a
+            // target-less CreateOrUpdateNodeRequest posted there runs on the router (ROUTER_TRAFFIC).
             return Observable.Using(
                     () => hub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem()
                           ?? System.Reactive.Disposables.Disposable.Empty,
-                    _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(record)))
+                    _ => hub.NodeOperationIssuingHub()
+                        .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(record)))
                 .FirstAsync().Select(d => d.Message)
                 .SelectMany(resp => resp.Success
                     ? Observable.Return(resp.Node!)
@@ -1994,11 +1997,15 @@ public static class PackageInstaller
     // post happens when hub.Observe's stream is SUBSCRIBED, so the impersonation must still be
     // alive then (Defer+using disposes it before the post — the exact trap the Edu redeemer
     // documented). The admin-gated install is the authorization (see Install).
+    // Off-router issuing (NodeOperationIssuingHub): the boot default-install seed calls this with
+    // the DI root mesh hub, and a target-less CreateOrUpdateNodeRequest posted there EXECUTES the
+    // whole bulk upsert on the router's action block (ROUTER_TRAFFIC). No-op for any other caller.
     private static IObservable<int> Upsert(IMessageHub hub, MeshNode node) =>
         Observable.Using(
                 () => hub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem()
                       ?? System.Reactive.Disposables.Disposable.Empty,
-                _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)))
+                _ => hub.NodeOperationIssuingHub()
+                    .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)))
             .FirstAsync().Select(d => d.Message)
             .SelectMany(resp => resp.Success
                 ? Observable.Return(1)

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeOperationIssuingHubTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeOperationIssuingHubTest.cs
@@ -1,0 +1,158 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the ISSUING half of "the router must be neither end of a delivery" — the half
+/// <see cref="NodeOperationOriginTest"/> cannot see. That test covers a request a CLIENT hub aims at
+/// the node-operation target; this one covers work issued while HOLDING the root mesh hub itself —
+/// the DI-injected <c>IMessageHub</c> every mesh-singleton service gets (the plugin-catalog boot
+/// seed, the log-incident ingest, the credential resolvers). Before the fix, their one-shot reads
+/// went out stamped <c>Sender = mesh/{id}</c> and the <c>GetDataResponse</c> — or, for a missing
+/// node, the <c>DeliveryFailure</c> — was addressed straight back at <c>mesh/{id}</c>: production
+/// 2026-08-10 logged <c>"GetDataResponse has the mesh hub as target (sender:
+/// Hosting/_Access/Public_Access…)"</c> and <c>"DeliveryFailure has the mesh hub as target (sender:
+/// Plugins/_DefaultInstallLedger…)"</c> (issue #1113).
+///
+/// <para>The assertion reads the ERROR the <c>ROUTER_TRAFFIC</c> detector itself logs, so a
+/// regression here is exactly one production ERROR line — plus <see cref="RouterTrafficRule"/>, the
+/// detector's own predicate, applied to the real response delivery of the write-shaped seam.</para>
+/// </summary>
+public class NodeOperationIssuingHubTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly RouterTrafficCapture capture = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            // Capture the detector's ERROR lines out of the REAL logging pipeline — asserting on
+            // them is the only way to pin the detector's verdict without re-implementing it.
+            .ConfigureServices(s => s.AddLogging(l =>
+                l.Services.AddSingleton<ILoggerProvider>(capture)));
+
+    [Fact(Timeout = 60_000)]
+    public async Task WorkIssuedWhileHoldingTheRouter_NeverMakesTheRouterAnEnd()
+    {
+        // ── The seam itself ─────────────────────────────────────────────────────────────
+        // The router hops onto the shared off-router execution hub; any other hub is returned
+        // unchanged (a portal/session/import caller keeps its identity byte-for-byte).
+        Mesh.NodeOperationIssuingHub().Should().BeSameAs(Mesh.NodeOperationExecutionHub()!,
+            "the ROUTER must issue node work on the dedicated off-router hub");
+        var client = GetClient();
+        client.NodeOperationIssuingHub().Should().BeSameAs(client,
+            "a non-router hub is its own issuing hub — the seam is a no-op for it");
+
+        // ── Read-shaped seam: hub.GetMeshNode issued while holding the router ──────────
+        var path = $"{TestPartition}/IssuingHub-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Issuing Hub Probe",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        var create = await AwaitResponseAsync(
+            new CreateNodeRequest(node), o => o.WithTarget(client.NodeOperationTarget()), client);
+        create.Message.Error.Should().BeNull("the probe node must exist for the read to resolve");
+
+        // The exact shape of InstanceAutoRegistrationService / RegistryTokenResolver: a one-shot
+        // GetMeshNode read on the DI root mesh hub. Must resolve — and off the router.
+        var read = await Mesh.GetMeshNode(path).FirstAsync().ToTask();
+        read.Should().NotBeNull("the read must still resolve after the off-router retarget");
+        read!.Path.Should().Be(path);
+
+        // The DeliveryFailure arm: a MISSING node's read (the default-install ledger on a fresh
+        // instance) answers with a routing failure — which must land on the issuing hub, never mesh.
+        var missing = await Mesh.GetMeshNode($"{TestPartition}/missing-{Guid.NewGuid():N}")
+            .FirstAsync().ToTask();
+        missing.Should().BeNull("a genuinely absent node resolves to null");
+
+        // ── Write-shaped seam: the target-less CreateOrUpdate the boot services post ────
+        // LogIncidentIngestService / PackageInstaller.Upsert shape: a target-less
+        // CreateOrUpdateNodeRequest issued via the seam. Target-less ⇒ it EXECUTES on the posting
+        // hub, so issuing off the router is also what keeps the work off the router's action block.
+        var recordPath = $"{TestPartition}/IssuingHubRecord-{Guid.NewGuid():N}";
+        var record = MeshNode.FromPath(recordPath) with
+        {
+            Name = "Issuing Hub Record",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        var upsert = await Mesh.NodeOperationIssuingHub()
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(record))
+            .FirstAsync().ToTask();
+        upsert.Message.Success.Should().BeTrue(
+            "the upsert must genuinely succeed — a rejected op would prove nothing about where work runs");
+        RouterTrafficRule.RoleOf(upsert.Target?.Type, upsert.Sender?.Type, upsert.Message)
+            .Should().BeNull("the router must be neither end of the write's response delivery");
+
+        // ── The detector's own verdict over everything this test drove ──────────────────
+        // Zero ROUTER_TRAFFIC ERROR lines: each captured record here is exactly one production
+        // ERROR line of issue #1113.
+        capture.Records.Should().BeEmpty(
+            "work issued while holding the router must never make the router an end of any delivery; "
+            + $"got: [{string.Join("; ", capture.Records.Select(r => r.ToString()))}]");
+    }
+
+    /// <summary>Captures the <c>ROUTER_TRAFFIC</c> ERROR records the detector logs.</summary>
+    private sealed record RouterTrafficRecord(string MessageType, string Role, string Sender, string Target);
+
+    private sealed class RouterTrafficCapture : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<RouterTrafficRecord> records = new();
+
+        internal RouterTrafficRecord[] Records => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(records);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(ConcurrentQueue<RouterTrafficRecord> sink) : ILogger
+        {
+            private sealed class NullScope : IDisposable
+            {
+                internal static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel < LogLevel.Error || state is not IReadOnlyList<KeyValuePair<string, object?>> values)
+                    return;
+                if (!formatter(state, exception).StartsWith("ROUTER_TRAFFIC:", StringComparison.Ordinal))
+                    return;
+
+                sink.Enqueue(new RouterTrafficRecord(
+                    Value(values, "MessageType"),
+                    Value(values, "Role"),
+                    Value(values, "Sender"),
+                    Value(values, "Target")));
+            }
+
+            private static string Value(IReadOnlyList<KeyValuePair<string, object?>> values, string key)
+            {
+                foreach (var pair in values)
+                    if (pair.Key == key)
+                        return pair.Value?.ToString() ?? "";
+                return "";
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficRuleTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficRuleTest.cs
@@ -62,4 +62,28 @@ public class RouterTrafficRuleTest
         Assert.Null(RouterTrafficRule.RoleOf("Mesh", "portal", new object()));
         Assert.Null(RouterTrafficRule.RoleOf("meshx", "portal", new object()));
     }
+
+    /// <summary>
+    /// The routing layer's own undeliverable-mail NACK: <c>RoutingServiceBase.PostNotFound</c> /
+    /// <c>NackRouteFailure</c> post a <c>DeliveryFailure</c> FROM the mesh hub via <c>ResponseFor</c>,
+    /// so its sender is honestly <c>mesh/{id}</c> — routing duty, not work. The structural signal is
+    /// the request-id correlation (<c>isResponse</c>), because the payload is opaque at the detector
+    /// (a routed NACK arrives packed as <c>RawJson</c>). Production shape: issue #1113's
+    /// <c>"RawJson has the mesh hub as sender"</c> line for a bounced read of a missing node.
+    /// </summary>
+    [Fact]
+    public void ARoutersOwnNack_IsRoutingDuty_AndSilent() =>
+        Assert.Null(RouterTrafficRule.RoleOf("portal", Mesh, new object(), isResponse: true));
+
+    /// <summary>
+    /// The exclusion must not widen: a response ADDRESSED AT the router proves the router ISSUED a
+    /// request (the violation the issuing seam removes); a NON-response from the router is the
+    /// router originating work; and a router-to-router response is work either way.
+    /// </summary>
+    [Theory]
+    [InlineData(Mesh, "ApiToken", true, "target")]   // response back to a router-issued request
+    [InlineData("portal", Mesh, false, "sender")]    // router originating work (no correlation)
+    [InlineData(Mesh, Mesh, true, "sender AND target")]
+    public void OnlyTheRoutersOwnAnswer_IsExcluded(string target, string sender, bool isResponse, string expected) =>
+        Assert.Equal(expected, RouterTrafficRule.RoleOf(target, sender, new object(), isResponse));
 }


### PR DESCRIPTION
Fixes #1113

**No traffic was ever dropped.** `ReportRouterTraffic` is a detector, not a guard — it logs and returns before routing, so every flagged delivery routed exactly as it would have without it. The issue body's "potential functional impact" does not exist; the cost was log volume and router action-block contention.

## What was producing the 840 ROUTER_TRAFFIC errors

Live-log triage (24 h of the current memex image, aggregated by type+role) — corroborated by the read-only A/B across the three AKS portals (see the review comment below) — put the volume here:

| Arm | Share | Producer | Status |
|---|---|---|---|
| `RawJson` sender=mesh (+ `CreateNodeRequest`/`CreateOrUpdateNodeRequest` target=mesh) | ~97% | node-CRUD fallback ran requests AND responses through the router — one report per *receiving hub*, so the count scales with node count | already fixed on main by the nodeops retarget (eea2dd248) |
| `ValidateTokenRequest/Response` | (issue sample) | SignalR/gRPC transport issued token validation on the router | already fixed (50bfb0fa7, in the deployed image) |
| `GetDataResponse`/`DeliveryFailure`/`ImportContentResponse`/`CreateNodeResponse` target=mesh | tail | **this PR, producer 1** | fixed here |
| `RawJson` sender=mesh at the *issuing* hub (bounce of a missing-node read) | subset of the RawJson volume | **this PR, producer 2** | fixed here |
| `ClickedEvent` / `UnsubscribeRequest` / `PatchDataChangeRequest` | (issue sample only) | artifacts of the pre-`953ab9245` detector, which keyed on the receiving hub's `Address` and reported every routing hop | not live defects — images carrying `953ab9245` emit none |

## Producer 1 — mesh-singleton services issue work on the DI root hub (= the router)

`InstanceAutoRegistrationService` (default-install seed + ledger), `ModuleDiscoveryService`, `PackageInstaller`, `RegistryTokenResolver`, `LogIncidentIngestService`, GitSync services, `InstanceSyncWorker` and `MeshDocumentSink` all hold the DI-injected `IMessageHub` — the root mesh hub — and issued request/response work on it:

- one-shot `GetMeshNode` reads → `GetDataResponse` / `DeliveryFailure` addressed straight back at `mesh/{id}` (production lines: `sender: Hosting/_Access/Public_Access`, `sender: Plugins/_DefaultInstallLedger`),
- content imports → `ImportContentResponse` → mesh (`sender: Agent`),
- target-less `CreateOrUpdateNodeRequest`s — which **execute on the posting hub**, so the plugin default-install's bulk upserts and log-incident creates ran on the router's single-threaded action block (the starvation shape the detector exists for).

**Fix**: `MeshExtensions.NodeOperationIssuingHub` — the off-router issuing seam extracted from `MeshService.IssuingHub` — applied at the helper roots (`GetMeshNode`, the `ImportContent`/`SyncContentFiles` builders) so every mesh-singleton caller of those helpers is covered, plus every direct target-less `CreateOrUpdate` post. A non-router hub gets itself back, so portal/session/import callers are byte-for-byte unchanged.

**Known survivors** (direct cross-hub `Observe` on the root hub that bypasses the helpers — named in the review comment): `PackageInstaller.cs` `PingRequest` probe loop and `ContentIndexingObserver.cs`'s cross-hub `GetDataRequest`. A separate follow-up PR against `main` covers those (deliberately not stacked and without a closing keyword).

## Producer 2 — the guard misclassified the router's own undeliverable-mail NACK

`RoutingServiceBase.PostNotFound` / `NackRouteFailure` post their `DeliveryFailure` from the mesh hub via `ResponseFor` — explicitly "routing infrastructure's OWN NotFound NACK", i.e. the router doing its job, but the detector reported it as work (`RawJson has the mesh hub as sender` on every bounced read of a missing node; the payload is `RawJson`-packed at the detector — `RawJson` means "opaque here", not a real message type — so the request-id correlation is the structural signal). **Fix**: `RouterTrafficRule` excludes a *response* the router posts at another hub. Coverage is preserved: a response *addressed at* the router still reports (it proves the router issued a request), as does any non-response send from it. `NodeOperationIssuingHubTest` caught this arm red before the classification fix — the missing-node read's bounce produced exactly the production line. Per Copilot review, the pre-existing 3-arg `RoleOf` overload is kept for binary compatibility (shipped Contract package).

## Evidence

- `NodeOperationIssuingHubTest` (new, MonolithMeshTestBase): seam shape, read seam, missing-node bounce, write seam, and the detector's own captured ERROR stream must stay empty. Red before producer-2's fix (caught the bounce), green after.
- `RouterTrafficRuleTest` extended with the NACK cases (exclusion + its three non-widening counter-cases); `RouterTrafficDetectorTest` 16/16.
- Suites over every touched module: NodeOperations 89/89, PluginCatalog 234/236 (the 2 = `StaleStampRootBindingTest`, the pre-existing main flake fixed by #1153 — 3/3 green after merging main), Observability 105/105, GitSync 157/157, ContentCollections 29/29, InstanceSync 24/24, Indexing.Graph 31/31, What's New integrity 1/1.
- Touched projects build clean with `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5
