### PR TITLE
One failed subscribe poisoned a path for the pod's lifetime

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -157,6 +157,23 @@ A read whose owner answers *NotFound* is cached as a **negative entry** with exp
 
 The primary rule still stands: **optional / maybe-absent nodes are read via a query** (empty result on absence), never by pointing an exact-path stream at them. The breaker is the backstop, not the pattern.
 
+A failure that is *not* a genuine missing node — a transient reactivation miss, a request timeout, a lost database connection, or anything else the classifier does not recognise — is recorded in the **transient breaker** instead. Its first `TransientGraceFailures` (3) faults open no window at all (the just-idle-page case keeps its instant re-probe); beyond the grace, re-probes back off 1 s doubling to a 60 s cap. Every fault lands in exactly one of the two breakers — there is no un-broker'd bucket where a fault can repeat unbounded.
+
+### A faulted entry is never served twice
+
+Both breakers *suppress* while their window is open. When no window is open, the opposite must hold: the read has to actually re-probe. `GetStreamRaw`'s third guard enforces that — an entry whose hydration terminated with an error is evicted before the read resolves, so `SharedView` opens a fresh upstream.
+
+The eviction (`EvictFaultedEntry`) is the one teardown shared by all three re-probe triggers, and it must reach **two** layers:
+
+1. the cache's own `Entry`, whose `Replay(1)` holds the terminal error, and
+2. the cacheHub **workspace's** remote-stream cache, keyed `(owner, reference, identity)`, which holds the errored `ISynchronizationStream`.
+
+Dropping only (1) re-creates a fresh entry over the same dead stream: no `SubscribeRequest` is posted and the reader gets the *identical exception instance* back. That was #1202 — three probes eleven minutes apart returning the byte-identical request id, a path unreadable for the pod's lifetime, and breakers whose fail counters were frozen at one because no new upstream ever ran the bookkeeping observer again.
+
+The protocol is the idle sweep's: **detach → claim pair-exact → tear down** (a loser re-parks what it detached). Detaching first is what makes disposal safe — a concurrent read builds a new stream with a new `StreamId`, so the `UnsubscribeRequest` for the old one cannot race it. Only a **faulted** entry qualifies; a healthy live entry is never torn down, because a breaker record can outlive the fault that wrote it and severing live subscribers over a stale counter would be a regression.
+
+🚨 The guard lives in `GetStreamRaw`, **never in `GetEntry`** — `GetEntry` is a pin-or-recreate loop, and evicting there spins forever on an entry that faults during creation. Running once per read *call* also bounds the re-probe: only a terminal entry qualifies, so an in-flight probe is shared, giving one new upstream per **fault**, not per read.
+
 ## 🚨 Never go around the cache
 
 An ad-hoc `workspace.GetRemoteStream<MeshNode, …>(addr, …)` would open a **separate** stream instance. Writes through it are invisible to every reader on the cached handle (and vice versa) — this exact bug once made compile results never land on a NodeType's node. So the public overloads now **throw `InvalidOperationException`** for `MeshNode` (`Workspace.ThrowIfMeshNode`); framework plumbing that legitimately needs the raw reduce uses the internal `GetRemoteStreamUnchecked` overload.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-page-that-failed-to-load-once-no-longer-stays-broken.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-page-that-failed-to-load-once-no-longer-stays-broken.md
@@ -1,0 +1,40 @@
+---
+Name: A page that failed to load once no longer stays broken
+Category: Fix
+Description: A single slow or unreachable moment could leave a document permanently unreadable until the server restarted — reloading just replayed the same old error. Reloading now genuinely tries again.
+Icon: ArrowSync
+Order: -20260812
+---
+
+# A page that failed to load once no longer stays broken
+
+Some documents simply refused to open. Not slowly — instantly, with the same technical message
+every time: *"No response received … the request may have been undeliverable."* Reloading changed
+nothing. Waiting changed nothing. The page stayed broken for hours, while its neighbours in the
+very same folder opened fine, the search results still listed it, and the folder listing still
+showed it. Only opening the document itself failed.
+
+That combination is the clue. Nothing was wrong with the document, and nothing was wrong with the
+server. What was wrong was the memory of a single bad moment.
+
+Behind every open document there is one shared connection to the piece of the system that owns it.
+When that owner is briefly unreachable — it was asleep and is waking up, a deployment is rolling,
+the database blinks — the connection fails, and the failure is handed to whoever was waiting. That
+part is fine and expected; the next visitor should simply get a fresh connection.
+
+Except the failed connection was kept. Every later reader was handed the *recorded* failure instead
+of a new attempt, so no new attempt was ever made — which meant the system never learned that the
+owner had come back. The proof was in the error itself: three attempts eleven minutes apart came
+back quoting the identical internal request number. It was not failing three times; it was showing
+one old failure three times. The safety valve designed to notice repeated failures and slow them
+down could not help either, because from its point of view the failure had only ever happened once.
+
+Two things kept the stale connection alive: the shared connection register, and a second cache one
+layer below it that handed the same dead connection back even after the first was cleared. Both are
+now dropped the moment a reader arrives and finds the previous attempt had ended in failure, with
+nothing currently holding it back on purpose. The next read opens a genuinely new connection to the
+owner, and a document that failed once opens normally as soon as its owner is reachable again.
+
+The protection against a genuinely broken owner is unchanged, and in fact now works as intended:
+repeated real failures are still counted and still backed off, briefly and then progressively, so a
+wedged owner is never hammered. The difference is that "try again" now means trying again.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -109,9 +109,12 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         /// <summary>Marks the entry's hydration as terminally errored — its replay
         /// subject holds an OnError terminal, so every future subscriber would
         /// replay the stale failure. Set by the storm-breaker bookkeeping observer;
