### PR TITLE
fix(content): a denied file answers like a missing one, not a 500 that names the reason

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-content-denial-is-not-an-error.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-content-denial-is-not-an-error.md
@@ -1,0 +1,15 @@
+---
+Name: Files you may not read answer like files that are not there
+Category: Fix
+Description: A denied content file now returns the same 404 as a missing one, instead of a 500 that named the reason.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Files you may not read answer like files that are not there
+
+Requesting a file from a space you do not have access to used to fail differently from requesting a file that simply does not exist: the first returned a server error, the second a plain "not found". Anyone could tell the two apart without signing in, which made it possible to work out which spaces exist and are private just by trying addresses.
+
+The server error also quoted the reason back to the caller, naming the permission that was missing and the space it belonged to.
+
+Both are fixed. A file you are not allowed to read now answers exactly like a file that is not there — a plain "not found", with no explanation attached. The real reason is still recorded in the server log, where administrators can see it. Nothing changes for files you are allowed to read.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -388,8 +388,30 @@ public static class BlazorHostingExtensions
             // No await on hub round-trips — chain via SelectMany; deadlock surface
             // (await pathResolver.ResolvePath / hub.Observe) eliminated.
             return ResolveContentFile(context, mainHub, path, caller)
-                .Catch<IResult, Exception>(ex =>
-                    Observable.Return(Results.Problem($"Error retrieving content: {ex.Message}")))
+                // 🚨 A DENIAL IS NOT AN ERROR — it must be indistinguishable from absence.
+                // The owning hub refuses a GetDataRequest the caller lacks Read on by posting a
+                // DeliveryFailure, which hub.Observe surfaces through onError as a
+                // DeliveryFailureException. That is the ONLY way a denial arrives here: the
+                // documented "config reads back null ⇒ 404" path never runs for one, because the
+                // stream faults instead of delivering null. Catching it as a generic error gave
+                // BOTH of the following to any unauthenticated caller:
+                //
+                //   • a 500-vs-404 ORACLE — "500" meant the node exists and you are denied, "404"
+                //     meant no such file, so a prober could map every private partition by URL
+                //     alone, which is the enumeration half of the #587 hole on the route the
+                //     content MOVED to; and
+                //   • the denial text itself, verbatim, in the problem body:
+                //     "Access denied: user 'Anonymous' lacks Read permission on 'Doc'" — the
+                //     permission model, the principal and the node's existence, unauthenticated.
+                //
+                // So a refused read answers exactly like a missing one: 404, no detail. The
+                // AccessControlPipeline has already logged the real reason server-side, which is
+                // where it belongs. Genuine faults (transport, IO) keep Problem — they are not
+                // caller-triggerable this way — but never echo the exception text.
+                .Catch<IResult, Exception>(ex => Observable.Return(
+                    ex is DeliveryFailureException
+                        ? Results.NotFound()
+                        : Results.Problem("Error retrieving content")))
                 .FirstAsync()
                 .ToTask(context.RequestAborted);
         });

--- a/test/MeshWeaver.Hosting.Blazor.Test/StaticContentUnmountedTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/StaticContentUnmountedTest.cs
@@ -304,6 +304,62 @@ public class StaticContentUnmountedTest(ITestOutputHelper output) : MonolithMesh
         body.Should().Be(SecretBody);
     }
 
