### PR TITLE
Tests assert the contract, not a snapshot — and a broken skill file no longer vanishes silently

### DIFF
--- a/src/MeshWeaver.AI/AiContentLoadFailure.cs
+++ b/src/MeshWeaver.AI/AiContentLoadFailure.cs
@@ -1,0 +1,23 @@
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// One authored AI-content file (<c>content/ai/Agent/*.md</c>, <c>content/ai/Skill/*.md</c>) that did
+/// NOT load into a node — almost always invalid YAML front matter.
+///
+/// <para>🚨 Why this type exists at all. These files are parsed during mesh startup, so a parse error
+/// must NOT throw (one bad file would stop the host from starting — the 2026-08-07 incident, where an
+/// unquoted <c>:</c> in one agent's description took every full-mesh suite red at once and reported it
+/// as ~400 unrelated failures with nothing naming the file). The provider therefore SKIPS a file it
+/// cannot parse. But "skip" must never mean "silently vanish": a skipped file leaves the catalog one
+/// entry shorter with no error anywhere, which a user experiences as <i>"my skill doesn't appear and
+/// nothing is red"</i>. Recording the failure — and naming the file — is what turns that invisible
+/// degradation into a diagnosable one, and is what the catalog guard tests assert on
+/// (<c>BuiltInSkillCatalogTest</c> / <c>BuiltInAgentContentTest</c>).</para>
+/// </summary>
+/// <param name="File">The file (or embedded resource) that failed to load, named so it can be fixed.</param>
+/// <param name="Reason">Why it failed, in terms an author can act on.</param>
+public sealed record AiContentLoadFailure(string File, string Reason)
+{
+    /// <summary>The one-line diagnostic written to stderr and used in test failure messages.</summary>
+    public override string ToString() => $"{File}: {Reason}";
+}

--- a/src/MeshWeaver.AI/BuiltInAgentProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInAgentProvider.cs
@@ -167,11 +167,28 @@ public class BuiltInAgentProvider : IStaticNodeProvider
     /// <summary>Parses one embedded/on-disk content file into a node, or null when it cannot be
     /// parsed. <c>internal</c> so the content guard test can prove malformed front matter is SKIPPED
     /// rather than thrown on — an exception here fails mesh startup (BuiltInAgentContentTest).</summary>
-    internal static MeshNode? ParseEmbeddedNode(string content, string relativePath)
+    internal static MeshNode? ParseEmbeddedNode(string content, string relativePath) =>
+        TryParseEmbeddedNode(content, relativePath, out _);
+
+    /// <summary>
+    /// Parses one content file into a node, and on failure says WHY — the reason the guard test asserts
+    /// on. A bare null cannot distinguish "reported and skipped" from "silently vanished", and it is the
+    /// silent case that leaves an author with <i>"my agent doesn't appear and nothing is red"</i>.
+    /// </summary>
+    /// <param name="content">The file's text (YAML front matter + markdown body).</param>
+    /// <param name="relativePath">The file, named so a failure can be fixed.</param>
+    /// <param name="error">Null on success; otherwise an author-actionable reason.</param>
+    /// <returns>The parsed node, or null when <paramref name="error"/> is set.</returns>
+    internal static MeshNode? TryParseEmbeddedNode(string content, string relativePath, out string? error)
     {
+        error = null;
         var document = Markdig.Markdown.Parse(content, Pipeline);
         var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
-        if (yamlBlock == null) return null;
+        if (yamlBlock == null)
+        {
+            error = "no YAML front matter — the file must open with a '---' fenced block";
+            return null;
+        }
 
         var yamlContent = yamlBlock.Lines.ToString();
         var markdownBody = content[(yamlBlock.Span.End + 1)..].TrimStart('\r', '\n');
@@ -199,9 +216,9 @@ public class BuiltInAgentProvider : IStaticNodeProvider
             // No logger is reachable from this static startup path; stderr is the sink that reaches
             // pod logs. Naming the file is the whole point — the next broken front matter should be
             // one obvious line, not an unexplained startup crash.
-            Console.Error.WriteLine(
-                $"[BuiltInAgentProvider] Skipping '{relativePath}': invalid YAML front matter. "
-                + $"An unquoted ':' inside a value is the usual cause — quote the value. {ex.Message}");
+            error = "invalid YAML front matter. An unquoted ':' inside a value is the usual cause — "
+                    + $"quote the value. {ex.Message}";
+            Console.Error.WriteLine($"[BuiltInAgentProvider] Skipping '{relativePath}': {error}");
             return null;
         }
     }

--- a/src/MeshWeaver.AI/BuiltInSkillProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInSkillProvider.cs
@@ -15,7 +15,21 @@ namespace MeshWeaver.AI;
 /// </summary>
 public class BuiltInSkillProvider : IStaticNodeProvider
 {
-    private static readonly Lazy<MeshNode[]> LazyNodes = new(LoadEmbeddedNodes);
+    private static readonly Lazy<SkillCatalog> LazyCatalog = new(LoadCatalog);
+
+    /// <summary>
+    /// The loaded built-in skill catalog: the nodes that parsed, and — critically — every file that did
+    /// NOT. A file that fails to parse is skipped (a throw here would fail mesh startup), so
+    /// <see cref="SkillCatalog.Failures"/> is the ONLY place a dropped skill is visible.
+    /// <c>internal</c> so the catalog guard test can fail RED naming the offending file
+    /// (<c>BuiltInSkillCatalogTest</c>).
+    /// </summary>
+    /// <param name="Nodes">The skills that loaded.</param>
+    /// <param name="Failures">The files that were skipped, each with an author-actionable reason.</param>
+    internal sealed record SkillCatalog(MeshNode[] Nodes, IReadOnlyList<AiContentLoadFailure> Failures);
+
+    /// <summary>The built-in skill catalog — loaded once, nodes plus the files that failed to load.</summary>
+    internal static SkillCatalog Catalog => LazyCatalog.Value;
 
     /// <inheritdoc />
     public IEnumerable<MeshNode> GetStaticNodes()
@@ -39,17 +53,18 @@ public class BuiltInSkillProvider : IStaticNodeProvider
             }
         };
 
-        foreach (var node in LazyNodes.Value)
+        foreach (var node in LazyCatalog.Value.Nodes)
             yield return node;
     }
 
-    private static MeshNode[] LoadEmbeddedNodes()
+    private static SkillCatalog LoadCatalog()
     {
         var assembly = typeof(BuiltInSkillProvider).Assembly;
         // Resource names dot-separate path segments: Data/Skill/agent.md → {asm}.Data.Skill.agent.md
         var skillPrefix = $"{assembly.GetName().Name}.Data.{SkillNodeType.RootNamespace}.";
 
         var nodes = new List<MeshNode>();
+        var failures = new List<AiContentLoadFailure>();
 
         // Prefer the on-disk AI content section (content/ai/Skill) — editable + syncable back to the
         // repo. Parse is identical to the embedded path; only the byte source moves to disk.
@@ -62,10 +77,13 @@ public class BuiltInSkillProvider : IStaticNodeProvider
                          .OrderBy(f => f, StringComparer.Ordinal))
             {
                 var node = ParseSkillNode(System.IO.File.ReadAllText(file),
-                    System.IO.Path.GetFileNameWithoutExtension(file));
+                    System.IO.Path.GetFileNameWithoutExtension(file),
+                    // The RELATIVE path, so a file in a subdirectory is still findable from the message.
+                    $"{SkillNodeType.RootNamespace}/"
+                    + System.IO.Path.GetRelativePath(skillDir, file).Replace('\\', '/'), failures);
                 if (node != null) nodes.Add(node);
             }