-        /// consumed by the change-feed invalidation reset, which evicts ONLY
-        /// faulted entries (a healthy live entry must never be torn down by a
-        /// routine post-commit Updated broadcast).</summary>
+        /// consumed by TWO evict-only readers, both of which evict ONLY faulted
+        /// entries (a healthy live entry must never be torn down): the change-feed
+        /// invalidation reset (a routine post-commit Updated broadcast) and the
+        /// faulted-entry guard in <c>GetStreamRaw</c>, which drops the entry on the
+        /// next read whenever NO breaker window is open — without it a single owner
+        /// fault poisons the path for the process lifetime (#1202).</summary>
         public void MarkFaulted() { lock (gate) faulted = true; }
 
         /// <summary>True when the entry's hydration terminated with an error.</summary>
@@ -864,10 +867,25 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 {
                     entry.MarkFaulted();
                     if (IsMissingNodeFailure(ex)) RecordNegative(p, ex);
-                    // A transient owner failure stays out of the negative cache (the node
-                    // exists — see IsTransientOwnerFailure), but a STREAK of them is the
-                    // poisoned-activation loop; record it so re-probes back off past the grace.
-                    else if (IsTransientOwnerFailure(ex)) RecordTransient(p, ex);
+                    // Everything that is NOT a genuine missing node stays out of the negative
+                    // cache (the node exists — see IsTransientOwnerFailure), but a STREAK of
+                    // failures is the poisoned-activation loop; record it so re-probes back off
+                    // past the grace.
+                    //
+                    // 🚨 The `else` is deliberately unconditional, not `else if
+                    // (IsTransientOwnerFailure(ex))`. EVERY fault must land in exactly one
+                    // breaker, because the faulted-entry guard in GetStreamRaw now re-probes any
+                    // entry the breakers left unwindowed — an error class recorded by NEITHER
+                    // breaker would re-probe once per read with no bound at all. That
+                    // "un-broker'd" bucket is also what wedged memex on 2026-07-23 (an Npgsql
+                    // connect failure fell through both predicates and replayed forever until a
+                    // manual recycle); the classifier grew a marker list to plug that ONE class,
+                    // and this closes the bucket in general. The transient breaker is the right
+                    // home: its grace keeps the "clean cache, instant re-probe" contract for the
+                    // first TransientGraceFailures faults of ANY class, then bounds a persistent
+                    // one at ≤ TransientMaxCooldown. A successful read or a change-feed
+                    // invalidation clears it immediately, exactly as before.
+                    else RecordTransient(p, ex);
                 });
             disposal.Add(bookkeeping);
             return entry;
@@ -1021,6 +1039,76 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     }
 
     /// <summary>
