### PR TITLE
Composer load no longer surfaces a transient owner miss as a raw error

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -823,6 +823,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// so the read never hits a missing node. <see cref="MeshWeaver.AI.ThreadComposerNodeType.ComposerOf"/>
     /// discriminates by NodeType: a ThreadComposer node's own content, or the thread's embedded
     /// <c>Thread.Composer</c>.
+    /// <para>An idle-collected composer grain whose reactivation outruns the request budget answers
+    /// the subscribe with a TRANSIENT owner failure ("No response received in hub … target hub was
+    /// not found"). The stream-cache contract forwards that to the subscriber for the CALLER to
+    /// retry (<c>MeshNodeStreamCache.IsTransientOwnerFailure</c>) — the bounded backoff here is that
+    /// retry, the same <see cref="AreaStreamRetry"/> every layout area uses. Only a NON-transient
+    /// failure is surfaced; a transient one that survives the whole budget is logged and stays
+    /// silent (the raw framework banner is hostile and unactionable), and the next chat rebind
+    /// restarts the projection naturally.</para>
     /// </summary>
     private void OpenComposerProjection(string path)
     {
@@ -832,6 +840,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         composerSubscription = Hub.GetMeshNodeStream(path)
             .Select(n => MeshWeaver.AI.ThreadComposerNodeType.ComposerOf(n, Hub.JsonSerializerOptions, Logger))
             .Where(c => c is not null)
+            .RetryAreaWithBackoff(AreaErrorClassifier.ShouldRetryArea)
             .Subscribe(
                 c => InvokeAsync(() =>
                 {
@@ -842,7 +851,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                     boundEffort = c.Effort;
                     StateHasChanged();
                 }),
-                ex => SurfaceError(ex, "Loading the composer"));
+                ex =>
+                {
+                    if (AreaErrorClassifier.IsTransientHubFailure(ex))
+                        Logger.LogWarning(ex,
+                            "[ThreadChat:{InstanceId}] composer projection for {Path} still unavailable after bounded retries — staying silent; the next chat rebind resubscribes",
+                            _instanceId, path);
+                    else
+                        SurfaceError(ex, "Loading the composer");
+                });
         StateHasChanged();
     }
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor.cs
@@ -158,10 +158,16 @@ public partial class ThreadSidePanelContent : ComponentBase, IDisposable
     {
         if (_observedComposerPath != path) return;
         _composerObserver?.Dispose();
+        // Bounded retry for the transient owner miss (idle-collected composer grain whose
+        // reactivation outruns the request budget → "No response received in hub … target hub was
+        // not found"): the stream cache forwards it for the CALLER to retry. Without this, one
+        // transient miss silently killed the observer for the circuit's whole lifetime — Send from
+        // the composer then never navigated to the created thread.
         _composerObserver = Hub.GetMeshNodeStream(path)
             .Select(n => ThreadComposerNodeType.ComposerOf(n, Hub.JsonSerializerOptions, _logger)?.OpenThreadPath)
             .Where(p => !string.IsNullOrEmpty(p))
             .DistinctUntilChanged()
+            .RetryAreaWithBackoff(AreaErrorClassifier.ShouldRetryArea)
             .Subscribe(
                 threadPath => InvokeAsync(() =>
                 {
@@ -194,7 +200,8 @@ public partial class ThreadSidePanelContent : ComponentBase, IDisposable
                     selectedThreadPath = threadPath;
                     StateHasChanged();
                 }),
-                ex => _logger?.LogDebug(ex, "[ThreadSidePanel] composer observer errored for {Path}", path));
+                ex => _logger?.LogWarning(ex,
+                    "[ThreadSidePanel] composer observer for {Path} gave up after bounded retries — Send-click navigation is inert until the panel rebinds", path));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-chat-input-no-longer-greets-you-with-a-technical-error.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-chat-input-no-longer-greets-you-with-a-technical-error.md
@@ -1,0 +1,29 @@
+---
+Name: The chat input no longer greets you with a technical error
+Category: Fix
+Description: Opening the portal could pop a raw "No response received…" message while the chat input was waking up. The chat now waits and retries quietly, and only reports genuine failures.
+Icon: Sparkle
+Order: -20260810
+---
+
+# The chat input no longer greets you with a technical error
+
+Navigating to the home page sometimes greeted you with an internal-looking error — "Loading the
+composer: No response received in hub … the target hub was not found" — before you had done
+anything at all. Dismissing it and carrying on usually worked, which made the message all the more
+confusing: nothing was actually broken.
+
+Your chat input keeps its selections (agent, model, effort) on a small per-user record. Like
+everything else in the mesh, that record's owner is put to sleep when it has been idle for a while
+and woken on the next visit. Waking up occasionally takes longer than a single request is allowed
+to wait, and the chat treated that late wake-up as a hard failure: it gave up on the first try and
+showed you the framework's raw timeout text — a message that describes plumbing, not anything you
+could act on.
+
+The rest of the portal already knew better. Every page view classifies this exact situation as
+transient and retries a bounded number of times while the owner finishes waking; the chat input was
+the one reader that never did. It now uses the same bounded retry: a slow wake-up is retried
+quietly until the record answers, and the selections appear on their own. If something genuinely
+fails — a real error, not a slow start — it is still reported. The same fix covers the side
+panel's listener that opens your newly created thread after you press Send, which a single slow
+wake-up could previously switch off unnoticed until the next page visit.


### PR DESCRIPTION
## Symptom

Navigating to the home page on memex.meshweaver.cloud popped a raw framework error in the portal modal:

> Loading the composer: No response received in hub cache/gmIIqhF220CKKxqxgY_J7Q within 00:01:00 for request SubscribeRequest (id=…) → target rbuergi/_Thread/ThreadComposer. The request may have been undeliverable or the target hub was not found.

Nothing was actually broken — dismissing it and carrying on worked.

## Root cause

The per-user composer grain had idle-collected, and its reactivation outran the 60 s request budget. That is the exact failure class `MeshNodeStreamCache.IsTransientOwnerFailure` documents: the error is forwarded to the current subscriber **for the caller to retry**, and the cache stays clean so a resubscribe re-probes. Every layout area implements that contract via `RetryAreaWithBackoff(AreaErrorClassifier.ShouldRetryArea)` — but the two composer-node readers never did:

- `ThreadChatView.OpenComposerProjection` surfaced the very first failure verbatim (`SurfaceError` → portal error modal).
- `ThreadSidePanelContent.OpenComposerObserver` died silently on the first miss (Debug log), leaving Send-click navigation inert for the circuit's whole lifetime.

## Fix

Both readers now use the same bounded, backoff-throttled retry as every layout area. A transient failure that survives the whole retry budget is logged at Warning and stays silent (the raw banner is hostile and unactionable; the next rebind resubscribes naturally). Non-transient failures still surface. The side panel's give-up log is promoted Debug → Warning permanently — a dead navigation observer is a real defect worth seeing, and it only fires after the retry budget is exhausted.

No new classification or retry logic: the transient predicate is already pinned by `AreaErrorClassifierTest` (including the "No response received in hub … SubscribeRequest" banner) and the backoff by `AreaStreamRetryTest`. This PR is the missing wiring around those tested helpers, so there is no unbounded-resubscribe storm risk (the 2026-06-14 wedge class).

## Verification

- `dotnet build src/MeshWeaver.Blazor.Portal -c Release -warnaserror` — clean, 0 warnings.
- `WhatsNewEntryIntegrityTest` — passed (entry `2026-08-10-the-chat-input-no-longer-greets-you-with-a-technical-error.md`, Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)