### PR TITLE
A refused cross-hub write was dropped, not re-applied — the owner had said to re-apply

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -103,9 +103,10 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     // not a detached hub.Observe subscription.
     private static readonly TimeSpan UpdateResponseWaitBound = TimeSpan.FromSeconds(2);
 
-    // 🚨 Retry budget for the ONE provably-safe late-NACK case (OwnerDisposing — the owner
-    // stated the patch NEVER applied). Each re-enqueue re-runs the ORIGINAL update lambda
-    // against the freshest state and re-diffs, so a superseding write makes it a no-op;
+    // 🚨 Retry budget for the provably-safe NACK cases — the ones where the owner STATED the
+    // patch never applied: OwnerDisposing, OwnerNotReady, and Conflict. Each re-enqueue re-runs
+    // the ORIGINAL update lambda against the freshest state and re-diffs, so a superseding write
+    // makes it a no-op;
     // two re-enqueues cover a re-enqueue that itself lands on a disposing fresh activation
     // (recycle churn). NEVER retried: silence (a busy owner still applies the original
     // patch) and every other NACK code (validation/RLS/NotFound are terminal verdicts).
@@ -1078,9 +1079,12 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                     resp.Error ?? "Update rejected by owner");
                                 // OwnerNotReady carries the same provably-never-applied contract
                                 // as OwnerDisposing (activation had not loaded its state — #667),
-                                // so the same idempotent re-enqueue applies.
+                                // so the same idempotent re-enqueue applies — and so does Conflict,
+                                // which the owner emits only when nothing landed (see the primary
+                                // rejection site for the concurrent-writer data loss it caused).
                                 if (lateErr.Code is MeshNodeErrorCode.OwnerDisposing
                                         or MeshNodeErrorCode.OwnerNotReady
+                                        or MeshNodeErrorCode.Conflict
                                     && attempt < MaxOwnerDisposingReenqueues)
                                 {
                                     diagLogger?.LogWarning(
@@ -1156,8 +1160,28 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                             // (the re-diff against the freshest state makes it
                                             // idempotent), chaining its outcome to THIS caller.
                                             // Every other code stays a fail-fast terminal.
+                                            // 🚨 Conflict belongs to this set, and dropping it
+                                            // was silent data loss. The owner emits Conflict ONLY
+                                            // when the merge refused keys AND the node is
+                                            // byte-identical to its pre-merge state — i.e. nothing
+                                            // landed — and its own message says "re-read and
+                                            // re-apply". Nobody did: the write was surfaced as a
+                                            // terminal error and the caller's change vanished.
+                                            // That is exactly what stream.Update promises NOT to
+                                            // do; concurrent writers are supposed to coalesce.
+                                            // Re-enqueueing re-runs the update lambda against the
+                                            // owner's current state, which IS the re-read-and-
+                                            // re-apply the owner asked for.
+                                            //
+                                            // Measured: 5 concurrent TrackActivity calls, 4
+                                            // increments (UserActivityTrackingTests
+                                            // .TrackActivity_ConcurrentSamePath_DoesNotRaceAlreadyExists,
+                                            // CI shard 1) — one writer composed against a base the
+                                            // other four had already moved, was refused, and its
+                                            // increment was thrown away.
                                             if (err.Code is MeshNodeErrorCode.OwnerDisposing
                                                     or MeshNodeErrorCode.OwnerNotReady
+                                                    or MeshNodeErrorCode.Conflict
                                                 && attempt < MaxOwnerDisposingReenqueues)
                                             {
                                                 diagLogger?.LogWarning(


### PR DESCRIPTION
`stream.Update`'s contract is that concurrent writers **coalesce**: each folds its change onto the
owner's current state and none is lost. A write the owner refused with `Conflict` broke that
silently.

The owner emits `Conflict` in exactly one situation — the merge refused keys **and** the node is
byte-identical to its pre-merge state, i.e. *nothing landed* — and its message says so in words:

> cross-hub write refused: N field(s) changed on the owner since the writer's base and nothing was
> applied — **re-read and re-apply**

Nobody re-read and nobody re-applied. `UpdateRemote` logged `OWNER_REJECTED` and called
`observer.OnError`, so the caller's change was gone. Callers of a coalescing API don't carry retry
loops — coalescing is the thing they were promised.

## The fix

`Conflict` joins the same provably-never-applied set as `OwnerDisposing`/`OwnerNotReady`, which
already re-enqueue two lines above: the original update lambda re-runs against the owner's freshest
state and re-diffs — which *is* the re-read-and-re-apply the owner asked for, and is idempotent
because a superseding write makes the re-diff a no-op. Same bounded budget (2), both rejection sites.

## Evidence

From the `.trx` of CI run 31517983312, shard 1:

```
ENTER: 5   DONE: 4
UpdateQueue: ENQUEUE 4, START 4, LOCAL_EMIT 3, COMPLETE 3, FAILED 1
[UpdateRemote] OWNER_REJECTED target=charlie/_UserActivity/charlie_doc code=Conflict
```

Five concurrent `TrackActivity` calls, four increments. One writer composed against a base the other
four had already moved, was refused, and its increment was thrown away — surfacing as
`TrackActivity_ConcurrentSamePath_DoesNotRaceAlreadyExists` *"expected 5, found 4"*. It reads as a
flaky test; it is a lost write.

## 🚨 Honest scope

**The diagnosis is evidenced; the fix is reasoned, not proven.** I could not build a deterministic
repro. Tried and failed:

- 24 concurrent `stream.Update` writers from the mesh workspace — never reaches `UpdateRemote`, it
  resolves to the local owner
- the same from a client workspace — the cache's per-path `UpdateQueue` serialises them, so the
  compose windows never overlap
- the activity-tracking shape at **40** writers, 8× the failing case — passes locally either way

The race needs the CI machine's timing. Both discarded test attempts are recorded in the commit
message rather than left as dead files.

**What supports shipping anyway:** the change only *adds a code* to an existing, bounded, idempotent
re-enqueue whose contract `Conflict` satisfies by construction; the status quo is known silent data
loss; and the owner's own error text prescribes exactly this behaviour.
**What would disprove it:** the CI flake recurring on a branch carrying this.

`MeshWeaver.Query.Test` 368/368, `MeshWeaver.Hosting.Monolith.Test` 547/551 (4 pre-existing skips);
`dotnet build -c Release -p:CIRun=true -warnaserror` clean.

No What's New entry — an internal write-path correctness fix with no user-visible surface change,
though the user-visible effect of the bug was a silently lost update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)