### PR TITLE
fix(catalog): a sales contact makes a package commercial, not free

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-module-sold-through-your-sales-team-no-longer-installs-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-module-sold-through-your-sales-team-no-longer-installs-itself.md
@@ -1,0 +1,30 @@
+---
+Name: A module sold through your sales team no longer installs itself
+Category: Fix
+Description: A plugin offered as "contact sales" rather than at a price was treated as free by the install machinery — any installation could pull it in unattended, and on a fresh install its pages were briefly readable by everyone, including visitors who were not signed in.
+Icon: Sparkle
+Order: -20260812
+---
+
+# A module sold through your sales team no longer installs itself
+
+A plugin in the store says how it is sold. Most say it with a price. Some say it with a person: no
+price at all, a sales contact instead — "talk to us, and we will set this up with you". The store
+has always rendered that correctly, offering **Contact sales** where a priced plugin offers a buy
+button.
+
+The machinery that installs plugins was reading only the price. A plugin that named no price was, as
+far as it was concerned, free — and free means two specific things on every installation: it may be
+pulled in with nobody in the loop, and its pages are published to the world the moment it lands.
+Neither is what "contact us first" means.
+
+The effect was worst exactly where it mattered. An installation that could see the catalogue would
+install such a module by itself, with no administrator ever approving it. And on a first install the
+partition was opened up — cover, pages, everything — until the store's own gating caught up and shut
+it again. Nothing warned anybody; the module simply behaved like something given away.
+
+A named sales contact now counts as commercial, on equal footing with a price. Installing or
+auto-updating one takes a global administrator on the receiving installation, an unattended install
+refuses it and says so, and the content lands gated from the first moment — reachable only after the
+conversation that the plugin asked for. Plugins that genuinely are free are untouched: nothing to
+pay and nobody to ask still installs and publishes exactly as before.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -785,8 +785,9 @@ public sealed class InstanceAutoRegistrationService(
         if (priced.Count > 0)
             logger?.LogWarning(
                 "[DefaultInstall] {Count} required package(s) are COMMERCIAL and were not installed: "
-                + "[{Priced}]. A paid dependency has to be acquired deliberately — install it from "
-                + "the catalog as a global admin.", priced.Count, string.Join(", ", priced));
+                + "[{Priced}]. A paid or contact-sales dependency has to be acquired deliberately — "
+                + "install it from the catalog as a global admin.",
+                priced.Count, string.Join(", ", priced));
 
         if (missing.Count > 0)
             logger?.LogWarning(

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -147,6 +147,8 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         Icon = peeked.Icon,
                         Price = peeked.Price,
                         Currency = peeked.Currency,
+                        // Contact-sales: commercial without a price (PackageEntitlement.IsCommercial).
+                        ContactEmail = peeked.ContactEmail,
                         Poster = peeked.Poster,
                         // The package's own declaration that it belongs to the platform's default
                         // install — read off the ROOT's content, where the plugins repo authors it.
@@ -183,7 +185,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
         string? NodeType, string? Name, string? Description,
         string? Category, string? Icon, decimal? Price, string? Currency, string? Poster,
         bool PreInstalled, ImmutableList<string> Requires, ImmutableList<string> PublicSegments,
-        string? License);
+        string? License, string? ContactEmail);
 
     // Reads the node's type/name/description — plus the storefront card fields (category/icon on
     // the node, price/currency/poster inside the content) — straight from the JSON: no MeshNode
@@ -198,6 +200,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
             decimal? price = null;
             string? currency = null;
             string? poster = null;
+            string? contactEmail = null;
             var preInstalled = false;
             var requires = ImmutableList<string>.Empty;
             string? license = null;
@@ -211,6 +214,11 @@ public sealed class NodeRepoPackageSource : IPackageSource
                     currency = c.GetString();
                 if (content.TryGetProperty("poster", out var po) && po.ValueKind == JsonValueKind.String)
                     poster = po.GetString();
+                // The sales contact ("contactEmail"). A contact-sales package normally names NO
+                // price, so leaving this unread is what made it arrive as free — installable with
+                // no admin and published by the access step. See PackageManifest.ContactEmail.
+                if (content.TryGetProperty("contactEmail", out var ce) && ce.ValueKind == JsonValueKind.String)
+                    contactEmail = ce.GetString();
                 // Only a literal `true` opts in — anything else (absent, false, a string) leaves the
                 // package out of the default install. A malformed value must never silently install
                 // a package on every instance.
