### PR TITLE
An in-place update no longer costs the router a storage query per message

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-portal-comes-back-faster-after-its-daily-update.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-the-portal-comes-back-faster-after-its-daily-update.md
@@ -1,0 +1,39 @@
+---
+Name: The portal comes back faster after its daily update
+Category: Fix
+Description: After an update, the portal rebuilds every dynamic type — and its own progress reports were clogging the router that the rebuild itself depends on. Rebuilds no longer fight their own bookkeeping, so startup no longer stretches from minutes into hours.
+Icon: TopSpeed
+Order: -20260810
+---
+
+# The portal comes back faster after its daily update
+
+Every time the portal updates itself it rebuilds all of its dynamic types — the
+compiled node types your spaces are made of. That rebuild is designed to take
+about ten minutes in the background. Lately it was taking two hours, and while it
+ran the portal was slow for everyone: pages waited, messages queued, and the
+router kept reporting that it was falling behind.
+
+The cause was a feedback loop between the rebuild and its own progress reports.
+
+Each compile writes a running log — every line an update to a small activity
+record, every update a message routed to that record's home. To route a message,
+the portal looks up where the path lives, and it keeps a cache of those answers
+so the lookup is instant. But every write to a record also *invalidated* the
+cached answer for that record — so the very next progress line had to look the
+path up in the database again, from scratch. During a rebuild, with hundreds of
+compiles each writing dozens of lines, the router spent nearly all its time
+re-answering a question whose answer never changes: an update cannot move a
+record. The router saturated, the rebuild's own status checks timed out behind
+it, each timeout burned its full budget, and a ten-minute rebuild became a
+two-hour one — which kept the storm alive that much longer.
+
+Now the router distinguishes the two things that can happen to a record. When a
+record is *created or deleted*, the cached route is discarded — those are the
+changes that can actually move things. When a record is merely *updated*, the
+route stays warm, because the record is exactly where it was; only the cached
+copy of its content is marked stale for the readers that need fresh content.
+
+Routing to a busy record is a dictionary lookup again, the rebuild's status
+checks come back promptly, and the update window shrinks back to the minutes it
+was designed to take.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -254,7 +254,14 @@ internal class RoutingGrain(
         return Observable.Defer(() =>
         {
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_BEGIN id={delivery.Id} addr={addressPath}");
-            return pathResolver.ResolvePath(addressPath)
+            // 🚨 ResolveRoute, not ResolvePath: this branch reads ONLY Prefix/Remainder, so it
+            // may be served a cached entry whose NODE snapshot is stale. That is what keeps the
+            // per-message lookup a dictionary hit for hot-WRITTEN paths — with ResolvePath,
+            // every activity-log write invalidated the entry the NEXT routed message to that
+            // activity needed, each route then held an in-flight slot for a full storage query,
+            // and during the boot NodeType bake the window saturated at 64 while the bake's own
+            // stream waits timed out behind it (issue #1172's routing/compile feedback loop).
+            return pathResolver.ResolveRoute(addressPath)
                 .Take(1)
                 .Timeout(ResolveTimeout)
                 .Select(resolution =>

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -88,11 +88,25 @@ namespace MeshWeaver.Hosting;
 ///
 /// <para><b>Invalidation</b>: the constructor subscribes the optional
 /// <see cref="IMeshChangeFeed"/> (the same post-commit broadcast
-/// <c>MeshNodeStreamCache</c> uses). Any <see cref="MeshChangeEvent"/> with path
-/// <c>P</c> — Created, Updated or Deleted — removes every entry whose key equals
-/// <c>P</c> or starts with <c>P + "/"</c>: Created(P) can deepen resolutions of
-/// P and its descendants; Deleted/Updated(P) invalidate anything resolving to or
-/// under P. Iterating the whole dictionary per event is fine — events are rare
+/// <c>MeshNodeStreamCache</c> uses). A <see cref="MeshChangeEvent"/> with path
+/// <c>P</c> sweeps every entry whose key equals <c>P</c> or starts with
+/// <c>P + "/"</c> — but what the sweep DOES depends on the kind, because the cache
+/// serves two freshness contracts (see <see cref="CachedResolution"/>):
+/// <list type="bullet">
+///   <item><b>Created/Deleted</b> REMOVE matching entries and drop matching in-flight
+///     fill claims — these are the only events that can change a path's resolution
+///     SHAPE (Created(P) can deepen resolutions of P and its descendants; Deleted(P)
+///     invalidates anything resolving to or under P).</item>
+///   <item><b>Updated</b> only STALE-MARKS matching entries (and in-flight claims):
+///     an in-place write cannot move a node, so the route shape stays valid and
+///     <see cref="ResolveRoute"/> keeps serving from cache, while the cached NODE
+///     snapshot is dropped and node-reading callers (<see cref="ResolvePath"/>)
+///     re-query. Removing on Updated was the issue #1172 routing/compile feedback
+///     loop: every activity-log write invalidated the entry the next routed message
+///     to that activity needed, so the silo router paid a storage query per message
+///     during the boot NodeType bake and saturated its in-flight window.</item>
+/// </list>
+/// Iterating the whole dictionary per event is fine — events are rare
 /// relative to resolutions. When no <see cref="IMeshChangeFeed"/> is registered
 /// (minimal test fixtures) the service does not cache at all and behaves exactly
 /// like the uncached implementation.</para>
@@ -107,29 +121,52 @@ internal class PathResolutionService : IPathResolver, IDisposable
     private readonly bool _hasWritablePartitionProvider;
 
     /// <summary>
+    /// One cached resolution. <see cref="NodeStale"/> tracks the TWO freshness contracts the
+    /// cache serves: the route SHAPE (<see cref="AddressResolution.Prefix"/>/<c>Remainder</c>)
+    /// is invariant under in-place <c>Updated</c> writes, so a stale-marked entry still answers
+    /// <see cref="ResolveRoute"/>; the NODE snapshot is not, so <see cref="ResolvePath"/>
+    /// treats the same entry as a miss and re-queries. A stale entry carries
+    /// <c>Resolution.Node == null</c> — keeping the superseded node (with its whole Content)
+    /// pinned for a route-only answer would grow process memory with every hot-written path.
+    /// </summary>
+    private sealed record CachedResolution(AddressResolution Resolution, bool NodeStale);
+
+    /// <summary>
     /// Positive-only value cache: joined segment path → the resolved
-    /// <see cref="AddressResolution"/> (never null). Non-null ONLY when an
+    /// <see cref="CachedResolution"/> (never null). Non-null ONLY when an
     /// <see cref="IMeshChangeFeed"/> is registered — without the invalidation
     /// signal, caching would serve stale routes forever, so the service then
     /// resolves uncached (exactly the pre-cache behaviour). Storing the VALUE (not
     /// the in-flight observable) means a hung / errored / null resolution caches
     /// nothing and so can never poison the path — see the class doc.
     /// </summary>
-    private readonly ConcurrentDictionary<string, AddressResolution>? _resolutionCache;
+    private readonly ConcurrentDictionary<string, CachedResolution>? _resolutionCache;
 
     /// <summary>
-    /// In-flight fill claims: joined segment path → the monotonic claim stamped when its
-    /// resolution query started. <see cref="OnMeshChange"/> drops matching claims, so an
-    /// answer computed from a PRE-change snapshot can no longer be committed to
-    /// <see cref="_resolutionCache"/> after the invalidation swept an entry that did not
-    /// exist yet. Bounded by the number of CONCURRENT resolutions (entries are removed in
-    /// the resolution's <c>Finally</c>), never by the number of paths. Non-null exactly
-    /// when <see cref="_resolutionCache"/> is.
+    /// One in-flight fill claim. Reference identity IS the claim (see
+    /// <see cref="ClaimStillHeld"/>); <see cref="NodeStale"/> is flipped by an <c>Updated</c>
+    /// event landing while the fill's query is open — the fill still commits (its route SHAPE
+    /// is valid), but marked stale so node-reading callers re-query. Without the flag,
+    /// dropping the claim on every Updated meant a hot-WRITTEN path could NEVER commit a
+    /// cache entry at all: writes interleaved every fill, and every routed message paid a
+    /// fresh storage query — the issue #1172 routing/compile feedback loop.
     /// </summary>
-    private readonly ConcurrentDictionary<string, long>? _pendingFills;
+    private sealed class PendingFill
+    {
+        /// <summary>Set by <see cref="OnMeshChange"/> when an Updated event affects this fill's key mid-query.</summary>
+        public volatile bool NodeStale;
+    }
 
-    /// <summary>Monotonic source for <see cref="_pendingFills"/> claims.</summary>
-    private long _fillSequence;
+    /// <summary>
+    /// In-flight fill claims: joined segment path → the claim stamped when its
+    /// resolution query started. <see cref="OnMeshChange"/> drops matching claims on
+    /// <c>Created</c>/<c>Deleted</c> (an answer computed from a PRE-change snapshot can no
+    /// longer be committed after the invalidation swept an entry that did not exist yet) and
+    /// stale-marks them on <c>Updated</c>. Bounded by the number of CONCURRENT resolutions
+    /// (entries are removed in the resolution's <c>Finally</c>), never by the number of
+    /// paths. Non-null exactly when <see cref="_resolutionCache"/> is.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, PendingFill>? _pendingFills;
 
     /// <summary>Change-feed invalidation subscription; disposed with the singleton.</summary>
     private readonly IDisposable? _changeFeedSubscription;
@@ -150,8 +187,8 @@ internal class PathResolutionService : IPathResolver, IDisposable
         var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
         if (changeFeed is not null)
         {
-            _resolutionCache = new ConcurrentDictionary<string, AddressResolution>(StringComparer.Ordinal);
-            _pendingFills = new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
+            _resolutionCache = new ConcurrentDictionary<string, CachedResolution>(StringComparer.Ordinal);
+            _pendingFills = new ConcurrentDictionary<string, PendingFill>(StringComparer.Ordinal);
             _changeFeedSubscription = changeFeed.Subscribe(OnMeshChange);
         }
         // Gates the partition-root MeshNode synthesis below — we only fall back
@@ -169,10 +206,19 @@ internal class PathResolutionService : IPathResolver, IDisposable
     }
 
     public IObservable<AddressResolution?> ResolvePath(string path)
-        => Resolve(path, forNavigation: false);
+        => Resolve(path, forNavigation: false, routeShapeOnly: false);
+
+    /// <summary>
+    /// Route-shape resolution (see <see cref="IPathResolver.ResolveRoute"/>): serves cached
+    /// entries even when their NODE snapshot is stale, because an in-place Updated write
+    /// cannot change any path's Prefix/Remainder. This is the silo router's per-message
+    /// lookup — it must stay a dictionary hit for hot-written paths (issue #1172).
+    /// </summary>
+    public IObservable<AddressResolution?> ResolveRoute(string path)
+        => Resolve(path, forNavigation: false, routeShapeOnly: true);
 
     public IObservable<AddressResolution?> ResolveNavigationPath(string path)
-        => Resolve(path, forNavigation: true);
+        => Resolve(path, forNavigation: true, routeShapeOnly: false);
 
     /// <summary>
     /// Shared resolution core. <paramref name="forNavigation"/> gates the legacy
@@ -185,7 +231,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// "no legacy User mirror" onboarding invariant
     /// (<c>UserOnboardingServiceTests.CreateUser_WritesPartitionRootOnly_NoUserMirror</c>).
     /// </summary>
-    private IObservable<AddressResolution?> Resolve(string path, bool forNavigation)
+    private IObservable<AddressResolution?> Resolve(string path, bool forNavigation, bool routeShapeOnly)
     {
         if (string.IsNullOrEmpty(path))
             return Observable.Return<AddressResolution?>(null);
@@ -194,7 +240,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
         if (string.IsNullOrEmpty(normalized))
             return Observable.Return<AddressResolution?>(null);
 
-        var resolved = ResolveSegments(normalized.Split('/'));
+        var resolved = ResolveSegments(normalized.Split('/'), routeShapeOnly);
         if (forNavigation)
             resolved = resolved.SelectMany(RewriteLegacyUserHome);
         return resolved.DistinctUntilChanged(AddressResolutionEquality.Instance);
@@ -227,7 +273,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
         => resolution is not null
             && string.Equals(resolution.Prefix, UserNodeType.NodeType, StringComparison.OrdinalIgnoreCase)
             && !string.IsNullOrEmpty(resolution.Remainder)
-            ? ResolveSegments(resolution.Remainder.Split('/'))
+            ? ResolveSegments(resolution.Remainder.Split('/'), routeShapeOnly: false)
             : Observable.Return(resolution);
 
     /// <summary>
@@ -244,7 +290,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// see that method for why pinning it is a permanent, silent mis-binding of the
     /// partition root's hub.</para>
     /// </summary>
-    private IObservable<AddressResolution?> ResolveSegments(string[] segments)
+    private IObservable<AddressResolution?> ResolveSegments(string[] segments, bool routeShapeOnly)
     {
         if (_resolutionCache is null || _pendingFills is null)
             return ResolveSegmentsCore(segments)
@@ -253,8 +299,14 @@ internal class PathResolutionService : IPathResolver, IDisposable
                     : SynthesizePartitionRoot(segments));
 
         var key = string.Join("/", segments);
-        if (_resolutionCache.TryGetValue(key, out var cached))
-            return Observable.Return<AddressResolution?>(cached);
+        // A stale-marked entry still has a VALID route shape (Updated cannot move a node),
+        // so a route-shape caller is served from cache — this is what keeps the silo router
+        // off the storage backend for hot-written paths (issue #1172). A node-reading caller
+        // treats the same entry as a miss and re-queries below; its fresh commit replaces
+        // the stale entry for everyone.
+        if (_resolutionCache.TryGetValue(key, out var cached)
+            && (routeShapeOnly || !cached.NodeStale))
+            return Observable.Return<AddressResolution?>(cached.Resolution);
 
         // 🚨 CLAIM the fill BEFORE the query runs. The query is a live round-trip that
         // can take milliseconds-to-seconds under load; a write landing WHILE it is in
@@ -265,7 +317,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
         // race is how a freshly-created node answers "No node found" (or resolves to its
         // ancestor with a remainder) for the rest of the process.
         // Repro: PathResolutionCachePoisonTest.InvalidationDuringInFlightQuery_DoesNotPinThePreChangeAnswer.
-        var claim = Interlocked.Increment(ref _fillSequence);
+        var claim = new PendingFill();
         _pendingFills[key] = claim;
         return ResolveSegmentsCore(segments)
             .Do(resolution =>
@@ -274,20 +326,34 @@ internal class PathResolutionService : IPathResolver, IDisposable
                 // (absent path) is never cached — a concurrent CreateNode may still
                 // be propagating — and a query that never emits or errors stores
                 // nothing at all, so it can only stall its own caller, never the
-                // whole path. The change feed invalidates positive entries on write.
+                // whole path. The change feed invalidates positive entries on
+                // Created/Deleted and stale-marks them on Updated.
                 if (resolution is null)
                     return;
                 if (!ClaimStillHeld(key, claim))
                     return;
-                _resolutionCache.TryAdd(key, resolution);
+                // An Updated that landed mid-query makes the NODE snapshot stale but not
+                // the route shape — commit stale-marked (Node dropped: a route-only answer
+                // must not pin the superseded node's Content in memory).
+                var stale = claim.NodeStale;
+                var entry = new CachedResolution(
+                    stale ? resolution with { Node = null } : resolution, stale);
+                // Indexer, not TryAdd: a node-reading caller refreshing a stale-marked
+                // entry must REPLACE it.
+                _resolutionCache[key] = entry;
                 // Re-check AFTER the add: an invalidation that ran between the check
                 // above and the add would have swept an empty slot. Undoing here makes
                 // the pair safe in BOTH interleavings — worst case the entry is dropped
                 // twice and the next resolution re-queries.
                 if (!ClaimStillHeld(key, claim))
                     _resolutionCache.TryRemove(key, out _);
+                else if (!stale && claim.NodeStale)
+                    // An Updated raced the commit itself: downgrade the just-written
+                    // fresh entry so node-reading callers re-query.
+                    _resolutionCache.TryUpdate(key,
+                        new CachedResolution(resolution with { Node = null }, true), entry);
             })
-            .Finally(() => _pendingFills.TryRemove(new KeyValuePair<string, long>(key, claim)))
+            .Finally(() => _pendingFills.TryRemove(new KeyValuePair<string, PendingFill>(key, claim)))
             .SelectMany(resolution => resolution is not null
                 ? Observable.Return<AddressResolution?>(resolution)
                 : SynthesizePartitionRoot(segments));
@@ -295,13 +361,13 @@ internal class PathResolutionService : IPathResolver, IDisposable
 
     /// <summary>
     /// True while this resolution's fill claim is still the live one for <paramref name="key"/>:
-    /// no invalidation for that key has run since the query started
-    /// (<see cref="OnMeshChange"/> drops matching claims).
+    /// no Created/Deleted invalidation for that key has run since the query started
+    /// (<see cref="OnMeshChange"/> drops matching claims; Updated only stale-marks them).
     /// </summary>
-    private bool ClaimStillHeld(string key, long claim) =>
+    private bool ClaimStillHeld(string key, PendingFill claim) =>
         _pendingFills is not null
         && _pendingFills.TryGetValue(key, out var current)
-        && current == claim;
+        && ReferenceEquals(current, claim);
 
     /// <summary>
     /// Change-feed invalidation: any Created/Updated/Deleted event with path
@@ -325,6 +391,32 @@ internal class PathResolutionService : IPathResolver, IDisposable
             return;
         var path = change.Path;
         var childPrefix = path + "/";
+
+        if (change.Kind == MeshChangeKind.Updated)
+        {
+            // 🚨 An in-place update cannot change ANY path's resolution SHAPE — the node
+            // existed at that path before the write and still does (moves publish
+            // Deleted(old)+Created(new), deletes publish Deleted). Only the cached NODE
+            // snapshot goes stale. Stale-MARK instead of remove, claims first so a fill
+            // committing between the two sweeps cannot land a fresh entry the entry-sweep
+            // already passed: route-shape callers (the silo router's per-message lookup)
+            // keep their warm entry, node-reading callers re-query. Removing here was the
+            // issue #1172 amplifier: every activity-log write invalidated the very entry
+            // the NEXT routed message to that activity needed, so during the boot NodeType
+            // bake every route to a compile activity paid a fresh storage query while
+            // holding a RoutingGrain in-flight slot — 64+ filled, the bake's own stream
+            // waits timed out behind the saturated router, and the bake inflated ~10×.
+            if (_pendingFills is not null)
+                foreach (var (key, fill) in _pendingFills)
+                    if (Affected(key))
+                        fill.NodeStale = true;
+            foreach (var (key, cached) in _resolutionCache)
+                if (!cached.NodeStale && Affected(key))
+                    _resolutionCache.TryUpdate(key,
+                        new CachedResolution(cached.Resolution with { Node = null }, true), cached);
+            return;
+        }
+
         foreach (var key in _resolutionCache.Keys)
         {
             if (Affected(key))

--- a/src/MeshWeaver.Mesh.Contract/Services/IPathResolver.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IPathResolver.cs
@@ -39,6 +39,26 @@ public interface IPathResolver
     IObservable<AddressResolution?> ResolvePath(string path);
 
     /// <summary>
+    /// ROUTE-SHAPE resolution: like <see cref="ResolvePath"/>, but the caller only consumes
+    /// <see cref="AddressResolution.Prefix"/> / <see cref="AddressResolution.Remainder"/> — never
+    /// <see cref="AddressResolution.Node"/>. That contract lets the implementation serve a cached
+    /// entry whose NODE snapshot is stale: an in-place <c>Updated</c> write cannot change any
+    /// path's resolution SHAPE (the node existed at that path before the write and still does),
+    /// so only <c>Created</c>/<c>Deleted</c> invalidate this view.
+    ///
+    /// <para>🚨 This is what keeps the silo router off the storage backend for hot-WRITTEN paths
+    /// (issue #1172): a compile activity receives one routed <c>PatchDataRequest</c> per appended
+    /// log line, and each write used to invalidate the very cache entry the NEXT routed message
+    /// needed — so during the boot NodeType bake every route to <c>…/_Activity/compile-*</c> paid
+    /// a fresh storage query while holding a RoutingGrain in-flight slot. 64+ slots filled, the
+    /// pre-warmer's own stream waits timed out behind the saturated router, and the bake inflated
+    /// ~10× — the routing/compile feedback loop. Callers that read <see cref="AddressResolution.Node"/>
+    /// (grain activation, monolith hub creation, navigation) MUST stay on
+    /// <see cref="ResolvePath"/>, which re-queries when the node snapshot is stale.</para>
+    /// </summary>
+    IObservable<AddressResolution?> ResolveRoute(string path) => ResolvePath(path);
+
+    /// <summary>
     /// Navigation-only resolution: <see cref="ResolvePath"/> plus the legacy
     /// <c>/User/{id}[/area]</c> home rewrite (strips the obsolete <c>User/</c> prefix and
     /// re-resolves against the user's own root partition so the home area renders on the

--- a/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
@@ -244,4 +244,137 @@ public class PathResolutionCachePoisonTest
         Assert.Null(fresh.Remainder);
         Assert.True(query.Calls >= 2, "the pre-change answer must not be served from cache");
     }
+
+    /// <summary>
+    /// 🚨 Issue #1172 — an in-place UPDATE must not evict the route-shape cache.
+    ///
+    /// <para>An Updated event cannot change any path's resolution SHAPE: the node existed at that
+    /// path before the write and still does (moves publish Deleted+Created). Yet the sweep used to
+    /// REMOVE the entry, so a hot-WRITTEN path — a compile activity receiving one routed
+    /// <c>PatchDataRequest</c> per appended log line — paid a fresh storage query for EVERY routed
+    /// message, each holding a RoutingGrain in-flight slot for the query's duration. During the
+    /// boot NodeType bake that saturated the silo's routing window at 64, the bake's own stream
+    /// waits timed out behind the saturated router, and the bake inflated ~10× (pods not-Ready for
+    /// 80+ minutes). Route-shape resolution (<see cref="IPathResolver.ResolveRoute"/>) must stay a
+    /// warm cache hit across Updated writes; node-reading resolution
+    /// (<see cref="IPathResolver.ResolvePath"/>) must re-query for the fresh node.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task UpdatedNode_KeepsRouteResolutionWarm_WhileNodeReadersRefresh()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        var (svc, query) = BuildService(_ => InitialWith("B", "A"), changeFeed: feed);
+
+        var first = await svc.ResolvePath("A/B").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A/B", first!.Prefix);
+        var callsAfterFill = query.Calls;
+
+        // The hot-write: the node at A/B is updated in place (an activity-log append).
+        feed.Publish(MeshChangeEvent.Updated(new MeshNode("B", "A") { NodeType = "Markdown" }));
+
+        // ROUTE-shape resolution is served synchronously from the cache — NO new query. This is
+        // the silo router's per-message lookup; before the fix the Updated sweep removed the
+        // entry and this line ran a fresh storage query (the #1172 amplifier).
+        AddressResolution? routed = null;
+        using (svc.ResolveRoute("A/B").Take(1).Subscribe(r => routed = r))
+            Assert.NotNull(routed);
+        Assert.Equal("A/B", routed!.Prefix);
+        Assert.Null(routed.Remainder);
+        // The stale entry must not pin the superseded node (whole Content) in memory — the
+        // route-only answer carries no node.
+        Assert.Null(routed.Node);
+        Assert.Equal(callsAfterFill, query.Calls);
+
+        // A NODE-reading caller (grain activation) sees the same entry as a miss and re-queries.
+        var refreshed = await svc.ResolvePath("A/B").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A/B", refreshed!.Prefix);
+        Assert.NotNull(refreshed.Node);
+        Assert.True(query.Calls > callsAfterFill, "a node-reading caller must re-query after Updated");
+
+        // …and its fresh commit repairs the entry for node readers too: the next ResolvePath is
+        // a warm hit again.
+        var callsAfterRefresh = query.Calls;
+        AddressResolution? warmAgain = null;
+        using (svc.ResolvePath("A/B").Take(1).Subscribe(r => warmAgain = r))
+            Assert.NotNull(warmAgain);
+        Assert.Equal(callsAfterRefresh, query.Calls);
+    }
+
+    /// <summary>
+    /// 🚨 Issue #1172, the storm shape: on a path written CONTINUOUSLY, an Updated lands during
+    /// every resolution query, so dropping the fill claim on Updated (the old behaviour) meant
+    /// the cache could NEVER commit an entry for exactly the paths that need it most — every
+    /// routed message paid a fresh storage query forever. The fill must still commit
+    /// (stale-marked: its route shape is valid), so the NEXT routed message is a cache hit.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task UpdatedDuringInFlightFill_StillCommitsTheRouteShape()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        var inFlight = new Subject<QueryResultChange<MeshNode>>();
+        var (svc, query) = BuildService(
+            call => call == 1 ? inFlight : InitialWith("B", "A"),
+            changeFeed: feed);
+
+        AddressResolution? first = null;
+        using var subscription = svc.ResolveRoute("A/B").Take(1).Subscribe(r => first = r);
+
+        // The node is UPDATED while the resolution query is open — the per-log-line write storm.
+        feed.Publish(MeshChangeEvent.Updated(new MeshNode("B", "A") { NodeType = "Markdown" }));
+
+        inFlight.OnNext(Snapshot(new MeshNode("B", "A") { NodeType = "Markdown" }));
+        Assert.NotNull(first);
+        Assert.Equal("A/B", first!.Prefix);
+        var callsAfterFill = query.Calls;
+
+        // The route shape committed despite the mid-flight Updated: the next routed message is a
+        // synchronous cache hit. Before the fix the Updated dropped the claim, nothing was
+        // committed, and this ran query #2 — as would every routed message after it.
+        AddressResolution? second = null;
+        using (svc.ResolveRoute("A/B").Take(1).Subscribe(r => second = r))
+            Assert.NotNull(second);
+        Assert.Equal("A/B", second!.Prefix);
+        Assert.Equal(callsAfterFill, query.Calls);
+
+        // But the mid-flight Updated must have marked the committed entry stale for NODE readers:
+        // ResolvePath re-queries rather than serving a node snapshot from a pre-update query.
+        var refreshed = await svc.ResolvePath("A/B").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A/B", refreshed!.Prefix);
+        Assert.True(query.Calls > callsAfterFill,
+            "a node-reading caller must not be served the pre-update node snapshot");
+    }
+
+    /// <summary>
+    /// Created and Deleted CAN change a path's resolution shape (deepen it / remove it), so they
+    /// must keep invalidating the route-shape view too — the #1172 fix is scoped to Updated only.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task CreatedAndDeleted_StillInvalidateRouteResolution()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        // Query #1: only the ancestor A exists → A/B/C resolves to prefix A. Query #2 (after
+        // Created(A/B)): the deeper node exists → prefix A/B. Query #3 (after Deleted(A/B)):
+        // back to prefix A.
+        var (svc, query) = BuildService(call => call switch
+        {
+            1 => Answer(Snapshot(new MeshNode("A"))),
+            2 => Answer(Snapshot(new MeshNode("A"), new MeshNode("B", "A") { NodeType = "Markdown" })),
+            _ => Answer(Snapshot(new MeshNode("A")))
+        }, changeFeed: feed);
+
+        var shallow = await svc.ResolveRoute("A/B/C").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A", shallow!.Prefix);
+
+        // Created(A/B) deepens the resolution of A/B/C — the cached route entry must go.
+        feed.Publish(MeshChangeEvent.Created(new MeshNode("B", "A") { NodeType = "Markdown" }));
+        var deeper = await svc.ResolveRoute("A/B/C").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A/B", deeper!.Prefix);
+        Assert.True(query.Calls >= 2, "Created must invalidate the route-shape cache");
+
+        // Deleted(A/B) shallows it again.
+        feed.Publish(MeshChangeEvent.Deleted("A/B"));
+        var shallowAgain = await svc.ResolveRoute("A/B/C").Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+        Assert.Equal("A", shallowAgain!.Prefix);
+        Assert.True(query.Calls >= 3, "Deleted must invalidate the route-shape cache");
+    }
 }


