### PR TITLE
One fault logged twice became two tickets

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -12,7 +12,7 @@ agent-written description of what is probably broken, filed in the repository th
                                 ▼
                        mw-log-watcher            (ns monitoring, its own PVC)
                           │ group lines into bursts
-                          │ fingerprint  =  hash(top app frame, exception)  — or hash(log site) with no frame
+                          │ fingerprint  =  hash(top app frame, exception)  — or hash(category, event id, exception) with no frame
                           │ queue to disk
                           ▼  POST /api/log-incidents   (Bearer, in-cluster)
                        Portal

--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -12,7 +12,7 @@ agent-written description of what is probably broken, filed in the repository th
                                 ▼
                        mw-log-watcher            (ns monitoring, its own PVC)
                           │ group lines into bursts
-                          │ fingerprint  =  hash(category, exception, normalized message, top frame)
+                          │ fingerprint  =  hash(top app frame, exception)  — or hash(log site) with no frame
                           │ queue to disk
                           ▼  POST /api/log-incidents   (Bearer, in-cluster)
                        Portal
@@ -41,28 +41,45 @@ GitHub App credential already live.
 
 ## One fault, one ticket
 
-The fingerprint (`StructuralLogIncidentIdentity.Compute`) is
-`sha256(category, eventId, discriminator)` truncated to **16 hex characters** (the first 8 bytes),
-where the discriminator is `"{exceptionType}|{topFrame}"` — or whichever of the two is present, or
-the empty string when neither is. Four details make it collapse the right things and only the right
-things:
+The fingerprint (`StructuralLogIncidentIdentity.Compute`) identifies **the fault, not the reporter**.
+It is a `sha256` truncated to **16 hex characters** (the first 8 bytes) over one of two payloads,
+chosen by the burst itself:
 
-- **🚨 The message text is NOT hashed — deliberately, and this is the part that changed.** Earlier
-  revisions folded a *normalized* message (guids, timestamps, paths, quoted literals, hex blobs and
-  bare numbers masked) into the identity. That still fanned out: the varying subject sits in an
-  arbitrary position that no masking rule reliably anticipates, and one defect produced ~50
-  incidents. The message is now structurally excluded. It is still normalized and *carried* on the
-  report (`NormalizedMessage`), it just does not contribute to identity.
-- **Category + `EventId` identify the log SITE**, and are the whole identity for a bare diagnostic
-  with no exception and no frame — so every burst from one site is one incident.
-- **The exception type is part of the identity.** The same log line can precede different failures;
-  folding them together would hide the second bug behind the first one's already-filed ticket.
-- **The top frame excludes framework code** (`System.` / `Microsoft.` prefixes are skipped) and
-  drops its `in /path/file.cs:line NNN` suffix, so an unrelated edit above the faulting line does
-  not fork the fingerprint into a second ticket.
+| The burst names… | The identity is | Why |
+|---|---|---|
+| an application stack frame | `("frame", topFrame, exceptionType)` | the frame names the exact method that faulted — the most specific locator available |
+| no application frame | `("site", category, eventId, exceptionType)` | there is no location to key on, so the log site the code assigns is the locator |
+
+- **🚨 The reporting category is NOT in the identity when a frame is present.** The category names
+  the class that *caught and printed* the fault, which is not where the fault is. One exception
+  unwinding through two catch sites is one defect however many of them log it — production
+  2026-08-10 filed issues #1170 and #1171 for a single `ObjectDisposedException` raised at
+  `SynchronizationStream<T>.OnCompleted()` during a single hub teardown, on one pod, at one instant,
+  because `MessageHub` and `HostedHubsCollection` each logged it on the way out.
+- **🚨 The message text is NOT hashed, in either branch.** Earlier revisions folded a *normalized*
+  message (guids, timestamps, paths, quoted literals, hex blobs and bare numbers masked) into the
+  identity. That still fanned out: the varying subject sits in an arbitrary position that no masking
+  rule reliably anticipates, and one defect produced ~50 incidents. The message is still normalized
+  and *carried* on the report (`NormalizedMessage`), it just does not contribute to identity.
+- **The exception type is part of the identity in both branches** — the same method can fail two
+  ways, and folding those together would hide the second bug behind the first one's ticket. It is
+  compared on its **simple** name: `ex.ToString()` prints `System.ObjectDisposedException` while a
+  message interpolating `ex.GetType().Name` prints `ObjectDisposedException`, and one fault must not
+  fork on the caller's formatting. For the same reason the parser recovers the type from the message
+  text when the call site formatted the exception *into* it instead of passing it to the logger.
+- **The top frame excludes framework code** (`System.` / `Microsoft.` / `Npgsql.` / `Orleans.`
+  prefixes are skipped) and drops its `in /path/file.cs:line NNN` suffix, so an unrelated edit above
+  the faulting line does not fork the fingerprint into a second ticket.
 - **Namespace and pod are NOT in the fingerprint.** The same defect on two pods is one ticket; the
   pods are recorded on the incident instead — and so a defect every tenant hits opens one ticket
   rather than one per tenant.