@@ -246,7 +254,8 @@ public sealed class NodeRepoPackageSource : IPackageSource
                 r.TryGetProperty("description", out var d) ? d.GetString() : null,
                 r.TryGetProperty("category", out var cat) ? cat.GetString() : null,
                 r.TryGetProperty("icon", out var ic) ? ic.GetString() : null,
-                price, currency, poster, preInstalled, requires, publicSegments, license);
+                price, currency, poster, preInstalled, requires, publicSegments, license,
+                contactEmail);
         }
         catch (JsonException ex)
         {

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -136,6 +136,22 @@ public record PackageManifest
     /// <summary>ISO currency code of <see cref="Price"/>.</summary>
     public string? Currency { get; init; }
 
+    /// <summary>
+    /// The sales contact (the root content's <c>contactEmail</c>). Set = the package is sold
+    /// CONTACT-SALES rather than self-service: the Store's cover offers "Contact sales" instead of a
+    /// buy button, and the content is gated exactly as a priced package's is.
+    ///
+    /// <para>🚨 Read here because the ENTITLEMENT and ACCESS decisions key on the manifest, not on
+    /// the Store's own view of the root: a contact-sales package that named no price used to arrive
+    /// as FREE, so <see cref="PackageEntitlement.Authorize"/> waved it through with no admin and
+    /// <see cref="PackageInstaller.EnsureDeclaredAccess"/> published the whole partition
+    /// (<c>_Policy · PublicRead = true</c>) until the Store's <c>PluginGate</c> darkened it again.
+    /// The package said "talk to us before you use this" and the install path could not hear it —
+    /// the same dead-metadata defect <c>preInstalled</c> and <c>publicSegments</c> each had (#920).
+    /// <see cref="PackageEntitlement.IsCommercial"/> now counts it.</para>
+    /// </summary>
+    public string? ContactEmail { get; init; }
+
     /// <summary>The store-card picture URL (the root content's <c>poster</c>).</summary>
     public string? Poster { get; init; }
 

--- a/src/MeshWeaver.PluginCatalog/PackageEntitlement.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageEntitlement.cs
@@ -9,11 +9,12 @@ namespace MeshWeaver.PluginCatalog;
 /// <summary>
 /// WHO may bring a package onto this instance — the free / commercial boundary (#830).
 ///
-/// <para><b>The rule.</b> A <b>free</b> package (<see cref="PackageManifest.Price"/> null or 0)
-/// syncs, installs and auto-updates with NO special permission: that is what makes the platform
-/// baseline and every gratis plugin land on a fresh instance without an operator in the loop. A
-/// <b>commercial</b> package (a non-zero price — positive = purchasable, negative = coupon-only;
-/// the same "priced" test <see cref="PackageInstaller.EnsureDeclaredAccess"/> already applies when
+/// <para><b>The rule.</b> A <b>free</b> package (<see cref="PackageManifest.Price"/> null or 0, and
+/// no <see cref="PackageManifest.ContactEmail"/>) syncs, installs and auto-updates with NO special
+/// permission: that is what makes the platform baseline and every gratis plugin land on a fresh
+/// instance without an operator in the loop. A <b>commercial</b> package (a non-zero price —
+/// positive = purchasable, negative = coupon-only — or a named sales contact; the same
+/// <see cref="IsCommercial"/> test <see cref="PackageInstaller.EnsureDeclaredAccess"/> applies when
 /// it decides a partition installs gated) requires <b>Global Admin</b> on the installing instance
 /// to be accessed, installed or auto-updated.</para>
 ///
@@ -53,13 +54,24 @@ public static class PackageEntitlement
 
     /// <summary>
     /// True when the package is COMMERCIAL — it carries a non-zero
-    /// <see cref="PackageManifest.Price"/> (positive = purchasable, negative = coupon-only).
-    /// Free is the complement: no price at all, or an explicit 0.
+    /// <see cref="PackageManifest.Price"/> (positive = purchasable, negative = coupon-only) OR it
+    /// names a sales contact (<see cref="PackageManifest.ContactEmail"/>: sold with a person in the
+    /// loop). Free is the complement: nothing to pay and nobody to ask.
+    ///
+    /// <para>🚨 The contact-sales half is not a nicety. A package sold that way normally names NO
+    /// price — "nothing to self-serve" — so on the price-only test it read as FREE, and the two
+    /// decisions that call this both took the wrong branch at once: <see cref="Authorize"/> let any
+    /// unattended install pull it in with no admin, and
+    /// <see cref="PackageInstaller.EnsureDeclaredAccess"/> published the partition
+    /// (<c>_Policy · PublicRead = true</c>, since these declare no <c>publicSegments</c>) until the
+    /// Store's <c>PluginGate</c> reconciled it dark again. The whole point of naming a sales contact
+    /// is that the content is NOT self-service.</para>
     /// </summary>
     /// <param name="manifest">The package manifest (null counts as free — nothing to gate).</param>
-    /// <returns><c>true</c> for a priced package.</returns>
+    /// <returns><c>true</c> for a priced or contact-sales package.</returns>
     public static bool IsCommercial(this PackageManifest? manifest) =>
-        manifest?.Price is { } price && price != 0m;
+        manifest?.Price is { } price && price != 0m
+        || !string.IsNullOrWhiteSpace(manifest?.ContactEmail);
 
     /// <summary>
     /// Authorizes installing / auto-updating <paramref name="manifest"/> on this instance. Emits
@@ -127,15 +139,21 @@ public static class PackageEntitlement
     public static string Reason(PackageManifest manifest, string? userId)
     {
         ArgumentNullException.ThrowIfNull(manifest);
-        var price = manifest.Currency is { Length: > 0 } currency
-            ? $"{manifest.Price} {currency}"
-            : $"{manifest.Price}";
+        // Name what made it commercial — a price, or the sales contact. A contact-sales package has
+        // no price, and reporting "price " with a blank where the number goes reads as a bug in the
+        // gate rather than as the deliberate refusal it is.
+        var terms = manifest.Price is { } amount
+            ? manifest.Currency is { Length: > 0 } currency
+                ? $"price {amount} {currency}"
+                : $"price {amount}"
+            : $"contact sales: {manifest.ContactEmail}";
         var who = string.IsNullOrWhiteSpace(userId)
             ? "no authorizing principal (unattended install)"
             : $"'{userId}'";
-        return $"Package '{manifest.Id}' is commercial (price {price}) — installing or auto-updating "
+        return $"Package '{manifest.Id}' is commercial ({terms}) — installing or auto-updating "
                + $"it requires Global Admin on this instance, and {who} is not one. "
-               + "Free packages (no price, or price 0) need no special permission.";
+               + "Free packages (no price and no sales contact, or price 0) need no special "
+               + "permission.";
     }
 }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -331,7 +331,8 @@ public static class PackageInstaller
     ///     baseline, fully public: <c>PartitionAccessPolicy { PublicRead = true }</c> at
     ///     <c>{partition}/_Policy</c> (#902). Declared segments are irrelevant — everything is
     ///     readable.</item>
