### PR TITLE
Batch bake's global source fetch could not see a single Code node Postgres stores (#1216)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-update-preparation-reads-all-of-your-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-update-preparation-reads-all-of-your-content.md
@@ -1,0 +1,25 @@
+---
+Name: Update preparation now reads all of your content
+Category: Fix
+Description: The faster update-preparation path used to read only the first page of source content on a large mesh; it now reads all of it, and refuses to guess when it cannot.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Update preparation now reads all of your content
+
+When the platform updates, it prepares every content type on your mesh so the first person to open
+a page does not have to wait. The faster preparation path introduced earlier today asked the mesh
+for its source content in a single request — and on a large mesh that request came back with only
+the first page of results. Types whose content sat beyond that page were prepared against nothing,
+and then reported as broken even though nothing was wrong with them.
+
+The request now asks for everything, and — this is the part that matters — it **checks** that it
+got everything. If the answer could be incomplete, or if a type that says it has source content
+comes back with none and nothing else on the mesh agrees, preparation stops and hands the whole
+update back to the slower, proven path. It no longer reports a type as broken on evidence it never
+actually gathered.
+
+You would have seen this as an update that took much longer than usual, or as content types
+briefly showing a preparation error after a platform update. Nothing was lost either way: the
+update safety-check kept the previous version serving.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -883,7 +883,13 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
         // this shape and resolved 50 Code nodes out of thousands). A request that states no limit at
         // all still gets the fan-out's default: an unanchored UNION over every partition schema
         // needs SOME bound, and changing that default is a separate decision.
-        if (request.Limit.HasValue)
+        // 🚨 POSITIVE limits only. `Limit <= 0` means "do not clip" upstream —
+        // MeshQuery.ClipMergedInitial applies a limit only `if (effectiveLimit is int limit &&
+        // limit > 0)` — but propagated into SQL a zero becomes a literal `LIMIT 0`, i.e. ZERO ROWS
+        // returned for a caller that asked for everything. That is the same silent-empty-result
+        // failure this very PR exists to fix (#1216: discovery that cannot see rows reports the
+        // content as missing), so it must not be re-introduced one layer down.
+        if (request.Limit is > 0)
             queryForSql = queryForSql with { Limit = request.Limit };
 
         var userId = GetEffectiveUserId(request);

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -874,6 +874,18 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
         if (!string.IsNullOrEmpty(queryForSql.Path) && queryForSql.Path.Contains('*'))
             queryForSql = queryForSql with { Path = null, Scope = QueryScope.Exact };
 
+        // 🚨 Carry the REQUEST-level limit into the parsed query — the same propagation the
+        // per-schema delegate does (PostgreSqlMeshQuery: `if (request.Limit.HasValue) parsedQuery =
+        // parsedQuery with { Limit = request.Limit }`). Without it, `request.Limit` was silently
+        // DROPPED on the unpinned path: QueryAcrossSchemasAsync reads only ParsedQuery.Limit and
+        // substitutes a hard default of 50, so a caller asking for 500 across partitions got 50 and
+        // had no way to tell (issue #1216 — the batch bake's global `nodeType:Code` fetch is exactly
+        // this shape and resolved 50 Code nodes out of thousands). A request that states no limit at
+        // all still gets the fan-out's default: an unanchored UNION over every partition schema
+        // needs SOME bound, and changing that default is a separate decision.
+        if (request.Limit.HasValue)
+            queryForSql = queryForSql with { Limit = request.Limit };
+
         var userId = GetEffectiveUserId(request);
         // activityUserId is only meaningful for source:accessed today (joins
         // user_activities); source:activity reads the activity satellite,

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
@@ -417,7 +417,10 @@ public sealed class SnowflakePartitionedMeshQuery : IMeshQueryProvider
         // QueryAcrossSchemasAsync reads only ParsedQuery.Limit and substitutes a hard default of 50.
         // A request that states no limit at all still gets that default: an unanchored UNION over
         // every partition schema needs SOME bound.
-        if (request.Limit.HasValue)
+        // 🚨 POSITIVE limits only — same guard as the PostgreSQL twin. `Limit <= 0` means "do not
+        // clip" upstream (MeshQuery.ClipMergedInitial applies a limit only when `limit > 0`), but in
+        // SQL a zero is a literal `LIMIT 0`: zero rows for a caller that asked for everything.
+        if (request.Limit is > 0)
             queryForSql = queryForSql with { Limit = request.Limit };
 
         var userId = GetEffectiveUserId(request);

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
@@ -411,6 +411,15 @@ public sealed class SnowflakePartitionedMeshQuery : IMeshQueryProvider
         if (!string.IsNullOrEmpty(queryForSql.Path) && queryForSql.Path.Contains('*'))
             queryForSql = queryForSql with { Path = null, Scope = QueryScope.Exact };
 
+        // 🚨 Carry the REQUEST-level limit into the parsed query — the same propagation the
+        // per-schema delegate does (SnowflakeMeshQuery) and the exact twin of the PostgreSQL fix for
+        // issue #1216. Without it `request.Limit` is silently DROPPED on the unpinned path, because
+        // QueryAcrossSchemasAsync reads only ParsedQuery.Limit and substitutes a hard default of 50.
+        // A request that states no limit at all still gets that default: an unanchored UNION over
+        // every partition schema needs SOME bound.
+        if (request.Limit.HasValue)
+            queryForSql = queryForSql with { Limit = request.Limit };
+
         var userId = GetEffectiveUserId(request);
         // activityUserId is only meaningful for source:accessed today (joins
         // user_activities); source:activity reads the activity satellite,

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -584,6 +584,15 @@ public static class DynamicTypePreWarmer
         // Batch discovery first — ONE pass resolving every pending type's source queries.
         // Only a DISCOVERY failure falls back to the activation-driven sweep (before any
         // outcome was produced); a failure inside the sweep itself propagates as usual.
