### PR TITLE
A cancelled health check is not a verdict about the database

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/DbVersionGate.cs
+++ b/memex/aspire/Memex.Portal.Distributed/DbVersionGate.cs
@@ -103,6 +103,11 @@ public sealed class DbVersionGate(
 /// </summary>
 public sealed class DbVersionHealthCheck(NpgsqlDataSource dataSource) : IHealthCheck
 {
+    /// <summary>
+    /// Runs the db_version probe. Returns <c>Unhealthy</c> for anything the DATABASE says, and
+    /// propagates a cancellation the CALLER raised — those are different events and only one of
+    /// them is a verdict about the database.
+    /// </summary>
     public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
@@ -119,8 +124,30 @@ public sealed class DbVersionHealthCheck(NpgsqlDataSource dataSource) : IHealthC
                 : HealthCheckResult.Unhealthy(
                     $"db_version={version} < expected {DbVersionGate.ExpectedDbVersion}");
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // 🚨 The CALLER gave up — the /health request was aborted, or the host is stopping.
+            // Nothing was learned about the database, so there is no verdict to report: on
+            // 2026-08-10 this check was cancelled 3.46 s into `PoolingDataSource.RentAsync`, i.e.
+            // still waiting to RENT a connector, before a connection was even open. Reporting that
+            // as Unhealthy claims a database failure that was never observed.
+            //
+            // Swallowing it into `Unhealthy(exception)` is also what put it on the board (#1183).
+            // DefaultHealthCheckService logs an Unhealthy entry at ERROR with the attached stack
+            // (HealthCheckEnd, event 103) — and its own catch filter is
+            // `catch (Exception ex) when (ex as OperationCanceledException == null)`, commented
+            // "Allow cancellation to propagate if it's not a timeout". Catching first denies the
+            // framework that classification, turning an aborted probe into a production incident
+            // for a pod that was 19 s past "Application started" and served for three more hours.
+            // Rethrow, and an aborted check unwinds silently the way the framework intends; a
+            // registration TIMEOUT (a linked token, caller not cancelled) still lands on the
+            // framework's timeout branch and is still reported.
+            throw;
+        }
         catch (Exception ex)
         {
+            // Everything the DATABASE says — refused, unauthenticated, missing table, timed out —
+            // is a genuine verdict and stays Unhealthy.
             return HealthCheckResult.Unhealthy("db_version check threw", ex);
         }
     }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-an-interrupted-health-check-no-longer-blames-the-database.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-an-interrupted-health-check-no-longer-blames-the-database.md
@@ -1,0 +1,28 @@
+---
+Name: An interrupted health check no longer blames the database
+Category: Fix
+Description: When a health probe gave up waiting, the portal recorded it as "the database is unhealthy" — a verdict it had never actually obtained — and opened an engineering ticket about a database that was fine.
+Icon: PlugConnected
+Order: -20260811
+---
+
+# An interrupted health check no longer blames the database
+
+A portal that has just been updated spends its first minute rebuilding everything it serves. While
+that is going on it is asked, every ten seconds, whether it is ready yet — and one of those checks
+asks the database which version of the schema it holds. On a busy first minute that question
+sometimes has to queue for a free connection, and the asker occasionally gives up before it is
+answered.
+
+Giving up is not an answer. The check had learned nothing at all about the database — it had not
+even opened a connection yet — but it reported "unhealthy" anyway, attached the interruption as
+though it were a database error, and that report was written down at the severity that opens an
+engineering ticket. So a routine restart, on a portal that then served normally for hours, produced
+a ticket about a database outage that never happened.
+
+Now the two are kept apart. If the database itself refuses, cannot be reached, or answers with the
+wrong schema version, that is still reported as unhealthy, in full, exactly as before — that is the
+whole point of the check, and it is what catches a portal started against a half-migrated database.
+But an interruption raised by whoever asked is passed back as an interruption, which is what the
+underlying framework expects and already knows how to ignore. No verdict is invented from a
+question that was never answered.