-    ///   <item><b>Free</b> (<see cref="PackageManifest.Price"/> 0 or absent) with no declared
+    ///   <item><b>Free</b> (<see cref="PackageManifest.Price"/> 0 or absent AND no
+    ///     <see cref="PackageManifest.ContactEmail"/>) with no declared
     ///     <see cref="PackageManifest.PublicSegments"/> — the same fully-public policy: a free
     ///     package that a catalog hands out must be readable by everyone, signed in or not.</item>
     ///   <item><b>Free with declared <see cref="PackageManifest.PublicSegments"/></b> — public read
@@ -341,10 +342,12 @@ public static class PackageInstaller
     ///     Store's <c>CatalogGate</c> seeds for <c>/Store</c> (#200/#204). Underscore satellites
     ///     and the well-known <c>Public</c> segment follow the <c>PluginGate</c> conventions so the
     ///     two mechanisms converge instead of fighting.</item>
-    ///   <item><b>Priced</b> (any non-zero <see cref="PackageManifest.Price"/> — positive =
-    ///     purchasable, negative = coupon-only) — the installer writes NOTHING: the partition lands
-    ///     gated, readable only via the entitlement machinery (PluginGate / purchase), which is
-    ///     exactly the point of a price.</item>
+    ///   <item><b>Commercial</b> (<see cref="PackageEntitlement.IsCommercial"/>: any non-zero
+    ///     <see cref="PackageManifest.Price"/> — positive = purchasable, negative = coupon-only —
+    ///     or a <see cref="PackageManifest.ContactEmail"/>, i.e. sold contact-sales) — the installer
+    ///     writes NOTHING: the partition lands gated, readable only via the entitlement machinery
+    ///     (PluginGate / purchase / an admin-issued grant), which is exactly the point of asking to
+    ///     be paid or to be called.</item>
     /// </list>
     ///
     /// <para><b>Why the installer owns it.</b> An installed package is written entirely under
