### PR TITLE
Content-broken NodeTypes no longer stall rollouts; a baking silo no longer captures traffic

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-bake-gate-content-vs-image.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-bake-gate-content-vs-image.md
@@ -1,0 +1,18 @@
+---
+Name: Rollouts no longer stall on deleted course content
+Category: Fix
+Description: A course whose source files were removed can no longer block platform updates, and pages stay fast while an update is being prepared.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Rollouts no longer stall on deleted course content
+
+When a course or package was re-installed under a new name, its old type definitions could be
+left behind without their source files. The platform's update safety-check mistook those
+leftovers for damage caused by the new version and refused to finish the update — and while it
+waited, pages across the portal could become very slow to open.
+
+Both parts are fixed: content that is broken because its sources were deleted is now reported
+separately and never blocks an update, and new page activations now stay on the healthy side
+of the platform while an update is being prepared, so browsing stays fast during updates.

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -21,10 +21,26 @@ namespace MeshWeaver.Hosting.Orleans;
 /// node's <c>HubConfiguration</c> reactively and builds the hub; incoming deliveries park
 /// on a ready-signal until the hub is available and are then dispatched to it. The grain is
 /// reentrant so deliveries can be queued while activation is still in flight.
+///
+/// <para><b>Why <c>[PreferLocalPlacement]</c> and not the default Random.</b> A new activation
+/// should live on the silo whose traffic caused it. Random placement sprays activations across
+/// every compatible silo — including one that is mid-rollout: a pod whose NodeType bake gate is
+/// refusing readiness is OUT of the k8s Service (no HTTP reaches it) yet fully IN the Orleans
+/// cluster, so with Random up to half of the serving pod's new hub activations landed on the
+/// not-ready silo. On 2026-08-10/11 (memex-cloud) that silo's routing had additionally wedged,
+/// so every activation placed there died on the 60s SubscribeRequest timeout — the whole store
+/// crawled for a day while the gate (correctly, per its own rules at the time) held the rollout.
+/// Prefer-local keeps the two worlds apart with no coordination: the serving silo's user traffic
+/// activates hubs ON the serving silo, and the baking silo's warm sweep activates the type hubs
+/// it is compiling ON ITSELF — which the bake REQUIRES, because the assemblies must be built
+/// against the NEW image's framework version. (Single-activation semantics are untouched: this
+/// only biases where a NOT-yet-activated grain comes to life; an existing activation anywhere
+/// still wins.)</para>
 /// </summary>
 /// <param name="logger">Logger for activation, deactivation and delivery diagnostics.</param>
 /// <param name="meshHub">The mesh hub used to resolve services, addresses and node streams.</param>
 [global::Orleans.Concurrency.Reentrant]
+[global::Orleans.Placement.PreferLocalPlacement]
 public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHub)
     : Grain, IMessageHubGrain
 {

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -53,6 +53,36 @@ public enum PreWarmStatus
     /// Only "no answer" propagates as "no answer".</para>
     /// </summary>
     UpstreamUnevaluated,
+    /// <summary>
+    /// The compile settled at Error AND the type's declared source queries currently match ZERO
+    /// Code nodes (<see cref="NodeTypeDefinition.CurrentSourceVersions"/> is EXPLICITLY empty) —
+    /// the sources were deleted or moved out from under the type. This is a CONTENT verdict, not
+    /// an image verdict: which nodes a mesh query matches is a property of the mesh, not of the
+    /// framework being rolled out, so no image caused it and no rollout can fix it.
+    ///
+    /// <para>🚨 This member exists because on 2026-08-10 four such types (KmuBasics/* — their
+    /// Source subtrees removed when the course was re-installed under a new id, the type nodes
+    /// left behind) were counted as image regressions and stalled memex-cloud's self-update for a
+    /// day, across two successive images. A failure the image cannot influence must never hold
+    /// the image out of rotation — the same deploy-freeze rule as
+    /// <see cref="PreWarmOutcome.WasHealthyBeforeBake"/>, arriving through content deletion
+    /// instead of an abandoned Error record.</para>
+    ///
+    /// <para>Deliberately narrow: only an EXPLICITLY empty snapshot reclassifies. A null snapshot
+    /// means the sources watcher never seeded, so the sweep does not actually know the sources are
+    /// gone — that stays <see cref="CompileError"/>, because a real regression must not hide
+    /// behind an unseeded snapshot.</para>
+    /// </summary>
+    NoSources,
+    /// <summary>
+    /// NOT ATTEMPTED, and content-broken one hop up: a NodeType this one draws sources from is
+    /// <see cref="NoSources"/>-broken, so this type cannot build either — for the same
+    /// content-not-image reason, which must propagate AS ITSELF rather than as a gating
+    /// <see cref="UpstreamFailed"/>. This is the same depth-1 hole
+    /// <see cref="UpstreamUnevaluated"/> closes for timeouts: leniency on the direct outcome is
+    /// worth nothing if the identical condition gates through the dependents.
+    /// </summary>
+    UpstreamContentBroken,
     /// <summary>The warm subscription faulted (best-effort — the lazy path still works).</summary>
     Faulted
 }
