### PR TITLE
fix(#1209): refuse a durable install into a statically-served path, loudly

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticNodeProviders.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticNodeProviders.md
@@ -116,6 +116,34 @@ services.AddSingleton<IStaticNodeProvider, MyBuiltInsProvider>();
 
 Use option B whenever the nodes depend on configuration, embedded resources, or constructor parameters. Option A is fine for stateless, one-off registrations from a `NodeType.Add…Type()` extension method.
 
+## 🚨 A static node and a durable row must never claim the same path
+
+A static node is **not persistence-backed**. When one is served at a path, `MeshDataSource.WithMeshNodes` seeds that path's per-node hub from the static node via `WithInitialData` and skips persistence entirely — and the persistence sampler is gated off for the same hub, deliberately (a type-def path routes to a schema that is by design never provisioned). So if durable content ever lands at that same path, it is unreachable: the hub emits one Full snapshot at v0 and never again.
+
+That state is total and silent. The path becomes simultaneously
+
+- **unreadable** — the static-node query provider excludes it, so `get @X` 404s,
+- **un-creatable** — the create path answers `NodeAlreadyExists` from the static entry, and
+- **un-writable** — every upsert lands on the static-served hub, whose save is suppressed.
+
+Nothing in that chain says "collision"; downstream it surfaces only as a timeout on whatever waited for the node's stream to carry the durable state. That is exactly how the `Agent`/`Skill` plugin packages failed on a host calling bare `.AddAI()`: a deterministic 30 s `TimeoutException` per package, 0 nodes imported, no diagnostic (#1209).
+
+**The cure is per-host configuration.** Pass the partition in `serveFromPartition` (`AddAI(serveFromPartition: […])`, driven by `Features:StaticRepoSync:Partitions`). That marks the in-memory type definition `IsDefinitionOnly` — it still supplies its `HubConfiguration` *by name*, but it is no longer the runtime node at its path, so the durable row owns it. See [NodeType Catalogs](/Doc/Architecture/NodeTypeCatalogs).
+
+**One predicate answers "who serves this path".** Every serve seam reads the same helper, which skips definition-only entries:
+
+```csharp
+// The static node genuinely SERVED at a path — null when persistence owns it
+var served = serviceProvider.FindServedStaticNode("Agent");
+
+// The canonical operator-facing diagnostic (null when there is no collision)
+var detail = serviceProvider.DescribeStaticServeCollision("Agent");
+```
+
+`FindServedStaticNode` — not `FindStaticNode` — is what `WithMeshNodes`, the persistence-sampler gate, the create path's already-exists check and the plugin installer's pre-flight all consult, so "served static" ⇔ "not persistence-backed" cannot drift apart.
+
+**The collision is refused, not written.** `PackageInstaller` sweeps a package's node paths against that predicate *before* the first write (zero I/O) and fails the install immediately, naming the contested path, the claiming provider, and the `serveFromPartition` setting. The `CreateNodeRequest` handler distinguishes the two ways a create can be refused for the same reason code: a durable duplicate still reads `Node already exists at path: X`, while a static claim over empty persistence gets the collision message and a `Warning`. Regression guard: `test/MeshWeaver.PluginCatalog.Test/StaticShadowedInstallTest.cs`, which also pins that static-**only** serving — the legitimate arrangement on every host that serves `Doc`/`Agent`/`Harness`/`Skill` from memory and installs no durable package there — is unaffected.
+
 ## What happens when a node type is missing
 
 When a `MeshNode` references `nodeType = "X"` and no provider returns a node at path `X`, `EnrichWithNodeType` runs a 3-second existence probe (`path:X` against `IMeshQueryCore`). If the probe returns empty, activation fails fast with a clear error overlay:
@@ -132,6 +160,6 @@ See `test/MeshWeaver.Persistence.Test/UnregisteredNodeTypeTest.cs` for the regre
 | Symbol | Location |
 |---|---|
 | `IStaticNodeProvider` | namespace `MeshWeaver.Mesh.Services` (assembly **`MeshWeaver.Mesh.Contract`**) |
-| `StaticNodeProviderExtensions` | same namespace/assembly — `FindStaticNode` / `EnumerateStaticNodes` helpers |
+| `StaticNodeProviderExtensions` | same namespace/assembly — `FindStaticNode` / `EnumerateStaticNodes` / `FindServedStaticNode` / `DescribeStaticServeCollision` helpers |
 | `StaticMeshNodeListProvider` | same namespace/assembly — wrapper bridging `AddMeshNodes` to the provider model, registered in `MeshBuilder.Build` |
 | `NodeTypeEnrichmentHelpers` | `MeshWeaver.Graph.Configuration` — existence probe and slow path |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-plugin-that-cannot-install-here-now-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-a-plugin-that-cannot-install-here-now-says-so.md
@@ -1,0 +1,28 @@
+---
+Name: A plugin that cannot install on this instance now says so, immediately
+Category: Fix
+Description: Installing a plugin whose content collides with a catalog this instance already serves from memory used to stall for thirty seconds and then fail with nothing to act on — it now stops at once and names the setting that fixes it.
+Icon: Sparkle
+Order: -20260811
+---
+
+# A plugin that cannot install on this instance now says so, immediately
+
+Some catalogs — agents, skills, harnesses, model providers, the documentation — can be served
+two ways: straight from the instance's own program, or from its database. Which one an instance
+uses is a setting, and it must be the database whenever a plugin is going to put content there.
+Get it wrong and the two claim the same place at once: the built-in copy wins every read, and the
+plugin's content lands somewhere nothing can see it again.
+
+Until now nothing said any of that. The install simply sat there for thirty seconds and gave up
+with a timeout, having written nothing. Repeating it produced the same thirty seconds and the
+same empty result, and the message pointed at a wait rather than at the cause — so the only way
+to the answer was to already know it.
+
+Now the collision is checked before anything is written. The install stops in under a second and
+says exactly which path is contested, which built-in catalog is claiming it, and which setting to
+change so the database owns that content instead. Nothing is half-written, so there is nothing to
+clean up before retrying once the setting is right.
+
+Instances that serve those catalogs from memory and install no plugin into them are unaffected —
+that arrangement is perfectly valid and keeps working exactly as before.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -810,10 +810,11 @@ public static class MeshDataSourceExtensions
     /// this hub). Keeping both on the same lookup guarantees "served static" ⇔ "not
     /// auto-persisted" can never drift apart.</para>
     /// </summary>
+    /// <remarks>Thin alias over <see cref="StaticNodeProviderExtensions.FindServedStaticNode"/> —
+    /// the ONE definition, shared with the create path and the plugin installer's shadowing
+    /// pre-flight so every "who serves this path" seam answers identically (#1209).</remarks>
     internal static MeshNode? FindServedStaticNode(IServiceProvider serviceProvider, string hubPath)
-        => serviceProvider.EnumerateStaticNodes()
-            .FirstOrDefault(n => !n.IsDefinitionOnly
-                && string.Equals(n.Path, hubPath, StringComparison.OrdinalIgnoreCase));
+        => serviceProvider.FindServedStaticNode(hubPath);
 
     /// <summary>
     /// Emits a diagnostic that can NEVER take down its caller — the ONLY sanctioned way to log from

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -619,19 +619,22 @@ public static class MeshExtensions
             {
                 if (existing == null)
                 {
-                    var configNode = hub.ServiceProvider.FindStaticNode(node.Path);
                     // A definition-only catalog type-def is NOT a real node at this path (Postgres
                     // owns the nodeType:NodeType partition root) — it must never stand in as an
                     // "existing" node and block creating the real PG root. See NodeTypeCatalogs.md.
-                    if (configNode is { IsDefinitionOnly: true })
-                        configNode = null;
+                    // FindServedStaticNode applies exactly that rule.
+                    var configNode = hub.ServiceProvider.FindServedStaticNode(node.Path);
                     if (configNode is not null)
-                        return configNode;
+                        // FromStatic: persistence holds NOTHING here — the refusal below comes from a
+                        // static provider CLAIMING the path, which is a configuration collision, not
+                        // a duplicate node. It gets its own message (#1209).
+                        return (Node: configNode, FromStatic: true);
                 }
-                return existing;
+                return (Node: existing, FromStatic: false);
             })