@@ -378,13 +381,14 @@ public static class PackageInstaller
         if (string.IsNullOrWhiteSpace(partition))
             return Observable.Return(Unit.Default);
 
-        // A priced package (positive = purchasable, negative = coupon-only) installs GATED: no
-        // public read of any kind — entitlement (PluginGate / purchase / coupon) is the only way
-        // in. Pre-installed overrides a price: platform baseline is public by definition.
+        // A commercial package — priced (positive = purchasable, negative = coupon-only) or
+        // contact-sales — installs GATED: no public read of any kind, entitlement (PluginGate /
+        // purchase / coupon / a grant issued after the sales conversation) is the only way in.
+        // Pre-installed overrides both: platform baseline is public by definition.
         if (!manifest.PreInstalled && manifest.IsCommercial())
         {
             logger?.LogDebug(
-                "[PackageInstaller] {Id} is priced — {Partition} stays gated (entitlement only)",
+                "[PackageInstaller] {Id} is commercial — {Partition} stays gated (entitlement only)",
                 manifest.Id, partition);
             return Observable.Return(Unit.Default);
         }

--- a/test/MeshWeaver.PluginCatalog.Test/CommercialPackageAuthorizationTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CommercialPackageAuthorizationTest.cs
@@ -68,6 +68,15 @@ public class CommercialPackageAuthorizationTest(ITestOutputHelper output) : Mono
         Currency = "CHF",
     };
 
+    /// <summary>
+    /// Sold with a person in the loop: NO price — "nothing to self-serve" — and a sales contact.
+    /// Commercial all the same, which is the half the price-only test used to miss.
+    /// </summary>
+    private static PackageManifest ContactSales(string id) => Free(id) with
+    {
+        ContactEmail = "info@systemorph.com",
+    };
+
     /// <summary>A source serving one package's single file — the shape both install paths consume.</summary>
     private sealed class SingleFileSource(PackageManifest manifest) : IPackageSource
     {
@@ -135,6 +144,34 @@ public class CommercialPackageAuthorizationTest(ITestOutputHelper output) : Mono
         refusedUnattended.Should().BeOfType<PackageAuthorizationException>(
             "an unattended install has no principal — for a priced package that fails closed");
         (await Read($"{PackageInstaller.InstalledPartition}/paid-unattended")).Should().BeNull();
+    }
+
+    /// <summary>
+    /// A CONTACT-SALES package is commercial without carrying a price, so the same gate applies:
+    /// refused for a plain principal and for the unattended paths. Before this, such a package read
+    /// as free and any instance that could see the catalog auto-installed it — the opposite of what
+    /// "call us before you use this" means. The refusal names the contact instead of an absent
+    /// price, so the log line does not read as a broken gate.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ContactSalesPackage_IsRefusedForANonAdmin_AndForAnUnattendedInstall()
+    {
+        var refusedForUser = await Record.ExceptionAsync(
+            () => Install(ContactSales("contact-by-user"), PlainUser));
+        refusedForUser.Should().BeOfType<PackageAuthorizationException>(
+            "a contact-sales package requires Global Admin to be installed at all");
+        refusedForUser!.Message.Should().Contain("contact sales: info@systemorph.com",
+            "the refusal must name what made it commercial — there is no price to print");
+        refusedForUser.Message.Should().Contain("contact-by-user", "the reason must name the package");
+
+        (await Read($"{PackageInstaller.InstalledPartition}/contact-by-user"))
+            .Should().BeNull("a refused install must write nothing — not even the record");
+
+        var refusedUnattended = await Record.ExceptionAsync(
+            () => Install(ContactSales("contact-unattended"), authorizingUserId: null));
+        refusedUnattended.Should().BeOfType<PackageAuthorizationException>(
+            "an unattended install has no principal — for a contact-sales package that fails closed");
+        (await Read($"{PackageInstaller.InstalledPartition}/contact-unattended")).Should().BeNull();
     }
 
     [Fact(Timeout = 180_000)]

