### PR TITLE
fix: gate content-collection files on the owning node's real permissions

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-private-partition-files-are-no-longer-served-to-strangers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-private-partition-files-are-no-longer-served-to-strangers.md
@@ -1,0 +1,36 @@
+---
+Name: Private partition files are no longer served to strangers
+Category: Fix
+Description: A file uploaded to a private partition could be fetched by anyone with the URL, without signing in. Content files now require exactly the same permission as the node that owns them.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Private partition files are no longer served to strangers
+
+A file stored in a partition's content collection — an upload, an attachment, an image — could be
+fetched over `/api/content/{partition}/content/{file}` by a caller who had never signed in, and by
+a signed-in caller who held no permission on that partition. Only the URL was needed, and the URL
+scheme is entirely predictable.
+
+The route was always meant to be the access-controlled one. It asked the owning node's hub for the
+collection's configuration, a request that carries a read-permission requirement, and treated that
+as the gate. The gate was real, but one rule quietly satisfied it: user partitions grant read
+access to "every signed-in user", and the rule that decided who counted as signed in tested only
+that the caller had a name. An unauthenticated caller does have one — it is called `Anonymous` —
+so it passed, and with it the whole hub's read check, the collection's configuration, and the file
+itself. A caller with no identity at all would have been refused; naming the anonymous caller
+correctly is what opened the door.
+
+Two things changed. "Signed in" is now a single shared definition that excludes the anonymous and
+public placeholder identities, so no rule can drift into admitting them again. And the content
+route now asks the permission evaluator directly, about the node that owns the file, instead of
+inheriting the answer from a configuration read that a hub-wide rule can satisfy on its own. For a
+logged-out visitor that is the same check the public share-card and crawler pages already use: a
+file is served anonymously only where its partition carries an explicit grant for anonymous
+readers.
+
+Public pages are unaffected — plugin covers, course landing pages and share cards carry that
+explicit grant and keep serving to logged-out visitors. What changes is everything else: a refused
+file now answers exactly as a missing one, so the response cannot be used to discover which files
+exist, and a permission check that cannot reach a verdict refuses the read rather than allowing it.

--- a/src/MeshWeaver.Graph/Configuration/NodeAccessExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeAccessExtensions.cs
@@ -30,15 +30,21 @@ public static class NodeAccessExtensions
     /// Grants read access to all authenticated users.
     /// Registers both a node-level access rule (for row-level security)
     /// and a hub-level permission rule (for AccessControlPipeline).
+    ///
+    /// <para>🚨 "Authenticated" is <see cref="WellKnownUsers.IsAuthenticated"/>, never
+    /// <c>!string.IsNullOrEmpty(userId)</c> — an unauthenticated caller arrives NAMED
+    /// (<see cref="WellKnownUsers.Anonymous"/>), so the emptiness spelling grants this blanket
+    /// Read to the logged-out internet. That is the exact defect that leaked private partitions'
+    /// content files; this helper carried an identical copy of it.</para>
     /// </summary>
     public static MessageHubConfiguration WithPublicRead(this MessageHubConfiguration config)
         => config
             .AddAccessRule(
                 [NodeOperation.Read],
-                (_, userId) => !string.IsNullOrEmpty(userId))
+                (_, userId) => WellKnownUsers.IsAuthenticated(userId))
             .AddHubPermissionRule(
                 Permission.Read,
-                (_, userId) => !string.IsNullOrEmpty(userId));
+                (_, userId) => WellKnownUsers.IsAuthenticated(userId));
 
     /// <summary>
     /// Allows users to edit nodes under their own partition (path = userId or userId/...).

--- a/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
@@ -200,18 +200,27 @@ public static class UserNodeType
     }
 
     /// <summary>
-    /// Grants public read access ONLY on the User node itself (path == "{userId}"),
+    /// Grants read access to every SIGNED-IN user on the User node itself (path == "{userId}"),
     /// not on its children (threads, activities, etc.). Children inherit normal
     /// access control — the user gets read access via UserScopeGrantHandler.
     /// Post-v10 paths are root-level ({userId}); legacy "User/{userId}" still
     /// matches so transitional data does not lose visibility before migration.