--- a/test/Memex.Portal.Shared.Test/DbVersionHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/DbVersionHealthCheckTest.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Distributed;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Npgsql;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// What <see cref="DbVersionHealthCheck"/> is allowed to call a database failure — issue #1183.
+///
+/// <para>Production, 2026-08-10 19:28:57Z:</para>
+/// <code>
+/// fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
+///       Health check db_version with status Unhealthy completed after 3462.0492ms with message 'db_version check threw'
+///       System.OperationCanceledException: The operation was canceled.
+///          at Npgsql.PoolingDataSource.RentAsync(...)
+/// </code>
+/// <para>The pod was NOT shutting down — it logged "Application started." at 19:28:38.552Z and
+/// served for three more hours. It was 19 s into a fresh rollout, mid NodeType-bake, and the
+/// startup probe's <c>/health</c> request was cancelled while the check was still waiting to RENT a
+/// connector — before a connection was even open. Nothing was learned about Postgres.</para>
+///
+/// <para>The check nevertheless converted its caller's cancellation into
+/// <c>HealthCheckResult.Unhealthy(exception)</c>. <c>DefaultHealthCheckService</c> logs an Unhealthy
+/// entry at ERROR with the attached stack, and the red-log filer turns Error into an incident — so
+/// an aborted probe opened a production ticket. The framework's own catch filter is
+/// <c>catch (Exception ex) when (ex as OperationCanceledException == null)</c>, commented
+/// "Allow cancellation to propagate if it's not a timeout"; catching first is what denied it that
+/// classification.</para>
+///
+/// <para>Both halves are pinned: a caller's cancellation propagates, and a database that genuinely
+/// cannot be reached is still Unhealthy.</para>
+/// </summary>
+public class DbVersionHealthCheckTest
+{
+    /// <summary>
+    /// A data source that can never answer — nothing listens on this loopback port. Which failure
+    /// the connect produces is irrelevant to both tests below; what matters is that the check has
+    /// to go to the database, so the cancellation is observed on the same code path production
+    /// took (<c>NpgsqlConnection.Open</c> → <c>PoolingDataSource</c>).
+    /// </summary>
+    private static NpgsqlDataSource UnreachableDataSource()
+        => NpgsqlDataSource.Create(
+            "Host=127.0.0.1;Port=59321;Username=nobody;Password=nothing;Database=nowhere;Timeout=2");
+
+    /// <summary>
+    /// 🚨 The regression pin. A cancellation raised by the CALLER is not a verdict about the
+    /// database, so it must leave the check as a cancellation — not as an Unhealthy report carrying
+    /// an exception for <c>DefaultHealthCheckService</c> to log at Error.
+    /// </summary>
+    [Fact]
+    public async Task ACallerCancellation_Propagates_InsteadOfBeingReportedAsAnUnhealthyDatabase()
+    {
+        await using var dataSource = UnreachableDataSource();
+        var check = new DbVersionHealthCheck(dataSource);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => check.CheckHealthAsync(new HealthCheckContext(), cts.Token));
+    }
+
+    /// <summary>
+    /// The guard that keeps the fix honest: propagating cancellations must not stop the check
+    /// reporting a database it genuinely could not reach. This is the whole reason the check
+    /// exists (a half-migrated or unreachable DB behind a portal that started anyway).
+    /// </summary>
+    [Fact]
+    public async Task AnUnreachableDatabase_IsStillReportedUnhealthy()
+    {
+        await using var dataSource = UnreachableDataSource();
+        var check = new DbVersionHealthCheck(dataSource);
+
+        var result = await check.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().NotBeNull(
+            "the cause has to reach the log — only CANCELLATION is excluded, never a real fault");
+    }
+}

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -8,6 +8,9 @@
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
     <!-- MapDefaultEndpoints / MapVersionEndpoint live here, beside /health and /alive. -->
     <ProjectReference Include="..\..\memex\aspire\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
+    <!-- DbVersionHealthCheckTest drives the portal's own db_version health check: whether a
+         cancellation raised by the CALLER is reported as a database verdict (#1183). -->
+    <ProjectReference Include="..\..\memex\aspire\Memex.Portal.Distributed\Memex.Portal.Distributed.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <!-- OAuthCodeStoreTest runs against a full monolith mesh (the store persists
          authorization codes as mesh nodes — the multi-replica safety contract). -->


### PR DESCRIPTION
## First: was that pod shutting down? **No — settled from pod lifecycle timestamps.**

That was the one open question on #1183, and the shutdown reading is **falsified**, not merely
unsupported:

| Evidence | Value |
|---|---|
| ReplicaSet `memex-portal-deployment-748bfcc86b` created | `2026-08-10T19:28:30Z` (image `…ci.2828`) |
| That pod's `Application started.` | `19:28:38.552Z` |
| The reported failure | `19:28:57.310Z` — **19 s later** |
| Pod scaled away | `~22:29Z`, by the next rollout — it served for **three more hours** |

`kubectl get rs --sort-by=.metadata.creationTimestamp` in `memex-cloud` for the timestamps; the
in-cluster Loki for the pod's own log. So it was **startup**, not shutdown — and #1107's precedent
(errors 409 ms after `Application is shutting down`) does not apply here.