+        //
+        // 🚨 "Discovery failure" is now ASSERTED, not assumed (issue #1216). ResolveSources errors
+        // when its query hit its own ceiling (possible truncation) or when a type that declares
+        // source queries resolved to an empty set with nothing corroborating it. Both mean the batch
+        // does not know what the sources ARE, and a compile driven from a set you did not establish
+        // produces verdicts about code from evidence you do not have — on memex-cloud 2026-08-11
+        // that read as "169 of 237 types are content-broken" and, on an ungated pod, would have
+        // baked a fleet of empty assemblies with nothing refusing readiness. Whole-batch fallback is
+        // the only safe answer: the activation-driven sweep resolves each type's sources itself.
         return NodeTypeBatchBake
             .ResolveSources(batchMeshService!, accessService, definitions, pending, logger)
             .Select(index =>
@@ -591,8 +600,11 @@ public static class DynamicTypePreWarmer
             .Catch<ImmutableDictionary<string, IReadOnlyList<MeshNode>>?, Exception>(ex =>
             {
                 logger?.LogWarning(ex,
-                    "DynamicTypePreWarmer: batched source discovery failed — falling back to the "
-                    + "activation-driven sweep");
+                    "DynamicTypePreWarmer: batched source discovery did not establish the source "
+                    + "sets — abandoning the batch and falling back to the activation-driven sweep "
+                    + "for ALL {Pending} pending type(s). No type is reported from this pass, so "
+                    + "nothing here can be mistaken for a content or compile verdict.",
+                    pending.Count);
                 return Observable.Return(
                     (ImmutableDictionary<string, IReadOnlyList<MeshNode>>?)null);
             })

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -60,9 +60,77 @@ internal static class NodeTypeBatchBake
     private static readonly TimeSpan DiscoveryBudget = TimeSpan.FromMinutes(2);
 
     /// <summary>
+    /// The EXPLICIT ceiling every discovery query carries — and the reason issue #1216 can never
+    /// recur silently.
+    ///
+    /// <para><b>What went wrong.</b> Discovery used to issue a bare
+    /// <c>MeshQueryRequest.FromQuery("nodeType:Code")</c>, which leaves both
+    /// <see cref="MeshQueryRequest.Limit"/> and <see cref="ParsedQuery.Limit"/> null. "No limit"
+    /// is NOT read the same way by every backend: the in-memory
+    /// <c>StorageAdapterMeshQueryProvider</c> (<c>LoadCap</c>) and the per-schema
+    /// <c>PostgreSqlMeshQuery</c> treat it as UNBOUNDED, but the cross-schema fan-out that serves
+    /// an UNPINNED query on Postgres substitutes a hard default of 50
+    /// (<c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c>). <c>nodeType:Code</c>
+    /// carries no <c>namespace:</c>/<c>path:</c>, so it is exactly that unpinned shape — and on
+    /// memex-cloud 2026-08-11 the batch resolved 50 Code nodes out of thousands and compiled 169
+    /// of 237 types against NOTHING. A test mesh has fewer than 50 Code nodes, so the cap never
+    /// bound and every test stayed green.</para>
+    ///
+    /// <para><b>Why a number and not "unbounded".</b> Unbounded is not honoured uniformly (above),
+    /// and it cannot be reached by paging either: <c>public.search_across_schemas</c> takes a LIMIT
+    /// but no OFFSET, and its <c>ORDER BY n.last_modified DESC</c> is not a total order, so a
+    /// Skip/Limit loop over it would silently drop and duplicate rows across pages — worse than one
+    /// big page. So discovery states its ceiling EXPLICITLY (every backend honours an explicit
+    /// <c>limit:</c>) and then ASSERTS it was not reached. A mesh that genuinely exceeds this many
+    /// Code nodes gets a loud discovery failure and the activation-driven sweep — slower, correct,
+    /// and impossible to mistake for a content verdict.</para>
+    /// </summary>
+    internal const int SourceDiscoveryLimit = 25_000;
+
+    /// <summary>
+    /// The global fetches whose UNION is every Code node on the mesh. Three queries, not one —
+    /// and the reason is the second half of issue #1216, invisible until this ran against a real
+    /// partitioned Postgres mesh.
+    ///
+    /// <para>🚨 <c>nodeType:Code</c> ALONE CANNOT SEE MOST CODE NODES. On the partitioned backend a
+    /// node's table is chosen by PATH SEGMENT: anything under a <c>Source/</c> or <c>Test/</c>
+    /// segment is written to the per-schema <c>code</c> satellite table, and everything else to
+    /// <c>mesh_nodes</c>. Resolving a table from a <c>nodeType:</c> filter is a DIFFERENT map, and
+    /// <c>Code</c> is deliberately absent from it — <see cref="SatelliteTableMapping.Defaults"/>
+    /// states it outright: "<c>Source</c>/<c>Test</c> are primary code content sharing the
+    /// <c>code</c> table (no leading underscore — matched as a path segment, and not
+    /// nodeType-resolvable)". So an unpinned <c>nodeType:Code</c> query fans out over every
+    /// schema's <c>mesh_nodes</c> and returns ZERO of the Code nodes that live where Code nodes
+    /// actually live. Measured on a two-partition PG mesh holding 60 Code nodes: <c>nodeType:Code</c>
+    /// returned 2 (both from the static catalog, none from Postgres), while
+    /// <c>namespace:*/Source scope:subtree nodeType:Code</c> returned all 60.</para>
+    ///
+    /// <para>That is what turned "the limit truncated the set" into "169 of 237 types resolved
+    /// NOTHING" in production: the cap explains a PARTIAL set, never an empty one. The wildcard
+    /// namespace shapes route through <c>PostgreSqlPartitionedMeshQuery.ResolveTable</c>'s
+    /// wildcard-namespace branch, which reads the satellite segment out of the <c>namespace LIKE</c>
+    /// value and lands on <c>code</c>. The union stays O(1) in the number of pending types — three
+    /// queries regardless of whether the mesh has 3 types or 300 — which is the whole point of the
+    /// batched pass, and each one is bounded and truncation-checked by <see cref="RunQuery"/>.</para>
+    ///
+    /// <para>Overlap is free: the results fold into one path-keyed map, and the in-memory matcher
+    /// then selects each type's set from it exactly as before.</para>
+    /// </summary>
+    private static IReadOnlyList<string> GlobalCodeQueries =>
+    [
+        // mesh_nodes across every schema, plus every non-Postgres provider (the static catalog).
+        $"nodeType:{CodeNodeType.NodeType}",
+        // The `code` satellite table across every schema — where a Source/ or Test/ segment puts a
+        // Code node, and therefore where nearly all of them are.
+        $"namespace:*/{CodeNodeType.SourceSubNamespace} scope:subtree nodeType:{CodeNodeType.NodeType}",
+        $"namespace:*/{CodeNodeType.TestSubNamespace} scope:subtree nodeType:{CodeNodeType.NodeType}",
+    ];
+
+    /// <summary>
     /// ONE batched source-discovery pass for every pending type: instead of each compile issuing
     /// its own source queries (2 × N queries, each against a per-type synced-query cache that can
-    /// stall for a 45s heartbeat), a single <c>nodeType:Code</c> fetch pulls every Code node once
+    /// stall for a 45s heartbeat), a fixed set of global fetches (<see cref="GlobalCodeQueries"/> —
+    /// three, independent of the number of types) pulls every Code node once
     /// and each type's source set is selected in memory with the framework's own query matcher
     /// (<see cref="CodeQueryResolver.Matches"/> — the same heuristic release records use to
     /// classify compiled sources). A query the matcher cannot evaluate (free text / exotic
