### PR TITLE
Node pages publish their own icon, so previews stop showing the portal logo

### DIFF
--- a/content/ai/Skill/og-card.md
+++ b/content/ai/Skill/og-card.md
@@ -58,6 +58,17 @@ A portal mid-restart, a login wall, or any SPA catch-all answers **200 with its 
 
 Every Blazor portal serves `<base href="/">` plus a relative `href="favicon.ico"`. Resolved against the *page* URL that yields `/Some/Section/favicon.ico`, which a catch-all-routed SPA answers **200 text/html** rather than 404 — a silently broken image that looks like a working link.
 
+### A `data:` URI icon works in browsers and NOT in email
+
+A node whose icon is an **inline `<svg>`** publishes it as a `data:image/svg+xml,…` URI. Every browser renders that — tab, card, unfurl. **Email does not.** Outlook renders through Word, which supports no inline SVG at all, and classic Outlook for Windows blocks `data:` URIs outright; the icon silently becomes a broken image or nothing.
+
+So **any email or export path needs a RASTER icon at an `http(s)` URL** — never the head's `data:` URI. Two things already on that side of the line and safe to use:
+
+- **`/api/og/{nodePath}`** — the generated PNG share card, an ordinary cacheable http URL. It is a wide card, not a square icon, but it is a real raster.
+- A node whose icon is stored as a **file** (`content:mark.png`) already resolves to an http content-route URL rather than a data URI, so it is email-safe as authored.
+
+For a square raster icon of an inline-SVG node there is currently **no route** — the icon exists only as markup in the head. Rasterising it is a separate endpoint, not something to fake by inlining.
+
 ### Ties between icons are broken by the LAST declaration
 
 Site chrome emits its favicon early; a page that declares its own icon emits it later. Preferring the first would mean a page could never override the site-wide mark, and every card in a grid would draw the same portal logo.

