### PR TITLE
A view no longer fails to render over a data type it does not stock

### DIFF
--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -192,8 +192,15 @@ public class Workspace : IWorkspace
     /// <inheritdoc />
     public IObservable<T[]?>? GetStream<T>()
     {
-        var collection = DataContext.GetTypeSource(typeof(T));
-        if (collection == null)
+        // 🚨 EXACT type source, never the base-walking DataContext.GetTypeSource(Type).
+        // That walk is a WRITE-path affordance — WorkspaceOperations.ClassifyForRouting stores a
+        // derived instance into its base's collection, and ImportManager falls back to the base
+        // explicitly. Used as the READ guard it admitted a type that owns NO collection of its
+        // own, and the very next line resolves the collection name through TypeRegistry, which
+        // does NOT walk: the mismatch threw "Type X is unknown." straight out of the caller's
+        // layout-area render ("Rendering failed for area X") instead of returning the documented
+        // null that every caller already handles with `?? Observable.Return(...)`.
+        if (DataContext.GetCollectionName(typeof(T)) == null)
             return null;
         // Hub already past Started → SynchronizationStream..ctor would throw
         // ObjectDisposedException synchronously and the exception would

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-renders-even-when-one-of-its-data-sets-is-empty.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-10-a-page-renders-even-when-one-of-its-data-sets-is-empty.md
@@ -1,0 +1,37 @@
+---
+Name: A page renders even when one of its data sets is empty
+Category: Fix
+Description: A view that asked for a kind of data the page never actually stocks took the whole area down with it, showing a rendering error instead of the page. Now that question simply answers "nothing here" and the rest of the page renders.
+Icon: Bug
+Order: -20260810
+---
+
+# A page renders even when one of its data sets is empty
+
+A page in MeshWeaver is assembled from several questions asked of your data at
+once: give me the products, give me the orders, give me the packages. Most pages
+ask for several kinds at a time, and it is completely normal for one of them to
+have nothing in it.
+
+Asking for a kind of data the page does not stock is supposed to answer
+"nothing here" — and every page is written to expect exactly that answer, showing
+an empty list and carrying on. For one family of data types it answered with an
+error instead, and because that error surfaced while the page was being drawn, it
+did not just blank out one list: it replaced the whole page with **"Rendering
+failed."** Everything else on it — the parts with data, the parts that had nothing
+to do with the missing set — went away too.
+
+The cause was two different address books that disagreed.
+
+Before answering, the page's data workspace checks whether it knows the kind of
+data being asked for. That check was generous: if it did not recognise the exact
+kind, it accepted a close relative instead — a deliberate convenience elsewhere in
+the system, where a specialised record is filed under its general category. But
+the step that actually goes and fetches the data is strict, and looks only for the
+exact kind. So a request could pass the friendly check and then fail the strict
+one, and the mismatch became an error at the worst possible moment: mid-render.
+
+Now both steps ask the same question. A kind of data the page genuinely stocks
+resolves exactly as before; one it does not gets the plain "nothing here" the page
+already knows how to display. A missing data set costs you an empty list, never
+the page.

--- a/test/MeshWeaver.Data.Test/GetStreamUnknownTypeContractTest.cs
+++ b/test/MeshWeaver.Data.Test/GetStreamUnknownTypeContractTest.cs
@@ -1,0 +1,58 @@
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>An entity that IS a workspace type source.</summary>
+public record MappedEntity(string Id, string Text);
+
+/// <summary>
+/// Derives from a mapped entity but has NO collection of its own. The write path deliberately
+/// resolves such a type to its BASE's type source (WorkspaceOperations.ClassifyForRouting stores a
+/// derived instance into the base collection; ImportManager falls back to the base explicitly).
+/// </summary>
+public record UnmappedDerivedEntity(string Id, string Text, int Extra) : MappedEntity(Id, Text);
+
+/// <summary>
+/// <see cref="IWorkspace.GetStream{T}()"/> promises <c>null</c> for a type that is not a workspace
+/// type source — a documented contract every caller codes to with <c>?? Observable.Return(...)</c>
+/// (SpaceLayoutAreas.Overview, the Store plugin's Catalog area). Breaking it does not degrade
+/// gracefully: the <see cref="System.ArgumentException"/> escapes the layout-area render and the
+/// user gets "Rendering failed for area X" instead of the area.
+/// </summary>
+public class GetStreamUnknownTypeContractTest : HubTestBase
+{
+    public GetStreamUnknownTypeContractTest(ITestOutputHelper output) : base(output) { }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds.WithType<MappedEntity>()));
+
+    /// <summary>
+    /// 🚨 The guard and the resolution must consult the SAME lookup.
+    ///
+    /// The guard used <c>DataContext.GetTypeSource(Type)</c>, which walks the BASE-TYPE chain —
+    /// an affordance the WRITE path needs. The very next line resolved the collection name through
+    /// <c>TypeRegistry.TryGetCollectionName</c>, which does NOT walk. So a type whose base is a
+    /// type source, but which owns no collection, passed the guard and then threw
+    /// "Type UnmappedDerivedEntity is unknown." out of the caller's render.
+    /// </summary>
+    [Fact]
+    public void DerivedTypeWithoutItsOwnCollection_ReturnsNull_InsteadOfThrowing()
+    {
+        var workspace = GetHost().GetWorkspace();
+
+        // An ArgumentException here escapes the layout-area render as "Rendering failed for area X".
+        var exception = Record.Exception(() => workspace.GetStream<UnmappedDerivedEntity>());
+        Assert.Null(exception);
+
+        // ...and the documented answer for an unmapped type is null, not an empty stream.
+        Assert.Null(workspace.GetStream<UnmappedDerivedEntity>());
+    }
+
+    /// <summary>Scope guard: tightening the guard must not stop a genuinely mapped type resolving.</summary>
+    [Fact]
+    public void MappedType_StillResolves()
+        => Assert.NotNull(GetHost().GetWorkspace().GetStream<MappedEntity>());
+}