@@ -80,7 +148,7 @@ internal static class NodeTypeBatchBake
     {
         // Expand every pending type's Source + Test queries — the SAME union the compiler's own
         // snapshot consumes (NodeSources / SnapshotSources), so the batch compiles the same set.
-        var perType = new List<(string TypePath, IReadOnlyList<string> Matchable, IReadOnlyList<string> Exotic)>();
+        var perType = new List<PendingType>();
         foreach (var typePath in pendingTypePaths)
         {
             definitions.TryGetValue(typePath, out var def);
@@ -91,7 +159,17 @@ internal static class NodeTypeBatchBake
                 .ToList();
             var matchable = expanded.Where(IsInMemoryMatchable).ToList();
             var exotic = expanded.Where(q => !IsInMemoryMatchable(q)).ToList();
-            perType.Add((typePath, matchable, exotic));
+            perType.Add(new PendingType(
+                typePath, matchable, exotic,
+                // The invariant's subject: only a type that DECLARES source queries is required to
+                // resolve a non-empty set. A type that relies on the DEFAULT queries may legitimately
+                // own no Code at all (a Configuration-only type is still compilable).
+                DeclaresSources: def?.Sources is { Count: > 0 },
+                // The one independent witness for "genuinely zero matches": the type's OWN live
+                // sources snapshot, maintained by its per-NodeType sources watcher and persisted on
+                // the record. EXPLICITLY empty (Count 0, not null) is the #1204 deleted-content
+                // shape; the same discriminator DynamicTypePreWarmer.ClassifyCompileFailure uses.
+                SourcesKnownDeleted: def?.CurrentSourceVersions is { Count: 0 }));
         }
 
         var needsGlobalFetch = perType.Any(t => t.Matchable.Count > 0);
@@ -114,7 +192,13 @@ internal static class NodeTypeBatchBake
                 _ =>
                 {
                     var globalFetch = needsGlobalFetch
-                        ? RunQuery(meshService, $"nodeType:{CodeNodeType.NodeType}")
+                        ? GlobalCodeQueries
+                            .Select(q => RunQuery(meshService, q, logger))
+                            .Concat()
+                            .Aggregate(
+                                ImmutableDictionary<string, MeshNode>.Empty
+                                    .WithComparers(StringComparer.OrdinalIgnoreCase),
+                                (all, page) => all.SetItems(page))
                         : Observable.Return(ImmutableDictionary<string, MeshNode>.Empty
                             .WithComparers(StringComparer.OrdinalIgnoreCase));
 
@@ -123,7 +207,7 @@ internal static class NodeTypeBatchBake
                     var exoticFetch = exoticQueries.Count == 0
                         ? Observable.Return(ImmutableDictionary<string, ImmutableDictionary<string, MeshNode>>.Empty)
                         : exoticQueries
-                            .Select(q => RunQuery(meshService, q).Select(nodes => (Query: q, Nodes: nodes)))
+                            .Select(q => RunQuery(meshService, q, logger).Select(nodes => (Query: q, Nodes: nodes)))
                             .Concat()
                             .ToList()
                             .Select(results => results.ToImmutableDictionary(
@@ -176,46 +260,118 @@ internal static class NodeTypeBatchBake
     }
 
     /// <summary>
+    /// One pending type's discovery inputs, plus the two facts the source-set invariant needs.
+    /// </summary>
+    /// <param name="TypePath">The NodeType's mesh path.</param>
+    /// <param name="Matchable">Expanded queries the in-memory matcher provably mirrors.</param>
+    /// <param name="Exotic">Expanded queries that must run against the mesh individually.</param>
+    /// <param name="DeclaresSources">The type declares its OWN source queries (not the defaults).</param>
+    /// <param name="SourcesKnownDeleted">
+    /// The type's own persisted source snapshot is EXPLICITLY empty — independent corroboration
+    /// that "no matches" is the mesh's real answer rather than a broken discovery pass.
+    /// </param>
+    private sealed record PendingType(
+        string TypePath,
+        IReadOnlyList<string> Matchable,
+        IReadOnlyList<string> Exotic,
+        bool DeclaresSources,
+        bool SourcesKnownDeleted);
+
+    /// <summary>
+    /// Raised when the batched discovery pass cannot be TRUSTED to have established the source
+    /// sets. It fails the WHOLE batch on purpose: <see cref="DynamicTypePreWarmer"/> catches it and
+    /// falls back to the activation-driven sweep for the entire run.
+    ///
+    /// <para>🚨 The alternative — letting a starved pass produce per-type verdicts — is issue #1216.
+    /// An empty source set classifies as <see cref="PreWarmStatus.NoSources"/>, which is
+    /// DELIBERATELY non-gating (it means "the content was deleted", #1204), so a discovery bug wore
+    /// the costume of content breakage: 169 of 237 types "content-broken", nothing refusing
+    /// readiness, and on an ungated pod a fleet of empty assemblies would have been baked and
+    /// stamped as good. A verdict about code requires a source set you actually established;
+    /// anything less is "I don't know", and "I don't know" must never look like an answer.</para>
+    /// </summary>
+    internal sealed class SourceDiscoveryFailedException(string message) : Exception(message);
+
+    /// <summary>
     /// One mesh query, chunk-accumulated to a settled path→node map: fold every
     /// <see cref="QueryResultChange{T}"/> (the compiler's own pure fold,
     /// <see cref="MeshNodeCompilationService.ApplyQueryChange"/>) and treat a
     /// <see cref="QueryQuietWindow"/> of silence as completion — a bare <c>Take(1)</c> on a
     /// chunked Initial would hand the compiler a PARTIAL source set, which compiles wrong.
+    ///
+    /// <para>🚨 The query carries an EXPLICIT <see cref="SourceDiscoveryLimit"/> — stated in the
+    /// query TEXT as well as on the request, because the Postgres cross-schema fan-out reads only
+    /// <see cref="ParsedQuery.Limit"/> and never <see cref="MeshQueryRequest.Limit"/> — and the
+    /// result is then CHECKED against it. Reaching the ceiling means the set may be truncated, and
+    /// a truncated source set compiles wrong in the most convincing possible way (see #1218: a
+    /// starved source set produces a genuine-looking CS0246 that the bake gate reads as an image
+    /// regression). So a full page is a discovery FAILURE, never a result.</para>
     /// </summary>
     private static IObservable<ImmutableDictionary<string, MeshNode>> RunQuery(
-        IMeshService meshService, string query)
-        => Observable
-            .Defer(() => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
+        IMeshService meshService, string query, ILogger? logger)
+    {
+        // Last `limit:` wins in QueryParser, so appending overrides an author-supplied one. That is
+        // intended: a `limit:` inside a NodeType's source query truncates the set the compiler is
+        // handed, which is never what the author meant, and the ceiling below is far larger anyway.
+        if (query.Contains("limit:", StringComparison.OrdinalIgnoreCase))
+            logger?.LogWarning(
+                "BatchBake: source query '{Query}' carries its own limit: — discovery overrides it "
+                + "with {Limit}, because a truncated source set compiles WRONG", query, SourceDiscoveryLimit);
+        var bounded = $"{query} limit:{SourceDiscoveryLimit}";
+        return Observable
+            .Defer(() => meshService.Query<MeshNode>(new MeshQueryRequest
+            {
+                Query = bounded,
+                Limit = SourceDiscoveryLimit
+            }))
             .Scan(
                 ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
                 MeshNodeCompilationService.ApplyQueryChange)
             .Throttle(QueryQuietWindow)
-            .Take(1);
+            .Take(1)
+            .SelectMany(nodes => nodes.Count < SourceDiscoveryLimit
+                ? Observable.Return(nodes)
+                : Observable.Throw<ImmutableDictionary<string, MeshNode>>(
+                    new SourceDiscoveryFailedException(
+                        $"source discovery query '{bounded}' returned {nodes.Count} node(s) — its own "
+                        + $"ceiling of {SourceDiscoveryLimit}, so the source set may be TRUNCATED and "
+                        + "no compile driven from it would be a verdict about the code")));
+    }
 
-    /// <summary>Select each type's source set from the batched fetches.</summary>
+    /// <summary>
+    /// Select each type's source set from the batched fetches, then ASSERT the pass actually
+    /// established them (see <see cref="SourceDiscoveryFailedException"/>).
+    /// </summary>
     private static ImmutableDictionary<string, IReadOnlyList<MeshNode>> Assemble(
-        IReadOnlyList<(string TypePath, IReadOnlyList<string> Matchable, IReadOnlyList<string> Exotic)> perType,
+        IReadOnlyList<PendingType> perType,
         ImmutableDictionary<string, MeshNode> allCode,
         ImmutableDictionary<string, ImmutableDictionary<string, MeshNode>> exoticResults,
         ILogger? logger)
     {
         var builder = ImmutableDictionary.CreateBuilder<string, IReadOnlyList<MeshNode>>(
             StringComparer.OrdinalIgnoreCase);
-        foreach (var (typePath, matchable, exotic) in perType)
+        // Types whose DECLARED source queries resolved to NOTHING and whose own persisted snapshot
+        // does not corroborate that. Discovery cannot tell such a type apart from a broken pass, so
+        // it refuses to answer for the whole batch rather than guess per type.
+        var unestablished = new List<string>();
+        foreach (var pending in perType)
         {
             var matched = new Dictionary<string, MeshNode>(StringComparer.OrdinalIgnoreCase);
-            if (matchable.Count > 0)
+            if (pending.Matchable.Count > 0)
                 foreach (var (path, node) in allCode)
-                    if (CodeQueryResolver.Matches(path, matchable))
+                    if (CodeQueryResolver.Matches(path, pending.Matchable))
                         matched[path] = node;
-            foreach (var q in exotic)
+            foreach (var q in pending.Exotic)
                 if (exoticResults.TryGetValue(q, out var nodes))
                     foreach (var (path, node) in nodes)
                         matched[path] = node;
 
+            if (matched.Count == 0 && pending.DeclaresSources && !pending.SourcesKnownDeleted)
+                unestablished.Add(pending.TypePath);
+
             // Deterministic order: the compiler concatenates the files into one syntax tree, so
             // any order compiles identically — but a stable order keeps artifacts reproducible.
-            builder[typePath] = matched.Values
+            builder[pending.TypePath] = matched.Values
                 .OrderBy(n => n.Path, StringComparer.Ordinal)
                 .ToList();
         }
@@ -224,6 +380,23 @@ internal static class NodeTypeBatchBake
             "BatchBake: source discovery resolved {CodeNodes} Code node(s) into source sets for "
             + "{Types} pending type(s) in one pass",
             allCode.Count, builder.Count);
+
+        if (unestablished.Count > 0)
+        {
+            // 🚨 LOUD, and naming every type — this is the line that would have made #1216 obvious
+            // on the first production run instead of reading as "169 types are content-broken".
+            logger?.LogWarning(
+                "BatchBake: source discovery resolved an EMPTY source set for {Count} type(s) that "
+                + "DECLARE source queries, and none of them records an explicitly-empty source "
+                + "snapshot to corroborate it: {Types}. That is a DISCOVERY failure, not a content "
+                + "verdict — abandoning the batch for the activation-driven sweep rather than "
+                + "compiling anything against nothing.",
+                unestablished.Count, string.Join(", ", unestablished));
+            throw new SourceDiscoveryFailedException(
+                $"{unestablished.Count} pending type(s) declare source queries that resolved to an "
+                + $"EMPTY source set with no corroborating empty snapshot: {string.Join(", ", unestablished)}");
+        }
+
         return builder.ToImmutable();
     }
 
@@ -315,11 +488,19 @@ internal static class NodeTypeBatchBake
                 // Same classification the activation path applies (ClassifyCompileFailure): a
                 // type that DECLARES source queries whose resolution is EXPLICITLY empty is
                 // broken by CONTENT (its sources were deleted from the mesh) — NoSources, which
-                // must never gate a rollout. The batch's own resolved snapshot is the authority
-                // here — it IS the set the compile just consumed.
-                var declaredSources = typeNode
-                    .ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions)?.Sources;
-                var status = declaredSources is { Count: > 0 } && sources.Count == 0
+                // must never gate a rollout.
+                //
+                // 🚨 BOTH witnesses are required (#1216). The batch's own resolved snapshot alone is
+                // NOT sufficient authority: when discovery is starved or truncated it also reports
+                // "no sources", and NoSources does not gate — so a discovery bug would quietly
+                // reclassify itself as deleted content on an ungated pod and bake empty assemblies.
+                // The type's persisted CurrentSourceVersions is the independent corroboration, and
+                // ResolveSources already refuses to produce a set at all when it is missing; this
+                // check keeps the classification honest even if a future caller bypasses that.
+                var def = typeNode.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions);
+                var status = def?.Sources is { Count: > 0 }
+                        && sources.Count == 0
+                        && def.CurrentSourceVersions is { Count: 0 }
                     ? PreWarmStatus.NoSources
                     : PreWarmStatus.CompileError;
                 return new PreWarmOutcome(

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBatchBakeDiscoveryInvariantTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBatchBakeDiscoveryInvariantTest.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The batch bake's source-discovery INVARIANT (issue #1216): a pass that cannot establish a type's
+/// source set must fail the WHOLE batch, never hand back a per-type verdict.
+///
+/// <para><b>Why this is the load-bearing half of the fix.</b> An empty source set classifies as
+/// <see cref="PreWarmStatus.NoSources"/>, which is deliberately NON-gating — it means "the content
+/// was deleted" (#1204). So a broken discovery pass does not look broken: it looks like content
+/// breakage. On memex-cloud 2026-08-11 a truncated global fetch reported 169 of 237 types as
+/// content-broken, and on a pod whose bake did NOT gate readiness the same pass would have baked a
+/// fleet of empty assemblies and stamped every one of them as good, with nothing refusing to
+/// serve. Raising the query limit alone fixes the instance; asserting the invariant is what stops
+/// the CLASS, because any future way of starving discovery lands here instead of in a verdict.</para>
+///
+/// <para>The one exception is the genuinely-deleted case, and it needs INDEPENDENT corroboration:
+/// the type's own persisted <see cref="NodeTypeDefinition.CurrentSourceVersions"/> snapshot being
+/// EXPLICITLY empty. That is the same discriminator
+/// <see cref="DynamicTypePreWarmer.ClassifyCompileFailure"/> uses; a NULL snapshot is "the watcher
+/// never seeded", which is not evidence of anything and must not be read as one.</para>
+/// </summary>
+public class NodeTypeBatchBakeDiscoveryInvariantTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "BatchBakeInvariant";
+
+    /// <summary>The ordinary declared-sources shape: rebased to <c>{typePath}/Source</c>.</summary>
+    private static readonly IReadOnlyList<string> DeclaredSources = ["namespace:Source scope:subtree"];
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService? Access => Mesh.ServiceProvider.GetService<AccessService>();
+    private ILogger? Logger => Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("BatchBakeInvariant");
+
+    private Task<ImmutableDictionary<string, IReadOnlyList<MeshNode>>> Resolve(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions)
+        => NodeTypeBatchBake
+            .ResolveSources(MeshService, Access, definitions, definitions.Keys.ToList(), Logger)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .ToTask();
+
+    /// <summary>
+    /// 🚨 The invariant. A type DECLARES source queries, discovery resolves NOTHING for it, and the
+    /// type's own snapshot says nothing either — so discovery does not know whether the sources are
+    /// gone or whether it simply failed to see them. It must refuse to answer for the whole batch.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ResolveSources_FailsTheWholeBatch_WhenDeclaredSourcesResolveEmptyWithNoCorroboration()
+    {
+        var typePath = $"{Partition}/Ghost";
+        var definitions = new Dictionary<string, NodeTypeDefinition?>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Declares sources; nothing was ever written under {typePath}/Source. CurrentSourceVersions
+            // is null — the type's own watcher never recorded a snapshot, so there is no witness that
+            // "no matches" is the mesh's real answer.
+            [typePath] = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                Sources = DeclaredSources
+            }
+        };
+
+        var act = () => Resolve(definitions);
+        await act.Should()
+            .ThrowAsync<NodeTypeBatchBake.SourceDiscoveryFailedException>(
+                "a source set that was never established is not a content verdict — the batch must "
+                + "abandon and let the activation-driven sweep resolve each type itself")
+            .WithMessage($"*{typePath}*");
+    }
+
+    /// <summary>
+    /// The genuine #1204 case still works: declared sources, a healthy query, genuinely zero
+    /// matches — corroborated by an EXPLICITLY empty source snapshot on the type's own record.
+    /// Discovery answers normally with an empty set, so the compile that follows can report the
+    /// non-gating <see cref="PreWarmStatus.NoSources"/>.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ResolveSources_AcceptsAnEmptySet_WhenTheTypesOwnSnapshotCorroboratesDeletedSources()
+    {
+        var typePath = $"{Partition}/Deleted";
+        var definitions = new Dictionary<string, NodeTypeDefinition?>(StringComparer.OrdinalIgnoreCase)
+        {
+            [typePath] = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                Sources = DeclaredSources,
+                // The witness: the type's sources watcher DID run and recorded that there are none.
+                CurrentSourceVersions = ImmutableDictionary<string, long>.Empty
+            }
+        };
+
+        var resolved = await Resolve(definitions);
+
+        resolved[typePath].Should().BeEmpty(
+            "deleted content is a real answer when the type's own snapshot corroborates it — this "
+            + "is what keeps #1204's non-gating NoSources verdict working");
+    }
+
+    /// <summary>
+    /// The invariant must not over-fire: a type whose declared sources DO resolve passes straight
+    /// through, with the full set. Without this, "abandon the batch" could quietly become the
+    /// normal path and batch bake would silently never run.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ResolveSources_ResolvesDeclaredSources_AndDoesNotTripTheInvariant()
+    {
+        var typePath = $"{Partition}/Healthy";
+        for (var i = 0; i < 3; i++)
+            await NodeFactory.CreateNode(new MeshNode($"Src{i}", $"{typePath}/Source")
+            {
+                Name = $"Src{i}",
+                NodeType = CodeNodeType.NodeType,
+                Content = new CodeConfiguration
+                {
+                    Code = $"public static class InvariantSrc{i} {{ public const int N = {i}; }}"
+                }
+            }).Should().Within(30.Seconds()).Emit();
+
+        var definitions = new Dictionary<string, NodeTypeDefinition?>(StringComparer.OrdinalIgnoreCase)
+        {
+            [typePath] = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                Sources = DeclaredSources
+            }
+        };
+
+        var resolved = await Resolve(definitions);
+
+        resolved[typePath].Should().HaveCount(3,
+            "the declared source query matches three Code nodes, so discovery resolves all three");
+        // Discovery orders each set by path (Ordinal), so an exact ordered comparison is valid.
+        resolved[typePath].Select(n => n.Path).Should().Equal(
+            Enumerable.Range(0, 3).Select(i => $"{typePath}/Source/Src{i}"));
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The SCALE contract for the batch bake's source discovery (issue #1216) — and the reason this
+/// test lives on PostgreSQL rather than beside the other batch-bake tests.
+///
+/// <para><b>The defect was invisible to every in-memory test.</b> Discovery issues ONE global
+/// <c>nodeType:Code</c> fetch. That query carries no <c>namespace:</c> and no <c>path:</c>, so on
+/// Postgres it is the UNPINNED shape served by the cross-schema fan-out — and
+/// <c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c> answers a query with no stated
+/// limit by substituting a hard default of <b>50</b>. The in-memory
+/// <c>StorageAdapterMeshQueryProvider</c> and the per-schema <c>PostgreSqlMeshQuery</c> both treat
+/// "no limit" as UNBOUNDED, so the identical code path is correct on the adapter every unit test
+/// uses. On memex-cloud 2026-08-11 the pass reported <c>resolved 50 Code node(s) … for 237 pending
+/// type(s)</c> and 169 types compiled against NOTHING.</para>
+///
+/// <para><b>What this pins.</b> A mesh holding MORE Code nodes than that default, spread across two
+/// partitions, must resolve EVERY type's full source set — and resolve exactly what the ACTIVATION
+/// path resolves. The activation path is not approximated here: it issues each type's expanded
+/// source queries individually (<c>MeshNodeCompilationService.DirectSourceProbe</c>), and those
+/// queries ARE partition-pinned, which is precisely why it never hit the cap and the batch did. The
+/// two sets are compared node-for-node.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class BatchBakeSourceDiscoveryScaleTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    /// <summary>
+    /// Code nodes per type. Two types ⇒ 60 in total, comfortably above the cross-schema fan-out's
+    /// 50-row default — the whole point of the test. Anything at or below it reproduces nothing.
+    /// </summary>
+    private const int SourcesPerType = 30;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddGraph();
+    }
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private IObservable<Unit> ProvisionPartition(string ns) =>
+        Mesh.ServiceProvider.GetServices<IPartitionStorageProvider>()
+            .Select(p => p.EnsurePartitionProvisioned(ns))
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastOrDefaultAsync();
+
+    /// <summary>
+    /// The declared source query every type in this test uses. <c>namespace:Source</c> is relative,
+    /// so <see cref="CodeQueryResolver"/> rebases it to <c>{typePath}/Source</c> and ANDs
+    /// <c>nodeType:Code</c> — the ordinary shape, and one the in-memory matcher fully mirrors, so
+    /// discovery serves it from the GLOBAL fetch (the query under test) rather than individually.
+    /// </summary>
+    private static readonly IReadOnlyList<string> DeclaredSources = ["namespace:Source scope:subtree"];
+
+    /// <summary>
+    /// Provisions a partition and writes <see cref="SourcesPerType"/> Code nodes under
+    /// <c>{ns}/{typeId}/Source</c>. Returns the type's path.
+    /// </summary>
+    private async Task<string> SeedTypeWithSources(string ns, string typeId)
+    {
+        await ProvisionPartition(ns).Should().Within(60.Seconds()).Emit();
+
+        var typePath = $"{ns}/{typeId}";
+        for (var i = 0; i < SourcesPerType; i++)
+            await MeshService.CreateNode(new MeshNode($"Src{i:D2}", $"{typePath}/Source")
+            {
+                Name = $"Src{i:D2}",
+                NodeType = CodeNodeType.NodeType,
+                State = MeshNodeState.Active,
+                Content = new CodeConfiguration
+                {
+                    Code = $"public static class Src{i:D2}_{typeId} {{ public const int N = {i}; }}"
+                }
+            }).Should().Within(30.Seconds()).Emit();
+
+        Output.WriteLine($"seeded {typePath} with {SourcesPerType} Code node(s)");
+        return typePath;
+    }
+
+    /// <summary>
+    /// The same pure fold the compiler's own probe applies
+    /// (<c>MeshNodeCompilationService.ApplyQueryChange</c>, internal to MeshWeaver.Graph so it is
+    /// restated rather than referenced): every change ACCUMULATES, and only a <c>Removed</c> takes
+    /// anything out.
+    ///
+    /// <para>🚨 An <c>Initial</c> must NOT reset the accumulator. A query's Initial arrives in
+    /// CHUNKS — several <c>Initial</c> emissions, each carrying part of the snapshot — so a fold
+    /// that clears on Initial keeps only the LAST chunk. Written that way first, this helper
+    /// reported 2 nodes for a 60-node mesh and looked exactly like the truncation bug under test.
+    /// </para>
+    /// </summary>
+    private static ImmutableDictionary<string, MeshNode> ApplyChange(
+        ImmutableDictionary<string, MeshNode> accumulated, QueryResultChange<MeshNode> change)
+    {
+        if (change?.Items is not { Count: > 0 } items)
+            return accumulated;
+        foreach (var node in items)
+        {
+            if (string.IsNullOrEmpty(node?.Path)) continue;
+            accumulated = change.ChangeType == QueryChangeType.Removed
+                ? accumulated.Remove(node.Path)
+                : accumulated.SetItem(node.Path, node);
+        }
+        return accumulated;
+    }
+
+    /// <summary>
+    /// 🚨 The SECOND half of #1216, pinned separately because it is the one that produced the
+    /// EMPTY source sets (a row cap can only ever produce a PARTIAL one).
+    ///
+    /// <para>On the partitioned Postgres backend a node's table is chosen by PATH SEGMENT — a
+    /// <c>Source/</c> or <c>Test/</c> segment routes to the per-schema <c>code</c> satellite table.
+    /// Resolving a table from a <c>nodeType:</c> filter uses a different map, and <c>Code</c> is
+    /// deliberately absent from it, so the discovery pass's original single <c>nodeType:Code</c>
+    /// fetch fans out over <c>mesh_nodes</c> and finds NONE of them. This asserts the two facts
+    /// directly against the database, so a future change to satellite routing that silently
+    /// re-breaks the batch fails HERE, naming the mechanism, instead of somewhere downstream as
+    /// "types are content-broken".</para>
+    /// </summary>
+    private async Task AssertCodeNodesLiveInTheSatelliteTable(string ns)
+    {
+        await using var code = _fixture.DataSource.CreateCommand($"SELECT count(*) FROM \"{ns}\".code");
+        var inCode = (long)(await code.ExecuteScalarAsync())!;
+        await using var primary = _fixture.DataSource.CreateCommand($"SELECT count(*) FROM \"{ns}\".mesh_nodes");
+        var inPrimary = (long)(await primary.ExecuteScalarAsync())!;
+        Output.WriteLine($"storage {ns}: code={inCode} mesh_nodes={inPrimary}");
+
+        inCode.Should().Be(SourcesPerType,
+            "a Source/ path segment routes a Code node to the per-schema 'code' satellite table — "
+            + "this is the premise the global discovery fetch has to be built around");
+        inPrimary.Should().Be(0,
+            "no Code node lands in mesh_nodes here, so a discovery pass that only fans out over "
+            + "mesh_nodes (which is what an unpinned nodeType:Code query does) sees nothing at all");
+    }
+
+    private IObservable<IReadOnlyList<string>> ActivationPathSources(string typePath, int expected)
+    {
+        var queries = CodeQueryResolver
+            .ExpandAll(DeclaredSources, CodeQueryResolver.DefaultSources, typePath)
+            .Concat(CodeQueryResolver.ExpandAll(null, CodeQueryResolver.DefaultTests, typePath))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        // 🚨 System-scoped, exactly like the batched discovery under test
+        // (NodeTypeBatchBake.ResolveSources wraps the identical Observable.Using). Source discovery
+        // is framework infrastructure that reads across every partition; running the BASELINE as the
+        // ambient test user instead would compare a full set against an RLS-filtered one.
+        return Observable.Using(
+            () => AccessContextScope.AsSystem(Mesh.ServiceProvider.GetService<AccessService>()),
+            _ =>
+            {
+                var probe = Observable
+                    .CombineLatest(queries.Select(q => Observable
+                        .Defer(() => MeshService.Query<MeshNode>(MeshQueryRequest.FromQuery(q)))
+                        .Scan(
+                            ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+                            ApplyChange)
+                        .Throttle(TimeSpan.FromSeconds(1))
+                        .Take(1)))
+                    // Sorted Ordinal, matching the order the batched discovery emits each set in, so
+                    // the two can be compared exactly rather than as bags.
+                    .Select(results => (IReadOnlyList<string>)results
+                        .SelectMany(r => r.Keys)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(p => p, StringComparer.Ordinal)
+                        .ToList());
+
+                return Observable.Interval(TimeSpan.FromMilliseconds(500))
+                    .StartWith(0L)
+                    .SelectMany(_ => probe)
+                    .Do(set => Output.WriteLine(
+                        $"activation probe {typePath}: {set.Count}/{expected} via [{string.Join(" | ", queries)}]"))
+                    .Where(set => set.Count >= expected)
+                    .FirstAsync()
+                    .Timeout(TimeSpan.FromSeconds(60));
+            });
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION TEST FOR #1216. Sixty Code nodes across two partitions — more than the
+    /// cross-schema fan-out's 50-row default — and the batched discovery must resolve every one of
+    /// them into the right type's source set.
+    ///
+    /// <para>Before the fix this fails on the very first assertion: the global <c>nodeType:Code</c>
+    /// fetch comes back with 50 rows for a 60-node mesh, so at least one type's set is short and
+    /// its compile would have run against a partial set — producing a genuine-looking CS0246 the
+    /// bake gate reads as an image regression (#1218), or an empty set that reports as the
+    /// non-gating <c>NoSources</c> (#1204's class) while the type is perfectly healthy.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task Discovery_ResolvesEveryTypesFullSourceSet_WhenTheMeshHasMoreCodeNodesThanTheDefaultQueryLimit()
+    {
+        var nsA = $"bbs{Guid.NewGuid():N}"[..12].ToLowerInvariant();
+        var nsB = $"bbs{Guid.NewGuid():N}"[..12].ToLowerInvariant();
+        var typeA = await SeedTypeWithSources(nsA, "TypeA");
+        var typeB = await SeedTypeWithSources(nsB, "TypeB");
+
+        // The activation path's answer — the baseline the batch must match. Also the barrier that
+        // proves the seed is fully visible before discovery runs, so a short batch result below can
+        // only mean truncation.
+        var activationA = await ActivationPathSources(typeA, SourcesPerType)
+            .Should().Within(70.Seconds()).Emit();
+        var activationB = await ActivationPathSources(typeB, SourcesPerType)
+            .Should().Within(70.Seconds()).Emit();
+        Output.WriteLine($"activation path: {typeA}={activationA.Count} {typeB}={activationB.Count}");
+        await AssertCodeNodesLiveInTheSatelliteTable(nsA);
+        await AssertCodeNodesLiveInTheSatelliteTable(nsB);
+
+        var definitions = new Dictionary<string, NodeTypeDefinition?>(StringComparer.OrdinalIgnoreCase)
+        {
+            [typeA] = new NodeTypeDefinition { Configuration = "config => config", Sources = DeclaredSources },
+            [typeB] = new NodeTypeDefinition { Configuration = "config => config", Sources = DeclaredSources },
+        };
+
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("BatchBakeScale");
+        var resolved = await NodeTypeBatchBake
+            .ResolveSources(
+                MeshService,
+                Mesh.ServiceProvider.GetService<AccessService>(),
+                definitions,
+                [typeA, typeB],
+                logger)
+            .Should().Within(150.Seconds()).Emit();
+
+        foreach (var (path, nodes) in resolved)
+            Output.WriteLine($"batch discovery: {path}={nodes.Count}");
+
+        // Every node, for every type — the headline claim. `>= SourcesPerType` would pass on a
+        // truncated pass that happened to favour one partition, so the count is asserted exactly.
+        resolved[typeA].Should().HaveCount(SourcesPerType,
+            "the batched discovery must resolve TypeA's full source set — against the code before "
+            + "#1216 this is 0, because the single global nodeType:Code fetch fans out over "
+            + "mesh_nodes and never reaches the 'code' satellite table");
+        resolved[typeB].Should().HaveCount(SourcesPerType,
+            "the batched discovery must resolve TypeB's full source set, in a SECOND partition — "
+            + "the cross-schema fan-out is where both #1216 mechanisms bite");
+
+        // …and the same set the activation path resolves, node for node. This is the property the
+        // batch driver exists to preserve: it is a faster route to the SAME compile, never a
+        // different one.
+        resolved[typeA].Select(n => n.Path).Should().Equal(activationA,
+            "the batch must compile exactly what the activation path would have compiled");
+        resolved[typeB].Select(n => n.Path).Should().Equal(activationB,
+            "the batch must compile exactly what the activation path would have compiled");
+    }
+}


