### PR TITLE
fix(licensing): drop the dead AGPL package and gate dependency licences in CI

### DIFF
--- a/.github/scripts/check-licenses.py
+++ b/.github/scripts/check-licenses.py
@@ -76,11 +76,15 @@ ALLOWED_COMPOUND = {
 EXCEPTIONS = {
     # --- Known-incompatible, removal in flight. These are DEBT, not approvals. ---
     "questpdf": (
-        "VIOLATION, removal tracked by #1230. Dual-licensed: the Community tier is "
-        "free only below a revenue threshold, above which a paid commercial licence "
-        "is required. Cannot be deleted in isolation - the browser (Chromium) export "
-        "path does not yet render cover pages, TOC or running headers/footers, so the "
-        "deletion lands with the document-export migration. Delete this entry with it."
+        "VIOLATION, added 2026-08-11, removal tracked by #1230 and BLOCKED on it. "
+        "Dual-licensed: the Community tier is free only below a revenue threshold, "
+        "above which a paid commercial licence is required. It is not deletable today "
+        "for a hard reason: the intended replacement is the headless-Chromium renderer, "
+        "and Chromium is deliberately NOT in the deployed base image "
+        "(deploy/base-images/portal-ai/Dockerfile), so removing QuestPDF now would "
+        "leave the portal with NO PDF renderer at all. Sequence: #1222 -> #1234 -> a "
+        "base-image decision on shipping Chromium -> this removal. Delete this entry "
+        "with it; until then the exception is dated debt, not an approval."
     ),
     "jsonpatch.net": (
         "Open Source Maintenance Fee (OSMFEULA.txt); decision tracked by #1231. The "

--- a/.github/scripts/check-licenses.py
+++ b/.github/scripts/check-licenses.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Licence gate: fail RED when a NuGet dependency carries a licence that is not
+compatible with shipping MeshWeaver under Apache-2.0 / MIT.
+
+MeshWeaver is dual-licensed Apache-2.0 / MIT and is distributed as a
+network-served product. That makes two whole licence families unacceptable:
+
+  * copyleft (AGPL / GPL / LGPL) - viral for a network-served product, and
+  * pay-to-use (a "community" tier that becomes a paid licence above a revenue
+    threshold, or a maintenance fee attached to the published binary).
+
+Both families are easy to add by accident: a single `<PackageVersion>` line is
+all it takes, the compiler never complains, and nothing else in CI looks at
+licence metadata. This gate is what makes that regression loud.
+
+It resolves the licence for every package in the RESTORED dependency graph -
+direct AND transitive - from the .nuspec in the local NuGet cache, because a
+copyleft dependency that arrives transitively binds us exactly as hard as one
+we declared ourselves.
+
+Usage:
+    dotnet restore MeshWeaver.slnx
+    python3 .github/scripts/check-licenses.py            # gate: exit 1 on violation
+    python3 .github/scripts/check-licenses.py --report   # print the full table
+
+This script NEVER skips. It has no "if the cache is missing, pass" branch: an
+unresolvable licence is reported as a violation, because a gate that goes green
+on absent evidence is worse than no gate at all (AGENTS.md: "A gate NEVER tests
+its own inputs - no skip-trapdoors").
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# ---------------------------------------------------------------------------
+# Allowlist: SPDX expressions compatible with shipping under Apache-2.0 / MIT.
+# Permissive only. Adding an entry here is a licensing decision - not a way to
+# make the build green.
+# ---------------------------------------------------------------------------
+ALLOWED_LICENSES = {
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSD",  # licence FILE that is recognisably BSD but names no clause count
+    "ISC",
+    "0BSD",
+    "Unlicense",
+    "public-domain",
+    "MS-PL",
+    "PostgreSQL",
+    "MICROSOFT-NET-LIBRARY",  # ms-net-library: permissive redistribution
+}
+
+# Compound expressions we accept because at least one disjunct is allowed.
+ALLOWED_COMPOUND = {
+    "MS-PL OR Apache-2.0",
+    "Apache-2.0 OR MIT",
+    "MIT OR Apache-2.0",
+}
+
+# ---------------------------------------------------------------------------
+# Exceptions: packages allowed DESPITE unresolvable or non-SPDX metadata.
+# Every entry needs a reason. This list is deliberately short and reviewed.
+# ---------------------------------------------------------------------------
+EXCEPTIONS = {
+    # --- Known-incompatible, removal in flight. These are DEBT, not approvals. ---
+    "questpdf": (
+        "VIOLATION, removal tracked by #1230. Dual-licensed: the Community tier is "
+        "free only below a revenue threshold, above which a paid commercial licence "
+        "is required. Cannot be deleted in isolation - the browser (Chromium) export "
+        "path does not yet render cover pages, TOC or running headers/footers, so the "
+        "deletion lands with the document-export migration. Delete this entry with it."
+    ),
+    "jsonpatch.net": (
+        "Open Source Maintenance Fee (OSMFEULA.txt); decision tracked by #1231. The "
+        "SOURCE is MIT and the EULA states the fee is not a licence fee and that the "
+        "OSI licence governs on conflict - so this is a fee expectation on the "
+        "published binary, not a licence breach. Core dependency: the RFC 7396 "
+        "merge-patch path behind every cross-hub stream.Update."
+    ),
+    "jsonpath.net": ("Open Source Maintenance Fee; see jsonpatch.net above and #1231."),
+    "json.more.net": ("Transitive under the json-everything family; see #1231."),
+    "jsonpointer.net": ("Transitive under the json-everything family; see #1231."),
+    # --- Permissive upstream, metadata simply absent from the package. ---
+    "uglytoad.pdfpig": (
+        "Apache-2.0 upstream (github.com/UglyToad/PdfPig). The 1.7.0-custom-* "
+        "build on nuget.org ships no <license> element, so the expression "
+        "cannot be resolved from metadata; the source licence is Apache-2.0."
+    ),
+    "uglytoad.pdfpig.core": ("Apache-2.0 upstream, same custom build as UglyToad.PdfPig."),
+    "uglytoad.pdfpig.fonts": ("Apache-2.0 upstream, same custom build as UglyToad.PdfPig."),
+    "uglytoad.pdfpig.tokenization": ("Apache-2.0 upstream, same custom build as UglyToad.PdfPig."),
+    "uglytoad.pdfpig.tokens": ("Apache-2.0 upstream, same custom build as UglyToad.PdfPig."),
+}
+
+# ---------------------------------------------------------------------------
+# Licence-body classifiers, for packages that ship a licence FILE rather than an
+# SPDX expression. Ordered: the disqualifying patterns are tested first so a
+# copyleft or pay-to-use notice can never be mistaken for the permissive grant
+# that such files usually also contain.
+# ---------------------------------------------------------------------------
+DENY_PATTERNS = [
+    ("AGPL-3.0", ("gnu affero general public license", "affero general public")),
+    ("GPL", ("gnu general public license",)),
+    ("LGPL", ("gnu lesser general public license",)),
+    (
+        "OSMF-maintenance-fee",
+        ("open source maintenance fee", "in exchange for a maintenance fee"),
+    ),
+    (
+        "dual-commercial",
+        (
+            "community license",
+            "professional license",
+            "enterprise license",
+            "commercial license is required",
+        ),
+    ),
+]
+
+ALLOW_PATTERNS = [
+    ("MIT", ("permission is hereby granted, free of charge", "mit license")),
+    ("Apache-2.0", ("apache license", "www.apache.org/licenses/license-2.0")),
+    ("BSD", ("redistribution and use in source and binary forms",)),
+    ("MS-PL", ("microsoft public license", "ms-pl")),
+    ("MICROSOFT-NET-LIBRARY", ("microsoft .net library",)),
+    ("public-domain", ("public domain",)),
+]
+
+# licenseUrl hosts that identify a known-permissive first-party licence. Legacy
+# packages predate the SPDX <license> element and carry only a URL.
+LICENSE_URL_MAP = [
+    ("github.com/dotnet/", "MIT"),
+    ("github.com/aspnet/", "Apache-2.0"),
+    ("apache.org/licenses/license-2.0", "Apache-2.0"),
+    ("opensource.org/licenses/mit", "MIT"),
+    ("licenses.nuget.org/mit", "MIT"),
+]
+
+
+def nuget_cache() -> str:
+    return os.environ.get(
+        "NUGET_PACKAGES", os.path.join(os.path.expanduser("~"), ".nuget", "packages")
+    )
+
+
+def classify_body(body: str) -> str:
+    """Classify a licence FILE body. Deny patterns win over allow patterns."""
+    low = body.lower()
+    for name, needles in DENY_PATTERNS:
+        if any(n in low for n in needles):
+            return name
+    for name, needles in ALLOW_PATTERNS:
+        if any(n in low for n in needles):
+            return name
+    return "UNKNOWN"
+
+
+def resolve_license(pid: str, version: str) -> str:
+    """Resolve a package's licence from the .nuspec in the local NuGet cache."""
+    pdir = os.path.join(nuget_cache(), pid.lower())
+    if not os.path.isdir(pdir):
+        return "UNRESOLVED(not-restored)"
+    candidates = [version] + sorted(os.listdir(pdir), reverse=True)
+    for ver in candidates:
+        nuspec = os.path.join(pdir, ver, pid.lower() + ".nuspec")
+        if not os.path.isfile(nuspec):
+            continue
+        try:
+            meta = ET.parse(nuspec).getroot().find(".//{*}metadata")
+        except ET.ParseError:
+            continue
+        if meta is None:
+            continue
+        lic = meta.find("{*}license")
+        if lic is not None and lic.text:
+            text = lic.text.strip()
+            if lic.get("type") == "file":
+                path = os.path.join(pdir, ver, text.replace("\\", "/"))
+                body = ""
+                if os.path.isfile(path):
+                    with open(path, encoding="utf-8", errors="ignore") as handle:
+                        body = handle.read()
+                return classify_body(body)
+            return text
+        url = meta.find("{*}licenseUrl")
+        if url is not None and url.text:
+            low = url.text.strip().lower()
+            for needle, resolved in LICENSE_URL_MAP:
+                if needle in low:
+                    return resolved
+            return "UNRESOLVED(url-only)"
+        return "UNRESOLVED(no-license-element)"
+    return "UNRESOLVED(no-nuspec)"
+
+
+def declared_packages() -> dict[str, tuple[str, str]]:
+    """Packages declared in central package management."""
+    path = os.path.join(REPO_ROOT, "Directory.Packages.props")
+    with open(path, encoding="utf-8") as handle:
+        content = handle.read()
+    found = re.findall(r'<PackageVersion\s+Include="([^"]+)"\s+Version="([^"]+)"', content)
+    return {pid.lower(): (pid, ver) for pid, ver in found}
+
+
+def restored_packages() -> dict[str, tuple[str, str]]:
+    """Every package in the restored graph - direct and transitive."""
+    packages: dict[str, tuple[str, str]] = {}
+    pattern = os.path.join(REPO_ROOT, "**", "obj", "project.assets.json")
+    for assets in glob.glob(pattern, recursive=True):
+        # Skip nested agent worktrees (.claude/worktrees/*), which carry their own
+        # copy of the tree. Tested RELATIVE to the repo root, because the repo root
+        # itself may legitimately sit under a .claude/worktrees path.
+        relative = os.path.relpath(assets, REPO_ROOT)
+        if relative.startswith(".claude" + os.sep):
+            continue
+        try:
+            with open(assets, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+        for target in data.get("targets", {}).values():
+            for key, meta in target.items():
+                if meta.get("type") != "package":
+                    continue
+                pid, _, ver = key.partition("/")
+                packages[pid.lower()] = (pid, ver)
+    return packages
+
+
+def is_allowed(license_id: str) -> bool:
+    if license_id in ALLOWED_LICENSES or license_id in ALLOWED_COMPOUND:
+        return True
+    # Accept an SPDX OR-expression when any disjunct is allowed.
+    if " OR " in license_id:
+        return any(part.strip().strip("()") in ALLOWED_LICENSES for part in license_id.split(" OR "))
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", action="store_true", help="print the full licence table")
+    args = parser.parse_args()
+
+    declared = declared_packages()
+    restored = restored_packages()
+
+    if not restored:
+        print(
+            "LICENCE GATE FAILED: no project.assets.json found. Run "
+            "`dotnet restore MeshWeaver.slnx` before this gate - it resolves licences "
+            "from the restored graph and must never pass on absent evidence.",
+            file=sys.stderr,
+        )
+        return 1
+
+    everything: dict[str, tuple[str, str]] = dict(restored)
+    for key, value in declared.items():
+        everything.setdefault(key, value)
+
+    rows = []
+    for key in sorted(everything):
+        pid, ver = everything[key]
+        license_id = resolve_license(pid, ver)
+        if key in declared and key in restored:
+            scope = "direct"
+        elif key in declared:
+            scope = "declared-unused"
+        else:
+            scope = "transitive"
+        rows.append((pid, ver, license_id, scope, key))
+
+    # A violation is a package that actually SHIPS - i.e. one NuGet resolved into a
+    # project's dependency graph. A `<PackageVersion>` line that no project
+    # references restores nothing, is downloaded by nobody and is redistributed in
+    # no image, so it carries no licence obligation; it is dead configuration, and
+    # reported as such rather than failed on. (itext7 was exactly this: an AGPL
+    # declaration that had never once been resolved.)
+    violations = [
+        row
+        for row in rows
+        if row[3] != "declared-unused"
+        and not is_allowed(row[2])
+        and row[4] not in EXCEPTIONS
+    ]
+    dead = [row for row in rows if row[3] == "declared-unused"]
+
+    if args.report:
+        width = max(len(r[0]) for r in rows) + 2
+        for pid, ver, license_id, scope, key in rows:
+            if scope == "declared-unused":
+                flag = ". "
+            elif key in EXCEPTIONS:
+                flag = "~ "
+            elif not is_allowed(license_id):
+                flag = "X "
+            else:
+                flag = "  "
+            print(f"{flag}{pid.ljust(width)}{ver.ljust(22)}{license_id.ljust(30)}{scope}")
+        shipping = len(rows) - len(dead)
+        print(
+            f"\n{len(rows)} packages ({shipping} shipping, {len(dead)} declared-unused), "
+            f"{len(violations)} violations"
+        )
+        print("Legend: X violation   ~ documented exception   . declared but never restored")
+
+    if violations:
+        print("\nLICENCE GATE FAILED - dependencies incompatible with Apache-2.0 / MIT:\n", file=sys.stderr)
+        for pid, ver, license_id, scope, _ in violations:
+            print(f"  {pid} {ver} [{scope}] -> {license_id}", file=sys.stderr)
+        print(
+            "\nMeshWeaver ships under Apache-2.0 / MIT. A copyleft (AGPL/GPL/LGPL) or "
+            "pay-to-use dependency is a licensing defect, not a preference.\n"
+            "Remove the package, replace it with a permissively-licensed one, or - if "
+            "the metadata is simply missing and the upstream licence IS permissive - add "
+            "it to EXCEPTIONS in this script WITH a reason.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # A green run still prints the outstanding exceptions. An exception is tracked
+    # debt, not an approval, and a gate that hides its own carve-outs on success
+    # lets them become permanent silently.
+    shipping = len(rows) - len(dead)
+    carried = sorted(key for _, _, _, scope, key in rows if key in EXCEPTIONS and scope != "declared-unused")
+    print(f"Licence gate passed: {shipping} shipping packages checked ({len(dead)} declared-unused ignored).")
+    if carried:
+        print(f"\n{len(carried)} documented exception(s) still carried - each is tracked debt, not an approval:")
+        for key in carried:
+            print(f"  - {key}: {EXCEPTIONS[key]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -907,13 +907,51 @@ jobs:
           exit "$status"
         fi
 
+  licence-gate:
+    name: "Dependency licences"
+    # MeshWeaver ships dual-licensed Apache-2.0 / MIT. A copyleft (AGPL/GPL/LGPL) or
+    # pay-to-use dependency is a licensing DEFECT — and it is invisible to every other
+    # check we run: one `<PackageVersion>` line adds it, the compiler is happy, and the
+    # tests are happy. #1230 (QuestPDF, pay-to-use above a revenue threshold) and a dead
+    # AGPL `itext7` declaration both sat in the tree unnoticed until a manual audit.
+    #
+    # 🚨 NO `continue-on-error`, and NO input-shaped `if:`. This gate reads only the repo
+    # and the public NuGet feed — it needs no secret, so it has no legitimate reason to be
+    # skipped and no fork exemption. It runs on every PR including forks.
+    needs: [precheck]
+    # Mirrors `build`: the ONLY thing that skips this is the already-green-tree
+    # optimisation, which means this exact tree already passed this exact gate.
+    if: ${{ !cancelled() && needs.precheck.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    # ⏱️ Depends only on `precheck`, so it runs CONCURRENTLY with the build and the test
+    # shards and costs the PR no wall-clock. It restores (not builds) the solution, which
+    # is what produces the project.assets.json graph it reads.
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v6
+      with: { fetch-depth: 1 }
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+    # The gate resolves licences from the RESTORED graph — direct and transitive — because a
+    # copyleft dependency that arrives transitively binds us exactly as hard as a declared one.
+    # No `continue-on-error`: if the restore fails, the gate has no evidence, and a gate that
+    # passes on absent evidence is worse than no gate (the script fails closed on this too).
+    # Same invocation as the `build` job's restore step, so the graph this gate reads is the
+    # same graph CI actually builds and ships.
+    - name: Restore (produces the dependency graph the gate reads)
+      run: dotnet restore
+    - name: Check dependency licences
+      run: python3 .github/scripts/check-licenses.py --report
+
   collect-results:
     name: "Consolidate test results"
     # plugin-gate is a NEEDS so this required check cannot go green while the plugins are
     # broken by this PR — that is the whole point of the gate (see its step below). preflight
     # is a NEEDS for the same reason one level up: this job is the repo's ONLY required status
-    # check, so anything that must block a merge has to be able to fail it.
-    needs: [precheck, preflight, build, test, plugin-gate]
+    # check, so anything that must block a merge has to be able to fail it. licence-gate is a
+    # NEEDS on the same principle: a licensing defect must be able to block a merge.
+    needs: [precheck, preflight, build, test, plugin-gate, licence-gate]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1107,6 +1145,17 @@ jobs:
             echo "::error::A failing 'compile' check means a public API change here broke plugin node source that is Roslyn-compiled at runtime from the plugins repo."
             ;;
         esac
+        exit 1
+
+    # ── …and a licensing defect decides it too ──────────────────────────────────────────────
+    # 🚨 `needs:` alone is NOT enough under `if: always()` — same lesson as the step above. A
+    # dependency licence that is incompatible with shipping under Apache-2.0 / MIT must be able
+    # to turn the repo's ONLY required status check RED, or the gate is decorative.
+    - name: Fail if the licence gate failed
+      if: needs.licence-gate.result == 'failure'
+      run: |
+        echo "::error::A dependency licence is incompatible with shipping MeshWeaver under Apache-2.0 / MIT — see the 'Dependency licences' job for the offending package(s) and their licence."
+        echo "::error::Fix it by removing the package or replacing it with a permissively-licensed one. Do NOT add it to EXCEPTIONS unless the upstream licence genuinely IS permissive and only the package metadata is missing."
         exit 1
 
     # ── …and a missing CI INPUT decides it too ──────────────────────────────────────────────

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,6 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.71.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageVersion Include="itext7" Version="9.6.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="JsonPatch.Net" Version="5.0.3" />
     <PackageVersion Include="JsonPath.Net" Version="3.0.2" />

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -79,6 +79,7 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 | **Testing & debugging** | [Writing Tests](WritingTests) | [Negative Controls](NegativeControls) — a pin is only a pin if it fails against the defect · [Reactive Test Assertions](ReactiveTestAssertions) · [Test State Isolation](TestStateIsolation) · [Disposable-mesh e2e](DisposableMeshE2E) · [Debugging Message Flow](DebuggingMessageFlow) · [Debugging Disposal & Leaks](DebuggingDisposalAndLeaks) |
 | **Deployment & ops** | [Deployment](Deployment) (the router) | [AKS](DeploymentAKS) · [Container Apps](DeploymentContainerApps) · [Local Dev Workflow](LocalDevWorkflow) · [Onboarding a New Environment](OnboardingNewEnvironment) · [Release & Self-Update Strategy](ReleaseStrategy) · [The Continuous Delivery Contract](ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick · [Release Process](ReleaseProcess) · [Red-Log Watching & Ticketing](LogWatchTriage) — every `fail:`/`crit:` becomes exactly one triaged issue |
 | **Contributing docs** | [Authoring Documentation](AuthoringDocumentation) | [Specifying Software](SpecifyingSoftware) · [Glossary](/Doc/Glossary) |
+| **Licensing** | [Dependency Licensing](DependencyLicensing) — Apache-2.0/MIT compatible only; the CI gate that enforces it | |
 
 ## Getting started
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DependencyLicensing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DependencyLicensing.md
@@ -1,0 +1,102 @@
+# Dependency Licensing
+
+MeshWeaver is open source, dual-licensed **Apache-2.0 / MIT**, and is distributed
+both as NuGet packages and as a network-served product. Two families of
+dependency licence are therefore incompatible with shipping it, and adding one is
+a **defect**, not a preference:
+
+| Family | Why it is incompatible |
+|---|---|
+| **Copyleft** — AGPL, GPL, LGPL | Viral. AGPL in particular reaches a network-served product: serving the portal over HTTP is "conveying" for AGPL purposes, so it would attempt to impose its terms on MeshWeaver itself. |
+| **Pay-to-use** — a "community" tier that becomes a paid licence above a revenue threshold, or a fee attached to the published binary | An open-source product cannot carry a dependency its users must pay to run. |
+
+## Why this needs a gate
+
+A licence is added by **one line** in `Directory.Packages.props`. The compiler
+never complains, no test fails, and no other check in CI looks at licence
+metadata. A licensing problem is therefore completely silent — it can sit in the
+tree indefinitely and first surface in a legal review.
+
+It already had. An audit in August 2026 found an **AGPL-licensed `itext7`
+declaration** in central package management. It had never been resolved into any
+project's dependency graph, so nothing shipped with it — but nothing in the build
+would have said so either way, and the same line with a `PackageReference`
+beside it would have shipped AGPL code into every portal image.
+
+## The gate
+
+`.github/scripts/check-licenses.py`, run by the **`Dependency licences`** job in
+`dotnet-test.yml`. It:
+
+1. restores the solution, then reads every package in the **restored dependency
+   graph** from the `project.assets.json` files — **direct and transitive**,
+   because a copyleft library that arrives indirectly binds the product exactly
+   as hard as one we chose ourselves;
+2. resolves each package's licence from the `.nuspec` in the NuGet cache — the
+   SPDX `<license>` expression where present, otherwise by classifying the
+   licence **file** the package ships;
+3. fails RED, naming each offending package and its licence.
+
+### What counts as a violation
+
+Only packages that **actually ship**. A `<PackageVersion>` line that no project
+references restores nothing, is downloaded by nobody, and is redistributed in no
+image — it is dead configuration, reported but not failed on. (`itext7` was
+exactly this.) The audit found ~41 such dead declarations.
+
+### The allowlist
+
+Permissive only: `MIT`, `MIT-0`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`,
+`ISC`, `0BSD`, `Unlicense`, `MS-PL`, `PostgreSQL`, public domain, and the
+Microsoft .NET Library licence. An SPDX `OR` expression passes when any disjunct
+is allowed (e.g. `MS-PL OR Apache-2.0`).
+
+**Adding an entry to the allowlist is a licensing decision — never a way to make
+a build green.**
+
+### Classifying licence files
+
+Many packages ship a licence *file* instead of an SPDX expression. The classifier
+tests **disqualifying patterns first**: a licence file that grants MIT-style
+permissions *and* mentions the Affero GPL is classified AGPL, not MIT. This
+ordering matters — dual-licensed and relicensed packages routinely contain the
+permissive text alongside the restrictive terms, and matching the permissive text
+first is how a copyleft dependency slips through.
+
+### Exceptions
+
+`EXCEPTIONS` in the script names packages allowed despite a non-allowlisted or
+unresolvable result. **Every entry carries a written reason**, and there are only
+two legitimate kinds:
+
+- **The upstream licence genuinely is permissive and only the package metadata is
+  missing** — e.g. the `UglyToad.PdfPig` custom build ships no `<license>`
+  element while upstream is Apache-2.0.
+- **Tracked debt**: a known-incompatible package whose removal is in flight, with
+  the issue that removes it. An exception of this kind is **not an approval**, and
+  a passing run still prints it so it cannot quietly become permanent.
+
+## Gate shape
+
+Per the repo's no-skip-trapdoor rule (`AGENTS.md` → "A gate NEVER tests its own
+inputs"), this gate:
+
+- carries **no `continue-on-error`** and **no input-shaped `if:`**. It reads only
+  the repo and the public NuGet feed, so it needs no secret, has no legitimate
+  reason to be skipped, and has **no fork exemption** — it runs on fork PRs too;
+- **fails closed on missing evidence**. If no dependency graph is found, or a
+  licence cannot be resolved, that is a failure — a gate that passes on absent
+  evidence is worse than no gate at all;
+- is wired into `collect-results` (the repo's only required status check) with an
+  **explicit fail step**, because `needs:` alone does not fail an `always()` job.
+
+## Running it locally
+
+```bash
+dotnet restore MeshWeaver.slnx
+python3 .github/scripts/check-licenses.py            # the gate
+python3 .github/scripts/check-licenses.py --report   # the full table
+```
+
+The report marks each package: `X` violation, `~` documented exception, `.`
+declared but never restored.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-dependency-licences-checked-in-ci.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-dependency-licences-checked-in-ci.md
@@ -1,0 +1,38 @@
+---
+Name: Dependency licences are checked on every build
+Category: Fix
+Description: A dead AGPL package declaration is gone, and CI now fails when a dependency's licence is incompatible with shipping MeshWeaver under Apache-2.0 / MIT.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Dependency licences are checked on every build
+
+MeshWeaver is open source, dual-licensed Apache-2.0 / MIT. That makes two whole
+families of dependency unacceptable: copyleft licences (AGPL / GPL / LGPL), which
+are viral for a network-served product, and pay-to-use licences, where a
+"community" tier turns into a paid one above a revenue threshold.
+
+Nothing checked for either. A licence is added by a single line in the package
+list, the compiler is perfectly happy with it, and every test still passes — so a
+licensing problem could sit in the tree indefinitely without anyone noticing. One
+had: an **AGPL-licensed PDF library was declared in the package list** and had
+been for some time. It turned out never to have been resolved into any project,
+so nothing shipped with it, but nothing would have told us either way.
+
+An audit of all 432 packages in the dependency graph — direct *and* transitive —
+now backs three changes:
+
+- The dead AGPL declaration is **deleted**.
+- **CI fails** when any package in the restored graph carries a licence that is
+  not on a documented permissive allowlist (MIT, Apache-2.0, BSD, ISC, MS-PL and
+  friends). It reads the real licence from each package's own metadata, and it
+  covers transitive dependencies, because a copyleft library that arrives
+  indirectly binds the product exactly as hard as one we chose ourselves.
+- The two packages that do carry non-permissive terms are recorded as **tracked
+  exceptions with a written reason and a linked issue**, so they stay visible
+  instead of quietly becoming permanent. Each is being removed.
+
+The check has no way to skip itself: it needs no credential, it runs on every
+pull request including forks, and if it cannot resolve a licence it fails rather
+than assuming the best.


### PR DESCRIPTION
MeshWeaver ships dual-licensed **Apache-2.0 / MIT**. A copyleft or pay-to-use dependency is therefore a licensing **defect**, and nothing in the build checked for one: a licence is added by a single line in `Directory.Packages.props`, the compiler is happy, and every test still passes.

This audits all **432 packages** in the dependency graph — direct *and* transitive — deletes the one free win, and adds a gate so it cannot regress silently.

## What the audit found

| | Package(s) | Licence | Verdict |
|---|---|---|---|
| 🔴 | **`itext7` 9.6.0** | **AGPL-3.0** or paid commercial | **Deleted in this PR** |
| 🔴 | `QuestPDF` 2026.7.2 | dual: Community free only below a revenue threshold, else paid | Tracked exception → **#1230** |
| 🟠 | `JsonPatch.Net`, `JsonPath.Net`, `Json.More.Net`, `JsonPointer.Net` | **Open Source Maintenance Fee** EULA | Needs a decision → **#1231** |
| 🟡 | `UglyToad.PdfPig` (+4 sub-packages) | no `<license>` element at all | Documented exception (Apache-2.0 upstream) |
| 🟢 | everything else | MIT ×290, Apache-2.0 ×75, BSD ×10, PostgreSQL ×3, MS-PL, public domain | fine |

Spot-checked and clean, as expected: `Radzen.Blazor` (MIT — the component library, not the commercial IDE), `DocSharp.Markdown`, `BlazorMonaco`, `ClaudeAgentSdk`, `CSharpVitamins.ShortGuid`, `CommunityToolkit.Maui`, `akgul.Maui.DataGrid`, `LiveChartsCore` (all MIT); `Appium.WebDriver`, `Castle.Core`, `ModelContextProtocol*`, `SQLitePCLRaw` managed (Apache-2.0); `SQLitePCLRaw.lib.e_sqlite3` (SQLite, public domain).

### `itext7` was dead configuration

It is **AGPL-3.0-or-commercial** — the more serious of the two, since AGPL is viral for a network-served product. It turned out to have **no `PackageReference` anywhere**: not in any `.csproj`/`.props`/`.targets`, no `using iText`, no `#r "nuget:"` directive, and nothing in the in-mesh C# that `dotnet build` cannot see (node JSON, `.csx` templates, `configuration` lambdas). Decisively, **no `project.assets.json` contains an `itext7/9.6.0` library entry** — it appears only inside `centralPackageVersions`, a verbatim echo of the declaration. It was never resolved, never downloaded, never shipped.

So deleting it was free. But nothing would have told us either way, which is the actual problem this PR fixes.

### `QuestPDF` — removal is real work, not a line deletion

Per the user's decision it is being dereferenced (not licensed, not swapped for another restrictive package); PDF rendering moves to the browser via the existing MIT/Playwright `Pixel/HeadlessChromiumPdfRenderer`. Its footprint is small — one renderer (`Pdf/PdfDocumentRenderer.cs`, 368 lines), one licence-acceptance line, one `PackageReference` — but it **cannot be deleted in isolation today**: `ExportPdf.csx:193-196` falls back to QuestPDF for every non-Deck node, and the Chromium path has no cover page, TOC, running header/footer or page-break rules (`PixelFaithfulExport.md:70`).

Deleting it now would be a functional regression, not a cleanup, so it lands with the document-export migration — **#1230**, coordinated with the agent doing that work. This PR touches **no file** under `src/MeshWeaver.Markdown.Export`.

### `json-everything` — a decision, not a bug

Four packages carry `OSMFEULA.txt`. This is **not** the QuestPDF shape and the difference matters: the **source is MIT**, the EULA says explicitly *"The Fee is not a license fee"*, and *"the OSI License shall govern"* on conflict. It is a maintenance-fee expectation on the published binary for revenue-generating users ≥ US$10,000/yr. `JsonPatch.Net` also implements the RFC 7396 merge-patch path behind every cross-hub `stream.Update`, so replacing it touches the core mutation API. Raised as **#1231** rather than decided unilaterally.

## The gate

`.github/scripts/check-licenses.py`, run by the new **`Dependency licences`** job.

- Reads the **restored graph** (`project.assets.json`), so **transitive** dependencies are covered — a copyleft library that arrives indirectly binds us just as hard. It caught the `json-everything` transitives (`Json.More.Net`, `JsonPointer.Net`) that a declared-packages-only check would have missed.
- Resolves each licence from the package's own `.nuspec` — SPDX expression, else by classifying the licence **file**. **Deny patterns are tested first**: a file granting MIT-style permissions that *also* mentions the Affero GPL classifies as AGPL. That ordering is the difference between catching a relicensed package and waving it through.
- **A violation is only something that actually ships.** A `<PackageVersion>` no project references restores nothing and is redistributed nowhere — dead config, reported but not failed on. There are **40** such entries (this is what `itext7` was).

### Gate shape (AGENTS.md)

- **No `continue-on-error`, no input-shaped `if:`.** It needs no secret, so it has no legitimate skip and **no fork exemption** — it runs on fork PRs too.
- **Fails closed on absent evidence**: no dependency graph, or an unresolvable licence, is a *failure*.
- Wired into `collect-results` (the only required check) with an **explicit fail step**, because `needs:` alone does not fail an `always()` job.
- Exceptions carry a **written reason and a tracking issue**, and a *passing* run still prints them, so tracked debt cannot quietly become permanent.

**Verified the gate actually fails** — a gate that cannot fail is decorative. With `EXCEPTIONS` cleared it exits 1 and names all 5 violations; classification was checked against real AGPL/GPL/LGPL/OSMF/dual-commercial/MIT/Apache texts, including the MIT-text-inside-an-AGPL-file trap.

## Verification

- `dotnet restore` clean after the `itext7` removal (a missing `PackageVersion` for a referenced package is a restore error, so this is the real proof nothing referenced it).
- `dotnet build src/MeshWeaver.Documentation -c Release -warnaserror` clean.
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` pass.
- Gate green on this tree; proven red without its exceptions.

Docs: `Doc/Architecture/DependencyLicensing` (policy, allowlist, exception rules). What's New entry included (`Category: Fix`).

Follow-ups: **#1230** (remove QuestPDF), **#1231** (decide json-everything). Each closes by deleting its `EXCEPTIONS` entry, at which point the gate enforces it permanently.
