### PR TITLE
The gate harness serves Agent/Skill from the partition it installs them into

### DIFF
--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -429,7 +429,7 @@ public static class PluginGateRunner
                 // The AI node types (Agent / Skill / Model / …) — plugin packages ship Agent
                 // and Skill nodes (LinkedIn, Feedback, ExplainerVideo), and a portal always
                 // registers these; without them those installs are refused "not registered".
-                .AddAI()
+                .AddAI(MeshWeaver.AI.AiContentSources.ContentPartitions)
                 .AddPluginCatalog()
                 .AddMeshNodes(RootAdminAccess())
                 // Per-run isolated assembly store + compilation cache (AddInMemoryPersistence


### PR DESCRIPTION
## The failure

The plugins gate began failing deterministically on exactly two modules once the platform pin moved to core `22e4a0c9a`:

```
[FAIL] Agent (0 node(s), 0 type(s))    install: TimeoutException: The operation has timed out.
[FAIL] Skill (0 node(s), 0 type(s))    install: TimeoutException: The operation has timed out.
```

30.2 s from install start, every run, same two modules — while all 18 other modules pass.

## Root cause (a configuration-truth violation, not the installer)

`PluginGateRunner` calls bare `.AddAI()`, which registers `BuiltInAgentProvider`/`BuiltInSkillProvider` as **static** node providers serving paths `Agent` and `Skill`. The gate then installs the **durable** `Agent`/`Skill` plugin packages at those same paths:

1. the durable root create is refused `NodeAlreadyExists` → applied as an update, activating the `Agent` hub on the STATIC node;
2. `MeshDataSource.WithMeshNodes()` takes its static branch (`FindServedStaticNode`) and seeds that hub from `AgentNodeType.CreateMeshNode()` — **NodeType `null`, no persistence backing**;
3. the hub emits one Full snapshot at v0 and nothing ever again, so `PackageInstaller.RootRetypeReconciled` (`PackageInstaller.cs:1762-1775`) — which waits for the root to appear with its new NodeType — sits out its 30 s timeout.

Core already documents this exact hazard: `AgentNodeType.cs` (#902 — *"the static type-def and the durable row BOTH claim @Agent, and the static one wins the serve seams … the per-node hub is seeded from a node that is by design NEVER PERSISTED"*) and `AiContentSources.cs` (*"Drop `Agent` and the in-memory provider comes back and SHADOWS the DB nodes the Agent plugin installs"*). The portal gets it right through Helm's `serveFromPartition` list; the gate harness did not.

**`NodeTypeRebindWatcher` (`72df41936`) did not cause this** — it stopped masking it. It recycles a hub whose node's NodeType changes; for `Agent` it fires twice, the second landing inside the final retype's write window. The file is absent at the previous pin, which is why the same content passed there.

## Evidence

| Run | Image | Result |
|---|---|---|
| CI 31480459309 | new digest | `[FAIL] Agent`, `[FAIL] Skill` |
| local ×2 | new digest | same two failures |
| control | previous digest | `[PASS] Agent (16)`, `[PASS] Skill (29)` |
| falsification: root renamed `Agent`→`Agentz`, identical content | new digest | **`[PASS] Agentz`** |
| **this fix**, tester DLL overlaid into the failing image | new digest | `[PASS] Agent (16)`, `[PASS] Skill (29)`; **full 20-module run green, exit 0** |

## The fix

One line — the harness serves those partitions from the mesh it installs into, exactly as the portal does.

## Follow-up

Issue #1209 tracks the wider hazard: any bare-`.AddAI()` host that installs these packages hits the same hard failure (incl. `memex/Memex.Client/MauiProgram.cs:108` and any deployment whose `Features:StaticRepoSync:Partitions` is empty — the default). Proposal there is to make the static-vs-durable collision loud at startup rather than a silent 30 s hang downstream.

No What's New entry: internal test tooling, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)