### PR TITLE
A rebuilt node type must win the full-name alias, not lose it to the build it replaced

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
@@ -284,7 +284,26 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
     private void IndexFullNameAlias(Type type, TypeDefinition definition, string canonicalName)
     {
         var fullName = (type.FullName ?? type.Name).Replace('+', '.');
-        if (fullName != canonicalName)
+        if (fullName == canonicalName)
+            return;
+
+        // 🚨 …EXCEPT for a COLLECTIBLE type, where "full names are unique" is false. Every recompile
+        // of a dynamic node mints a NEW assembly whose types carry the SAME full name, so TryAdd
+        // hands the alias to the FIRST build and never lets go: a full-name $type discriminator
+        // then keeps resolving a SUPERSEDED assembly's type long after a newer build replaced it.
+        // Content deserialised into it fails every `Content is X` downstream — the bound view
+        // renders empty or its reactive wait never emits (the foreign-assembly content class).
+        //
+        // This used to be masked: the superseded context unloaded almost immediately and its
+        // entries were swept. Neither is true now — the entries are DEMOTED to the weak shadow
+        // rather than dropped, and a context LEASED by a live hub (NodeAssemblyLoadContext.Lease)
+        // does not begin unloading at all, so nothing clears the way for the newer registration.
+        //
+        // Newest-wins is the correct rule for a rebuild and changes nothing for ordinary
+        // assemblies, whose full names genuinely are unique.
+        if (type.Assembly.IsCollectible)
+            aliasByName[fullName] = definition;
+        else
             aliasByName.TryAdd(fullName, definition);
     }
 

--- a/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
@@ -358,6 +358,44 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
             (Type?)definition.GetType().GetProperty("Type")?.GetValue(definition);
     }
 
+    /// <summary>
+    /// 🚨 A RECOMPILE must win the full-name alias. Every recompile of a dynamic node mints a new
+    /// collectible assembly whose types carry the SAME full name as the previous build's, and the
+    /// alias index is what resolves a full-name <c>$type</c> discriminator on the way in.
+    ///
+    /// <para><c>IndexFullNameAlias</c> used <c>TryAdd</c> for everything, on the reasoning that full
+    /// names are unique — true for an ordinary assembly, false for a rebuilt node. So the FIRST
+    /// build owned the alias forever. That was masked while a superseded context unloaded promptly
+    /// and its entries were swept; it is not masked now, because those entries are DEMOTED to the
+    /// weak shadow rather than dropped, and a context leased by a live hub does not begin unloading
+    /// at all. Resolving a live payload to a superseded assembly's type is the foreign-content
+    /// class: <c>Content is X</c> goes false and the bound view renders empty or never emits.</para>
+    /// </summary>
+    [Fact]
+    public void RecompiledCollectibleType_ReplacesTheFullNameAlias_RatherThanKeepingTheFirst()
+    {
+        var typeRegistry = GetHost().ServiceProvider.GetRequiredService<ITypeRegistry>();
+
+        // Two builds of "the same" node type: same full name, different collectible assemblies —
+        // exactly what a recompile produces.
+        var v1 = EmitCollectibleType("RecompiledEntry", "Position");
+        var v2 = EmitCollectibleType("RecompiledEntry", "Position");
+        v1.Should().NotBeSameAs(v2, "the fixture must reproduce two distinct builds");
+        v1.FullName.Should().Be(v2.FullName, "a recompile keeps the type's full name");
+
+        // Registered under DISTINCT canonical names, so ONLY the full-name alias is under test —
+        // typeByName's last-write-wins cannot mask the defect.
+        typeRegistry.WithType(v1, "RecompiledEntry_v1");
+        typeRegistry.WithType(v2, "RecompiledEntry_v2");
+
+        typeRegistry.TryGetType(v2.FullName!, out var resolved).Should().BeTrue(
+            "the full name must still resolve after the recompile");
+        resolved!.Type.Should().BeSameAs(v2,
+            "the alias must resolve the CURRENT build; keeping the first one pins a superseded "
+            + "assembly's type, and content deserialised into it fails every 'Content is X' check "
+            + "downstream — the view then renders empty or waits forever");
+    }
+
     private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger
     {
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;


### PR DESCRIPTION
## The defect

`IndexFullNameAlias` uses `TryAdd` for every type, on the reasoning stated right above it: full
names are unique, so the first registration owns the key and an explicit one is never clobbered.
True for an ordinary assembly — **false for a dynamically compiled node.** Every recompile mints a
new collectible assembly whose types carry the *same* full name, so the first build owns the alias
forever and a full-name `$type` discriminator keeps resolving a **superseded** assembly's type.

Content deserialised into that type fails every `Content is X` downstream — the foreign-assembly
content class: the bound view renders empty, or its reactive wait never emits.

## Why it surfaces now

It used to be masked by timing: the superseded context unloaded almost immediately and its entries
were swept. Neither half holds any more, and both changes are recent and correct:

- **#1169's weak shadow** *demotes* those entries instead of dropping them, precisely so a hub still
  running on the superseded assembly keeps resolving its own types.
- **#1148's NodeType-assembly lease** means a context still in use does not begin unloading at all,
  so nothing demotes and nothing clears the way for the newer registration.

Together they leave the first build sitting on the alias indefinitely.

## The fix

Newest-wins for collectible types — the rule a rebuild actually wants. Ordinary assemblies keep
`TryAdd`, so the never-clobber-an-explicit-registration guarantee and every non-collectible full
name behave exactly as before.

## Verification

`RecompiledCollectibleType_ReplacesTheFullNameAlias_RatherThanKeepingTheFirst` pins it, and it is a
real oracle — seen **red** without the change (*"keeping the first one pins a superseded assembly's
type"*), green with it. Two emitted collectible assemblies, same full name, registered under
**distinct** canonical names so `typeByName`'s last-write-wins cannot mask the defect: only the
alias is in play.

`MeshWeaver.Messaging.Hub.Test` 182/182; `dotnet build -c Release -p:CIRun=true -warnaserror` clean.

## Scope, stated honestly

The defect is proven to **exist**; it is **not** proven to have caused any specific failure. I found
it while chasing two CI reds (`CodeCellOutputCaptureTest.Progress_Of_Succeeded_Activity`,
`VersionCompareViewTest`) which turned out to be cured by merging newer main, not by this. It is
worth fixing on its own terms — a stale type alias is a silent wrong answer — but it should not be
credited with anything else.

No What's New entry: no user-visible behaviour change on its own (internal correctness of the type
registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)