### PR TITLE
A disposed sync stream's store now completes instead of disposing — parallel teardown no longer throws ObjectDisposedException

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -118,7 +118,9 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// Subscribes an observer to the stream's change items, replaying the most recent change immediately.
     /// </summary>
     /// <param name="observer">The observer to receive change items.</param>
-    /// <returns>A disposable that ends the subscription; a no-op disposable if the underlying store is disposed.</returns>
+    /// <returns>A disposable that ends the subscription. On a DISPOSED stream the store is
+    /// completed (never disposed — #1170/#1171), so a late subscriber still receives the
+    /// replayed last value and graceful completion instead of a silent no-op.</returns>
     public virtual IDisposable Subscribe(IObserver<ChangeItem<TStream>> observer)
     {
         // Fallback creation-context capture: a stream constructed off the subscriber's
@@ -136,7 +138,10 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
         }
         catch (ObjectDisposedException e)
         {
-            logger.LogDebug("[SYNC_STREAM] Subscribe failed for {StreamId} - Store is disposed: {Exception}", StreamId, e.Message);
+            // Not the store (completed on disposal, never disposed): this is the OBSERVER's
+            // own teardown throwing out of the synchronous replay/completion delivery inside
+            // Subscribe — e.g. a disposed Blazor circuit. Benign during teardown.
+            logger.LogDebug("[SYNC_STREAM] Subscribe failed for {StreamId} - observer disposed during replay: {Exception}", StreamId, e.Message);
             return new AnonymousDisposable(() => { });
         }
     }
@@ -672,12 +677,16 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     }
 
     /// <summary>
-    /// Completes the stream, signalling no further change items to subscribers.
+    /// Completes the stream, signalling no further change items to subscribers. Safe at any
+    /// point of teardown: the store is COMPLETED on disposal, never disposed (#1170/#1171),
+    /// and a completed subject ignores further terminal notifications per the Rx grammar — so
+    /// a completion draining out of a concurrently-disposing upstream chain lands as a no-op.
+    /// (The previous <c>!Store.IsDisposed</c> pre-check was check-then-act across threads and
+    /// could not close that window; with the store never disposed, no window exists.)
     /// </summary>
     public void OnCompleted()
     {
-        if (!Store.IsDisposed)
-            Store.OnCompleted();
+        Store.OnCompleted();
     }
 
     /// <summary>
@@ -687,7 +696,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// <param name="error">The error to propagate.</param>
     public void OnError(Exception error)
     {
-        if (!Store.IsDisposed)
+        // Gate on the stream's own disposal flag (set-once under disposeLock), NOT the
+        // subject's state: a disposed stream must not fault its (already-disposing) hub's
+        // startup or reopen its gate. The store itself is completion-terminated on disposal
+        // and ignores a racing OnError per the Rx grammar, so the branch below is safe even
+        // when disposal lands concurrently after this check.
+        if (!isDisposed)
         {
             // Classify the failure to avoid the log dashboard pageant where every
             // teardown / transient-timeout cascade dumps full stack traces 5×.
@@ -734,8 +748,8 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
         }
         else
         {
-            // Store already disposed — benign during teardown, never log Warning.
-            logger.LogDebug("[SYNC_STREAM] OnError skipped for {StreamId} - Store is disposed", StreamId);
+            // Stream already disposed — benign during teardown, never log Warning.
+            logger.LogDebug("[SYNC_STREAM] OnError skipped for {StreamId} - stream is disposed", StreamId);
         }
     }
 
@@ -845,12 +859,13 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 StreamId);
             try
             {
-                if (!Store.IsDisposed)
-                    Store.OnError(ex);
+                // Safe on a disposed stream: the store is completion-terminated on disposal,
+                // never disposed, and a terminated subject ignores OnError (Rx grammar).
+                Store.OnError(ex);
             }
             catch
             {
-                // Store may already be terminated — best effort.
+                // A subscriber's OnError handler may throw — best effort.
             }
         }
     }
@@ -1435,7 +1450,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
 
 
     /// <summary>
-    /// Disposes the stream: completes and disposes the underlying store and tears down the hosted hub.
+    /// Disposes the stream: completes the underlying store and tears down the hosted hub.
     /// Idempotent.
     /// </summary>
     public void Dispose()
@@ -1446,8 +1461,22 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 return;
             isDisposed = true;
         }