--- a/content/ai/Skill/og-card.md
+++ b/content/ai/Skill/og-card.md
@@ -1,0 +1,88 @@
+---
+nodeType: Skill
+name: /og-card
+description: Embed link-preview cards (OgCard) in a document — one card or a responsive grid, for external pages or mesh nodes. Covers the embed forms that actually work, how a card gets its picture and title, and the traps that make a broken card look fine (and a fine card look broken).
+icon: Link
+category: Skills
+order: 40
+---
+
+`OgCard` renders a **link-preview card** — picture, title, description, the whole card a link — for any target: an external page (its Open Graph head is fetched server-side) or a mesh node (read live off its node stream). Several targets compose into one responsive grid, so a document embeds a whole catalog with a single reference.
+
+# 1. The embed forms
+
+```
+@@("area:OgCard?urls=https://a.org/X,https://a.org/Y,https://a.org/Z")   ← a responsive GRID
+@@("area:OgCard?url=https://a.org/Page")                                 ← ONE external card
+@@("area:OgCard/Some/Node/Path")                                         ← ONE mesh-node card
+```
+
+- **`area:OgCard`** (colon) and **`area/OgCard`** (slash) both resolve. The colon form is what live documents use.
+- **`?urls=` is comma-separated** and is the multi-target form. Mesh paths and external URLs can be mixed in one list.
+- **`?url=` (singular) never splits** — a comma in it is data. Use it for a URL that genuinely contains a comma.
+- A literal comma inside a URL in a `?urls=` list must be double-encoded (`%252C`), because the separator is honoured both raw (`,`) and percent-encoded (`%2C`).
+- Entries may be percent-encoded; plain URLs work as written.
+
+A single target renders width-bounded like a chat unfurl; two or more render as a grid of `minmax(280px, 1fr)` columns.
+
+# 2. Where a card's content comes from
+
+| Card field | External target | Mesh-node target |
+|---|---|---|
+| Title | `og:title`, else `<title>`, else the URL's **last path segment** | the node's `Name` |
+| Description | `og:description`, else `<meta name="description">` | the node's `Description` |
+| Picture | the page's declared **icon** → `og:image` → `/favicon.ico` | the node's own icon |
+| Link | the URL (new tab) | `/{nodePath}` |
+
+**The picture is the ICON, not the `og:image` poster.** The card's image box is a fixed 48 px square with `object-fit: cover`; a 1200×630 banner cropped into that is a meaningless sliver, while an icon is drawn for exactly that size.
+
+**A MeshWeaver page's icon is the NODE's icon.** The per-page SEO head emits `<link rel="icon">` from `MeshNode.Icon`, so a card for a node page shows that node's mark rather than the portal logo. A node that carries no icon of its own keeps the portal favicon — nothing is synthesised.
+
+# 3. 🚨 The traps
+
+### An MCP `get` of the area is NEVER a pass/fail signal
+
+Every target renders **immediately** as a placeholder card and fills in when its fetch lands — one slow target must never block the grid. A one-shot read of the area returns **frame 0**, which is *always* the placeholder. A card that is perfectly healthy and a card that is permanently broken are byte-identical in that frame.
+
+**Only a browser render tells you whether a card works.** Do not report an area snapshot as evidence either way.
+
+### The placeholder's title is the URL's last path segment — learn to recognise it
+
+A card showing **`Ifrs17`** with no description, where the page declares `og:title` **`IFRS 17`**, is not a "wrong title" — it is the card **still on its placeholder**, i.e. the fetch has not landed. The two failure modes look the same on screen, so read the title against the target's real `og:title` before concluding anything.
+
+### A successful-but-useless 200 must not be cached
+
+A portal mid-restart, a login wall, or any SPA catch-all answers **200 with its shell page** and no `og:*` tags. Nothing throws, so an exception-eviction path never fires. The preview cache is therefore gated on the page having declared **`og:title`** — not on having *a* title (the shell has one, which is exactly how it used to slip through) and not on having an icon (practically every page yields one). An unresolved preview is evicted and re-fetched on the next view.
+
+### Relative icons resolve against `<base href>`, not the page URL
+
+Every Blazor portal serves `<base href="/">` plus a relative `href="favicon.ico"`. Resolved against the *page* URL that yields `/Some/Section/favicon.ico`, which a catch-all-routed SPA answers **200 text/html** rather than 404 — a silently broken image that looks like a working link.
+
+### Ties between icons are broken by the LAST declaration
+
+Site chrome emits its favicon early; a page that declares its own icon emits it later. Preferring the first would mean a page could never override the site-wide mark, and every card in a grid would draw the same portal logo.
+
+### Only anonymous-readable pages have a head worth fetching
+
+The rich SEO head (`og:*`, the node icon) is emitted for **anonymous** requests to anonymous-readable nodes. A private page serves the generic shell, so its card falls back to the URL's last path segment. That is correct behaviour, not a bug — publish the page if you want it to preview.
+
+# 4. Verifying a card
+
+1. **Check the target's head first** — this is the input, and it is one command:
+   ```bash
+   curl -sL https://portal.example.org/SomePage | grep -o '<meta property="og:[^>]*>'
+   curl -sL https://portal.example.org/SomePage | grep -o '<link rel="icon"[^>]*>'
+   ```
+   No `og:title` ⇒ the card can only ever show the URL's last segment. Fix the page, not the card.
+2. **Open the document in a browser.** That is the only real test (see the traps).
+3. **If a card is stuck on its placeholder**, look for the one log line that distinguishes the two silent failures — the message text is `Open Graph fetch of {Url}` (a *space* in "Open Graph"; grepping `opengraph` matches only the logger category, which some log formats omit):
+   ```bash
+   kubectl -n <ns> logs <portal-pod> -c memex-portal --since=30m | grep -E 'no og: metadata|Open Graph'
+   ```
+   A warning ⇒ the fetch faulted. An info "returned no og: metadata" ⇒ it succeeded but the page carried nothing. **Neither line ⇒ the fetch was fine**, and the problem is downstream of the fetch.
+
+# 5. Guard rails
+
+- The fetcher refuses anything that is not `http(s)`, and refuses literal **and DNS-resolved** loopback / private / link-local addresses — card targets are author-supplied, so this is the SSRF boundary. A public URL that 302s to a private one is not followed.
+- Each URL is fetched **once per process** and replayed to every card; a failed or metadata-less fetch evicts its entry so the next view retries once. No timer, no retry loop.
+- Only the page **head** is parsed; the fetch is bounded in both bytes and time.