### PR DESCRIPTION
Fixes the batch bake's source discovery so it reads the whole mesh — and, more importantly, makes it
**refuse to answer** when it cannot. Closes the defect in #1216.

## Production evidence (memex-cloud, 2026-08-11, image ci.2947)

```
BatchBake: source discovery resolved 50 Code node(s) into source sets for 237 pending type(s) in one pass
BatchBake: AgenticOffice/Buchungsjournal → NoSources
BatchBake: AgenticPrimer/DiceGame       → NoSources
BatchBake: BusinessRules/Scope          → CompileError
...
DynamicTypePreWarmer: warm-up complete in 00:00:19.36 — compiled=4 compileErrors=59 timedOut=0 skipped=5 contentBroken=169
```

## What was actually wrong — TWO mechanisms, not one

The issue identified the row cap. Building the scale test found a second, larger one: **a cap can only
ever produce a PARTIAL source set, never an empty one**, so it does not explain 169 empties.

**1. The global fetch was capped at 50.** `ResolveSources` issued
`MeshQueryRequest.FromQuery("nodeType:Code")`, leaving both `MeshQueryRequest.Limit` and
`ParsedQuery.Limit` null. "No limit" is not read the same way by every backend — see the table below.

**2. The global fetch could not see Postgres Code nodes AT ALL.** On the partitioned backend a node's
table is chosen by **path segment**: a `Source/` or `Test/` segment routes to the per-schema `code`
satellite table. Resolving a table from a `nodeType:` filter uses a *different* map, and `Code` is
deliberately absent from it — `SatelliteTableMapping.Defaults` says so outright: *"`Source`/`Test` are
primary code content sharing the `code` table (no leading underscore — matched as a path segment, and
**not nodeType-resolvable**)"*. So an unpinned `nodeType:Code` query fans out over every schema's
`mesh_nodes` and returns none of the Code nodes that live where Code nodes actually live.

