### PR TITLE
fix(#1214): retract a bake regression when the type rebuilds on the same image

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-updates-no-longer-stall-on-a-type-that-already-repaired-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-11-updates-no-longer-stall-on-a-type-that-already-repaired-itself.md
@@ -1,0 +1,35 @@
+---
+Name: Platform updates no longer stall on a type that has already repaired itself
+Category: Fix
+Description: If a custom type fails to build because a package update was landing at that exact moment, the update now finishes as soon as the type builds again — instead of stopping until someone noticed.
+Icon: Sparkle
+Order: -20260811
+---
+
+# Platform updates no longer stall on a type that has already repaired itself
+
+While a platform update is being prepared, every custom type is rebuilt, and a type that used to
+work but no longer does will hold the update back. That safety-check is deliberate: it is what
+keeps a bad version from reaching you, and it has caught real breakage.
+
+But a type can also fail to build for a reason that has nothing to do with the new version. A
+plugin update rewrites several files, and it does not rewrite them all in the same instant. If the
+rebuild happens to run between two of those writes, it sees a half-changed set of files — one file
+already updated, the files that use it not yet — and reports errors about code that, moments later,
+no longer exists anywhere. It reads exactly like real damage: an error message, a line number, a
+type that stopped working.
+
+Until now that verdict was final. Seconds later the remaining files landed, the platform rebuilt
+the affected types by itself, and everything was healthy again — but the update stayed stopped,
+because nothing ever went back to look. It took someone noticing and restarting to get moving
+again.
+
+Now the platform keeps watching every type it held the update for. The moment such a type builds
+successfully on the new version, its objection is withdrawn and the update carries on by itself.
+Nothing is retried or timed out to make this happen — the type building is simply better evidence
+than the earlier failure, and it wins.
+
+A genuine problem is unaffected. A type that is really broken never builds, so nothing withdraws
+its objection and the update stays held exactly as before. And when this does happen, the platform
+now says so in the log while it waits: if a type's source files changed while it was being built,
+the log names that as the likely cause instead of blaming the new version.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -112,6 +112,21 @@ public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Deta
     /// would let one abandoned NodeType block every future deploy.</para>
     /// </summary>
     public bool WasHealthyBeforeBake { get; init; } = true;
+
+    /// <summary>
+    /// Evidence that this compile sampled a TORN source snapshot: at least one of the type's
+    /// sources was last modified AT OR AFTER the compile started
+    /// (<see cref="DynamicTypePreWarmer.SourcesMovedDuringCompile(NodeTypeDefinition)"/>), so the
+    /// diagnostics describe a source set the mesh was in the middle of replacing.
+    ///
+    /// <para>Diagnostic only — it deliberately does NOT reclassify the outcome. A source moving
+    /// mid-compile makes a failure SUSPECT, not innocent, and a torn compile of genuinely broken
+    /// code must still gate. What clears the gate is the type actually rebuilding on this image
+    /// (<c>NodeTypeBakeGateState.RetractRegression</c>); this flag is what lets the log say WHY the
+    /// pod is refusing readiness on content that may repair itself, instead of telling an operator
+    /// at 3am that the image is broken (issue #1214, proposal 3).</para>
+    /// </summary>
+    public bool SourcesMovedDuringCompile { get; init; }
 }
 
 /// <summary>
