### PR TITLE
fix(ogcard): an appended reference parameter ate the last target

### DIFF
--- a/src/MeshWeaver.Graph/OgCardLayoutArea.cs
+++ b/src/MeshWeaver.Graph/OgCardLayoutArea.cs
@@ -128,7 +128,7 @@ public static class OgCardLayoutArea
     {
         if (string.IsNullOrWhiteSpace(id))
             return [];
-        var value = id.Trim().TrimStart('?');
+        var value = StripReferenceParameters(id.Trim().TrimStart('?'));
 
         if (value.StartsWith("urls=", StringComparison.OrdinalIgnoreCase))
             return SplitTargets(value["urls=".Length..]);
@@ -141,6 +141,35 @@ public static class OgCardLayoutArea
         }
 
         return SplitTargets(value);
+    }
+
+    /// <summary>
+    /// Drops REFERENCE PARAMETERS the client appends to the area id, which are configuration and
+    /// never targets.
+    /// </summary>
+    /// <remarks>
+    /// 🚨 An <c>@@</c> embed hides the embedded node's header, and the client carries that by
+    /// appending to the <c>LayoutAreaReference.Id</c> — see
+    /// <c>PathBasedLayoutArea.AppendParameter</c>, which picks its separator with
+    /// <c>s.Contains('?') ? "&amp;" : "?"</c>. Our id already IS a query
+    /// (<c>ParseAreaAndId</c> keeps the leading '?'), so the append lands as
+    /// <c>?urls=A,B,C&amp;showHeader=false</c>.
+    /// <para>Every other area reads its parameters with query semantics and is unaffected. This
+    /// one does not: the multi-target list is COMMA-separated, so without this strip the trailing
+    /// <c>&amp;showHeader=false</c> is swallowed into the LAST entry, turning it into
+    /// <c>https://host/Page&amp;showHeader=false</c> — one path segment matching no route. The
+    /// portal answers that 200 with its "does not match any registered address pattern" shell,
+    /// which carries no og: tags, so the final card of EVERY <c>@@</c>-embedded grid renders blank
+    /// and its link dead-ends. Found in production 2026-08-12: two grids of eight cards, and in
+    /// each the eighth was empty.</para>
+    /// <para>Splitting on the first '&amp;' is the documented contract, not a heuristic: a target
+    /// carrying a literal <c>&amp;</c>, <c>=</c>, <c>%</c> or comma must be percent-encoded (see
+    /// the class remarks), so an unencoded '&amp;' is always a parameter boundary.</para>
+    /// </remarks>
+    private static string StripReferenceParameters(string value)
+    {
+        var amp = value.IndexOf('&');
+        return amp < 0 ? value : value[..amp];
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
+++ b/test/MeshWeaver.Graph.Test/OgCardLayoutAreaTest.cs
@@ -196,6 +196,40 @@ public class OgCardLayoutAreaTest(ITestOutputHelper output) : HubTestBase(output
     }
 
     /// <summary>
+    /// 🚨 The LAST card of every <c>@@</c>-embedded grid rendered blank, and its link dead-ended on
+    /// "does not match any registered address pattern".
+    /// <para>An <c>@@</c> embed hides the embedded node's header by appending to the reference id
+    /// (<c>PathBasedLayoutArea.AppendParameter</c>, separator <c>s.Contains('?') ? "&amp;" : "?"</c>).
+    /// This area's id already IS a query — <c>ParseAreaAndId</c> keeps the leading '?' — so the
+    /// append lands as <c>?urls=A,B,C&amp;showHeader=false</c>. Every other area reads parameters
+    /// with query semantics and is fine; this one splits on COMMAS, so the trailing parameter was
+    /// swallowed into the final target as <c>https://host/Page&amp;showHeader=false</c> — one path
+    /// segment matching no route, answered 200 with the SPA shell and no og: tags. Two live grids
+    /// of eight cards each had exactly the eighth empty.</para>
+    /// </summary>
+    [Fact]
+    public void ParseTargets_DropsAppendedReferenceParameters_LastTargetSurvivesIntact()
+    {
+        const string a = "https://memex.meshweaver.cloud/RiskTransfer";
+        const string z = "https://memex.meshweaver.cloud/ThinkInStreams";
+
+        // The EXACT id the client builds for an @@ embed of a multi-target grid.
+        OgCardLayoutArea.ParseTargets($"?urls={a},{z}&showHeader=false")
+            .Should().Equal(a, z);
+
+        // …and without the leading '?', which AppendParameter would join with '?' instead.
+        OgCardLayoutArea.ParseTargets($"urls={a},{z}&showHeader=false")
+            .Should().Equal(a, z);
+
+        // The singular and bare-path forms take the same treatment.
+        OgCardLayoutArea.ParseTargets($"?url={z}&showHeader=false").Should().Equal(z);
+        OgCardLayoutArea.ParseTargets($"{a},{z}&showHeader=false").Should().Equal(a, z);
+
+        // A parameter-only id has no targets at all — it must not become a bogus one.
+        OgCardLayoutArea.ParseTargets("?urls=&showHeader=false").Should().BeEmpty();
+    }
+
+    /// <summary>
     /// 🚨 The reported defect: the bare PATH/areaId form did not split on commas AT ALL — it fell
     /// through to a single-target return, so four URLs became ONE card whose href was the four
     /// URLs concatenated. That fetch can never succeed, so the card degraded to the bare domain


### PR DESCRIPTION
## Symptom

The **last** card of every `@@`-embedded OgCard grid renders blank, and clicking it lands on:

```
Page not found: 'ThinkInStreams&showHeader=false' does not match any registered address pattern.
```

Live repro: two grids of eight cards on one page — in each, only the **eighth** was empty.

## Cause

An `@@` embed hides the embedded node's header by appending to the reference id:

```csharp
// PathBasedLayoutArea.AppendParameter
var sep = s.Contains('?') ? "&" : "?";
```

This area's id already *is* a query — `ParseAreaAndId` keeps the leading `?` (`querySuffix = remainder[q..]`) — so the append lands as `?urls=A,B,C&showHeader=false`.

Every other area reads its parameters with query semantics and is unaffected. This one splits its multi-target list on **commas**, so the trailing parameter was swallowed into the final entry:

```
https://memex.meshweaver.cloud/ThinkInStreams&showHeader=false
```

With no `?`, that is a single path segment matching no route. The portal answers it **200** with the SPA "does not match any registered address pattern" shell, which carries no `og:` tags — so the card degrades to its placeholder and the link dead-ends. Because it's a 200 *with* a title, nothing faults and nothing logs, and the preview cache's own no-`og:title` guard is what keeps it from being cached rather than anything that reports the problem.

## Fix

`ParseTargets` drops appended reference parameters before splitting. Cutting at the first `&` is the documented contract, not a heuristic — a target carrying a literal `&`, `=`, `%` or comma must be percent-encoded (class remarks), so an unencoded `&` is always a parameter boundary.

## Why this was hard to see

The eight targets in each grid publish **byte-identical head structure**, and anonymous fetch of every one of them succeeds — verified both externally and from inside the rendering pod. Nothing about the failing targets is different; only their **position** in the list. That is what makes it look like a content, sync or access problem.

## Test

`ParseTargets_DropsAppendedReferenceParameters_LastTargetSurvivesIntact` covers the exact client-built id in all four shapes plus the parameter-only id. Verified it **fails** without the strip and passes with it; full `OgCardLayoutAreaTest` (9 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)