+    /// Drops the path's TERMINALLY-ERRORED read entry so the next resolution re-probes the owner
+    /// for real. The single teardown behind all three re-probe triggers — the storm breaker's
+    /// window expiry, the transient breaker's, and the faulted-entry guard — so they cannot drift.
+    ///
+    /// <para>🚨 It must detach the UPSTREAM, not just the cache entry. The poison is TWO layers
+    /// deep: the cache's <c>Entry</c> holds the terminal on its <c>Replay(1)</c>, and the
+    /// cacheHub WORKSPACE holds the errored <c>ISynchronizationStream</c> in its own
+    /// <c>(owner, reference, identity)</c> cache. Dropping only the entry re-creates a fresh
+    /// entry over the SAME dead stream — no <c>SubscribeRequest</c> is ever posted, and the
+    /// reader gets the identical exception instance back. That is why the memex-cloud probes
+    /// kept returning the byte-identical request id (#1202), and why the breakers' own
+    /// "re-probe" branches only ever grew their backoff instead of reaching the owner.</para>
+    ///
+    /// <para>The protocol is the idle sweep's, for the same reason: DETACH first, so from that
+    /// instant a concurrent read builds a FRESH stream (new StreamId) and can no longer adopt
+    /// the doomed one; then CLAIM the entry pair-exact; only the winner tears down. This is what
+    /// makes disposing safe here — the earlier "never dispose the upstream on a re-probe" rule
+    /// guarded against disposing a stream the fresh subscribe could still adopt, which detaching
+    /// first makes impossible (the <c>UnsubscribeRequest</c> carries the OLD StreamId). A loser
+    /// re-parks what it detached, so a stream belonging to someone else's fresh entry is never
+    /// disposed.</para>
+    ///
+    /// <para>Only a FAULTED entry qualifies. A healthy live entry is never torn down — the same
+    /// rule <see cref="ResetFailureState"/> follows: a breaker record can outlive the fault that
+    /// wrote it (the write path records too), and severing live GUI subscribers over a stale
+    /// counter would be a regression, not a fix.</para>
+    /// </summary>
+    /// <returns>True when this caller claimed and tore the entry down.</returns>
+    private bool EvictFaultedEntry(string path, string reason)
+    {
+        if (!_streams.TryGetValue(path, out var lazy) || !lazy.IsValueCreated || !lazy.Value.IsFaulted)
+            return false;
+
+        var stale = lazy.Value;
+        IReadOnlyList<ISynchronizationStream> detached;
+        try
+        {
+            detached = stale.Handle.DetachUpstreams();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "MeshNodeStreamCache: error detaching upstreams for {Path}", path);
+            detached = [];
+        }
+
+        // Pair-exact: never unlink an entry a concurrent reader has already replaced.
+        if (!_streams.TryRemove(new KeyValuePair<string, Lazy<Entry>>(path, lazy)))
+        {
+            // Lost the claim — the detach above may have taken the WINNER's fresh stream with it
+            // (DetachRemoteStreams scans by (owner, reference) across identities). Hand everything
+            // back; the workspace re-owns the lifetime and the winner's probe keeps running.
+            try { stale.Handle.ReparkUpstreams(detached); }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "MeshNodeStreamCache: error re-parking upstreams for {Path}", path);
+            }
+            return false;
+        }
+
+        stale.MarkEvicted();
+        var released = TearDownEntry(path, stale, detached);
+        readStreamEvictions.OnNext(new ReadStreamEviction(path, released, reason));
+        logger.LogDebug(
+            "MeshNodeStreamCache: evicted faulted read entry for {Path} ({Reason}; upstreams disposed: {Count}) "
+            + "— the next resolution opens a fresh SubscribeRequest instead of replaying the stale terminal error",
+            path, reason, detached.Count);
+        return true;
+    }
+
+    /// <summary>
     /// Records an upstream read failure for <paramref name="path"/> in the storm
     /// breaker's negative cache with an exponential-backoff window
     /// (<see cref="StormBaseCooldown"/> · 2^(n-1), capped at
@@ -1051,8 +1139,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     }
 
     /// <summary>
-    /// Records a TRANSIENT owner fault (<see cref="IsTransientOwnerFailure"/>) for
-    /// <paramref name="path"/> in the transient-fault breaker. The first
+    /// Records an owner fault that is NOT a genuine missing node — the transient class
+    /// (<see cref="IsTransientOwnerFailure"/>) and, since #1202, every other non-missing
+    /// class too, so no fault is left un-broker'd — for <paramref name="path"/>. The first
     /// <see cref="TransientGraceFailures"/> consecutive faults open NO window (the ordinary
     /// just-idle reactivation miss keeps its instant re-probe); past the grace, each further
     /// fault opens an exponential-backoff window (<see cref="TransientBaseCooldown"/> ·