--- a/memex/Memex.Portal.Shared/Seo/SeoHead.razor
+++ b/memex/Memex.Portal.Shared/Seo/SeoHead.razor
@@ -21,6 +21,14 @@
 {
     <meta name="description" content="@_description" />
     <link rel="canonical" href="@_canonical" />
+    @if (_icon is not null)
+    {
+        @* The NODE's own icon, so a node page identifies itself rather than the portal it lives
+           in — for the browser tab, for our own OgCard link previews, and for any Slack / Teams /
+           LinkedIn unfurl. Declared AFTER App.razor's site-wide favicon so it wins: an icon later
+           in the head outranks an earlier one of equal rank. *@
+        <link rel="icon" href="@_icon.Href" type="@_icon.Type" />
+    }
     <meta property="og:site_name" content="@SiteName" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="@_data.Node.Name" />
@@ -49,6 +57,7 @@
     private string? _canonical;
     private string? _image;
     private string? _jsonLd;
+    private PageIcon? _icon;
 
     private string SiteName =>
         Configuration["Portal:SiteName"] ?? Configuration["Portal:InstanceName"] ?? "Memex";
@@ -74,6 +83,7 @@
         var baseUrl = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
         _canonical = $"{baseUrl}/{node.Path}";
         _image = _data.Image is { } img && img.StartsWith('/') ? baseUrl + img : _data.Image;
+        _icon = SeoResolver.ResolveIcon(node);
         _jsonLd = BuildJsonLd(node, _description, _image, _canonical);
     }
 

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -7,6 +8,17 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Memex.Portal.Shared.Seo;
+
+/// <summary>
+/// A page's OWN icon, ready to hang off a <c>&lt;link rel="icon"&gt;</c> in its head.
+/// </summary>
+/// <param name="Href">The icon as something an <c>href</c> can carry: a URL the portal already
+/// serves (a content-collection file, a shipped glyph), or an inline <c>data:</c> URI for an icon
+/// whose value is MARKUP rather than a location (an inline <c>&lt;svg&gt;</c>, an emoji).</param>
+/// <param name="Type">The media type to declare, or null when the value alone does not pin one
+/// down — declaring the WRONG type is worse than declaring none, and a consumer that ranks icons
+/// by type would then rank this one on a lie.</param>
+public sealed record PageIcon(string Href, string? Type);
 
 /// <summary>
 /// What the crawler-facing head needs to know about the requested page: the resolved node and
@@ -115,6 +127,67 @@ public static class SeoResolver
     /// </summary>
     public static string ShareImage(MeshNode node) =>
         ExtractImage(node) ?? $"/api/og/{node.Path}";