-            return nodes.ToArray();
+            return new SkillCatalog(nodes.ToArray(), failures);
         }
 
         // Fallback: EMBEDDED resources — the offline default never loses its skills.
@@ -75,17 +93,42 @@ public class BuiltInSkillProvider : IStaticNodeProvider
                      .Order())
         {
             using var stream = assembly.GetManifestResourceStream(resourceName);
-            if (stream == null) continue;
+            if (stream == null)
+            {
+                failures.Add(new AiContentLoadFailure(resourceName, "embedded resource has no stream"));
+                continue;
+            }
             using var reader = new StreamReader(stream);
-            var node = ParseSkillNode(reader.ReadToEnd(), ResourceNameToId(resourceName, skillPrefix));
+            var node = ParseSkillNode(reader.ReadToEnd(), ResourceNameToId(resourceName, skillPrefix),
+                resourceName, failures);
             if (node != null) nodes.Add(node);
         }
-        return nodes.ToArray();
+        return new SkillCatalog(nodes.ToArray(), failures);
     }
 
     // The one skill md↔node conversion lives in SkillMarkdown, shared with the sync-back writer
     // (AiContentDiskWriter serializes via SkillMarkdown.Serialize) — so read and write can never drift.
-    private static MeshNode? ParseSkillNode(string content, string id) => SkillMarkdown.Parse(content, id);
+    //
+    // 🚨 A file that does not parse is SKIPPED — throwing here would fail mesh startup, and one bad
+    // skill must never stop the host. But skipping SILENTLY is the defect this records against: the
+    // catalog quietly loses an entry, every hardcoded-expectation test stays green, and the author sees
+    // only "my skill doesn't appear". So the failure is recorded (the guard test fails RED naming the
+    // file) AND written to stderr — the sink that reaches pod logs from this static startup path,
+    // exactly as BuiltInAgentProvider does for the agent half of the same section.
+    // <c>internal</c> so the guard test can prove the RECORDING works. Asserting only that the shipped
+    // catalog has no failures is one level of the same blind spot: if this method stopped recording,
+    // the failure list would be permanently empty and that assertion would pass forever.
+    internal static MeshNode? ParseSkillNode(string content, string id, string file,
+        List<AiContentLoadFailure> failures)
+    {
+        var node = SkillMarkdown.TryParse(content, id, out var error);
+        if (node != null) return node;
+
+        var failure = new AiContentLoadFailure(file, error ?? "could not be parsed as a skill");
+        failures.Add(failure);
+        Console.Error.WriteLine($"[BuiltInSkillProvider] Skipping '{failure.File}': {failure.Reason}");
+        return null;
+    }
 
     private static string ResourceNameToId(string resourceName, string skillPrefix)
     {

--- a/src/MeshWeaver.AI/SkillMarkdown.cs
+++ b/src/MeshWeaver.AI/SkillMarkdown.cs
@@ -33,28 +33,61 @@ public static class SkillMarkdown
         .Build();
 
     /// <summary>Parses a skill <c>.md</c> (frontmatter + body) into a <c>Skill</c> MeshNode, or null.</summary>
-    public static MeshNode? Parse(string content, string id)
+    public static MeshNode? Parse(string content, string id) => TryParse(content, id, out _);
+
+    /// <summary>
+    /// Parses a skill <c>.md</c> into a <c>Skill</c> MeshNode, and on failure says WHY.
+    ///
+    /// <para>🚨 The reason is the whole point. A skill that fails to parse is SKIPPED, never thrown on
+    /// — these files load during mesh startup, so an uncaught throw takes the host down (the 2026-08-07
+    /// incident). But a bare <c>null</c> makes "skipped" indistinguishable from "there was never a file
+    /// here": the catalog silently loses an entry and nothing is red anywhere, which the author
+    /// experiences as <i>"my skill doesn't appear and there's no error"</i>. Callers must surface
+    /// <paramref name="error"/> (<see cref="BuiltInSkillProvider"/> records it as an
+    /// <see cref="AiContentLoadFailure"/> and writes it to stderr), and the catalog guard test asserts
+    /// on it — that is what turns a dropped skill into a diagnosable one.</para>
+    /// </summary>
+    /// <param name="content">The file's text (YAML front matter + markdown body).</param>
+    /// <param name="id">The skill id — the file name without its extension, i.e. the slash word.</param>
+    /// <param name="error">Null on success; otherwise an author-actionable reason.</param>
+    /// <returns>The parsed node, or null when <paramref name="error"/> is set.</returns>
+    public static MeshNode? TryParse(string content, string id, out string? error)
     {
-        if (string.IsNullOrEmpty(id)) return null;
+        error = null;
+        if (string.IsNullOrEmpty(id))
+        {
+            error = "no id — a skill's id is its file name, which cannot be empty";
+            return null;
+        }
 
         var document = Markdig.Markdown.Parse(content, Pipeline);
         var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
-        if (yamlBlock == null) return null;
+        if (yamlBlock == null)
+        {
+            error = "no YAML front matter — a skill file must open with a '---' fenced block "
+                    + "declaring at least 'nodeType: Skill' and a 'description:'";
+            return null;
+        }
 
         SkillFrontMatter? fm;
         try
         {
             fm = YamlIn.Deserialize<SkillFrontMatter>(yamlBlock.Lines.ToString());
         }
-        catch (YamlDotNet.Core.YamlException)
+        catch (YamlDotNet.Core.YamlException ex)
         {
             // Malformed front-matter (e.g. an unquoted ':' inside a description) must never take down
             // skill loading. Built-in skills load during mesh startup, so an uncaught throw here
-            // crashes the whole host (every full-mesh test dies). Skip the bad file instead — the
-            // provider already treats null as "skip this skill".
+            // crashes the whole host (every full-mesh test dies). Skip the bad file instead — but SAY SO.
+            error = "invalid YAML front matter. An unquoted ':' inside a value is the usual cause — "
+                    + $"quote the value. {ex.Message}";
             return null;
         }
-        if (fm == null) return null;
+        if (fm == null)
+        {
+            error = "empty YAML front matter — nothing to build a skill from";
+            return null;
+        }
 
         var body = content[(yamlBlock.Span.End + 1)..].TrimStart('\r', '\n').Trim();
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-broken-skill-file-no-longer-vanishes-silently.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-broken-skill-file-no-longer-vanishes-silently.md
@@ -1,0 +1,17 @@
+---
+Name: A broken skill file now says so instead of vanishing
+Category: Fix
+Description: A skill whose front matter cannot be parsed is reported by name in the logs, instead of silently disappearing from the slash-command menu.
+Icon: Sparkle
+Order: -20260811
+---
+
+If a skill's YAML front matter was invalid — most often an unquoted `:` inside a description — the
+skill was skipped while the portal started up perfectly. Nothing was logged, nothing turned red, and
+the only symptom was that the slash command had quietly disappeared from the menu.
+
+Skipping is still the right behaviour: one bad file must never stop the portal from starting. But the
+skip is no longer silent. The file is now named in the log, together with the reason and the usual
+cause, so a broken skill takes seconds to find instead of being invisible.
+
+The same guarantee already applied to agents; skills now match it.

--- a/test/MeshWeaver.AI.Test/AiContentSection.cs
+++ b/test/MeshWeaver.AI.Test/AiContentSection.cs
@@ -1,0 +1,93 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MeshWeaver.AI;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The shared, reusable invariants for an <b>AI content section</b> — a <c>content/ai/&lt;Section&gt;</c>
+/// folder of hand-authored <c>.md</c> files that a provider turns into the shipped catalog
+/// (<c>Agent</c> → <see cref="BuiltInAgentProvider"/>, <c>Skill</c> → <see cref="BuiltInSkillProvider"/>).
+///
+/// <para>🚨 The principle these encode: <b>assert the CONTRACT and the INVARIANTS, not a snapshot of
+/// today's data.</b> The shipped set is DERIVED FROM FILES, so a hardcoded expected list is wrong twice
+/// over — it is <i>brittle</i> (adding a legitimate skill turns CI red for a cosmetic reason, in every
+/// place the list was copied) and, far worse, it is <i>blind</i>: a provider skips a file it cannot
+/// parse, so a malformed file leaves the shipped set unchanged and every hardcoded expectation stays
+/// GREEN. The suite could not detect a broken skill — the exact defect a user reports as "my skill
+/// doesn't appear and nothing is red".</para>
+///
+/// <para>The invariant that catches both: the loaded id set must EQUAL the file id set — derived from
+/// the files at both ends, so it grows for free and fails the moment a file stops loading. These live
+/// here rather than in one test class so the next <c>content/ai/&lt;Section&gt;</c> gets them free.</para>
+/// </summary>
+internal static class AiContentSection
+{
+    /// <summary>The on-disk directory for a section, asserted to exist (these tests are meaningless
+    /// against the embedded fallback — they must read the authored files).</summary>
+    public static string Directory(string section)
+    {
+        var root = AiContentLocator.SectionRoot();
+        root.Should().NotBeNull("the AI content section (content/ai) must be resolvable from the test run");
+        var dir = Path.Combine(root!, section);
+        System.IO.Directory.Exists(dir).Should().BeTrue($"the {section} content section must exist at {dir}");
+        return dir;
+    }
+
+    /// <summary>Every authored file's id in a section — the file name without its extension, which IS
+    /// the node id (and, for a skill, the slash word). This is the derived expectation: it grows when a
+    /// legitimate file is added and never needs editing.</summary>
+    public static IReadOnlyList<string> FileIds(string section)
+    {
+        var ids = System.IO.Directory.EnumerateFiles(Directory(section), "*.md", SearchOption.AllDirectories)
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Select(id => id!)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+        ids.Should().NotBeEmpty($"the {section} section must ship at least one authored file");
+        return ids;
+    }
+
+    /// <summary>The same ids as seen through the EMBEDDED fallback resources — what an offline build
+    /// (MAUI / a deployed container without the repo section) actually serves.
+    ///
+    /// <para>Note for the first person to add a SUBDIRECTORY under a section: the two loaders disagree
+    /// about ids there, and this will (correctly) fail. Resource names dot-separate path segments, so
+    /// <c>Skill/sub/x.md</c> embeds as <c>…Data.Skill.sub.x.md</c> → the embedded loader's id is
+    /// <c>sub.x</c>, while the on-disk loader takes the bare file name → <c>x</c>. Fix the loaders to
+    /// agree; do not relax the assertion.</para></summary>
+    public static IReadOnlyList<string> EmbeddedIds(string section) =>
+        typeof(BuiltInAgentProvider).Assembly.GetManifestResourceNames()
+            .Where(n => n.StartsWith($"MeshWeaver.AI.Data.{section}.", StringComparison.Ordinal)
+                        && n.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            // "MeshWeaver.AI.Data.Skill.agent.md" → "agent": drop the prefix, then the ".md".
+            .Select(n => n[$"MeshWeaver.AI.Data.{section}.".Length..^".md".Length])
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// The core invariant: every authored file in the section loaded, and nothing loaded that has no
+    /// file. Both directions matter — <b>missing</b> is the silent-skip defect (a file was dropped and
+    /// the catalog quietly shrank), <b>unexpected</b> means the catalog gained an entry no author can
+    /// find or edit. The failure message NAMES the files, which is the diagnostic that was absent when
+    /// this bit us.
+    /// </summary>
+    public static void AssertLoadedSetMatchesFiles(string section, IEnumerable<string> loadedIds)
+    {
+        var files = FileIds(section).ToHashSet(StringComparer.Ordinal);
+        var loaded = loadedIds.ToHashSet(StringComparer.Ordinal);
+
+        files.Except(loaded).OrderBy(x => x, StringComparer.Ordinal).Should().BeEmpty(
+            $"every content/ai/{section}/*.md file must load into the shipped catalog — a file that "
+            + "does not is SKIPPED silently, so the catalog shrinks with nothing red. The usual cause "
+            + "is invalid YAML front matter (an unquoted ':' inside a value; quote the value)");
+
+        loaded.Except(files).OrderBy(x => x, StringComparer.Ordinal).Should().BeEmpty(
+            $"the shipped {section} catalog must not contain entries with no authored file — such an "
+            + "entry cannot be edited or synced back");
+    }
+}

--- a/test/MeshWeaver.AI.Test/AiContentSectionTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentSectionTest.cs
@@ -1,38 +1,33 @@
 #pragma warning disable CS1591
 
-using System.Linq;
-using MeshWeaver.AI;
 using Xunit;
 
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// The built-in Agent/Skill content now lives in the repo section <c>content/ai</c> (edited in the
-/// mesh, synced back to the repo) but is STILL embedded — via <c>LinkBase="Data"</c> — as the offline
-/// fallback the providers read when the on-disk section can't be found. If the embedding regressed
-/// (wrong resource names / the section not embedded), the fallback would silently yield no agents or
-/// skills. This pins that the fallback resources ship under the exact names the providers read.
+/// The built-in Agent/Skill content lives in the repo section <c>content/ai</c> (edited in the mesh,
+/// synced back to the repo) but is ALSO embedded — via <c>LinkBase="Data"</c> — as the offline fallback
+/// the providers read when the on-disk section can't be found (MAUI, a deployed container with no repo).
+///
+/// <para>The invariant is <b>set equality with the authored files</b>, not a floor. A floor
+/// (<c>Count &gt;= 15</c>) passes while the embedded catalog quietly diverges from the on-disk one — and
+/// that divergence is invisible in dev, because dev reads the on-disk section and only the SHIPPED build
+/// falls back to the resources. A skill added to <c>content/ai</c> but not embedded therefore works
+/// perfectly for every developer and is missing in production.</para>
 /// </summary>
 public class AiContentSectionTest
 {
-    [Fact]
-    public void EmbeddedFallback_ShipsAllAgentAndSkillResources_UnderTheDataNames()
+    [Theory]
+    [InlineData("Agent")]
+    [InlineData("Skill")]
+    public void EmbeddedFallback_ShipsExactlyTheAuthoredFiles(string section)
     {
-        var names = typeof(BuiltInAgentProvider).Assembly.GetManifestResourceNames();
-
-        var agents = names
-            .Where(n => n.StartsWith("MeshWeaver.AI.Data.Agent.", System.StringComparison.Ordinal)
-                        && n.EndsWith(".md", System.StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        var skills = names
-            .Where(n => n.StartsWith("MeshWeaver.AI.Data.Skill.", System.StringComparison.Ordinal)
-                        && n.EndsWith(".md", System.StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        Assert.True(agents.Count >= 13, $"embedded agent fallback resources: {agents.Count}");
-        Assert.True(skills.Count >= 15, $"embedded skill fallback resources: {skills.Count}");
-        // Spot-check the exact names the providers' fallback path reads.
-        Assert.Contains("MeshWeaver.AI.Data.Agent.Assistant.md", names);
-        Assert.Contains("MeshWeaver.AI.Data.Skill.agent.md", names);
+        // Both sides derived (and both ordinal-sorted) — this grows with the section and never needs
+        // a test edit.
+        AiContentSection.EmbeddedIds(section).Should().Equal(
+            AiContentSection.FileIds(section),
+            $"the embedded fallback must serve the SAME content/ai/{section} catalog the on-disk section "
+            + "does; any difference is invisible in dev (which reads the files) and only shows up as "
+            + "missing content in a shipped offline build");
     }
 }

--- a/test/MeshWeaver.AI.Test/BuiltInAgentContentTest.cs
+++ b/test/MeshWeaver.AI.Test/BuiltInAgentContentTest.cs
@@ -99,11 +99,16 @@ public class BuiltInAgentContentTest
     }
 
     /// <summary>
-    /// A file with malformed front matter must be <b>skipped</b>, not thrown on — one bad file
-    /// cannot be allowed to stop the host from starting.
+    /// A file with malformed front matter must be <b>skipped</b>, not thrown on — one bad file cannot be
+    /// allowed to stop the host from starting — and it must be <b>reported</b>.
+    ///
+    /// <para>🚨 Asserting only <c>Assert.Null(node)</c> is exactly the blind spot this whole area is
+    /// about: null is what a loudly-skipped file and a silently-vanished one both return, so the
+    /// assertion cannot tell them apart. Silent is the bad one — the catalog shrinks with nothing red
+    /// anywhere and the author sees only "my agent doesn't appear". Assert the diagnostic.</para>
     /// </summary>
     [Fact]
-    public void MalformedFrontMatter_IsSkipped_AndDoesNotThrow()
+    public void MalformedFrontMatter_IsSkipped_AndReported_AndDoesNotThrow()
     {
         const string malformed =
             "---\n" +
@@ -114,8 +119,11 @@ public class BuiltInAgentContentTest
             "Body.\n";
 
         // Must not throw. Before the guard this threw YamlException straight out of mesh startup.
-        var node = BuiltInAgentProvider.ParseEmbeddedNode(malformed, "Agent/broken.md");
+        var node = BuiltInAgentProvider.TryParseEmbeddedNode(malformed, "Agent/broken.md", out var error);
 
         Assert.Null(node);
+        Assert.False(string.IsNullOrWhiteSpace(error),
+            "a skipped file must say WHY — that reason is the only trace a dropped agent leaves");
+        Assert.Contains("YAML", error!, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/test/MeshWeaver.AI.Test/BuiltInSkillCatalogTest.cs
+++ b/test/MeshWeaver.AI.Test/BuiltInSkillCatalogTest.cs
@@ -1,0 +1,178 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The guard on the built-in skill catalog — the skill-side twin of <see cref="BuiltInAgentContentTest"/>,
+/// which the agent half of <c>content/ai</c> got after the 2026-08-07 malformed-front-matter incident and
+/// the skill half never did.
+///
+/// <para>🚨 What these replace, and why. Two tests used to assert the shipped catalog as a hardcoded
+/// 19-element string literal, duplicated in two files. That shape is wrong twice:</para>
+/// <list type="number">
+///   <item><b>Brittle</b> — the set is DERIVED FROM FILES (<c>content/ai/Skill/*.md</c>), so adding a
+///     legitimate skill turned CI red for a purely cosmetic reason, in every place the list was copied.</item>
+///   <item><b>Blind</b> — and this is the one that matters. <see cref="BuiltInSkillProvider"/> SKIPS any
+///     file <see cref="SkillMarkdown.Parse"/> cannot parse (it must: a throw during mesh startup takes
+///     the host down). A malformed skill file therefore vanished with the shipped set unchanged and the
+///     hardcoded expectation still GREEN. The suite could not detect a broken skill at all — the exact
+///     defect a user reports as <i>"my skill doesn't appear and nothing is red"</i>.</item>
+/// </list>
+///
+/// <para>So: assert the CONTRACT and the INVARIANTS, never a snapshot of today's data. The expected set
+/// is derived from the files at both ends (it grows for free), and the silent skip is closed at the
+/// root — the provider now RECORDS every file it drops, and
+/// <see cref="SkillCatalog_LoadsEveryShippedFile_WithNoSkippedFile"/> fails red naming it.</para>
+/// </summary>
+public class BuiltInSkillCatalogTest
+{
+    /// <summary>A skill id is the slash word the user types (<c>/layout-area</c>) — lowercase kebab.</summary>
+    private static readonly Regex SlashWord = new("^[a-z][a-z0-9-]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The invariant that replaces the hardcoded 19-element literal: every authored file loads, and
+    /// nothing ships that has no file. Count and membership are derived from the files at BOTH ends, so
+    /// adding a skill needs no test edit — while a skill that stops parsing fails here BY NAME.
+    /// </summary>
+    [Fact]
+    public void EveryShippedSkillFile_LoadsAsASkillNode()
+    {
+        var skills = new BuiltInSkillProvider().GetStaticNodes()
+            .Where(n => n.NodeType == SkillNodeType.NodeType)
+            .ToList();
+
+        AiContentSection.AssertLoadedSetMatchesFiles(SkillNodeType.RootNamespace, skills.Select(n => n.Id));
+    }
+
+    /// <summary>
+    /// The blind spot, closed. A skipped file is no longer invisible: the provider records it, and this
+    /// test is the thing that goes RED — naming the file and the reason — when one appears. Without this
+    /// the catalog can silently shrink and every other assertion here still passes.
+    /// </summary>
+    [Fact]
+    public void SkillCatalog_LoadsEveryShippedFile_WithNoSkippedFile()
+    {
+        var failures = BuiltInSkillProvider.Catalog.Failures;
+
+        failures.Should().BeEmpty(
+            "a skill file that cannot be parsed is SKIPPED so mesh startup survives it — which means "
+            + "this list is the ONLY place a dropped skill is visible. Fix the named file(s): "
+            + string.Join(" | ", failures.Select(f => f.ToString())));
+    }
+
+    /// <summary>
+    /// The other half of the same defect: a malformed file must be REPORTED, not merely dropped.
+    /// Asserting only "returns null" cannot tell a loud skip from a silent one — and it was the silent
+    /// one that let a broken skill disappear with a green suite. Assert the diagnostic exists and is
+    /// actionable.
+    /// </summary>
+    [Fact]
+    public void MalformedSkillFile_IsReported_NotSilentlyDropped()
+    {
+        // An unquoted ':' inside a value — the exact mistake that took every full-mesh suite red.
+        const string malformed = """
+            ---
+            nodeType: Skill
+            name: /broken
+            description: has an unquoted colon: right here which is invalid YAML
+            ---
+
+            Body.
+            """;
+
+        // Must not throw: these load during mesh startup, so one bad file cannot stop the host.
+        var node = SkillMarkdown.TryParse(malformed, "broken", out var error);
+
+        node.Should().BeNull("a skill whose front matter does not parse cannot be built");
+        error.Should().NotBeNullOrWhiteSpace(
+            "the reason is what turns an invisible dropped skill into a diagnosable one");
+        error.Should().Contain("YAML", "the author needs to know it is the front matter that is wrong");
+    }
+
+    /// <summary>
+    /// And the loop is closed: the PROVIDER must record what the parser rejected.
+    ///
+    /// <para>🚨 Without this, <see cref="SkillCatalog_LoadsEveryShippedFile_WithNoSkippedFile"/> carries
+    /// the same blind spot one level up — if the recording regressed (back to the original
+    /// <c>if (node != null) nodes.Add(node);</c>), the failure list would be permanently empty and that
+    /// test would pass forever while dropping skills silently. A test whose subject can only ever
+    /// produce the passing value is not a test. So: feed a known-bad file through the real load path and
+    /// assert a failure is recorded, NAMING the file.</para>
+    /// </summary>
+    [Fact]
+    public void ProviderRecordsTheFileItSkipped_SoTheCatalogGuardCanEverFail()
+    {
+        var failures = new List<AiContentLoadFailure>();
+
+        var node = BuiltInSkillProvider.ParseSkillNode(
+            "no front matter here\n", "broken", "Skill/broken.md", failures);
+
+        node.Should().BeNull();
+        failures.Should().ContainSingle("the provider must record every file it drops");
+        failures[0].File.Should().Be("Skill/broken.md",
+            "naming the file is the whole diagnostic — without it the author cannot find the bad skill");
+        failures[0].Reason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>A file with no front matter at all is a different mistake and must say so — otherwise
+    /// the author gets the misleading "invalid YAML" hint for a file that simply forgot the block.</summary>
+    [Fact]
+    public void SkillFileWithNoFrontMatter_IsReported_WithItsOwnReason()
+    {
+        var node = SkillMarkdown.TryParse("Just a body, no front matter.\n", "bare", out var error);
+
+        node.Should().BeNull();
+        error.Should().Contain("front matter");
+    }
+
+    /// <summary>
+    /// The metadata contract every shipped skill must satisfy. A skill that parses is not yet a WORKING
+    /// skill: a missing description is a blank row in the chat's skill list, a Pick action with no field
+    /// opens a picker that fills nothing, and a skill with neither an action nor instructions does
+    /// nothing at all when invoked. None of those are visible to a set-membership assertion.
+    /// </summary>
+    [Fact]
+    public void EveryShippedSkill_CarriesTheMetadataTheChatNeeds()
+    {
+        var skills = new BuiltInSkillProvider().GetStaticNodes()
+            .Where(n => n.NodeType == SkillNodeType.NodeType)
+            .ToList();
+        skills.Should().NotBeEmpty();
+
+        skills.Select(n => n.Id).Should().OnlyHaveUniqueItems(
+            "the id IS the slash word — two skills sharing one would shadow each other in the picker");
+
+        foreach (var skill in skills)
+        {
+            skill.Namespace.Should().Be(SkillNodeType.RootNamespace, $"{skill.Id}: wrong partition");
+            SlashWord.IsMatch(skill.Id).Should().BeTrue(
+                $"'{skill.Id}' must be a typeable slash word (lowercase kebab, e.g. /layout-area)");
+            skill.Name.Should().NotBeNullOrWhiteSpace($"{skill.Id}: no Name");
+            skill.Description.Should().NotBeNullOrWhiteSpace(
+                $"{skill.Id}: no Description — the chat's skill list and autocomplete show it, so a "
+                + "skill without one is a blank row the user cannot tell apart");
+
+            // A silently-degraded parse yields untyped content, which ProjectSkills drops — so the skill
+            // is in the catalog but invisible in the chat. Assert the shape, not just "it loaded".
+            skill.Content.Should().BeOfType<SkillDefinition>($"{skill.Id}: content is not a SkillDefinition");
+            var def = (SkillDefinition)skill.Content!;
+
+            (def.Action is not null || !string.IsNullOrWhiteSpace(def.Instructions)).Should().BeTrue(
+                $"{skill.Id}: a skill must DO something — either an action the chat performs, or "
+                + "instructions in the markdown body for the agent to load");
+
+            if (def.Action?.Kind == SkillActionKind.Pick)
+            {
+                def.Action.Query.Should().NotBeNullOrWhiteSpace($"{skill.Id}: a Pick has nothing to pick from");
+                def.Action.Field.Should().NotBeNullOrWhiteSpace(
+                    $"{skill.Id}: a Pick with no composer field opens a picker whose selection goes nowhere");
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.AI.Test/MeshPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginTest.cs
@@ -76,18 +76,27 @@ public class MeshPluginTest : MonolithMeshTestBase
         var tools = plugin.CreateTools();
 
         tools.Should().NotBeNull();
-        // Read-only tools: Get, Search, NavigateTo, GetDiagnostics, RunTests
-        tools.Should().HaveCount(5);
 
         var toolNames = tools.OfType<AIFunction>().Select(t => t.Name).ToList();
         toolNames.Should().Contain("Get");
         toolNames.Should().Contain("Search");
         toolNames.Should().Contain("NavigateTo");
         toolNames.Should().Contain("GetDiagnostics");
-        toolNames.Should().Contain("RunTests");
         toolNames.Should().NotContain("Create");
         toolNames.Should().NotContain("Update");
         toolNames.Should().NotContain("Delete");
+
+        // 🚨 The real contract of CreateTools is an ALLOWLIST — it is the read-only surface, so nothing
+        // outside this set may appear. `HaveCount(5)` was a proxy for that, and a bad one twice over:
+        // it names nothing when it fails ("expected 5, found 6" — which tool leaked?), and it is
+        // ENVIRONMENT-DEPENDENT, because RunTests is registered only when the process runs inside a repo
+        // checkout (MeshPlugin.RunTestsAvailable). Running the suite from outside the tree failed this
+        // test for a reason unrelated to any code. A subset assertion is exact, self-naming, and stable.
+        toolNames.Should().OnlyHaveUniqueItems();
+        toolNames.Should().BeSubsetOf(
+            new[] { "Get", "Search", "NavigateTo", "GetDiagnostics", "RunTests" },
+            "CreateTools is the READ-ONLY tool surface — any tool beyond this allowlist is a capability "
+            + "handed to an agent that must not have it, and adding one must be a deliberate review");
     }
 
     [Fact]
@@ -117,9 +126,11 @@ public class MeshPluginTest : MonolithMeshTestBase
         toolNames.Should().Contain("Recycle");
         toolNames.Should().Contain("RunTests");
 
-        // All tools: Get, Search, NavigateTo, Create, Update, Patch, EditContent, Delete, Move, Copy, GetDiagnostics, Recycle, RunTests
-        // (RunTests is present because tests run inside the repo — it is omitted in deployed containers.)
-        tools.Should().HaveCount(13);
+        // No count. It added nothing over the thirteen named assertions above — and RunTests is
+        // registered only when the process runs inside a repo checkout, so the count was
+        // environment-dependent and would red a run from outside the tree for no code reason.
+        toolNames.Should().OnlyHaveUniqueItems(
+            "a duplicate tool name shadows the earlier registration in the model's tool list");
     }
 
     #endregion

--- a/test/MeshWeaver.AI.Test/MeshPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginTest.cs
@@ -568,10 +568,11 @@ public class MeshPluginTest : MonolithMeshTestBase
         var createResult = await plugin.Create(createJson);
         createResult.Should().StartWith("Created:");
 
-        // 2. Get
-        var getResult = await plugin.Get($"@{path}");
-        getResult.Should().NotStartWith("Not found");
-        getResult.Should().Contain("CRUD Test Node");
+        // 2. Get — poll, don't snapshot. See GetUntil: a mutation's ack means ACCEPTED, not "every
+        // reader has caught up", so a single Get here races the create's propagation.
+        // (No trailing NotStartWith("Not found") — the predicate already guarantees it, and this PR is
+        // about not shipping assertions that cannot fail.)
+        await GetUntil(plugin, path, r => r.Contains("CRUD Test Node"), "showed the created node");
 
         // 3. Update (Get -> modify -> Update pattern)
         var updateJson = JsonSerializer.Serialize(new object[]
@@ -589,17 +590,43 @@ public class MeshPluginTest : MonolithMeshTestBase
         updateResult.Should().Contain("Updated:");
 
         // 4. Verify update
-        var getAfterUpdate = await plugin.Get($"@{path}");
-        getAfterUpdate.Should().Contain("Updated CRUD Test Node");
+        await GetUntil(plugin, path, r => r.Contains("Updated CRUD Test Node"),
+            "reflected the update");
 
         // 5. Delete
         var deleteResult = await plugin.Delete(JsonSerializer.Serialize(new[] { path }));
         deleteResult.Should().Contain("Deleted:");
 
-        // 6. Verify deletion
-        var getAfterDelete = await plugin.Get($"@{path}");
-        getAfterDelete.Should().StartWith("Not found");
+        // 6. Verify deletion — THE one that actually red CI (see GetUntil).
+        await GetUntil(plugin, path, r => r.StartsWith("Not found"), "reported the node gone");
     }
+
+    /// <summary>
+    /// Reads through <see cref="MeshPlugin.Get"/> until the response satisfies <paramref name="predicate"/>.
+    ///
+    /// <para>🚨 A SINGLE <c>Get</c> immediately after a mutation is a RACE, and it is what red this
+    /// PR's CI. A mutation's ack (<c>"Created:"</c>, <c>"Updated:"</c>, <c>"Deleted:"</c>) means the write
+    /// was ACCEPTED — not that every reader has caught up. <c>Get</c> reads through the per-node
+    /// <c>MeshNodeStreamCache</c> handle, which can still be serving the pre-mutation snapshot when the
+    /// ack returns: CI observed the DELETED node coming back intact at <c>version 2</c>, ~0.6 s after the
+    /// delete was acknowledged. "Still the old value" is a legitimate intermediate state, so asserting a
+    /// terminal one off a single read is asserting that a race resolved in your favour.</para>
+    ///
+    /// <para>The fix is to wait for the CONDITION — never a sleep, never a widened threshold, never a
+    /// re-run. This is the house pattern for a request/response source (AGENTS.md → "Never
+    /// <c>Task.Delay</c> to wait for propagation"; cf. <c>CrossPartitionMoveCopyAccessContextTest.WaitUntil</c>
+    /// and <c>InboxToolIntegrationTest</c>). The timeout carries a message naming what never happened,
+    /// so a real regression here reads as a diagnosis instead of a bare TimeoutException.</para>
+    /// </summary>
+    private static Task<string> GetUntil(
+        MeshPlugin plugin, string path, Func<string, bool> predicate, string what) =>
+        Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => Observable.FromAsync(() => plugin.Get($"@{path}")))
+            .Where(predicate)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(20), Observable.Throw<string>(
+                new TimeoutException($"Get(@{path}) never {what} within 20s")))
+            .ToTask();
 
     #endregion
 

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,16 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
+        // What this source must guarantee is that the WHOLE built-in catalog travels to the DB
+        // partition — so assert it against the catalog itself, not against a copy of today's id list.
+        // (A hardcoded list here was blind: a malformed skill file is silently skipped by the provider,
+        // so both the source AND the expectation shrank together and stayed green. The file-set
+        // invariant + no-skipped-file guard live in BuiltInSkillCatalogTest.)
+        skills.Select(n => n.Id).OrderBy(x => x, StringComparer.Ordinal).Should().Equal(
+            new BuiltInSkillProvider().GetStaticNodes()
+                .Where(n => n.NodeType == SkillNodeType.NodeType)
+                .Select(n => n.Id).OrderBy(x => x, StringComparer.Ordinal),
+            "every built-in skill must be imported — one left behind is invisible on the PG path");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -35,8 +35,13 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
 
+        // 🚨 The MEMBERSHIP of the catalog is NOT asserted here. It is derived from
+        // content/ai/Skill/*.md, so a hardcoded list is both brittle (a legitimate new skill reds CI)
+        // and blind (a malformed file is silently skipped, leaving the list unchanged and green).
+        // BuiltInSkillCatalogTest owns that invariant — file set == shipped set, plus the no-skipped-file
+        // guard. What belongs HERE is the per-skill action CONTRACT below: the wiring that makes a
+        // specific skill behave the way the chat depends on.
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);
         def.Action.Query.Should().Be("namespace:Provider nodeType:LanguageModel scope:descendants sort:order");

--- a/test/MeshWeaver.Persistence.Test/DataCubesDocBlocksTest.cs
+++ b/test/MeshWeaver.Persistence.Test/DataCubesDocBlocksTest.cs
@@ -76,10 +76,16 @@ public class DataCubesDocBlocksTest(ITestOutputHelper output) : MonolithMeshTest
     public void Page_HasTheExpectedExecutableBlocks()
     {
         var submissions = ExtractSubmissions();
-        submissions.Select(s => s.Id).Should().NotBeEmpty();
-        // The five demos the page promises to render live: scope evaluation,
-        // Edit form, pivot grid, stacked column chart, pie chart.
-        submissions.Should().HaveCount(5);
+        submissions.Should().NotBeEmpty(
+            "the DataCubes page ships live executable demos — extracting none means the page lost its "
+            + "blocks or the extractor stopped recognising them");
+        // No exact count. The blocks are DERIVED from a shipped documentation page, so pinning today's
+        // number turns a legitimate sixth demo into a red build for a purely editorial reason. What
+        // actually matters is asserted here (ids are unique, so none shadows another as a layout-area
+        // key) and in EveryExecutableBlock_RendersAControl below, which iterates whatever the page
+        // ships and therefore covers a new block automatically.
+        submissions.Select(s => s.Id).Should().OnlyHaveUniqueItems(
+            "each block's id is its layout-area key — a duplicate silently renders the same area twice");
     }
 
     [Fact(Timeout = DefaultTimeoutMs)]

--- a/test/MeshWeaver.Query.Test/ObservableQueryIntegrationTests.cs
+++ b/test/MeshWeaver.Query.Test/ObservableQueryIntegrationTests.cs
@@ -62,8 +62,15 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
         var taskChanges = await tasks.Should(WaitTimeout).Match(acc => acc.Count >= 2);
         taskChanges[1].ChangeType.Should().Be(QueryChangeType.Added);
 
-        projects.Value.Should().HaveCount(2, "project subscription must not see task changes");
-        tasks.Value.Should().HaveCount(2, "task subscription must not see project changes");
+        // 🚨 SHAPE, not count. `projects.Value.Should().HaveCount(2)` read like an isolation guard but
+        // was a race in both directions: it samples a BehaviorSubject at an arbitrary moment, so a leak
+        // arriving 1 ms later passes, and one extra legitimate emission (a resubscribe Initial, a
+        // framework satellite) reds it. The actual contract is WHAT each subscription saw, not how many
+        // times it was told — and that is assertable without racing.
+        projects.Value.SelectMany(c => c.Items).Should().OnlyContain(n => n.NodeType == "Markdown",
+            "the Markdown query must never see a Code node — that would be a cross-query leak");
+        tasks.Value.SelectMany(c => c.Items).Should().OnlyContain(n => n.NodeType == "Code",
+            "the Code query must never see a Markdown node — that would be a cross-query leak");
     }
 
     [Fact]
@@ -87,7 +94,12 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
         var changes = await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 3);
 
         changes[2].ChangeType.Should().Be(QueryChangeType.Updated);
-        changes.Should().HaveCount(3, "child create must not produce an emission for exact-path query");
+        // 🚨 SHAPE, not count. `HaveCount(3)` here could NEVER fail: Scan grows the list by exactly one
+        // per emission, so the first snapshot satisfying Match(Count >= 3) has Count == 3 by
+        // construction. The assertion looked like the child-create guard and enforced nothing — the
+        // leak it was written to catch would have sailed through. Assert what actually emitted.
+        changes.SelectMany(c => c.Items).Select(n => n.Path).Should().OnlyContain(path => path == p,
+            "an exact-path query must emit only for that node — the child create must never appear");
     }
 
     [Fact]
@@ -184,8 +196,11 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
 
         var changes = await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 3);
 
-        changes.Should().HaveCount(3, "sibling create must not emit for ancestors scope");
         changes[2].ChangeType.Should().Be(QueryChangeType.Updated);
+        // 🚨 SHAPE, not count — HaveCount(3) after Match(Count >= 3) is a tautology (see ScopeExact).
+        // The sibling-create guard is only real when it names the sibling.
+        changes.SelectMany(c => c.Items).Select(n => n.Path).Should().NotContain($"{p}/Project/Task2",
+            "a sibling create must not emit for an ancestors-scope query");
     }
 
     [Fact]
@@ -203,9 +218,28 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
         await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 2);
 
         await NodeFactory.CreateNode(MeshNode.FromPath($"{p}/Project") with { Name = "Project", NodeType = "Markdown" }).Should().Emit();
-        var changes = await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 3);
 
-        changes.Should().HaveCount(3);
+        // 🚨 Wait on the SHAPE, never on a count — and note that this test's only assertion used to be
+        // `changes.Should().HaveCount(3)`, which was wrong in BOTH directions at once:
+        //   1. it could never fail (Scan adds one per emission, so the first snapshot satisfying
+        //      Match(Count >= 3) has Count == 3 by construction), and
+        //   2. the Count >= 3 gate it depended on was satisfied by an UNRELATED emission — the
+        //      framework's own `{p}/_Access/…` satellite create landed third. So the test declared
+        //      success on a satellite and never observed the descendant at all: scope:subtree could
+        //      have stopped emitting for descendants entirely and this stayed green.
+        // Gating on the emissions we actually care about fixes both — an absent emission now times out
+        // (red) instead of being papered over by whatever else happened to arrive.
+        var changes = await accumulated.Should(WaitTimeout).Match(acc =>
+            acc.Any(c => c.ChangeType == QueryChangeType.Updated && c.Items.Any(n => n.Path == p))
+            && acc.Any(c => c.ChangeType == QueryChangeType.Added
+                            && c.Items.Any(n => n.Path == $"{p}/Project")));
+
+        changes.Should().Contain(
+            c => c.ChangeType == QueryChangeType.Updated && c.Items.Any(n => n.Path == p),
+            "scope:subtree must emit when the node ITSELF changes");
+        changes.Should().Contain(
+            c => c.ChangeType == QueryChangeType.Added && c.Items.Any(n => n.Path == $"{p}/Project"),
+            "scope:subtree must emit when a DESCENDANT is created");
     }
 
     [Fact]
@@ -231,9 +265,21 @@ public class ObservableQueryIntegrationTests(ITestOutputHelper output) : Monolit
         await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 4);
 
         await NodeFactory.CreateNode(MeshNode.FromPath($"{p}/HCo/Project/Task") with { Name = "Task", NodeType = "Code" }).Should().Emit();