Measured on a two-partition PG mesh holding 60 Code nodes (all in `{schema}.code`, `mesh_nodes` empty):

| query | rows |
|---|---|
| `nodeType:Code` | **2** (both from the static catalog; zero from Postgres) |
| `namespace:*/Source scope:subtree nodeType:Code` | **60** |
| `namespace:*/Test scope:subtree nodeType:Code` | 0 (nothing seeded under `Test/`) |

That is the shape of the production numbers: the ~59 `CompileError` types were the static/doc ones
that the capped `nodeType:Code` query partially covered, and the 169 `NoSources` were the PG-stored
ones it could not see at all.

## Limit semantics, verified per backend (not assumed)

| provider | absent limit | `request.Limit` honoured? |
|---|---|---|
| `StorageAdapterMeshQueryProvider.LoadCap` (`:381`) | **unbounded** | yes (`request.Limit ?? parsed.Limit`) |
| `MeshQuery.ClipMergedInitial` (`:817`) | **unbounded** | yes |
| `PostgreSqlMeshQuery` (per-schema, pinned) (`:276`, `:455`) | **unbounded** | yes — copies it into `parsedQuery` |
| `CosmosMeshQuery` (`:121`) | **unbounded** | yes |
| `PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync` (`:364`) | **50** | **no — dropped** |
| `SnowflakeCrossSchemaQueryProvider` (`:408`) | **50** | **no — dropped** |

