### PR TITLE
Denied layout renders surface the standard access-denied view and name their area

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-page-you-cannot-see-now-says-so-properly.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-page-you-cannot-see-now-says-so-properly.md
@@ -1,0 +1,22 @@
+---
+Name: A page you cannot see now says so properly
+Category: Fix
+Description: Opening content you lack permission for showed a technical "This area failed to render" panel quoting an internal error. It now shows the standard, localized "Access denied" message.
+Icon: Sparkle
+Order: -20260811
+---
+
+# A page you cannot see now says so properly
+
+When you opened a page whose content you did not have permission to read, the portal showed a
+broken-looking "⚠️ This area failed to render." panel quoting an internal error message —
+including your user name and the exact node path the check refused. That read as a crash, when
+in fact everything worked exactly as designed: you simply were not allowed to see the content.
+
+Such a page now shows the same clean, localized "Access denied" message the rest of the portal
+uses, with the usual hint to ask the owner for access. Genuine rendering errors keep their
+detailed panel so real problems stay visible.
+
+Behind the scenes the same event was also logged as an error with a nameless area
+("Rendering failed for area (null)"), which paged operators for a non-problem and hid which
+page was involved. It is now recorded as a routine warning naming the actual area.

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -209,6 +209,27 @@ public static class AreaErrorClassifier
            && (failure.Message ?? string.Empty).StartsWith("No node found", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// True when the failure IS a definite access DENIAL — a typed
+    /// <see cref="UnauthorizedAccessException"/> anywhere in the chain, or one of the
+    /// access-denied banners <see cref="TryGetAccessDeniedPath"/> recognises. Narrower than
+    /// <see cref="IsExpectedUserActionFailure"/> (which also covers validation rejections and
+    /// NotFound): this predicate drives the server-side render pipeline's decision to swap the
+    /// raw exception text for the standard localized access-denied presentation (issue #1182 —
+    /// a viewer without Read on a node saw "⚠️ This area failed to render." plus the internal
+    /// permission banner). An availability failure (NO VERDICT, issue #974) must never be
+    /// presented as a denial, so it short-circuits first — same as
+    /// <see cref="IsExpectedUserActionFailure"/>.
+    /// </summary>
+    public static bool IsAccessDenied(Exception? ex)
+    {
+        if (IsAvailabilityFailure(ex)) return false;
+        for (var e = ex; e != null; e = e.InnerException)
+            if (e is UnauthorizedAccessException)
+                return true;
+        return TryGetAccessDeniedPath(ex) is not null;
+    }
+
+    /// <summary>
     /// The node PATH an access-denied failure names — extracted so the GUI can degrade gracefully
     /// (e.g. redirect a not-yet-enrolled visitor to a course's public paywall) instead of showing a
     /// raw "Access denied" card. Both access-denied banners put the path in the segment right after

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -69,6 +69,14 @@ public record LayoutAreaHost : IDisposable
     private readonly ILogger<LayoutAreaHost> logger;
 
     /// <summary>
+    /// The area this host actually renders: <see cref="LayoutAreaReference.Area"/> when the
+    /// reference names one, otherwise the DEFAULT area the ctor resolved. Kept so failure
+    /// paths always report a real area name — <c>Reference.Area</c> is <c>null</c> for every
+    /// default-area URL, which made render failures log "area (null)" (issue #1182).
+    /// </summary>
+    private readonly string resolvedArea;
+
+    /// <summary>
     /// Id of the EntityStore "data"-collection item carrying the phase-aware
     /// loading progress (<c>{ message, progress }</c>). Seeded by
     /// <see cref="BuildInitialization"/> ("Building layout…"), advanced by the
@@ -100,6 +108,7 @@ public record LayoutAreaHost : IDisposable
         // When Area is null/empty, resolve to the default area
         var isDefaultArea = string.IsNullOrEmpty(reference.Area);
         var resolvedArea = isDefaultArea ? ResolveDefaultArea() : reference.Area!;
+        this.resolvedArea = resolvedArea;
         var context = new RenderingContext(resolvedArea) { Layout = reference.Layout };
 
         // Capture the delivery-scoped AccessContext (AsyncLocal only) at construction time.
@@ -713,12 +722,21 @@ public record LayoutAreaHost : IDisposable
     private EntityStoreAndUpdates RenderRenderingError(
         RenderingContext context, EntityStoreAndUpdates cleared, Exception ex)
     {
-        logger.LogError(ex, "Rendering failed for area {Area}", Reference.Area);
+        // context.Area is ALWAYS the resolved area name — the ctor resolves a null/empty
+        // Reference.Area (a default-area URL) to the default area before building the
+        // RenderingContext. Logging Reference.Area here printed "Rendering failed for
+        // area (null)" for exactly those renders, hiding WHICH area failed (issue #1182).
+        var area = context.Area;
+        if (AreaErrorClassifier.IsAccessDenied(ex))
+            // A denial is a user-action outcome (the viewer lacks the right on the node
+            // being rendered), not an engineering fault — Warning, so error dashboards
+            // don't page / auto-file an incident for "user opened a node they cannot read".
+            logger.LogWarning(ex, "Rendering denied for area {Area}: {Message}", area, ex.Message);
+        else
+            logger.LogError(ex, "Rendering failed for area {Area}", area);
         try
         {
-            var errorControl = MeshWeaver.Layout.Controls.Markdown(
-                $"⚠️ **This area failed to render.**\n\n```\n{ex.Message}\n```");
-            var rendered = RenderArea(context, errorControl, cleared.Store);
+            var rendered = RenderArea(context, CreateRenderErrorControl(ex), cleared.Store);
             return new EntityStoreAndUpdates(
                 rendered.Store, cleared.Updates.Concat(rendered.Updates), Stream.StreamId);
         }
@@ -727,10 +745,25 @@ public record LayoutAreaHost : IDisposable
             // The error placeholder itself failed to render (extremely unlikely for a
             // Markdown control) — log and emit the cleared store rather than recursing
             // back into the Catch above.
-            logger.LogError(renderEx, "Failed to render the error placeholder for area {Area}", Reference.Area);
+            logger.LogError(renderEx, "Failed to render the error placeholder for area {Area}", area);
             return cleared;
         }
     }