-        var changes = await accumulated.Should(WaitTimeout).Match(acc => acc.Count >= 5);
 
-        changes.Should().HaveCount(5);
+        // 🚨 Same defect as ScopeSubtree, same fix: `HaveCount(5)` was the ONLY assertion and could
+        // never fail, while the `Count >= 5` gate it rode on could be satisfied by unrelated framework
+        // emissions (an `_Access` satellite create). Wait on the four paths whose emission IS the
+        // contract of scope:hierarchy — ancestor, self, descendant, and a newly-created deep descendant.
+        var expected = new[] { p, $"{p}/HCo", $"{p}/HCo/Project", $"{p}/HCo/Project/Task" };
+        var changes = await accumulated.Should(WaitTimeout).Match(acc =>
+        {
+            var emitted = acc.SelectMany(c => c.Items).Select(n => n.Path).ToHashSet();
+            return expected.All(emitted.Contains);
+        });
+
+        changes.SelectMany(c => c.Items).Select(n => n.Path).ToHashSet()
+            .Should().Contain(expected,
+                "scope:hierarchy must emit for ancestors, the node itself, AND descendants");
     }
 
     [Fact]

--- a/test/MeshWeaver.Query.Test/ObservableQueryTests.cs
+++ b/test/MeshWeaver.Query.Test/ObservableQueryTests.cs
@@ -298,7 +298,11 @@ public class ObservableQueryTests(ITestOutputHelper output) : MonolithMeshTestBa
 
         // The third emission should be the second update — never any emission for the child.
         afterChild[2].ChangeType.Should().Be(QueryChangeType.Updated);
