### PR TITLE
fix: bake enumerates only after the static repo import has settled

### DIFF
--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -50,6 +50,12 @@ public static class StaticRepoSyncExtensions
             if (serveFromPartition.Overlaps(AiContentSources.ContentPartitions))
                 services.AddBuiltInAiContentSources();
 
+            // The boot signal the NodeType pre-warm sweep sequences on: without it the sweep's ONE
+            // enumeration snapshot can be taken while this import is still landing content, and
+            // every type it misses is left to compile on a user's first click. See
+            // StaticRepoImportSettled.
+            services.AddSingleton<StaticRepoImportSettled>();
+
             // Runs after the PG schema-provisioning hosted service (registered earlier by
             // AddPartitionedPostgreSqlPersistence) — hosted services start in registration order.
             // A factory (not AddHostedService<T>) so the deploy-time per-partition mode overrides
@@ -58,7 +64,8 @@ public static class StaticRepoSyncExtensions
                 sp.GetRequiredService<IMessageHub>(),
                 sp.GetServices<IStaticRepoSource>(),
                 syncModeOverrides,
-                sp.GetService<ILogger<StaticRepoImportHostedService>>()));
+                sp.GetService<ILogger<StaticRepoImportHostedService>>(),
+                sp.GetRequiredService<StaticRepoImportSettled>()));
             return services;
         });
         return builder;
@@ -76,14 +83,18 @@ internal sealed class StaticRepoImportHostedService(
     IMessageHub hub,
     IEnumerable<IStaticRepoSource> sources,
     IReadOnlyDictionary<string, PartitionSyncMode>? syncModeOverrides = null,
-    ILogger<StaticRepoImportHostedService>? logger = null) : IHostedService
+    ILogger<StaticRepoImportHostedService>? logger = null,
+    StaticRepoImportSettled? settled = null) : IHostedService
 {
     private IDisposable? _subscription;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         if (!sources.Any())
+        {
+            settled?.MarkSettled();
             return Task.CompletedTask;
+        }
 
         logger?.LogInformation(
             "[StaticRepoImport] starting sync-context init for {Count} source(s).", sources.Count());
@@ -105,7 +116,14 @@ internal sealed class StaticRepoImportHostedService(
                 r => logger?.LogInformation(
                     "[StaticRepoImport] {Partition}: {Outcome} ({Count} node(s)).",
                     r.Partition, r.Outcome, r.Count),
-                ex => logger?.LogWarning(ex, "[StaticRepoImport] sync-context init failed."));
+                ex =>
+                {
+                    logger?.LogWarning(ex, "[StaticRepoImport] sync-context init failed.");
+                    // Settle on failure TOO: a faulted import must never park the NodeType bake
+                    // forever. The sweep proceeds and bakes whatever did land.
+                    settled?.MarkSettled();
+                },
+                () => settled?.MarkSettled());
         return Task.CompletedTask;
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-node-types-are-pre-baked-before-the-portal-serves.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-node-types-are-pre-baked-before-the-portal-serves.md
@@ -1,0 +1,19 @@
+---
+Name: Node types are pre-baked before the portal serves
+Category: Fix
+Description: The startup pre-build now waits for shipped content to finish loading, so node types are compiled up front instead of on a user's first click.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Node types are pre-baked before the portal serves
+
+A portal compiles its node types once at startup so that opening a page later is instant. That
+pre-build took its list of types before the content shipped with the release had finished loading,
+which is a race: on one start the list was complete, on the next it was missing everything that had
+not landed yet. Whatever was missing never got pre-built, and the first person to open one of those
+pages waited for it to compile right then.
+
+The pre-build now waits for the shipped content to finish loading before it takes its list, so the
+whole set is compiled up front. If that content fails to load, the pre-build still runs and compiles
+everything that did arrive rather than waiting forever.