### PR DESCRIPTION
## Root cause (issue #1172, duplicate #1174)

Every occurrence sits in a boot-window NodeType bake, and the "64 route dispatches in flight … not terminating" criticals and the ~10× bake inflation (per-type `TimedOut`, pods not-Ready 80 min–2 h 20 min) are one feedback loop:

1. Each compile writes its activity log line-by-line to `{type}/_Activity/compile-{id}` — every line a routed `PatchDataRequest` — plus compile-state mirror writes and heartbeats.
2. Every write published an `Updated` change event, and `PathResolutionService.OnMeshChange` **removed** the resolution-cache entry for that path. The NEXT routed message to the same activity paid a fresh storage query. Worse, on a hot-written path the cache could never even fill: an `Updated` landing during a fill dropped the claim, so nothing was ever committed — a query per message, forever.
3. In `RoutingGrain.BuildGrainRoute` the in-flight slot is held for the duration of that resolution (the grain hand-off is fire-and-forget), and the queries funnel through the bounded `pg-read` pool — at bake write rates the window saturates at 64.
4. The bake's own progress waits (`DynamicTypePreWarmer`'s `GetMeshNodeStream(typePath)` subscriptions) ride the same router, time out behind the backlog, burn their full per-type budget as `TimedOut`, and stretch the bake — keeping the storm alive that much longer.