## And it was not "Postgres could not be reached in 3.5 s" either

The deployment's **startupProbe** hits `/health` with `periodSeconds: 10` — and `/health` is the
only endpoint that runs `db_version` (`/alive` filters on the `live` tag). The probes are visible in
the log at 19:28:43.22, **19:28:53.85**, 19:29:02.31, 19:29:12.42, each with `nodetype_bake`
reporting "bake in progress". The failure is 3.46 s into the second one.

On that same request **both** Postgres-touching checks were cancelled at the same instant — ours and
`HealthChecks.NpgSql` (#1184) — and both stacks end in `PoolingDataSource.RentAsync`: still waiting
to **rent a connector**, before a connection was even open, on a pod mid-NodeType-bake with
`[ROUTE] 64 route dispatches in flight`. Neither check ever reached Postgres, so neither learned
anything about it. **There is no database verdict in this event to chase.**

I have not identified which producer cancelled the token at 3.46 s (the probe's own
`timeoutSeconds` is 5, and the registration carries no timeout). That is left **not established** —
and it does not need to be, because the defect below is wrong for *every* producer.

## The defect: a cancellation was reported as a database verdict

```csharp
catch (Exception ex)
{
    return HealthCheckResult.Unhealthy("db_version check threw", ex);
}
```

That blanket catch swallows the caller's own `OperationCanceledException` into an Unhealthy result
**carrying the exception**. `DefaultHealthCheckService` logs an Unhealthy entry at **Error with the
stack** (`HealthCheckEnd`, event id 103 — the exact line in the ticket), and the red-log filer turns
Error into an incident. An aborted probe opened a production ticket.

**That the production line came from OUR result is verifiable, not inferred.** The three message
templates in the shipped `Microsoft.Extensions.Diagnostics.HealthChecks` assembly are distinct:

| Path | Template |
|---|---|
| `HealthCheckEnd` (103) — reports a **returned result** | `Health check {HealthCheckName} with status {HealthStatus} completed after {ElapsedMilliseconds}ms with message '{HealthCheckDescription}'` |
| `HealthCheckError` (104) — the framework's own catch | `Health check {HealthCheckName} threw an unhandled exception after {ElapsedMilliseconds}ms` |
| the OCE branch's description | `A timeout occurred while running check.` |

The ticket's line is the first template, and `{HealthCheckDescription}` carries `db_version check
threw` — **our** string, from `HealthCheckResult.Unhealthy("db_version check threw", ex)`. So the
Error came from the result we returned, not from anything the framework decided.

The framework's own filter is the opposite, and says so in a comment:

```csharp
// Allow cancellation to propagate if it's not a timeout.
catch (Exception ex) when (ex as OperationCanceledException == null)
```

Catching first is what denied it that classification. The fix rethrows when the caller's token is
the one that fired — so an aborted check unwinds silently, the way the framework intends.

**This is not a log-level change** (AGENTS.md): no `Log*` call is touched anywhere. It corrects an
exception *classification*, and the level follows from the framework's existing contract.

**Nothing the database says is affected.** Refused, unauthenticated, missing table, slow, wrong
schema version — all still report Unhealthy with the cause attached, which is the whole reason the
check exists. A registration *timeout* (a linked token, caller not cancelled) still lands on the
framework's timeout branch and is still reported.

## Regression test + negative control

`DbVersionHealthCheckTest` (`test/Memex.Portal.Shared.Test`, which now references
`Memex.Portal.Distributed`) drives the real check against a data source that can never answer, so
the cancellation is observed on the same code path production took.

| Run | `ACallerCancellation_Propagates_InsteadOfBeingReportedAsAnUnhealthyDatabase` | `AnUnreachableDatabase_IsStillReportedUnhealthy` |
|---|---|---|
| with the fix | **pass** | **pass** |
| `DbVersionGate` reverted, tests kept | **fail** — `Assert.ThrowsAny() Failure: No exception was thrown` | **pass** |

The reverted run reproduces the defect exactly: the check silently converts its caller's
cancellation into an Unhealthy report. The second test is the guard — propagating cancellations must
not stop the check reporting a database it genuinely could not reach, and it does not.

## On #1184 and PR #1188

#1184 is the same *environmental event* seen by a second reporter. #1188 (now merged) is right that
the two are different code sites and must stay two incidents; this PR does not touch identity and
does not collide with it. But `HealthChecks.NpgSql.NpgSqlHealthCheck` has the identical blanket
`catch (Exception ex)`, and it is third-party: it cannot be fixed here. If its ticket recurs, the
lever is the registration, not our code.

Fixes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