--- a/src/MeshWeaver.Graph/StaticRepoImportSettled.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImportSettled.cs
@@ -1,0 +1,53 @@
+using System.Reactive;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The boot signal "the static repo import has SETTLED" — mesh-scoped, one-shot, reactive.
+///
+/// <para>🚨 Why this exists. <c>StaticRepoImportHostedService</c> kicks
+/// <see cref="StaticRepoImporter.ImportAll"/> fire-and-forget onto the thread pool and returns
+/// immediately (it must: subscribing on the startup thread re-enters the hub schedulers and
+/// deadlocks). The NodeType pre-warm sweep then starts from <c>ApplicationStarted</c> — which fires
+/// as soon as every <c>StartAsync</c> has returned, i.e. while the import is still landing content
+/// — and enumerates the fleet with ONE snapshot (<c>Query(...).Take(1)</c>). Whatever the import
+/// has not written yet is silently absent from that snapshot, so those NodeTypes are never baked
+/// and each one compiles on a user's first click instead.</para>
+///
+/// <para>That is a RACE, and it was observed resolving both ways on memex-cloud on 2026-08-12: the
+/// pod started at 23:02 enumerated <b>237</b> types (the whole statically-served
+/// <c>MeshWeaver/…</c> tree missing), while its successor at 05:52 enumerated <b>279</b> — same
+/// content, same image family. The 42 unbaked types are the "waiting for code" complaint: they
+/// compile on the activation path, one at a time, when someone opens them.</para>
+///
+/// <para><b>Settles on failure too, deliberately.</b> A faulted import must not park the bake
+/// forever — the sweep proceeds and bakes what IS there. This is a one-shot ordering signal, never
+/// a retry or a timeout: subscribers get the current state immediately once settled
+/// (<see cref="AsyncSubject{T}"/> replays to late subscribers), so there is nothing to poll.</para>
+/// </summary>
+public sealed class StaticRepoImportSettled
+{
+    private readonly AsyncSubject<Unit> settled = new();
+
+    /// <summary>
+    /// Completes once the boot import has settled — successfully, with an error, or immediately
+    /// when there is nothing to import. Replays to subscribers that arrive after the fact.
+    /// </summary>
+    public IObservable<Unit> Settled => settled;
+
+    /// <summary>Whether <see cref="MarkSettled"/> has already run (diagnostics/logging only).</summary>
+    public bool IsSettled => settled.IsCompleted;
+
+    /// <summary>
+    /// Signals that the boot import has settled. Idempotent: later calls are no-ops, so the
+    /// hosted service can mark from its completion AND its error handler without ordering care.
+    /// </summary>
+    public void MarkSettled()
+    {
+        if (settled.IsCompleted)
+            return;
+        settled.OnNext(Unit.Default);
+        settled.OnCompleted();
+    }
+}

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -1,5 +1,7 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using MeshWeaver.Graph;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -201,9 +203,32 @@ public sealed class DynamicTypePreWarmerHostedService(
                     batchBake ? "gated (batch)" : "serving (activation-driven)");
         }
 
