### PR TITLE
A cross-partition subtree search returned only its top level, silently (#1216)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-shared-source-in-subfolders-is-found-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-shared-source-in-subfolders-is-found-again.md
@@ -1,0 +1,29 @@
+---
+Name: Shared source files in subfolders are found again
+Category: Fix
+Description: A content type that borrows code from another area kept in a subfolder had those files silently left out when the platform prepared an update, so the type reported an error naming a symbol that exists — and the update refused to roll out.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Shared source files in subfolders are found again
+
+A content type can borrow source files from somewhere else on the mesh — a shared library of
+fixtures in another area, say. When the platform prepares an update it gathers every type's source
+files in one sweep, and that sweep asked the mesh for "everything below any *Source* folder".
+
+It did not get everything below. It got the files sitting **directly** in each *Source* folder, and
+nothing from a subfolder underneath — the "and everything below" part of the request was quietly
+dropped for a search that spans areas. So a type whose shared library lives one folder deeper was
+prepared with that library missing, and reported an error naming a class that is right there on the
+mesh: *the name 'MtplClaimFixtures' does not exist*.
+
+This was the most misleading shape a failure can take. The type had plenty of its **own** files, so
+nothing looked empty or absent; the only symptom was a compile error that reads exactly like broken
+content. The update safety-check then did its job and refused the roll-out — correctly, on
+evidence that was wrong.
+
+Two things follow from the fix. Those types prepare and compile again, so the update proceeds. And,
+more generally, any search that asks for a folder's whole subtree **across areas** now really
+returns the subtree: previously it returned only that one level, silently, with no error to tell
+you the answer was narrower than the question.

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -115,6 +115,19 @@ internal static class NodeTypeBatchBake
     ///
     /// <para>Overlap is free: the results fold into one path-keyed map, and the in-memory matcher
     /// then selects each type's set from it exactly as before.</para>
+    ///
+    /// <para>🚨 <b>The union's COMPLETENESS is what makes the in-memory match sound</b>, and it rests
+    /// on <c>scope:subtree</c> meaning the same thing for a WILDCARD namespace as for a concrete
+    /// one. It did not, and that was the residual half of #1216: the wildcard form cannot become a
+    /// <c>ParsedQuery.Path</c>, so it is emitted as a <c>namespace LIKE '%/Source'</c> filter and the
+    /// scope — which only ever drove a PATH walk — was silently dropped. The fetch then reached only
+    /// the Code nodes sitting DIRECTLY in a <c>…/Source</c> folder, and a type whose sources include
+    /// a cross-partition <c>shared=@Other/SampleData/Source/Fixtures</c> resolved a PARTIAL set: its
+    /// own sources present, that one absent, a convincing <c>CS0103</c> out of Roslyn, and the bake
+    /// gate refusing readiness on healthy content. A partial set is strictly worse than an empty
+    /// one — the emptiness invariant below cannot see it. <c>QueryParser</c> now widens the wildcard
+    /// namespace to self-or-below (<c>WidenWildcardNamespacesToSubtree</c>), which is what lets the
+    /// matcher keep serving these queries from the global map instead of re-running them.</para>
     /// </summary>
     private static IReadOnlyList<string> GlobalCodeQueries =>
     [

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -457,6 +457,10 @@ public partial class QueryParser
         // built-in + per-context + per-NodeType + per-user instances (see AgentPickerProjection).
         string[]? namespaceAlternation = null;
         bool namespaceAlternationNegated = false;
+        // Where each wildcard `namespace:*/X` LIKE filter landed in filterTokens, so the post-loop
+        // pass can widen it to the SUBTREE once `scope:` is known (the qualifier may appear AFTER
+        // the namespace token). See WidenWildcardNamespacesToSubtree.
+        List<int>? namespaceWildcardIndices = null;
         OrderByClause? orderBy = null;
         int? limit = null;
         var source = QuerySource.Default;
@@ -510,7 +514,11 @@ public partial class QueryParser
                     }
                     if (value.Contains('*'))
                     {
-                        // Wildcard namespace: add as LIKE filter (e.g., namespace:*/_Thread)
+                        // Wildcard namespace: add as LIKE filter (e.g., namespace:*/_Thread).
+                        // REMEMBER where it landed — `scope:` may still be ahead of us in the token
+                        // stream, and a subtree scope widens this single LIKE into a self-or-below
+                        // OR pair (WidenWildcardNamespacesToSubtree).
+                        (namespaceWildcardIndices ??= []).Add(filterTokens.Count);
                         filterTokens.Add(new Token(TokenType.Comparison, string.Empty,
                             new QueryCondition("namespace", QueryOperator.Like, [value.Replace("*", "%")])));
                     }
@@ -621,6 +629,13 @@ public partial class QueryParser
             scope = QueryScope.Descendants;
         }
 