--- a/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
@@ -119,6 +119,23 @@ public class DeclaredAccessInstallTest(ITestOutputHelper output) : MonolithMeshT
              "mainNode":"PaidPlug/Doc","name":"Doc","nodeType":"Markdown","state":"Active",
              "content":"# Paid content"}
             """),
+        // CONTACT-SALES — no price at all, a sales contact instead. Must install EXACTLY as the
+        // priced one does. This is the shape that regressed: with the peek blind to contactEmail
+        // the manifest arrived priceless, the installer read "free", and a module sold with a
+        // person in the loop was published to the whole internet on its first install.
+        new("ContactPlug/index.json",
+            """
+            {"$type":"MeshNode","id":"ContactPlug","namespace":"","path":"ContactPlug",
+             "mainNode":"ContactPlug","name":"Contact Plug","nodeType":"Space","state":"Active",
+             "content":{"$type":"PluginManifest","description":"Talk to us first.",
+                        "contactEmail":"info@systemorph.com","publicSegments":[]}}
+            """),
+        new("ContactPlug/Doc.json",
+            """
+            {"$type":"MeshNode","id":"Doc","namespace":"ContactPlug","path":"ContactPlug/Doc",
+             "mainNode":"ContactPlug/Doc","name":"Doc","nodeType":"Markdown","state":"Active",
+             "content":"# Contact-sales content"}
+            """),
         // FREE, but the package SHIPS ITS OWN _Policy — the installer's step is create-only and
         // must leave the shipped shape completely alone.
         new("ShippedPolicy/index.json",
@@ -266,6 +283,39 @@ public class DeclaredAccessInstallTest(ITestOutputHelper output) : MonolithMeshT
                 .Should().Within(TimeSpan.FromSeconds(30))
                 .Match(p => p == Permission.None,
                     $"'{identity}' must be denied on a priced package's content");
+        }
+    }
+
+    /// <summary>
+    /// A CONTACT-SALES package (no price, a <c>contactEmail</c>) installs gated exactly as a priced
+    /// one does — the regression this fixture exists to forbid. A module sold with a person in the
+    /// loop declares no price, so on the old price-only test it read as FREE and the installer
+    /// published the whole partition: <c>_Policy · PublicRead = true</c>, cover and content readable
+    /// by anyone on the internet, until the Store's PluginGate happened to reconcile it dark again.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ContactSalesPackage_InstallsGated_ExactlyLikeAPricedOne()
+    {
+        var result = await Install("ContactPlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        (await Read($"ContactPlug/{PackageInstaller.PartitionPolicyId}"))
+            .Should().BeNull("a contact-sales package must not get a public-read policy");
+        (await Read("ContactPlug/_Access/Public_Access"))
+            .Should().BeNull("a contact-sales package must not get a Public grant");
+        (await Read("ContactPlug/_Access/Anonymous_Access"))
+            .Should().BeNull("a contact-sales package must not get an Anonymous grant");
+
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            await Mesh.GetEffectivePermissions("ContactPlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must be denied on a contact-sales package's partition");
+            await Mesh.GetEffectivePermissions("ContactPlug/Doc", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must be denied on a contact-sales package's content");
         }
     }
 

--- a/test/MeshWeaver.PluginCatalog.Test/NodeRepoPluginListingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/NodeRepoPluginListingTest.cs
@@ -31,6 +31,11 @@ public class NodeRepoPluginListingTest
         // A free-to-browse plugin root without a price — listed, Price null.
         new("Chess/index.json",
             """{"$type":"MeshNode","id":"Chess","path":"Chess","name":"Chess","nodeType":"Store/Plugin","category":"Games","content":{"$type":"PluginContent"}}"""),
+        // Sold contact-sales: NO price, a sales contact. The contact has to reach the manifest —
+        // it is what makes the package commercial (PackageEntitlement.IsCommercial), and while it
+        // went unread such a package installed as free: no admin required, partition published.
+        new("Reinsurance/index.json",
+            """{"$type":"MeshNode","id":"Reinsurance","path":"Reinsurance","name":"Reinsurance","nodeType":"Store/Plugin","category":"Insurance","content":{"$type":"PluginContent","description":"Talk to us.","contactEmail":"info@systemorph.com"}}"""),
         // The Store package's own root (the /Store catalog page) — listed too.
         new("Store/index.json",
             """{"$type":"MeshNode","id":"Store","path":"Store","name":"Store","nodeType":"Store/Catalog","content":{"$type":"StoreContent"}}"""),
@@ -54,7 +59,8 @@ public class NodeRepoPluginListingTest
     {
         var packages = await Source().ListPackages("HEAD").FirstAsync().ToTask();
 
-        packages.Select(p => p.Id).Should().Equal("AgenticEngineering", "Chess", "Store", "Widget");
+        packages.Select(p => p.Id).Should()
+            .Equal("AgenticEngineering", "Chess", "Reinsurance", "Store", "Widget");
 
         var course = packages.Single(p => p.Id == "AgenticEngineering");
         course.Name.Should().Be("Agentic Engineering");
@@ -68,6 +74,14 @@ public class NodeRepoPluginListingTest
         var chess = packages.Single(p => p.Id == "Chess");
         chess.Category.Should().Be("Games");
         chess.Price.Should().BeNull("no price = not purchasable, still listed");
+        chess.IsCommercial().Should().BeFalse("nothing to pay and nobody to ask = free");
+
+        var contactSales = packages.Single(p => p.Id == "Reinsurance");
+        contactSales.Price.Should().BeNull("a contact-sales package sells nothing self-service");
+        contactSales.ContactEmail.Should().Be("info@systemorph.com");
+        contactSales.IsCommercial().Should()
+            .BeTrue("a named sales contact makes the package commercial — admin to install, "
+                + "gated on install, exactly like a priced one");
 
         var widget = packages.Single(p => p.Id == "Widget");
         widget.Category.Should().BeNull();


### PR DESCRIPTION
## The defect

`PackageManifest` knows a package's terms only as `Price`. A plugin sold **contact-sales** declares no price — "nothing to self-serve" — and names a `contactEmail` instead, so it arrived as **free**, and both decisions that key on that took the wrong branch:

| | before | after |
|---|---|---|
| `PackageEntitlement.Authorize` | no Global Admin needed — **any instance that could see the catalog auto-installed it unattended** | commercial: admin required, unattended install refused |
| `PackageInstaller.EnsureDeclaredAccess` | `_Policy { PublicRead = true }` — the whole partition **published** on a fresh install (these declare no `publicSegments`), until the Store's `PluginGate` reconciled it dark | writes nothing; lands gated, entitlement only |

The Store has always rendered the contact-sales funnel off this same field (`PluginLayoutAreas.UnentitledCta` → "Contact sales" → the inquiry form). Only the install path was blind to it, because `NodeRepoPackageSource.Peek` never read it off the root — the same dead-metadata defect `preInstalled` and `publicSegments` each had (#920).

Live trigger: MeshWeaver.Reinsurance's nine modules moved from `price: 900` / `-1` to contact-sales this morning ([Reinsurance#50](https://github.com/Systemorph/MeshWeaver.Reinsurance/pull/50)), which is what surfaced this.

## The change

- `PackageManifest.ContactEmail` — peeked off the root's `content.contactEmail`, carried onto the manifest.
- `PackageEntitlement.IsCommercial` counts it: a named sales contact is commercial on equal footing with a non-zero price. Everything else already funnels through this one predicate (`EnsureDeclaredAccess`, `Authorize`, `InstanceAutoRegistrationService`, `CatalogLayoutAreas`), so all four follow.
- The refusal reason names *what* made it commercial — a contact-sales package has no price, and printing `price ` with a blank where the number goes reads as a broken gate rather than the deliberate refusal it is.

Free is unchanged: nothing to pay **and** nobody to ask.

## Testing

- `DeclaredAccessInstallTest.ContactSalesPackage_InstallsGated_ExactlyLikeAPricedOne` — through the real listing + installer: no policy, no grants, `Permission.None` for a plain signed-in principal and anonymously.
- `CommercialPackageAuthorizationTest.ContactSalesPackage_IsRefusedForANonAdmin_AndForAnUnattendedInstall` — including the speaking reason.
- `NodeRepoPluginListingTest` — pins the peek/parse and both `IsCommercial` verdicts.
- 5/5 green locally (new + the free/paid ones they sit next to); `dotnet build -c Release -p:CIRun=true -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)