@@ -1086,7 +1175,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         _transientStreaks[path] = new TransientStreak(error, failCount, openUntil, now);
         if (failCount == TransientGraceFailures + 1)
             logger.LogWarning(
-                "[TRANSIENT-BREAKER] '{Path}' has faulted {FailCount} consecutive times with a transient-classified "
+                "[TRANSIENT-BREAKER] '{Path}' has faulted {FailCount} consecutive times with a non-missing-node "
                 + "owner failure: {Error}. The fault is empirically NOT transient (a poisoned activation / wedged owner) — "
                 + "re-probes now back off exponentially (cap {Cap}s) instead of hammering the owner. A recycle or a "
                 + "successful resolution clears the streak immediately.",
@@ -1254,35 +1343,21 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         //      it (the atomic TryUpdate lets exactly one reader win). Without this, every
         //      ~100ms read re-evicted the still-hydrating fresh probe before it resolved,
         //      so the negative entry never cleared.
-        //   2. The stale-entry eviction disposes ONLY the Rx hydration + marks the entry
-        //      evicted — it does NOT synchronously dispose the upstream sync stream. A
-        //      terminally-errored upstream ("No node found") has ALREADY torn down its own
-        //      keep-alive/heartbeat, so it leaks nothing; but posting UnsubscribeRequest to
-        //      the owner mid-reprobe RACES the fresh re-subscribe and wedges the owner's
-        //      action block (its snapshot DataChangedEvent then never lands → the read
-        //      never resolves). The idle sweep reaps genuinely-idle LIVE upstreams (the
-        //      actual leak); an errored/superseded upstream is reaped by the change-feed
-        //      parking + workspace disposal, exactly as before the idle-release change.
+        //   2. The stale-entry eviction (EvictFaultedEntry) DETACHES the upstream before it
+        //      claims the entry, so the fresh probe builds a NEW sync stream and can never
+        //      adopt the doomed one. That ordering is what makes the teardown safe: the old
+        //      "dispose nothing, the change feed will reap it" rule was guarding against
+        //      disposing a stream the fresh re-subscribe could still adopt (UnsubscribeRequest
+        //      racing it wedges the owner's action block). It also left the errored stream in
+        //      the WORKSPACE's remote-stream cache — so the "re-probe" re-created an entry over
+        //      the same dead stream, posted no SubscribeRequest at all, and replayed the
+        //      identical exception while the backoff grew. See EvictFaultedEntry (#1202).
         if (_negative.TryGetValue(path, out var neg))
         {
             if (neg.OpenUntil > DateTimeOffset.UtcNow)
                 return Observable.Throw<MeshNode>(neg.Error);
-            if (!neg.Reprobing
-                && _negative.TryUpdate(path, neg with { Reprobing = true }, neg)
-                && _streams.TryRemove(path, out var staleLazy) && staleLazy.IsValueCreated)
-            {
-                try
-                {
-                    // Drop the errored entry's Rx hydration and mark it evicted so any
-                    // straggling SharedView wrapper transparently re-resolves. Deliberately
-                    // NOT DetachUpstreams()/TearDownEntry() here — see guard #2 above.
-                    var stale = staleLazy.Value;
-                    stale.MarkEvicted();
-                    stale.HydrationSub.Dispose();
-                    readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "storm-breaker"));
-                }
-                catch (Exception ex) { logger.LogDebug(ex, "MeshNodeStreamCache: error disposing stale entry for {Path}", path); }
-            }
+            if (!neg.Reprobing && _negative.TryUpdate(path, neg with { Reprobing = true }, neg))
+                EvictFaultedEntry(path, "storm-breaker");
         }
 
         // TRANSIENT-FAULT BREAKER: same fast-fail + single-flight re-probe discipline as the
@@ -1295,19 +1370,41 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 return Observable.Throw<MeshNode>(streak.Error);
             if (streak.FailCount > TransientGraceFailures
                 && !streak.Reprobing
-                && _transientStreaks.TryUpdate(path, streak with { Reprobing = true }, streak)
-                && _streams.TryRemove(path, out var staleTransientLazy) && staleTransientLazy.IsValueCreated)
-            {
-                try
-                {
-                    var stale = staleTransientLazy.Value;
-                    stale.MarkEvicted();
-                    stale.HydrationSub.Dispose();
-                    readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "transient-breaker"));
-                }
-                catch (Exception ex) { logger.LogDebug(ex, "MeshNodeStreamCache: error disposing stale entry for {Path}", path); }
-            }
+                && _transientStreaks.TryUpdate(path, streak with { Reprobing = true }, streak))
+                EvictFaultedEntry(path, "transient-breaker");
         }
+
+        // 🚨 FAULTED-ENTRY GUARD (#1202). Reaching this line means NO breaker window is open
+        // for the path — both branches above RETURN while theirs is. If the cached entry's
+        // hydration nonetheless terminated with an ERROR, its Replay(1) holds that terminal
+        // and would hand this reader — and every future one — the SAME exception INSTANCE,
+        // i.e. the same failed SubscribeRequest id, forever. Nothing ever re-opens an
+        // upstream, so the bookkeeping observer never fires again, the breakers' fail
+        // counters stay frozen at the value the FIRST fault wrote, and their eviction
+        // branches (which require a count past the grace) are dead BY CONSTRUCTION.
+        //
+        // That is the memex-cloud poison: one 60s owner timeout on `DataModeling/Formatting`
+        // made the path permanently unreadable for the pod's lifetime, the decisive evidence
+        // being the byte-identical request id `3kjIJ9lXPUCqPU5Zkgmhjw` returned by three
+        // reads spanning eleven minutes. The only escapes were a change-feed invalidation
+        // (ResetFailureState — a write on a read-only path never comes) and the 10-minute
+        // idle sweep, whose sliding window every read's Touch() resets: the failure is
+        // self-sustaining under exactly the load pattern that surfaces it.
+        //
+        // A fault that left NO window is either inside the transient grace — where the stated
+        // contract is "clean cache, instant re-probe" — or a class no breaker records. Both
+        // mean the same thing: PROBE AGAIN. So drop the errored entry and let SharedView below
+        // open a fresh upstream.
+        //
+        // 🚨 Why here and NOT in GetEntry: GetEntry runs a pin-or-recreate LOOP, so evicting a
+        // faulted entry there would spin forever on an entry that faults during creation
+        // (create → faulted → evict → create → …). This guard runs once per read CALL, which
+        // also bounds the re-probe rate: only a TERMINAL entry qualifies, so an upstream that
+        // is still in flight is shared rather than torn down — one new probe per FAULT, never
+        // one per read. And because a fresh probe re-runs the bookkeeping observer, the fail
+        // counters finally advance, so the transient breaker's exponential backoff engages on
+        // a persistently-failing path exactly as it was designed to.
+        EvictFaultedEntry(path, "faulted");
 
         var shared = SharedView(path);
 