+    ///
+    /// <para>🚨 "Public" here has always meant <b>every authenticated user</b>, never "the
+    /// anonymous internet". The gate is <see cref="WellKnownUsers.IsAuthenticated"/> — spelled
+    /// <c>!string.IsNullOrEmpty(userId)</c>, it admitted the caller literally named
+    /// <c>"Anonymous"</c>, and since the hub-permission rule below applies to EVERY
+    /// <c>[RequiresPermission(Read)]</c> message reaching a user-partition hub, that one predicate
+    /// served logged-out callers the partition's content collection over
+    /// <c>/api/content/{user}/…</c>. An anonymous caller is not shut out by this: it falls through
+    /// to the real evaluator, where an explicit Anonymous grant still allows the read.</para>
     /// </summary>
     private static MessageHubConfiguration WithUserNodePublicRead(this MessageHubConfiguration config)
         => config.AddAccessRule(
             [NodeOperation.Read],
             (context, userId) =>
             {
-                if (string.IsNullOrEmpty(userId)) return false;
+                if (!WellKnownUsers.IsAuthenticated(userId)) return false;
                 var nodePath = context.Node.Path;
                 if (string.IsNullOrEmpty(nodePath)) return false;
                 // Root-level user node ("Alice") with no namespace separator: public.
@@ -223,7 +232,7 @@ public static class UserNodeType
             })
         .AddHubPermissionRule(
             Permission.Read,
-            (_, userId) => !string.IsNullOrEmpty(userId));
+            (_, userId) => WellKnownUsers.IsAuthenticated(userId));
 
     /// <summary>
     /// Adds a create-access rule for portal namespace hubs (onboarding flow).

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -8,6 +8,7 @@ using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Layout.Client;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Blazor.Services;
 using MeshWeaver.Mesh.Services;
@@ -388,12 +389,82 @@ public static class BlazorHostingExtensions
             // No await on hub round-trips — chain via SelectMany; deadlock surface
             // (await pathResolver.ResolvePath / hub.Observe) eliminated.
             return ResolveContentFile(context, mainHub, path, caller)
-                .Catch<IResult, Exception>(ex =>
-                    Observable.Return(Results.Problem($"Error retrieving content: {ex.Message}")))
+                .Catch<IResult, Exception>(ex => Observable.Return(ContentFailure(ex)))
                 .FirstAsync()
                 .ToTask(context.RequestAborted);
         });
     }
