### PR TITLE
Batch bake is opt-in: its source discovery read 50 of thousands of Code nodes in production

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-batch-bake-opt-in.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-batch-bake-opt-in.md
@@ -1,0 +1,19 @@
+---
+Name: Platform updates keep using the proven preparation path
+Category: Fix
+Description: The new batched preparation is now opt-in after it mis-read content at production scale; updates use the proven path by default.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Platform updates keep using the proven preparation path
+
+A new, much faster way of preparing content types during a platform update was introduced earlier
+today. Its first run against a large production mesh read only part of the available source
+content, and reported many healthy types as broken. Nothing was lost and no page changed — the
+update safety-check spotted it and kept the previous version serving — but the fast path is not
+trustworthy yet.
+
+Updates now use the proven preparation path by default, and the faster one has to be switched on
+deliberately. The speed improvements that did hold up — no more artificial pauses between types
+during an update — remain in place.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -60,15 +60,15 @@ public sealed class DynamicTypePreWarmerHostedService(
     public const string BetweenTypesConfigKey = "PreWarm:BetweenTypes";
 
     /// <summary>
-    /// Config key overriding whether the sweep runs as ONE LINKED BATCH BUILD (issue #1207):
+    /// Config key opting a deployment INTO the ONE LINKED BATCH BUILD sweep (issue #1207):
     /// batched source discovery + direct compiler drive, no per-type hub activations, no
-    /// compile-watcher settles, no cross-silo hops. When the key is absent the mode follows the
-    /// SAME initial-bake discriminator as <see cref="BetweenTypesConfigKey"/>: a pod whose bake
-    /// GATES readiness batches (it serves nobody while it bakes, and every activation round-trip
-    /// it skips is one that cannot land on a wedged peer silo and eat a 5-minute timeout — the
-    /// 2026-08-10/11 20-min/5-h bakes); an ungated pod keeps the activation-driven background
-    /// trickle. Set <c>false</c> to force the activation path on a gated pod (the ops escape
-    /// hatch), or <c>true</c> to batch an ungated warm-up.
+    /// compile-watcher settles, no cross-silo hops.
+    ///
+    /// <para><b>Default: OFF, everywhere.</b> It is not yet trustworthy at production scale — see
+    /// the note in <c>KickWarmup</c> and #1216: its first production run resolved zero sources for
+    /// 169 of 237 types. Set <c>true</c> only where the discovery has been verified against that
+    /// mesh's own content, and check the sweep summary (`compiled` vs `contentBroken`) afterwards.
+    /// The activation-driven path remains the default and is unaffected by this key.</para>
     /// </summary>
     public const string BatchBakeConfigKey = "PreWarm:BatchBake";
 
@@ -161,11 +161,23 @@ public sealed class DynamicTypePreWarmerHostedService(
                     gate is { GatesReadiness: true } ? "gated (zero)" : "serving (trickle)");
         }
 
-        // Batch mode (issue #1207): explicit config wins; otherwise the SAME initial-bake
-        // discriminator as the pacing above — a readiness-GATED pod runs the bake as one linked
-        // batch build (direct compiler drive — no per-type activations) and an ungated pod keeps
-        // the activation-driven trickle. See BatchBakeConfigKey.
-        var batchBake = gate is { GatesReadiness: true };
+        // Batch mode (issue #1207) is OPT-IN — it must be asked for explicitly.
+        //
+        // 🚨 It shipped defaulting ON for a gated pod and was WRONG AT PRODUCTION SCALE the first
+        // time it ran there (memex-cloud, 2026-08-11, ci.2947): the sweep finished in 19s with
+        // `compiled=4 compileErrors=59 contentBroken=169` out of 237 — i.e. the batched source
+        // discovery resolved NO sources for 169 types and PARTIAL sources for 59 more, so types
+        // that compile fine on the activation path were reported broken. The bake gate caught it
+        // and refused readiness (no outage, previous image kept serving), but with the default ON
+        // every gated portal that self-updates would stall its own rollout the same way — and a
+        // helm upgrade would silently undo the live `PreWarm__BatchBake=false` patches.
+        //
+        // The defect is in the discovery, not the gate: a wrongly-empty source set becomes
+        // PreWarmStatus.NoSources ("content-broken"), which by design does NOT gate — so on an
+        // UNGATED pod the same bug would ship a fleet of empty assemblies silently. Until
+        // discovery is proven at scale, correctness beats speed: no config, no batch.
+        // Tracked in #1216.
+        var batchBake = false;
         var batchRaw = services.GetService<IConfiguration>()?[BatchBakeConfigKey];
         if (!string.IsNullOrWhiteSpace(batchRaw))
         {


### PR DESCRIPTION
## What happened

First production run of #1207/#1211 (memex-cloud, image `ci.2947`, gated pod):

```
DynamicTypePreWarmer: warm-up complete in 00:00:19.36 —
  compiled=4 compileErrors=59 timedOut=0 skipped=5 contentBroken=169
REFUSING READINESS — 64 NodeType(s) regressed on this image
```

Loki carried the cause in the sweep's own diagnostic:

```
BatchBake: source discovery resolved 50 Code node(s) into source sets for 237 pending type(s) in one pass
```

**50 is the default query limit.** `ResolveSources` issues one global `nodeType:Code` fetch through `MeshQueryRequest.FromQuery`, which leaves `Limit` null, so on a mesh with thousands of Code nodes it returns the first 50. 169 types resolved an **empty** source set (`NoSources`), 59 a **partial** one (`CompileError`) — all of them types that compile fine on the activation path. The tests pass because a test mesh has fewer than 50 Code nodes, so the cap never binds.

## Why this PR flips the default rather than only fixing the limit

- The mode defaulted **ON for any readiness-gated pod**, so every gated portal that self-updates stalls its own rollout the same way. The live `PreWarm__BatchBake=false` patches on memex-cloud / memex / atioz are a stopgap that a helm upgrade would revert.
- On an **ungated** pod it is worse than a stall: a wrongly-empty source set classifies as `PreWarmStatus.NoSources`, a content verdict that deliberately does **not** gate — so the same bug would bake a fleet of empty assemblies with nothing refusing readiness.

Correctness before speed: batch bake now has to be asked for explicitly, and the code says why. The measured win that *did* hold — #1206's zero pacing on gated bakes — is untouched.

## Follow-up (#1216)

Unbounded/paginated discovery, verified through the Postgres provider rather than assumed; a scale test with more Code nodes than the default limit; and — the deeper fix — discovery asserting its own invariant, so a type with a non-empty `Sources` list that resolves to nothing fails the BATCH (falling back to the activation path) instead of being reported as content-broken, which currently makes a discovery bug indistinguishable from genuinely deleted content.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)