### PR DESCRIPTION
## Root cause

`IWorkspace.GetStream<T>()` documents *"an observable of the collection array, or **null** if the type is unknown to this workspace"*, and every caller codes to that null — `SpaceLayoutAreas.Overview` and the Store plugin's Catalog area both write `?? Observable.Return(...)`. For one family of types it **threw** instead, and because the throw happens while a layout area is being composed, the `ArgumentException` escapes the render: the user gets **"Rendering failed for area X"** instead of the page — not merely an empty list.

The guard and the resolution consulted two different lookups:

```csharp
var collection = DataContext.GetTypeSource(typeof(T));   // walks BaseType
if (collection == null) return null;
return GetStream(typeof(T))                              // TypeRegistry — no walk
```

`DataContext.GetTypeSource(Type)` falls back **up the base-type chain**. That walk is a **WRITE-path affordance**: `WorkspaceOperations.ClassifyForRouting` files a derived instance into its base's collection, and `ImportManager` falls back to the base explicitly. Used as the **READ** guard it admitted a type that owns no collection of its own, and the very next line resolves the collection name through `TypeRegistry.TryGetCollectionName`, which does **not** walk — so the mismatch threw `Type X is unknown.`

## Fix

Guard on the same, exact-type lookup the resolution needs: `DataContext.GetCollectionName(Type)` (reads `TypeSourcesByType`, no base walk). A type genuinely mapped to a collection resolves exactly as before; one that is not gets the documented `null`.

Scope note — this is deliberately **not** the eviction defect in #1169 and does not mask it. There the type **source** stays intact and only the `TypeRegistry` entry is dropped, so `GetCollectionName` still returns non-null and that path still throws; it needs its own fix (PR #1181). Different trigger, different file, no overlap.

## Verification

- `DerivedTypeWithoutItsOwnCollection_ReturnsNull_InsteadOfThrowing` — **RED on origin/main** (`Assert.Null() Failure: Value is not null` / `Actual: System.ArgumentException: Type MeshWeaver.Data.Test.UnmappedDerivedEntity is unknown.`), green after. That is the same exception shape prod reported out of `LayoutAreaHost`.
- `MappedType_StillResolves` — scope guard that a genuinely mapped type keeps resolving; passes before and after.
- `MeshWeaver.Data.Test` 307/307.
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Data`, `MeshWeaver.Graph`, `MeshWeaver.Documentation`.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)