### PR TITLE
fix: anchor @@ code includes onto the including node's mount

### DIFF
--- a/samples/Graph/Data/ACME/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/ACME/Article/Source/ArticleLayoutAreas.cs
@@ -102,8 +102,8 @@ public static class ArticleLayoutAreas
             container = container.WithView(Controls.Markdown(rawContent));
         }
 
-        // Children area
-        container = container.WithView(LayoutAreaControl.Children(host.Hub));
+        // No children section — children are injected inline with the @@(query) operator, or
+        // browsed via the Catalog / Search areas (the framework dropped its hardcoded one too).
 
         return container;
     }

--- a/samples/Graph/Data/Cornerstone/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/Cornerstone/Article/Source/ArticleLayoutAreas.cs
@@ -102,8 +102,8 @@ public static class ArticleLayoutAreas
             container = container.WithView(Controls.Markdown(rawContent));
         }
 
-        // Children area
-        container = container.WithView(LayoutAreaControl.Children(host.Hub));
+        // No children section — children are injected inline with the @@(query) operator, or
+        // browsed via the Catalog / Search areas (the framework dropped its hardcoded one too).
 
         return container;
     }

--- a/samples/Graph/Data/Northwind/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Article/Source/ArticleLayoutAreas.cs
@@ -102,8 +102,8 @@ public static class ArticleLayoutAreas
             container = container.WithView(Controls.Markdown(rawContent));
         }
 
-        // Children area
-        container = container.WithView(LayoutAreaControl.Children(host.Hub));
+        // No children section — children are injected inline with the @@(query) operator, or
+        // browsed via the Catalog / Search areas (the framework dropped its hardcoded one too).
 
         return container;
     }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-node-pages-open-without-waiting-on-a-failed-compile.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-node-pages-open-without-waiting-on-a-failed-compile.md