@@ -2113,6 +2210,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
 /// <paramref name="UpstreamReleased"/> is true when at least one upstream sync
 /// stream (the <c>SubscribeRequest</c> client whose 45s heartbeat kept the
 /// owner-side mirror alive) was actually disposed as part of the release.
-/// <paramref name="Reason"/> ∈ { "idle", "invalidate", "storm-breaker" }.
+/// <paramref name="Reason"/> ∈ { "idle", "invalidate", "storm-breaker", "transient-breaker",
+/// "faulted" } — the last three all come from <c>EvictFaultedEntry</c>, distinguished by which
+/// re-probe trigger claimed the entry.
 /// </summary>
 internal sealed record ReadStreamEviction(string Path, bool UpstreamReleased, string Reason);

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheFaultedEntryReprobeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheFaultedEntryReprobeTest.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the fix for #1202 (and its symptom reports #1194/#1195/#1196/#1197/#1203): ONE failed
+/// owner subscribe must not make a path permanently unreadable through the shared cache.
+///
+/// <para><b>The live defect.</b> On memex-cloud a point read of <c>DataModeling/Formatting</c>
+/// failed instantly, forever, by replaying a cached <c>TimeoutException</c> from an earlier failed
+/// subscribe. The decisive evidence: three reads spanning ELEVEN MINUTES all returned the
+/// byte-identical request id <c>3kjIJ9lXPUCqPU5Zkgmhjw</c>. A genuine re-probe allocates a fresh
+/// request id every time, so after the first failure no further <c>SubscribeRequest</c> was ever
+/// issued for that path — and that is exactly what these tests measure.</para>
+///
+/// <para><b>The mechanism.</b> The bookkeeping observer marks the entry <c>Faulted</c> and records
+/// the failure, but a fault that is not a genuine missing node opens NO backoff window until the
+/// streak passes the grace. <c>GetEntry</c> gates only on <c>TryTouch()</c> (evicted?), never on
+/// <c>IsFaulted</c> — so the next read was handed the SAME entry, whose <c>Replay(1)</c>
+/// re-delivered the SAME exception instance. Because no new upstream was ever opened, the
+/// bookkeeping observer never fired again, the fail counter stayed frozen at the value the first
+/// fault wrote, and the breaker's own eviction branch (which needs a count past the grace) was dead
+/// by construction. The two escapes could not fire either: a change-feed invalidation needs a WRITE
+/// on a path nobody writes, and the 10-minute idle sweep is reset by every read's <c>Touch()</c>.
+/// </para>
+///
+/// <para><b>The contract under test.</b> A faulted entry is never served twice: with no breaker
+/// window open, the next read EVICTS it and opens a genuinely NEW upstream (a new request id).
+/// While a breaker window IS open the entry is left alone and the read fast-fails without opening
+/// anything, so the storm / transient breakers keep bounding a persistently-failing owner exactly
+/// as before.</para>
+/// </summary>
+public class MeshNodeStreamCacheFaultedEntryReprobeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    /// <summary>
+    /// Stands in as the OWNER of one throwaway node path, through the framework's own
+    /// <see cref="IRoutingService.RegisterStream(Address, SyncDelivery)"/> seam — the same call
+    /// every hub makes for itself. <c>MonolithRoutingService.RouteImpl</c> consults the stream
+    /// registry FIRST, so the node's real per-node hub is never activated and every
+    /// <c>SubscribeRequest</c> the cache opens for the path lands here instead.
+    ///
+    /// <para>Each attempt is answered with the verbatim production banner
+    /// (<c>MessageHub.BuildTimeoutMessage</c>) carrying a FRESH request id, and the ids are
+    /// recorded. That makes the incident's signature directly measurable: a second read that
+    /// records no new id — and returns the first id's error — is a replay, not a re-probe.</para>
+    /// </summary>
+    private sealed class UnreachableOwner : IDisposable
+    {
+        private readonly IDisposable registration;
+        private ImmutableList<string> requestIds = ImmutableList<string>.Empty;
+
+        public UnreachableOwner(IMessageHub mesh, IRoutingService routing, string path)
+        {
+            var access = mesh.ServiceProvider.GetService<AccessService>();
+            SyncDelivery answer = delivery =>
+            {
+                // Mirror PostNotFound's guard: never NACK a NACK, and never answer a
+                // [CanBeIgnored] lifecycle message (that is the disposal ping-pong storm).
+                // Everything else — the cache's SubscribeRequest, typed or already serialised to
+                // RawJson by the monolith transport — is an ATTEMPT to reach this owner.
+                if (delivery.Message is DeliveryFailure
+                    || delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+                    return delivery.Processed();
+                var requestId = Guid.NewGuid().ToString("N")[..12];
+                ImmutableInterlocked.Update(ref requestIds, ids => ids.Add(requestId));
+                var banner = Banner(path, requestId);
+                // Answer the sender exactly as MonolithRoutingService.PostNotFound does — post the
+                // DeliveryFailure ourselves, then mark the delivery FailedAndNacked so nothing
+                // NACKs it a second time. ErrorType.Exception, not ShuttingDown: a shutdown reject
+                // is ridden out by JsonSynchronizationStream's resubscribe latch by design; this is
+                // the owner-unreachable class that TERMINATES the subscribe — the production shape.
+                using (delivery.AccessContext is null ? access?.ImpersonateAsSystem() : null)
+                    mesh.Post(
+                        new DeliveryFailure(delivery) { ErrorType = ErrorType.Exception, Message = banner },
+                        o => o.ResponseFor(delivery));
+                return delivery.FailedAndNacked(banner);
+            };
+            registration = routing.RegisterStream(new Address(path), answer);
+        }
+
+        /// <summary>One entry per delivery that actually reached this owner — i.e. per upstream
+        /// subscribe ATTEMPT the cache opened for the path.</summary>
+        public ImmutableList<string> RequestIds => Volatile.Read(ref requestIds);
+
+        public void Dispose() => registration.Dispose();
+
+        private static string Banner(string path, string requestId) =>
+            $"No response received in hub cache/mesh-node-cache within 00:01:00 for request " +
+            $"SubscribeRequest (id={requestId}) → target {path}. The request may have been " +
+            "undeliverable or the target hub was not found.";
+    }
+
+    private async Task<string> CreateNodeAsync(string prefix)
+    {
+        var path = $"{TestPartition}/{prefix}-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Original",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(60.Seconds()).Emit();
+        return path;
+    }
+
+    private Task<Notification<MeshNode>> ReadFailure(string path, string because) =>
+        Cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(30.Seconds()).Match(n => n.Kind == NotificationKind.OnError, because);
+
+    private UnreachableOwner Hijack(string path) =>
+        new(Mesh, Mesh.ServiceProvider.GetRequiredService<IRoutingService>(), path);
+
+    /// <summary>
+    /// THE pin, measured exactly as the live probes measured it. Two successive reads of a path
+    /// whose owner cannot answer must issue TWO SubscribeRequests with DIFFERENT ids. Before the
+    /// fix the second read issued none at all and replayed the first one's cached exception —
+    /// forever, for the process lifetime.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FaultedEntry_IsNotServedTwice_NextReadOpensANewUpstream()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("poison");
+        using var owner = Hijack(path);
+
+        var first = await ReadFailure(path,
+            "an owner that cannot answer the SubscribeRequest must surface as OnError");
+        var afterFirst = owner.RequestIds;
+        afterFirst.Should().NotBeEmpty("the read must have reached the owner at least once");
+        first.Exception!.Message.Should().Contain(afterFirst[^1],
+            "the surfaced error must be the one this SubscribeRequest produced");
+
+        // Precondition: this is the poisoning class. A transient owner failure is deliberately
+        // NOT negative-cached, and within the grace it opens no window either — so nothing
+        // suppresses the path and the ONLY thing standing between the reader and a fresh probe
+        // is the faulted entry itself.
+        MeshNodeStreamCache.IsTransientOwnerFailure(first.Exception!).Should().BeTrue(
+            "precondition: the 'no response received' banner is the transient class (#1202's shape)");
+        MeshNodeStreamCache.IsMissingNodeFailure(first.Exception!).Should().BeFalse(
+            "precondition: the node EXISTS — its owner is unreachable, which is not an absence");
+        cache.IsReadStreamLive(path).Should().BeTrue(
+            "precondition: the failed read left its entry cached, holding the terminal error");
+
+        var second = await ReadFailure(path, "the re-probe must reach a terminal verdict too");
+
+        owner.RequestIds.Count.Should().BeGreaterThan(afterFirst.Count,
+            "the second read must issue a NEW SubscribeRequest. Serving the cached faulted entry "
+            + "issues none — that is the byte-identical request id seen across eleven minutes on "
+            + "memex-cloud (#1202), and it never healed.");
+        second.Exception.Should().NotBeSameAs(first.Exception,
+            "a replayed exception INSTANCE is the poison: the entry's Replay(1) terminal, not a "
+            + "fresh failure from a fresh probe");
+        second.Exception!.Message.Should().Contain(owner.RequestIds[^1],
+            "the second read's error must carry the SECOND request's id");
+    }
+
+    /// <summary>
+    /// The same invariant stated on the cache's own eviction seam: the read that finds a faulted
+    /// entry with no open breaker window must DROP it (reason <c>faulted</c>) — that eviction is
+    /// what lets a fresh upstream be opened at all.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FaultedEntry_IsEvicted_OnTheNextRead()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("evict");
+        using var owner = Hijack(path);
+
+        await ReadFailure(path, "the first read must fault");
+        cache.IsReadStreamLive(path).Should().BeTrue("the faulted entry is still cached");
+
+        // Attach BEFORE the read that must evict — an eviction is a point event on a hot subject,
+        // so observing it must not be able to race the action that produces it. Replay().Connect()
+        // establishes the subscription synchronously, on this thread.
+        var evictions = cache.ReadStreamEvictions
+            .Where(e => e.Path == path && e.Reason == "faulted")
+            .Replay();
+        using var connection = evictions.Connect();
+
+        await ReadFailure(path, "the second read must reach a terminal verdict");
+
+        await evictions.FirstAsync().Should().Within(30.Seconds()).Emit(
+            "a faulted entry with no breaker window open must be evicted so the read re-probes");
+    }
+
+    /// <summary>
+    /// The other half of the contract — do NOT regress the breaker. With a transient streak past
+    /// the grace the window is open: the read must fast-fail by replaying the RECORDED error,
+    /// leaving the entry alone and opening NO upstream. This is the bound that stops a
+    /// persistently-faulting owner from being re-probed once per read (the 2026-07-21 poisoned
+    /// activation that leaked 4→22&#160;GiB in twelve minutes).
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FaultedEntry_InsideAnOpenBreakerWindow_StillShortCircuits()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("window");
+        using var owner = Hijack(path);
+
+        await ReadFailure(path, "the first read must fault and leave a faulted entry");
+        cache.IsReadStreamLive(path).Should().BeTrue("precondition: the faulted entry is cached");
+        var beforeSuppression = owner.RequestIds.Count;
+
+        // Ten recordings put the window at 1s·2^6 = 64s ⇒ capped at 60s — impossible to outwait
+        // within the test budget, exactly like the production loop.
+        var recorded = new TimeoutException("owner wedged — recorded by the transient breaker");
+        for (var i = 0; i < 10; i++)
+            cache.RecordTransient(path, recorded);
+
+        var suppressed = await ReadFailure(path, "an open breaker window must fast-fail the read");
+        suppressed.Exception.Should().BeSameAs(recorded,
+            "an open window replays the RECORDED error — the faulted-entry guard must never "
+            + "pre-empt a breaker that is actively suppressing");
+        owner.RequestIds.Count.Should().Be(beforeSuppression,
+            "a suppressed read must not open an upstream SubscribeRequest — that IS the bound");
+        cache.IsReadStreamLive(path).Should().BeTrue(
+            "a fast-failed read must leave the entry alone: eviction is for reads that re-probe");
+    }
+}