-            .SelectMany(existingNode =>
+            .SelectMany(found =>
             {
+                var (existingNode, fromStatic) = found;
                 if (existingNode != null)
                 {
                     // Transient → Active confirmation path.
@@ -658,8 +661,22 @@ public static class MeshExtensions
                         return saveObs.Select(savedConfirmed => (mode: "confirm", node: savedConfirmed));
                     }
                     // Node exists & not a confirmation → fail.
+                    // 🚨 Two very different situations reach this line, and conflating them is what
+                    // made #1209 undiagnosable. A DURABLE row at the path is a plain duplicate. A
+                    // STATIC provider claiming the path while persistence holds nothing is a
+                    // configuration collision whose downstream symptom is a 30 s timeout somewhere
+                    // else entirely (the caller falls back to an UPDATE, which activates the hub on
+                    // the static node — a hub with no persistence backing that emits one v0 snapshot
+                    // and never again). Say which one it is, name the claimant, and name the cure.
+                    var collision = fromStatic
+                        ? hub.ServiceProvider.DescribeStaticServeCollision(node.Path)
+                        : null;
+                    if (collision is not null)
+                        logger.LogWarning(
+                            "[CreateNode] REFUSED {Path}: static/durable claim collision. {Detail}",
+                            node.Path, collision);
                     Respond(CreateNodeResponse.Fail(
-                        $"Node already exists at path: {node.Path}",
+                        collision ?? $"Node already exists at path: {node.Path}",
                         NodeCreationRejectionReason.NodeAlreadyExists));
                     return Observable.Empty<(string mode, MeshNode node)>();
                 }
@@ -1264,8 +1281,9 @@ public static class MeshExtensions
                 {
                     if (existing.Contains(candidate.Path))
                         continue;
-                    var configNode = hub.ServiceProvider.FindStaticNode(candidate.Path);
-                    if (configNode is not null && configNode is not { IsDefinitionOnly: true })
+                    // Same ONE predicate the singular create and every serve seam use (#1209) —
+                    // a definition-only catalog type-def is not a real node at this path.
+                    if (hub.ServiceProvider.FindServedStaticNode(candidate.Path) is not null)
                         existing.Add(candidate.Path);
                 }
 

--- a/src/MeshWeaver.Mesh.Contract/Services/StaticNodeProviderExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/StaticNodeProviderExtensions.cs
@@ -27,4 +27,84 @@ public static class StaticNodeProviderExtensions
     public static MeshNode? FindStaticNode(this IServiceProvider serviceProvider, string path) =>
         serviceProvider.EnumerateStaticNodes()
             .FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The static node genuinely <b>SERVED</b> at <paramref name="path"/>: the first
+    /// non-<see cref="MeshNode.IsDefinitionOnly"/> static node across every registered
+    /// <see cref="IStaticNodeProvider"/> whose <see cref="MeshNode.Path"/> matches
+    /// (case-insensitive), or <c>null</c>.
+    ///
+    /// <para>Definition-only entries are skipped deliberately: a DB-synced NodeType catalog's
+    /// in-memory type-def supplies its <c>HubConfiguration</c> BY NAME but is NOT the runtime node
+    /// at its path — Postgres owns that row (Doc/Architecture/NodeTypeCatalogs.md). This is the ONE
+    /// resolution shared by every "who serves this path" seam: <c>MeshDataSource.WithMeshNodes</c>
+    /// (which serves the match via <c>WithInitialData</c>, bypassing persistence entirely), the
+    /// persistence-sampler gate, the create path's already-exists check, and the plugin installer's
+    /// shadowing pre-flight. Keeping them on one lookup is what guarantees "served static" ⇔ "not
+    /// persistence-backed" can never drift apart.</para>
+    /// </summary>
+    public static MeshNode? FindServedStaticNode(this IServiceProvider serviceProvider, string path) =>
+        serviceProvider.EnumerateStaticNodes()
+            .FirstOrDefault(n => !n.IsDefinitionOnly
+                && string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The type name of the <see cref="IStaticNodeProvider"/> that SERVES <paramref name="path"/>,
+    /// or <c>null</c> when nothing does. Names the claimant in a collision diagnostic so the fix is
+    /// a lookup away instead of a bisect.
+    /// </summary>
+    public static string? ServingStaticProviderName(this IServiceProvider serviceProvider, string path)
+    {
+        foreach (var provider in serviceProvider.GetServices<IStaticNodeProvider>())
+        {
+            var served = provider.GetStaticNodes().FirstOrDefault(
+                n => !n.IsDefinitionOnly
+                     && string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
+            if (served is null)
+                continue;
+            // The AddMeshNodes seed is by far the most common claimant (every built-in NodeType
+            // definition sits at a top-level path); name the CALL, not the internal wrapper type.
+            return provider is StaticMeshNodeListProvider
+                ? "MeshBuilder.AddMeshNodes"
+                : provider.GetType().Name;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The ONE message describing a static-vs-durable claim collision at <paramref name="path"/> —
+    /// a registered <see cref="IStaticNodeProvider"/> SERVES the path while durable content is
+    /// trying to live there.
+    ///
+    /// <para>🚨 Why this needs its own diagnostic (#1209): the static claim wins every serve seam,
+    /// so the per-node hub at that path is seeded from a node that is BY DESIGN never persisted. It
+    /// emits one Full snapshot at v0 and never again — which makes the partition root
+    /// simultaneously unreadable (the static-node query provider excludes it), un-creatable (the
+    /// create path answers "node already exists" from the static entry) and un-writable (every
+    /// upsert lands on the static-served hub, whose save is suppressed). Nothing in that chain says
+    /// "collision"; downstream it surfaces only as a 30 s timeout on whatever waited for the node's
+    /// stream to carry the durable state (the deterministic <c>install: TimeoutException</c> on the
+    /// <c>Agent</c>/<c>Skill</c> plugin packages, 2026-08-11). The cure is per-host configuration —
+    /// <c>serveFromPartition</c>, which flips the static entry to
+    /// <see cref="MeshNode.IsDefinitionOnly"/> so the durable row owns the path — and this message
+    /// is what points at it.</para>
+    /// </summary>
+    /// <param name="serviceProvider">Resolves the registered static node providers.</param>
+    /// <param name="path">The contested path.</param>
+    /// <returns>The diagnostic, or <c>null</c> when nothing serves <paramref name="path"/> statically.</returns>
+    public static string? DescribeStaticServeCollision(this IServiceProvider serviceProvider, string path)
+    {
+        // ONE sweep: the provider name is non-null on exactly the same condition as
+        // FindServedStaticNode, so resolving the claimant also answers "is there a collision".
+        if (serviceProvider.ServingStaticProviderName(path) is not { } claimant)
+            return null;
+        var partition = path.Split('/', 2)[0];
+        return $"Path '{path}' is SERVED BY A STATIC NODE PROVIDER ({claimant}), so durable content "
+               + $"cannot live there: the per-node hub at '{path}' is seeded from the static node and "
+               + "has no persistence backing, which leaves the path unreadable, un-creatable and "
+               + "un-writable (MeshWeaver#1209). Configure this host to serve the partition from the "
+               + $"database instead — pass '{partition}' in serveFromPartition (e.g. "
+               + $"AddAI(serveFromPartition: [\"{partition}\"]), or Features:StaticRepoSync:Partitions) "
+               + "— which marks the static entry definition-only and lets the durable row own the path.";
+    }
 }

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -124,6 +124,9 @@ public static class PackageInstaller
             return Observable.Throw<InstallResult>(new InvalidOperationException(
                 $"Package '{manifest.Id}' has no installable content files."));
 
+        if (RefuseIfStaticShadowed(hub, manifest, nodes, logger) is { } shadowed)
+            return shadowed;
+
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         return EnsurePartitionsProvisioned(hub, partition, InstalledPartition)
@@ -150,6 +153,66 @@ public static class PackageInstaller
                     .SelectMany(_ => RunInstallHooks(hub, partition!, logger))
                     .Select(_ => result);
             });
+    }
+
+    /// <summary>
+    /// The reason this install must be REFUSED because one or more of its nodes would land at a
+    /// path a registered <see cref="IStaticNodeProvider"/> already SERVES on this host — or
+    /// <c>null</c> when there is no such collision (the overwhelmingly common case: zero I/O, one
+    /// in-memory sweep of the static providers).
+    ///
+    /// <para>🚨 Why REFUSING beats writing (#1209). A statically-served path is not persistence-
+    /// backed: the static claim wins every serve seam, so the per-node hub at that path is seeded
+    /// from a node that is by design never persisted and emits one Full snapshot at v0, forever.
+    /// An install into it therefore cannot succeed in any useful sense — the root's create is
+    /// answered "node already exists" by the static entry, the fallback UPDATE lands on the
+    /// static-served hub and is never reconciled or persisted, and the install's own post-write
+    /// confirmation (<c>RootRetypeReconciled</c>) waits out its 30 s and throws a bare
+    /// <see cref="TimeoutException"/> with nothing naming the cause. That is exactly how the
+    /// <c>Agent</c>/<c>Skill</c> plugin packages failed on a host calling bare <c>.AddAI()</c>
+    /// (2026-08-11): a deterministic 30 s hang per package, 0 nodes imported, no diagnostic.</para>
+    ///
+    /// <para>The check is deliberately EXACT-PATH, never prefix: a package writing <c>X/Child</c>
+    /// while only <c>X</c> is served statically is a different (and separately guarded) situation,
+    /// and a prefix rule would refuse legitimate installs. Static-only hosts — the ones that serve
+    /// <c>Doc</c>/<c>Agent</c>/<c>Harness</c>/<c>Skill</c> from memory and install NO durable
+    /// package there — see an empty collision set and are completely unaffected.</para>
+    /// </summary>
+    internal static string? StaticShadowedReason(
+        IMessageHub hub, PackageManifest manifest, IEnumerable<MeshNode> nodes)
+    {
+        var collisions = nodes
+            .Select(n => n.Path)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            // Shortest path first so the package ROOT — the collision that matters and the one an
+            // operator recognises — leads the list and supplies the detailed explanation.
+            .OrderBy(p => p.Length).ThenBy(p => p, StringComparer.Ordinal)
+            .Select(p => (Path: p, Detail: hub.ServiceProvider.DescribeStaticServeCollision(p)))
+            .Where(c => c.Detail is not null)
+            .ToArray();
+        if (collisions.Length == 0)
+            return null;
+        return $"Install of '{manifest.Id}' REFUSED: {collisions.Length} of its node path(s) are "
+               + "already served by a static node provider on this host "
+               + $"[{string.Join(", ", collisions.Select(c => c.Path))}]. {collisions[0].Detail}";
+    }
+
+    /// <summary>
+    /// <see cref="StaticShadowedReason"/> as a terminal install outcome: the failing observable to
+    /// return, or <c>null</c> to proceed. Fails LOUDLY and IMMEDIATELY — before any write — instead
+    /// of writing into a shadowed path and timing out 30 s later somewhere downstream.
+    /// </summary>
+    private static IObservable<InstallResult>? RefuseIfStaticShadowed(
+        IMessageHub hub, PackageManifest manifest, IEnumerable<MeshNode> nodes, ILogger? logger)
+    {
+        var reason = StaticShadowedReason(hub, manifest, nodes);
+        if (reason is null)
+            return null;
+        logger?.LogError(
+            "Package {Id}: static/durable path collision — refusing the install. {Reason}",
+            manifest.Id, reason);
+        return Observable.Throw<InstallResult>(new InvalidOperationException(reason));
     }
 
     /// <summary>
@@ -1265,6 +1328,10 @@ public static class PackageInstaller
         };
 
         var all = new[] { nodeTypeNode }.Concat(sourceNodes).ToArray();
+
+        if (RefuseIfStaticShadowed(hub, manifest, all, logger) is { } shadowed)
+            return shadowed;
+
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
 
@@ -1539,6 +1606,9 @@ public static class PackageInstaller
         if (nodes.Length == 0)
             return Observable.Throw<InstallResult>(new InvalidOperationException(
                 $"Node-repo plugin '{manifest.Id}' has no installable nodes."));
+
+        if (RefuseIfStaticShadowed(hub, manifest, nodes, logger) is { } shadowed)
+            return shadowed;
 
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
@@ -2031,6 +2101,9 @@ public static class PackageInstaller
             .Select(f => ParseCanonical(parsers, f, logger))
             .Where(n => n is not null).Select(n => n!)
             .ToArray();
+
+        if (RefuseIfStaticShadowed(hub, manifest, nodes, logger) is { } shadowed)
+            return shadowed;
 
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();

--- a/test/MeshWeaver.PluginCatalog.Test/StaticShadowedInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StaticShadowedInstallTest.cs
@@ -1,0 +1,200 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// #1209 — A STATIC node must not silently shadow durable content at the same path.
+///
+/// <para>The incident: a host calling bare <c>.AddAI()</c> registers the built-in Agent/Skill
+/// catalogs as static node providers serving the paths <c>Agent</c> and <c>Skill</c>. Installing the
+/// DURABLE <c>Agent</c>/<c>Skill</c> plugin packages — which write real rows at exactly those paths —
+/// collided: the root's create was answered "node already exists" BY THE STATIC ENTRY (persistence
+/// held nothing), the installer fell back to an UPDATE, that update activated the per-node hub on the
+/// STATIC node — a hub seeded from a node that is by design never persisted, which emits one Full
+/// snapshot at v0 and never again — and the install's post-write confirmation
+/// (<c>RootRetypeReconciled</c>) waited out its 30 s and threw a bare <c>TimeoutException</c> with
+/// 0 nodes imported and nothing naming the cause.</para>
+///
+/// <para>Both halves are pinned here, because the fix must be surgical: the collision fails LOUDLY
+/// and IMMEDIATELY (naming the path, the claimant and the <c>serveFromPartition</c> cure), while
+/// static-ONLY serving — the legitimate configuration on every host that serves
+/// <c>Doc</c>/<c>Agent</c>/<c>Harness</c>/<c>Skill</c> from memory and installs no durable package
+/// there — keeps working untouched.</para>
+/// </summary>
+public class StaticShadowedInstallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// A static NodeType definition at the TOP-LEVEL path <c>Widget</c> — the exact shape of
+    /// <c>AgentNodeType.CreateMeshNode()</c> on a bare <c>.AddAI()</c> host: an
+    /// <c>AddMeshNodes</c> seed node (surfaced through <c>StaticMeshNodeListProvider</c>, an
+    /// <see cref="IStaticNodeProvider"/>) that is NOT definition-only, so it wins every serve seam
+    /// at that path while having no persistence backing.
+    /// </summary>
+    private static MeshNode WidgetTypeDefinition() => new("Widget")
+    {
+        Name = "Widget",
+        IsSatelliteType = false,
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source.WithContentType<WidgetContent>())
+    };
+
+    public record WidgetContent
+    {
+        public string? Intro { get; init; }
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .AddMeshNodes(WidgetTypeDefinition());
+
+    /// <summary>
+    /// The colliding package: a node-repo plugin whose ROOT sits at <c>Widget</c> — the very path the
+    /// static definition above serves — and whose root type ships in the package (the self-typed-root
+    /// shape, which is what puts <c>RootRetypeReconciled</c>'s 30 s wait in the path).
+    /// </summary>
+    private static readonly IReadOnlyList<RepoFile> CollidingRepo = new List<RepoFile>
+    {
+        new("Widget/index.json",
+            """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget","nodeType":"Widget/Front","state":"Active","content":{"$type":"FrontContent","intro":"hello"}}"""),
+        new("Widget/Front.json",
+            """{"$type":"MeshNode","id":"Front","namespace":"Widget","path":"Widget/Front","mainNode":"Widget/Front","name":"Front","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The widget front.","configuration":"config => config.WithContentType<FrontContent>()","includeGlobalTypes":true}}"""),
+        new("Widget/Front/Source/FrontContent.cs",
+            "public record FrontContent { public string? Intro { get; init; } }"),
+    };
+
+    /// <summary>The same package shape at a path NOTHING serves statically — the control.</summary>
+    private static readonly IReadOnlyList<RepoFile> CleanRepo = new List<RepoFile>
+    {
+        new("Gadget/index.json",
+            """{"$type":"MeshNode","id":"Gadget","namespace":"","path":"Gadget","mainNode":"Gadget","name":"Gadget","nodeType":"Gadget/Front","state":"Active","content":{"$type":"GadgetContent","intro":"hello"}}"""),
+        new("Gadget/Front.json",
+            """{"$type":"MeshNode","id":"Front","namespace":"Gadget","path":"Gadget/Front","mainNode":"Gadget/Front","name":"Front","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The gadget front.","configuration":"config => config.WithContentType<GadgetContent>()","includeGlobalTypes":true}}"""),
+        new("Gadget/Front/Source/GadgetContent.cs",
+            "public record GadgetContent { public string? Intro { get; init; } }"),
+    };
+
+    private static NodeRepoPackageSource Source(IReadOnlyList<RepoFile> repo)
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-1209", repo));
+        return new NodeRepoPackageSource(fetch, "https://github.com/acme/widgets");
+    }
+
+    private static PackageManifest Manifest(string id) => new()
+    {
+        Id = id,
+        Name = id,
+        Kind = PackageKind.NodeRepo,
+        TargetPartition = id,
+        SourceFolder = id,
+        Version = "commit-1209",
+    };
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. Installing durable content at a statically-served path must fail LOUDLY and
+    /// FAST — naming the contested path, the static claimant, and the <c>serveFromPartition</c> cure —
+    /// instead of writing into a hub with no persistence backing and hanging out a 30 s timeout.
+    ///
+    /// <para>Before the fix this test failed on BOTH counts: the install ran the full placeholder
+    /// dance, then <c>RootRetypeReconciled</c> followed a stream that could never carry the durable
+    /// type and threw <see cref="TimeoutException"/> after 30 s — so the 20 s budget below tripped
+    /// first and the exception was neither an <see cref="InvalidOperationException"/> nor did its
+    /// message mention the collision.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task InstallIntoStaticallyServedPath_FailsFast_NamingBothClaimantsAndTheFix()
+    {
+        // The precondition the whole issue is about: this host SERVES `Widget` statically.
+        Mesh.ServiceProvider.FindServedStaticNode("Widget").Should().NotBeNull(
+            "the fixture must reproduce the bare-AddAI shape: a static provider claiming the path");
+
+        var manifest = Manifest("Widget");
+        var files = await Source(CollidingRepo).FetchPackageFiles(manifest, "HEAD")
+            .FirstAsync().ToTask();
+
+        var stopwatch = Stopwatch.StartNew();
+        var install = () => PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .FirstAsync()
+            // 20 s is the discriminator: the fix refuses before the first write (sub-second), the
+            // unfixed code cannot answer before RootRetypeReconciled's 30 s wait elapses.
+            .Timeout(TimeSpan.FromSeconds(20))
+            .ToTask();
+
+        var error = (await install.Should().ThrowAsync<InvalidOperationException>(
+            "a static/durable path collision must be refused up front, not surfaced as a downstream "
+            + "timeout")).Which;
+        stopwatch.Stop();
+
+        error.Message.Should().Contain("Widget", "the refusal must name the contested path");
+        error.Message.Should().Contain("static node provider",
+            "the refusal must name WHAT is claiming the path");
+        error.Message.Should().Contain("MeshBuilder.AddMeshNodes",
+            "the refusal must name WHICH provider claims it");
+        error.Message.Should().Contain("serveFromPartition",
+            "the refusal must name the per-host configuration that cures it");
+
+        // Tighter than the 20 s budget above on purpose: that one only proves the answer beat
+        // RootRetypeReconciled's 30 s wait, this one proves the refusal is the zero-I/O pre-flight
+        // it claims to be. Observed ≈0.5 s; 10 s is 20× headroom for a loaded CI runner.
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10),
+            "the collision is decidable with zero I/O — it must never cost a stream round-trip");
+
+        // And nothing was written: the refusal is a pre-flight, not a partial install. Asked of the
+        // STORAGE ADAPTER, which answers "no row" instead of routing to a hub that does not exist.
+        var persistence = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        (await persistence.Exists($"{PackageInstaller.InstalledPartition}/Widget")
+                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask())
+            .Should().BeFalse("a refused install must leave no install record behind");
+        (await persistence.Exists("Widget/Front").FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask())
+            .Should().BeFalse("a refused install must write none of the package's nodes");
+    }
+
+    /// <summary>
+    /// The other half of the contract: a host that serves a path statically and installs NOTHING
+    /// durable there is completely unaffected. The static node still resolves and is still served by
+    /// its per-node hub, and an ordinary install at an unclaimed path proceeds exactly as before.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task StaticOnlyServing_IsUnchanged_AndAnUnclaimedPathStillInstalls()
+    {
+        // (a) The statically-served node is still SERVED — read through the same per-node hub the
+        //     GUI and every reader use.
+        var served = await Mesh.GetWorkspace().GetMeshNodeStream("Widget")
+            .Where(n => n is not null).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        served!.Name.Should().Be("Widget",
+            "static-only serving must keep working — every host that serves Doc/Agent/Harness/Skill "
+            + "from memory depends on it");
+
+        // (b) An install at a path NOTHING claims statically is untouched by the new pre-flight.
+        var manifest = Manifest("Gadget");
+        var files = await Source(CleanRepo).FetchPackageFiles(manifest, "HEAD")
+            .FirstAsync().ToTask();
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+        result.Written.Should().Be(3, "an uncontested install must be unaffected by the collision guard");
+
+        var root = await Mesh.GetWorkspace().GetMeshNodeStream("Gadget")
+            .Where(n => n is not null).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        root!.NodeType.Should().Be("Gadget/Front");
+    }
+}


