### PR TITLE
Initial bake sweeps at full speed — only a serving pod's warm-up trickles

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-initial-bake-full-speed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-initial-bake-full-speed.md
@@ -1,0 +1,19 @@
+---
+Name: Platform updates prepare in about two minutes instead of twenty
+Category: Feature
+Description: The preparation step of a platform update now runs at full speed, since nobody is being served from the updating side while it runs.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Platform updates prepare in about two minutes instead of twenty
+
+When the platform updates itself, it first rebuilds every dynamic content type against the new
+version. That preparation deliberately paced itself so a busy portal would not slow down — but
+during an update the preparing side isn't serving anyone yet, so the pacing only made updates
+take longer. Measurements showed the actual rebuild work takes under a minute; the pacing
+accounted for most of the wait.
+
+Preparation now runs at full speed during an update and keeps its gentle pacing only when a
+running portal warms itself in the background. Updates get ready in a couple of minutes, and
+day-to-day editing and compiling of individual types is unchanged.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -159,6 +159,17 @@ public static class DynamicTypePreWarmer
     /// members run in parallel either, so the sweep is now strictly sequential and the knob is
     /// gone rather than left lying about what it does.</para>
     /// </summary>
+    /// <remarks>
+    /// 🚨 This is the SERVING-pod default, and on a big mesh it — not Roslyn — is the bake's
+    /// wall-clock. Measured on memex-cloud 2026-08-11 (healthy single silo): 162 types compiled in
+    /// a 7-minute sweep of which the compiles themselves summed to 51 SECONDS (p50 0.2s, p90 0.5s,
+    /// max 3.4s) — the 2s trickle was ~5.4 of the 7 minutes. The trickle exists to protect a pod
+    /// that is SERVING while it warms; an INITIAL BAKE on a readiness-gated pod serves nobody, so
+    /// the hosted service passes <see cref="TimeSpan.Zero"/> there (see
+    /// <c>DynamicTypePreWarmerHostedService</c> — the gated fast path, overridable via
+    /// <c>PreWarm:BetweenTypes</c>). That distinction is what turns "the bake takes 20 minutes"
+    /// into "the bake takes ~2".
+    /// </remarks>
     public static readonly TimeSpan BetweenTypes = TimeSpan.FromSeconds(2);
 
     /// <summary>Per-type warm budget — generous, because a cold Roslyn compile queued behind