+        // COMPLETE the store — deliberately do NOT dispose it (#1170/#1171). OnCompleted
+        // detaches every subscriber, and per the Rx grammar a completed subject silently
+        // ignores any further OnNext/OnError/OnCompleted — exactly the recognized-shutdown
+        // outcome an in-flight teardown delivery needs. Disposing the subject instead made
+        // it THROW: during MessageHub shutdown, sync hubs dispose in parallel (each disposal
+        // action on its own action block), and one stream's completion (this very line, on
+        // thread 1) drains through the Synchronize chain wired by CreateReducedStream
+        // (WorkspaceStreams.cs, `.Subscribe(reducedStream)`) into a sibling stream's
+        // OnCompleted while that sibling's own Dispose runs on thread 2. The sibling's
+        // `!Store.IsDisposed` pre-check was check-then-act, so a Store.Dispose() landing
+        // inside the window turned the benign completion into the ObjectDisposedException
+        // logged as "Error during shutdown of hub sync/…" / "Hub sync/… disposal faulted".
+        // Nothing is leaked by not disposing: completion drops all observer references, and
+        // the 1-item replay buffer is equally reachable via `current` for the stream's
+        // remaining lifetime.
         Store.OnCompleted();
-        Store.Dispose();
         if (Hub is not null && Hub.RunLevel <= MessageHubRunLevel.Started)
             Hub.Dispose();
     }

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -119,8 +119,9 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// </summary>
     /// <param name="observer">The observer to receive change items.</param>
     /// <returns>A disposable that ends the subscription. On a DISPOSED stream the store is