### PR DESCRIPTION
Fixes #1209.

## The collision, and why it was invisible

A host calling bare `.AddAI()` registers the built-in Agent/Skill catalogs as **static node providers** serving the paths `Agent` and `Skill`. Installing the **durable** Agent/Skill plugin packages — which write real rows at exactly those paths — collided:

1. the root's create was answered *"node already exists"* **by the static entry** (persistence held nothing), so the installer fell back to an UPDATE;
2. that update activated the per-node hub on the **static** node — a hub seeded from a node that is by design never persisted, with no persistence backing, which emits one Full snapshot at v0 and never again;
3. the install's own post-write confirmation (`PackageInstaller.RootRetypeReconciled`) followed a stream that could never carry the durable state, waited out its 30 s and threw a bare `TimeoutException` with **0 nodes imported**.

Nothing in that chain said "collision". The cure — `serveFromPartition` — already exists and the portal gets it right via Helm; this change is about a host that gets it wrong finding out **immediately** instead of via a downstream timeout.

## Altitude chosen, and why not option 1

The issue's option 1 (*`WithMeshNodes` refuses to serve a static node at a path that has a durable row*) needs to know, at hub-configuration time, whether persistence holds a row at the hub's path. That answer is not obtainable there without either:

- a **per-activation persistence probe** into a schema that is *by design* never provisioned — the exact boot-time `42P01` noise `MeshDataSource`'s sampler gate was added to stop (`MeshDataSource.cs:1167-1181`); or
- a **startup-race-dependent registry**, which would make the serve choice non-deterministic for any hub activating during the probe window.