+
+The direction of the remaining trade is deliberate: two genuinely different faults raised at the
+same frame with the same exception type collapse into one incident. An under-split incident is one
+ticket a human can split; an over-split one is fifty tickets nobody reads, and fifty is what
+production actually produced. What identity must *never* do is discard the fault site to make
+unrelated reporters agree — issues #1183 and #1184 (one logger, one event id, one exception type,
+two different health checks) are two code sites and stay two incidents.
 
 The fingerprint is also the incident's node id, so redelivery is idempotent by construction. That
 is what lets the watcher retry freely.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-one-fault-now-opens-one-ticket.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-one-fault-now-opens-one-ticket.md
@@ -1,0 +1,22 @@
+---
+Name: One fault now opens one ticket
+Category: Fix
+Description: Automatic incident tickets no longer double up when a single error is logged by more than one component.
+Icon: Sparkle
+Order: -20260811
+---
+
+# One fault now opens one ticket
+
+When the portal hits an error in production, it opens a ticket for you automatically — and the
+promise has always been one ticket per defect, however many times the error fires. That promise was
+being broken in a specific way: a single failure that gets logged more than once on its way up (once
+by the component that hit it, again by the component that cleaned up after it) was counted as two
+separate defects and opened two tickets, with the same stack trace in both.
+
+The incident's identity is now taken from the fault itself — the method that failed and the error it
+raised — instead of from whichever component happened to report it. Reports of the same failure now
+fold into one ticket with a single occurrence count, no matter how many places logged it.
+
+Errors that genuinely happen in two different places still get their own ticket each: the change
+removes duplicates without hiding one defect behind another.

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -35,8 +35,9 @@ public static partial class LogLineParser
     /// <param name="Severity">Error or Critical.</param>
     /// <param name="Category">The .NET log category.</param>
     /// <param name="EventId">The event id from the console header (<c>Category[0]</c>) — the log
-    /// SITE the code assigns, and the discriminator the incident identity leans on for bursts that
-    /// carry no exception or stack frame.</param>
+    /// SITE the code assigns. The incident identity uses it, together with the category and the
+    /// exception type, for bursts that carry no application stack frame; when a frame IS present
+    /// the frame locates the fault precisely and neither category nor event id participates.</param>
     /// <param name="Message">The message as logged (volatile parts intact).</param>
     /// <param name="NormalizedMessage">The message with volatile parts masked.</param>
     /// <param name="ExceptionType">The exception type name — read from the burst's own exception

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -6,8 +6,9 @@ using System.Text.RegularExpressions;
 namespace MeshWeaver.Observability;
 
 /// <summary>
-/// Turns raw .NET console log lines into the (category, normalized message, top frame)
-/// triple the incident fingerprint is computed over.
+/// Turns raw .NET console log lines into the <see cref="LogBurst"/> the incident fingerprint is
+/// computed over — log site (category, event id), fault (exception type, top application frame),
+/// and the message, which is carried for the report but never hashed.
 ///
 /// <para>This type lives in the framework — NOT in the watcher — on purpose: the watcher and the
 /// portal must agree on what "the same error" means, and the portal's tests are where that
@@ -30,9 +31,6 @@ public static partial class LogLineParser
             .Add("fail", LogSeverity.Error)
             .Add("crit", LogSeverity.Critical);
 
-    /// <summary>How much of a normalized message survives into the fingerprint. Long messages
-    /// (a serialized payload, a wall of SQL) differ in their tails far more often than in the
-    /// part that identifies the fault, so the tail is deliberately not fingerprinted.</summary>
     /// <summary>The parsed head of a red log burst.</summary>
     /// <param name="Severity">Error or Critical.</param>
     /// <param name="Category">The .NET log category.</param>
@@ -41,8 +39,10 @@ public static partial class LogLineParser
     /// carry no exception or stack frame.</param>
     /// <param name="Message">The message as logged (volatile parts intact).</param>
     /// <param name="NormalizedMessage">The message with volatile parts masked.</param>