+    /// <summary>
+    /// 🚨 THE ASSERTION THAT WAS MISSING. Every other <c>/api/content</c> test in this file passes
+    /// <c>asAdmin: true</c>, so the whole suite would stay green if the route stopped denying
+    /// anonymous callers entirely — the one regression that re-opens issue #587, just one route
+    /// over. <c>/static</c> is pinned against the unauthenticated caller; the route the content
+    /// MOVED to was not.
+    ///
+    /// <para>The deny is not a property of the endpoint — it is the owning hub's
+    /// <c>[RequiresPermission(Read)]</c> on the <c>GetDataRequest</c> that reads the collection
+    /// config. A denial arrives as a <c>DeliveryFailure</c>, which is not a <c>GetDataResponse</c>,
+    /// so the config reads back null and the route 404s without ever opening the file. That chain
+    /// is load-bearing and has no test holding it in place.</para>
+    ///
+    /// <para><b>The chain is conditional</b>, which is the real reason to pin it:
+    /// <c>AccessControlPipeline</c> skips every check when no <c>EffectivePermissionsDelegate</c>
+    /// is registered (<c>rlsDisabled</c>), and unlike <c>AnonymousGate</c> — which returns false
+    /// outright in that state precisely because the default evaluator would answer
+    /// <c>Permission.All</c> — the content route carries no equivalent fail-closed probe. This test
+    /// runs on a base that DOES register RLS, so it pins the enforced path.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ContentRoute_RefusesAnAnonymousCaller()
+    {
+        var response = await GetAsync(
+            $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{PrivateSpace}/{SecretFile}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "an unauthenticated caller holds no Read on the owning node, so the collection config " +
+            "must not resolve — this is the #587 hole re-checked on the route content moved to");
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody);
+        body.Should().NotContain("Access denied",
+            "the denial reason is server-side diagnostics — echoing it hands an anonymous caller " +
+            "the permission model, the principal and proof the node exists");
+        body.Should().NotContain(PrivateSpace);
+    }
+
+    /// <summary>
+    /// 🚨 THE ENUMERATION ORACLE. A refused read and a missing one must be BYTE-indistinguishable
+    /// from outside. While the denial surfaced as <c>500</c> and a genuine miss as <c>404</c>, the
+    /// status code alone told an unauthenticated prober which partitions exist and are private —
+    /// map the whole mesh with no credential and one request per guess. That is the enumeration
+    /// half of #587, and no assertion covered it because every other content test is an admin.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ContentRoute_DeniedAndMissing_AreIndistinguishable()
+    {
+        var denied = await GetAsync(
+            $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{PrivateSpace}/{SecretFile}");
+        var missing = await GetAsync(
+            $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/NoSuchNodeAtAll/{SecretFile}");
+
+        denied.StatusCode.Should().Be(missing.StatusCode,
+            "a node the caller may not read must answer exactly like a node that does not exist");
+    }
+
     /// <summary>Gated content is never shared-cacheable: a CDN or proxy that saw one authorized
     /// fetch would otherwise keep replaying it to callers the owning hub denies.</summary>
     [Fact(Timeout = 30000)]


### PR DESCRIPTION
## What

A permission denial on `/api/content` was reported as an unexpected error instead of as "not accessible". The read check itself is fine — an anonymous caller **is** denied Read on the owning node. What leaked was how that denial came back.

`/api/content` is the route content was **moved to in order to close #587**, where `/static/storage/content/{node}/{file}` "exposed every partition's uploads at a fully predictable URL to anyone who asked". The reporting bug re-opened the *enumeration* half of that hole.

## Why it happened

A denial reaches the endpoint only as a `DeliveryFailureException` — the owning hub refuses the `GetDataRequest` by posting a `DeliveryFailure`, which `hub.Observe` surfaces through `onError`. So the documented *"config reads back null ⇒ 404"* path never ran for a denial: the stream faults instead of delivering null, and the generic `.Catch` mapped it to `Results.Problem`.

That gave any unauthenticated caller:

- **a 500-vs-404 oracle** — `500` = the node exists and you are denied, `404` = no such file. One request per guess maps every private partition by URL alone, no credential needed.
- **the denial text verbatim**, live on prod today:
  ```json
  {"status":500,"detail":"Error retrieving content: Access denied: user 'Anonymous' lacks Read permission on 'Doc'"}
  ```
  — the permission model, the principal, and confirmation the node exists.

## The fix

A refused read now answers exactly like a missing one: `404`, no detail. `AccessControlPipeline` already logs the real reason server-side. Genuine faults keep `Problem` but no longer echo `ex.Message`.

## Tests

Two new, and **neither existed before** — every other `/api/content` assertion in `StaticContentUnmountedTest` passes `asAdmin: true`, so the suite would have stayed green if the route had stopped denying anonymous callers entirely.

- `ContentRoute_RefusesAnAnonymousCaller` — 404, and the body leaks neither the secret nor the denial reason.
- `ContentRoute_DeniedAndMissing_AreIndistinguishable` — the oracle itself.

`StaticContentUnmountedTest` 17/17. `MeshWeaver.Hosting.Blazor` clean under `-c Release -p:CIRun=true -warnaserror`.

## ⚠️ Separate issue this does NOT fix

While testing I uploaded a file to my own **private** partition and it serves **200 image/png to an anonymous caller**, stable across repeated requests:

```
curl https://memex.meshweaver.cloud/api/content/rbuergi/content/_icontest.png  →  200 image/png
```

`rbuergi` has three named grants and no anonymous grant. Since `500` turns out to be the denial signature, a `200` means the check **passed** for Anonymous there — unlike `Doc`, which correctly denies. That points at effective-permission data granting Anonymous Read on a user partition root, and it needs a query against prod's permission tables. **This PR does not address it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)