So the guard lands at the write seam instead — which is strictly earlier than option 3 (it *prevents* the collision rather than naming it after 30 s) and fires on first boot, unlike a startup assertion that can only observe a durable row that already exists.

## What lands

- **One predicate, one message.** `StaticNodeProviderExtensions.FindServedStaticNode` (hoisted out of `MeshDataSource`, which now delegates) is the single *"who serves this path"* resolution; `DescribeStaticServeCollision` is the single operator-facing diagnostic.
- **`PackageInstaller` refuses up front.** All four install paths sweep their node paths against that predicate **before the first write** — zero I/O, exact-path only — and fail immediately. Nothing is half-written.
- **`CreateNodeRequest` stops conflating** the two ways a create is refused under one reason code: a durable duplicate still reads `Node already exists at path: X`; a static claim over empty persistence gets the collision message plus a `Warning`.

The message an operator now sees:

> Install of 'Agent' REFUSED: 1 of its node path(s) are already served by a static node provider on this host [Agent]. Path 'Agent' is SERVED BY A STATIC NODE PROVIDER (MeshBuilder.AddMeshNodes), so durable content cannot live there: the per-node hub at 'Agent' is seeded from the static node and has no persistence backing, which leaves the path unreadable, un-creatable and un-writable (MeshWeaver#1209). Configure this host to serve the partition from the database instead — pass 'Agent' in serveFromPartition (e.g. AddAI(serveFromPartition: ["Agent"]), or Features:StaticRepoSync:Partitions) — which marks the static entry definition-only and lets the durable row own the path.

## Not regressed

**Static-only serving is untouched and pinned.** Every host that serves `Doc`/`Agent`/`Harness`/`Skill` from memory and installs no durable package there sees an empty collision set. The second test asserts both halves: the statically-served node still resolves through its per-node hub, and an install at an unclaimed path proceeds exactly as before.

## Verification — `StaticShadowedInstallTest`

The test reproduces the incident shape: a static NodeType definition at top-level path `Widget` (the `AgentNodeType.CreateMeshNode()` shape) plus a node-repo package whose **self-typed root** sits at `Widget`, which is what puts `RootRetypeReconciled`'s 30 s wait in the path.

| | `InstallIntoStaticallyServedPath_FailsFast_NamingBothClaimantsAndTheFix` |
|---|---|
| **before** (pre-flight disabled) | **FAILS after 20 s** — `Expected a InvalidOperationException … but found TimeoutException`. The unfixed install could not answer before the 30 s stream wait elapsed. |
| **after** | **PASSES in ~0.5 s** — refused before any write, message names the path, the claimant (`MeshBuilder.AddMeshNodes`) and `serveFromPartition`; storage confirms no install record and no package node landed. |

The control test (`StaticOnlyServing_IsUnchanged_AndAnUnclaimedPathStillInstalls`) passes both ways, as it must.

Full suites, Release, on the final tree:

| Suite | Result |
|---|---|
| `MeshWeaver.PluginCatalog.Test` | 256 / 256 |
| `MeshWeaver.AI.Test` | 1149 / 1149 (5 skipped, env-gated) |
| `MeshWeaver.Hosting.Monolith.Test` | 553 / 553 (4 skipped) |
| `MeshWeaver.Documentation.Test` | 20 / 20 |

Every touched project builds clean with `-c Release -warnaserror`.

Docs: `StaticNodeProviders.md` gains a section on the hazard, the one predicate, and the cure. What's New entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)