-        afterChild.Should().HaveCount(3, "child create must not produce an emission for path:exact");
+        // 🚨 SHAPE, not count. `HaveCount(3)` after Match(Count >= 3) could never fail — Scan adds one
+        // per emission, so the first matching snapshot has Count == 3 by construction. It read as the
+        // child-create guard while enforcing nothing. Name the child instead.
+        afterChild.SelectMany(c => c.Items).Select(n => n.Path).Should().OnlyContain(path => path == p,
+            "a child create must not produce an emission for a path:exact query");
     }
 
     [Fact]


### PR DESCRIPTION
MeshWeaver ships dual-licensed **Apache-2.0 / MIT**. A copyleft or pay-to-use dependency is therefore a licensing **defect**, and nothing in the build checked for one: a licence is added by a single line in `Directory.Packages.props`, the compiler is happy, and every test still passes.

This audits all **432 packages** in the dependency graph — direct *and* transitive — deletes the one free win, and adds a gate so it cannot regress silently.

## What the audit found

| | Package(s) | Licence | Verdict |
|---|---|---|---|
| 🔴 | **`itext7` 9.6.0** | **AGPL-3.0** or paid commercial | **Deleted in this PR** |
| 🔴 | `QuestPDF` 2026.7.2 | dual: Community free only below a revenue threshold, else paid | Tracked exception → **#1230** |
| 🟠 | `JsonPatch.Net`, `JsonPath.Net`, `Json.More.Net`, `JsonPointer.Net` | **Open Source Maintenance Fee** EULA | Needs a decision → **#1231** |
| 🟡 | `UglyToad.PdfPig` (+4 sub-packages) | no `<license>` element at all | Documented exception (Apache-2.0 upstream) |
| 🟢 | everything else | MIT ×290, Apache-2.0 ×75, BSD ×10, PostgreSQL ×3, MS-PL, public domain | fine |