+        // A WILDCARD namespace carries its own scope, because it never produced a Path to walk.
+        if (namespaceWildcardIndices is not null
+            && scope is QueryScope.Subtree or QueryScope.Descendants)
+        {
+            WidenWildcardNamespacesToSubtree(filterTokens, namespaceWildcardIndices);
+        }
+
         // Resolve a deferred `namespace:A|B|C` alternation into a `namespace IN (...)` membership
         // FILTER. With scope:selfAndAncestors each value expands to itself + every ancestor
         // namespace, so a node whose namespace is the value OR any ancestor matches (closest-wins
@@ -647,6 +662,62 @@ public partial class QueryParser
 
         var textSearch = textSearchParts.Count > 0 ? string.Join(" ", textSearchParts) : null;
         return (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths);
+    }
+
+    /// <summary>
+    /// Widens every wildcard <c>namespace:*/X</c> LIKE filter to cover the whole SUBTREE:
+    /// <c>(namespace LIKE '%/X' OR namespace LIKE '%/X/%')</c>.
+    ///
+    /// <para><b>Why this exists (issue #1216).</b> A concrete <c>namespace:A/B</c> becomes a
+    /// <see cref="ParsedQuery.Path"/> plus a <see cref="QueryScope"/>, and every backend walks that
+    /// path — so <c>scope:subtree</c> genuinely reaches nodes nested any number of levels below.
+    /// A WILDCARD namespace cannot become a Path (there is no path to walk: <c>*</c> spans
+    /// partitions), so it is emitted as a <c>namespace LIKE</c> FILTER instead — and a filter is all
+    /// the backend ever sees. <c>scope:subtree</c> was therefore silently DROPPED for the wildcard
+    /// form: <c>namespace:*/Source scope:subtree</c> matched only rows whose namespace ENDS in
+    /// <c>/Source</c>, i.e. the Code nodes sitting DIRECTLY in some <c>…/Source</c> folder, and
+    /// nothing one level deeper. No error, no warning — just a strictly narrower answer than the
+    /// query asked for.</para>
+    ///
+    /// <para>That is what stalled the memex-cloud rollout on 2026-08-11. The batch bake's global
+    /// source fetch (<c>NodeTypeBatchBake.GlobalCodeQueries</c>) is exactly this shape, and it is the
+    /// ONLY way to reach the per-schema <c>code</c> satellite table across partitions. Four NodeTypes
+    /// whose sources include a cross-partition <c>shared=@Claims/SampleData/Source/Fixtures</c> —
+    /// one level below <c>/Source</c> — had that source silently missing from the global fetch, so
+    /// the in-memory matcher selected a PARTIAL source set and Roslyn produced a perfectly
+    /// convincing <c>CS0103: The name 'MtplClaimFixtures' does not exist</c>. The bake gate read the
+    /// false CompileError as an image regression and refused readiness. A partial set is worse than
+    /// an empty one: the emptiness invariant added in #1220 cannot see it, because those types have
+    /// plenty of OTHER sources.</para>
+    ///
+    /// <para>Widening in the PARSER (rather than in any one caller's query text) is what makes the
+    /// fix hold for every backend at once — Postgres, Snowflake, Cosmos and the in-memory
+    /// evaluator all consume the same <see cref="ParsedQuery.Filter"/> — and it is what stops the
+    /// next author of a <c>namespace:*/X scope:subtree</c> query from inheriting the same silent
+    /// truncation.</para>
+    /// </summary>
+    /// <param name="filterTokens">The filter token stream being assembled; edited in place.</param>
+    /// <param name="indices">Positions of the single-LIKE wildcard namespace tokens to widen.</param>
+    private static void WidenWildcardNamespacesToSubtree(List<Token> filterTokens, List<int> indices)
+    {
+        // Descending, so an earlier index is still valid after a later one has been expanded.
+        foreach (var index in indices.OrderByDescending(i => i))
+        {
+            if (filterTokens[index].Condition is not { } self || self.Value.Length == 0)
+                continue;
+            var pattern = self.Value;
+            var below = new QueryCondition(
+                self.Selector, QueryOperator.Like, [$"{pattern.TrimEnd('/')}/%"]);
+            filterTokens.RemoveAt(index);
+            filterTokens.InsertRange(index,
+            [
+                new Token(TokenType.LeftParen, "("),
+                new Token(TokenType.Comparison, string.Empty, self),
+                new Token(TokenType.Or, "OR"),
+                new Token(TokenType.Comparison, string.Empty, below),
+                new Token(TokenType.RightParen, ")"),
+            ]);
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
@@ -164,10 +164,11 @@ public class BatchBakeSourceDiscoveryScaleTests(PostgreSqlFixture fixture, ITest
             + "mesh_nodes (which is what an unpinned nodeType:Code query does) sees nothing at all");
     }
 
-    private IObservable<IReadOnlyList<string>> ActivationPathSources(string typePath, int expected)
+    private IObservable<IReadOnlyList<string>> ActivationPathSources(
+        string typePath, int expected, IReadOnlyList<string>? declaredSources = null)
     {
         var queries = CodeQueryResolver
-            .ExpandAll(DeclaredSources, CodeQueryResolver.DefaultSources, typePath)
+            .ExpandAll(declaredSources ?? DeclaredSources, CodeQueryResolver.DefaultSources, typePath)
             .Concat(CodeQueryResolver.ExpandAll(null, CodeQueryResolver.DefaultTests, typePath))
             .Distinct(StringComparer.Ordinal)
             .ToArray();
@@ -273,5 +274,128 @@ public class BatchBakeSourceDiscoveryScaleTests(PostgreSqlFixture fixture, ITest
             "the batch must compile exactly what the activation path would have compiled");
         resolved[typeB].Select(n => n.Path).Should().Equal(activationB,
             "the batch must compile exactly what the activation path would have compiled");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION TEST FOR THE RESIDUAL HALF OF #1216 — the one that stalled the
+    /// memex-cloud rollout on ci.2969 after the first two mechanisms were fixed.
+    ///
+    /// <para><b>The production shape, reproduced exactly.</b> A NodeType in partition A declares a
+    /// cross-partition shared source in partition B — <c>shared=@{B}/SampleData/Source/Fixtures</c>
+    /// — and the Code node it needs lives one level BELOW that partition's <c>Source</c> folder, at
+    /// <c>{B}/SampleData/Source/Fixtures/MtplClaimFixtures</c>. Four types failed exactly this way
+    /// (<c>ReinsuranceDemo/SampleData</c>, <c>Claims/Claim</c>, <c>Claims/Enquiry</c>,
+    /// <c>Claims/Register</c>), all on the same missing symbol:
+    /// <c>CS0103: The name 'MtplClaimFixtures' does not exist in the current context</c>.</para>
+    ///
+    /// <para><b>Why the earlier invariant could not catch it.</b> Those types resolve PLENTY of
+    /// other sources — their own <c>Source</c> subtree and the shared folder's direct children — so
+    /// the set is PARTIAL, never empty, and #1220's emptiness invariant sees a healthy type. The
+    /// partial set reaches Roslyn and produces a compile error indistinguishable from real content
+    /// breakage, which the bake gate reads as an image regression and refuses readiness on.</para>
+    ///
+    /// <para><b>The mechanism</b> is <c>QueryParser</c>: a WILDCARD <c>namespace:*/Source</c> cannot
+    /// become a Path, so it is emitted as a <c>namespace LIKE '%/Source'</c> filter — and
+    /// <c>scope:subtree</c>, which only ever drives a PATH walk, was silently dropped. The batch's
+    /// global fetch (<c>NodeTypeBatchBake.GlobalCodeQueries</c>) is that query, and it is the only
+    /// shape that reaches the per-schema <c>code</c> satellite table across partitions, so a Code
+    /// node whose namespace does not END in <c>/Source</c> was invisible to the whole pass.</para>
+    ///
+    /// <para>The assertion is on CONTAINMENT of the nested node rather than a count, because that
+    /// is the production symptom: one missing file out of many present ones.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task Discovery_ResolvesACrossPartitionSharedSource_NestedBelowTheSourceFolder()
+    {
+        var nsConsumer = $"bbn{Guid.NewGuid():N}"[..12].ToLowerInvariant();
+        var nsShared = $"bbn{Guid.NewGuid():N}"[..12].ToLowerInvariant();
+        await ProvisionPartition(nsConsumer).Should().Within(60.Seconds()).Emit();
+        await ProvisionPartition(nsShared).Should().Within(60.Seconds()).Emit();
+
+        // The consumer type's OWN source — the reason its resolved set is never empty.
+        var typePath = $"{nsConsumer}/SampleData";
+        await MeshService.CreateNode(new MeshNode("Spine", $"{typePath}/Source")
+        {
+            Name = "Spine",
+            NodeType = CodeNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = "public static class Spine { }" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // The shared partition: one Code node DIRECTLY under Source (namespace ends in `/Source`,
+        // so the unfixed global fetch DOES see it — this is what keeps the set non-empty and hides
+        // the defect from the emptiness invariant) …
+        var sharedRoot = $"{nsShared}/SampleData/Source";
+        await MeshService.CreateNode(new MeshNode("Shared", sharedRoot)
+        {
+            Name = "Shared",
+            NodeType = CodeNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = "public static class Shared { }" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // … and the one that was missing in production: nested ONE level deeper, so its namespace
+        // is `{shared}/SampleData/Source/Fixtures` — which `namespace LIKE '%/Source'` never matches.
+        var nestedPath = $"{sharedRoot}/Fixtures/MtplClaimFixtures";
+        await MeshService.CreateNode(new MeshNode("MtplClaimFixtures", $"{sharedRoot}/Fixtures")
+        {
+            Name = "MtplClaimFixtures",
+            NodeType = CodeNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration
+            {
+                Code = "public static class MtplClaimFixtures { public const int N = 1; }"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // The declared sources of the production types, with the partition names substituted:
+        // own subtree + the cross-partition shared folder(s). `@` expands to `path:X` + a
+        // `namespace:X scope:subtree` folder match, both of which the in-memory matcher mirrors —
+        // so BOTH are served from the global fetch, which is exactly why the fetch has to be
+        // complete.
+        var declaredSources = new[]
+        {
+            "namespace:Source scope:subtree",
+            $"shared=@{sharedRoot}",           // the Claims/Claim shape — resolves the direct child
+            $"shared=@{sharedRoot}/Fixtures",  // the ReinsuranceDemo/SampleData shape — the nested one
+        };
+
+        // Barrier: the activation path (each source query issued individually, partition-pinned)
+        // is the baseline, and it also proves every seeded node is visible before discovery runs —
+        // so a node missing from the batch below can only be a discovery defect, never a race.
+        var activation = await ActivationPathSources(typePath, 3, declaredSources)
+            .Should().Within(70.Seconds()).Emit();
+        activation.Should().Contain(nestedPath,
+            "the activation path issues `namespace:{shared}/SampleData/Source scope:subtree` PINNED "
+            + "to the shared partition, where scope:subtree drives a real path walk — this is the "
+            + "answer the batched pass has to match");
+
+        var definitions = new Dictionary<string, NodeTypeDefinition?>(StringComparer.OrdinalIgnoreCase)
+        {
+            [typePath] = new NodeTypeDefinition { Configuration = "config => config", Sources = declaredSources },
+        };
+
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("BatchBakeNested");
+        var resolved = await NodeTypeBatchBake
+            .ResolveSources(
+                MeshService,
+                Mesh.ServiceProvider.GetService<AccessService>(),
+                definitions,
+                [typePath],
+                logger)
+            .Should().Within(150.Seconds()).Emit();
+
+        var paths = resolved[typePath].Select(n => n.Path).ToList();
+        Output.WriteLine($"batch discovery: {typePath}={paths.Count} [{string.Join(", ", paths)}]");
+
+        paths.Should().Contain(nestedPath,
+            "the batch's global fetch is `namespace:*/Source scope:subtree nodeType:Code`, and the "
+            + "wildcard form emits a `namespace LIKE '%/Source'` FILTER — scope:subtree drives a "
+            + "PATH walk and there is no path here, so before the fix it was silently dropped and "
+            + "this node (namespace `.../Source/Fixtures`) was invisible to the entire pass");
+        paths.Should().Equal(activation,
+            "the batch must resolve exactly what the activation path resolves — a PARTIAL set is "
+            + "the failure mode this test exists for: it compiles, and the CS0103 it produces reads "
+            + "as broken content rather than as broken discovery");
     }
 }

--- a/test/MeshWeaver.Query.Test/QueryParserTests.cs
+++ b/test/MeshWeaver.Query.Test/QueryParserTests.cs
@@ -776,6 +776,101 @@ public class QueryParserTests
 
     #endregion
 
+    #region Wildcard Namespace + scope (issue #1216 — `scope:subtree` was silently dropped)
+
+    /// <summary>
+    /// Every <c>namespace LIKE</c> pattern in <paramref name="node"/>, in tree order. A wildcard
+    /// namespace never becomes a <see cref="ParsedQuery.Path"/> — it is a FILTER — so the patterns
+    /// are the entire reach of the query and asserting on them asserts on what the backend sees.
+    /// </summary>
+    private static List<string> NamespaceLikePatterns(QueryNode? node)
+    {
+        var found = new List<string>();
+        void Walk(QueryNode? n)
+        {
+            switch (n)
+            {
+                case QueryComparison c
+                    when c.Condition.Selector.Equals("namespace", System.StringComparison.OrdinalIgnoreCase)
+                         && c.Condition.Operator == QueryOperator.Like:
+                    found.Add(c.Condition.Value);
+                    break;
+                case QueryAnd a:
+                    foreach (var child in a.Children) Walk(child);
+                    break;
+                case QueryOr o:
+                    foreach (var child in o.Children) Walk(child);
+                    break;
+            }
+        }
+        Walk(node);
+        return found;
+    }
+
+    /// <summary>
+    /// 🚨 THE PARSER-LEVEL REGRESSION FOR #1216. Without <c>scope:</c> a wildcard namespace means
+    /// "the nodes whose namespace IS something ending in /Source" — one LIKE, no subtree. That part
+    /// is unchanged and asserted here so the widening below cannot quietly become the default.
+    /// </summary>
+    [Fact]
+    public void Parse_WildcardNamespace_WithoutScope_MatchesThatLevelOnly()
+    {
+        var result = _parser.Parse("namespace:*/Source nodeType:Code");
+
+        result.Path.Should().BeNull("a wildcard namespace spans partitions — there is no path to walk");
+        NamespaceLikePatterns(result.Filter).Should().Equal(new[] { "%/Source" });
+    }
+
+    /// <summary>
+    /// 🚨 <c>scope:subtree</c> on a WILDCARD namespace must reach nodes nested BELOW the matched
+    /// namespace, exactly as it does for a concrete <c>namespace:A/B scope:subtree</c> (which walks
+    /// the path). It did not: the scope qualifier was parsed, stored — and then never consulted,
+    /// because the wildcard form produces a filter and only a Path is walked. So
+    /// <c>namespace:*/Source scope:subtree</c> silently returned only the Code nodes sitting
+    /// DIRECTLY in a <c>…/Source</c> folder.
+    ///
+    /// <para>That is the whole of the memex-cloud rollout stall: the batch bake's global source
+    /// fetch is this exact query, four NodeTypes referenced a shared source at
+    /// <c>…/Source/Fixtures/MtplClaimFixtures</c> — one level deeper — and the resulting PARTIAL
+    /// source set compiled to a convincing <c>CS0103</c> that the bake gate read as a regression.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("namespace:*/Source scope:subtree nodeType:Code")]
+    [InlineData("namespace:*/Source scope:descendants nodeType:Code")]
+    // The scope qualifier BEFORE the namespace must widen it too — the parser reads tokens in
+    // order, so this is the case a fix applied inline (rather than post-loop) would miss.
+    [InlineData("scope:subtree namespace:*/Source nodeType:Code")]
+    public void Parse_WildcardNamespace_WithSubtreeScope_ReachesNestedNamespaces(string query)
+    {
+        var result = _parser.Parse(query);
+
+        NamespaceLikePatterns(result.Filter).Should().Equal(
+            new[] { "%/Source", "%/Source/%" },
+            "scope:subtree on a wildcard namespace has no path to walk, so the only way it can "
+            + "reach a nested namespace is for the LIKE filter itself to cover self AND below");
+    }
+
+    /// <summary>The widened pair is an OR, not an AND — an AND would match NOTHING.</summary>
+    [Fact]
+    public void Parse_WildcardNamespace_WithSubtreeScope_CombinesTheTwoPatternsWithOr()
+    {
+        var result = _parser.Parse("namespace:*/Source scope:subtree nodeType:Code");
+
+        var or = FindNode<QueryOr>(result.Filter);
+        or.Should().NotBeNull("self-or-below is a disjunction; ANDing the two patterns is unsatisfiable");
+        NamespaceLikePatterns(or).Should().Equal(new[] { "%/Source", "%/Source/%" });
+    }
+
+    private static T? FindNode<T>(QueryNode? node) where T : QueryNode => node switch
+    {
+        T match => match,
+        QueryAnd a => a.Children.Select(FindNode<T>).FirstOrDefault(x => x is not null),
+        QueryOr o => o.Children.Select(FindNode<T>).FirstOrDefault(x => x is not null),
+        _ => null
+    };
+
+    #endregion
+
     #region Namespace Alternation (A|B|C exact membership — the agent / model registry union)
 
     private static QueryCondition? FindCondition(QueryNode? node, string selector) => node switch


### PR DESCRIPTION
Closes #1216 (the residual defect; PR #1220 fixed the first two mechanisms).

## The symptom, in production

memex-cloud `ci.2969`, gate armed, `PreWarm__BatchBake=true`. Batch bake itself works — 64 s for the
whole fleet against an 18 m 55 s activation-path baseline:

```
BatchBake: source discovery resolved 1691 Code node(s) into source sets for 237 pending type(s) in one pass
DynamicTypePreWarmer: warm-up complete in 00:01:03.97 —
  compiled=233 compileErrors=4 timedOut=0 skipped=0 contentBroken=0
```

But four types (`ReinsuranceDemo/SampleData`, `Claims/Claim`, `Claims/Enquiry`, `Claims/Register`)
failed on the same missing symbol, so the bake gate refused readiness and the rollout stalled:

```
CS0103: The name 'MtplClaimFixtures' does not exist in the current context
CS0246: The type or namespace name 'MtplClaimFixture' could not be found
```

`Claims/SampleData/Source/Fixtures/MtplClaimFixtures` exists (verified in the `claims` schema's
`code` table). All four types declare it as a **cross-partition shared source**:

```
ReinsuranceDemo/SampleData: ["namespace:Source scope:subtree",
                             "shared=@Reinsurance/DemoData/Source",
                             "shared=@Claims/SampleData/Source/Fixtures"]
Claims/Claim:               ["namespace:Source scope:subtree",
                             "shared=@Claims/Source",
                             "shared=@Claims/SampleData/Source"]
```

## The mechanism

`QueryParser.ExtractReservedQualifiers` (`src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs:511-521`
before this change): a **concrete** `namespace:A/B` becomes a `ParsedQuery.Path` + a `QueryScope`,
and every backend walks that path — so `scope:subtree` reaches any depth. A **wildcard**
`namespace:*/Source` cannot become a Path, so it is emitted as a `namespace LIKE '%/Source'`
filter — and `scope:subtree`, which only ever drove a **path** walk, was then silently dropped.

`namespace:*/Source scope:subtree` therefore matched only rows whose namespace *ends* in `/Source`:
Code nodes sitting directly in a `…/Source` folder, and nothing one level deeper. No error, no
warning, just a strictly narrower answer than the query asked for.

`NodeTypeBatchBake.GlobalCodeQueries` (`src/MeshWeaver.Hosting/NodeTypeBatchBake.cs:132`) is exactly
that query, and it is the **only** shape that reaches the per-schema `code` satellite table across
partitions (an unpinned `nodeType:Code` fans out over `mesh_nodes` only — that was #1220's second
half). `MtplClaimFixtures` has namespace `Claims/SampleData/Source/Fixtures`, so it was absent from
the global fetch; `IsInMemoryMatchable` (line 240) correctly classifies
`namespace:Claims/SampleData/Source/Fixtures scope:subtree nodeType:Code` as matchable, so the
matcher selected from a map that did not contain it and yielded a **partial** source set. Roslyn
then produced an entirely convincing CS0103, and the bake gate read the false CompileError as an
image regression.

A partial set is strictly worse than an empty one: #1220's emptiness invariant cannot see it,
because those types have plenty of *other* sources.

## The fix, and why at this altitude

`QueryParser` now widens a wildcard namespace under `scope:subtree` / `scope:descendants` into
`(namespace LIKE '%/X' OR namespace LIKE '%/X/%')` — deferred to after the token loop, because
`scope:` may appear *after* the `namespace:` token.

- It is the actual defect: `scope:subtree` on a wildcard namespace was **inert**, for every caller,
  with no diagnostic. The batch bake is simply the first caller to depend on it.
- It holds for every backend at once — Postgres, Snowflake, Cosmos and the in-memory evaluator all
  consume the same `ParsedQuery.Filter`.
- It restores the invariant `NodeTypeBatchBake`'s in-memory matching silently assumes: the global
  fetch is a **superset** of every matchable query's result.

The alternative proposed in the issue — re-running any matchable query that yields *nothing* from
the global fetch — was considered and **rejected as insufficient**, because a zero-yield trigger
cannot fire for three of the four production failures. `Claims/Claim`, `Claims/Enquiry` and
`Claims/Register` declare `shared=@Claims/SampleData/Source`, and nothing else naming the `Fixtures`
folder. That query DOES yield rows from the global fetch — the folder's direct children, which the
unfixed fetch can see — it is simply missing the nested file. Non-zero and incomplete: exactly the
case a zero-yield heal is blind to, the same blind spot as #1220's emptiness invariant one level
down. Only `ReinsuranceDemo/SampleData`, which names the `Fixtures` folder explicitly, would have
healed.

## Verification

New PG-backed regression test (`BatchBakeSourceDiscoveryScaleTests`, the two-partition harness from
#1220 — the in-memory Monolith adapter cannot see this class of bug at all, since its unbounded
`nodeType:Code` fetch covers everything). It reproduces the production shape: a type in partition A
whose sources include `shared=@B/SampleData/Source` **and** `shared=@B/SampleData/Source/Fixtures`,
with the fixture Code node nested one level below `Source`.

**Before the fix** — the activation path (partition-pinned, real path walk) resolves 3/3, the batch
resolves 2:

```
activation probe .../SampleData: 3/3
batch discovery: bbn2cef08441/SampleData=2 [bbn1ca92fe8e/SampleData/Source/Shared,
                                            bbn2cef08441/SampleData/Source/Spine]
Expected collection {...} to contain "bbn1ca92fe8e/SampleData/Source/Fixtures/MtplClaimFixtures"
Failed!  - Failed: 1, Passed: 0, Total: 1
```

**After the fix**: `Passed! - Failed: 0, Passed: 2, Total: 2`.

Also three parser-level tests pinning the semantics directly (including the scope-before-namespace
token order, and that the pair is an OR — an AND would be unsatisfiable), plus the unchanged
no-scope behaviour so the widening cannot quietly become the default.

Full suites, Release: `MeshWeaver.Query.Test` 368/368, `MeshWeaver.Hosting.PostgreSql.Test` and
`MeshWeaver.Hosting.Monolith.Test` green. Release `-warnaserror` clean for every touched project.

## Not fixed here (noted while investigating)

`QueryEvaluator.CompareWildcard` interprets `*` but not `%`, while the parser emits `%` patterns for
this LIKE. In-memory, a wildcard-namespace filter therefore matches nothing — harmless for the batch
bake (which takes only the Initial snapshot), but it does mean the PG fan-out's live relevance gate
cannot see a *new* row entering a `namespace:*/…` query. Pre-existing, unchanged by this PR, and
deserves its own change with its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