+
+    /// <summary>The one media type that tells every consumer "this icon scales losslessly".</summary>
+    private const string SvgMediaType = "image/svg+xml";
+
+    /// <summary>
+    /// 🚨 THE PAGE'S OWN ICON — the node's icon, so a node page identifies itself rather than the
+    /// portal it happens to live in.
+    ///
+    /// <para>Every page of a Blazor portal serves ONE site-wide <c>&lt;link rel="icon"&gt;</c> (see
+    /// <c>App.razor</c>), so every link preview of every node — our own <c>OgCard</c>, and equally a
+    /// Slack / Teams / LinkedIn unfurl — drew the same MeshWeaver logo. Yet each node already
+    /// carries a distinctive icon, which the portal renders everywhere INSIDE the app. This lifts
+    /// that same icon into the head, where the standards-based icon channel is, so every consumer
+    /// gets it for free without knowing anything about MeshWeaver.</para>
+    ///
+    /// <para>🚨 It is the icon ON THE NODE — <see cref="MeshNode.Icon"/> — and nothing else. No
+    /// synthesised badge, no letter tile, no NodeType stand-in: those would put a picture in the
+    /// head that the node never chose and that the app never renders for it. A node that carries no
+    /// icon of its own simply keeps the portal favicon, which is the honest answer for a page with
+    /// no mark of its own.</para>
+    ///
+    /// <para>The value is resolved exactly the way the in-app icon is
+    /// (<see cref="MeshNodeImageHelper.ResolveContentPath"/>) — a <c>content:</c> reference becomes
+    /// the access-controlled content URL, an inline <c>&lt;svg&gt;</c> stays that same svg, a URL
+    /// stays that URL — so the tab, the card and the app can never disagree about what a node looks
+    /// like.</para>
+    /// </summary>
+    /// <param name="node">The node whose page is being served.</param>
+    /// <returns>Its own icon, or null when it carries none an <c>href</c> can point at.</returns>
+    public static PageIcon? ResolveIcon(MeshNode node)
+    {
+        var icon = MeshNodeImageHelper.ResolveContentPath(node.Icon, node.Path);
+        if (string.IsNullOrWhiteSpace(icon))
+            return null;
+
+        // An inline <svg> is MARKUP, not a location, so it travels as a data URI — the same
+        // mechanism App.razor already uses for the per-instance favicon. The svg itself is
+        // untouched: it is the node's icon, byte for byte.
+        if (MeshNodeImageHelper.IsInlineSvg(icon))
+            return new PageIcon(SvgDataUri(icon), SvgMediaType);
+
+        // A URL or data URI the node carries — used as written.
+        if (MeshNodeImageHelper.IsImageUrl(icon))
+            return new PageIcon(icon, MediaTypeOf(icon));
+
+        // Anything else (an emoji, a bare word) is a character, not a picture, and no href can
+        // carry it. The portal favicon stays rather than inventing a graphic for it.
+        return null;
+    }
+
+    /// <summary>The media type an icon URL pins down by itself, or null when it does not — a
+    /// consumer ranking icons by type must never be told a wrong one.</summary>
+    private static string? MediaTypeOf(string icon) =>
+        icon.StartsWith("data:" + SvgMediaType, StringComparison.OrdinalIgnoreCase)
+        || (!icon.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+            && icon.EndsWith(".svg", StringComparison.OrdinalIgnoreCase))
+            ? SvgMediaType
+            : null;
+
+    private static string SvgDataUri(string svg) =>
+        "data:" + SvgMediaType + "," + Uri.EscapeDataString(svg);
 
     /// <summary>
     /// A string member of the node's content, by camelCase JSON name. Content arrives here in two

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-pages-show-their-own-icon.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-pages-show-their-own-icon.md
@@ -1,0 +1,39 @@
+---
+Name: Every page shows its own icon
+Category: Feature
+Description: A node page now publishes the node's own icon to the web, so link previews of it — the portal's own preview cards and Slack, Teams or LinkedIn unfurls alike — show that node's mark instead of the same portal logo on every card.
+Icon: ImageSparkle
+Order: -20260811
+---
+
+# Every page shows its own icon
+
+A grid of preview cards is supposed to help you tell pages apart. Ours did the
+opposite: eight modules, eight identical MeshWeaver logos. The same happened
+wherever a page was shared — a link dropped into Slack, Teams or LinkedIn unfurled
+with the portal's mark, never the page's.
+
+The cause was mundane and completely invisible from inside the app. Every page of
+the portal served one site-wide icon, declared once in the shared layout. Each
+node already had a distinctive icon, and the portal rendered it everywhere
+*internally* — in the tree, in menus, on cards — but that icon never reached the
+one place the outside world looks: the page's own head.
+
+Now it does. A node page publishes **its own icon** through the standard
+`<link rel="icon">` channel, alongside the title, description and share image it
+already published. Nothing had to learn anything about MeshWeaver to benefit:
+
+- the portal's own **preview cards** now show each target's mark;
+- **Slack / Teams / LinkedIn** unfurls show it too;
+- and the **browser tab** shows it when you open the page.
+
+It is the icon on the node, and only that. Nothing is invented: a node that
+carries no icon of its own keeps the portal favicon, which is the honest answer
+for a page with no mark to show. An icon drawn as an inline graphic travels
+unchanged; one stored as a file resolves through the same access-controlled route
+the app uses, so a private space's mark stays private.
+
+One related correction: when a page declares its own icon and the site declares
+one too, the page's now wins — matching how browsers resolve it. Without that, a
+page could never override the site-wide mark, which is exactly how every card
+ended up wearing the same logo.

--- a/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
+++ b/src/MeshWeaver.Graph/OpenGraph/OpenGraphHtmlParser.cs
@@ -168,7 +168,13 @@ public static partial class OpenGraphHtmlParser
     /// on ONE axis — effective pixel size — so the winner is simply the icon that renders sharpest
     /// in the card's 48 px box: a scalable SVG beats every raster, a declared <c>sizes</c> is
     /// taken at face value, and a sizeless <c>apple-touch-icon</c> (conventionally 180 px) beats a
-    /// sizeless <c>favicon.ico</c> (conventionally 16–32 px). Ties keep document order.</para>
+    /// sizeless <c>favicon.ico</c> (conventionally 16–32 px).</para>
+    ///
+    /// <para>🚨 <b>A tie is broken by the LAST declaration, as browsers break it.</b> Site chrome
+    /// emits its favicon early (in the shared layout); a PAGE that declares an icon of its own
+    /// emits it later, in the per-page head. Preferring the first would mean a page could never
+    /// override the site-wide mark with its own — every card in a grid of pages would then draw the
+    /// same portal logo, which is exactly the defect this rule exists to prevent.</para>
     ///
     /// <para><c>rel="mask-icon"</c> is deliberately NOT a candidate: it is a monochrome Safari
     /// pinned-tab silhouette, not the site's icon.</para>
@@ -190,7 +196,9 @@ public static partial class OpenGraphHtmlParser
                 continue;
 
             var score = IconScore(rel.Groups[2].Value, tag.Value);
-            if (score is null || score.Value <= bestScore)
+            // `<` not `<=`: an equally-ranked LATER declaration wins, so a page's own icon
+            // overrides the site-wide favicon its layout emitted earlier.
+            if (score is null || score.Value < bestScore)
                 continue;
 
             bestScore = score.Value;