@@ -1,0 +1,20 @@
+---
+Name: Node pages open without waiting on a failed compile
+Category: Fix
+Description: Sample and documentation node types that referenced code from a neighbouring node now compile wherever they are served, instead of stalling and then showing a compile error.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Node pages open without waiting on a failed compile
+
+Some node types pull in code from a neighbouring node — an analysis page reusing the currency and
+line-of-business definitions next to it, for example. Those references are written the way the
+content is laid out, and they stopped being found when the same content was served from a different
+place in the mesh. The reference was then left in the code as-is, so the page failed to compile and
+reported errors pointing at the reference line rather than at anything a user had written.
+
+Opening such a page was slow before it failed: every reference that could not be found waited on its
+own lookup first. References are now matched against wherever the node is actually served, so the
+pages compile and open normally. Three sample article pages that used a view helper removed earlier
+this summer were fixed at the same time.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -349,21 +349,36 @@ internal class MeshNodeCompilationService(
 
     /// <summary>
     /// Reads one include target — <paramref name="path"/> first, then
-    /// <paramref name="fallbackPath"/> when it differs and the first read found nothing — and
-    /// reports which path actually produced the node so nested includes anchor from there.
+    /// <paramref name="fallbackPath"/> when it differs and the first read found the node genuinely
+    /// ABSENT — and reports which path actually produced the node so nested includes anchor there.
     ///
-    /// <para>EmitNull, not a fault: this runs on the hub-ACTIVATION path, where turning a
-    /// transient stall into a hard fault would park the type. A miss leaves the include
-    /// unresolved and logs the warning at the call site.</para>
+    /// <para>🚨 The anchored read uses <see cref="ReadTimeoutBehavior.Throw"/>, not
+    /// <c>EmitNull</c>, for one reason: only "absent" justifies spending a second 15s read, and
+    /// <c>EmitNull</c> collapses a STALL into the same null — which would let one I/O stall cost
+    /// 30s per include instead of 15s. The <see cref="TimeoutException"/> is caught here and
+    /// degrades to exactly what <c>EmitNull</c> produced (an unresolved include, warned at the call
+    /// site), so a stalled include still costs ONE read. The exception's diagnostics — elapsed
+    /// time, the reading hub's in-flight snapshot — are logged rather than swallowed.</para>
+    ///
+    /// <para>Not a fault either way: this runs on the hub-ACTIVATION path, where turning a
+    /// transient stall into a hard fault would park the type.</para>
     /// </summary>
     private IObservable<(MeshNode? Node, string Path)> ReadIncludeNode(
         string path, string? fallbackPath)
-        => hub.GetMeshNode(path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+        => hub.GetMeshNode(path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.Throw)
             .SelectMany(node => node is not null || fallbackPath is null
                 ? Observable.Return<(MeshNode? Node, string Path)>((node, path))
+                // Genuinely absent (no timeout) — the authored path is the other legal reading.
                 : hub.GetMeshNode(fallbackPath, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
                     .Select<MeshNode?, (MeshNode? Node, string Path)>(
-                        fallback => (fallback, fallbackPath)));
+                        fallback => (fallback, fallbackPath)))
+            .Catch<(MeshNode? Node, string Path), TimeoutException>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "Code include @@{Path} STALLED (not absent) — the include stays unresolved and "
+                    + "no fallback read is attempted, so one stall costs one read, not two", path);
+                return Observable.Return<(MeshNode? Node, string Path)>((null, path));
+            });
 
     /// <inheritdoc />
     public IObservable<string?> GetAssemblyLocation(MeshNode node)

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -260,7 +260,42 @@ internal class MeshNodeCompilationService(
     /// </summary>
     internal static readonly Regex CodeIncludePattern = new(@"@@([\w][\w\-./]*)", RegexOptions.Compiled);
 
-    private IObservable<string> ResolveCodeIncludes(string code, HashSet<string> resolved)
+    /// <summary>
+    /// Rebases a mount-relative <c>@@</c> include path onto the prefix the INCLUDING node lives
+    /// under, so the same content resolves from whichever mount point it is served.
+    ///
+    /// <para>🚨 Why this exists: include paths are authored mount-relative. A sample tree that sits
+    /// at the mesh root in the Monolith (<c>FutuRe/GroupAnalysis/Source/…</c>, which is what
+    /// <c>FutuReAnalysisTest</c> exercises) is served from a PREFIX in a statically-imported
+    /// partition (<c>MeshWeaver/samples/Graph/Data/FutuRe/…</c>). Resolving the authored path
+    /// verbatim there finds nothing, and an unresolved include is left VERBATIM in the source —
+    /// so Roslyn parses the <c>@@</c> line itself and reports CS9008 / CS8803 / CS0103 on symbol
+    /// names that are really path segments. On memex-cloud 2026-08-12 that parked 15 NodeTypes
+    /// (FutuRe, Cession, SocialMedia, Northwind/AnalyticsCatalog, Type/article) and cost a serial
+    /// 15s read per unresolved include on the ACTIVATION path — the "waiting for code" stall.</para>
+    ///
+    /// <para>The anchor is the DEEPEST occurrence of the include's first segment in the including
+    /// node's path — the most local reading. An already-absolute include anchors at index 0 and is
+    /// returned unchanged, so a root mount keeps behaving exactly as before.</para>
+    /// </summary>
+    internal static string AnchorIncludePath(string includePath, string? anchorPath)
+    {
+        if (string.IsNullOrEmpty(anchorPath) || string.IsNullOrEmpty(includePath))
+            return includePath;
+
+        var slash = includePath.IndexOf('/');
+        var first = slash < 0 ? includePath : includePath[..slash];
+        var segments = anchorPath.Split('/');
+        for (var i = segments.Length - 1; i > 0; i--)
+        {
+            if (string.Equals(segments[i], first, StringComparison.Ordinal))
+                return string.Join('/', segments, 0, i) + '/' + includePath;
+        }
+        return includePath;
+    }
+
+    private IObservable<string> ResolveCodeIncludes(
+        string code, HashSet<string> resolved, string? anchorPath)
     {
         if (string.IsNullOrWhiteSpace(code) || !code.Contains("@@"))
             return Observable.Return(code);
@@ -276,28 +311,34 @@ internal class MeshNodeCompilationService(
         IObservable<string> chain = Observable.Return(code);
         foreach (Match match in matches)
         {
-            var path = match.Groups[1].Value;
+            var authored = match.Groups[1].Value;
+            var anchored = AnchorIncludePath(authored, anchorPath);
             var matchValue = match.Value;
             chain = chain.SelectMany(current =>
             {
-                if (!resolved.Add(path))
+                if (!resolved.Add(anchored))
                     return Observable.Return(current.Replace(matchValue, string.Empty));
 
-                // EmitNull — see the note on the NodeType-definition reads below: this is the
-                // hub-ACTIVATION path, where turning a transient stall into a hard fault would
-                // park the type. Behaviour is unchanged (the include stays unresolved and the
-                // LogWarning below fires); the read itself now also logs the stall + diagnostics.
-                return hub.GetMeshNode(path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
-                    .SelectMany(referencedNode =>
+                // The anchored candidate is tried FIRST and the authored path only as a fallback:
+                // on a root mount the two are identical (one read, unchanged behaviour), and the
+                // second read is reached only where today's single read already failed.
+                return ReadIncludeNode(anchored, anchored == authored ? null : authored)
+                    .SelectMany(hit =>
                     {
-                        if (referencedNode?.Content is CodeConfiguration cf
+                        if (hit.Node?.Content is CodeConfiguration cf
                             && !string.IsNullOrWhiteSpace(cf.Code))
                         {
-                            logger.LogDebug("Resolved code include @@{Path}", path);
-                            return ResolveCodeIncludes(cf.Code, resolved)
+                            logger.LogDebug("Resolved code include @@{Path}", hit.Path);
+                            // Nested includes anchor from where THIS one was found, so a chain of
+                            // mount-relative includes stays inside the same mount.
+                            return ResolveCodeIncludes(cf.Code, resolved, hit.Path)
                                 .Select(resolvedInner => current.Replace(matchValue, resolvedInner));
                         }
-                        logger.LogWarning("Could not resolve code include @@{Path}", path);
+                        logger.LogWarning(
+                            "Could not resolve code include @@{Path} referenced from {Anchor} "
+                            + "— it stays VERBATIM in the source, so the compiler will report "
+                            + "errors on the @@ line itself",
+                            authored, anchorPath ?? "(no anchor)");
                         return Observable.Return(current);
                     });
             });
@@ -305,6 +346,24 @@ internal class MeshNodeCompilationService(
 
         return chain;
     }
+
+    /// <summary>
+    /// Reads one include target — <paramref name="path"/> first, then
+    /// <paramref name="fallbackPath"/> when it differs and the first read found nothing — and
+    /// reports which path actually produced the node so nested includes anchor from there.
+    ///
+    /// <para>EmitNull, not a fault: this runs on the hub-ACTIVATION path, where turning a
+    /// transient stall into a hard fault would park the type. A miss leaves the include
+    /// unresolved and logs the warning at the call site.</para>
+    /// </summary>
+    private IObservable<(MeshNode? Node, string Path)> ReadIncludeNode(
+        string path, string? fallbackPath)
+        => hub.GetMeshNode(path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+            .SelectMany(node => node is not null || fallbackPath is null
+                ? Observable.Return<(MeshNode? Node, string Path)>((node, path))
+                : hub.GetMeshNode(fallbackPath, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+                    .Select<MeshNode?, (MeshNode? Node, string Path)>(
+                        fallback => (fallback, fallbackPath)));
 
     /// <inheritdoc />
     public IObservable<string?> GetAssemblyLocation(MeshNode node)
@@ -948,7 +1007,7 @@ internal class MeshNodeCompilationService(
                 {
                     var cf = codeFile;
                     includeChain = includeChain.SelectMany(acc =>
-                        ResolveCodeIncludes(cf.Code!, new HashSet<string>())
+                        ResolveCodeIncludes(cf.Code!, new HashSet<string>(), node.Path)
                             .Select(resolvedCode =>
                             {
                                 acc.Add(resolvedCode != cf.Code ? cf with { Code = resolvedCode } : cf);
@@ -1480,7 +1539,7 @@ internal class MeshNodeCompilationService(
         {
             var pair = p;
             chain = chain.SelectMany(acc =>
-                ResolveCodeIncludes(pair.Config.Code!, new HashSet<string>())
+                ResolveCodeIncludes(pair.Config.Code!, new HashSet<string>(), pair.Path)
                     .Select(resolvedCode =>
                     {
                         var resolvedConfig = !ReferenceEquals(resolvedCode, pair.Config.Code)

--- a/test/MeshWeaver.Graph.Test/CodeIncludePatternTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeIncludePatternTest.cs
@@ -54,4 +54,61 @@ public class CodeIncludePatternTest
         var match = Assert.Single(MeshNodeCompilationService.CodeIncludePattern.Matches(sourceLine).Cast<System.Text.RegularExpressions.Match>());
         Assert.Equal(expectedPath, match.Groups[1].Value);
     }
+
+    /// <summary>
+    /// An include path is authored MOUNT-relative, so it must resolve from whichever prefix the
+    /// including node is served under (<see cref="MeshNodeCompilationService.AnchorIncludePath"/>).
+    ///
+    /// <para>memex-cloud 2026-08-12: <c>samples/Graph/Data/FutuRe/GroupAnalysis/Source/ExternalDependencies</c>
+    /// is nothing but <c>@@FutuRe/&lt;sibling&gt;/Source/…</c> lines. Mounted at the mesh root (what
+    /// <c>FutuReAnalysisTest</c> exercises) they resolve; served from the imported
+    /// <c>MeshWeaver/samples/Graph/Data/…</c> partition they did not, and an unresolved include is
+    /// left VERBATIM — so Roslyn parsed the <c>@@</c> lines themselves and reported CS9008 / CS8803 /
+    /// CS0103 on path segments ('FutuRe', 'GroupAnalysis', 'Source') as if they were symbols. 15
+    /// NodeTypes parked that way, each burning a serial 15s read per include first.</para>
+    /// </summary>
+    [Theory]
+    // The incident: authored at the root, served under a prefix → rebased onto that prefix.
+    [InlineData(
+        "FutuRe/AmountType/Source/AmountType",
+        "MeshWeaver/samples/Graph/Data/FutuRe/GroupAnalysis/Source/ExternalDependencies",
+        "MeshWeaver/samples/Graph/Data/FutuRe/AmountType/Source/AmountType")]
+    // Self-referencing include inside the same prefixed subtree.
+    [InlineData(
+        "FutuRe/GroupAnalysis/Source/FutuReDataCube",
+        "MeshWeaver/samples/Graph/Data/FutuRe/GroupAnalysis/Source/ExternalDependencies",
+        "MeshWeaver/samples/Graph/Data/FutuRe/GroupAnalysis/Source/FutuReDataCube")]
+    // Root mount (the Monolith / CI shape): the anchor adds nothing — behaviour unchanged.
+    [InlineData(
+        "FutuRe/AmountType/Source/AmountType",
+        "FutuRe/GroupAnalysis/Source/ExternalDependencies",
+        "FutuRe/AmountType/Source/AmountType")]
+    // Already absolute: the include's first segment IS the anchor's root → unchanged.
+    [InlineData(
+        "MeshWeaver/src/MeshWeaver.Documentation/Data/Architecture/BusinessRules/Cession/Source/CessionSampleData",
+        "MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession/Source/Deps",
+        "MeshWeaver/src/MeshWeaver.Documentation/Data/Architecture/BusinessRules/Cession/Source/CessionSampleData")]
+    // Nothing to anchor on → unchanged, so an unrelated tree is never silently rewritten.
+    [InlineData("Edu/Shared/NodeContent", "Store/Plugin/Source/PluginGate", "Edu/Shared/NodeContent")]
+    // The DEEPEST occurrence wins — the most local reading of a repeated segment.
+    [InlineData(
+        "Source/Helper",
+        "Space/Source/Nested/Source/Deps",
+        "Space/Source/Nested/Source/Helper")]
+    public void IncludePathAnchorsOntoTheIncludingNodesMount(
+        string authored, string anchorPath, string expected)
+    {
+        Assert.Equal(expected, MeshNodeCompilationService.AnchorIncludePath(authored, anchorPath));
+    }
+
+    /// <summary>With no anchor there is nothing to rebase against — the authored path stands.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NoAnchorLeavesThePathAlone(string? anchorPath)
+    {
+        Assert.Equal(
+            "FutuRe/AmountType/Source/AmountType",
+            MeshNodeCompilationService.AnchorIncludePath("FutuRe/AmountType/Source/AmountType", anchorPath));
+    }
 }


### PR DESCRIPTION
## Why

memex-cloud, 2026-08-12. Four PRs merged at 04:46–04:49 UTC → GitSync push-webhook fired 13 re-imports → the statically-served `MeshWeaver/…` node trees recompiled on the activation path, and **18 NodeTypes ended `PARKED` on compile errors**. Route dispatch saturated (`64 route dispatches in flight and not terminating`) from 05:05 to ~05:37 and node opens crawled portal-wide.

The startup pre-bake was healthy and is not the cause — it compiled 237/237 types in 67 s with zero errors. But its population is the DB partitions only; the repo-shipped trees compile on first open.

## Root cause

`@@path` includes in Code nodes are authored **mount-relative**. `samples/Graph/Data/FutuRe/GroupAnalysis/Source/ExternalDependencies` is nothing but:

```
@@FutuRe/AmountType/Source/AmountType
@@FutuRe/Currency/Source/Currency
…
```

At the mesh root (Monolith, and what `FutuReAnalysisTest` exercises) those resolve. Served from `MeshWeaver/samples/Graph/Data/FutuRe/…` they do not — and an unresolved include is left **verbatim** in the source, so Roslyn parses the `@@` line and reports `CS9008` / `CS8803` / `CS0103` on path segments as if they were symbols:

```
Could not resolve code include @@FutuRe/AmountType/Source/AmountType
CS0103 Error (line 58): The name 'FutuRe' does not exist in the current context
CS9008 Error (line 58): Sequence of '@' characters is not allowed…
```

Each miss also costs a **serial 15 s** `GetMeshNode` read on the activation path before failing — GroupAnalysis alone declares 7. That is the "waiting for code" stall.

Invisible to every build: the in-mesh sources are `<None>` content, and the only test covering them mounts at the root, where the authored path happens to be correct.

## What changed

- `MeshNodeCompilationService.AnchorIncludePath` rebases an include onto the prefix the including node is served under — the **deepest** occurrence of the include's first segment, i.e. the most local reading. An already-absolute include anchors at index 0 and is returned unchanged, so a root mount behaves exactly as before.
- The authored path is still tried as a **fallback**; that second read is only reached where today's single read already failed, so no healthy path gets slower.
- Nested includes anchor from where their parent was found.
- Both compile paths get it — activation and batch bake share `ResolveIncludesForPairs`.
- Separately: the three in-mesh `Article` layout areas dropped `LayoutAreaControl.Children(host.Hub)`. That factory was deleted **2026-06-26** (21aa5eef8, "remove the hardcoded children section") and these callers were never ported, so they had been failing `CS0117` on every recompile since. Children are injected inline with `@@(query)`, matching the framework's own change.

## Tests

`CodeIncludePatternTest` gains the anchor cases — prefixed mount, root mount, already-absolute, nothing-to-anchor-on, deepest-occurrence-wins, no anchor. 22/22 pass in `-c Release`.

```
dotnet build src/MeshWeaver.Graph -c Release -warnaserror     # 0 warnings, 0 errors
dotnet test test/MeshWeaver.Graph.Test --filter CodeIncludePatternTest   # 22 passed
```

## Not in this PR (filed for follow-up)

- **Pre-bake excludes the statically-served partition** — those types only compile on first open, and a re-import forces them all onto the per-type activation path instead of the batch driver.
- **A lost `SubscribeRequest` reply** to `MeshWeaver/_Activity/import-…` ("a reply WAS posted … the callback is STILL pending") is what turned the recompiles into portal-wide saturation.
- **In-mesh content rot the anchor fix does not cover**: `Northwind/AnalyticsCatalog` references `OrderViews`/`SalesViews` (symbols that exist nowhere in the repo — the additive import leaves orphan Code nodes behind), and `Northwind/Product` needs `MeshWeaver.Import`, which `Memex.Portal.Distributed` does not reference (the Monolith does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)