### PR DESCRIPTION
## The defect

One failed owner subscribe made a node path **permanently unreadable** through the shared
`MeshNodeStreamCache` for the pod's lifetime. The decisive live evidence in #1202: three reads of
`DataModeling/Formatting` spanning **eleven minutes** all came back with the byte-identical request
id `3kjIJ9lXPUCqPU5Zkgmhjw`. A genuine re-probe allocates a fresh id every time — so after the first
failure, **no further `SubscribeRequest` was ever issued for that path**.

### Mechanism (verified against the code, then pinned by a test)

The poison is **two layers deep**, and both had to be fixed:

1. **`MeshNodeStreamCache._streams`** keeps the faulted `Entry`. `bookkeeping` calls
   `MarkFaulted()`, but `GetEntry` gates only on `TryTouch()` (evicted?) — never on `IsFaulted` —
   so the next read is handed the same entry, whose `Replay(1)` re-delivers the **same exception
   instance**.
2. **The cacheHub workspace's `_remoteStreamCache`** keeps the terminally-errored
   `ISynchronizationStream`, keyed `(owner, reference, identity)`. So even after the entry is
   dropped, `CreateEntry` re-opens over the **same dead stream** — still no `SubscribeRequest`.

Because no new upstream ever runs, the bookkeeping observer never fires again: the breakers' fail
counters stay **frozen at the value the first fault wrote**, and their eviction branches (which
require a count past `TransientGraceFailures`) are dead **by construction**. The two escapes cannot
fire either — a change-feed invalidation needs a *write* on a path nobody writes, and the 10-minute
idle sweep's sliding window is reset by every read's `Touch()`. The failure is self-sustaining under
exactly the load pattern that surfaces it (a user reloading a broken page).