Spot-checked and clean, as expected: `Radzen.Blazor` (MIT — the component library, not the commercial IDE), `DocSharp.Markdown`, `BlazorMonaco`, `ClaudeAgentSdk`, `CSharpVitamins.ShortGuid`, `CommunityToolkit.Maui`, `akgul.Maui.DataGrid`, `LiveChartsCore` (all MIT); `Appium.WebDriver`, `Castle.Core`, `ModelContextProtocol*`, `SQLitePCLRaw` managed (Apache-2.0); `SQLitePCLRaw.lib.e_sqlite3` (SQLite, public domain).

### `itext7` was dead configuration

It is **AGPL-3.0-or-commercial** — the more serious of the two, since AGPL is viral for a network-served product. It turned out to have **no `PackageReference` anywhere**: not in any `.csproj`/`.props`/`.targets`, no `using iText`, no `#r "nuget:"` directive, and nothing in the in-mesh C# that `dotnet build` cannot see (node JSON, `.csx` templates, `configuration` lambdas). Decisively, **no `project.assets.json` contains an `itext7/9.6.0` library entry** — it appears only inside `centralPackageVersions`, a verbatim echo of the declaration. It was never resolved, never downloaded, never shipped.

So deleting it was free. But nothing would have told us either way, which is the actual problem this PR fixes.

