### PR TITLE
feat(ogcard): show the page ICON not a cropped poster; fix multi-URL splitting and a pinned-degraded preview

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-list-of-links-renders-a-card-each-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-list-of-links-renders-a-card-each-again.md
@@ -1,0 +1,33 @@
+---
+Name: A list of links renders one card each again
+Category: Fix
+Description: Embedding several links in one preview-card reference produced a single broken card instead of one card per link. Every form of the list now splits correctly, and a card that cannot be reached names the page it points at instead of just the domain.
+Icon: PreviewLink
+Order: -20260811
+---
+
+# A list of links renders one card each again
+
+Preview cards are meant to be embedded as a list — that is the whole point of
+the grid. Four links in one reference, four cards.
+
+Instead you got **one** card, and a broken one: the four addresses were glued
+together into a single address that leads nowhere, so nothing could be loaded
+for it. What rendered was a lone card labelled with just the site's name — for
+all the world a broken link to the portal itself.
+
+The cause was narrow. A card list can be written two ways: as a query on the end
+of the reference, or as part of the reference's own path. The query form split
+its list on the commas correctly; **the path form never split at all** and
+treated the whole line as one address.
+
+Both forms now split, and they accept the separator whichever way it arrives —
+plain, or in the escaped shape a link picks up when the reference is encoded as
+one piece. If you genuinely need a comma *inside* one address, write it doubly
+escaped, or use the single-link form, which never splits.
+
+While fixing it, one related annoyance went too. A card whose page cannot be
+reached used to fall back to showing just the domain, so a row of unreachable
+cards all read alike and none said where it led. Such a card now shows the page's
+own name — *Reinsurance*, *Underwriting* — and still links exactly where it
+always pointed, so what you read and where you land agree.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-link-preview-cards-show-the-site-icon.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-link-preview-cards-show-the-site-icon.md
@@ -1,0 +1,38 @@
+---
+Name: Link-preview cards show the icon, not a cropped poster
+Category: Feature
+Description: Preview cards now show the target page's icon — the small square site or node icon — instead of a slice cut out of its big banner picture. Cards read as a clean, compact catalog again.
+Icon: PreviewLink
+Order: -20260811
+---
+
+# Link-preview cards show the icon, not a cropped poster
+
+A preview card puts its picture in a small square, about the size of a
+fingernail. The picture it was given, though, was the page's **poster** — the
+wide banner graphic made for sharing a link on social media, roughly twice as
+wide as it is tall.
+
+Squeezing a wide banner into a small square means cropping away most of it. What
+survived was an arbitrary slice out of the middle: a corner of a chart, half a
+word, a patch of background. Every card in a grid looked vaguely similar and
+none of them told you anything.
+
+Cards now show the page's **icon** instead — the small square mark a site or a
+node already carries, drawn to be legible at exactly this size. A grid of cards
+becomes scannable: you recognise each destination at a glance instead of
+squinting at banner fragments.
+
+This applies to both kinds of card:
+
+- **Pages on other portals** — the platform reads the icon the page declares,
+  picking the sharpest one on offer (a scalable icon beats a large one, a large
+  one beats a small one). If a page declares no icon at all, its poster is still
+  used rather than showing nothing.
+- **Nodes on your own portal** — the card shows the node's own icon, the same
+  mark you see beside it everywhere else, so a card and a search result finally
+  agree with each other.
+
+Node cards elsewhere in the portal — search results, pinned items — got the same
+treatment for the same reason. Full-size thumbnail tiles are unchanged: they are
+poster-shaped, so they keep the poster.

