### PR TITLE
fix(data): key the remote-stream cache by subscribing identity

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -90,6 +90,47 @@ public static class JsonSynchronizationStream
         || objectId.StartsWith("activity/", StringComparison.OrdinalIgnoreCase)
         || objectId.StartsWith("portal/", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// The identity a remote subscribe runs under, resolved from the ambient
+    /// <see cref="AccessService"/> context. <see cref="Id"/> is the value stamped on
+    /// <c>SubscribeRequest.Identity</c>; <see cref="RealUser"/> is the captured context to
+    /// re-apply around the post (null ⇒ the subscribe runs as System).
+    /// </summary>
+    internal readonly record struct RemoteSubscribeIdentity(string Id, AccessContext? RealUser)
+    {
+        /// <summary>True when a genuine end-user identity was resolved (not the System fallback).</summary>
+        public bool IsRealUser => RealUser is not null;
+    }
+
+    /// <summary>
+    /// Resolves the identity that <see cref="CreateExternalClient{TReduced,TReference}"/> will
+    /// stamp on its <c>SubscribeRequest</c>.
+    ///
+    /// <para>🚨 This is ALSO the identity component of <c>Workspace._remoteStreamCache</c>'s key.
+    /// The owner applies its RLS gate ONCE, at subscribe time, for exactly this identity — so the
+    /// resulting stream carries that identity's permission view for its whole life. Cache key and
+    /// subscribe identity must therefore be computed from the SAME function: if they ever drift,
+    /// one identity's stream is served to another, which is a cross-user information disclosure
+    /// (and, in the other ordering, a refused stream handed to a permitted reader whose view then
+    /// renders empty). Both directions are pinned by
+    /// <c>MeshWeaver.Security.Test/RemoteStreamCacheIdentityTest</c>.</para>
+    ///
+    /// <para>Prefer the REAL user when the ambient AccessContext identifies one (the typical
+    /// Blazor-circuit / API-token path). Fall back to System ONLY when AsyncLocal carries no user
+    /// — empty, or a hub-shaped principal (<c>sync/</c>, <c>mesh/</c>, <c>node/</c>, …) that leaked
+    /// from a workspace emission scheduler.</para>
+    /// </summary>
+    internal static RemoteSubscribeIdentity ResolveSubscribeIdentity(AccessService? accessService)
+    {
+        var ambient = accessService?.Context ?? accessService?.CircuitContext;
+        var isRealUser = ambient is not null
+            && !string.IsNullOrEmpty(ambient.ObjectId)
+            && !LooksLikeHubPrincipal(ambient.ObjectId);
+        return isRealUser
+            ? new RemoteSubscribeIdentity(ambient!.ObjectId!, ambient)
+            : new RemoteSubscribeIdentity(SystemUserId, null);
+    }
+
     private static ILogger GetLogger(IServiceProvider serviceProvider)
     {
         try
@@ -311,11 +352,12 @@ public static class JsonSynchronizationStream
         // for the page owner. Per-user identity must flow into the SubscribeRequest
         // so the owner's RLS can enforce per-user reads; System fallback exists
         // only for the bare-infrastructure paths where no user identity exists.
-        var ambient = accessService?.Context ?? accessService?.CircuitContext;
-        var isRealUser = ambient is not null
-            && !string.IsNullOrEmpty(ambient.ObjectId)
-            && !LooksLikeHubPrincipal(ambient.ObjectId);
-        var identityForSubscribe = isRealUser ? ambient!.ObjectId : SystemUserId;
+        // 🚨 Resolved through the SHARED helper so this identity is bit-for-bit the one
+        // Workspace._remoteStreamCache keyed this stream under — see ResolveSubscribeIdentity.
+        var subscribeIdentity = ResolveSubscribeIdentity(accessService);
+        var ambient = subscribeIdentity.RealUser;
+        var isRealUser = subscribeIdentity.IsRealUser;
+        var identityForSubscribe = subscribeIdentity.Id;
 
         // Keep-alive machinery (the 45s heartbeat + the change-feed resubscribe) for a
         // REMOTE owner is collected here so a TERMINAL failure of the initial

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -39,6 +39,13 @@ public class Workspace : IWorkspace
     private readonly ILogger<Workspace> _logger;
     private readonly IDisposable? _changeFeedSubscription;
 
+    // Resolved once: GetExternalClientSynchronizationStream reads the ambient identity on every
+    // call — including every cache HIT (a Blazor re-render re-binding an area) — so this must not
+    // be a per-call service-provider lookup. The AccessService itself is a singleton whose
+    // Context/CircuitContext are AsyncLocal, so holding the instance still reads the CURRENT
+    // caller's identity; it is the resolution that is cached, never the identity.
+    private readonly AccessService? _accessService;
+
     /// <summary>Creates the workspace, builds and initializes its data context, and subscribes to the mesh change feed for remote-stream cache eviction.</summary>
     /// <param name="hub">The message hub that owns this workspace.</param>
     /// <param name="logger">Logger for workspace lifecycle and stream-cache diagnostics.</param>
@@ -46,6 +53,7 @@ public class Workspace : IWorkspace
     {
         Hub = hub;
         _logger = logger;
+        _accessService = hub.ServiceProvider.GetService<AccessService>();
         logger.LogDebug("Creating data context of address {address}", Id);
         DataContext = this.CreateDataContext();
         logger.LogDebug("Started initialization of data context of address {address}", Id);
@@ -129,7 +137,8 @@ public class Workspace : IWorkspace
         // against the (re-)activated owner.
         foreach (var key in _remoteStreamCache.Keys)
         {
-            if (string.Equals(key.Item1.ToString(), path, StringComparison.OrdinalIgnoreCase)
+            // Owner-address match only — every identity's stream for that owner is evicted.
+            if (string.Equals(key.Owner.ToString(), path, StringComparison.OrdinalIgnoreCase)
                 && _remoteStreamCache.TryRemove(key, out var removed))
             {
                 // Keep ownership of the evicted stream so Dispose still tears
@@ -140,7 +149,7 @@ public class Workspace : IWorkspace
                     _evictedRemoteStreams[removed.Value] = 0;
                 _logger.LogDebug(
                     "Evicted remote stream cache for {Address} after change event.",
-                    key.Item1);
+                    key.Owner);
             }
         }
     }
@@ -289,7 +298,23 @@ public class Workspace : IWorkspace
     // Symptom this fixes: streaming-text test sequence
     // `[0, 19, 22, 19, 22, 46]` — every patch delivered twice via the
     // orphaned stream.
-    private readonly ConcurrentDictionary<(Address, WorkspaceReference), Lazy<ISynchronizationStream>> _remoteStreamCache = new();
+    //
+    // 🚨 IDENTITY IS PART OF THE KEY, and must stay that way.
+    // A remote stream is NOT identity-neutral: CreateExternalClient stamps the subscribing
+    // user onto the SubscribeRequest and the OWNER evaluates its RLS gate ONCE, at subscribe
+    // time, for exactly that user. The stream therefore carries that user's permission view
+    // for its entire life. Keyed on (owner, reference) alone — as it was until this comment —
+    // the FIRST reader on a workspace fixed the permission view every later reader inherited,
+    // in both directions: a permitted reader's stream disclosed content to a denied reader,
+    // and a denied reader's refused stream made a permitted reader's view render empty. That
+    // is a cross-user information disclosure wherever one workspace serves two identities
+    // (the shared `portal/anonymous` hub, MCP/REST session hubs with an `anon` fallback).
+    // Regression: MeshWeaver.Security.Test/RemoteStreamCacheIdentityTest.
+    //
+    // The identity component MUST come from JsonSynchronizationStream.ResolveSubscribeIdentity
+    // — the same function that stamps SubscribeRequest.Identity — so key and subscribe can
+    // never drift apart.
+    private readonly ConcurrentDictionary<(Address Owner, WorkspaceReference Reference, string Identity), Lazy<ISynchronizationStream>> _remoteStreamCache = new();
 
     // Streams that EvictForPath removed from the cache but did NOT dispose (their
     // live subscribers keep them attached). The workspace still OWNS their lifetime —
@@ -340,8 +365,16 @@ public class Workspace : IWorkspace
         Address owner, WorkspaceReference reference)
     {
         var detached = new List<ISynchronizationStream>();
-        if (_remoteStreamCache.TryRemove((owner, reference), out var cached))
+        // 🚨 Scan, don't index: the cache is keyed (owner, reference, IDENTITY), so one
+        // (owner, reference) pair can hold one stream PER identity. Detaching only a single
+        // identity's entry would leave the others attached and defeat the caller's
+        // "no consumer remains" proof (the shared mesh-node cache's idle release).
+        foreach (var key in _remoteStreamCache.Keys)
         {
+            if (!key.Owner.Equals(owner) || !Equals(key.Reference, reference))
+                continue;
+            if (!_remoteStreamCache.TryRemove(key, out var cached))
+                continue;
             // A cached Lazy is materialised immediately by its creator
             // (GetExternalClientSynchronizationStream calls .Value right after
             // GetOrAdd); taking .Value here at worst briefly waits for that
@@ -388,7 +421,11 @@ public class Workspace : IWorkspace
     >(Address address, TReference reference)
         where TReference : WorkspaceReference
     {
-        var key = (address, (WorkspaceReference)reference);
+        // 🚨 The subscribing identity is part of the key — see the _remoteStreamCache field note.
+        // Resolved from the SAME helper that stamps SubscribeRequest.Identity so a stream can
+        // only ever be served back to the identity it was subscribed for.
+        var key = (address, (WorkspaceReference)reference,
+            JsonSynchronizationStream.ResolveSubscribeIdentity(_accessService).Id);
 
         while (true)
         {
@@ -416,8 +453,8 @@ public class Workspace : IWorkspace
             // Dead — remove (if still ours) and retry. The TryRemove guards
             // against the case where another thread already replaced the
             // entry: only the original Lazy is removed.
-            ((ICollection<KeyValuePair<(Address, WorkspaceReference), Lazy<ISynchronizationStream>>>)_remoteStreamCache)
-                .Remove(new KeyValuePair<(Address, WorkspaceReference), Lazy<ISynchronizationStream>>(key, lazy));
+            ((ICollection<KeyValuePair<(Address Owner, WorkspaceReference Reference, string Identity), Lazy<ISynchronizationStream>>>)_remoteStreamCache)
+                .Remove(new KeyValuePair<(Address Owner, WorkspaceReference Reference, string Identity), Lazy<ISynchronizationStream>>(key, lazy));
         }
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-one-persons-view-of-a-page-can-no-longer-be-shown-to-another.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-one-persons-view-of-a-page-can-no-longer-be-shown-to-another.md
@@ -1,0 +1,38 @@
+---
+Name: One person's view of a page can no longer be shown to another
+Category: Fix
+Description: Rendered views were cached without recording who they were built for, so whoever opened a page first could fix what everyone after them saw — either showing them content they had no right to, or an empty view where they should have seen everything.
+Icon: Sparkle
+Order: -20260811
+---
+
+# One person's view of a page can no longer be shown to another
+
+Almost everything the portal draws — a page, a card, an embedded area inside a document, a table
+that updates as data changes — is fed by a live subscription to the node that owns it. Opening that
+subscription is the moment access is decided: the owner is told who is asking, checks what that
+person is allowed to read, and from then on the subscription carries exactly that person's view of
+the data for as long as it stays open.
+
+Those subscriptions are reused, which is what makes a busy page cheap to draw. The reuse was
+recorded under what was being read and where it lived, but not under **who it had been opened for**.
+So when two people read the same thing through the same connection, the second one silently
+inherited the first one's subscription — and with it, the first one's permissions.
+
+That went wrong in both directions, decided by nothing more than who happened to arrive first. If
+someone with access opened the view first, a person without access who followed was handed it and
+saw content the owner would have refused them. If the person without access arrived first, their
+refusal was the thing left behind, and the next reader — fully entitled to the content — got the
+refused view and an area that rendered empty. The same page, the same permissions, two different
+outcomes depending on the order people opened it, which is exactly why this could sit unnoticed:
+most of the time everyone looking at a page is entitled to it, and the reuse is invisible and
+correct.
+
+Reuse now records who a subscription was opened for, and hands it back only to that same person.
+Everyone else gets their own, checked from scratch against their own permissions. The identity is
+taken from the very same place that tells the owner who is asking, so the two can never disagree
+about whose view a subscription holds.
+
+Nothing changes for a page whose readers all have the same access, which is the overwhelming
+majority — the reuse still happens, so pages draw exactly as quickly as before. What changes is
+that being first no longer decides what anyone else is allowed to see.

--- a/test/MeshWeaver.Security.Test/RemoteStreamCacheIdentityTest.cs
+++ b/test/MeshWeaver.Security.Test/RemoteStreamCacheIdentityTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// SECURITY repro — a remote synchronization stream (the machinery behind EVERY layout-area
+/// render, node mirror and remote collection read) must NEVER be shared between two different
+/// identities.
+///
+/// <para><b>The defect.</b> <c>Workspace._remoteStreamCache</c> memoises the stream under
+/// <c>(Address, WorkspaceReference)</c> — the identity is NOT part of the key. But the stream's
+/// content is identity-SPECIFIC: <c>JsonSynchronizationStream.CreateExternalClient</c> stamps the
+/// ambient user onto the <c>SubscribeRequest</c> (<c>Identity = …</c>) and the OWNER applies its
+/// RLS gate once, at subscribe time, for exactly that identity. So the FIRST reader of an
+/// (address, reference) pair fixes the permission view that every later reader on the same
+/// workspace inherits — in both directions:</para>
+/// <list type="bullet">
+///   <item><b>Disclosure</b> — a permitted reader subscribes first, an unauthorised reader then
+///   gets a cache HIT and receives content the owner would have denied them.</item>
+///   <item><b>False denial</b> — an unauthorised reader subscribes first and errors; the cached
+///   errored stream is then handed to a permitted reader, whose view renders empty.</item>
+/// </list>
+///
+/// <para>Both are asserted below, because both are the SAME bug and a fix that only closes the
+/// disclosure direction would leave the render-nothing regression live.</para>
+///
+/// <para>Reachability is not hypothetical: the Blazor portal hub falls back to a single
+/// process-wide <c>portal/anonymous</c> address whenever it is constructed before the request's
+/// identity is resolved (<c>UserContextMiddleware</c> resolves <c>PortalApplication</c> on line 58,
+/// <c>SetContext</c> only afterwards), so authenticated SSR render passes and anonymous visitors
+/// share one workspace — and therefore one of these caches.</para>
+/// </summary>
+public class RemoteStreamCacheIdentityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly AccessContext Permitted = new() { ObjectId = "alice", Name = "Alice" };
+    private static readonly AccessContext Denied = new() { ObjectId = "bob", Name = "Bob" };
+
+    private static readonly Address SecuredHub = new("SecuredHub");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .AddMeshNodes(
+                new MeshNode("SecuredHub") { Name = "Secured Hub" },
+                // Only alice may read SecuredHub. bob has no assignment at all.
+                AssignmentNodeFactory.UserRole(Permitted.ObjectId!, "Viewer", scope: "SecuredHub"))
+            .ConfigureDefaultNodeHub(c => c.AddData(d => d));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddData(d => d);
+
+    /// <summary>No blanket admin grant — the whole point is that bob genuinely has nothing.</summary>
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// The permitted user reads FIRST. The denied user must still be denied — he must not be
+    /// handed the stream the permitted user opened.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task DeniedUser_DoesNotInherit_PermittedUsersCachedStream()
+    {
+        var (client, accessService, workspace) = await ArrangeAsync();
+        var reference = new CollectionsReference("test");
+
+        ISynchronizationStream<EntityStore> permittedStream;
+        using (accessService.SwitchAccessContext(Permitted))
+            permittedStream = workspace.GetRemoteStream<EntityStore>(SecuredHub, reference);
+
+        ISynchronizationStream<EntityStore> deniedStream;
+        using (accessService.SwitchAccessContext(Denied))
+            deniedStream = workspace.GetRemoteStream<EntityStore>(SecuredHub, reference);
+
+        ReferenceEquals(deniedStream, permittedStream).Should().BeFalse(
+            "a cached remote stream carries the permission view of whoever subscribed it — "
+            + "handing bob alice's stream discloses content the owner would have denied him");
+
+        var notification = await deniedStream
+            .Timeout(10.Seconds())
+            .Take(1)
+            .Materialize()
+            .Should().Within(30.Seconds()).Match(n => n.Kind == NotificationKind.OnError,
+                "bob has no Read on SecuredHub, so his subscribe must fail closed");
+
+        notification.Exception!.ToString().Should().Contain("Access denied",
+            "bob's own subscribe must be refused by the owner's RLS gate, not silently satisfied "
+            + "from alice's cached stream");
+
+        GC.KeepAlive(client);
+    }
+
+    /// <summary>
+    /// The denied user reads FIRST and errors. The permitted user must NOT inherit that errored
+    /// stream — this is the "renders nothing" half of the same order-dependence.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PermittedUser_DoesNotInherit_DeniedUsersFailedStream()
+    {
+        var (client, accessService, workspace) = await ArrangeAsync();
+        var reference = new CollectionsReference("test");
+
+        ISynchronizationStream<EntityStore> deniedStream;
+        using (accessService.SwitchAccessContext(Denied))
+            deniedStream = workspace.GetRemoteStream<EntityStore>(SecuredHub, reference);
+
+        // Let bob's subscribe reach its terminal (denied) state before alice asks, so the cache
+        // genuinely holds a failed stream rather than an in-flight one.
+        await deniedStream
+            .Timeout(10.Seconds())
+            .Take(1)
+            .Materialize()
+            .Should().Within(30.Seconds()).Match(n => n.Kind == NotificationKind.OnError);
+
+        ISynchronizationStream<EntityStore> permittedStream;
+        using (accessService.SwitchAccessContext(Permitted))
+            permittedStream = workspace.GetRemoteStream<EntityStore>(SecuredHub, reference);
+
+        ReferenceEquals(permittedStream, deniedStream).Should().BeFalse(
+            "alice must get her own subscribe; inheriting bob's refused stream renders her view empty");
+
+        var notification = await permittedStream
+            .Timeout(10.Seconds())
+            .Take(1)
+            .Materialize()
+            .Should().Within(30.Seconds()).Match(_ => true);
+
+        // With Read granted the stream may still error about unmapped collections — but never
+        // about access (that would be bob's denial leaking into alice's view).
+        if (notification.Kind == NotificationKind.OnError)
+            notification.Exception!.ToString().Should().NotContain("Access denied",
+                "alice holds Viewer on SecuredHub — an access denial here is bob's, inherited via the cache");
+
+        GC.KeepAlive(client);
+    }
+
+    private async Task<(IMessageHub Client, AccessService Access, IWorkspace Workspace)> ArrangeAsync()
+    {
+        var client = GetClient();
+        // Make sure the owning hub is up before we subscribe, so a NotFound cannot masquerade
+        // as (or mask) an access denial.
+        await client.Observe(new PingRequest(), o => o.WithTarget(SecuredHub))
+            .Should().Within(30.Seconds()).Emit();
+        return (client,
+            client.ServiceProvider.GetRequiredService<AccessService>(),
+            client.GetWorkspace());
+    }
+}


### PR DESCRIPTION
## What

`Workspace._remoteStreamCache` memoised remote synchronization streams under `(Address, WorkspaceReference)` — **without the subscriber's identity**. But a remote stream is not identity-neutral: `JsonSynchronizationStream.CreateExternalClient` stamps the ambient user onto `SubscribeRequest.Identity`, and the **owner evaluates its RLS gate once, at subscribe time**, so the stream carries that user's permission view for its entire life.

On any workspace serving two identities, the **first** reader therefore fixed the permission view every later reader inherited — in both directions:

- a permitted reader's stream handed to a denied reader → **disclosure**;
- a denied reader's refused stream handed to a permitted reader → their view **renders empty**.

Which one you got depended only on read order. That order-dependence is what a sibling agent observed while testing export area resolution, and it reproduces deterministically.

## Root fix

Identity is now part of the cache key, resolved by the **same** helper that stamps `SubscribeRequest.Identity` (new `JsonSynchronizationStream.ResolveSubscribeIdentity`), so key and subscribe can never drift apart. `DetachRemoteStreams` scans rather than indexes, since one `(owner, reference)` pair can now hold one stream per identity.

Deliberately **not** done: disabling the cache (a performance band-aid), or adding a second gate on top of a cache that still crosses identities.

## Cost

No change where it matters. A per-circuit Blazor workspace and an MCP/REST session workspace each only ever see one identity, and `IMeshNodeStreamCache` subscribes under its single stable `cache/mesh-node-cache` identity — all keep exactly one upstream per key, as before. Only a genuinely shared workspace opens more streams, which is the correct semantics.

## Reachability — stated honestly

**No live production path was demonstrated, and this is materially less severe than #1224.** The leading hypothesis (authenticated SSR sharing the process-wide `portal/anonymous` hub) was **falsified**: that hub is genuinely shared — `UserContextMiddleware.cs:58` resolves `PortalApplication` before `SetContext`, so every HTTP request lands on it — but `LayoutAreaView.razor.cs:83` gates `BindStream()` on `IsNotPreRender`, so the prerender pass opens no area stream there. MCP and REST both `RequireAuthorization`; exports run per-run hubs.

So this is correctness + defence-in-depth, most relevant to the shared per-node-hub data sources (`MeshDataSource.cs:168-170`, `SyncedQueryDataSourceExtensions.cs:89-91`) whose ambient identity at reduce time is not established.

## Adjacent finding — NOT fixed here, worth its own look

`AccessService.persistentCircuitContext` (`AccessService.cs:55,89`) is a **plain instance field, not AsyncLocal**, on a process-wide singleton, rewritten by `CircuitAccessHandler` on every circuit activity. Since `CircuitContext => circuitContext.Value ?? persistentCircuitContext`, any thread without the AsyncLocal set reads *the last circuit user active anywhere in the process*. That is a shared-mutable-identity defect feeding the very identity resolution this PR keys on.

## Tests

- `MeshWeaver.Security.Test/RemoteStreamCacheIdentityTest` — pins **both** directions. Failed before the fix (bob received alice's stream instance; alice inherited bob's `Access denied`), passes after. Real mesh, RLS, no mocking, no `Task.Delay`.
- `MeshWeaver.Query.Test/RemoteStreamCacheTest` — same-identity reuse + post-dispose freshness, still green unchanged.
- `MeshWeaver.Data` and `MeshWeaver.Security.Test` both build clean with `-c Release -warnaserror` (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)