The violated invariant: **an in-place `Updated` cannot change any path's resolution shape** — the node existed at that path before the write and still does (moves publish `Deleted`+`Created`). Only the cached NODE snapshot goes stale, and only node-reading callers (grain activation, monolith hub creation, navigation) care.

Re the issue's own hypothesis: routes to a pending activation do NOT hold dispatch slots — `DeliverToGrainWithRetry` is fire-and-forget and pending deliveries park inside the reentrant `MessageHubGrain` on `HubReady`. The slot-holder is the per-message resolution, and the churn above is what made it a storage round-trip instead of a dictionary hit.

## Fix

- `PathResolutionService` entries become `(Resolution, NodeStale)`. `Updated` **stale-marks** matching entries (dropping the cached `Node` so no superseded content is pinned) and stale-marks in-flight fill claims instead of dropping them, so hot-written paths commit their route shape. `Created`/`Deleted` remove entries and drop claims exactly as before.
- `IPathResolver.ResolveRoute` (default: `ResolvePath`) — the route-shape view that may serve a stale-marked entry because its callers read only `Prefix`/`Remainder`. `ResolvePath` keeps full freshness: a stale-marked entry is a miss whose re-query repairs the entry for everyone.
- `RoutingGrain.BuildGrainRoute` — which never reads `Resolution.Node` — switches to `ResolveRoute`.

Routing to a busy node is a dictionary hit again; the pre-warmer's waits complete; the boot window shrinks back to its designed size. This also holds under mid-bake Orleans placement (a joining silo receiving activations immediately): routes to not-yet-baked types no longer consume dispatch slots for a storage query per message.

## Verification

Red verified against origin/main (interface default + tests only):
- `UpdatedNode_KeepsRouteResolutionWarm_WhileNodeReadersRefresh` — RED before / green after; also pins that a stale entry carries no `Node` and that `ResolvePath` re-queries then repairs.
- `UpdatedDuringInFlightFill_StillCommitsTheRouteShape` — RED before (the dropped claim = nothing ever cached for a continuously-written path) / green after.
- `CreatedAndDeleted_StillInvalidateRouteResolution` — scope guard.

Suites: Hosting.Test 143/143 · PathResolution.Test 123/123 · Hosting.Orleans.Test 155/155 (incl. `RoutingGrainTurnIsolationTest` through the new `ResolveRoute` path) · `dotnet build -c Release -warnaserror` clean for the touched chain.

Fixes #1172
Fixes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYLgoPK1qLtyxZ2ixdFtj5