Paging is not available as an alternative: `public.search_across_schemas` takes a LIMIT but **no
OFFSET**, and its `ORDER BY n.last_modified DESC` is not a total order, so a Skip/Limit loop would
silently drop and duplicate rows across pages — worse than one big page.

## The fix

1. **Discovery states an explicit ceiling and then ASSERTS it was not reached.** Every discovery query
   carries `limit:25000` in the query **text** (the cross-schema fan-out reads only `ParsedQuery.Limit`)
   *and* on the request. A result that reaches the ceiling is a discovery **failure**, not a result.
2. **The global fetch is the union of the three shapes that actually cover both tables** —
   `nodeType:Code` (mesh_nodes + the static catalog) plus the two wildcard-namespace shapes that route
   to `code`. Still O(1) in the number of pending types: three queries whether the mesh has 3 types or 300.
3. **`request.Limit` is no longer dropped by the cross-schema fan-out** (`PostgreSqlPartitionedMeshQuery`,
   and the identical twin in `SnowflakePartitionedMeshQuery`) — the same propagation the per-schema
   delegate already does. The `?? 50` default for a request that states *no* limit is untouched; an
   unanchored UNION over every partition schema needs some bound, and changing that default is a
   separate decision.
4. **The invariant — the half that stops the CLASS, not the instance.** If a type with a NON-EMPTY
   declared `Sources` list resolves to an EMPTY source set, and the type's own persisted
   `CurrentSourceVersions` snapshot does not corroborate it as explicitly empty, that is a **discovery
   failure**: the whole batch is abandoned, loudly, naming every offending type, and the run falls back
   to the activation-driven sweep. It never emits a per-type verdict.

   This matters because `NoSources` is deliberately **non-gating** (it means "the content was deleted",
   #1204) — so a broken discovery pass did not look broken, it looked like content breakage. On an
   **ungated** pod the same pass would have baked a fleet of empty assemblies and stamped every one of
   them good, with nothing refusing readiness. The genuinely-deleted case (#1204) still works: it has
   the corroborating empty snapshot.

## What is now guaranteed, and what is not

**Guaranteed (proven by test):**
- Discovery resolves every type's full source set on a real partitioned Postgres mesh holding more Code
  nodes than the default cap, across two partitions, and resolves **exactly** what the activation path
  resolves (compared node-for-node).
- A truncated or unestablished source set can no longer become a per-type verdict — it fails the batch.
- The genuinely-deleted-content case still reports the non-gating `NoSources`.

**Not verified:**
- **Nothing has run at production scale.** The scale test uses 60 Code nodes across 2 partitions; prod
  has thousands across ~136 schemas. The 25 000 ceiling is a judgement, not a measurement, and the
  memory cost of holding every Code node's content in one map is unchanged from the original design.
- **Snowflake is compile-verified only** — the fan-out fix there is a line-for-line twin of the
  Postgres one, but no Snowflake instance ran it.
- The `nodeType:Code`-is-not-nodeType-resolvable asymmetry is left as-is: it is documented, deliberate,
  and any query outside the batch bake that filters `nodeType:Code` unpinned still cannot see the `code`
  table. Widening it is a routing change with a much larger blast radius and belongs in its own PR.

## `PreWarm:BatchBake` stays OFF by default

`DynamicTypePreWarmerHostedService.KickWarmup` still defaults `batchBake = false` (PR #1217).
**Turning it back on is a separate decision for @rbuergi after this is verified at scale in prod** —
this PR makes the path correct and self-refusing, it does not re-enable it.

## Tests

- `BatchBakeSourceDiscoveryScaleTests` (new, Postgres/Testcontainers) — 60 Code nodes across two
  partitions. **Verified RED before the fix** (`batch discovery: TypeA=0, TypeB=0`, "Expected collection
  to have 30 item(s) … but found 0") and green after. Also asserts, directly against the database, that
  Code nodes live in `{schema}.code` and not `mesh_nodes` — so a future satellite-routing change that
  re-breaks the batch fails *here*, naming the mechanism.
- `NodeTypeBatchBakeDiscoveryInvariantTest` (new, Monolith) — the invariant fails the batch with no
  corroboration, accepts an empty set when the snapshot corroborates it, and does not over-fire on a
  healthy type.

Local: `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Graph.Test` (956/956),
`MeshWeaver.Hosting.PostgreSql.Test`, `MeshWeaver.Documentation.Test` (20/20) green; every touched
project builds clean under `-c Release -warnaserror`.

Related: #1218 (the activation path's twin of "a starved source set becomes a CompileError"), #1207
(design), #1211 (implementation), #1204 (content-vs-image verdicts), #1217 (opt-in default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
