### PR TITLE
Three wire types asked to be registered; register them

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
@@ -150,7 +150,14 @@ public static class ContentCollectionsExtensions
                 return config;
             config = config.Set(true, nameof(AddContentCollectionsInfrastructure));
             return config
-                .WithTypes(typeof(ContentCollectionReference))
+                // ContentCollectionConfig travels inside a MeshNode's collection declarations, so
+                // it crosses the wire on any hub that carries one — unregistered, such a hub
+                // auto-registers it under its short name on first use and logs the resolver's
+                // warning asking for exactly this. WithTypes registers under the short name, i.e.
+                // the name the auto-registration already agreed on, so nothing on the wire changes;
+                // what it buys is that a RECEIVING hub resolves it typed instead of as an untyped
+                // JsonElement.
+                .WithTypes(typeof(ContentCollectionReference), typeof(ContentCollectionConfig))
                 .WithServices(AddContentService)
                 .AddData(data =>
                 {

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -201,6 +201,14 @@ public static class DataExtensions
             // ActivityLog content children — serialised inside log entries / user attribution.
             .WithType(typeof(LogMessage), nameof(LogMessage))
             .WithType(typeof(UserInfo), nameof(UserInfo))
+            // 🚨 Carried INSIDE a DataChangeRequest, so it crosses the wire on the ordinary write
+            // path. Unregistered, each hub auto-registers it under its short name the first time it
+            // writes one and logs the resolver's warning to say so. The auto-registered short name
+            // happens to agree everywhere, so nothing was breaking — but that is luck, not
+            // contract: the resolver's message asks for an explicit registration precisely because
+            // short names can collide across namespaces, and a receiving hub that never registered
+            // it reads the value as an untyped JsonElement.
+            .WithType(typeof(UpdateOptions), nameof(UpdateOptions))
             .RegisterDataEvents()
             .WithInitializationGate(DataContext.InitializationGateName, d => d.Message is PingRequest);
     }

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -408,6 +408,12 @@ public static class MeshNodeExtensions
     {
         typeRegistry.WithType(typeof(NodeTypeDefinition), nameof(NodeTypeDefinition));
         typeRegistry.WithType(typeof(CodeConfiguration), nameof(CodeConfiguration));
+        // The compile control-plane's own state, mirrored onto the NodeType node and therefore
+        // serialised by every per-NodeType hub that compiles. Unregistered it is auto-registered
+        // under its short name on that hub's first write, with the resolver's "register it
+        // explicitly" warning — which is asking for exactly this line, so that a receiving hub
+        // resolves it typed rather than as an untyped JsonElement.
+        typeRegistry.WithType(typeof(NodeTypeCompileState), nameof(NodeTypeCompileState));
         typeRegistry.WithType(typeof(Comment), nameof(Comment));
         typeRegistry.WithType(typeof(MarkdownContent), nameof(MarkdownContent));
         // Slide MeshNode Content — presentation pages (see SlideNodeType). Registered


### PR DESCRIPTION
`PolymorphicTypeInfoResolver` logs, once per hub, that these three were auto-registered under their
short names because no hub declared them — and its message asks, in those words, for an explicit
`WithType(typeof(X), nameof(X))` where the hub is configured:

| type | how it crosses the wire |
|---|---|
| `MeshWeaver.Data.UpdateOptions` | inside every `DataChangeRequest` |
| `MeshWeaver.ContentCollections.ContentCollectionConfig` | inside a node's collection declarations |
| `MeshWeaver.Graph.Configuration.NodeTypeCompileState` | on every per-NodeType hub that compiles |

## What this is not

Nothing was breaking, and this shouldn't pretend otherwise: the auto-registered short name happens
to agree on both sides today. But that is luck rather than contract — the resolver asks for the
explicit registration because short names can collide across namespaces, and a **receiving** hub
that never registered the type reads the value as an untyped `JsonElement`, which is the
renders-empty / reactive-wait-never-emits class. Each is registered under the same short name the
auto-registration already used, so nothing on the wire changes.

## Measurement note

I got this wrong on the first pass and would rather record it than repeat it: `dotnet test` prints
per-test output only for **failing** tests, so a green run's console log contains no warnings at all
and cannot be used to count them. My initial claim that these were "the most frequent lines in a test
run" came from a sample of failing-test output — the real rate is once per hub, per type, on first
serialisation. The three occurrences that identified them came from a single failing test.

`MeshWeaver.Hosting.Monolith.Test` 537/541 (4 pre-existing skips); `dotnet build -c Release
-p:CIRun=true -warnaserror` clean.

No What's New entry — no user-visible behaviour change (internal serialisation registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)