+
+    /// <summary>
+    /// The body a refused content read answers with. Byte-identical to the "no such file" answer on
+    /// purpose: a caller who may not read <c>{partition}/{file}</c> must not be able to learn from
+    /// the response whether it exists. The URL scheme is fully predictable, so a distinguishable
+    /// refusal is itself a disclosure — an existence oracle over every partition.
+    /// </summary>
+    private const string ContentNotFound = "Content not found";
+
+    /// <summary>
+    /// 🚨 THE AUTHORIZATION GATE ON THE CONTENT ROUTE — Read on the OWNING NODE, decided by the
+    /// REAL <c>PermissionEvaluator</c>, before a single byte is read.
+    ///
+    /// <para><b>Why this is explicit and not inherited.</b> The route used to lean entirely on the
+    /// collection-config <c>GetDataRequest</c> being <c>[RequiresPermission(Read)]</c> — "the file
+    /// is gated by exactly the decision an ordinary node read makes". That is true only while no
+    /// hub-level rule short-circuits the check, and on a USER partition one did:
+    /// <c>UserNodeType</c>'s blanket read rule is PATH-BLIND (its predicate takes only the delivery
+    /// and the user id), so it satisfied the check for the whole hub — collection config included —
+    /// and the bytes followed. Riding an incidental permission is what made a single wrong
+    /// predicate into a file disclosure; asking the evaluator directly cannot be short-circuited
+    /// that way.</para>
+    ///
+    /// <para><b>Anonymous takes the SEO route's predicate, exactly.</b>
+    /// <see cref="AnonymousGate.AllowAnonymous"/> — an explicit positive Anonymous Read grant, and
+    /// fail-closed when no <c>EffectivePermissionsDelegate</c> is registered (where the default
+    /// evaluator would otherwise answer <see cref="Permission.All"/> and open every partition to
+    /// the internet). So <c>/api/content</c> and <c>/api/og</c> now answer the same question the
+    /// same way, and a public plugin page's card keeps serving because that partition really does
+    /// carry the grant.</para>
+    ///
+    /// <para><b>Fail closed.</b> Any error in the probe settles on false — a read is served only on
+    /// a positive verdict, never on the absence of a negative one.</para>
+    /// </summary>
+    /// <param name="hub">The hub used to evaluate the permission.</param>
+    /// <param name="caller">The request's identity (never null; anonymous is a named context).</param>
+    /// <param name="owner">The node the content reference resolved to.</param>
+    /// <returns>True when this caller may read this node's content.</returns>
+    private static IObservable<bool> AllowContentRead(IMessageHub hub, AccessContext caller, Address owner)
+    {
+        var ownerPath = owner.ToString() ?? string.Empty;
+        if (string.IsNullOrEmpty(ownerPath))
+            return Observable.Return(false);
+
+        return WellKnownUsers.IsAuthenticated(caller.ObjectId)
+            ? Observable.Defer(() =>
+                    hub.CheckPermission(ownerPath, caller.ObjectId!, Permission.Read).Take(1))
+                .Catch<bool, Exception>(_ => Observable.Return(false))
+            : AnonymousGate.AllowAnonymous(hub, ownerPath);
+    }
+
+    /// <summary>
+    /// Maps a faulted content read onto its HTTP answer, keeping the tri-state the access pipeline
+    /// took care to preserve (#974): "we checked, you may not" and "we could not check" are
+    /// different answers and must not collapse into one.
+    /// </summary>
+    /// <param name="ex">The exception that faulted the read.</param>
+    /// <returns>The response to send.</returns>
+    private static IResult ContentFailure(Exception ex) => ex switch
+    {
+        // Refused: answer exactly as a missing file, so the status cannot be used to probe which
+        // paths exist. (A 403 here would confirm the file to a caller who may not see it.)
+        DeliveryFailureException { Failure.ErrorType: ErrorType.Unauthorized } =>
+            Results.NotFound(ContentNotFound),
+        // No verdict reached — a degraded dependency, NOT a statement about this caller's rights.
+        // Still fail closed (nothing is served), but 503 so the caller retries instead of caching
+        // an absence that was never asserted.
+        DeliveryFailureException { Failure.ErrorType: ErrorType.Unavailable } =>
+            Results.StatusCode(StatusCodes.Status503ServiceUnavailable),
+        _ => Results.Problem($"Error retrieving content: {ex.Message}")
+    };
 
     /// <summary>
     /// The identity of a content-file request. NEVER null — an unauthenticated caller resolves to
@@ -451,21 +522,30 @@ public static class BlazorHostingExtensions
             if (!sourceConfig.IsStatic)
                 return Observable.Return(NotServable(sourceConfig.Name));
 
-            // The portal hub is where the resolved config is cached and the bytes are read.
-            // Fall back to the mesh hub for hosts that do not run the Blazor portal (the
-            // sidecar, tests) — the access decision has already been made above.
-            var portal = mainHub.ServiceProvider.GetService<PortalApplication>()?.Hub ?? mainHub;
-            var portalContentService = portal.ServiceProvider.GetService<IContentService>();
-            if (portalContentService is null)
-                return Observable.Return(Results.NotFound("Content service not configured"));
+            // 🚨 THE ACCESS DECISION, taken HERE and on the resolved OWNER — not inherited from
+            // the config read above, which a path-blind hub rule can satisfy for the whole hub.
+            // Nothing below this line may run for a caller the owner would refuse.
+            return AllowContentRead(mainHub, caller, resolution.Owner).SelectMany(allowed =>
+            {
+                if (!allowed)
+                    return Observable.Return(Results.NotFound(ContentNotFound));
 
-            portalContentService.AddConfiguration(resolution.QualifiedConfig);
-            // Pure composition — collection resolution and the file read both run on the
-            // collection's own IIoPool; ServeFile only shapes the (already-read) result.
-            return portalContentService.GetCollection(resolution.QualifiedName)
-                .SelectMany(contentCollection => contentCollection == null
-                    ? Observable.Return(Results.NotFound($"Content collection '{sourceConfig.Name}' not found"))
-                    : ServeFile(context, contentCollection, resolution.FilePath));
+                // The portal hub is where the resolved config is cached and the bytes are read.
+                // Fall back to the mesh hub for hosts that do not run the Blazor portal (the
+                // sidecar, tests) — the access decision has already been made above.
+                var portal = mainHub.ServiceProvider.GetService<PortalApplication>()?.Hub ?? mainHub;
+                var portalContentService = portal.ServiceProvider.GetService<IContentService>();
+                if (portalContentService is null)
+                    return Observable.Return(Results.NotFound("Content service not configured"));
+
+                portalContentService.AddConfiguration(resolution.QualifiedConfig);
+                // Pure composition — collection resolution and the file read both run on the
+                // collection's own IIoPool; ServeFile only shapes the (already-read) result.
+                return portalContentService.GetCollection(resolution.QualifiedName)
+                    .SelectMany(contentCollection => contentCollection == null
+                        ? Observable.Return(Results.NotFound($"Content collection '{sourceConfig.Name}' not found"))
+                        : ServeFile(context, contentCollection, resolution.FilePath));
+            });
         });
     }
 