+        // 🚨 SEQUENCE THE SWEEP BEHIND THE STATIC REPO IMPORT — it is content this bake must see.
+        //
+        // The import is kicked fire-and-forget from its own StartAsync (it has to be: subscribing on
+        // the startup thread re-enters the hub schedulers and deadlocks), and ApplicationStarted —
+        // where this method runs — fires as soon as every StartAsync has RETURNED. So without this
+        // wait the sweep's ONE enumeration snapshot (Query(...).Take(1)) can be taken while the
+        // import is still landing content, and every NodeType missing from that snapshot is never
+        // baked: it compiles on the activation path when a user first opens it.
+        //
+        // Observed resolving BOTH ways on memex-cloud 2026-08-12 — the 23:02 pod enumerated 237
+        // types with the whole statically-served MeshWeaver/… tree absent, its 05:52 successor 279
+        // on the same content. Those 42 unbaked types are the "waiting for code" stall.
+        //
+        // Absent (no static import registered — every test host, non-portal hosts) this is
+        // immediate, so the shape is unchanged there. The signal also settles when the import FAILS,
+        // so a faulted import delays the bake rather than cancelling it.
+        var importSettled = services.GetService<StaticRepoImportSettled>();
+        if (importSettled is { IsSettled: false })
+            logger.LogInformation(
+                "DynamicTypePreWarmer: waiting for the static repo import to settle before "
+                + "enumerating — types it has not written yet would be missed by the bake");
+
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
-        _warmSubscription = DynamicTypePreWarmer
-            .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes, batchBake)
+        _warmSubscription = (importSettled?.Settled ?? Observable.Return(Unit.Default))
+            .SelectMany(_ => DynamicTypePreWarmer
+                .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes, batchBake))
             .Subscribe(
                 outcome =>
                 {

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -847,5 +849,99 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
             d => d.CompilationStatus == CompilationStatus.Ok, TimeSpan.FromSeconds(10));
         after.LastCompileSucceededAt.Should().Be(baseline,
             "AlreadyBaked means NOT rebuilt — the record must be untouched by the sweep");
+    }
+
+    /// <summary>
+    /// 🚨 THE SWEEP MUST NOT ENUMERATE BEFORE THE STATIC REPO IMPORT HAS SETTLED.
+    ///
+    /// <para>The sweep takes exactly ONE enumeration snapshot (<c>Query(...).Take(1)</c>), and the
+    /// static repo import that writes a large part of the fleet is kicked fire-and-forget from its
+    /// own <c>StartAsync</c> — so <c>ApplicationStarted</c>, where the sweep is launched, fires while
+    /// that import is still landing content. Anything missing from the snapshot is never baked and
+    /// compiles on the activation path when a user first opens it.</para>
+    ///
+    /// <para>memex-cloud 2026-08-12 showed the race resolving both ways on consecutive pods: 23:02
+    /// enumerated <b>237</b> types with the whole statically-served <c>MeshWeaver/…</c> tree absent,
+    /// 05:52 enumerated <b>279</b> on the same content. Those 42 unbaked types were the
+    /// "waiting for code" stall.</para>
+    ///
+    /// <para>This pins the two halves of the contract with the SAME composition
+    /// <see cref="DynamicTypePreWarmerHostedService"/> uses: nothing is enumerated while the signal
+    /// is unsettled, and a type written in that window IS in the snapshot once it settles.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task Sweep_WaitsForTheStaticImportToSettle_SoLateContentIsStillBaked()
+    {
+        const string LatePath = $"{Partition}/LateImportedType";
+        var importSettled = new StaticRepoImportSettled();
+        var enumerations = 0;
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("PreWarmGate");
+
+        // The exact shape KickWarmup composes: the sweep is DEFERRED behind the signal, so
+        // enumeration cannot happen at subscribe time.
+        var sweep = importSettled.Settled.SelectMany(_ => Observable.Defer(() =>
+        {
+            Interlocked.Increment(ref enumerations);
+            return DynamicTypePreWarmer.WarmDynamicTypes(
+                Mesh, logger, perTypeBudget: TimeSpan.FromSeconds(90));
+        }));
+
+        // Subscribe FIRST — this is the moment the un-gated sweep would have enumerated.
+        var lateTypeSeen = sweep
+            .Where(o => o.TypePath == LatePath)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(100))
+            .ToTask();
+
+        // …then write the type, standing in for what the import is still landing.
+        await NodeFactory.CreateNode(new MeshNode("LateImportedType", Partition)
+        {
+            Name = "Late Imported Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Written while the static import was still running.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        Volatile.Read(ref enumerations).Should().Be(0,
+            "the sweep must still be waiting on the import signal — enumerating here is exactly the "
+            + "race that left 42 memex-cloud types unbaked");
+
+        importSettled.MarkSettled();
+
+        var outcome = await lateTypeSeen;
+        Output.WriteLine($"{outcome.TypePath} → {outcome.Status} {outcome.Detail}");
+        Volatile.Read(ref enumerations).Should().Be(1,
+            "settling enumerates exactly once — the signal is a one-shot ordering gate, not a poll");
+        outcome.ReachedUsableBuild.Should().BeTrue(
+            "a type written before the signal settled must be baked by the sweep, not left to a "
+            + "user's first click");
+    }
+
+    /// <summary>
+    /// The signal's own contract: one-shot, replayed to late subscribers, and idempotent — the
+    /// hosted service marks it from BOTH its completion and its error handler (a faulted import must
+    /// delay the bake, never cancel it), so a second mark cannot re-fire the sweep.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task StaticImportSignal_IsOneShot_ReplayedAndIdempotent()
+    {
+        var settled = new StaticRepoImportSettled();
+        settled.IsSettled.Should().BeFalse();
+
+        var emissions = 0;
+        using var sub = settled.Settled.Subscribe(_ => Interlocked.Increment(ref emissions));
+        Volatile.Read(ref emissions).Should().Be(0, "nothing emits before the import settles");
+
+        settled.MarkSettled();
+        settled.MarkSettled();   // idempotent — both handlers may mark
+        settled.IsSettled.Should().BeTrue();
+        Volatile.Read(ref emissions).Should().Be(1, "one-shot: a second mark must not re-fire");
+
+        // A subscriber arriving AFTER the fact still gets it — the pre-warmer may resolve the signal
+        // late (its own hosted service starts after the import's), and must not hang.
+        await settled.Settled.Take(1).Timeout(TimeSpan.FromSeconds(5)).ToTask();
     }
 }