@@ -186,9 +197,11 @@ public static class DynamicTypePreWarmer
     public static IObservable<PreWarmOutcome> WarmDynamicTypes(
         IMessageHub mesh,
         ILogger? logger = null,
-        TimeSpan? perTypeBudget = null)
+        TimeSpan? perTypeBudget = null,
+        TimeSpan? betweenTypes = null)
     {
         var budget = perTypeBudget ?? DefaultPerTypeBudget;
+        var pacing = betweenTypes ?? BetweenTypes;
         var meshService = mesh.ServiceProvider.GetService<IMeshService>();
         if (meshService is null)
         {
@@ -240,7 +253,8 @@ public static class DynamicTypePreWarmer
                     return NodeTypeBakeStatus
                         .Probe(definitions, store, logger: logger)
                         .SelectMany(report => BakeOrFollow(
-                            mesh, workspace, accessService, definitions, store, report, budget, logger));
+                            mesh, workspace, accessService, definitions, store, report, budget, pacing,
+                            logger));
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>
                 {
@@ -289,15 +303,16 @@ public static class DynamicTypePreWarmer
         IAssemblyStore store,
         NodeTypeBakeReport report,
         TimeSpan budget,
+        TimeSpan pacing,
         ILogger? logger)
     {
         // Nothing outstanding — no lease needed, and nothing for a follower to wait for.
         if (report.IsComplete)
-            return WarmPending(workspace, accessService, definitions, report, budget, logger);
+            return WarmPending(workspace, accessService, definitions, report, budget, pacing, logger);
 
         var coordination = mesh.ServiceProvider.GetService<BakeCoordination>();
         if (coordination is null)
-            return WarmPending(workspace, accessService, definitions, report, budget, logger);
+            return WarmPending(workspace, accessService, definitions, report, budget, pacing, logger);
 
         var lease = NodeTypeBakeLease.TryAcquire(
             coordination.LeaseDirectory, report.FrameworkVersion, Environment.MachineName, logger);
@@ -308,7 +323,7 @@ public static class DynamicTypePreWarmer
             // fleet out until it went stale.
             return Observable.Using(
                 () => lease,
-                _ => WarmPending(workspace, accessService, definitions, report, budget, logger));
+                _ => WarmPending(workspace, accessService, definitions, report, budget, pacing, logger));
 
         logger?.LogInformation(
             "DynamicTypePreWarmer: another pod holds the bake lease — following the shared assembly "
@@ -336,6 +351,7 @@ public static class DynamicTypePreWarmer
         IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
         NodeTypeBakeReport report,
         TimeSpan budget,
+        TimeSpan pacing,
         ILogger? logger)
     {
         var baked = report.Entries
@@ -494,7 +510,7 @@ public static class DynamicTypePreWarmer
                         : WarmOne(workspace, accessService, p, budget, logger);
 
                     return warm
-                        .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes)
+                        .DelaySubscription(i == 0 ? TimeSpan.Zero : pacing)
                         .Do(o =>
                         {
                             // A timeout is not a verdict — route it to `unevaluated` so its

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -337,7 +337,7 @@ public static class DynamicTypePreWarmer
             .Timer(FollowPollInterval)
             .SelectMany(_ => NodeTypeBakeStatus.Probe(definitions, store, logger: logger))
             .SelectMany(fresh => BakeOrFollow(
-                mesh, workspace, accessService, definitions, store, fresh, budget, logger));
+                mesh, workspace, accessService, definitions, store, fresh, budget, pacing, logger));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -47,6 +47,18 @@ public sealed class DynamicTypePreWarmerHostedService(
     /// </summary>
     public const string PerTypeBudgetConfigKey = "PreWarm:PerTypeBudget";
 
+    /// <summary>
+    /// Config key overriding the pause between types, as a <see cref="TimeSpan"/> string. When the
+    /// key is absent the pacing DIFFERENTIATES by what the pod is doing (the initial-bake vs
+    /// usual-compile distinction): a pod whose bake GATES readiness serves nobody while it bakes,
+    /// so it sweeps at full speed (<see cref="TimeSpan.Zero"/>); an ungated pod is warming in the
+    /// background of live traffic, so it keeps the trickle
+    /// (<see cref="DynamicTypePreWarmer.BetweenTypes"/>). Measured 2026-08-11: the 2s trickle was
+    /// ~5.4 of a 7-minute sweep whose compiles summed to 51s — on a gated pod that pacing was pure
+    /// added rollout time.
+    /// </summary>
+    public const string BetweenTypesConfigKey = "PreWarm:BetweenTypes";
+
     private IDisposable? _warmSubscription;
     private IDisposable? _startedRegistration;
 
@@ -119,9 +131,26 @@ public sealed class DynamicTypePreWarmerHostedService(
         var gate = services.GetService<NodeTypeBakeGateState>();
         gate?.MarkRunning("enumerating dynamic NodeTypes");
 
+        // Pacing: explicit config wins; otherwise a readiness-GATED pod sweeps at full speed (it
+        // serves nobody while it bakes — the initial-bake case) and an ungated pod keeps the
+        // serving-friendly trickle. See BetweenTypesConfigKey for the measurement behind this.
+        TimeSpan? betweenTypes = gate is { GatesReadiness: true } ? TimeSpan.Zero : null;
+        var pacingRaw = services.GetService<IConfiguration>()?[BetweenTypesConfigKey];
+        if (!string.IsNullOrWhiteSpace(pacingRaw))
+        {
+            if (TimeSpan.TryParse(pacingRaw, out var parsedPacing) && parsedPacing >= TimeSpan.Zero)
+                betweenTypes = parsedPacing;
+            else
+                logger.LogWarning(
+                    "DynamicTypePreWarmer: ignoring invalid {Key}='{Value}' — using the "
+                    + "{Mode} pacing default",
+                    BetweenTypesConfigKey, pacingRaw,
+                    gate is { GatesReadiness: true } ? "gated (zero)" : "serving (trickle)");
+        }
+
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         _warmSubscription = DynamicTypePreWarmer
-            .WarmDynamicTypes(mesh, logger, perTypeBudget)
+            .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes)
             .Subscribe(
                 outcome =>
                 {


### PR DESCRIPTION
## The measurement (memex-cloud, 2026-08-11, healthy single silo)

162 dynamic NodeTypes compiled in a 7.0-minute sweep — of which the compiles themselves summed to **51 seconds** (p50 0.2s, p90 0.5s, max 3.4s `Store/Plugin`). The fixed `BetweenTypes = 2s` pacing accounted for ~5.4 of the 7 minutes. Roslyn is not the bake's bottleneck; the pacing is.

## The distinction

The trickle exists to keep a **serving** pod's background warm-up from looking like load. An **initial bake** on a readiness-gated pod (the rollout path armed by `PreWarm:GateReadiness`) serves nobody while it bakes — pacing there is pure added rollout time, during which the fleet self-update sits still.

- Gate arms readiness → sweep runs with `TimeSpan.Zero` pacing → whole fleet ready in ~2 minutes.
- Ungated background warm → keeps the 2s trickle, unchanged.
- `PreWarm:BetweenTypes` (TimeSpan) overrides either explicitly; invalid/negative values are logged and ignored.
- Per-type lazy compiles (the "usual compile" path) untouched.

Mechanics: `WarmDynamicTypes` gains an optional `betweenTypes` threaded through `BakeOrFollow` → `WarmPending` to the one `DelaySubscription` site; the hosted service resolves gated-vs-serving and the config override. Pure plumbing — no behavioral change for any existing caller that passes nothing.

What's New entry included (`Category: Feature`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)