--- a/src/MeshWeaver.Mesh.Contract/Security/UserAccess.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/UserAccess.cs
@@ -23,4 +23,36 @@ public static class WellKnownUsers
     /// PartitionAccessPolicy nodes) must not be blocked by the permissions they manage.
     /// </summary>
     public const string System = "system-security";
+
+    /// <summary>
+    /// 🚨 THE ONE definition of "this caller is signed in" — the predicate every
+    /// grant-to-all-authenticated-users rule MUST use.
+    ///
+    /// <para><b>Why it exists.</b> The obvious spelling — <c>!string.IsNullOrEmpty(userId)</c> —
+    /// reads as "somebody is there" and is WRONG, because an unauthenticated caller is not
+    /// nameless: it is named <see cref="Anonymous"/>, a perfectly non-empty string. Two access
+    /// rules were spelled that way (<c>WithUserNodePublicRead</c>, <c>WithPublicRead</c>) and so
+    /// handed a blanket Read grant to logged-OUT callers on every user partition hub. The route
+    /// that serves a partition's uploaded files rides that decision, so a private partition's
+    /// content was served to anonymous HTTP callers. The bitter irony of the old spelling: a
+    /// caller with NO context at all was denied, and only naming the anonymous caller correctly
+    /// opened the door.</para>
+    ///
+    /// <para><b>Fail closed.</b> Null, empty, whitespace and the well-known pseudo-subjects are
+    /// all "not authenticated". <see cref="Anonymous"/> and <see cref="Public"/> exist only as
+    /// grant SUBJECTS — neither is ever a real caller — so neither may satisfy a rule whose whole
+    /// meaning is "a real user signed in".</para>
+    ///
+    /// <para><b>This does not deny anonymous callers by itself.</b> Failing this predicate only
+    /// withholds the blanket grant; the request falls through to the real
+    /// <c>PermissionEvaluator</c>, where an explicit Anonymous grant still allows the read. That
+    /// is precisely the semantics the crawler-facing SEO route already relies on
+    /// (<c>AnonymousGate</c>), so the two surfaces now agree.</para>
+    /// </summary>
+    /// <param name="userId">The caller identity, as resolved onto the delivery's AccessContext.</param>
+    /// <returns><c>true</c> only for a real, signed-in user.</returns>
+    public static bool IsAuthenticated(string? userId) =>
+        !string.IsNullOrWhiteSpace(userId)
+        && !string.Equals(userId, Anonymous, StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(userId, Public, StringComparison.OrdinalIgnoreCase);
 }

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentFileAnonymousAccessTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentFileAnonymousAccessTest.cs
@@ -1,0 +1,276 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 THE <c>/api/content</c> AUTHORIZATION CONTRACT, driven over REAL HTTP against a REAL monolith
+/// mesh with the REAL <see cref="PermissionEvaluator"/> (<c>AddRowLevelSecurity</c>, no mocks).
+///
+/// <para><b>What was broken.</b> <c>/api/content/{node}/{file}</c> — the route
+/// <c>UserContextMiddleware</c> calls "the access-controlled route", and the route
+/// <see cref="StaticContentUnmountedTest"/> moved every partition's uploads onto — served a file
+/// out of a PRIVATE partition to a fully ANONYMOUS caller. Reproduced against production:
+/// <c>GET /api/content/rbuergi/content/_icontest.png</c> returned <c>200 image/png</c> for a
+/// caller with no cookie and no token, on a partition whose only grants name three users.</para>
+///
+/// <para><b>Why the gap existed.</b> The route's own doc says the collection-config
+/// <c>GetDataRequest</c> "IS the permission check". That request is answered by the owning node's
+/// hub, and the answer — the collection's <i>configuration</i> — is not the node's content, so the
+/// read-permission rule that guards node content never denied it. The previous test suite only
+/// ever exercised this route as an ADMIN (<see cref="StaticContentUnmountedTest"/> has no
+/// anonymous case at all), so a permissive answer looked identical to a correct one.</para>
+///
+/// <para><b>What must hold now.</b> A collection file inherits EXACTLY the authorization of its
+/// owning node — the same predicate the crawler-facing SEO route already uses
+/// (<see cref="AnonymousGate.AllowAnonymous"/>): a logged-out caller is served only where the node
+/// carries an explicit positive Anonymous Read grant, and an indeterminate answer denies.</para>
+/// </summary>
+public class ContentFileAnonymousAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// A USER partition with NO anonymous grant — the EXACT production shape of the disclosure
+    /// (<c>rbuergi</c>). It must be a real <c>User</c> node, not a Markdown one: the permissive
+    /// rule lives on the <c>User</c> node type's hub configuration
+    /// (<c>UserNodeType.WithUserNodePublicRead</c>), so a Markdown fixture cannot reproduce this
+    /// and would "pass" against the unfixed code.
+    /// </summary>
+    private const string PrivateSpace = "privateuser";
+
+    /// <summary>A partition carrying an explicit Anonymous Viewer grant — the public plugin page
+    /// shape (<c>/api/content/BusinessRules/content/og-card.png</c>), which MUST keep working.</summary>
+    private const string PublicSpace = "PublicSpace";
+
+    private const string SecretFile = "secret.pdf";
+    private const string SecretBody = "confidential-bytes";
+    private const string PublicFile = "og-card.txt";
+    private const string PublicBody = "public-share-card";
+
+    /// <summary>The owner of <see cref="PrivateSpace"/> — the partition is theirs.</summary>
+    private const string Owner = PrivateSpace;
+
+    /// <summary>An authenticated caller holding no grant anywhere.</summary>
+    private const string Stranger = "stranger-user";
+
+    private static readonly string UserHeader = "X-Test-User";
+
+    private readonly string storageRoot = CreateStorageFixture();
+
+    private WebApplication? portal;
+    private HttpClient client = null!;
+
+    private static string CreateStorageFixture()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "content-gate-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(Path.Combine(root, "content", PrivateSpace));
+        Directory.CreateDirectory(Path.Combine(root, "content", PublicSpace));
+        File.WriteAllText(Path.Combine(root, "content", PrivateSpace, SecretFile), SecretBody);
+        File.WriteAllText(Path.Combine(root, "content", PublicSpace, PublicFile), PublicBody);
+        return root;
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                // 🚨 A real User node — this is what carries the permissive hub rule in production.
+                new MeshNode(PrivateSpace) { Name = "Private User", NodeType = "User" },
+                new MeshNode(PublicSpace) { Name = "Public Space", NodeType = "Markdown" },
+                // The owner may read their own partition; nobody else is named.
+                AssignmentNodeFactory.UserRole(Owner, "Admin", PrivateSpace),
+                // The public partition carries the explicit Anonymous grant — exactly what
+                // AnonymousGate keys on, and exactly what the shipped public plugin pages have.
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", PublicSpace,
+                    accessObject: WellKnownUsers.Anonymous))
+            .ConfigureDefaultNodeHub(config =>
+                config.Address.ToString() is PrivateSpace or PublicSpace
+                    ? config.AddContentCollection(_ => new ContentCollectionConfig
+                    {
+                        Name = ContentCollectionsExtensions.DefaultCollectionName,
+                        SourceType = "FileSystem",
+                        BasePath = Path.Combine(storageRoot, "content", config.Address.ToString()!),
+                        Address = config.Address,
+                        IsEditable = true,
+                        ExposeInChildren = true,
+                        IsStatic = true,
+                    })
+                    : config);
+
+    // Granular permissions — skip the blanket PublicAdmin seed, exactly as the other
+    // access-control suites do; otherwise every caller trivially holds Read.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        portal = BuildPortal();
+        await portal.StartAsync(TestContext.Current.CancellationToken);
+        client = portal.GetTestClient();
+    }
+
+    /// <summary>
+    /// The REAL <c>MapMeshWeaver()</c> endpoints, preceded by the identity middleware production
+    /// runs: the request's <see cref="AccessContext"/> is stamped on the mesh-wide
+    /// <c>AccessService</c>, NEVER null, anonymous when unauthenticated.
+    /// </summary>
+    private WebApplication BuildPortal()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(Mesh);
+
+        var app = builder.Build();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        app.Use(async (ctx, next) =>
+        {
+            var userId = ctx.Request.Headers[UserHeader].ToString();
+            accessService.SetContext(string.IsNullOrEmpty(userId)
+                ? new AccessContext { ObjectId = WellKnownUsers.Anonymous, Name = WellKnownUsers.Anonymous }
+                : new AccessContext { ObjectId = userId, Name = userId });
+            await next();
+        });
+        app.MapMeshWeaver();
+        return app;
+    }
+
+    private async Task<HttpResponseMessage> GetAsync(string url, string? asUser = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        if (!string.IsNullOrEmpty(asUser))
+            request.Headers.Add(UserHeader, asUser);
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private static string Url(string space, string file) =>
+        $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{space}/{file}";
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  (a) THE VULNERABILITY — anonymous must NOT read a private partition's collection file.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE REGRESSION TEST FOR THE DISCLOSURE. A caller with no identity at all asks for a file
+    /// in a partition that grants nothing to Anonymous. It must be refused, and — the part that
+    /// actually matters — the bytes must not appear in the response under any status code.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AnonymousRead_OfAPrivatePartitionsFile_IsDenied()
+    {
+        var response = await GetAsync(Url(PrivateSpace, SecretFile));
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody,
+            "a partition with no Anonymous grant must never serve its content to a logged-out caller");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a denied file answers exactly as a missing one — the 404 must not confirm it exists");
+    }
+
+    /// <summary>
+    /// The same refusal for a file addressed through the EXPLICIT collection segment
+    /// (<c>{node}/{collection}/{file}</c>). The resolver reads the two shapes differently, so the
+    /// gate has to hold on both — a gate that only covers the default-collection shape leaves the
+    /// documented URL form open.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AnonymousRead_ViaTheExplicitCollectionSegment_IsAlsoDenied()
+    {
+        var response = await GetAsync(
+            $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{PrivateSpace}/"
+            + $"{ContentCollectionsExtensions.DefaultCollectionName}/{SecretFile}");
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  (b) THE OVER-STRICTNESS CATCHER — an anonymous grant still serves.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 Without this, "deny everything anonymous" would pass by breaking every public page. The
+    /// shipped public plugin covers (<c>/api/content/BusinessRules/content/og-card.png</c>) are
+    /// exactly this shape — a partition carrying an explicit Anonymous Viewer grant — and they must
+    /// keep serving to a logged-out visitor.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AnonymousRead_OfAPartitionWithAnAnonymousGrant_Succeeds()
+    {
+        var response = await GetAsync(Url(PublicSpace, PublicFile));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an explicit Anonymous Read grant is what 'published' means — it must still serve");
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().Be(PublicBody);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  (c) + (d) — the authenticated cases bracket the gate from both sides.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// An authenticated caller who simply holds no grant on the partition is refused too. This is
+    /// the assertion that proves the gate keys on the PERMISSION and not merely on "has a cookie".
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AuthenticatedNonMember_IsDenied()
+    {
+        var response = await GetAsync(Url(PrivateSpace, SecretFile), asUser: Stranger);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().NotContain(SecretBody,
+            "signing in is not a grant — the caller holds nothing on this partition");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// The grant holder is served. Without this the whole feature could be "fixed" by refusing
+    /// everyone, and the private-partition uploads that legitimately render in the product would
+    /// silently become broken images.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TheGrantHolder_IsServed()
+    {
+        var response = await GetAsync(Url(PrivateSpace, SecretFile), asUser: Owner);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the owner holds Viewer on this partition — the file must still serve");
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().Be(SecretBody);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        client?.Dispose();
+        if (portal is not null)
+            await portal.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(storageRoot))
+                Directory.Delete(storageRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover fixture directory is harmless; never fail teardown on it.
+        }
+        await base.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## The disclosure

`/api/content/{node}/{file}` served a **private user partition's uploaded files to callers who held nothing on that partition — anonymous HTTP callers included**. Reproduced against production before the fix:

```
$ curl -s -o /dev/null -w '%{http_code} %{content_type} %{size_download}' \
    https://memex.meshweaver.cloud/api/content/rbuergi/content/_icontest.png
200 image/png 1389
```

No cookie, no token. The URL scheme is fully predictable, and this is the route `UserContextMiddleware` calls "the access-controlled route" — the one built to close #587, where `/static/storage/content/{node}/{file}` exposed every partition's uploads.

## Root cause

`UserNodeType.WithUserNodePublicRead` (`src/MeshWeaver.Graph/Configuration/UserNodeType.cs:224-226`, applied at :117) grants "every signed-in user" Read on a user-partition hub, spelled:

```csharp
.AddHubPermissionRule(Permission.Read, (_, userId) => !string.IsNullOrEmpty(userId));
```

Two compounding defects:

1. **An unauthenticated caller is not nameless.** `UserContextMiddleware` resolves it to `WellKnownUsers.Anonymous` — the string `"Anonymous"` — which is perfectly non-empty, so it satisfied the rule. `AccessControlPipeline` then *drops* the pending check (`:133-138`) and returns `next.Invoke(...)` (`:163`) — the real `PermissionEvaluator` is **never subscribed**. The bitter irony: a caller with a *null* context would have been denied; naming the anonymous caller correctly is what opened the door. Because `userId` is non-empty, the pipeline's "ANONYMOUS delivery" warning never fired either — no log signal.
2. **The rule is path-blind.** Its predicate takes only `(delivery, userId)`, so it satisfied **every** `[RequiresPermission(Read)]` message on that hub — including the collection-config `GetDataRequest` the content route relies on as its gate. That is why an **authenticated non-member** was served the bytes too.

The route's own contract ("the file is gated by exactly the decision an ordinary node read makes") was therefore true only while no hub rule short-circuited the check. One did.

## Blast radius

`UserNodeType` is the **only** live carrier — `NodeAccessExtensions.WithPublicRead` has zero call sites. So the exposure is precisely **user-partition roots**: `/api/content/{user}/content/…` and `/api/content/{user}/attachments/…`, both registered `IsStatic = true` (`MemexConfiguration.cs:858,871`). Space partitions and child nodes under a user partition were correctly gated throughout.

## The fix

* **`WellKnownUsers.IsAuthenticated`** — one shared definition of "signed in" that excludes the anonymous and public pseudo-subjects, used by both rule sites so neither can drift back to the emptiness spelling.
* **The content route asks the evaluator directly**, about the **resolved owning node** (`resolution.Owner`, not the first path segment), instead of inheriting the answer from a config read a hub-wide rule can satisfy on its own. Anonymous callers go through `AnonymousGate` — the same fail-closed predicate the crawler-facing `/api/og` route uses, so the two surfaces now answer the same question the same way.
* **Fail closed**: a refused read answers exactly as a missing one (no existence oracle over a predictable URL scheme); an *undetermined* verdict refuses with 503 rather than serving, keeping the tri-state #974 established.

Public pages are unaffected, **verified rather than assumed**: `/api/og/BusinessRules.png` returns 200 in production, which means `AnonymousGate` already allows that partition — and that is now the same predicate the content route uses.

## Tests

`ContentFileAnonymousAccessTest` drives the **real** route over HTTP against a real monolith mesh and the real `PermissionEvaluator` (no mocks), on a **real `User` node** — the shape a Markdown fixture cannot reproduce, and the reason this was never caught: the existing suite exercised `/api/content` only as an admin.

Against the unfixed tree 3 of 5 fail, including the bytes being served to anonymous *and* to an authenticated stranger; all 5 pass after.

| Case | Before | After |
|---|---|---|
| anonymous, partition without an anonymous grant | **served** | 404 |
| anonymous, via explicit collection segment | **served** | 404 |
| authenticated non-member | **served** | 404 |
| anonymous, partition **with** an anonymous grant | 200 | 200 |
| the grant holder | 200 | 200 |

Local suites green: Hosting.Blazor 306, Security 388, Graph 975, Memex.Portal.Shared 291, Documentation 20. Release `-warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)