+
+    /// <summary>
+    /// The visible control a faulted render surfaces (both the top-level Catch and the
+    /// nested-area <see cref="FailRendering(Exception, string?)"/> path). An access DENIAL
+    /// renders the standard localized access-denied presentation — the same
+    /// <c>error.accessDenied</c> copy the pages and layout areas use — instead of leaking
+    /// the internal permission banner (issue #1182); every other fault keeps the generic
+    /// error panel carrying the exception message so the cause stays visible.
+    /// </summary>
+    private UiControl CreateRenderErrorControl(Exception ex)
+        => AreaErrorClassifier.IsAccessDenied(ex)
+            ? Controls.Markdown(
+                $"**{this.Localize("error.accessDenied")}**\n\n{this.Localize("error.accessDeniedHint")}")
+            : Controls.Markdown(
+                $"⚠️ **This area failed to render.**\n\n```\n{ex.Message}\n```");
 
     /// <summary>
     /// Reactive render of a top-level area whose generator is an observable of
@@ -1160,8 +1193,11 @@ public record LayoutAreaHost : IDisposable
     }
 
     // Top-level render failures (the init observable's WithExceptionCallback and the
-    // main render subscription) surface on the area this host renders — Reference.Area.
-    private void FailRendering(Exception ex) => FailRendering(ex, Reference.Area);
+    // main render subscription) surface on the area this host renders. Use the RESOLVED
+    // area, not Reference.Area — the latter is null for default-area URLs, which both
+    // logged "area (null)" AND made the null-area guard below drop the visible error
+    // control entirely (issue #1182).
+    private void FailRendering(Exception ex) => FailRendering(ex, resolvedArea);
 
     /// <summary>
     /// 🚨 A render fault is SURFACED, never swallowed. The previous body only
@@ -1180,8 +1216,7 @@ public record LayoutAreaHost : IDisposable
         if (string.IsNullOrEmpty(area))
             return;
 