Layer 2 also means the storm/transient breakers' own "re-probe" branches never actually re-probed —
they only grew their backoff while replaying the same error.

**On the prior hypothesis:** the "faulted entry is served forever because the counter is frozen at 1"
half held exactly as stated. The claim that the fix is a single guard clause did **not** — evicting
the cache entry alone leaves the workspace's dead stream in place and issues no new subscribe (the
first version of the test proved this: attempt count stayed at 1). #1202's own guess (a stuck
`Reprobing` latch) is not the primary cause, though the fix covers it too: a faulted entry is now
evicted regardless of the latch.

## The fix

`src/MeshWeaver.Hosting/MeshNodeStreamCache.cs`

- **New `EvictFaultedEntry(path, reason)`** — the single teardown behind all three re-probe
  triggers, so they cannot drift. It uses the idle sweep's proven protocol: **detach the upstream
  → claim the entry pair-exact → tear down** (a loser re-parks what it detached). Detaching first is
  what makes disposing safe: a concurrent read builds a new stream with a new `StreamId`, so the
  `UnsubscribeRequest` for the old one cannot race it — the exact hazard the old "never dispose on a
  re-probe" comment guarded against. Only a **faulted** entry qualifies; a healthy live entry is
  never torn down (a breaker record can outlive the fault that wrote it — the write path records
  too — and severing live GUI subscribers over a stale counter would be a regression).