--- a/test/Memex.Portal.Shared.Test/SeoResolverIconTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoResolverIconTest.cs
@@ -1,0 +1,89 @@
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins <see cref="SeoResolver.ResolveIcon"/> — the page-icon channel of the SEO head.
+///
+/// <para>🚨 THE DEFECT: every page of a Blazor portal serves ONE site-wide
+/// <c>&lt;link rel="icon"&gt;</c>, so every link preview of every node — the portal's own
+/// <c>OgCard</c> grid, and equally a Slack / Teams / LinkedIn unfurl — drew the same MeshWeaver
+/// logo, even though each node already carries a distinctive icon that the app renders everywhere
+/// internally.</para>
+///
+/// <para>The rule these tests pin is deliberately narrow: it is THE ICON ON THE NODE, and nothing
+/// else. No synthesised badge, no letter tile, no NodeType stand-in — a node that carries no icon
+/// of its own keeps the portal favicon, which is the honest answer for a page with no mark.</para>
+/// </summary>
+public class SeoResolverIconTest
+{
+    private static MeshNode Node(string? icon, string id = "Ifrs17", string? ns = null) =>
+        new(id, ns) { NodeType = "Store/Plugin", Icon = icon };
+
+    /// <summary>
+    /// The real shape the failing cards had: an inline <c>&lt;svg&gt;</c> on the node. It is markup,
+    /// not a location, so it travels as a data URI — and the svg inside it is the node's icon
+    /// UNCHANGED, byte for byte.
+    /// </summary>
+    [Fact]
+    public void InlineSvgIcon_BecomesADataUriCarryingThatExactSvg()
+    {
+        const string svg = "<svg viewBox='0 0 24 24'><rect width='24' height='24' fill='#4c1d95'/></svg>";
+
+        var icon = SeoResolver.ResolveIcon(Node(svg));
+
+        Assert.NotNull(icon);
+        Assert.Equal("image/svg+xml", icon.Type);
+        Assert.StartsWith("data:image/svg+xml,", icon.Href);
+        Assert.Equal(svg, Uri.UnescapeDataString(icon.Href["data:image/svg+xml,".Length..]));
+    }
+
+    /// <summary>A <c>content:</c> reference resolves the SAME way the in-app icon does — through
+    /// the access-controlled content route, never <c>/static</c>.</summary>
+    [Fact]
+    public void ContentReferenceIcon_ResolvesToTheAccessControlledContentUrl()
+    {
+        var icon = SeoResolver.ResolveIcon(Node("content:mark.svg", id: "Page", ns: "Space"));
+
+        Assert.NotNull(icon);
+        Assert.Contains("mark.svg", icon.Href);
+        Assert.DoesNotContain("/static/", icon.Href);
+        Assert.Equal("image/svg+xml", icon.Type);
+    }
+
+    /// <summary>A URL the node carries is used as written; the media type is declared only when the
+    /// value pins one down, because a consumer that ranks icons by type must not be told a lie.</summary>
+    [Fact]
+    public void UrlIcon_UsedAsWritten_TypeOnlyWhenTheValuePinsItDown()
+    {
+        var png = SeoResolver.ResolveIcon(Node("https://cdn.example.org/mark.png"));
+        Assert.NotNull(png);
+        Assert.Equal("https://cdn.example.org/mark.png", png.Href);
+        Assert.Null(png.Type);
+
+        var svg = SeoResolver.ResolveIcon(Node("https://cdn.example.org/mark.svg"));
+        Assert.Equal("image/svg+xml", svg!.Type);
+
+        var dataPng = SeoResolver.ResolveIcon(Node("data:image/png;base64,iVBORw0KGgo="));
+        Assert.Null(dataPng!.Type);
+    }
+
+    /// <summary>
+    /// 🚨 Nothing is invented. A node with no icon, an emoji, or a legacy Fluent icon NAME yields
+    /// no page icon at all — the portal favicon stays. Emitting a drawn badge or a NodeType glyph
+    /// here would put a picture in the head that the node never chose.
+    /// </summary>
+    [Fact]
+    public void NoIconOfItsOwn_YieldsNothing_SoThePortalFaviconStays()
+    {
+        Assert.Null(SeoResolver.ResolveIcon(Node(null)));
+        Assert.Null(SeoResolver.ResolveIcon(Node("")));
+        Assert.Null(SeoResolver.ResolveIcon(Node("   ")));
+        // An emoji is a character, not a picture — no href can carry it.
+        Assert.Null(SeoResolver.ResolveIcon(Node("📊")));
+        // A legacy Fluent icon name is a component reference, not a location.
+        Assert.Null(SeoResolver.ResolveIcon(Node("Document")));
+    }
+}