-    /// completed (never disposed — #1170/#1171), so a late subscriber still receives the
-    /// replayed last value and graceful completion instead of a silent no-op.</returns>
+    /// completed (never disposed — #1170/#1171), so a late subscriber receives any replayed
+    /// last value — there is none if the stream was disposed before it ever published — and
+    /// then graceful completion, instead of a silent no-op.</returns>
     public virtual IDisposable Subscribe(IObserver<ChangeItem<TStream>> observer)
     {
         // Fallback creation-context capture: a stream constructed off the subscriber's

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-syncstream-shutdown-completion.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-syncstream-shutdown-completion.md
@@ -1,0 +1,22 @@
+---
+Name: Clean shutdown no longer reports stream-teardown errors
+Category: Fix
+Description: Shutting the portal down could log "Error during shutdown of hub sync/…" faults when parallel stream teardowns raced each other. Teardown completions are now recognized as normal shutdown and land silently.
+Icon: Sparkle
+Order: -20260810
+---
+
+# Clean shutdown no longer reports stream-teardown errors
+
+When the portal shut down, its synchronization streams were torn down in parallel. A stream
+that finished tearing down could still receive the final "we're done" signal from a sibling
+stream that was completing at the same moment — and instead of ignoring it, the stream faulted
+with an error ("Error during shutdown of hub sync/…" / "Hub sync/… disposal faulted"). Nothing
+was actually wrong: both streams were doing exactly what shutdown asked of them, and the fault
+was pure noise in the error logs.
+
+A stream's teardown now leaves it in a state that recognizes late shutdown signals as the
+normal end of life they are: they land silently, no matter how the parallel teardowns
+interleave. As a bonus, anything that subscribes to an already-closed stream now immediately
+hears "this stream has ended" instead of waiting forever on a subscription that could never
+speak.

--- a/test/MeshWeaver.Data.Test/SyncStreamDisposalCompletionTest.cs
+++ b/test/MeshWeaver.Data.Test/SyncStreamDisposalCompletionTest.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the teardown terminal state of <see cref="SynchronizationStream{TStream}"/>'s store
+/// (issues #1170/#1171): disposal COMPLETES the underlying subject — it never DISPOSES it.
+///
+/// <para><b>The production sequence</b> (one event, logged twice — fingerprints
+/// <c>4f955f0319f9bea9</c> / <c>0857ac252fa6c3e9</c>, pod memex-portal, 2026-08-10 12:55:52Z):
+/// during MessageHub shutdown, sync hubs dispose in parallel, each disposal action on its own
+/// action block. Thread 1 runs a stream's <c>Dispose()</c> → <c>Store.OnCompleted()</c>, and
+/// that completion drains synchronously through the <c>Synchronize()</c> chain that
+/// <c>CreateReducedStream</c> wires (<c>WorkspaceStreams.cs</c>,
+/// <c>.Subscribe(reducedStream)</c>) into a SIBLING stream's <c>OnCompleted()</c>. Thread 2 is
+/// concurrently running that sibling's own <c>Dispose()</c>, which used to call
+/// <c>Store.Dispose()</c>. The sibling's <c>OnCompleted</c> guard (<c>!Store.IsDisposed</c>)
+/// was check-then-act: thread 2's <c>Store.Dispose()</c> landing between the check and the
+/// <c>Store.OnCompleted()</c> call turned the benign completion into
+/// <c>ObjectDisposedException</c>, which rode the chain back into thread 1's hub disposal
+/// action and was logged as "Error during shutdown of hub sync/…" (MessageHub, #1170) and
+/// "Hub sync/… disposal faulted" (HostedHubsCollection, #1171).</para>
+///
+/// <para><b>The fix</b>: correct terminal state instead of a wider guard. <c>Dispose()</c>
+/// completes the store and never disposes it. A COMPLETED subject ignores any further
+/// OnNext/OnError/OnCompleted per the Rx grammar, so an in-flight teardown delivery lands as a
+/// no-op no matter how the threads interleave — there is no window left to guard.</para>
+/// </summary>
+public class SyncStreamDisposalCompletionTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Empty;
+
+    /// <summary>
+    /// Exposes the two constituent operations of the pre-fix <c>OnCompleted()</c> — the guard
+    /// check and the subject call — so the test can interleave <c>Dispose()</c> BETWEEN them,
+    /// rendering the production thread interleaving deterministically.
+    /// </summary>
+    private sealed record ProbeStream : SynchronizationStream<Empty>
+    {
+        public ProbeStream(IMessageHub host) : base(
+            new StreamIdentity(host.Address, null),
+            host,
+            new EntityReference("X", "Y"),
+            new ReduceManager<Empty>(host),
+            null)
+        { }
+
+        /// <summary>The delivering thread's guard check (the pre-fix <c>!Store.IsDisposed</c>):
+        /// is the completion delivery approved?</summary>
+        public bool CompletionDeliveryApproved => !Store.IsDisposed;
+
+        /// <summary>The delivery the guard approved — what the Rx chain executes next.</summary>
+        public void DeliverApprovedCompletion() => Store.OnCompleted();
+    }
+
+    /// <summary>
+    /// The production race, rendered deterministically: the upstream teardown cascade
+    /// (thread 1) has already passed the OnCompleted guard when this stream's own disposal
+    /// (thread 2) runs; the approved delivery then executes. RED before the fix
+    /// (<c>Store.Dispose()</c> in <c>Dispose()</c> made the delivery throw
+    /// ObjectDisposedException); GREEN after (the completed-not-disposed store ignores it).
+    /// </summary>
+    [HubFact]
+    public void CompletionDelivery_InterleavedWithDisposal_IsANoOp_NeverThrows()
+    {
+        var stream = new ProbeStream(GetHost());
+
+        // Thread 1 (a sibling stream's completion draining through the Synchronize chain)
+        // evaluates the guard — the stream is alive, the delivery is approved:
+        stream.CompletionDeliveryApproved.Should().BeTrue("the stream has not been disposed yet");
+
+        // Thread 2 (this stream's own hub disposal action, a different action block) disposes
+        // exactly inside the check-then-act window:
+        stream.Dispose();
+
+        // Thread 1 proceeds with the delivery it already approved:
+        var act = stream.DeliverApprovedCompletion;
+        act.Should().NotThrow(
+            "a terminal notification draining out of a concurrently-disposing upstream chain is a "
+            + "recognized shutdown outcome — the disposed stream's store must be COMPLETED (which "
+            + "ignores it, Rx grammar), never DISPOSED (which throws the ObjectDisposedException "
+            + "logged as 'Error during shutdown of hub sync/…' in #1170/#1171)");
+    }
+
+    /// <summary>
+    /// Hub-disposal shape of the same contract, plus its behavioral consequence: disposing the
+    /// HOST hub (which disposes the stream via its registered disposal action, as every
+    /// production creator wires it) completes active subscribers gracefully — and a LATE
+    /// subscriber still observes completion instead of silence. RED before the fix: the disposed
+    /// store made <c>Subscribe</c> throw ObjectDisposedException, which was swallowed into a
+    /// no-op subscription — the late subscriber never heard anything, forever.
+    /// </summary>
+    [HubFact]
+    public async Task HubDisposal_CompletesActiveSubscribers_AndLateSubscribersStillSeeCompletion()
+    {
+        var host = GetHost();
+        var stream = new SynchronizationStream<Empty>(
+            new StreamIdentity(host.Address, null),
+            host,
+            new EntityReference("X", "Y"),
+            new ReduceManager<Empty>(host),
+            null);
+        host.RegisterForDisposal(stream);
+
+        var activeSubscriberCompleted = false;
+        stream.Subscribe(_ => { }, _ => { }, () => activeSubscriberCompleted = true);
+
+        host.Dispose();
+        await host.DisposalCompleted
+            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+            .FirstOrDefaultAsync()
+            .Timeout(10.Seconds())
+            .ToTask(TestContext.Current.CancellationToken);
+
+        activeSubscriberCompleted.Should().BeTrue(
+            "disposing the hub disposes the stream, which must complete its active subscribers");
+
+        var lateSubscriberCompleted = false;
+        stream.Subscribe(_ => { }, _ => { }, () => lateSubscriberCompleted = true);
+        lateSubscriberCompleted.Should().BeTrue(
+            "a subscriber attaching AFTER disposal must observe graceful completion immediately — "
+            + "a DISPOSED store instead threw ObjectDisposedException out of Subscribe, which was "
+            + "swallowed into a no-op subscription: the subscriber heard nothing, forever");
+    }
+}