- **A third guard in `GetStreamRaw`**, after the two breaker branches: reaching it means no breaker
  window is open, so a still-faulted entry must be dropped and the read must re-probe.
  🚨 Deliberately **not** in `GetEntry` — that is a pin-or-recreate loop and would spin forever on
  an entry that faults during creation. Running once per read *call* also bounds the re-probe rate:
  only a **terminal** entry qualifies, so an in-flight probe is shared — one new upstream per
  **fault**, never one per read.
- **Both breaker branches now route through the same helper**, so their re-probe finally reaches the
  owner instead of re-adopting the dead stream.
- **`bookkeeping`'s `else if (IsTransientOwnerFailure)` becomes an unconditional `else`.** With the
  guard re-probing anything the breakers left unwindowed, an error class recorded by *neither*
  breaker would re-probe once per read with no bound at all. Every fault now lands in exactly one
  breaker. This also closes the "un-broker'd" bucket in general — the same bucket that wedged memex
  on 2026-07-23, when an Npgsql connect failure fell through both predicates and replayed forever
  until a manual recycle (that was patched by growing a marker list for that one class).

Net effect: `RecordTransient`'s counter can finally advance, so the transient breaker's exponential
backoff (grace 3, then 1 s doubling to a 60 s cap) engages on a persistently-failing path exactly as
designed — bounded re-probing instead of either a frozen poison or an unbounded loop.

## Test

`test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheFaultedEntryReprobeTest.cs` — three
deterministic tests on `MonolithMeshTestBase`, no mocks, no `Task.Delay`.

A stand-in owner registers itself for one throwaway node path through the framework's own
`IRoutingService.RegisterStream` seam (the same call every hub makes for itself), and answers each
delivery with the verbatim production timeout banner carrying a **fresh request id** — so the
incident's signature is directly measurable.

| Test | Asserts | Before the fix |
|---|---|---|
| `FaultedEntry_IsNotServedTwice_NextReadOpensANewUpstream` | the 2nd read issues a **new** `SubscribeRequest` (id changes, exception is not the same instance) | ❌ `Expected 1 to be greater than 1` |
| `FaultedEntry_IsEvicted_OnTheNextRead` | the eviction fires with reason `faulted` | ❌ no eviction, ever |
| `FaultedEntry_InsideAnOpenBreakerWindow_StillShortCircuits` | an open window replays the recorded error and opens **no** upstream | ✅ (regression guard — green both ways by design) |

## Verification

- `dotnet build -c Release -warnaserror` on `MeshWeaver.Hosting.Monolith.Test` (which builds
  `MeshWeaver.Hosting` and every dependent in that graph) — **0 Warning(s), 0 Error(s)**.
- New tests: 3/3 pass with the fix; 2/3 fail with the fix reverted (verified by reverting
  `MeshNodeStreamCache.cs`, rebuilding and re-running).
- Full `MeshWeaver.Hosting.Monolith.Test` project run — green.

Closes #1202
Closes #1194
Closes #1195
Closes #1196
Closes #1197
Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