@@ -678,8 +693,7 @@ public static class DynamicTypePreWarmer
                                     var d = (NodeTypeDefinition)n!.Content!;
                                     return d.CompilationStatus switch
                                     {
-                                        CompilationStatus.Error => new PreWarmOutcome(
-                                            typePath, ClassifyCompileFailure(d), d.CompilationError),
+                                        CompilationStatus.Error => FromFailedCompile(typePath, d),
                                         // The rebuild never reported an answer — not a
                                         // compile failure, so never labelled one.
                                         CompilationStatus.Unavailable => new PreWarmOutcome(
@@ -745,6 +759,124 @@ public static class DynamicTypePreWarmer
             : PreWarmStatus.CompileError;
 
     /// <summary>
+    /// Whether the type's SOURCES MOVED while this compile was running — at least one entry of
+    /// <see cref="NodeTypeDefinition.CurrentSourceVersions"/> (each value is that Code node's
+    /// <c>LastModified.UtcTicks</c>, written by the per-NodeType sources watcher) is at or after
+    /// <see cref="NodeTypeDefinition.LastCompileStartedAt"/> (stamped on the Pending → Compiling
+    /// transition). When that holds, Roslyn's verdict was produced against a source set the mesh
+    /// was concurrently replacing — a half-applied plugin auto-update, a git sync, a bulk edit.
+    ///
+    /// <para>Both fields survive a failed compile: <c>ApplyCompileFailure</c> nulls
+    /// <c>CompiledSources</c> but leaves the start stamp and the live snapshot alone, so the
+    /// evidence is readable exactly where the verdict is formed.</para>
+    ///
+    /// <para>🚨 SUSPICION, NOT ABSOLUTION. This never downgrades an outcome: a torn compile of
+    /// code that is genuinely broken must still gate, and the check is one-sided anyway — a source
+    /// written a second AFTER the compile failed is just as much a torn snapshot but is invisible
+    /// here until the write lands (in the 2026-08-11 incident the callers landed at 11:06:57, after
+    /// the failures). That asymmetry is precisely why the CURE is
+    /// <c>NodeTypeBakeGateState.RetractRegression</c> — level-triggered on the type rebuilding —
+    /// and this predicate is only what names the suspicion in the log.</para>
+    /// </summary>
+    public static bool SourcesMovedDuringCompile(NodeTypeDefinition d) =>
+        d.LastCompileStartedAt is { } started
+        && d.CurrentSourceVersions is { Count: > 0 } current
+        && current.Values.Any(ticks => ticks >= started.UtcTicks);
+
+    /// <summary>
+    /// The outcome for a compile that settled at <see cref="CompilationStatus.Error"/>: Roslyn's
+    /// verdict classified by <see cref="ClassifyCompileFailure"/>, carrying the torn-snapshot
+    /// evidence (<see cref="SourcesMovedDuringCompile(NodeTypeDefinition)"/>) so the reporting
+    /// layer can say whether the source set was stable when the verdict was formed.
+    /// </summary>
+    internal static PreWarmOutcome FromFailedCompile(string typePath, NodeTypeDefinition d) =>
+        new(typePath, ClassifyCompileFailure(d), d.CompilationError)
+        {
+            SourcesMovedDuringCompile = SourcesMovedDuringCompile(d)
+        };
+
+    /// <summary>
+    /// Watch a REGRESSED NodeType until it reaches a usable build on this image, then retract its
+    /// regression from <paramref name="gate"/> — the cure for issue #1214, where a bake compiled a
+    /// half-applied plugin update, recorded four false regressions, and stalled the rollout even
+    /// though the content converged (and the types recompiled green) seconds later.
+    ///
+    /// <para><b>Observation, not a watchdog.</b> Nothing here triggers, retries or polls: the
+    /// platform's own park registry already un-parks and recompiles a failed type the moment its
+    /// source snapshot changes (<c>NodeTypeCompileParkRegistry.ShouldRetryForSourceChange</c>), and
+    /// a lazy activation compiles it too. This subscription only READS the type's own node stream
+    /// — the same level-triggered surface the sweep and the GUI use — and stops at the first
+    /// emission that shows a usable build. There is deliberately no timeout: a regression that is
+    /// never repaired must gate forever, which is what "no emission" already means.</para>
+    ///
+    /// <para>Holding the subscription also keeps the condemned type's per-node hub ACTIVATED, which
+    /// is what keeps its sources watcher — the thing that notices the repair — installed and
+    /// running. So the watch is not merely a listener for a recovery; on an idle pod it is part of
+    /// why the recovery can happen at all.</para>
+    ///
+    /// <para>🚨 <b>The recovery must be a compile that is demonstrably FRESH</b> — a settled
+    /// <see cref="CompilationStatus.Ok"/> whose
+    /// <see cref="NodeTypeDefinition.LastCompileSucceededAt"/> is strictly newer than the one this
+    /// watch observed when it started. <see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>
+    /// alone is NOT sufficient and matching on it would silently disable the whole gate: a failed
+    /// compile keeps the PREVIOUS build's assembly coordinates and framework stamp
+    /// (<c>ApplyCompileFailure</c> clears only the status, the error and
+    /// <c>CompiledSources</c>), so any type that had ever compiled successfully on this image would
+    /// satisfy that check the instant its regression was recorded, and every regression would
+    /// retract itself immediately. The <see cref="RebuildMissingBytes"/> path guards the identical
+    /// trap the identical way; this is the same <see cref="IsFreshSuccess"/> rule.</para>
+    ///
+    /// <para>The subscription is returned so its owner disposes it at shutdown; a discarded
+    /// subscription would root the hub.</para>
+    /// </summary>
+    public static IDisposable WatchForRecovery(
+        IMessageHub mesh, NodeTypeBakeGateState gate, string typePath, ILogger? logger)
+    {
+        var workspace = mesh.GetWorkspace();
+        var accessService = mesh.ServiceProvider.GetService<AccessService>();
+        // System-scoped for the same reason the sweep's reads are: watching a NodeType record
+        // across partitions is infrastructure, not a user-attributable read.
+        return Observable
+            .Using(
+                () => AccessContextScope.AsSystem(accessService),
+                _ =>
+                {
+                    // One shared handle (IMeshNodeStreamCache): the baseline read and the wait are
+                    // the SAME stream, and it replays its latest node to the second subscriber — so
+                    // a success landing between the two cannot fall through the gap.
+                    var stream = workspace.GetMeshNodeStream(typePath);
+                    return stream
+                        .Take(1)
+                        .Select(current =>
+                            (current?.Content as NodeTypeDefinition)?.LastCompileSucceededAt)
+                        .SelectMany(baseline => stream
+                            .Where(n => n?.Content is NodeTypeDefinition d
+                                && d.CompilationStatus == CompilationStatus.Ok
+                                && NodeTypeCompilationHelpers.HasUsableBuild(n, d)
+                                && IsFreshSuccess(d.LastCompileSucceededAt, baseline))
+                            .Take(1));
+                })
+            .Subscribe(
+                _ =>
+                {
+                    if (gate.RetractRegression(
+                            typePath, "rebuilt to a usable build on this image after the bake"))
+                        logger?.LogWarning(
+                            "DynamicTypePreWarmer: RETRACTING the regression recorded for "
+                            + "{TypePath} — it has since reached a usable build on THIS image, so "
+                            + "the earlier failure was not evidence against the image (typically a "
+                            + "compile that sampled a half-applied content update — issue #1214). "
+                            + "Gate now: {Detail}",
+                            typePath, gate.Detail);
+                },
+                ex => logger?.LogWarning(ex,
+                    "DynamicTypePreWarmer: recovery watch for the regressed type {TypePath} "
+                    + "faulted — the regression STANDS (a watch that cannot observe a recovery "
+                    + "must never be read as one)",
+                    typePath));
+    }
+
+    /// <summary>
     /// Activate one dynamic NodeType's hub by subscribing to its own MeshNode stream —
     /// which routes a SubscribeRequest to the owning hub, activating it and firing the
     /// compile watcher's framework-stale / first-build kickoff. Holds the subscription
@@ -775,8 +907,7 @@ public static class DynamicTypePreWarmer
                         var d = (NodeTypeDefinition)n!.Content!;
                         return d.CompilationStatus switch
                         {
-                            CompilationStatus.Error => new PreWarmOutcome(
-                                typePath, ClassifyCompileFailure(d), d.CompilationError),
+                            CompilationStatus.Error => FromFailedCompile(typePath, d),
                             // TimedOut, never CompileError: the type is not broken, its
                             // state simply never came back.
                             //

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -127,6 +127,22 @@ public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Deta
     /// at 3am that the image is broken (issue #1214, proposal 3).</para>
     /// </summary>
     public bool SourcesMovedDuringCompile { get; init; }
+
+    /// <summary>
+    /// For a DERIVED outcome — <see cref="PreWarmStatus.UpstreamFailed"/>,
+    /// <see cref="PreWarmStatus.UpstreamContentBroken"/>,
+    /// <see cref="PreWarmStatus.UpstreamUnevaluated"/> — the upstream type that blocked this one.
+    /// <c>null</c> for an outcome the sweep measured directly.
+    ///
+    /// <para>It is what makes a derived regression retractable WITHOUT touching this type: such a
+    /// verdict's entire evidentiary basis is the blocker's verdict (the sweep never attempted this
+    /// type — deliberately, since attempting it would burn a whole per-type budget on a build that
+    /// cannot succeed). So when the blocker's regression is withdrawn, this one has nothing left
+    /// holding it up and is withdrawn too. The alternative — watching each dependent for its own
+    /// recovery — would ACTIVATE every skipped dependent's hub and hold it for the pod's lifetime,
+    /// undoing exactly the saving the skip exists for.</para>
+    /// </summary>
+    public string? BlockedBy { get; init; }
 }
 
 /// <summary>
@@ -544,7 +560,13 @@ public static class DynamicTypePreWarmer
                             p, named, outcome);
                         // No pacing for a skip: it activates nothing, so there is no
                         // burst to spread out and no reason to slow the sweep down.
-                        return Observable.Return(new PreWarmOutcome(p, outcome, $"blocked by {named}"));
+                        //
+                        // BlockedBy carries the blocker as DATA, not just inside the detail text:
+                        // a derived regression is retracted when its blocker's is, and parsing that
+                        // relationship back out of a message would be the kind of coupling that
+                        // breaks the next time the wording changes.
+                        return Observable.Return(
+                            new PreWarmOutcome(p, outcome, $"blocked by {named}") { BlockedBy = named });
                     }
 
                     // Batch mode drives the ONE compiler directly with the pre-resolved source

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
@@ -74,6 +75,15 @@ public sealed class DynamicTypePreWarmerHostedService(
 
     private IDisposable? _warmSubscription;
     private IDisposable? _startedRegistration;
+
+    /// <summary>
+    /// One recovery watch per RECORDED REGRESSION (#1214) — each observes its type until it
+    /// reaches a usable build on this image and then retracts the regression. They outlive the
+    /// sweep by design (the content that tore the compile converges after it), so they are owned
+    /// here and disposed with the service; a discarded subscription would root the hub.
+    /// Empty on a healthy bake, which is the overwhelmingly common case.
+    /// </summary>
+    private readonly CompositeDisposable _recoveryWatches = new();
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
@@ -197,7 +207,26 @@ public sealed class DynamicTypePreWarmerHostedService(
             .Subscribe(
                 outcome =>
                 {
-                    gate?.MarkOutcome(outcome);
+                    // A recorded regression stalls the rollout — so from this moment the gate
+                    // WATCHES the type it just condemned. The platform recompiles a failed type by
+                    // itself once its sources change (the park registry's source-change auto-retry),
+                    // and a type that then builds on this image is no longer evidence against the
+                    // image: the regression is retracted and the pod may go Ready without a human.
+                    // #1214: a bake that compiled a half-applied plugin update recorded four false
+                    // regressions and hung the rollout although the content converged seconds later.
+                    if (gate?.MarkOutcome(outcome) == true)
+                    {
+                        if (outcome.SourcesMovedDuringCompile)
+                            logger.LogWarning(
+                                "DynamicTypePreWarmer: {TypePath} regressed, but its SOURCES MOVED "
+                                + "at or after the compile started — this verdict may describe a "
+                                + "half-applied content update (a plugin auto-update or git sync "
+                                + "landing mid-bake), not this image. It STANDS until the type is "
+                                + "seen to build here, and is retracted automatically when it does.",
+                                outcome.TypePath);
+                        _recoveryWatches.Add(
+                            DynamicTypePreWarmer.WatchForRecovery(mesh, gate, outcome.TypePath, logger));
+                    }
                     switch (outcome.Status)
                     {
                         case PreWarmStatus.Compiled: Interlocked.Increment(ref compiled); break;
@@ -257,7 +286,11 @@ public sealed class DynamicTypePreWarmerHostedService(
                         if (gate.GatesReadiness)
                             logger.LogCritical(
                                 "DynamicTypePreWarmer: REFUSING READINESS — {Detail}. The rollout will stall "
-                                + "with the previous image still serving. Regressions: {Regressions}",
+                                + "with the previous image still serving. Each of these types is now being "
+                                + "WATCHED: if it reaches a usable build on this image (the platform "
+                                + "recompiles a failed type once its sources change), its regression is "
+                                + "retracted and readiness follows — so a verdict formed against a "
+                                + "half-applied content update clears itself. Regressions: {Regressions}",
                                 gate.Detail, regressions);
                         else
                             logger.LogCritical(
@@ -293,6 +326,7 @@ public sealed class DynamicTypePreWarmerHostedService(
         _startedRegistration = null;
         _warmSubscription?.Dispose();
         _warmSubscription = null;
+        _recoveryWatches.Dispose();
     }
 }
 

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -214,6 +214,13 @@ public sealed class DynamicTypePreWarmerHostedService(
                     // image: the regression is retracted and the pod may go Ready without a human.
                     // #1214: a bake that compiled a half-applied plugin update recorded four false
                     // regressions and hung the rollout although the content converged seconds later.
+                    //
+                    // MarkOutcome returns true only for a DIRECTLY-MEASURED regression. A derived
+                    // one (a dependent skipped because its upstream failed) is recorded and still
+                    // gates, but is deliberately NOT watched: the sweep skipped it to avoid
+                    // activating its hub at all, and one broken upstream would otherwise activate
+                    // its whole fan-out and hold it for the pod's lifetime. Those are retracted
+                    // through their blocker instead (NodeTypeBakeGateState.RetractRegression).
                     if (gate?.MarkOutcome(outcome) == true)
                     {
                         if (outcome.SourcesMovedDuringCompile)

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -41,6 +41,13 @@ public sealed class NodeTypeBakeGateState
     private readonly ConcurrentDictionary<string, string> retracted = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// For each DERIVED regression (an <c>Upstream*</c> outcome), the upstream that blocked it —
+    /// see <see cref="PreWarmOutcome.BlockedBy"/>. Retracting a blocker cascades to these, because
+    /// their only evidence was the blocker's verdict. Guarded by <see cref="verdict"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, string> blockedBy = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Guards the (regressions ↔ phase ↔ detail) invariant across the four writers, so a
     /// retraction that empties the set cannot interleave with a fresh regression and leave the
     /// phase disagreeing with the dictionary.
@@ -125,9 +132,16 @@ public sealed class NodeTypeBakeGateState
     /// abandoned NodeType freeze the platform.
     /// </summary>
     /// <returns>
-    /// <c>true</c> when this outcome RECORDED A REGRESSION — i.e. the caller now holds a verdict
-    /// that stalls the rollout, and should therefore watch the named type for the recovery that
-    /// retracts it (<see cref="RetractRegression"/>). <c>false</c> for every non-gating outcome.
+    /// <c>true</c> when this outcome recorded a regression the caller should WATCH FOR RECOVERY —
+    /// a DIRECTLY-MEASURED verdict on a type the sweep actually compiled
+    /// (<see cref="RetractRegression"/> is what a recovery then calls).
+    ///
+    /// <para><c>false</c> for every non-gating outcome AND for a DERIVED regression (one carrying
+    /// <see cref="PreWarmOutcome.BlockedBy"/>), which is still recorded and still gates but must
+    /// NOT be watched: the sweep skipped that type precisely to avoid activating its hub, and
+    /// watching it would activate every skipped dependent of one broken upstream and hold them for
+    /// the pod's lifetime. A derived regression is retracted through its blocker instead — see the
+    /// cascade in <see cref="RetractRegression"/>.</para>
     /// </returns>
     public bool MarkOutcome(PreWarmOutcome outcome)
     {
@@ -182,10 +196,14 @@ public sealed class NodeTypeBakeGateState
             // A fresh verdict supersedes an earlier retraction of the SAME type: if it broke again
             // after recovering, the health payload must say "regressed", not "recovered".
             retracted.TryRemove(outcome.TypePath, out _);
+            if (outcome.BlockedBy is { Length: > 0 } blocker)
+                blockedBy[outcome.TypePath] = blocker;
+            else
+                blockedBy.TryRemove(outcome.TypePath, out _);
             Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
             detail = RegressedDetail();
         }
-        return true;
+        return outcome.BlockedBy is null;
     }
 
     /// <summary>
@@ -231,6 +249,34 @@ public sealed class NodeTypeBakeGateState
                 return false;
 
             retracted[typePath] = $"{reason} (had been {was})";
+
+            // 🚨 CASCADE THROUGH THE DERIVED VERDICTS. A dependent skipped as UpstreamFailed was
+            // never compiled — its regression's ENTIRE evidence is "my upstream failed". With that
+            // verdict withdrawn there is nothing left saying this type is broken, so it must be
+            // withdrawn too; leaving it would keep the pod out of rotation on a claim whose basis
+            // no longer exists. This is the same principle the Upstream* statuses already encode —
+            // a derived verdict is only ever as strong as the one it derives from.
+            //
+            // Transitive (a dependent of a dependent), and terminating: each round removes at least
+            // one entry from a finite, shrinking set.
+            var cascade = new Queue<string>();
+            cascade.Enqueue(typePath);
+            while (cascade.Count > 0)
+            {
+                var blocker = cascade.Dequeue();
+                foreach (var dependent in blockedBy
+                             .Where(kv => string.Equals(
+                                 kv.Value, blocker, StringComparison.OrdinalIgnoreCase))
+                             .Select(kv => kv.Key)
+                             .ToList())
+                {
+                    blockedBy.TryRemove(dependent, out _);
+                    if (!regressions.TryRemove(dependent, out var derived))
+                        continue;
+                    retracted[dependent] = $"its blocker {blocker} was retracted (had been {derived})";
+                    cascade.Enqueue(dependent);
+                }
+            }
 
             if (!regressions.IsEmpty)
             {

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -38,8 +38,27 @@ public sealed class NodeTypeBakeGateState
     private readonly ConcurrentDictionary<string, string> regressions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> unevaluated = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> contentBroken = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> retracted = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Guards the (regressions ↔ phase ↔ detail) invariant across the four writers, so a
+    /// retraction that empties the set cannot interleave with a fresh regression and leave the
+    /// phase disagreeing with the dictionary.
+    ///
+    /// <para>Writers only. <see cref="Phase"/> and <see cref="Detail"/> stay lock-free
+    /// (<see cref="Volatile"/> / <c>volatile</c>) because the readiness probe reads them
+    /// synchronously from ASP.NET's health endpoint — a probe that can block on a lock is a probe
+    /// that can take the pod out of rotation under load. Nothing awaits inside the lock; it is a
+    /// handful of dictionary operations and a string build.</para>
+    /// </summary>
+    private readonly object verdict = new();
+
     private int phase = (int)BakePhase.NotStarted;
     private volatile string detail = "pre-warm not started";
+
+    /// <summary>The message <see cref="MarkComplete"/> was given, or <c>null</c> while the sweep
+    /// is still running. Guarded by <see cref="verdict"/>.</summary>
+    private string? completedMessage;
 
     /// <summary>
     /// Whether a readiness probe actually CONSUMES this state — i.e. the host registered its
@@ -81,11 +100,22 @@ public sealed class NodeTypeBakeGateState
     /// </summary>
     public IReadOnlyDictionary<string, string> ContentBroken => contentBroken;
 
+    /// <summary>
+    /// Regressions that were RETRACTED because the type has since been observed reaching a usable
+    /// build on this image — see <see cref="RetractRegression"/>. Kept (rather than simply
+    /// forgotten) so a rollout that recovered by itself still says so in the health payload: a
+    /// silently-vanished regression is indistinguishable from one that never happened.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Retracted => retracted;
+
     /// <summary>The sweep has begun.</summary>
     public void MarkRunning(string message)
     {
-        Interlocked.Exchange(ref phase, (int)BakePhase.Running);
-        detail = message;
+        lock (verdict)
+        {
+            Interlocked.Exchange(ref phase, (int)BakePhase.Running);
+            detail = message;
+        }
     }
 
     /// <summary>
@@ -94,10 +124,15 @@ public sealed class NodeTypeBakeGateState
     /// broken in production right now, and blocking every future rollout on it would let one
     /// abandoned NodeType freeze the platform.
     /// </summary>
-    public void MarkOutcome(PreWarmOutcome outcome)
+    /// <returns>
+    /// <c>true</c> when this outcome RECORDED A REGRESSION — i.e. the caller now holds a verdict
+    /// that stalls the rollout, and should therefore watch the named type for the recovery that
+    /// retracts it (<see cref="RetractRegression"/>). <c>false</c> for every non-gating outcome.
+    /// </returns>
+    public bool MarkOutcome(PreWarmOutcome outcome)
     {
         if (outcome.ReachedUsableBuild || !outcome.WasHealthyBeforeBake)
-            return;
+            return false;
 
         // 🚨 A TIMEOUT IS NOT A VERDICT. The per-type budget elapsing means the sweep never got an
         // answer — it says nothing about whether the type builds. During a roll the baking pod and
@@ -124,7 +159,7 @@ public sealed class NodeTypeBakeGateState
         if (outcome.Status is PreWarmStatus.TimedOut or PreWarmStatus.UpstreamUnevaluated)
         {
             unevaluated[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
-            return;
+            return false;
         }
 
         // A CONTENT verdict is not an IMAGE verdict. NoSources means the type's declared source
@@ -138,41 +173,152 @@ public sealed class NodeTypeBakeGateState
         if (outcome.Status is PreWarmStatus.NoSources or PreWarmStatus.UpstreamContentBroken)
         {
             contentBroken[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
-            return;
+            return false;
         }
 
-        regressions[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
-        Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
-        detail = $"{regressions.Count} NodeType(s) regressed on this image";
+        lock (verdict)
+        {
+            regressions[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
+            // A fresh verdict supersedes an earlier retraction of the SAME type: if it broke again
+            // after recovering, the health payload must say "regressed", not "recovered".
+            retracted.TryRemove(outcome.TypePath, out _);
+            Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
+            detail = RegressedDetail();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// 🚨 A REGRESSION IS A MEASUREMENT, NOT A LABEL — retract it when the type it names is
+    /// afterwards observed reaching a usable build ON THIS IMAGE.
+    ///
+    /// <para>This is NOT "completion is absolution", which <see cref="MarkComplete"/> still
+    /// refuses: the sweep finishing proves nothing about a type that failed during it. This is the
+    /// opposite direction — a LATER, BETTER measurement of the SAME type on the SAME image
+    /// supersedes an earlier one. A type that compiles here cannot also be evidence that this image
+    /// broke it, and the gate exists to stop a bad IMAGE.</para>
+    ///
+    /// <para><b>The incident this exists for (memex-cloud, 2026-08-11 11:04–11:12 UTC, issue
+    /// #1214).</b> A gated pod refused readiness with four <c>Store/*</c> types "regressed" and
+    /// CS0117 diagnostics naming <c>Localizer</c> members. Nothing was wrong with the image: the
+    /// plugins repo had reverted a branch and the portal's plugin auto-update was applying that
+    /// revert WHILE the bake compiled — <c>Store/Plugin/Source/Localizer</c> landed at 11:04:59
+    /// (members gone) and its callers at 11:06:57. The bake, running 10:47→11:06, compiled against
+    /// the gap between the two writes, so Roslyn's verdict described a source set that existed for
+    /// roughly two minutes and never again.</para>
+    ///
+    /// <para>The platform itself already treats such a failure as provisional:
+    /// <c>NodeTypeCompileParkRegistry.ShouldRetryForSourceChange</c> un-parks and recompiles a
+    /// failed type the moment its source snapshot changes, so those four types went green seconds
+    /// after the content converged. The ONLY thing that stayed broken was this record — latched,
+    /// sticky, and never re-read — so the pod never became Ready and the rollout hung until a human
+    /// noticed. Making the latch level-triggered on the truth it claims to represent is the fix;
+    /// widening a timeout or ignoring CompileErrors would not be.</para>
+    ///
+    /// <para><b>It cannot launder a real regression.</b> The retraction is driven by the type
+    /// reaching a usable build — a genuinely broken type never does, so a real compile error on a
+    /// stable source set gates exactly as long as it did before: forever. No timer, no retry, no
+    /// budget; the caller merely observes state the platform already publishes.</para>
+    /// </summary>
+    /// <param name="typePath">The NodeType whose regression is being retracted.</param>
+    /// <param name="reason">Why — recorded in <see cref="Retracted"/> and the health payload.</param>
+    /// <returns><c>true</c> if a regression was actually held for this type and has now been removed.</returns>
+    public bool RetractRegression(string typePath, string reason)
+    {
+        lock (verdict)
+        {
+            if (!regressions.TryRemove(typePath, out var was))
+                return false;
+
+            retracted[typePath] = $"{reason} (had been {was})";
+
+            if (!regressions.IsEmpty)
+            {
+                // Still red on other types — only the wording changes.
+                detail = RegressedDetail();
+                return true;
+            }
+
+            // That was the last one. Where the gate lands depends on whether the sweep has
+            // finished: mid-sweep it goes back to Running (still measuring), afterwards to the
+            // Complete verdict MarkComplete would have produced had this type never failed.
+            if (completedMessage is not { } done)
+            {
+                Interlocked.Exchange(ref phase, (int)BakePhase.Running);
+                detail = "the last recorded regression was retracted — sweep still running";
+                return true;
+            }
+
+            Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
+            detail = CompleteDetail(done);
+            return true;
+        }
     }
 
     /// <summary>
     /// The sweep finished. A run that recorded a regression STAYS regressed — completion is not
-    /// absolution.
+    /// absolution. (What DOES absolve a single type is that type building on this image afterwards
+    /// — see <see cref="RetractRegression"/>, which is a fresh measurement rather than an amnesty.)
     /// </summary>
     public void MarkComplete(string message)
     {
-        if (!regressions.IsEmpty)
+        lock (verdict)
         {
-            detail = $"{regressions.Count} NodeType(s) regressed on this image: "
-                + string.Join(", ", regressions.Keys.OrderBy(k => k, StringComparer.Ordinal));
-            return;
-        }
+            // Remembered so a retraction arriving AFTER the sweep can land on the Complete verdict
+            // this call would have produced, instead of leaving the pod stuck mid-sweep forever.
+            completedMessage = message;
 
-        Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
-        // Ready, but say so honestly: a type we could not evaluate is not a type we verified, and
-        // a content-broken type is broken RIGHT NOW even though it must not stall the rollout.
-        // Surfacing both in the health payload is what keeps "non-blocking" from becoming
-        // "invisible" — a silently-swallowed bucket is how a real problem would hide behind this
-        // leniency.
-        var addenda = new List<string>(2);
+            if (!regressions.IsEmpty)
+            {
+                detail = RegressedDetail();
+                return;
+            }
+
+            Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
+            detail = CompleteDetail(message);
+        }
+    }
+
+    /// <summary>
+    /// The health payload while at least one regression stands. Names any RETRACTED regression
+    /// too: on a pod that is still red, "these other types failed and then rebuilt" is exactly the
+    /// signal that tells an operator they are looking at a content race rather than a bad image —
+    /// hiding it until the gate happens to go green would withhold it precisely when it is needed.
+    /// Caller holds <see cref="verdict"/>.
+    /// </summary>
+    private string RegressedDetail()
+    {
+        var head = $"{regressions.Count} NodeType(s) regressed on this image: "
+            + string.Join(", ", regressions.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        return retracted.IsEmpty
+            ? head
+            : $"{head} ({retracted.Count} further regression(s) retracted after the type rebuilt "
+                + "on this image — "
+                + string.Join(", ", retracted.Keys.OrderBy(k => k, StringComparer.Ordinal)) + ")";
+    }
+
+    /// <summary>
+    /// The health payload for a pod that may serve. Ready, but say so honestly: a type we could not
+    /// evaluate is not a type we verified, a content-broken type is broken RIGHT NOW even though it
+    /// must not stall the rollout, and a retracted regression means this pod DID record damage that
+    /// later healed. Surfacing all three is what keeps "non-blocking" from becoming "invisible" — a
+    /// silently-swallowed bucket is how a real problem would hide behind this leniency.
+    /// Caller holds <see cref="verdict"/>.
+    /// </summary>
+    private string CompleteDetail(string message)
+    {
+        var addenda = new List<string>(3);
         if (!unevaluated.IsEmpty)
             addenda.Add($"{unevaluated.Count} not evaluated — "
                 + string.Join(", ", unevaluated.Keys.OrderBy(k => k, StringComparer.Ordinal)));
         if (!contentBroken.IsEmpty)
             addenda.Add($"{contentBroken.Count} content-broken, sources missing — "
                 + string.Join(", ", contentBroken.Keys.OrderBy(k => k, StringComparer.Ordinal)));
-        detail = addenda.Count == 0
+        if (!retracted.IsEmpty)
+            addenda.Add($"{retracted.Count} regression(s) retracted after the type rebuilt on this "
+                + "image — "
+                + string.Join(", ", retracted.Keys.OrderBy(k => k, StringComparer.Ordinal)));
+        return addenda.Count == 0
             ? message
             : $"{message} ({string.Join("; ", addenda)})";
     }

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -526,7 +526,14 @@ internal static class NodeTypeBatchBake
                     ? PreWarmStatus.NoSources
                     : PreWarmStatus.CompileError;
                 return new PreWarmOutcome(
-                    typePath, status, NodeTypeCompilationHelpers.SummarizeCompileError(result, error));
+                    typePath, status, NodeTypeCompilationHelpers.SummarizeCompileError(result, error))
+                {
+                    // Same torn-snapshot evidence the activation path carries (#1214): whether the
+                    // type's sources moved while this compile ran. Read off the type record, which
+                    // holds both the compile-start stamp and the live source snapshot.
+                    SourcesMovedDuringCompile =
+                        def is not null && DynamicTypePreWarmer.SourcesMovedDuringCompile(def)
+                };
             });
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -291,6 +291,230 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     // =============================================================================================
+    // TORN SNAPSHOT (issue #1214): the bake can compile a HALF-APPLIED content update and report
+    // it as an image regression. memex-cloud, 2026-08-11 11:04–11:12 UTC — the plugins repo had
+    // reverted a branch and the portal's plugin auto-update was applying that revert WHILE the bake
+    // compiled: `Store/Plugin/Source/Localizer` landed at 11:04:59 with two members removed, its
+    // callers only at 11:06:57. The bake (10:47→11:06) compiled inside that two-minute gap, got
+    // CS0117 on members that no source references any more, and refused readiness for four
+    // `Store/*` types. Nothing was wrong with the image; the content converged seconds later and
+    // the platform recompiled every one of them green — but BakePhase.Regressed is sticky, so the
+    // pod never went Ready and the rollout hung until a human intervened.
+    // =============================================================================================
+
+    /// <summary>
+    /// 🚨 THE #1214 CONTRACT, both halves in one mesh so the negative half has a real
+    /// synchronisation point rather than a sleep.
+    ///
+    /// <para><b>Positive.</b> A previously-healthy type is broken by the FIRST write of a two-write
+    /// content update (the helper loses a member its caller still calls — `Localizer` at 11:04:59),
+    /// the gate records the regression and refuses readiness, and then the SECOND write lands (the
+    /// caller stops calling it — 11:06:57). Nothing else happens: no deliberate retry, no restart,
+    /// no human. The platform's own park registry un-parks and recompiles the type on the source
+    /// change, and the gate must FOLLOW it back to Complete.</para>
+    ///
+    /// <para><b>Negative.</b> A second type is genuinely broken on a source set that nobody
+    /// touches. Its regression must STAND — the retraction is driven by the type reaching a usable
+    /// build, which a broken type never does. By the time the first type has been retracted the
+    /// watch machinery has demonstrably run, so "still gated" here is evidence, not latency.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task RegressedType_ThatRebuildsAfterTheContentConverges_IsRetracted_ButARealBreakStillGates()
+    {
+        var workspace = Mesh.GetWorkspace();
+        const string ns = $"{Partition}Torn";
+        const string tornPath = $"{ns}/TornType";
+        const string helperPath = $"{ns}/TornType/Source/helper";
+        const string callerPath = $"{ns}/TornType/Source/caller";
+        const string brokenPath = $"{ns}/StaysBroken";
+        const string brokenSourcePath = $"{ns}/StaysBroken/Source/code";
+
+        // ── The torn type: ONE package update rewrites TWO source nodes, and the bake compiles
+        //    between the two writes. Helper defines the member; Caller uses it.
+        await NodeFactory.CreateNode(new MeshNode("helper", $"{tornPath}/Source")
+        {
+            Name = "Helper",
+            NodeType = "Code",
+            Content = new CodeConfiguration
+            {
+                Code = "public static class TornHelper { public static int Answer() => 42; }",
+                Language = "csharp"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("caller", $"{tornPath}/Source")
+        {
+            Name = "Caller",
+            NodeType = "Code",
+            Content = new CodeConfiguration
+            {
+                Code = "public static class TornCaller { public static int Get() => TornHelper.Answer(); }",
+                Language = "csharp"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("TornType", ns)
+        {
+            Name = "Torn Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Broken by a half-applied two-write content update, then repaired.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // ── The genuinely broken type: invalid C# in a source nobody will touch.
+        await NodeFactory.CreateNode(new MeshNode("code", $"{brokenPath}/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "this is not valid C#;", Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("StaysBroken", ns)
+        {
+            Name = "Stays Broken",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "A real compile error on a source set that never changes.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // Healthy on the way in — the WasHealthyBeforeBake baseline a real sweep takes when it
+        // starts (the torn type was Ok at 10:47). The broken one settles at Error by itself.
+        await Precompile(tornPath, d => d.CompilationStatus == CompilationStatus.Ok);
+        var reallyBroken = await WhenDefinition(brokenPath,
+            d => d.CompilationStatus == CompilationStatus.Error, TimeSpan.FromSeconds(120));
+
+        // ── 11:04:59. The revert lands on the HELPER: the member is gone, the caller still calls
+        //    it. The bake DRIVES the compile that samples this state (the sweep activates and
+        //    compiles each type), so the trigger here is explicit, exactly as it was in production.
+        await workspace.GetMeshNodeStream(helperPath).Update(curr =>
+                curr with
+                {
+                    Content = new CodeConfiguration
+                    {
+                        Code = "public static class TornHelper { }", Language = "csharp"
+                    }
+                })
+            .Should().Within(30.Seconds()).Emit();
+        await workspace.GetMeshNodeStream(tornPath).Update(curr =>
+            {
+                if (curr?.Content is not NodeTypeDefinition def) return curr!;
+                return curr with
+                {
+                    Content = def with
+                    {
+                        RequestedReleaseAt = DateTimeOffset.UtcNow,
+                        RequestedReleaseForce = true
+                    }
+                };
+            })
+            .Should().Within(30.Seconds()).Emit();
+
+        var tornFailure = await WhenDefinition(tornPath,
+            d => d.CompilationStatus == CompilationStatus.Error, TimeSpan.FromSeconds(120));
+        Output.WriteLine($"{tornPath} → Error: {tornFailure.CompilationError}");
+        tornFailure.CompilationError.Should().MatchRegex(@"CS\d{4}",
+            "the premise of this test is a REAL Roslyn diagnostic produced against a source set "
+            + "that is being replaced — an infrastructure abort would prove nothing");
+
+        // ── The bake's verdict. Both types were previously healthy as far as this gate is
+        //    concerned, so both failures read as regressions and the pod refuses readiness.
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("TornSnapshot");
+        var gate = new NodeTypeBakeGateState { GatesReadiness = true };
+        gate.MarkRunning("baking");
+        gate.MarkOutcome(new PreWarmOutcome(
+                tornPath, PreWarmStatus.CompileError, tornFailure.CompilationError)
+            { WasHealthyBeforeBake = true })
+            .Should().BeTrue();
+        gate.MarkOutcome(new PreWarmOutcome(
+                brokenPath, PreWarmStatus.CompileError, reallyBroken.CompilationError)
+            { WasHealthyBeforeBake = true })
+            .Should().BeTrue();
+        gate.MarkComplete("baked in 00:19:00");
+        gate.Phase.Should().Be(BakePhase.Regressed, "two previously-healthy types failed to build");
+
+        // The production wiring: every type the gate condemned is WATCHED for a recovery.
+        using var tornWatch = DynamicTypePreWarmer.WatchForRecovery(Mesh, gate, tornPath, logger);
+        using var brokenWatch = DynamicTypePreWarmer.WatchForRecovery(Mesh, gate, brokenPath, logger);
+
+        // 🚨 THE TRAP THIS PINS. A failed compile KEEPS the previous build's assembly coordinates
+        // and framework stamp — ApplyCompileFailure clears only the status, the error text and
+        // CompiledSources — so `HasUsableBuild` is still TRUE for a type that has just failed. A
+        // recovery watch that matched on it would retract every regression the instant it was
+        // recorded and quietly disable the entire gate. (The first draft of this change did exactly
+        // that, and this assertion is what caught it.) Nothing has driven a compile since the
+        // failure, so the watch must be sitting still.
+        gate.Retracted.Should().BeEmpty(
+            "the torn type still carries the assembly of its LAST GOOD build — only a compile that "
+            + "is demonstrably NEWER than the failure may retract a regression");
+        gate.Phase.Should().Be(BakePhase.Regressed);
+
+        // ── 11:06:57. The update's SECOND write lands and the content is self-consistent again.
+        //    NOTHING ELSE HAPPENS — no compile trigger, no recycle, no restart.
+        await workspace.GetMeshNodeStream(callerPath).Update(curr =>
+                curr with
+                {
+                    Content = new CodeConfiguration
+                    {
+                        Code = "public static class TornCaller { public static int Get() => 7; }",
+                        Language = "csharp"
+                    }
+                })
+            .Should().Within(30.Seconds()).Emit();
+
+        // The platform recompiles the parked type on its own (the park registry's
+        // "retry only if the sources changed" path) — and the GATE must let go of it.
+        await WhenGate(gate, g => g.Retracted.ContainsKey(tornPath), TimeSpan.FromSeconds(150));
+
+        Output.WriteLine($"gate → {gate.Phase}: {gate.Detail}");
+        gate.Regressions.Keys.Should().NotContain(tornPath,
+            "the type rebuilt on THIS image, so the earlier failure was never evidence against it");
+        gate.Detail.Should().Contain("retracted",
+            "a regression that healed still happened — it must stay visible in the health payload");
+
+        // …and it was a FRESH build that retracted it, not the stale one the failure kept. This is
+        // the deterministic half of the same guard as the Retracted-is-empty check above.
+        var rebuilt = await WhenDefinition(tornPath,
+            d => d.CompilationStatus == CompilationStatus.Ok, TimeSpan.FromSeconds(30));
+        (rebuilt.LastCompileSucceededAt > tornFailure.LastCompileSucceededAt).Should().BeTrue(
+            "the retraction must be driven by a compile that ran AFTER the regression was recorded "
+            + "— the record's pre-failure success timestamp must never be enough. Failure carried "
+            + $"{tornFailure.LastCompileSucceededAt:O}, rebuild {rebuilt.LastCompileSucceededAt:O}");
+
+        // ── The negative half. The watch machinery has now demonstrably run (it retracted the
+        //    torn type), so the genuinely broken type still being held is evidence, not latency:
+        //    a real compile error on a source set nobody touched STILL GATES, and the pod stays
+        //    out of rotation — which is the entire point of the gate and must not have been
+        //    weakened by any of the above.
+        gate.Retracted.Keys.Should().NotContain(brokenPath,
+            "a genuinely broken type never reaches a usable build, so nothing may retract it");
+        gate.Regressions.Keys.Should().Equal(brokenPath);
+        gate.Phase.Should().Be(BakePhase.Regressed,
+            "one real compile error on a stable source set is enough to refuse readiness — "
+            + "retracting the torn type must not have released the gate");
+    }
+
+    /// <summary>
+    /// Waits (level-triggered) until the gate satisfies <paramref name="predicate"/>. The gate is a
+    /// deliberately non-reactive, lock-free singleton — the readiness probe pulls it synchronously
+    /// — so there is no stream to filter on and the sanctioned interval re-read applies
+    /// (WritingTests.md → "Polling loops around QueryAsync"); never a fixed <c>Task.Delay</c>.
+    /// </summary>
+    private static Task WhenGate(
+        NodeTypeBakeGateState gate, Func<NodeTypeBakeGateState, bool> predicate, TimeSpan timeout)
+        => Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .Select(_ => gate)
+            .Where(predicate)
+            .FirstAsync()
+            .Timeout(timeout)
+            .ToTask();
+
+    // =============================================================================================
     // Batch bake (issue #1207): the initial-bake mode drives the ONE compiler directly — batched
     // source discovery, no per-type hub activation, no compile-watcher settle — and must produce
     // the same artifacts (per-type assemblies on the share, compile-state stamps on the type

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -136,6 +136,198 @@ public class NodeTypeBakeGateStateTest
         state.Detail.Should().Contain("Store/Plugin");
     }
 
+    // =============================================================================================
+    // RETRACTION (issue #1214). "Completion is not absolution" is about the SWEEP finishing and
+    // stays true above. What DOES absolve one type is that type building on THIS image afterwards
+    // — a later, better measurement of the same thing, not an amnesty.
+    //
+    // The incident: memex-cloud 2026-08-11, a bake compiled `Store/*` against a half-applied plugin
+    // update (the reverted `Localizer` had landed, its callers had not), recorded four regressions
+    // with CS0117 diagnostics, and refused readiness. The content converged 2 minutes later and the
+    // platform recompiled every one of those types green — but the gate never re-read them, so the
+    // pod stayed out of rotation and the rollout hung until a human restarted it.
+    // =============================================================================================
+
+    /// <summary>
+    /// The headline: a regression retracted after the sweep completed lands on the COMPLETE verdict
+    /// <see cref="NodeTypeBakeGateState.MarkComplete"/> would have produced. Anything else (staying
+    /// Regressed, or falling back to Running) leaves the pod out of rotation forever, which is the
+    /// bug — the rollout hung on content that had already repaired itself.
+    /// </summary>
+    [Fact]
+    public void RetractingTheLastRegressionAfterTheSweep_ReturnsTheGateToComplete()
+    {
+        var state = new NodeTypeBakeGateState { GatesReadiness = true };
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Catalog", wasHealthy: true));
+        state.MarkComplete("baked in 00:19:00");
+        state.Phase.Should().Be(BakePhase.Regressed);
+
+        state.RetractRegression("Store/Catalog", "rebuilt on this image")
+            .Should().BeTrue("the gate was holding a regression for exactly this type");
+
+        state.Phase.Should().Be(BakePhase.Complete,
+            "a type that builds on this image is not evidence that this image broke it — the pod "
+            + "must be allowed to take traffic without a human noticing");
+        state.Regressions.Should().BeEmpty();
+        state.Retracted.Keys.Should().Contain("Store/Catalog");
+        state.Detail.Should().Contain("baked in 00:19:00").And.Contain("retracted",
+            "a regression that healed still HAPPENED — hiding it would make a real, recurring "
+            + "content race invisible");
+    }
+
+    /// <summary>
+    /// A retraction while the sweep is still running goes back to RUNNING, never to Complete: the
+    /// sweep has not finished measuring, and reporting Complete early would let a pod go Ready
+    /// before the types after this one were even attempted.
+    /// </summary>
+    [Fact]
+    public void RetractingTheLastRegressionMidSweep_ReturnsToRunning_NotComplete()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Catalog", wasHealthy: true));
+
+        state.RetractRegression("Store/Catalog", "rebuilt on this image").Should().BeTrue();
+
+        state.Phase.Should().Be(BakePhase.Running,
+            "the sweep is still measuring — only MarkComplete may declare the bake done");
+    }
+
+    /// <summary>One retraction among several regressions keeps the gate red — it is not a reset.</summary>
+    [Fact]
+    public void RetractingOneOfSeveralRegressions_StillGates()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Catalog", wasHealthy: true));
+        state.MarkOutcome(Failed("Store/Order", wasHealthy: true));
+        state.MarkComplete("done");
+
+        state.RetractRegression("Store/Catalog", "rebuilt").Should().BeTrue();
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Store/Order");
+        // The still-red payload names BOTH: what is holding the pod out of rotation, and what
+        // failed-then-rebuilt. The second half is the signal that says "you are looking at a
+        // content race, not a bad image" — and it is needed most while the gate is still red.
+        state.Detail.Should().Contain("Store/Order")
+            .And.Contain("Store/Catalog").And.Contain("retracted");
+    }
+
+    /// <summary>
+    /// 🚨 The retraction may NOT be used to launder a type nobody condemned, and it may not
+    /// resurrect a cleared one. Retracting an unheld type is a no-op that reports itself as such —
+    /// otherwise a caller could quietly move the gate to Complete on a type the sweep never failed.
+    /// </summary>
+    [Fact]
+    public void RetractingATypeThatNeverRegressed_ChangesNothing()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Order", wasHealthy: true));
+        state.MarkComplete("done");
+
+        state.RetractRegression("Never/Failed", "rebuilt").Should().BeFalse();
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Store/Order");
+        state.Retracted.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A type that breaks AGAIN after recovering gates again, and the health payload says
+    /// "regressed" rather than "recovered" — the newest measurement always wins.
+    /// </summary>
+    [Fact]
+    public void ATypeThatFailsAgainAfterRetraction_RegressesAgain()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Flaky/Type", wasHealthy: true));
+        state.MarkComplete("done");
+        state.RetractRegression("Flaky/Type", "rebuilt").Should().BeTrue();
+        state.Phase.Should().Be(BakePhase.Complete);
+
+        state.MarkOutcome(Failed("Flaky/Type", wasHealthy: true)).Should().BeTrue();
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Flaky/Type");
+        state.Retracted.Should().BeEmpty("a fresh verdict supersedes the earlier retraction");
+    }
+
+    /// <summary>
+    /// <see cref="NodeTypeBakeGateState.MarkOutcome"/> reports whether it RECORDED a regression —
+    /// that boolean is what tells the pre-warmer which types to watch for recovery. A non-gating
+    /// outcome must never start a watch (and never claim one was needed).
+    /// </summary>
+    [Fact]
+    public void MarkOutcome_ReportsOnlyGatingOutcomes()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+
+        state.MarkOutcome(new PreWarmOutcome("Ok/Type", PreWarmStatus.Compiled)).Should().BeFalse();
+        state.MarkOutcome(Failed("Abandoned/Type", wasHealthy: false)).Should().BeFalse(
+            "a type that was already broken is not a regression");
+        state.MarkOutcome(new PreWarmOutcome("Slow/Type", PreWarmStatus.TimedOut)
+            { WasHealthyBeforeBake = true }).Should().BeFalse("a timeout is not a verdict");
+        state.MarkOutcome(new PreWarmOutcome("Gone/Type", PreWarmStatus.NoSources)
+            { WasHealthyBeforeBake = true }).Should().BeFalse("content-broken is not an image verdict");
+        state.MarkOutcome(Failed("Real/Regression", wasHealthy: true)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The torn-snapshot EVIDENCE (issue #1214, proposal 3): a source whose <c>LastModified</c> is
+    /// at or after the compile's start stamp proves the compile sampled a source set the mesh was
+    /// mid-way through replacing. It is diagnostic only — it names the suspicion in the log and
+    /// never downgrades the verdict, because a torn compile of genuinely broken code must still gate.
+    /// </summary>
+    [Fact]
+    public void SourcesMovedDuringCompile_IsTrue_WhenASourceWasWrittenAfterTheCompileStarted()
+    {
+        var started = new DateTimeOffset(2026, 8, 11, 11, 4, 30, TimeSpan.Zero);
+        DynamicTypePreWarmer.SourcesMovedDuringCompile(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"],
+            LastCompileStartedAt = started,
+            CurrentSourceVersions = new Dictionary<string, long>
+            {
+                ["Store/Plugin/Source/Localizer"] = started.AddSeconds(29).UtcTicks
+            }
+        }).Should().BeTrue("the source moved WHILE the compile was running — a torn snapshot");
+    }
+
+    /// <summary>A source set that has not moved since the compile started is STABLE — no suspicion
+    /// to name, and Roslyn's verdict is about the code.</summary>
+    [Fact]
+    public void SourcesMovedDuringCompile_IsFalse_OnAStableSourceSet()
+    {
+        var started = new DateTimeOffset(2026, 8, 11, 11, 4, 30, TimeSpan.Zero);
+        DynamicTypePreWarmer.SourcesMovedDuringCompile(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"],
+            LastCompileStartedAt = started,
+            CurrentSourceVersions = new Dictionary<string, long>
+            {
+                ["Store/Plugin/Source/Localizer"] = started.AddMinutes(-10).UtcTicks
+            }
+        }).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// No start stamp ⇒ no evidence. The predicate must never guess: an absent
+    /// <see cref="NodeTypeDefinition.LastCompileStartedAt"/> means we cannot say when the compile
+    /// ran, and "I cannot tell" is not "the snapshot was torn".
+    /// </summary>
+    [Fact]
+    public void SourcesMovedDuringCompile_IsFalse_WithoutACompileStartStamp() =>
+        DynamicTypePreWarmer.SourcesMovedDuringCompile(new NodeTypeDefinition
+        {
+            Sources = ["namespace:Source scope:subtree"],
+            CurrentSourceVersions = new Dictionary<string, long> { ["P/Source/A"] = 42 }
+        }).Should().BeFalse();
+
     /// <summary>A regression among successes still gates — one bad type is enough.</summary>
     [Fact]
     public void OneRegressionAmongSuccesses_StillGates()

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -278,6 +278,74 @@ public class NodeTypeBakeGateStateTest
     }
 
     /// <summary>
+    /// 🚨 A DERIVED regression is retracted WITH its blocker, and is never watched on its own.
+    ///
+    /// <para>A dependent skipped as <see cref="PreWarmStatus.UpstreamFailed"/> was never compiled —
+    /// the sweep skips it precisely so it does not have to activate its hub. Its regression's whole
+    /// evidence is "my upstream failed", so when the upstream's verdict is withdrawn this one has
+    /// nothing holding it up. Watching each dependent for its own recovery instead would activate
+    /// every skipped dependent of one broken upstream and hold them for the pod's lifetime, undoing
+    /// the saving the skip exists for.</para>
+    /// </summary>
+    [Fact]
+    public void RetractingABlocker_AlsoRetractsTheRegressionsDerivedFromIt()
+    {
+        var state = new NodeTypeBakeGateState { GatesReadiness = true };
+        state.MarkRunning("go");
+
+        state.MarkOutcome(Failed("Store/Plugin", wasHealthy: true))
+            .Should().BeTrue("a directly-measured verdict is the one worth watching");
+        state.MarkOutcome(new PreWarmOutcome(
+                "Store/Catalog", PreWarmStatus.UpstreamFailed, "blocked by Store/Plugin")
+            { WasHealthyBeforeBake = true, BlockedBy = "Store/Plugin" })
+            .Should().BeFalse("a derived regression must not start a watch — that is what would "
+                + "activate the whole fan-out of one broken upstream");
+        // Transitive: a dependent of the dependent.
+        state.MarkOutcome(new PreWarmOutcome(
+                "Store/Order", PreWarmStatus.UpstreamFailed, "blocked by Store/Catalog")
+            { WasHealthyBeforeBake = true, BlockedBy = "Store/Catalog" })
+            .Should().BeFalse();
+        state.MarkComplete("baked");
+
+        state.Phase.Should().Be(BakePhase.Regressed,
+            "all three gate — a derived regression still stalls the rollout");
+        state.Regressions.Keys.OrderBy(k => k, StringComparer.Ordinal).Should().Equal(
+            "Store/Catalog", "Store/Order", "Store/Plugin");
+
+        // The blocker rebuilds. Its dependents' verdicts had no other basis.
+        state.RetractRegression("Store/Plugin", "rebuilt on this image").Should().BeTrue();
+
+        state.Phase.Should().Be(BakePhase.Complete,
+            "with the only measured failure withdrawn, nothing that was derived from it may keep "
+            + "the pod out of rotation");
+        state.Regressions.Should().BeEmpty();
+        state.Retracted.Keys.OrderBy(k => k, StringComparer.Ordinal).Should().Equal(
+            "Store/Catalog", "Store/Order", "Store/Plugin");
+    }
+
+    /// <summary>
+    /// The cascade is keyed on the ACTUAL blocker — an unrelated regression is not swept up with
+    /// it. Otherwise retracting one type would quietly release the gate on everything.
+    /// </summary>
+    [Fact]
+    public void RetractingABlocker_LeavesUnrelatedRegressionsStanding()
+    {
+        var state = new NodeTypeBakeGateState { GatesReadiness = true };
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Plugin", wasHealthy: true));
+        state.MarkOutcome(new PreWarmOutcome(
+                "Store/Catalog", PreWarmStatus.UpstreamFailed, "blocked by Store/Plugin")
+            { WasHealthyBeforeBake = true, BlockedBy = "Store/Plugin" });
+        state.MarkOutcome(Failed("Unrelated/Type", wasHealthy: true));
+        state.MarkComplete("baked");
+
+        state.RetractRegression("Store/Plugin", "rebuilt on this image").Should().BeTrue();
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Unrelated/Type");
+    }
+
+    /// <summary>
     /// The torn-snapshot EVIDENCE (issue #1214, proposal 3): a source whose <c>LastModified</c> is
     /// at or after the compile's start stamp proves the compile sampled a source set the mesh was
     /// mid-way through replacing. It is diagnostic only — it names the suspicion in the log and


### PR DESCRIPTION
Fixes #1214.

## The incident (memex-cloud, 2026-08-11 ~11:04–11:12 UTC)

A gated pod refused readiness with:

```
REFUSING READINESS — 4 NodeType(s) regressed on this image: Store/Catalog, Store/Coupon, Store/Enrollment, Store/Order
CS0117: 'Localizer' does not contain a definition for 'InstalledLocationOf'
CS0117: 'Localizer' does not contain a definition for 'ReadInstallRecord'
```

Nothing was wrong with the image. The plugins repo had reverted `fix/install-record-read`, and the portal's plugin auto-update was applying that revert **while the bake compiled**:

| node | last_modified |
|---|---|
| `Store/Plugin/Source/Localizer` (post-revert, members gone) | 11:04:59 |
| `Store/Plugin/Source/PluginLayoutAreas`, `InstallLayoutAreas` | 11:06:57 |

The bake ran 10:47→11:06 and compiled inside that two-minute gap, so Roslyn's verdict described a source set that existed briefly and never again — verified afterwards, no Store source references those members.

## Root cause

**The platform already treats such a failure as provisional.** `NodeTypeCompileParkRegistry.ShouldRetryForSourceChange` un-parks and recompiles a failed type the moment its source snapshot changes, so those four types went green seconds after the content converged at 11:06:57.

The only thing that stayed broken was the **gate's record** — latched, sticky, and never re-read. So the pod never became Ready and the rollout hung until a human noticed. This recurs on any portal with `PluginCatalog:AutoUpdateByDefault` on (the default), and on any concurrent content write — a git sync or a bulk edit, not just plugin installs.

## The fix — the latch becomes level-triggered on the truth it claims to represent

- **`NodeTypeBakeGateState.RetractRegression(path, reason)`** — a regression is retracted when the type it names is afterwards observed reaching a usable build **on this image**. This is *not* "completion is absolution" (`MarkComplete` still refuses that); it is a **later, better measurement of the same type on the same image superseding an earlier one**. `MarkComplete` now remembers its message so a retraction arriving *after* the sweep lands on the Complete verdict instead of leaving the pod stuck mid-sweep. Retractions stay visible in the health payload in **both** the red and the green wording.
- **`DynamicTypePreWarmer.WatchForRecovery`** — `MarkOutcome` now reports whether it recorded a regression, and the pre-warmer starts one watch per condemned type. It **observes only**: nothing is triggered, retried, polled or timed out. Holding the subscription also keeps the condemned type's hub activated, which is what keeps the sources watcher that notices the repair alive.
- **The recovery must be a compile that is demonstrably FRESH** — settled `Ok` with `LastCompileSucceededAt` strictly newer than the baseline the watch observed. `HasUsableBuild` alone is **not** sufficient and matching on it silently disables the whole gate: `ApplyCompileFailure` keeps the previous build's assembly coordinates and framework stamp, so any type that ever compiled on this image would satisfy it the instant its regression was recorded. The first draft did exactly that, the integration test caught it, and the test now pins it.
- **Proposal 3** — `PreWarmOutcome.SourcesMovedDuringCompile` carries the torn-snapshot evidence (a source's `LastModified` at or after `LastCompileStartedAt`) and the log names the suspicion instead of telling an operator the image is broken. Diagnostic only; it never downgrades a verdict.

### Altitude: why not proposal 1, and why the evidence alone is not enough

**Sequencing the bake behind the install would deadlock.** `InstanceAutoRegistrationService.cs:216` already waits on `PreWarmCompletion.Completed` before installing (that is what #1114 added), so the inverse ordering makes each wait on the other.

**The timestamp evidence cannot carry the fix by itself.** It is one-sided: in this incident the callers landed at 11:06:57, *after* the failures, so at the moment each verdict was formed no source had yet moved past that type's compile-start stamp. A tear is often only demonstrable in hindsight — which is exactly why the cure is the retraction (level-triggered, no deadline) and the evidence is used for the log line.

## Verification

**The torn-snapshot test fails against the current behaviour.** With `RetractRegression` neutered to today's "a regression is immortal" semantics:

```
BEFORE: === TEST FAILED: The operation has timed out.
        Failed: 1, Passed: 0 — Duration 2 m 32 s
AFTER:  Passed! - Failed: 0, Passed: 35, Skipped: 0, Total: 35 — Duration 3 s
```

The retraction lands ~200 ms after the content converges. The test's log shows the mechanism end to end:

```
[22:44:51] RETRACTING the regression recorded for PreWarmTestTorn/TornType — it has since
reached a usable build on THIS image … Gate now: 1 NodeType(s) regressed on this image:
PreWarmTestTorn/StaysBroken (1 further regression(s) retracted after the type rebuilt on
this image — PreWarmTestTorn/TornType)
```

`RegressedType_ThatRebuildsAfterTheContentConverges_IsRetracted_ButARealBreakStillGates` reproduces the incident's shape in one mesh — a helper losing a member its caller still calls, then the caller converging — and pins **both** halves: the torn type is retracted, and a genuinely broken type on a source set nobody touched **still gates**. The negative half has a real synchronisation point (the positive retraction) rather than a sleep.

Full suites:

```
test/MeshWeaver.Hosting.Monolith.Test   Passed: 563, Failed: 0, Skipped: 4  (5 m 53 s)
test/MeshWeaver.Graph.Test              Passed: 978, Failed: 0, Skipped: 0  (31 s)
```

Release `-warnaserror` clean, one project per invocation: `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Graph.Test`, `Memex.Portal.Distributed` (the gate's consumer — `MarkOutcome`'s `void`→`bool` is source-compatible).

#1204's `NoSources` and #1226's unestablished-source-set buckets are untouched — `SourceSnapshotEstablishmentTest.TheThreeCases_GateDifferently` still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