--- a/src/MeshWeaver.Graph/MeshNodeCardControl.cs
+++ b/src/MeshWeaver.Graph/MeshNodeCardControl.cs
@@ -30,7 +30,12 @@ public record MeshNodeCardControl(
     {
         var nodePath = node?.Path ?? fallbackPath;
         var title = node?.Name ?? fallbackPath;
-        var imageUrl = MeshNodeThumbnailControl.GetImageUrlForNode(node);
+        // The ICON, never the poster: the card's image box is a fixed 48 px square with
+        // object-fit: cover, so a wide MarkdownContent.Thumbnail banner cropped into it is a
+        // meaningless sliver. Skipping it falls through to the node's own icon — an inline SVG
+        // drawn in currentColor, sized for exactly this box. MeshNodeThumbnailControl is the
+        // poster-shaped control and keeps the thumbnail.
+        var imageUrl = MeshNodeThumbnailControl.GetImageUrlForNode(node, includeThumbnail: false);
         // Databind the card subtitle to the node's Description (blank when unset) —
         // no NodeType fallback, so the line reflects the real description, nothing else.
         var description = node?.Description;

--- a/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
+++ b/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
@@ -58,8 +58,21 @@ public record MeshNodeThumbnailControl(
     /// User-entered paths starting with <c>content:</c> or <c>content/</c> are resolved
     /// against the node's content collection; an inline <c>&lt;svg&gt;…&lt;/svg&gt;</c> value is
     /// returned verbatim (never treated as a path) so the client renders it inline.
+    ///
+    /// <para><paramref name="includeThumbnail"/> selects between the two SHAPES this resolution
+    /// serves. A thumbnail tile is poster-shaped, so it keeps
+    /// <see cref="MarkdownContent.Thumbnail"/> in the chain (the default). A CARD is not: its
+    /// image box is a fixed 48 px square with <c>object-fit: cover</c>, and a wide banner cropped
+    /// into that yields a meaningless sliver — so <see cref="MeshNodeCardControl"/> passes
+    /// <c>false</c> and falls straight through to the node's own icon, which is drawn for exactly
+    /// that size. An explicitly authored <c>avatar</c>/<c>logo</c>/<c>icon</c> on the content still
+    /// wins in both shapes.</para>
     /// </summary>
-    public static string? GetImageUrlForNode(MeshNode? node)
+    /// <param name="node">The node to resolve an image for.</param>
+    /// <param name="includeThumbnail">Whether <see cref="MarkdownContent.Thumbnail"/> (the wide
+    /// poster) participates. <c>true</c> for poster-shaped tiles, <c>false</c> for icon-shaped
+    /// cards.</param>
+    public static string? GetImageUrlForNode(MeshNode? node, bool includeThumbnail = true)
     {
         if (node == null)
             return null;
@@ -141,7 +154,7 @@ public record MeshNodeThumbnailControl(
         // reads the value from BOTH the typed MarkdownContent AND the degraded JsonElement frame,
         // so the resolved image URL doesn't alternate (typed → thumbnail vs JsonElement → node.Icon)
         // across frames and storm the card.
-        var thumbnail = GetThumbnail(node.Content);
+        var thumbnail = includeThumbnail ? GetThumbnail(node.Content) : null;
         if (!string.IsNullOrEmpty(thumbnail))
         {
             // Inline SVG thumbnail — return verbatim; it is markup, not a content-collection path.

--- a/src/MeshWeaver.Graph/OgCardLayoutArea.cs
+++ b/src/MeshWeaver.Graph/OgCardLayoutArea.cs
@@ -25,8 +25,12 @@ namespace MeshWeaver.Graph;
 /// <para>External URLs travel in the <c>?url=</c>/<c>?urls=</c> query form — the query suffix is
 /// the one areaId shape whose <c>://</c> survives every path-resolution hop verbatim. Entries may
 /// be percent-encoded (they are unescaped once); plain URLs without <c>&amp;</c>, <c>=</c>,
-/// <c>%</c> or commas work as written, and <c>urls</c> entries are comma-separated (a comma
-/// inside a URL is written <c>%2C</c>). Mesh paths and external URLs can be mixed.</para>
+/// <c>%</c> or commas work as written. Mesh paths and external URLs can be mixed.</para>
+/// <para>🚨 A MULTI-target list is comma-separated in EVERY form — the <c>?urls=</c> query form
+/// AND the bare path/areaId form alike — and the separator may arrive raw (<c>,</c>) or encoded
+/// (<c>%2C</c>), since a path-form areaId is commonly percent-encoded as one whole segment. A
+/// literal comma inside a URL must therefore be double-encoded (<c>%252C</c>), or carried by the
+/// singular <c>?url=</c> form, which never splits.</para>
 /// </summary>
 public static class OgCardLayoutArea
 {
@@ -90,7 +94,7 @@ public static class OgCardLayoutArea
     /// og:image poster — see <see cref="OpenGraphPreview.CardIcon"/> for the order and why.</summary>
     private static MeshNodeCardControl ExternalCard(string url, OpenGraphPreview preview) =>
         new(NodePath: string.Empty,
-            Title: preview.Title ?? HostOf(url),
+            Title: preview.Title ?? LabelOf(url),
             Description: preview.Description,
             ImageUrl: preview.CardIcon,
             Href: url);
@@ -99,7 +103,7 @@ public static class OgCardLayoutArea
     /// for an unreachable one): its name alone, still a working link.</summary>
     private static MeshNodeCardControl PlaceholderCard(string target) =>
         IsExternal(target)
-            ? new MeshNodeCardControl(NodePath: string.Empty, Title: HostOf(target), Href: target)
+            ? new MeshNodeCardControl(NodePath: string.Empty, Title: LabelOf(target), Href: target)
             : MeshNodeCardControl.FromNode(null, target.Trim('/'));
 
     /// <summary>One card renders width-bounded like a chat unfurl; several render as a
@@ -127,20 +131,44 @@ public static class OgCardLayoutArea
         var value = id.Trim().TrimStart('?');
 
         if (value.StartsWith("urls=", StringComparison.OrdinalIgnoreCase))
-            return value["urls=".Length..]
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(SafeUnescape)
-                .Where(entry => !string.IsNullOrWhiteSpace(entry))
-                .ToImmutableList();
+            return SplitTargets(value["urls=".Length..]);
 
         if (value.StartsWith("url=", StringComparison.OrdinalIgnoreCase))
         {
+            // The SINGULAR form is exactly one target and never splits — a comma in it is data.
             var single = SafeUnescape(value["url=".Length..].Trim());
             return string.IsNullOrWhiteSpace(single) ? [] : [single];
         }
 
-        return [SafeUnescape(value)];
+        return SplitTargets(value);
     }
+
+    /// <summary>
+    /// Splits a comma-separated target list into its entries.
+    ///
+    /// <para>🚨 The split runs on BOTH sides of the single unescape, because the separator itself
+    /// arrives raw or encoded depending on how the embed was authored. A PATH-form areaId is
+    /// commonly percent-encoded as one whole path segment — every <c>:</c>, <c>/</c> and
+    /// <c>,</c> alike — so its separators reach us as <c>%2C</c>; a query-form <c>?urls=</c> list
+    /// usually keeps its commas raw. Splitting raw, unescaping, then splitting again handles
+    /// either form (and a mix of the two) under one rule.</para>
+    ///
+    /// <para>Without this the path form did not split AT ALL: the whole joined string became a
+    /// single target, so four URLs rendered as ONE card whose href was the four URLs concatenated
+    /// — a fetch that could never succeed, degrading to a card titled with the bare domain that
+    /// read as a broken link to the portal.</para>
+    ///
+    /// <para>Consequence of treating <c>%2C</c> as a separator: a literal comma INSIDE a URL must
+    /// be double-encoded (<c>%252C</c>), or written with the singular <c>?url=</c> form, which
+    /// never splits.</para>
+    /// </summary>
+    private static IReadOnlyList<string> SplitTargets(string list) =>
+        list.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(SafeUnescape)
+            .SelectMany(entry =>
+                entry.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(entry => !string.IsNullOrWhiteSpace(entry))
+            .ToImmutableList();
 
     /// <summary>Unescapes a user-authored target defensively: a malformed percent sequence in
     /// markdown must degrade to the raw token, never fault the whole area render.</summary>
@@ -160,6 +188,21 @@ public static class OgCardLayoutArea
         target.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
         || target.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
 
-    private static string HostOf(string url) =>
-        Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : url;
+    /// <summary>
+    /// The readable label for an external target whose page declared no title — the card's state
+    /// before the fetch lands, and its terminal state when the target is unreachable.
+    ///
+    /// <para>The LAST PATH SEGMENT, not the bare host: a grid of cards all titled
+    /// <c>memex.meshweaver.cloud</c> reads as "several broken links to the portal", while
+    /// <c>Reinsurance</c> / <c>Underwriting</c> says which page each one actually points at. The
+    /// href is always the real target, so the label and the link agree. Falls back to the host
+    /// for an origin-root URL, which genuinely has no segment to name it by.</para>
+    /// </summary>
+    private static string LabelOf(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return url;
+        var segment = uri.Segments.LastOrDefault()?.Trim('/');
+        return string.IsNullOrWhiteSpace(segment) ? uri.Host : SafeUnescape(segment);
+    }
 }

--- a/src/MeshWeaver.Graph/OgCardLayoutArea.cs
+++ b/src/MeshWeaver.Graph/OgCardLayoutArea.cs
@@ -86,12 +86,13 @@ public static class OgCardLayoutArea
     }
 
     /// <summary>An external target's card, built from its fetched Open Graph metadata (URL host
-    /// as the title fallback when the page declared none).</summary>
+    /// as the title fallback when the page declared none). The visual is the page's ICON, not its
+    /// og:image poster — see <see cref="OpenGraphPreview.CardIcon"/> for the order and why.</summary>
     private static MeshNodeCardControl ExternalCard(string url, OpenGraphPreview preview) =>
         new(NodePath: string.Empty,
             Title: preview.Title ?? HostOf(url),
             Description: preview.Description,
-            ImageUrl: preview.Image,
+            ImageUrl: preview.CardIcon,
             Href: url);
 
     /// <summary>The placeholder card shown until a target's data arrives (and the terminal card

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
@@ -7,15 +7,37 @@ namespace MeshWeaver.Graph;
 /// Pure parser of a page's Open Graph head metadata. No I/O — it reads the HTML string a caller
 /// already fetched (see <see cref="OpenGraphPreviewService"/>) and extracts the
 /// <c>og:*</c> meta tags with their standard fallbacks (<c>&lt;title&gt;</c>,
-/// <c>&lt;meta name="description"&gt;</c>). Attribute order inside a tag is free
-/// (<c>property</c> before or after <c>content</c>), values are HTML-entity decoded, and a
-/// relative <c>og:image</c> is resolved against the page URL.
+/// <c>&lt;meta name="description"&gt;</c>) plus the page's declared ICON
+/// (<c>&lt;link rel="icon"&gt;</c> / <c>apple-touch-icon</c>). Attribute order inside a tag is
+/// free (<c>property</c> before or after <c>content</c>), values are HTML-entity decoded, and
+/// relative URLs are resolved against the page's effective base.
+///
+/// <para>🚨 <b>Relative URLs resolve against <c>&lt;base href&gt;</c>, not the page URL.</b> Every
+/// Blazor portal — MeshWeaver's included — serves <c>&lt;base href="/"&gt;</c> together with a
+/// RELATIVE <c>&lt;link rel="icon" href="favicon.ico"&gt;</c>. Resolving that against the page URL
+/// gives <c>/Some/Section/favicon.ico</c> for any nested page, which a catch-all-routed SPA
+/// answers with <b>200 text/html</b> rather than a 404 — a silently broken <c>&lt;img&gt;</c> that
+/// looks like a working link. Honouring the base tag is what makes the icon resolve to the real
+/// <c>/favicon.ico</c>.</para>
 /// </summary>
 public static partial class OpenGraphHtmlParser
 {
     // The og tags live in <head>; parsing stops there so a huge body is never scanned.
     // When no </head> is present (fragment, malformed page) a bounded prefix is used.
     private const int MaxScanLength = 262_144;
+
+    /// <summary>Effective pixel size credited to an icon that scales losslessly to any box —
+    /// an SVG, or one declaring <c>sizes="any"</c>. Ranks above every raster candidate.</summary>
+    private const int ScalableIconSize = 1024;
+
+    /// <summary>Effective size assumed for an <c>apple-touch-icon</c> that declares no
+    /// <c>sizes</c>: the de-facto convention is 180×180, purpose-built as a square tile — which is
+    /// exactly the card's icon box, so it outranks a sizeless favicon.</summary>
+    private const int DefaultAppleTouchIconSize = 180;
+
+    /// <summary>Effective size assumed for a <c>rel="icon"</c> that declares no <c>sizes</c>
+    /// (a classic <c>favicon.ico</c>, conventionally 16–32 px).</summary>
+    private const int DefaultIconSize = 32;
 
     [GeneratedRegex("<meta\\s[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex MetaTag();
@@ -29,16 +51,41 @@ public static partial class OpenGraphHtmlParser
     [GeneratedRegex("<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex TitleTag();
 
+    [GeneratedRegex("<link\\s[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex LinkTag();
+
+    [GeneratedRegex("<base\\s[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex BaseTag();
+
+    // The (?<![-\w:]) lookbehind pins each name to a REAL attribute: without it `href` also
+    // matches inside `data-href` / `xlink:href`, and `type` inside `data-type`.
+    [GeneratedRegex("(?<![-\\w:])rel\\s*=\\s*([\"'])(.*?)\\1", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex RelAttribute();
+
+    [GeneratedRegex("(?<![-\\w:])href\\s*=\\s*([\"'])(.*?)\\1", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex HrefAttribute();
+
+    [GeneratedRegex("(?<![-\\w:])sizes\\s*=\\s*([\"'])(.*?)\\1", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex SizesAttribute();
+
+    [GeneratedRegex("(?<![-\\w:])type\\s*=\\s*([\"'])(.*?)\\1", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex TypeAttribute();
+
+    [GeneratedRegex("(\\d+)\\s*[xX]\\s*(\\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex SizePair();
+
     /// <summary>
     /// Parses the Open Graph preview out of <paramref name="html"/>.
     /// </summary>
     /// <param name="url">The page URL the HTML was fetched from — kept on the preview as the
-    /// navigation target and used to resolve a relative <c>og:image</c>.</param>
+    /// navigation target and used (with any <c>&lt;base href&gt;</c>) to resolve relative
+    /// URLs.</param>
     /// <param name="html">The page HTML (any prefix containing the head suffices).</param>
     /// <returns>The parsed preview; fields the page does not declare are null.</returns>
     public static OpenGraphPreview Parse(string url, string html)
     {
         var head = HeadOf(html);
+        var baseUri = EffectiveBase(url, head);
 
         string? ogTitle = null, ogDescription = null, ogImage = null, ogSiteName = null,
             metaDescription = null;
@@ -71,9 +118,10 @@ public static partial class OpenGraphHtmlParser
             url,
             NullIfEmpty(title),
             NullIfEmpty(ogDescription ?? metaDescription),
-            AbsoluteImage(url, ogImage),
+            AbsoluteUrl(baseUri, ogImage),
             NullIfEmpty(ogSiteName),
-            Fetched: true);
+            Fetched: true,
+            Icon: AbsoluteUrl(baseUri, SelectIcon(head)));
     }
 
     /// <summary>The head slice of the document: everything up to <c>&lt;/head&gt;</c>, else a
@@ -86,18 +134,133 @@ public static partial class OpenGraphHtmlParser
         return html.Length <= MaxScanLength ? html : html[..MaxScanLength];
     }
 
-    /// <summary>Resolves the declared image to an absolute URL against the page URL. Already
-    /// absolute → unchanged; relative and resolvable → combined; otherwise null (a bare
-    /// unresolvable name would break the card's <c>&lt;img&gt;</c>).</summary>
-    private static string? AbsoluteImage(string pageUrl, string? image)
+    /// <summary>
+    /// The base every relative URL on the page resolves against: the page's own
+    /// <c>&lt;base href&gt;</c> when it declares one (itself resolved against the page URL, so a
+    /// relative base works), else the page URL. Null only when the page URL is not absolute.
+    /// </summary>
+    private static Uri? EffectiveBase(string pageUrl, string head)
     {
-        if (string.IsNullOrWhiteSpace(image))
+        if (!Uri.TryCreate(pageUrl, UriKind.Absolute, out var page))
             return null;
-        if (Uri.TryCreate(image, UriKind.Absolute, out var absolute)
+
+        var baseTag = BaseTag().Match(head);
+        if (!baseTag.Success)
+            return page;
+
+        var href = HrefAttribute().Match(baseTag.Value);
+        if (!href.Success)
+            return page;
+
+        var value = WebUtility.HtmlDecode(href.Groups[2].Value).Trim();
+        return value.Length > 0 && Uri.TryCreate(page, value, out var resolved) ? resolved : page;
+    }
+
+    /// <summary>
+    /// The best icon the page declares, or null when it declares none.
+    ///
+    /// <para>Candidates are every <c>&lt;link&gt;</c> whose <c>rel</c> carries the <c>icon</c>
+    /// token (<c>icon</c>, <c>shortcut icon</c>) or is an <c>apple-touch-icon</c>. They are ranked
+    /// on ONE axis — effective pixel size — so the winner is simply the icon that renders sharpest
+    /// in the card's 48 px box: a scalable SVG beats every raster, a declared <c>sizes</c> is
+    /// taken at face value, and a sizeless <c>apple-touch-icon</c> (conventionally 180 px) beats a
+    /// sizeless <c>favicon.ico</c> (conventionally 16–32 px). Ties keep document order.</para>
+    ///
+    /// <para><c>rel="mask-icon"</c> is deliberately NOT a candidate: it is a monochrome Safari
+    /// pinned-tab silhouette, not the site's icon.</para>
+    /// </summary>
+    private static string? SelectIcon(string head)
+    {
+        string? best = null;
+        var bestScore = int.MinValue;
+
+        foreach (Match tag in LinkTag().Matches(head))
+        {
+            var rel = RelAttribute().Match(tag.Value);
+            var href = HrefAttribute().Match(tag.Value);
+            if (!rel.Success || !href.Success)
+                continue;
+
+            var value = WebUtility.HtmlDecode(href.Groups[2].Value).Trim();
+            if (value.Length == 0)
+                continue;
+
+            var score = IconScore(rel.Groups[2].Value, tag.Value);
+            if (score is null || score.Value <= bestScore)
+                continue;
+
+            bestScore = score.Value;
+            best = value;
+        }
+
+        return best;
+    }
+
+    /// <summary>The effective pixel size of one <c>&lt;link&gt;</c> candidate, or null when the
+    /// tag is not an icon at all.</summary>
+    private static int? IconScore(string rel, string tag)
+    {
+        var isAppleTouch = false;
+        var isIcon = false;
+        foreach (var token in rel.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Equals("icon", StringComparison.OrdinalIgnoreCase))
+                isIcon = true;
+            else if (token.StartsWith("apple-touch-icon", StringComparison.OrdinalIgnoreCase))
+                isAppleTouch = true;
+        }
+
+        if (!isIcon && !isAppleTouch)
+            return null;
+
+        var type = TypeAttribute().Match(tag);
+        if (type.Success && type.Groups[2].Value.Contains("svg", StringComparison.OrdinalIgnoreCase))
+            return ScalableIconSize;
+
+        var sizes = SizesAttribute().Match(tag);
+        if (sizes.Success)
+        {
+            var declared = LargestSize(sizes.Groups[2].Value);
+            if (declared is not null)
+                return declared;
+        }
+
+        return isAppleTouch ? DefaultAppleTouchIconSize : DefaultIconSize;
+    }
+
+    /// <summary>The largest dimension declared in a <c>sizes</c> attribute
+    /// (<c>"16x16 32x32"</c> → 32), or <see cref="ScalableIconSize"/> for <c>"any"</c>. Null when
+    /// the attribute declares nothing parseable.</summary>
+    private static int? LargestSize(string sizes)
+    {
+        if (sizes.Contains("any", StringComparison.OrdinalIgnoreCase))
+            return ScalableIconSize;
+
+        int? largest = null;
+        foreach (Match pair in SizePair().Matches(sizes))
+        {
+            if (!int.TryParse(pair.Groups[1].Value, out var width))
+                continue;
+            largest = largest is null ? width : Math.Max(largest.Value, width);
+        }
+
+        return largest;
+    }
+
+    /// <summary>Resolves a declared URL to an absolute one against the page's effective base.
+    /// Already absolute http(s) → unchanged; a <c>data:</c> URI (a common inline-SVG icon) is
+    /// markup, returned verbatim; relative and resolvable → combined; otherwise null (a bare
+    /// unresolvable name would break the card's <c>&lt;img&gt;</c>).</summary>
+    private static string? AbsoluteUrl(Uri? baseUri, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        if (value.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            return value;
+        if (Uri.TryCreate(value, UriKind.Absolute, out var absolute)
             && (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
-            return image;
-        return Uri.TryCreate(pageUrl, UriKind.Absolute, out var baseUri)
-               && Uri.TryCreate(baseUri, image, out var resolved)
+            return value;
+        return baseUri is not null && Uri.TryCreate(baseUri, value, out var resolved)
             ? resolved.ToString()
             : null;
     }

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
@@ -121,7 +121,11 @@ public static partial class OpenGraphHtmlParser
             AbsoluteUrl(baseUri, ogImage),
             NullIfEmpty(ogSiteName),
             Fetched: true,
-            Icon: AbsoluteUrl(baseUri, SelectIcon(head)));
+            Icon: AbsoluteUrl(baseUri, SelectIcon(head)),
+            // The page declared Open Graph proper — not merely a <title> that every HTML
+            // document has, including an SPA catch-all shell. Gates the preview cache; see
+            // OpenGraphPreview.IsResolved.
+            DeclaresOpenGraph: ogTitle is not null);
     }
 
     /// <summary>The head slice of the document: everything up to <c>&lt;/head&gt;</c>, else a

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreview.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreview.cs
@@ -4,27 +4,60 @@ namespace MeshWeaver.Graph;
 /// The Open Graph metadata of one page, as read from its HTML head — the same tags every
 /// MeshWeaver portal emits for its public pages (<c>SeoHead</c>: <c>og:title</c>,
 /// <c>og:description</c>, <c>og:image</c>, <c>og:site_name</c>), and that any well-behaved
-/// external site provides for link unfurling.
+/// external site provides for link unfurling — plus the page's declared ICON, which is what a
+/// compact card actually renders (see <see cref="CardIcon"/>).
 /// </summary>
 /// <param name="Url">The page URL the preview was read from (the card's navigation target).</param>
 /// <param name="Title">The page's <c>og:title</c>, falling back to its <c>&lt;title&gt;</c>.</param>
 /// <param name="Description">The page's <c>og:description</c>, falling back to
 /// <c>&lt;meta name="description"&gt;</c>.</param>
-/// <param name="Image">The page's <c>og:image</c>, resolved to an absolute URL.</param>
+/// <param name="Image">The page's <c>og:image</c> — the wide POSTER graphic, resolved to an
+/// absolute URL. Only a last-resort card visual (see <see cref="CardIcon"/>).</param>
 /// <param name="SiteName">The page's <c>og:site_name</c>.</param>
 /// <param name="Fetched">Whether the page was actually fetched and parsed. <c>false</c> marks the
 /// fallback produced for an unfetchable or failed target — the card then renders from the URL
 /// alone (host as title), still navigating to the target.</param>
+/// <param name="Icon">The page's declared icon (<c>&lt;link rel="icon"&gt;</c> /
+/// <c>apple-touch-icon</c>), resolved to an absolute URL — the sharpest one it declares.</param>
 public sealed record OpenGraphPreview(
     string Url,
     string? Title,
     string? Description,
     string? Image,
     string? SiteName,
-    bool Fetched)
+    bool Fetched,
+    string? Icon = null)
 {
+    /// <summary>The conventional origin-root icon path every browser has probed since forever —
+    /// the last-resort guess for a page that declares no icon link.</summary>
+    private const string ConventionalFaviconPath = "/favicon.ico";
+
+    /// <summary>
+    /// The visual the card renders: the page's ICON, not its poster.
+    ///
+    /// <para>The card's image box is a fixed 48 px square with <c>object-fit: cover</c>. A 1200×630
+    /// <c>og:image</c> poster cropped into it yields a meaningless sliver of a banner, whereas an
+    /// icon is purpose-built for exactly that size — which is why the icon wins outright.</para>
+    ///
+    /// <para>Order: <b>declared icon</b> → <b><c>og:image</c></b> → <b>conventional
+    /// <c>/favicon.ico</c></b>. Everything the page DECLARED is preferred over the guess, so the
+    /// card never trades a guaranteed image for a possible 404; the guess is reached only when the
+    /// page declared no visual at all. A target that could not be fetched
+    /// (<see cref="Fetched"/> <c>== false</c>) guesses nothing — its origin is unproven, so the
+    /// card keeps its clean initials placeholder rather than showing a broken image.</para>
+    /// </summary>
+    public string? CardIcon => Icon ?? Image ?? (Fetched ? ConventionalFavicon(Url) : null);
+
     /// <summary>The fallback preview for a target that could not be fetched: no metadata, the
     /// card renders from the URL alone.</summary>
     public static OpenGraphPreview Unavailable(string url) =>
         new(url, null, null, null, null, false);
+
+    /// <summary>The origin-root <c>/favicon.ico</c> of a page URL, or null when the URL is not
+    /// absolute.</summary>
+    private static string? ConventionalFavicon(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            ? new Uri(uri, ConventionalFaviconPath).ToString()
+            : null;
 }

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreview.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreview.cs
@@ -19,6 +19,9 @@ namespace MeshWeaver.Graph;
 /// alone (host as title), still navigating to the target.</param>
 /// <param name="Icon">The page's declared icon (<c>&lt;link rel="icon"&gt;</c> /
 /// <c>apple-touch-icon</c>), resolved to an absolute URL — the sharpest one it declares.</param>
+/// <param name="DeclaresOpenGraph">Whether the page declared an <c>og:title</c> — the one tag
+/// every page that means to be link-previewed carries. See <see cref="IsResolved"/>: this is what
+/// separates a real preview from a transient degraded response.</param>
 public sealed record OpenGraphPreview(
     string Url,
     string? Title,
@@ -26,7 +29,8 @@ public sealed record OpenGraphPreview(
     string? Image,
     string? SiteName,
     bool Fetched,
-    string? Icon = null)
+    string? Icon = null,
+    bool DeclaresOpenGraph = false)
 {
     /// <summary>The conventional origin-root icon path every browser has probed since forever —
     /// the last-resort guess for a page that declares no icon link.</summary>
@@ -47,6 +51,29 @@ public sealed record OpenGraphPreview(
     /// card keeps its clean initials placeholder rather than showing a broken image.</para>
     /// </summary>
     public string? CardIcon => Icon ?? Image ?? (Fetched ? ConventionalFavicon(Url) : null);
+
+    /// <summary>
+    /// Whether this preview is worth REMEMBERING — the gate on the per-URL promise cache.
+    ///
+    /// <para>🚨 A 200 response is not the same as a usable answer. A portal mid-restart, a login
+    /// wall, or any SPA catch-all route serves its shell page with HTTP <b>200</b> and no
+    /// <c>og:*</c> tags at all — a successful fetch carrying nothing. Because it did not throw, the
+    /// exception-eviction path never fired, so that shell got cached and PINNED for the lifetime of
+    /// the process: one card stuck showing the catch-all's <c>&lt;title&gt;</c> ("Memex Portal")
+    /// with no description, while its neighbours rendered perfectly. Only a preview that actually
+    /// declared Open Graph metadata may be cached; anything else is evicted and re-fetched on the
+    /// next view, which is exactly right because those responses are the transient ones.</para>
+    ///
+    /// <para>The gate keys on <see cref="DeclaresOpenGraph"/>, NOT on <see cref="Title"/> — the
+    /// catch-all page HAS a <c>&lt;title&gt;</c>, which is precisely why it slipped through — and
+    /// NOT on <see cref="Icon"/>/<see cref="CardIcon"/>: a favicon is found for practically any
+    /// page, including a degraded one, so an icon is never evidence that the metadata is good.</para>
+    ///
+    /// <para>Cost, accepted deliberately: a genuinely Open-Graph-less page is re-fetched once per
+    /// view rather than cached. That is the honest trade — never pin a wrong answer for the
+    /// process lifetime to save a request.</para>
+    /// </summary>
+    public bool IsResolved => Fetched && DeclaresOpenGraph;
 
     /// <summary>The fallback preview for a target that could not be fetched: no metadata, the
     /// card renders from the URL alone.</summary>

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreviewService.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreviewService.cs
@@ -109,6 +109,21 @@ public sealed class OpenGraphPreviewService
             return Observable.Return(OpenGraphPreview.Unavailable(url));
 
         return pool().Run(ct => FetchAsync(url, ct))
+            // 🚨 A SUCCESSFUL fetch that carried no Open Graph metadata must not be cached
+            // either. A portal mid-restart / login wall / SPA catch-all answers 200 with its
+            // shell page, so nothing throws and the exception path below never runs — that
+            // response would otherwise be pinned for the process lifetime, leaving one card
+            // stuck on the catch-all's <title> while its neighbours render fine. Evicting it
+            // makes the next page view re-fetch, which is what such a transient response needs.
+            .Do(preview =>
+            {
+                if (preview.IsResolved)
+                    return;
+                logger()?.LogInformation(
+                    "Open Graph fetch of {Url} returned no og: metadata (HTTP succeeded); not "
+                    + "caching it, the next view re-fetches.", url);
+                cache.TryRemove(url, out _);
+            })
             // A failed fetch is a normal state for a card (target down, 404, DNS): surface the
             // URL-only fallback and EVICT the entry — the next page view's subscriber re-runs
             // the fetch once. TryRemove is idempotent across concurrent subscribers.

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreviewService.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphPreviewService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph;
 
@@ -53,6 +54,7 @@ public sealed class OpenGraphPreviewService
     private readonly Func<IIoPool> pool;
     private readonly Func<HttpClient> http;
     private readonly bool allowLoopback;
+    private readonly Func<ILogger?> logger;
 
     /// <summary>The per-URL promise cache: instance state on this mesh-scoped singleton, so it
     /// dies with the mesh.</summary>
@@ -69,7 +71,8 @@ public sealed class OpenGraphPreviewService
             () => serviceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http)
                   ?? IoPool.Unbounded,
             () => serviceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName)
-                  ?? SharedHttp)
+                  ?? SharedHttp,
+            logger: () => serviceProvider.GetService<ILogger<OpenGraphPreviewService>>())
     {
     }
 
@@ -78,11 +81,16 @@ public sealed class OpenGraphPreviewService
     /// <paramref name="allowLoopback"/> lets a test point the service at its local listener,
     /// which the production guard refuses.
     /// </summary>
-    internal OpenGraphPreviewService(Func<IIoPool> pool, Func<HttpClient> http, bool allowLoopback = false)
+    internal OpenGraphPreviewService(
+        Func<IIoPool> pool,
+        Func<HttpClient> http,
+        bool allowLoopback = false,
+        Func<ILogger?>? logger = null)
     {
         this.pool = pool;
         this.http = http;
         this.allowLoopback = allowLoopback;
+        this.logger = logger ?? (() => null);
     }
 
     /// <summary>
@@ -106,6 +114,14 @@ public sealed class OpenGraphPreviewService
             // the fetch once. TryRemove is idempotent across concurrent subscribers.
             .Catch<OpenGraphPreview, Exception>(ex =>
             {
+                // Don't swallow the fault silently: a degraded card is byte-identical to the
+                // pre-fetch PLACEHOLDER card — same title (the host), same absent image — so
+                // this line is the only thing that distinguishes "this target is failing" from
+                // "this frame is simply the placeholder". The original catch discarded `ex`,
+                // leaving a genuine fetch fault with no trace anywhere.
+                logger()?.LogWarning(ex,
+                    "Open Graph fetch failed for {Url}; its card falls back to the URL alone.",
+                    url);
                 cache.TryRemove(url, out _);
                 return Observable.Return(OpenGraphPreview.Unavailable(url));
             });

--- a/test/MeshWeaver.Graph.Test/MeshNodeCardPosterTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeCardPosterTest.cs
@@ -1,0 +1,71 @@
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the split between the two card SHAPES: <see cref="MeshNodeCardControl"/> is an
+/// ICON-beside-text card (a fixed 48 px square image box with <c>object-fit: cover</c>), while
+/// <see cref="MeshNodeThumbnailControl"/> is the poster-shaped tile. A wide
+/// <see cref="MarkdownContent.Thumbnail"/> banner cropped into 48 px is a meaningless sliver, so
+/// the card skips it and falls through to the node's own icon — drawn for exactly that box. An
+/// explicitly authored content avatar/logo/icon still wins in BOTH shapes
+/// (<see cref="MeshNodeCardIconTest"/>).
+/// </summary>
+public class MeshNodeCardPosterTest
+{
+    private const string InlineSvg =
+        "<svg viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M4 4h16v16H4z\"/></svg>";
+
+    private const string Poster = "/posters/wide-banner.png";
+
+    private static MeshNode DocWithPosterAndIcon() =>
+        new("Doc", "Space")
+        {
+            Name = "A Document",
+            NodeType = "Markdown",
+            Icon = InlineSvg,
+            Content = new MarkdownContent { Content = "# Body", Thumbnail = Poster },
+        };
+
+    [Fact]
+    public void Card_RendersNodeIcon_NotTheThumbnailPoster()
+    {
+        var node = DocWithPosterAndIcon();
+
+        var card = MeshNodeCardControl.FromNode(node, node.Path);
+
+        card.ImageUrl.Should().Be(InlineSvg, "the card's 48 px box shows the node's icon");
+        card.ImageUrl.Should().NotContain("wide-banner");
+    }
+
+    [Fact]
+    public void Thumbnail_KeepsThePoster()
+    {
+        var node = DocWithPosterAndIcon();
+
+        MeshNodeThumbnailControl.FromNode(node, node.Path).ImageUrl.Should().Be(Poster,
+            "a thumbnail tile is poster-shaped and keeps the banner");
+    }
+
+    /// <summary>A node with no thumbnail at all was ALREADY icon-driven — dropping the poster from
+    /// the card chain must not disturb it.</summary>
+    [Fact]
+    public void Card_WithoutThumbnail_StillRendersTheIcon()
+    {
+        var node = new MeshNode("Plain", "Space") { Name = "Plain", Icon = InlineSvg };
+
+        MeshNodeCardControl.FromNode(node, node.Path).ImageUrl.Should().Be(InlineSvg);
+    }
+
+    /// <summary>Every non-null node resolves to SOME icon (own icon → shipped glyph → NodeType
+    /// default → neutral box), so dropping the poster can never leave a card blank.</summary>
+    [Fact]
+    public void Card_WithoutIconOrThumbnail_StillResolvesAVisual()
+    {
+        var node = new MeshNode("Typed", "Space") { Name = "Typed", NodeType = "Markdown" };
+
+        MeshNodeCardControl.FromNode(node, node.Path).ImageUrl.Should().NotBeNullOrEmpty();
+    }
+}

--- a/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
+++ b/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
@@ -147,6 +147,72 @@ public class OgCardLayoutAreaTest(ITestOutputHelper output) : HubTestBase(output
         OgCardLayoutArea.ParseTargets("?urls=").Should().BeEmpty();
     }
 
+    /// <summary>
+    /// 🚨 The reported defect: the bare PATH/areaId form did not split on commas AT ALL — it fell
+    /// through to a single-target return, so four URLs became ONE card whose href was the four
+    /// URLs concatenated. That fetch can never succeed, so the card degraded to the bare domain
+    /// and read as a broken link to the portal. Both forms now split, and the separator may arrive
+    /// raw or percent-encoded.
+    /// </summary>
+    [Fact]
+    public void ParseTargets_SplitsMultipleTargets_InEveryForm()
+    {
+        const string a = "https://memex.meshweaver.cloud/Reinsurance";
+        const string b = "https://memex.meshweaver.cloud/Underwriting";
+        const string c = "https://memex.meshweaver.cloud/Claims";
+        const string d = "https://memex.meshweaver.cloud/Pricing";
+
+        // The EXACT areaId from the live repro: path form, percent-encoded whole (%2C separators).
+        OgCardLayoutArea.ParseTargets(
+                "https%3A%2F%2Fmemex.meshweaver.cloud%2FReinsurance"
+                + "%2Chttps%3A%2F%2Fmemex.meshweaver.cloud%2FUnderwriting"
+                + "%2Chttps%3A%2F%2Fmemex.meshweaver.cloud%2FClaims"
+                + "%2Chttps%3A%2F%2Fmemex.meshweaver.cloud%2FPricing")
+            .Should().Equal(a, b, c, d);
+
+        // Path form with RAW commas.
+        OgCardLayoutArea.ParseTargets($"{a},{b},{c},{d}").Should().Equal(a, b, c, d);
+
+        // Query form, raw and encoded separators.
+        OgCardLayoutArea.ParseTargets($"?urls={a},{b}").Should().Equal(a, b);
+        OgCardLayoutArea.ParseTargets("?urls=https%3A%2F%2Fa.org%2FX%2Chttps%3A%2F%2Fa.org%2FY")
+            .Should().Equal("https://a.org/X", "https://a.org/Y");
+
+        // Trailing / doubled separators and stray whitespace produce no empty targets.
+        OgCardLayoutArea.ParseTargets($"{a},{b},").Should().Equal(a, b);
+        OgCardLayoutArea.ParseTargets($"?urls={a}, {b} ,,").Should().Equal(a, b);
+
+        // A SINGLE target still yields exactly one card, in every form.
+        OgCardLayoutArea.ParseTargets(a).Should().Equal(a);
+        OgCardLayoutArea.ParseTargets($"?url={a}").Should().Equal(a);
+        OgCardLayoutArea.ParseTargets("Some/Node/Path").Should().Equal("Some/Node/Path");
+
+        // The singular form never splits — a comma there is data, not a separator.
+        OgCardLayoutArea.ParseTargets($"?url={a},{b}").Should().Equal($"{a},{b}");
+    }
+
+    /// <summary>
+    /// An unreachable target must stay HONEST: it names the page it points at (the last path
+    /// segment) rather than the bare domain, and its href remains the real target — so the card
+    /// never masquerades as a link to the portal root.
+    /// </summary>
+    [HubFact]
+    public async Task UnfetchableUrl_CardNamesThePage_AndKeepsTheRealHref()
+    {
+        server.StatusCode = 500;
+        var url = server.BaseUrl + "Reinsurance";
+        var reference = new LayoutAreaReference(OgCardLayoutArea.AreaName) { Id = $"?url={url}" };
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), reference);
+
+        var card = await stream.GetControlStream($"{reference.Area}/Card0")
+            .Should().Within(10.Seconds())
+            .Match(x => x is MeshNodeCardControl { Title: "Reinsurance" });
+
+        ((MeshNodeCardControl)card!).Href.Should().Be(url);
+    }
+
     [Fact]
     public void BuildLayout_SingleCardBounded_MultipleCardsGrid()
     {

--- a/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
+++ b/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
@@ -69,8 +69,35 @@ public class OgCardLayoutAreaTest(ITestOutputHelper output) : HubTestBase(output
         var typed = (MeshNodeCardControl)card!;
         typed.Href.Should().Be(url);
         typed.Description.Should().Be("Served description.");
+        // This page declares NO icon link, so the card falls through to the og:image poster —
+        // the page's only declared visual. See the icon-preferred case below.
         typed.ImageUrl.Should().Be(server.BaseUrl + "og.png");
         typed.NodePath.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The user-visible point of the card: when the page declares an icon, THAT is the visual —
+    /// not the wide og:image poster, which the card's fixed 48 px square would crop into a
+    /// meaningless sliver.
+    /// </summary>
+    [HubFact]
+    public async Task ExternalUrl_WithDeclaredIcon_RendersIconNotPoster()
+    {
+        server.IconHref = "/favicon.ico";
+        // A distinct URL — the preview promise-cache is keyed per URL.
+        var url = server.BaseUrl + "with-icon";
+        var reference = new LayoutAreaReference(OgCardLayoutArea.AreaName) { Id = $"?url={url}" };
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), reference);
+
+        var card = await stream.GetControlStream($"{reference.Area}/Card0")
+            .Should().Within(10.Seconds())
+            .Match(x => x is MeshNodeCardControl { Title: "Served Title" });
+
+        var typed = (MeshNodeCardControl)card!;
+        typed.ImageUrl.Should().Be(server.BaseUrl + "favicon.ico");
+        typed.ImageUrl.Should().NotContain("og.png");
     }
 
     [HubFact]

--- a/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
+++ b/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
@@ -90,6 +90,154 @@ public class OpenGraphHtmlParserTest
         Assert.Null(preview.Title);
         Assert.Null(preview.Description);
         Assert.Null(preview.Image);
+        Assert.Null(preview.Icon);
         Assert.Equal(Url, preview.Url);
+    }
+
+    /// <summary>
+    /// 🚨 The exact head a MeshWeaver (Blazor) portal serves: <c>&lt;base href="/"&gt;</c> plus a
+    /// RELATIVE <c>href="favicon.ico"</c>. Resolved against the PAGE URL this would yield
+    /// <c>/PartnerRe/favicon.ico</c> — which a catch-all-routed SPA answers with 200 text/html,
+    /// not a 404, i.e. a silently broken image. The base tag is what makes it resolve to the real
+    /// origin-root icon.
+    /// </summary>
+    [Fact]
+    public void Parse_RelativeIcon_ResolvesAgainstBaseHref_NotThePagePath()
+    {
+        const string nested = "https://portal.example.org/PartnerRe/EslProposalQA";
+        const string html = """
+            <html><head><base href="/">
+            <link rel="icon" type="image/png" href="favicon.ico">
+            </head><body></body></html>
+            """;
+
+        Assert.Equal("https://portal.example.org/favicon.ico",
+            OpenGraphHtmlParser.Parse(nested, html).Icon);
+    }
+
+    [Fact]
+    public void Parse_RelativeIcon_NoBaseTag_ResolvesAgainstPageUrl()
+    {
+        const string html = "<head><link rel=\"shortcut icon\" href=\"/icons/site.png\"></head>";
+
+        Assert.Equal("https://portal.example.org/icons/site.png",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    /// <summary>Ranking is on ONE axis — effective pixel size — so the icon that renders sharpest
+    /// in the card's 48 px box wins regardless of declaration order.</summary>
+    [Fact]
+    public void Parse_PrefersLargestDeclaredIcon()
+    {
+        const string html = """
+            <head>
+            <link rel="icon" sizes="16x16" href="/small.png">
+            <link rel="icon" sizes="192x192" href="/large.png">
+            <link rel="icon" sizes="32x32" href="/medium.png">
+            </head>
+            """;
+
+        Assert.Equal("https://portal.example.org/large.png",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    [Fact]
+    public void Parse_ScalableSvgIcon_OutranksEveryRaster()
+    {
+        const string html = """
+            <head>
+            <link rel="apple-touch-icon" sizes="180x180" href="/touch.png">
+            <link rel="icon" type="image/svg+xml" href="/site.svg">
+            </head>
+            """;
+
+        Assert.Equal("https://portal.example.org/site.svg",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    /// <summary>A sizeless <c>apple-touch-icon</c> is conventionally 180 px and purpose-built as a
+    /// square tile, so it outranks a sizeless <c>favicon.ico</c> (conventionally 16–32 px).</summary>
+    [Fact]
+    public void Parse_SizelessAppleTouchIcon_OutranksSizelessFavicon()
+    {
+        const string html = """
+            <head>
+            <link rel="icon" href="/favicon.ico">
+            <link rel="apple-touch-icon" href="/touch.png">
+            </head>
+            """;
+
+        Assert.Equal("https://portal.example.org/touch.png",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    [Fact]
+    public void Parse_DataUriIcon_ReturnedVerbatim()
+    {
+        const string data = "data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%2F%3E";
+        var html = $"<head><link rel=\"icon\" href=\"{data}\"></head>";
+
+        Assert.Equal(data, OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    /// <summary><c>mask-icon</c> is a monochrome Safari pinned-tab silhouette, not the site
+    /// icon — it must never be picked, not even as the only candidate.</summary>
+    [Fact]
+    public void Parse_MaskIconAndStylesheet_AreNotIconCandidates()
+    {
+        const string html = """
+            <head>
+            <link rel="stylesheet" href="/app.css">
+            <link rel="mask-icon" href="/pinned.svg" color="#000">
+            </head>
+            """;
+
+        Assert.Null(OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    /// <summary>Attribute names are matched as WHOLE attributes: a <c>data-href</c> decoy
+    /// preceding the real <c>href</c> must not be read as the icon.</summary>
+    [Fact]
+    public void Parse_AttributeLookalikes_DoNotHijackTheIcon()
+    {
+        const string html =
+            "<head><link rel=\"icon\" data-href=\"/decoy.png\" href=\"/real.png\"></head>";
+
+        Assert.Equal("https://portal.example.org/real.png",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
+    /// <summary>The card visual is the ICON, never the poster: declared icon → og:image →
+    /// conventional origin-root favicon.</summary>
+    [Fact]
+    public void CardIcon_PrefersDeclaredIcon_ThenOgImage_ThenConventionalFavicon()
+    {
+        const string withIcon = """
+            <head>
+            <link rel="icon" href="/site.png">
+            <meta property="og:image" content="/api/og/Poster.png">
+            </head>
+            """;
+        Assert.Equal("https://portal.example.org/site.png",
+            OpenGraphHtmlParser.Parse(Url, withIcon).CardIcon);
+
+        // No icon declared → the poster is the only visual the page declared, so it is used
+        // rather than guessing at a favicon that may 404.
+        const string posterOnly = "<head><meta property=\"og:image\" content=\"/api/og/P.png\"></head>";
+        Assert.Equal("https://portal.example.org/api/og/P.png",
+            OpenGraphHtmlParser.Parse(Url, posterOnly).CardIcon);
+
+        // Nothing declared → the conventional origin-root favicon, resolved off the ORIGIN
+        // (never the page path).
+        Assert.Equal("https://portal.example.org/favicon.ico",
+            OpenGraphHtmlParser.Parse(Url, "<head><title>T</title></head>").CardIcon);
+    }
+
+    /// <summary>An unreachable target's origin is unproven, so the card guesses nothing and keeps
+    /// its clean initials placeholder instead of showing a broken image.</summary>
+    [Fact]
+    public void CardIcon_UnfetchedTarget_GuessesNothing()
+    {
+        Assert.Null(OpenGraphPreview.Unavailable(Url).CardIcon);
     }
 }

--- a/test/MeshWeaver.Graph.Test/OpenGraphPreviewServiceTest.cs
+++ b/test/MeshWeaver.Graph.Test/OpenGraphPreviewServiceTest.cs
@@ -68,6 +68,68 @@ public sealed class OpenGraphPreviewServiceTest : IDisposable
         Assert.Equal(2, server.RequestCount);
     }
 
+    /// <summary>
+    /// 🚨 The pinned-degraded-card defect. A portal mid-restart answers HTTP <b>200</b> with its
+    /// SPA catch-all shell: a plain <c>&lt;title&gt;</c> and no <c>og:*</c> tags. Nothing throws,
+    /// so the exception-eviction path never fires — and that empty answer used to be cached for
+    /// the whole process lifetime, leaving one card stuck on "Memex Portal" with no description
+    /// while every neighbouring card rendered correctly. A successful-but-og-less fetch must be
+    /// evicted exactly like a failed one.
+    /// </summary>
+    [Fact]
+    public async Task Get_SuccessfulFetchWithoutOgTags_IsNotCachedAndRetries()
+    {
+        var service = CreateService();
+        var url = server.BaseUrl + "Ifrs17";
+
+        server.OmitOgTags = true;
+        var degraded = await Await(service.Get(url));
+
+        // The fetch SUCCEEDED — this is not the failure path — but it carried nothing usable.
+        Assert.True(degraded.Fetched);
+        Assert.False(degraded.IsResolved);
+        Assert.False(degraded.DeclaresOpenGraph);
+        // The catch-all's <title> is exactly why keying the cache on Title would not have
+        // caught this: the preview HAS a title, it is simply the wrong page's.
+        Assert.Equal("Memex Portal", degraded.Title);
+        Assert.Null(degraded.Description);
+        Assert.Equal(1, server.RequestCount);
+
+        // Not cached: the next view re-fetches, and now that the portal is back it resolves.
+        server.OmitOgTags = false;
+        var recovered = await Await(service.Get(url));
+
+        Assert.True(recovered.IsResolved);
+        Assert.Equal("Served Title", recovered.Title);
+        Assert.Equal("Served description.", recovered.Description);
+        Assert.Equal(2, server.RequestCount);
+
+        // And the good answer IS cached — the retry does not become a permanent re-fetch.
+        var replayed = await Await(service.Get(url));
+        Assert.Equal(recovered, replayed);
+        Assert.Equal(2, server.RequestCount);
+    }
+
+    /// <summary>An icon is found for practically any page, degraded ones included, so it must
+    /// never be mistaken for evidence that the metadata is good.</summary>
+    [Fact]
+    public async Task Get_OgLessPageWithAnIcon_IsStillNotCached()
+    {
+        var service = CreateService();
+        var url = server.BaseUrl + "shell";
+
+        server.OmitOgTags = true;
+        server.IconHref = "/favicon.ico";
+
+        var degraded = await Await(service.Get(url));
+
+        Assert.Equal(server.BaseUrl + "favicon.ico", degraded.Icon);
+        Assert.False(degraded.IsResolved);
+
+        await Await(service.Get(url));
+        Assert.Equal(2, server.RequestCount);
+    }
+
     [Fact]
     public async Task Get_GuardedTarget_YieldsFallbackWithoutAnyRequest()
     {

--- a/test/MeshWeaver.Graph.Test/TestOgServer.cs
+++ b/test/MeshWeaver.Graph.Test/TestOgServer.cs
@@ -33,6 +33,11 @@ internal sealed class TestOgServer : IDisposable
     /// default) declares NO icon link, so the card falls through to the og:image poster.</summary>
     public volatile string? IconHref;
 
+    /// <summary>Serve the SPA catch-all shell instead — HTTP 200 with a plain <c>&lt;title&gt;</c>
+    /// and no <c>og:*</c> tags — the successful-but-useless response a portal returns while it is
+    /// restarting.</summary>
+    public volatile bool OmitOgTags;
+
     public TestOgServer()
     {
         // HttpListener cannot bind port 0; reserve a free port via TcpListener first.
@@ -65,12 +70,15 @@ internal sealed class TestOgServer : IDisposable
             Interlocked.Increment(ref requestCount);
             var iconHref = IconHref;
             var iconLink = iconHref is null ? string.Empty : $"<link rel=\"icon\" href=\"{iconHref}\">";
-            var html =
-                $"<html><head><meta property=\"og:title\" content=\"{Title}\">" +
-                "<meta property=\"og:description\" content=\"Served description.\">" +
-                "<meta property=\"og:image\" content=\"/og.png\">" +
-                iconLink +
-                "</head><body></body></html>";
+            var head = OmitOgTags
+                // The SPA catch-all shell a portal serves mid-restart: HTTP 200, a plain
+                // <title>, and NO og:* tags whatsoever.
+                ? "<title>Memex Portal</title>" + iconLink
+                : $"<meta property=\"og:title\" content=\"{Title}\">"
+                  + "<meta property=\"og:description\" content=\"Served description.\">"
+                  + "<meta property=\"og:image\" content=\"/og.png\">"
+                  + iconLink;
+            var html = $"<html><head>{head}</head><body></body></html>";
             var bytes = Encoding.UTF8.GetBytes(html);
             try
             {

--- a/test/MeshWeaver.Graph.Test/TestOgServer.cs
+++ b/test/MeshWeaver.Graph.Test/TestOgServer.cs
@@ -29,6 +29,10 @@ internal sealed class TestOgServer : IDisposable
     /// <summary>The og:title the served head declares.</summary>
     public volatile string Title = "Served Title";
 
+    /// <summary>An optional <c>&lt;link rel="icon"&gt;</c> href for the served head. Null (the
+    /// default) declares NO icon link, so the card falls through to the og:image poster.</summary>
+    public volatile string? IconHref;
+
     public TestOgServer()
     {
         // HttpListener cannot bind port 0; reserve a free port via TcpListener first.
@@ -59,10 +63,13 @@ internal sealed class TestOgServer : IDisposable
             }
 
             Interlocked.Increment(ref requestCount);
+            var iconHref = IconHref;
+            var iconLink = iconHref is null ? string.Empty : $"<link rel=\"icon\" href=\"{iconHref}\">";
             var html =
                 $"<html><head><meta property=\"og:title\" content=\"{Title}\">" +
                 "<meta property=\"og:description\" content=\"Served description.\">" +
                 "<meta property=\"og:image\" content=\"/og.png\">" +
+                iconLink +
                 "</head><body></body></html>";
             var bytes = Encoding.UTF8.GetBytes(html);
             try


### PR DESCRIPTION
Follow-up to #1201. Primary ask, verbatim: *"for og card: icon is nicer. can we display icon rather than poster?"* Three defects found alongside it, all in the same area.

---

## 1. Icon instead of the og:image poster (the ask)

The card's image box is **already** a fixed **48 px square** with `object-fit: cover`. Handing it a 1200×630 `og:image` poster cover-crops a wide banner into a fingernail — an arbitrary sliver. An icon is drawn for exactly that size. This is not a layout change; it changes *which* image the card is given.

| Card kind | Before | After |
|---|---|---|
| **External URL** | `og:image` poster, cover-cropped | **declared icon** → `og:image` → conventional `/favicon.ico` |
| **Same-mesh node** | `MarkdownContent.Thumbnail` poster when present | **node's own icon** (inline SVG, `currentColor`) |

Icon priority is ranked on **one axis — effective pixel size**, so the winner is whichever renders sharpest at 48 px; ties keep document order:

- `type="image/svg+xml"` or `sizes="any"` → scalable, beats every raster
- declared `sizes` → largest dimension
- sizeless `apple-touch-icon` → 180 (de-facto convention, purpose-built square tile)
- sizeless `rel="icon"` / `shortcut icon` → 32

`rel="mask-icon"` is deliberately excluded (monochrome Safari pinned-tab silhouette). Everything the page *declared* is preferred over the `/favicon.ico` guess, so the card never trades a guaranteed image for a possible 404; an **unfetchable** target guesses nothing and keeps its initials placeholder.

### `<base href>` — relative icons do not resolve against the page URL

Checked what memex actually serves before designing (`/Reinsurance`, `/Underwriting`, `/RiskTransfer`, `/AgenticPrimer` — identical):

```html
<base href="/">
<link rel="icon" type="image/png" href="favicon.ico">
```

Resolved against a *nested* page URL that becomes `/PartnerRe/favicon.ico`, which the Blazor catch-all answers with **`200 text/html`, not 404**:

```
$ curl -o /dev/null -w "%{content_type}" https://memex.meshweaver.cloud/PartnerRe/favicon.ico
text/html; charset=utf-8      # ← 200, and it is the HTML page
$ curl -o /dev/null -w "%{content_type}" https://memex.meshweaver.cloud/favicon.ico
image/x-icon                  # ← the real icon
```

So page-relative resolution yields a silently broken `<img>` that *looks* like a working link. `<base href>` is now honoured (applied to `og:image` too), and `data:` URIs pass through verbatim.

---

## 2. A comma-separated list did not split in the PATH form

Reproduced live on ci.2940. This areaId rendered **one** card, not four:

```
OgCard/https%3A%2F%2F…%2FReinsurance%2C…%2FUnderwriting%2C…%2FClaims%2C…%2FPricing
→ { "title": "memex.meshweaver.cloud",
    "href":  "https://…/Reinsurance,https://…/Underwriting,https://…/Claims,https://…/Pricing" }
```

`ParseTargets` split on commas only in the `?urls=` branch; the bare path/areaId branch fell through to a single-target return — for **raw** commas as well as encoded ones. The joined string became one href whose fetch could never succeed.

Both forms now go through one `SplitTargets` helper that splits on **both sides of the single unescape**, because the separator arrives raw or encoded depending on authoring: a path-form areaId is commonly percent-encoded as one whole segment (`%2C` separators), while `?urls=` usually keeps commas raw. Documented consequence: a literal comma *inside* a URL must be double-encoded (`%252C`), or carried by the singular `?url=` form, which never splits.

**Honest fallback:** a target whose page declares no title now shows its **last path segment** ("Reinsurance") rather than the bare host — a grid of cards all titled `memex.meshweaver.cloud` reads as several broken links to the portal. The href was, and remains, the real target.

---

## 3. A successful fetch carrying no OG data was cached forever

Root cause of **one** permanently-degraded card in an otherwise perfect grid: `/Ifrs17` rendered as "Memex Portal" with no description while its seven neighbours were correct. The page is fine — the portal had cached a bad-but-**successful** fetch. During a restart window that URL returned the SPA catch-all shell: HTTP 200, a plain `<title>Memex Portal</title>`, no `og:*` tags. Nothing threw, so the failure-eviction path never fired, and the promise cache pinned that empty answer for the process lifetime.

Only a preview that actually declared Open Graph metadata may now be cached; a successful-but-og-less result is evicted exactly like the exception path, so the next view re-fetches — correct, because those responses (restart shell, login wall, error page) are the transient ones.

The gate keys on a real `og:title` (new `DeclaresOpenGraph`), **not** on `Title` — the catch-all page *has* a `<title>`, which is exactly how it slipped through — and **not** on the icon, since a favicon resolves for practically any page including a degraded one.

Not a TTL, not a `"Memex Portal"` special case: both would paper over a wrong answer rather than stop it being stored. Accepted cost, documented: a genuinely OG-less page re-fetches once per view instead of being cached.

---

## 4. The fetch fault was discarded

The service's `.Catch` bound `ex` and never used it, so a genuine fetch fault left no trace — the swallow-and-continue pattern AGENTS.md forbids. Especially costly here: a degraded card is **byte-identical** to the pre-fetch placeholder, so this line is the only thing distinguishing "this target is failing" from "this frame is just the placeholder". One `LogWarning` on the genuine exception path; no log level anywhere else is touched.

---

## Scoping

- **`MeshNodeThumbnailControl` unchanged** — it is the poster-shaped tile and keeps `MarkdownContent.Thumbnail`. The split is one `includeThumbnail` parameter; every other caller keeps the default. Only `MeshNodeCardControl` opts out, which also improves search-result and pinned cards (same 48 px shape).
- **No CSS change** — the compact icon-beside-text box already existed.
- **No domain row added** — `.mesh-node-card-content` has a fixed `height: 76px`; a third line would overflow without a layout redesign.
- **No new user-visible strings** → no localization keys; the react vendored catalogs remain byte-identical to the Hub ones (verified with `diff`).
- **Framework controls only** — no HTML strings.

## Tests

`test/MeshWeaver.Graph.Test` — **49 passed, 0 failed** under `-c Release -warnaserror`.

- `OpenGraphHtmlParserTest` — base-href resolution on a nested page (the real memex shape), page-relative fallback with no base tag, largest-size wins, SVG outranks every raster, sizeless apple-touch beats sizeless favicon, `data:` verbatim, `mask-icon`/`stylesheet` rejected, a `data-href` decoy cannot hijack the match, and the full `CardIcon` fallback order incl. the unfetched case.
- `OgCardLayoutAreaTest` — a page declaring an icon renders the icon not `og.png`; multi-URL via `?urls=` and via the path form; the exact `%2C` live-repro string; raw commas; trailing/doubled separators; whitespace; a single URL in every form; singular `?url=` not splitting; an unfetchable target keeping its page name and real href.
- `OpenGraphPreviewServiceTest` — 200-without-og-tags is not cached and re-fetches, resolves once the page recovers, and the good answer then *is* cached; an og-less page that does serve an icon is still not cached.
- `MeshNodeCardPosterTest` (new) — card takes the icon over the poster; thumbnail tile keeps the poster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)