@@ -395,6 +425,10 @@ public static class DynamicTypePreWarmer
         // reads them as they stand WHEN ITS TURN COMES, not when the chain was built.
         var verdictFailed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var unevaluated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // Third cascade, same reasoning one axis over: a type whose sources were DELETED
+        // (PreWarmStatus.NoSources) is a verdict — but a CONTENT verdict, and its dependents must
+        // inherit "content-broken", not the gating UpstreamFailed. See PreWarmStatus.NoSources.
+        var contentBroken = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
         // has completed, so "dependencies first" is structural rather than a convention.
@@ -416,20 +450,26 @@ public static class DynamicTypePreWarmer
 
                     // A real verdict upstream wins over a merely-unevaluated one: if ANY dependency
                     // actually failed to compile, this type is genuinely blocked and must gate,
-                    // regardless of some other dependency having also timed out.
+                    // regardless of some other dependency having also timed out. A content-broken
+                    // upstream sits between the two: it IS a verdict (so it beats "I don't know"),
+                    // but a content verdict — its dependents inherit content-broken, never gating.
                     var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, verdictFailed);
-                    var unevaluatedBlocker = blocker is null
+                    var contentBlocker = blocker is null
+                        ? NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, contentBroken)
+                        : null;
+                    var unevaluatedBlocker = blocker is null && contentBlocker is null
                         ? NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, unevaluated)
                         : null;
                     var missingBytes = bytesMissing.Contains(p);