-        var errorControl = new MarkdownControl(
-            $"⚠️ **This area failed to render.**\n\n```\n{ex.Message}\n```");
+        var errorControl = CreateRenderErrorControl(ex);
 
         Stream.Update(current =>
         {

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -302,4 +302,53 @@ public class AreaErrorClassifierTest
                 Failure("Permission check unavailable for user 'x' on 'AgenticEngineering/Intro' (Read)",
                     ErrorType.Unavailable))
             .Should().BeNull();
+
+    // ── IsAccessDenied: the server-side render pipeline swaps the raw exception text for the
+    //    standard localized access-denied presentation on a DEFINITE denial (issue #1182) ──
+
+    [Fact]
+    public void IsAccessDenied_TrueForTypedUnauthorizedAccessException()
+        // The exact prod shape: the access layer throws UnauthorizedAccessException
+        // ("User 'carson' lacks Read permission on 'Profiles/RolandLinkedIn'") mid-render.
+        => AreaErrorClassifier.IsAccessDenied(
+                new UnauthorizedAccessException("User 'carson' lacks Read permission on 'Profiles/RolandLinkedIn'"))
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAccessDenied_TrueWhenTheDenialIsWrapped()
+        => AreaErrorClassifier.IsAccessDenied(
+                new InvalidOperationException("render faulted",
+                    new UnauthorizedAccessException("User 'x' lacks Read permission on 'y'")))
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAccessDenied_TrueForTheAccessDeniedBanner()
+        // The delivery-failure banner carries no typed exception; the quoted-path banner is
+        // the same signal TryGetAccessDeniedPath keys the paywall redirect on.
+        => AreaErrorClassifier.IsAccessDenied(
+                Failure("Access denied: user 'x' lacks Read permission on 'AgenticEngineering'",
+                    ErrorType.Unauthorized))
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAccessDenied_FalseForAnEngineeringError()
+        // A crash must keep the generic error panel carrying the exception message —
+        // presenting it as "Access denied" would send the user to ask for rights they hold.
+        => AreaErrorClassifier.IsAccessDenied(new NullReferenceException("boom")).Should().BeFalse();
+
+    [Fact]
+    public void IsAccessDenied_FalseForAnAvailabilityFailure()
+        // NO VERDICT (issue #974): nothing was decided about the caller's rights, so it must
+        // never be presented as a denial — the typed check wins over any message wording.
+        => AreaErrorClassifier.IsAccessDenied(
+                Failure("Permission check unavailable for user 'x' on 'y' (Read) — no verdict was reached",
+                    ErrorType.Unavailable))
+            .Should().BeFalse();
+
+    [Fact]
+    public void IsAccessDenied_FalseForAValidationRejection()
+        // Validation is an expected USER-ACTION failure (Warning-level) but NOT a denial —
+        // its message is actionable and must stay visible verbatim.
+        => AreaErrorClassifier.IsAccessDenied(Failure("Validation failed for X", ErrorType.Failed))
+            .Should().BeFalse();
 }

--- a/test/MeshWeaver.Layout.Test/LayoutTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutTest.cs
@@ -37,6 +37,19 @@ public class LayoutTest(ITestOutputHelper output) : HubTestBase(output)
     private static IObservable<UiControl?> ThrowingObservableView(LayoutAreaHost host, RenderingContext ctx)
         => Observable.Throw<UiControl?>(new InvalidOperationException("BOOM_async_render"));
 
+    // Views whose render is DENIED — models the access layer throwing
+    // UnauthorizedAccessException while a view generator reads a node the viewer lacks
+    // Read on (issue #1182: "User 'carson' lacks Read permission on 'Profiles/RolandLinkedIn'").
+    // Both server-side failure paths must mask the internal banner behind the standard
+    // access-denied presentation: the sync throw (init pipeline → FailRendering) and the
+    // observable error (RenderObservable's Catch → RenderRenderingError).
+    private static IObservable<UiControl?> DeniedSyncView(LayoutAreaHost host, RenderingContext ctx)
+        => throw new UnauthorizedAccessException("User 'carson' lacks Read permission on 'Profiles/RolandLinkedIn'");
+
+    private static IObservable<UiControl?> DeniedObservableView(LayoutAreaHost host, RenderingContext ctx)
+        => Observable.Throw<UiControl?>(
+            new UnauthorizedAccessException("User 'carson' lacks Read permission on 'Profiles/RolandLinkedIn'"));
+
     /// <summary>
     /// A pathologically deep, self-similar control tree (a single-child stack
     /// nested far beyond <c>LayoutAreaHost.MaxRenderDepth</c>) ending in a leaf
@@ -102,6 +115,8 @@ public class LayoutTest(ITestOutputHelper output) : HubTestBase(output)
                     .WithView(RecursiveView, BuildDeeplyNestedStack())
                     .WithView(nameof(ThrowingSyncView), ThrowingSyncView)
                     .WithView(nameof(ThrowingObservableView), ThrowingObservableView)
+                    .WithView(nameof(DeniedSyncView), DeniedSyncView)
+                    .WithView(nameof(DeniedObservableView), DeniedObservableView)
             );
     }
 