### PR DESCRIPTION
## What

`SynchronizationStream<T>.Dispose()` no longer calls `Store.Dispose()` on its `ReplaySubject` — it only completes it. A completed-but-undisposed subject ignores any further `OnNext`/`OnError`/`OnCompleted` per the Rx grammar; a disposed one throws `ObjectDisposedException`.

## Why (the production event)

Issues #1170 and #1171 are **one event logged twice** — same pod, same timestamp (2026-08-10 12:55:52Z), same hub `sync/KVk1hB2Tw02ESgrSpL3Cgg`, identical stack; only the log category differs (MessageHub's shutdown handler vs HostedHubsCollection observing the faulted disposal).

The measured sequence, straight from the stack trace:

1. MessageHub shutdown disposes sync hubs in parallel — each disposal action on its own action block.
2. **Thread 1**: a stream's `Dispose()` (line 1449) runs `Store.OnCompleted()`; the completion drains synchronously through the `Synchronize()` chain wired by `CreateReducedStream` (`WorkspaceStreams.cs`, `.Subscribe(reducedStream)`) into a **sibling** stream's `OnCompleted()` (line 680) — the `Synchronize._`/`SafeObserver`/`FastImmediateObserver` frames in the trace.
3. **Thread 2**: that sibling's own `Dispose()` runs concurrently, and used to call `Store.Dispose()`.
4. The sibling's `!Store.IsDisposed` pre-check was **check-then-act**: thread 2's `Store.Dispose()` landing inside the window made line 680 throw `ReplaySubject…CheckDisposed → ObjectDisposedException`, which rode the chain back into thread 1's hub-disposal action → "Error during shutdown of hub sync/…" + "Hub sync/… disposal faulted".

## The fix — terminal state, not a wider guard

Root cause is the teardown terminal state: disposal must leave the store **COMPLETED, never DISPOSED**. Then an in-flight teardown delivery is a contract-compliant no-op under *every* interleaving — there is no window left to guard, so no try/catch and no extra flag can race. The racy `!Store.IsDisposed` checks are removed (`OnCompleted`, the `OnNext` error path) or replaced with the stream's own set-once `isDisposed` flag where behavior depends on it (`OnError` must not fail a disposing hub's startup). Nothing leaks: completion drops all observer references, and the 1-item replay buffer stays reachable via the `current` field regardless.

Behavioral bonus: a subscriber attaching **after** disposal now immediately observes graceful completion, instead of the old swallowed `ObjectDisposedException` in `Subscribe` that handed back a silent no-op subscription.

## Tests (red before, green after)

`test/MeshWeaver.Data.Test/SyncStreamDisposalCompletionTest.cs`:

- `CompletionDelivery_InterleavedWithDisposal_IsANoOp_NeverThrows` — renders the production interleaving deterministically: the delivering thread's guard check approves, `Dispose()` lands inside the check-then-act window, the approved delivery executes. **Pre-fix: fails with the exact production `ObjectDisposedException`.** Post-fix: no-op.
- `HubDisposal_CompletesActiveSubscribers_AndLateSubscribersStillSeeCompletion` — disposes the **host hub** while the stream has an active subscriber (completes gracefully) and pins the late-subscriber contract. **Pre-fix: the late subscriber hears nothing, forever.**

## Overlap with #1160

PR #1160 fixes the same defect *family* (teardown misclassified as failure) in `MessageHub.HandleInitialize` / `DataContext`'s init watchdog — it does not touch `SynchronizationStream.cs`, and this PR touches none of its files. The two compose cleanly.

## Verification

- New tests: red on unfixed code (both, with the production failure shapes), green after.
- `MeshWeaver.Data.Test` full suite: 307/307 green.
- `MeshWeaver.Layout.Test` full suite (heaviest stream consumer): 392/392 green.
- `dotnet build -c Release -warnaserror`: clean for `MeshWeaver.Data` and `MeshWeaver.Data.Test` (no API-surface change — dependents unaffected at compile level).
- Branch merged with current `origin/main` before push.

Fixes #1170
Fixes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5