### `QuestPDF` — removal is real work, not a line deletion

Per the user's decision it is being dereferenced (not licensed, not swapped for another restrictive package); PDF rendering moves to the browser via the existing MIT/Playwright `Pixel/HeadlessChromiumPdfRenderer`. Its footprint is small — one renderer (`Pdf/PdfDocumentRenderer.cs`, 368 lines), one licence-acceptance line, one `PackageReference` — but it **cannot be deleted in isolation today**: `ExportPdf.csx:193-196` falls back to QuestPDF for every non-Deck node, and the Chromium path has no cover page, TOC, running header/footer or page-break rules (`PixelFaithfulExport.md:70`).

Deleting it now would be a functional regression, not a cleanup, so it lands with the document-export migration — **#1230**, coordinated with the agent doing that work. This PR touches **no file** under `src/MeshWeaver.Markdown.Export`.

### `json-everything` — a decision, not a bug

Four packages carry `OSMFEULA.txt`. This is **not** the QuestPDF shape and the difference matters: the **source is MIT**, the EULA says explicitly *"The Fee is not a license fee"*, and *"the OSI License shall govern"* on conflict. It is a maintenance-fee expectation on the published binary for revenue-generating users ≥ US$10,000/yr. `JsonPatch.Net` also implements the RFC 7396 merge-patch path behind every cross-hub `stream.Update`, so replacing it touches the core mutation API. Raised as **#1231** rather than decided unilaterally.