--- a/test/MeshWeaver.AI.Test/BuiltInSkillCatalog.cs
+++ b/test/MeshWeaver.AI.Test/BuiltInSkillCatalog.cs
@@ -1,0 +1,28 @@
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The ids of the skills the framework ships — the ONE expectation every built-in-catalog test
+/// asserts against.
+///
+/// <para>🚨 The shipped set is derived from FILES, not from any list in production code:
+/// <see cref="BuiltInSkillProvider"/> enumerates <c>content/ai/Skill/*.md</c> (embedded as
+/// <c>Data/Skill/*.md</c> by a single <c>EmbeddedResource</c> glob), so adding a skill file IS
+/// adding a skill. There is therefore nothing to update on the production side — only this
+/// expectation.</para>
+///
+/// <para>It lives here because the literal used to be duplicated across two test files, and adding
+/// one skill turned both red at once with no hint that a second copy existed. Adding a skill is now
+/// a ONE-line change here rather than a hunt for every assertion that happens to spell the set
+/// out.</para>
+/// </summary>
+internal static class BuiltInSkillCatalog
+{
+    /// <summary>Every shipped skill id, in sorted order — compare against
+    /// <c>.Select(n =&gt; n.Id).OrderBy(x =&gt; x)</c>.</summary>
+    public static readonly string[] ExpectedIds =
+    [
+        "access", "activity", "agent", "clear", "code", "feedback", "group", "harness",
+        "layout-area", "markdown", "maui", "model", "navigate", "og-card", "presentation",
+        "provider-keys", "pull-request", "slide", "space", "thread",
+    ];
+}

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal(BuiltInSkillCatalog.ExpectedIds);
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -35,7 +35,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal(BuiltInSkillCatalog.ExpectedIds);
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);

--- a/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
+++ b/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
@@ -124,6 +124,54 @@ public class OgCardLayoutAreaTest(ITestOutputHelper output) : HubTestBase(output
         ((MeshNodeCardControl)cardB!).Href.Should().Be(second);
     }
 
+    /// <summary>
+    /// 🚨 THE REPORTED DEFECT, in the exact prod shape: the live grid embeds EIGHT targets
+    /// (<c>@@("area:OgCard?urls=…,…")</c>, the parse-time id form without the leading <c>?</c>),
+    /// and the LAST card of each of the page's two grids rendered with the wrong title and no
+    /// description — i.e. it stayed on its placeholder, whose title is the URL's last path segment
+    /// (<c>Ifrs17</c>) rather than the page's <c>og:title</c> (<c>IFRS 17</c>).
+    ///
+    /// <para>Every card must end up carrying ITS OWN target's fetched data, so the server declares
+    /// a per-path title: a fixed one would pass even if a card never resolved or two swapped.</para>
+    /// </summary>
+    [HubFact]
+    public async Task EightTargets_EveryCardCarriesItsOwnFetchedData_TheLastOneIncluded()
+    {
+        server.TitleFromPath = true;
+        // The live grid's targets, in order — Ifrs17 last, which is the one that failed.
+        string[] names =
+        [
+            "Reinsurance", "Underwriting", "Claims", "Pricing",
+            "LossModelling", "Planning", "SST", "Ifrs17",
+        ];
+        var urls = names.Select(name => server.BaseUrl + name).ToArray();
+        var reference = new LayoutAreaReference(OgCardLayoutArea.AreaName)
+        {
+            Id = "urls=" + string.Join(",", urls),
+        };
+
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Should().Within(10.Seconds()).Match(x => x != null);
+        root.Should().BeOfType<StackControl>().Which.Areas.Should().HaveCount(names.Length);
+
+        for (var index = 0; index < names.Length; index++)
+        {
+            var expected = names[index];
+            var card = await stream.GetControlStream($"{reference.Area}/Card{index}")
+                .Should().Within(20.Seconds())
+                .Match(x => x is MeshNodeCardControl { Description: "Served description." });
+
+            var typed = (MeshNodeCardControl)card!;
+            typed.Title.Should().Be(expected,
+                "card {0} must carry the og:title its OWN target declared", index);
+            typed.Href.Should().Be(urls[index]);
+        }
+    }
+
     [Fact]
     public void ParseTargets_AcceptsBothIdShapesAndEncodedEntries()
     {

--- a/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
+++ b/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
@@ -171,6 +171,54 @@ public class OpenGraphHtmlParserTest
             OpenGraphHtmlParser.Parse(Url, html).Icon);
     }
 