@@ -235,6 +250,44 @@ public class LayoutTest(ITestOutputHelper output) : HubTestBase(output)
             "a faulted render must surface a visible error control on the area, not stay null");
         text.Should().Contain(expectedCause,
             "the surfaced error must carry the underlying exception message so the cause is visible");
+    }
+
+    /// <summary>
+    /// Regression guard for issue #1182: a render DENIED by the access layer
+    /// (<see cref="UnauthorizedAccessException"/> from a view generator) must surface the
+    /// STANDARD access-denied presentation — the localized <c>error.accessDenied</c> copy the
+    /// pages use — never the generic "⚠️ This area failed to render." panel leaking the
+    /// internal permission banner ("User 'carson' lacks Read permission on '…'"). Covers both
+    /// server-side failure paths: the sync throw (init pipeline → <c>FailRendering</c>) and
+    /// the observable error (<c>RenderObservable</c>'s Catch → <c>RenderRenderingError</c>).
+    /// </summary>
+    [HubFact]
+    public Task DeniedSyncView_SurfacesAccessDenied_NotTheRawBanner()
+        => AssertDeniedViewSurfacesAccessDenied(nameof(DeniedSyncView));
+
+    [HubFact]
+    public Task DeniedObservableView_SurfacesAccessDenied_NotTheRawBanner()
+        => AssertDeniedViewSurfacesAccessDenied(nameof(DeniedObservableView));
+
+    private async Task AssertDeniedViewSurfacesAccessDenied(string view)
+    {
+        var reference = new LayoutAreaReference(view);
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(),
+            reference
+        );
+
+        var control = await stream.GetControlStream(reference.Area!)
+            .Should().Within(10.Seconds()).Match(x => x is MarkdownControl);
+
+        var text = control.Should().BeOfType<MarkdownControl>().Subject.Markdown?.ToString() ?? string.Empty;
+        text.Should().Contain("Access denied",
+            "a denied render must show the standard access-denied presentation");
+        text.Should().NotContain("lacks Read permission",
+            "the internal permission banner (user id + node path) must be masked behind the standard copy");
+        text.Should().NotContain("failed to render",
+            "a denial is a designed outcome, not a render fault");
     }
 
     private static async Task<UiControl?> ViewWithProgress(LayoutAreaHost area, RenderingContext ctx, CancellationToken ct)


### PR DESCRIPTION
Fixes #1182

## Root cause

Two independent defects met in `LayoutAreaHost` when a view generator threw `UnauthorizedAccessException` mid-render (user `carson` opening `Profiles/RolandLinkedIn` without Read):

1. **The area identity was dropped.** `RenderRenderingError` logged `Reference.Area`, which is `null` for every *default-area* URL (the ctor resolves the default area into the `RenderingContext`, but the error path never used it) — hence `Rendering failed for area (null)`. The top-level `FailRendering(ex)` overload had the same defect, and there the `string.IsNullOrEmpty(area)` guard additionally dropped the visible error control.
2. **A denial was classified as an engineering fault.** It logged at **Error** (which pages dashboards and is what auto-filed this incident) and rendered the internal permission banner — user id + node path — inside the generic "⚠️ This area failed to render." panel, reading as a crash for a designed outcome.

## Fix

- Both failure paths report the **resolved** area (`context.Area` / a new `resolvedArea` field), so the log names the real area and the error control always renders.
- New `AreaErrorClassifier.IsAccessDenied` (typed `UnauthorizedAccessException` or the access-denied banner; an `ErrorType.Unavailable` no-verdict short-circuits to false, per #974): a definite denial now logs at **Warning** and renders the standard localized `error.accessDenied` / `error.accessDeniedHint` presentation — the same copy the pages and layout areas use — in both the top-level `Catch` and the nested-area `FailRendering` path. All other faults keep the detailed error panel.

## Test evidence

- `DeniedSyncView_SurfacesAccessDenied_NotTheRawBanner` and `DeniedObservableView_SurfacesAccessDenied_NotTheRawBanner` (both server-side failure paths): **red before** the `LayoutAreaHost` change (`expected … to contain "Access denied"`), **green after**.
- 7 new `IsAccessDenied` classifier boundary tests (typed, wrapped, banner, engineering error, availability failure, validation rejection).
- `MeshWeaver.Layout.Test` filtered suite 71/71 green; `MeshWeaver.Blazor` + `MeshWeaver.Layout.Test` build clean with `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)