-                    if (blocker is not null || unevaluatedBlocker is not null)
+                    if (blocker is not null || contentBlocker is not null || unevaluatedBlocker is not null)
                     {
-                        var isVerdict = blocker is not null;
-                        var named = blocker ?? unevaluatedBlocker!;
-                        var outcome = isVerdict
-                            ? PreWarmStatus.UpstreamFailed
+                        var named = blocker ?? contentBlocker ?? unevaluatedBlocker!;
+                        var outcome = blocker is not null ? PreWarmStatus.UpstreamFailed
+                            : contentBlocker is not null ? PreWarmStatus.UpstreamContentBroken
                             : PreWarmStatus.UpstreamUnevaluated;
-                        (isVerdict ? verdictFailed : unevaluated).Add(p);
+                        (blocker is not null ? verdictFailed
+                            : contentBlocker is not null ? contentBroken
+                            : unevaluated).Add(p);
                         // {Outcome} carries WHICH cascade this is as a queryable token — the two
                         // differ in whether they may stall a rollout, so a log that blurred them
                         // would hide the thing an operator most needs to know.
@@ -458,10 +498,14 @@ public static class DynamicTypePreWarmer
                         .Do(o =>
                         {
                             // A timeout is not a verdict — route it to `unevaluated` so its
-                            // dependents inherit "no answer", not "it broke". Everything else that
-                            // missed a usable build (CompileError, Faulted) is a verdict.
+                            // dependents inherit "no answer", not "it broke". Deleted sources are
+                            // a CONTENT verdict — dependents inherit content-broken, never gating.
+                            // Everything else that missed a usable build (CompileError, Faulted)
+                            // is an image verdict.
                             if (o.Status is PreWarmStatus.TimedOut)
                                 unevaluated.Add(p);
+                            else if (o.Status is PreWarmStatus.NoSources)
+                                contentBroken.Add(p);
                             else if (!o.ReachedUsableBuild)
                                 verdictFailed.Add(p);
                         });
@@ -541,7 +585,7 @@ public static class DynamicTypePreWarmer
                                     return d.CompilationStatus switch
                                     {
                                         CompilationStatus.Error => new PreWarmOutcome(
-                                            typePath, PreWarmStatus.CompileError, d.CompilationError),
+                                            typePath, ClassifyCompileFailure(d), d.CompilationError),
                                         // The rebuild never reported an answer — not a
                                         // compile failure, so never labelled one.
                                         CompilationStatus.Unavailable => new PreWarmOutcome(
@@ -593,6 +637,20 @@ public static class DynamicTypePreWarmer
         succeeded is { } s && (baseline is not { } b || s > b);
 
     /// <summary>
+    /// Classify a compile that settled at Error. A type that DECLARES source queries whose live
+    /// snapshot (<see cref="NodeTypeDefinition.CurrentSourceVersions"/>, maintained by the
+    /// per-NodeType sources watcher) is EXPLICITLY empty is broken by CONTENT — its sources were
+    /// deleted from the mesh — and reports <see cref="PreWarmStatus.NoSources"/>; see that member
+    /// for why it must not gate a rollout. Anything else is
+    /// <see cref="PreWarmStatus.CompileError"/>: in particular a NULL snapshot (watcher never
+    /// seeded) stays a gating compile error, so a real regression cannot hide behind "not seeded".
+    /// </summary>
+    public static PreWarmStatus ClassifyCompileFailure(NodeTypeDefinition d) =>
+        d.Sources is { Count: > 0 } && d.CurrentSourceVersions is { Count: 0 }
+            ? PreWarmStatus.NoSources
+            : PreWarmStatus.CompileError;
+
+    /// <summary>
     /// Activate one dynamic NodeType's hub by subscribing to its own MeshNode stream —
     /// which routes a SubscribeRequest to the owning hub, activating it and firing the
     /// compile watcher's framework-stale / first-build kickoff. Holds the subscription
@@ -624,7 +682,7 @@ public static class DynamicTypePreWarmer
                         return d.CompilationStatus switch
                         {
                             CompilationStatus.Error => new PreWarmOutcome(
-                                typePath, PreWarmStatus.CompileError, d.CompilationError),
+                                typePath, ClassifyCompileFailure(d), d.CompilationError),
                             // TimedOut, never CompileError: the type is not broken, its
                             // state simply never came back.
                             CompilationStatus.Unavailable => new PreWarmOutcome(

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -36,6 +36,17 @@ public sealed class DynamicTypePreWarmerHostedService(
     /// <summary>Config key that opts a deployment into the startup warm-up (default: off).</summary>
     public const string EnabledConfigKey = "PreWarm:DynamicTypes";
 
+    /// <summary>
+    /// Config key overriding the per-type warm budget, as a <see cref="TimeSpan"/> string
+    /// (e.g. <c>"00:00:30"</c>). Default: <see cref="DynamicTypePreWarmer.DefaultPerTypeBudget"/>.
+    /// The budget only bites on types that never settle — a healthy compile is seconds — so this
+    /// knob bounds how long a WEDGED type can hold the sweep, per type, without a code change:
+    /// on 2026-08-11 (memex-cloud) every remaining compile timed out cross-silo at the full
+    /// default 5 minutes and 67 pending types priced the sweep at ~5.5 hours, with no way to
+    /// shorten it from the outside.
+    /// </summary>
+    public const string PerTypeBudgetConfigKey = "PreWarm:PerTypeBudget";
+
     private IDisposable? _warmSubscription;
     private IDisposable? _startedRegistration;
 
@@ -76,6 +87,23 @@ public sealed class DynamicTypePreWarmerHostedService(
             return;
         }
 
+        // Optional per-type budget override — raw string + TryParse like EnabledConfigKey, so a
+        // malformed value degrades to the default rather than faulting the warm-up. Zero/negative
+        // is refused for the same reason: a budget that can never elapse into a verdict would turn
+        // one wedged type into an eternal sweep.
+        TimeSpan? perTypeBudget = null;
+        var budgetRaw = services.GetService<IConfiguration>()?[PerTypeBudgetConfigKey];
+        if (!string.IsNullOrWhiteSpace(budgetRaw))
+        {
+            if (TimeSpan.TryParse(budgetRaw, out var parsed) && parsed > TimeSpan.Zero)
+                perTypeBudget = parsed;
+            else
+                logger.LogWarning(
+                    "DynamicTypePreWarmer: ignoring invalid {Key}='{Value}' — using the default "
+                    + "per-type budget {Default}",
+                    PerTypeBudgetConfigKey, budgetRaw, DynamicTypePreWarmer.DefaultPerTypeBudget);
+        }
+
         var startedAt = DateTimeOffset.UtcNow;
         var compiled = 0;
         var alreadyBaked = 0;
@@ -83,6 +111,7 @@ public sealed class DynamicTypePreWarmerHostedService(
         var timedOut = 0;
         var skipped = 0;
         var faulted = 0;
+        var contentBroken = 0;
 
         // The readiness gate reads this. Resolved (not required) so a host that never called
         // AddNodeTypeBakeGate simply warms without gating — the warmer stays a latency optimisation
@@ -92,7 +121,7 @@ public sealed class DynamicTypePreWarmerHostedService(
 
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         _warmSubscription = DynamicTypePreWarmer
-            .WarmDynamicTypes(mesh, logger)
+            .WarmDynamicTypes(mesh, logger, perTypeBudget)
             .Subscribe(
                 outcome =>
                 {
@@ -111,6 +140,10 @@ public sealed class DynamicTypePreWarmerHostedService(
                         // it in the health payload, while UpstreamFailed gates.)
                         case PreWarmStatus.UpstreamFailed:
                         case PreWarmStatus.UpstreamUnevaluated: Interlocked.Increment(ref skipped); break;
+                        // Broken by deleted CONTENT, not by this image — the gate files these
+                        // under ContentBroken (never gating); the count keeps them visible here.
+                        case PreWarmStatus.NoSources:
+                        case PreWarmStatus.UpstreamContentBroken: Interlocked.Increment(ref contentBroken); break;
                         default: Interlocked.Increment(ref faulted); break;
                     }
                 },
@@ -131,10 +164,11 @@ public sealed class DynamicTypePreWarmerHostedService(
                     var elapsed = DateTimeOffset.UtcNow - startedAt;
                     logger.LogInformation(
                         "DynamicTypePreWarmer: warm-up complete in {Elapsed} — compiled={Compiled} alreadyBaked={AlreadyBaked} "
-                        + "compileErrors={Errored} timedOut={TimedOut} skipped={Skipped} faulted={Faulted}",
+                        + "compileErrors={Errored} timedOut={TimedOut} skipped={Skipped} contentBroken={ContentBroken} faulted={Faulted}",
                         elapsed,
                         Volatile.Read(ref compiled), Volatile.Read(ref alreadyBaked), Volatile.Read(ref errored),
-                        Volatile.Read(ref timedOut), Volatile.Read(ref skipped), Volatile.Read(ref faulted));
+                        Volatile.Read(ref timedOut), Volatile.Read(ref skipped), Volatile.Read(ref contentBroken),
+                        Volatile.Read(ref faulted));
 
                     // MarkComplete keeps a recorded regression red — completion is not absolution.
                     gate?.MarkComplete(

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -37,6 +37,7 @@ public sealed class NodeTypeBakeGateState
 {
     private readonly ConcurrentDictionary<string, string> regressions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> unevaluated = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> contentBroken = new(StringComparer.OrdinalIgnoreCase);
     private int phase = (int)BakePhase.NotStarted;
     private volatile string detail = "pre-warm not started";
 
@@ -71,6 +72,14 @@ public sealed class NodeTypeBakeGateState
     /// is not "it broke". See <see cref="MarkOutcome"/>.
     /// </summary>
     public IReadOnlyDictionary<string, string> Unevaluated => unevaluated;
+
+    /// <summary>
+    /// Types broken by CONTENT on this image — their declared source queries match zero Code nodes
+    /// (the sources were deleted from the mesh), or an upstream in that state blocks them. Visible
+    /// for diagnosis, deliberately NOT readiness-blocking: no image caused it and no rollout can
+    /// fix it. See <see cref="PreWarmStatus.NoSources"/> for the incident that mandates this.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ContentBroken => contentBroken;
 
     /// <summary>The sweep has begun.</summary>
     public void MarkRunning(string message)
@@ -118,6 +127,20 @@ public sealed class NodeTypeBakeGateState
             return;
         }
 
+        // A CONTENT verdict is not an IMAGE verdict. NoSources means the type's declared source
+        // queries no longer match anything on the mesh — its sources were deleted out from under
+        // it (2026-08-10: four KmuBasics/* types whose course was re-installed under a new id,
+        // the type nodes left behind, stalled memex-cloud's self-update across two images). No
+        // image can change what a mesh query matches, so no rollout may be held hostage to it —
+        // the same deploy-freeze rule as WasHealthyBeforeBake, arriving through content deletion
+        // instead of an abandoned Error record. UpstreamContentBroken is the same condition one
+        // hop downstream (the depth-1 rule, again).
+        if (outcome.Status is PreWarmStatus.NoSources or PreWarmStatus.UpstreamContentBroken)
+        {
+            contentBroken[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
+            return;
+        }
+
         regressions[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
         Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
         detail = $"{regressions.Count} NodeType(s) regressed on this image";
@@ -137,13 +160,21 @@ public sealed class NodeTypeBakeGateState
         }
 
         Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
-        // Ready, but say so honestly: a type we could not evaluate is not a type we verified.
-        // Surfacing it in the health payload is what keeps "non-blocking" from becoming "invisible"
-        // — a silently-swallowed timeout is how a real regression would hide behind this change.
-        detail = unevaluated.IsEmpty
+        // Ready, but say so honestly: a type we could not evaluate is not a type we verified, and
+        // a content-broken type is broken RIGHT NOW even though it must not stall the rollout.
+        // Surfacing both in the health payload is what keeps "non-blocking" from becoming
+        // "invisible" — a silently-swallowed bucket is how a real problem would hide behind this
+        // leniency.
+        var addenda = new List<string>(2);
+        if (!unevaluated.IsEmpty)
+            addenda.Add($"{unevaluated.Count} not evaluated — "
+                + string.Join(", ", unevaluated.Keys.OrderBy(k => k, StringComparer.Ordinal)));
+        if (!contentBroken.IsEmpty)
+            addenda.Add($"{contentBroken.Count} content-broken, sources missing — "
+                + string.Join(", ", contentBroken.Keys.OrderBy(k => k, StringComparer.Ordinal)));
+        detail = addenda.Count == 0
             ? message
-            : $"{message} ({unevaluated.Count} not evaluated — "
-                + string.Join(", ", unevaluated.Keys.OrderBy(k => k, StringComparer.Ordinal)) + ")";
+            : $"{message} ({string.Join("; ", addenda)})";
     }
 }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -257,4 +258,126 @@ public class NodeTypeBakeGateStateTest
     [Fact]
     public void OutcomeWasHealthyBeforeBake_DefaultsToTrue() =>
         new PreWarmOutcome("A", PreWarmStatus.Compiled).WasHealthyBeforeBake.Should().BeTrue();
+
+    /// <summary>
+    /// 🚨 A CONTENT verdict is not an IMAGE verdict. A type whose declared source queries match
+    /// nothing any more — its sources deleted out from under it — fails on EVERY image, so gating
+    /// on it freezes the fleet exactly like the abandoned-Error case the WasHealthyBeforeBake rule
+    /// exists for. Lived through on 2026-08-10: four KmuBasics/* types (their course re-installed
+    /// under a new id, the type nodes left behind) stalled memex-cloud's self-update across two
+    /// successive images, while the stuck-but-baking pod wedged the cluster's routing.
+    /// </summary>
+    [Fact]
+    public void NoSourcesOnAPreviouslyHealthyType_DoesNotGate()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome(
+            "KmuBasics/Buchungsjournal", PreWarmStatus.NoSources, "0 source nodes matched")
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+        state.ContentBroken.Keys.Should().Contain("KmuBasics/Buchungsjournal");
+    }
+
+    /// <summary>
+    /// The depth-1 rule, content edition: leniency on the direct NoSources verdict is worth
+    /// nothing if the identical condition gates through the dependents as UpstreamFailed.
+    /// </summary>
+    [Fact]
+    public void UpstreamContentBrokenOnAPreviouslyHealthyType_DoesNotGate()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome(
+            "Dependent", PreWarmStatus.UpstreamContentBroken, "blocked by KmuBasics/Buchungsjournal")
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+        state.ContentBroken.Keys.Should().Contain("Dependent");
+    }
+
+    /// <summary>Non-blocking must not mean invisible — the health payload names what content broke.</summary>
+    [Fact]
+    public void ContentBrokenTypes_AreNamedInTheHealthDetail()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Gone/Type", PreWarmStatus.NoSources)
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkComplete("all good");
+
+        state.Detail.Should().Contain("Gone/Type").And.Contain("content-broken");
+    }
+
+    /// <summary>A content-broken type must not dilute a REAL regression happening beside it.</summary>
+    [Fact]
+    public void CompileErrorStillGates_EvenAlongsideAContentBrokenType()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Gone/Type", PreWarmStatus.NoSources)
+        {
+            WasHealthyBeforeBake = true
+        });
+        state.MarkOutcome(Failed("Broken/Type", wasHealthy: true));
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Broken/Type");
+    }
+
+    /// <summary>
+    /// The classifier that feeds the buckets above: declared source queries + an EXPLICITLY empty
+    /// live snapshot = the sources are gone = <see cref="PreWarmStatus.NoSources"/>.
+    /// </summary>
+    [Fact]
+    public void ClassifyCompileFailure_DeclaredSourcesWithEmptySnapshot_IsNoSources() =>
+        DynamicTypePreWarmer.ClassifyCompileFailure(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"],
+            CurrentSourceVersions = new Dictionary<string, long>()
+        }).Should().Be(PreWarmStatus.NoSources);
+
+    /// <summary>
+    /// 🚨 A NULL snapshot is "the watcher never seeded", NOT "the sources are gone" — the sweep
+    /// does not actually know, so the failure keeps gating. A real regression must not hide
+    /// behind an unseeded snapshot.
+    /// </summary>
+    [Fact]
+    public void ClassifyCompileFailure_NullSnapshot_StaysCompileError() =>
+        DynamicTypePreWarmer.ClassifyCompileFailure(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"]
+        }).Should().Be(PreWarmStatus.CompileError);
+
+    /// <summary>Sources still matching = the failure is about the CODE on this image. It gates.</summary>
+    [Fact]
+    public void ClassifyCompileFailure_MatchedSources_StaysCompileError() =>
+        DynamicTypePreWarmer.ClassifyCompileFailure(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"],
+            CurrentSourceVersions = new Dictionary<string, long> { ["P/Source/A"] = 42 }
+        }).Should().Be(PreWarmStatus.CompileError);
+
+    /// <summary>
+    /// A type that declares NO source queries compiles from its Configuration alone — an empty
+    /// snapshot is its normal state, so a failure is a verdict about this image and gates.
+    /// </summary>
+    [Fact]
+    public void ClassifyCompileFailure_NoDeclaredSources_StaysCompileError() =>
+        DynamicTypePreWarmer.ClassifyCompileFailure(new NodeTypeDefinition
+        {
+            CurrentSourceVersions = new Dictionary<string, long>()
+        }).Should().Be(PreWarmStatus.CompileError);
 }