### PR DESCRIPTION
## Why

"Long wait for code on memex-cloud." The startup pre-bake was healthy — but it had not baked the types being opened.

The sweep takes **one** enumeration snapshot (`Query(...).Take(1)`). The static repo import that writes a large part of the fleet is kicked **fire-and-forget** from its own `StartAsync` (it must be — subscribing on the startup thread re-enters the hub schedulers and deadlocks), and `ApplicationStarted`, where the sweep launches, fires as soon as every `StartAsync` has *returned*. So the snapshot can be taken while the import is still landing content.

The race resolved **both ways on consecutive memex-cloud pods**, same content, same image family:

```
23:02 pod — DynamicTypePreWarmer: 237 of 237 dynamic NodeType(s) need building
05:52 pod — DynamicTypePreWarmer: 279 of 279 dynamic NodeType(s) need building
```

The 42-type difference is the entire statically-served `MeshWeaver/…` tree (`samples/Graph/Data` + `MeshWeaver.Documentation/Data`). On the 23:02 pod they were never baked, so each compiled on the **activation path** when someone opened it — and that same population is what produced the serial 15 s include reads and the `64 route dispatches in flight and not terminating` saturation in that pod's log between 05:05 and 05:37.

## What changed

`StaticRepoImportSettled` — a one-shot reactive signal in `MeshWeaver.Graph`, mesh-scoped singleton:

- `StaticRepoImportHostedService` marks it on completion **and on error**. A faulted import must *delay* the bake, never cancel it: the sweep then bakes whatever did land. It also marks immediately when there are no sources.
- `DynamicTypePreWarmerHostedService` sequences the sweep behind it: `settled.Settled.SelectMany(_ => WarmDynamicTypes(...))`.
- `AsyncSubject`, so a subscriber arriving after the fact gets it immediately — nothing to poll, no timer, no timeout.
- **Absent ⇒ immediate.** Every test host and non-portal host never registers it, so the shape there is unchanged.

## Tests (`DynamicTypePreWarmerTest`)

- `Sweep_WaitsForTheStaticImportToSettle_SoLateContentIsStillBaked` — subscribes with the same composition `KickWarmup` uses, writes a NodeType *after* subscribing but *before* the signal, asserts **zero** enumerations at that point, then settles and asserts the late type was enumerated and reached a usable build. That write-after-subscribe window is precisely the import's shape.
- `StaticImportSignal_IsOneShot_ReplayedAndIdempotent` — one emission, idempotent marking (both handlers may mark), replayed to late subscribers.

```
dotnet build src/MeshWeaver.Hosting -c Release -warnaserror       # 0 warnings, 0 errors
dotnet build memex/Memex.Portal.Shared -c Release -warnaserror    # 0 warnings, 0 errors
dotnet test test/MeshWeaver.Hosting.Monolith.Test --filter "Sweep_WaitsForTheStaticImportToSettle|StaticImportSignal_IsOneShot"   # 2 passed
```

Honest scope note: the tests pin the signal's semantics and the composition shape. They do not assert the *wiring* inside `KickWarmup` (that would need a booted portal host with `PreWarm:DynamicTypes=true`); the boot path itself is what exercises it.

## Related

- #1251 fixes the compile failures this bake now reports on that same static tree (unresolved mount-relative `@@` includes + three dead `LayoutAreaControl.Children` callers).
- Still open: the import activity accumulated **167 simultaneous unanswered `SubscribeRequest`s** from `cache/…` to one `_Activity/import-…` node (`[STALE-CALLBACK] … 167 callback(s) pending > 30000ms`, all within ~1 ms of each other), with `MonotonicWriteGuard` conflicts on the same node. That fan-out — not a retry, not a lost single reply — is what saturated routing portal-wide. Not diagnosed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)