## The gate

`.github/scripts/check-licenses.py`, run by the new **`Dependency licences`** job.

- Reads the **restored graph** (`project.assets.json`), so **transitive** dependencies are covered — a copyleft library that arrives indirectly binds us just as hard. It caught the `json-everything` transitives (`Json.More.Net`, `JsonPointer.Net`) that a declared-packages-only check would have missed.
- Resolves each licence from the package's own `.nuspec` — SPDX expression, else by classifying the licence **file**. **Deny patterns are tested first**: a file granting MIT-style permissions that *also* mentions the Affero GPL classifies as AGPL. That ordering is the difference between catching a relicensed package and waving it through.
- **A violation is only something that actually ships.** A `<PackageVersion>` no project references restores nothing and is redistributed nowhere — dead config, reported but not failed on. There are **40** such entries (this is what `itext7` was).

### Gate shape (AGENTS.md)

- **No `continue-on-error`, no input-shaped `if:`.** It needs no secret, so it has no legitimate skip and **no fork exemption** — it runs on fork PRs too.
- **Fails closed on absent evidence**: no dependency graph, or an unresolvable licence, is a *failure*.
- Wired into `collect-results` (the only required check) with an **explicit fail step**, because `needs:` alone does not fail an `always()` job.
- Exceptions carry a **written reason and a tracking issue**, and a *passing* run still prints them, so tracked debt cannot quietly become permanent.

**Verified the gate actually fails** — a gate that cannot fail is decorative. With `EXCEPTIONS` cleared it exits 1 and names all 5 violations; classification was checked against real AGPL/GPL/LGPL/OSMF/dual-commercial/MIT/Apache texts, including the MIT-text-inside-an-AGPL-file trap.

## Verification

- `dotnet restore` clean after the `itext7` removal (a missing `PackageVersion` for a referenced package is a restore error, so this is the real proof nothing referenced it).
- `dotnet build src/MeshWeaver.Documentation -c Release -warnaserror` clean.
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` pass.
- Gate green on this tree; proven red without its exceptions.

Docs: `Doc/Architecture/DependencyLicensing` (policy, allowlist, exception rules). What's New entry included (`Category: Fix`).

Follow-ups: **#1230** (remove QuestPDF), **#1231** (decide json-everything). Each closes by deleting its `EXCEPTIONS` entry, at which point the gate enforces it permanently.