### PR DESCRIPTION
## The incident (memex-cloud, 2026-08-10/11)

Four `KmuBasics/*` NodeTypes whose `Source` subtrees had been deleted (the course was re-installed as `AgenticOffice`; the type nodes were left behind) failed their bake with `CS0246` + `Matched Code nodes (0)`. One of them had compiled green on Aug 7, so the bake gate counted it as an **image regression** and refused readiness — across **two successive images**, stalling the self-update for a day. Meanwhile the gated-but-baking pod joined Orleans, took grain placements with a wedged router (`64 route dispatches in flight and not terminating`), and every activation placed on it died on the 60s `SubscribeRequest` timeout — the whole store crawled.

## The fixes

1. **A content verdict is not an image verdict.** A compile error on a type whose declared source queries have an EXPLICITLY empty live snapshot (`CurrentSourceVersions == {}`) means the sources were deleted from the mesh — no image caused that and no rollout can fix it. New `PreWarmStatus.NoSources` (+ `UpstreamContentBroken` for dependents, the depth-1 rule applied to content) files into a new non-gating `ContentBroken` bucket on `NodeTypeBakeGateState`, named in the health detail. A **null** snapshot (watcher never seeded) still gates — a real regression must not hide behind "not seeded".
2. **`MessageHubGrain` is now `[PreferLocalPlacement]`** (was default Random). An activation lives on the silo whose traffic caused it: user traffic stays on Ready silos, and the bake's own compile activations stay on the baking silo — which the bake requires, because assemblies must build against the NEW image's framework. This is what keeps browsing fast while a rollout bakes.
3. **`PreWarm:PerTypeBudget`** config key: the per-type warm budget (default 5 min) is tunable without a code change. With every type timing out cross-silo, the fixed default priced 67 pending types at ~5.5 h with no external way to shorten it.

## Tests

- `NodeTypeBakeGateStateTest`: `NoSources`/`UpstreamContentBroken` do not gate; content-broken types are named in the health detail; a real `CompileError` beside a content-broken type still gates; `ClassifyCompileFailure` unit-pinned for all four snapshot shapes (25/25 green locally, Release `-warnaserror`).

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)