-    /// <param name="ExceptionType">The exception type name, when present.</param>
-    /// <param name="TopFrame">The top application stack frame, when present.</param>
+    /// <param name="ExceptionType">The exception type name — read from the burst's own exception
+    /// line, or recovered from the message when the call site formatted the exception into it.</param>
+    /// <param name="TopFrame">The top application stack frame, when present — where the fault IS,
+    /// and therefore the incident's locator in preference to the reporting category.</param>
     public record ParsedBurst(
         LogSeverity Severity,
         string Category,
@@ -98,6 +98,18 @@ public static partial class LogLineParser
             .Trim();
         if (message.Length == 0)
             message = exceptionIndex >= 0 ? body[exceptionIndex] : header;
+
+        // 🚨 A call site that interpolates the exception INTO its message — `LogError("… after {Ms}ms:
+        // {Exception}", …)` — leaves no own-line exception header, so the rule above finds nothing,
+        // while the SAME fault logged as `LogError(ex, "…")` yields the type. That asymmetry is a
+        // property of the caller's formatting, not of the fault, and it is half of why #1170 and
+        // #1171 became two tickets for one ObjectDisposedException. Recover the type from the message
+        // when no exception line exists; an own-line header always wins.
+        exceptionType ??= InlineException().Match(message) switch
+        {
+            { Success: true } inline => inline.Groups["type"].Value,
+            _ => null,
+        };
 
         return new ParsedBurst(
             severity,
@@ -172,6 +184,15 @@ public static partial class LogLineParser
 
     [GeneratedRegex(@"^(?<type>[A-Z][\w.]*(?:Exception|Error))(?::|\s*$)", RegexOptions.CultureInvariant)]
     private static partial Regex ExceptionLine();
+
+    // The same type name, but anywhere in a line rather than anchored at its start — the shape a
+    // message gets when the caller formatted the exception into it. `(?<![\w.])` pins the match to
+    // the START of the qualified name so `System.ObjectDisposedException` is never read as the bare
+    // `ObjectDisposedException`, and the trailing `:` keeps prose out ("Error during shutdown …" has
+    // no colon after "Error", so it does not match — which is why this is a fallback, not a rewrite).
+    [GeneratedRegex(@"(?<![\w.])(?<type>(?:[A-Za-z_]\w*\.)*[A-Z]\w*(?:Exception|Error))\s*:\s",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex InlineException();
 
     [GeneratedRegex(@"^\s*at\s+(?<frame>.+)$", RegexOptions.CultureInvariant)]
     private static partial Regex StackFrame();

--- a/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
+++ b/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
@@ -4,18 +4,37 @@ using System.Text;
 namespace MeshWeaver.Observability;
 
 /// <summary>
-/// The default identity: <b>structure first, prose last</b>.
+/// The default identity: <b>the fault, not the reporter</b>.
 ///
-/// <para>Keys ONLY on what the CODE determines — category, event id, exception type, top
-/// application frame. The message never participates. That is the correction for four rounds of getting this wrong: every failure came from prose
-/// being part of the key, because a message embeds its subject in an arbitrary position
-/// (<c>target: Claims</c>, <c>[PluginGating] Chess:</c>) and no amount of masking anticipates the
-/// next shape. Category+EventId is assigned at the log site and cannot drift with the subject.</para>
+/// <para>Two rules, and which one applies is decided by the burst itself:</para>
+/// <list type="number">
+/// <item><b>The burst names an application frame</b> ⇒ the incident IS
+/// <c>(top application frame, exception type)</c>. The log category and event id are DISCARDED —
+/// they say who caught and printed the fault, not where it is. One exception unwinding through two
+/// catch sites is one defect however many of them log it.</item>
+/// <item><b>It names no application frame</b> ⇒ there is no location to key on, so the log SITE
+/// (category + event id) is the locator, plus the exception type when there is one. This is the
+/// #1002 rule, unchanged: a bare diagnostic is identified by the site the code assigns it.</item>
+/// </list>
 ///
-/// <para>The trade is deliberate: two genuinely different faults logged at the same site with the
-/// same exception collapse into one incident. That is the SAFE direction — an under-split incident
-/// is one ticket a human can split, whereas an over-split one is fifty tickets nobody reads, and
-/// fifty was what production actually produced.</para>
+/// <para>The message never participates, in either branch. That is the correction for four rounds
+/// of getting this wrong: every failure came from prose being part of the key, because a message
+/// embeds its subject in an arbitrary position (<c>target: Claims</c>, <c>[PluginGating] Chess:</c>)
+/// and no amount of masking anticipates the next shape.</para>
+///
+/// <para>🚨 <b>Why the category had to go.</b> Keying on it split #1170 from #1171 — ONE
+/// <c>ObjectDisposedException</c> raised at <c>SynchronizationStream&lt;T&gt;.OnCompleted()</c>
+/// during one hub teardown on one pod at one instant, logged once by
+/// <c>MeshWeaver.Messaging.MessageHub</c> ("Error during shutdown of hub …") and once by
+/// <c>MeshWeaver.Messaging.HostedHubsCollection</c> ("Hub … disposal faulted"). Same fault, same
+/// frame, two reporters, two tickets. The frame is a strictly more specific locator than the
+/// category — it names the exact method — so dropping the category where a frame exists cannot
+/// merge anything the category was keeping apart for a good reason.</para>
+///
+/// <para>The remaining trade is deliberate and unchanged: two genuinely different faults raised at
+/// the same frame with the same exception type collapse into one incident. That is the SAFE
+/// direction — an under-split incident is one ticket a human can split, whereas an over-split one
+/// is fifty tickets nobody reads, and fifty was what production actually produced.</para>
 ///
 /// <para>Override it by implementing <see cref="ILogIncidentIdentity"/> in a Code node; this stays
 /// the fallback when none is compiled.</para>
@@ -36,26 +55,32 @@ public sealed class StructuralLogIncidentIdentity : ILogIncidentIdentity
     {
         ArgumentNullException.ThrowIfNull(burst);
 
-        // The discriminator, in order of how stable it is. A burst WITH an exception or a frame is
-        // identified by those alone — the message is the part that varies per subject, and including
-        // it is exactly what produced ~50 incidents for one defect.
-        var discriminator = (burst.ExceptionType, burst.TopFrame) switch
-        {
-            ({ Length: > 0 } ex, { Length: > 0 } frame) => $"{ex}|{frame}",
-            ({ Length: > 0 } ex, _) => ex,
-            (_, { Length: > 0 } frame) => frame,
-            // 🚨 No exception, no frame — a bare diagnostic. The message contributes NOTHING, on
-            // purpose. Prose was tried as the fallback and still fanned out: the subject sits in an
-            // arbitrary position (`[PluginGating] Chess:` puts it before the colon, where a
-            // `label: value` rule cannot see it), and masking only ever anticipates the shape you
-            // have already seen. Category + EventId identifies the log SITE, which is what the code
-            // itself asserts, so all bursts from one site are one incident.
-            _ => "",
-        };
+        var fault = SimpleTypeName(burst.ExceptionType);
 
-        var payload = $"{burst.Category}\n{burst.EventId}\n{discriminator}";
+        // The branch tag ("frame"/"site") is part of the payload so the two rules can never collide
+        // on a hash — a category that happens to read like a frame stays its own incident.
+        var payload = burst.TopFrame is { Length: > 0 } frame
+            ? $"frame\n{frame}\n{fault}"
+            // 🚨 No application frame — a bare diagnostic, or a fault whose whole stack is framework.
+            // The message contributes NOTHING here either: the subject sits in an arbitrary position
+            // (`[PluginGating] Chess:` puts it before the colon, where a `label: value` rule cannot
+            // see it), and masking only ever anticipates the shape you have already seen. Category +
+            // EventId identifies the log SITE, which is what the code itself asserts.
+            : $"site\n{burst.Category}\n{burst.EventId}\n{fault}";
+
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return Convert.ToHexStringLower(hash.AsSpan(0, 8));
     }
 
+    /// <summary>
+    /// The exception type without its namespace. One fault reaches the watcher in two spellings —
+    /// <c>ex.ToString()</c> prints <c>System.ObjectDisposedException</c> while a message that
+    /// interpolates <c>ex.GetType().Name</c> prints <c>ObjectDisposedException</c> — and keying on
+    /// the qualified form would fork the same defect on nothing but the caller's formatting choice.
+    /// The namespace is not part of what went wrong, and the frame (or the site) already localises.
+    /// </summary>
+    private static string SimpleTypeName(string? exceptionType) =>
+        exceptionType is { Length: > 0 } type
+            ? type[(type.LastIndexOf('.') + 1)..]
+            : "";
 }

--- a/src/MeshWeaver.Observability/LogIncident.cs
+++ b/src/MeshWeaver.Observability/LogIncident.cs
@@ -91,8 +91,11 @@ public record LogIncidentDraft
 public record LogIncident
 {
     /// <summary>
-    /// Stable hash over (category, normalized message, top stack frame) — the node id, and the
-    /// identity of "the same error happening again".
+    /// The node id, and the identity of "the same error happening again": a stable hash over the
+    /// FAULT — its top application frame and exception type — falling back to the log site
+    /// (category + event id) for a burst that names no frame. The message never participates, and
+    /// neither does the category of whoever caught and printed the fault. See
+    /// <see cref="StructuralLogIncidentIdentity"/>.
     /// </summary>
     [Browsable(false)]
     [Key]

--- a/src/MeshWeaver.Observability/LogIncident.cs
+++ b/src/MeshWeaver.Observability/LogIncident.cs
@@ -93,8 +93,10 @@ public record LogIncident
     /// <summary>
     /// The node id, and the identity of "the same error happening again": a stable hash over the
     /// FAULT — its top application frame and exception type — falling back to the log site
-    /// (category + event id) for a burst that names no frame. The message never participates, and
-    /// neither does the category of whoever caught and printed the fault. See
+    /// (category + event id) <b>plus the exception type</b> for a burst that names no frame. The
+    /// message never participates. The category participates ONLY in that no-frame fallback: when
+    /// a frame exists it locates the fault precisely, so who caught and printed it is irrelevant —
+    /// that is what stopped one fault from opening two tickets. See
     /// <see cref="StructuralLogIncidentIdentity"/>.
     /// </summary>
     [Browsable(false)]

--- a/test/MeshWeaver.Observability.Test/LogLineParserTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogLineParserTest.cs
@@ -72,14 +72,75 @@ public class LogLineParserTest
         second.Should().NotBe(first);
     }
 
+    /// <summary>
+    /// The category names who CAUGHT and printed the fault, not where the fault is. When the burst
+    /// carries an application frame, that frame is the locator and the category is dropped — one
+    /// exception unwinding through two catch sites is one defect however many of them log it
+    /// (production 2026-08-10: issues #1170 and #1171, one ObjectDisposedException, two tickets).
+    /// </summary>
     [Fact]
-    public void Fingerprint_DiffersForADifferentCategory()
+    public void Fingerprint_IgnoresTheReportingCategory_WhenTheBurstNamesAFaultSite()
     {
         var different = NodeNotFound.ToArray();
         different[0] = "fail: MeshWeaver.Graph.MeshCatalog[0]";
 
         LogLineParser.Fingerprint(LogLineParser.Parse(different)!)
-            .Should().NotBe(LogLineParser.Fingerprint(LogLineParser.Parse(NodeNotFound)!));
+            .Should().Be(LogLineParser.Fingerprint(LogLineParser.Parse(NodeNotFound)!));
+    }
+
+    /// <summary>
+    /// …and the other half of that rule: with no frame to locate the fault, the log site IS the
+    /// locator, so two categories are two incidents.
+    /// </summary>
+    [Fact]
+    public void Fingerprint_DiffersForADifferentCategory_WhenThereIsNoFaultSite()
+    {
+        string[] bare = ["crit: Memex.Portal.Startup[0]", "      Could not connect to the database"];
+        string[] elsewhere = ["crit: Memex.Portal.Shutdown[0]", "      Could not connect to the database"];
+
+        LogLineParser.Fingerprint(LogLineParser.Parse(elsewhere)!)
+            .Should().NotBe(LogLineParser.Fingerprint(LogLineParser.Parse(bare)!));
+    }
+
+    /// <summary>
+    /// The exception type must be recovered even when the call site formatted it INTO the message
+    /// instead of passing it to the logger — otherwise one fault reported both ways forks on nothing
+    /// but the caller's format string.
+    /// </summary>
+    [Fact]
+    public void Parse_ExtractsAnExceptionTypeFormattedIntoTheMessage()
+    {
+        var burst = LogLineParser.Parse(
+        [
+            "fail: MeshWeaver.Messaging.MessageHub[0]",
+            "      Error during shutdown of hub sync/KVk1hB2Tw02ESgrSpL3Cgg after 0ms (total disposal "
+            + "time: 0ms): System.ObjectDisposedException: Cannot access a disposed object.",
+            "         at MeshWeaver.Data.Serialization.SynchronizationStream`1.OnCompleted()",
+        ]);
+
+        burst.Should().NotBeNull();
+        burst!.ExceptionType.Should().Be("System.ObjectDisposedException");
+        // The message is still the logged text — only the TYPE is recovered, nothing is rewritten.
+        burst.Message.Should().StartWith("Error during shutdown of hub");
+    }
+
+    /// <summary>
+    /// The inline rule is a fallback and must stay one: prose that merely contains the word "Error"
+    /// is not an exception type, and an own-line exception header always wins over the message.
+    /// </summary>
+    [Fact]
+    public void Parse_DoesNotMistakeProseForAnExceptionType()
+    {
+        LogLineParser.Parse(
+            ["fail: Memex.Portal.Startup[0]", "      Error: could not reach the database"])!
+            .ExceptionType.Should().BeNull();
+
+        LogLineParser.Parse(
+        [
+            "fail: Memex.Portal.Startup[0]",
+            "      Retrying after a TimeoutException: attempt 2",
+            "      System.OperationCanceledException: The operation was canceled.",
+        ])!.ExceptionType.Should().Be("System.OperationCanceledException");
     }
 
     [Theory]

--- a/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
+++ b/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
@@ -75,6 +75,149 @@ public class StructuralIdentityTest
         b.Should().NotBe(a);
     }
 
+    /// <summary>
+    /// 2026-08-10, issues #1170 and #1171: ONE <c>ObjectDisposedException</c>, raised at
+    /// <c>SynchronizationStream&lt;T&gt;.OnCompleted()</c> during ONE hub teardown, on ONE pod, at ONE
+    /// instant — and two tickets, because the unwind was logged twice on its way out: once by
+    /// <c>MessageHub</c> ("Error during shutdown of hub …") and once by <c>HostedHubsCollection</c>
+    /// ("Hub … disposal faulted"). These are the verbatim bursts. They must fold into one incident.
+    ///
+    /// <para>Note the two report shapes: <c>MessageHub</c> formats the exception INTO its message,
+    /// <c>HostedHubsCollection</c> lets the logger print it on its own line. Both must yield the same
+    /// exception type, or the identity forks on the caller's formatting rather than on the fault.</para>
+    /// </summary>
+    [Fact]
+    public void OneFault_LoggedByTwoCatchSitesOnTheWayOut_IsOneIncident()
+    {
+        string[] viaMessageHub =
+        [
+            "fail: MeshWeaver.Messaging.MessageHub[0]",
+            "      Error during shutdown of hub sync/KVk1hB2Tw02ESgrSpL3Cgg after 0ms (total disposal "
+            + "time: 0ms): System.ObjectDisposedException: Cannot access a disposed object.",
+            "         at System.Reactive.Subjects.ReplaySubject`1.ReplayBase.CheckDisposed()",
+            "         at System.Reactive.Subjects.ReplaySubject`1.OnCompleted()",
+            "         at MeshWeaver.Data.Serialization.SynchronizationStream`1.OnCompleted() in "
+            + "/home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs:line 680",
+            "         at System.Reactive.SafeObserver`1.WrappingSafeObserver.OnCompleted()",
+        ];
+        string[] viaHostedHubsCollection =
+        [
+            "fail: MeshWeaver.Messaging.HostedHubsCollection[0]",
+            "      Hub sync/KVk1hB2Tw02ESgrSpL3Cgg disposal faulted",
+            "      System.ObjectDisposedException: Cannot access a disposed object.",
+            "         at System.Reactive.Subjects.ReplaySubject`1.ReplayBase.CheckDisposed()",
+            "         at System.Reactive.Subjects.ReplaySubject`1.OnCompleted()",
+            "         at MeshWeaver.Data.Serialization.SynchronizationStream`1.OnCompleted() in "
+            + "/home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs:line 680",
+            "         at System.Reactive.SafeObserver`1.WrappingSafeObserver.OnCompleted()",
+        ];
+
+        var a = LogLineParser.Parse(viaMessageHub)!;
+        var b = LogLineParser.Parse(viaHostedHubsCollection)!;
+
+        // One fingerprint ⇒ one incident node ⇒ one ticket. This is the whole claim.
+        LogLineParser.Fingerprint(b).Should().Be(LogLineParser.Fingerprint(a));
+
+        // …and why: the fault is the same one in both — the reporters differ, and only the reporters.
+        a.Category.Should().NotBe(b.Category);
+        a.TopFrame.Should().Be(b.TopFrame);
+        a.ExceptionType.Should().Be(b.ExceptionType);
+    }
+
+    /// <summary>
+    /// The negative control for the case above, and also real: issues #1183 and #1184 — the same
+    /// category (<c>DefaultHealthCheckService</c>), the same event id (103), the same exception
+    /// (<c>OperationCanceledException</c>), the same pod, the same second. Only the health check that
+    /// raised it differs. Two different code sites are two defects, and folding the reporter into the
+    /// identity must not be "fixed" by folding the fault site out of it as well.
+    /// </summary>
+    [Fact]
+    public void TwoCodeSites_ReportedByOneLogger_StayTwoIncidents()
+    {
+        string[] dbVersionCheck =
+        [
+            "fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]",
+            "      Health check db_version with status Unhealthy completed after 3462.0492ms with "
+            + "message 'db_version check threw'",
+            "      System.OperationCanceledException: The operation was canceled.",
+            "         at System.Threading.CancellationToken.ThrowIfCancellationRequested()",
+            "         at Npgsql.PoolingDataSource.<Get>g__RentAsync|33_0(NpgsqlConnection conn, "
+            + "NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)",
+            "         at Memex.Portal.Distributed.DbVersionHealthCheck.CheckHealthAsync("
+            + "HealthCheckContext context, CancellationToken cancellationToken) in "
+            + "/home/runner/work/MeshWeaver/MeshWeaver/memex/aspire/Memex.Portal.Distributed/DbVersionGate.cs:line 115",
+        ];
+        string[] npgsqlCheck =
+        [
+            "fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]",
+            "      Health check PostgreSql with status Unhealthy completed after 3459.7535ms with "
+            + "message 'The operation was canceled.'",
+            "      System.OperationCanceledException: The operation was canceled.",
+            "         at System.Threading.CancellationToken.ThrowIfCancellationRequested()",
+            "         at Npgsql.PoolingDataSource.<Get>g__RentAsync|33_0(NpgsqlConnection conn, "
+            + "NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken)",
+            "         at HealthChecks.NpgSql.NpgSqlHealthCheck.CheckHealthAsync(HealthCheckContext "
+            + "context, CancellationToken cancellationToken) in "
+            + "/home/runner/work/AspNetCore.Diagnostics.HealthChecks/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs:line 31",
+        ];
+
+        var a = LogLineParser.Parse(dbVersionCheck)!;
+        var b = LogLineParser.Parse(npgsqlCheck)!;
+
+        a.Category.Should().Be(b.Category);
+        a.ExceptionType.Should().Be(b.ExceptionType);
+        a.TopFrame.Should().NotBe(b.TopFrame);
+
+        LogLineParser.Fingerprint(b).Should().NotBe(LogLineParser.Fingerprint(a));
+    }
+
+    /// <summary>
+    /// The frame localises the fault, but WHAT went wrong there still discriminates: the same method
+    /// throwing two different exception types is two defects. Without this the "drop the reporter"
+    /// rule would have nothing left to split on inside a frame.
+    /// </summary>
+    [Fact]
+    public void DifferentExceptions_AtTheSameFrame_StayApart()
+    {
+        var a = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Data.MeshDataSource", 0, "boom",
+                exception: "System.InvalidOperationException", frame: "MeshDataSource.Apply(MeshNode)"));
+        var b = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Data.MeshDataSource", 0, "boom",
+                exception: "System.NullReferenceException", frame: "MeshDataSource.Apply(MeshNode)"));
+
+        b.Should().NotBe(a);
+    }
+
+    /// <summary>
+    /// Two spellings of one type — <c>ex.ToString()</c> prints the namespace, a message that
+    /// interpolates <c>ex.GetType().Name</c> does not — are the same fault, not two.
+    /// </summary>
+    [Fact]
+    public void QualifiedAndSimpleExceptionNames_AreTheSameFault()
+    {
+        var qualified = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Messaging.MessageHub", 0, "boom",
+                exception: "System.ObjectDisposedException", frame: "SynchronizationStream`1.OnCompleted()"));
+        var simple = StructuralLogIncidentIdentity.Compute(
+            Burst("MeshWeaver.Messaging.MessageHub", 0, "boom",
+                exception: "ObjectDisposedException", frame: "SynchronizationStream`1.OnCompleted()"));
+
+        simple.Should().Be(qualified);
+    }
+
+    /// <summary>
+    /// Dropping the reporting category applies ONLY where a fault site is known. A bare diagnostic has
+    /// no frame, so the log site is all the structure there is — and two different sites stay apart.
+    /// </summary>
+    [Fact]
+    public void WithoutAFaultSite_TheLogSiteStillSplits()
+    {
+        StructuralLogIncidentIdentity.Compute(Burst("MeshWeaver.Graph.MeshCatalog", 0, "boom"))
+            .Should().NotBe(
+                StructuralLogIncidentIdentity.Compute(Burst("MeshWeaver.Data.MeshDataSource", 0, "boom")));
+    }
+
     [Fact]
     public void DifferentTopFrames_ForTheSameException_StayApart()
     {


### PR DESCRIPTION
The red-log filer's promise is **one defect, one issue**. It breaks on the shape where a single
exception is logged more than once as it unwinds.

**#1170 and #1171 are the same fault**: one `ObjectDisposedException`, raised at
`SynchronizationStream<T>.OnCompleted()`, during one hub teardown, on one pod
(`memex-portal-deployment-7d68b474b4-qbmb4`), at one instant (`12:55:52Z`) — filed twice because
`MessageHub` logged it on the way out *and* `HostedHubsCollection` logged it again.

Two independent defects put them in different buckets. Both are fixed here.

## What the identity was

```
sha256( category \n eventId \n discriminator )        // discriminator = "{exceptionType}|{topFrame}"
```

## What it is now

| The burst names… | The identity is | Why |
|---|---|---|
| an application stack frame | `("frame", topFrame, exceptionType)` | the frame names the exact method that faulted — the most specific locator there is |
| no application frame | `("site", category, eventId, exceptionType)` | there is no location to key on, so the log site the code assigns is the locator |

**Kept:** the top application frame (where the fault is) and the exception type (what went wrong).
**Discarded:** the log category and event id **when a frame exists** — they name who *caught and
printed* the fault, not where it is. The frame is strictly more specific than the category, so
dropping it cannot merge anything the category was keeping apart for a good reason.
**Unchanged from #1002:** the message contributes nothing in either branch, and a bare diagnostic
(`ROUTER_TRAFFIC`, `DynamicTypePreWarmer`) is still identified by its log site alone.

### The second defect: the exception type was parse-luck

The type was only read from an own-line exception header. A call site that formats the exception
*into* its message leaves none — so #1170 parsed as carrying **no exception at all** while #1171
parsed as `System.ObjectDisposedException`. That is a fork on the caller's format string, not on the
fault. The type is now also recovered from the message text (an own-line header still wins), and
compared on its **simple** name so `ex.ToString()` and `ex.GetType().Name` spell one fault.

## Not over-merging

The trade stays the deliberate one: two different faults at one frame with one exception type share
an incident — under-split is one ticket a human can split; over-split is fifty nobody reads.

What identity must **never** do is discard the fault site to make unrelated reporters agree.
**#1183 and #1184** — one logger (`DefaultHealthCheckService`), one event id (`103`), one exception
type (`OperationCanceledException`), one pod, one second, but two *different health checks*
(`DbVersionHealthCheck` vs `NpgSqlHealthCheck`) — are two code sites and **stay two incidents**.
That is pinned as a test, not left to judgement.

## Regression tests + negative control

`StructuralIdentityTest` and `LogLineParserTest` carry the **verbatim production bursts**, not
hand-invented ones.

| Run | `OneFault_LoggedByTwoCatchSitesOnTheWayOut_IsOneIncident` | `TwoCodeSites_ReportedByOneLogger_StayTwoIncidents` |
|---|---|---|
| with the fix | **pass** (114/114 in the project) | **pass** |
| identity + parser reverted, tests kept | **fail** — `Expected "4f955f0319f9bea9", but found "0857ac252fa6c3e9"` | **pass** |

Those two hex values are the actual fingerprints of incidents #1170 and #1171 as production filed
them, so the reverted run reproduces the duplicate byte-for-byte.

## Related but NOT fixed here — shutdown artifacts

Several of the day's incidents are expected shutdown artifacts rather than defects (#1107 fires
409 ms after `Application is shutting down`; #1152's premise was exactly this). #1183/#1184 look
like the same shape but I have **no evidence** the pod was shutting down — a ~3.46 s wait is equally
consistent with a probe timeout, so I am not asserting it.

If it is worth doing, the clean shape exists and needs no log-level change: `LokiQuery.ForNamespace`
is deliberately **unfiltered**, so `Microsoft.Hosting.Lifetime`'s shutdown marker is already in the
batch `BurstAggregator.SplitBursts` walks — and it already walks per pod. It could carry a
`DuringShutdown` flag onto the report (keyed on the **pod**, never the namespace), and ingest could
record such an incident without requesting triage, so it stays visible and keeps folding recurrences
but does not open a ticket unless the same fingerprint ever fires *outside* shutdown. That is a
classification, not a mute — and it is a different change from this one, so it is not in this PR.

## Note on deploy

Changing the identity re-keys incidents. Incidents already filed keep their old fingerprint, so a
still-firing defect will open **one** new incident node under the new key after rollout. No
migration is included (none was in #1002 either) — flagging it so it is not mistaken for a
regression of this fix.

---

Does **not** close #1170/#1171/#1183/#1184 — it fixes the filer, not those defects. (The
`SynchronizationStream` defect behind #1170/#1171 was fixed separately in #1178.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