+    /// <summary>
+    /// 🚨 THE DEFECT that made every card in a grid draw the same portal logo: a MeshWeaver page
+    /// declares TWO icons — the site-wide favicon its shared layout emits first, then (for a node
+    /// page) the NODE's own icon from the per-page SEO head. Preferring the first meant a page
+    /// could never override the site mark, so eight different modules rendered eight identical
+    /// MeshWeaver logos. A tie is broken by the LAST declaration, as browsers break it.
+    /// </summary>
+    [Fact]
+    public void Parse_PageIconDeclaredAfterSiteFavicon_Wins()
+    {
+        // Same effective rank (both sizeless rel="icon"): the later one — the page's own — wins.
+        const string sameRank = """
+            <head><base href="/">
+            <link rel="icon" type="image/png" href="favicon.ico">
+            <link rel="icon" href="/api/content/Space/Page/mark.png">
+            </head>
+            """;
+        Assert.Equal("https://portal.example.org/api/content/Space/Page/mark.png",
+            OpenGraphHtmlParser.Parse(Url, sameRank).Icon);
+
+        // The real shape: the node's icon travels as an inline-SVG data URI, which also outranks
+        // the raster favicon outright.
+        const string svgDataUri = "data:image/svg+xml,%3Csvg%3E%3C/svg%3E";
+        var nodePage = $"""
+            <head><base href="/">
+            <link rel="icon" type="image/png" href="favicon.ico">
+            <link rel="icon" href="{svgDataUri}" type="image/svg+xml">
+            </head>
+            """;
+        Assert.Equal(svgDataUri, OpenGraphHtmlParser.Parse(Url, nodePage).Icon);
+    }
+
+    /// <summary>A LOWER-ranked later icon still loses — the tie-break relaxes ties only, it does
+    /// not turn ranking into "last one wins".</summary>
+    [Fact]
+    public void Parse_LaterButSmallerIcon_DoesNotWin()
+    {
+        const string html = """
+            <head>
+            <link rel="icon" sizes="192x192" href="/large.png">
+            <link rel="icon" sizes="16x16" href="/small.png">
+            </head>
+            """;
+
+        Assert.Equal("https://portal.example.org/large.png",
+            OpenGraphHtmlParser.Parse(Url, html).Icon);
+    }
+
     [Fact]
     public void Parse_DataUriIcon_ReturnedVerbatim()
     {

--- a/test/MeshWeaver.Graph.Test/TestOgServer.cs
+++ b/test/MeshWeaver.Graph.Test/TestOgServer.cs
@@ -38,6 +38,13 @@ internal sealed class TestOgServer : IDisposable
     /// restarting.</summary>
     public volatile bool OmitOgTags;
 
+    /// <summary>
+    /// Declare each page's <c>og:title</c> as its own last path segment instead of the fixed
+    /// <see cref="Title"/>. Lets a MULTI-target grid assert that every card carries ITS target's
+    /// data — a fixed title would pass even if two cards swapped or one never resolved.
+    /// </summary>
+    public volatile bool TitleFromPath;
+
     public TestOgServer()
     {
         // HttpListener cannot bind port 0; reserve a free port via TcpListener first.
@@ -70,11 +77,14 @@ internal sealed class TestOgServer : IDisposable
             Interlocked.Increment(ref requestCount);
             var iconHref = IconHref;
             var iconLink = iconHref is null ? string.Empty : $"<link rel=\"icon\" href=\"{iconHref}\">";
+            var title = TitleFromPath
+                ? (context.Request.Url?.AbsolutePath ?? "").Trim('/')
+                : Title;
             var head = OmitOgTags
                 // The SPA catch-all shell a portal serves mid-restart: HTTP 200, a plain
                 // <title>, and NO og:* tags whatsoever.
                 ? "<title>Memex Portal</title>" + iconLink
-                : $"<meta property=\"og:title\" content=\"{Title}\">"
+                : $"<meta property=\"og:title\" content=\"{title}\">"
                   + "<meta property=\"og:description\" content=\"Served description.\">"
                   + "<meta property=\"og:image\" content=\"/og.png\">"
                   + iconLink;


### PR DESCRIPTION
## Defect 1 (the priority) — "use the node's icon for the og card, not the meshweaver icon"

**Root cause.** Every page of the portal serves ONE site-wide `<link rel="icon">`, declared in the shared layout (`App.razor`). Nothing per-page ever emitted an icon, so every link preview of every node drew the same MeshWeaver logo — our own `OgCard` grids and Slack / Teams / LinkedIn unfurls alike.

Measured on the live modules grid, through the real `OpenGraphPreviewService`, all 16 targets came back identical:

```
https://memex.meshweaver.cloud/Ifrs17          icon=https://memex.meshweaver.cloud/favicon.ico
https://memex.meshweaver.cloud/Reinsurance     icon=https://memex.meshweaver.cloud/favicon.ico
… 14 more, all the same
```

**Fix — at the head emission, so it is the general, standards-based answer.** `SeoResolver.ResolveIcon` lifts `MeshNode.Icon` into the per-page SEO head as `<link rel="icon">`, alongside the title / description / share image it already published. Every consumer benefits without knowing anything about MeshWeaver, and the browser tab gets it too.

It is **the icon on the node and nothing else** — no synthesised badge, no letter tile, no NodeType stand-in. A node with no icon of its own keeps the portal favicon, which is the honest answer for a page with no mark to show.

| Node icon value | What the head carries |
|---|---|
| inline `<svg>` (the real case) | `data:image/svg+xml,…` carrying **that exact svg**, byte for byte |
| `content:mark.svg` | the access-controlled content route — never `/static`, so a private space's mark stays private |
| a URL / `data:` URI | used as written; `type` declared only when the value pins one down |
| emoji, Fluent name, absent | nothing — the portal favicon stays |

**One supporting parser change.** A tie between equally-ranked icons is now broken by the **last** declaration, as browsers break it. Site chrome emits its favicon early and a page emits its own later, so preferring the first meant a page could never override the site-wide mark — precisely how every card in a grid ended up wearing the same logo. Ranking is otherwise unchanged; a lower-ranked later icon still loses.

## Defect 2 — "the ifrs still does not have the correct title and text": NOT root-caused

No speculative change was made for it. What was falsified, with evidence:

- **The parser hypothesis is wrong.** IFRS 17, Think in Streams and the working control page have byte-structurally identical heads: an 80 KB importmap, `<link rel=icon>` at offset 80691 on all three, og tags at ~82.5 KB, `</head>` at ~83.9 KB — all far inside both the 256 KB fetch cap and the 256 KB scan cap. `og:description` decodes cleanly at 301 / 211 / 146 chars. No length, entity or truncation asymmetry exists for a bound to trip on.
- **The live pages resolve correctly.** All 16 grid targets probed concurrently through the real service: `Ifrs17` → `"IFRS 17"` + 301-char description, `ThinkInStreams` → `"Think in Streams"` + 211-char description. Every one `resolved=True`.
- **An 8-target grid renders correctly end-to-end.** New regression test in the live grid's exact shape (the `urls=` parse-time id form, the real target list, a per-target `og:title` so a card carrying another card's data cannot pass). All eight cards, the last included.
- **The embed parse round-trips.** Traced `@@("area:OgCard?urls=…")` through token capture (quoted content preserves `,` and `=`) → `ParsePath` → `CreateAreaBlock` → `ParseTargets`: the 8th target comes out as exactly `https://memex.meshweaver.cloud/Ifrs17`.
- **Prod is healthy.** ns `memex` runs 1 replica on the expected image, with zero Open Graph lines logged. Note the earlier grep pattern could not have matched: the message text is `Open Graph fetch of {Url}` — a space — so `opengraph` only ever matched the logger category, which some log formats omit.

One genuinely useful finding: a card stuck on its placeholder titles itself with the URL's **last path segment** — literally `Ifrs17` where the page says `IFRS 17`. A stuck card and a wrong title are indistinguishable by eye, which is documented in the skill as the diagnostic.

## Defect 3 — the skill

`/og-card`, at mesh path **`Essentials/Skill/og-card`**, version-controlled at `content/ai/Skill/og-card.md`. Covers the embed forms that work (`?urls=` grid, `?url=` single, node-path), where each card field comes from, six traps (frame 0 is always the placeholder so an area snapshot is never a pass/fail signal; the placeholder-title tell; the 200-with-no-og caching gate; `<base href>` icon resolution; the icon tie-break; anonymous-readable pages only), and how to verify.

## Verification

- `OpenGraphHtmlParserTest` 18 ✓ (2 new) · `SeoResolver*Test` 11 ✓ (4 new) · `OgCardLayoutAreaTest` 8 ✓ (1 new 8-target grid) · `WhatsNewEntryIntegrityTest` ✓
- `-c Release -warnaserror` clean: `MeshWeaver.Graph`, `Memex.Portal.Shared`, and both touched test projects.
- No new user-visible strings, so no localization keys needed.

**Visual confirmation of the rendered cards is the user's** — per the skill's own rule, an area snapshot is frame 0 and proves nothing either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
