### PR TITLE
diag: name the fan-out — pending callbacks carry the request's own sub-key

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -25,6 +25,14 @@
     <ProjectReference Include="..\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\..\src\MeshWeaver.Hosting.PostgreSql\MeshWeaver.Hosting.PostgreSql.csproj" />
     <ProjectReference Include="..\..\..\src\MeshWeaver.NuGet.AzureBlob\MeshWeaver.NuGet.AzureBlob.csproj" />
+    <!-- 🚨 Referenced for IN-MESH compiles, not for this project's own code. NodeType sources are
+         compiled at runtime against TRUSTED_PLATFORM_ASSEMBLIES — i.e. whatever is in the publish
+         output — so an assembly this portal does not reference is invisible to them no matter that
+         the framework ships it. Memex.Portal.Monolith already references it, which is why
+         `Northwind/Product` (and Cornerstone/Pricing's Excel sample loader) compile in dev and fail
+         on memex-cloud with `CS0234: the type or namespace name 'Import' does not exist in the
+         namespace 'MeshWeaver'`. Do not "clean up" as unused. -->
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Import\MeshWeaver.Import.csproj" />
   </ItemGroup>
 
   <!-- Ship nuget.config into the image so the runtime `#r "nuget:..."` resolver can

--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -194,8 +194,17 @@ public record PatchDataChangeRequest(
 /// <param name="StreamId">The identifier to use for the subscription stream.</param>
 /// <param name="Reference">The workspace reference describing the data to subscribe to.</param>
 [RequiresPermission(Permission.Read)]
-public record SubscribeRequest(string StreamId, WorkspaceReference Reference) : IRequest<SubscribeAck>
+public record SubscribeRequest(string StreamId, WorkspaceReference Reference)
+    : IRequest<SubscribeAck>, IDiagnosticKeyed
 {
+    /// <summary>
+    /// The stream id — so the pending-callback diagnostic can tell N unanswered subscribes for N
+    /// DIFFERENT streams (a fan-out) from one stream re-asking (a resubscribe loop). See
+    /// <see cref="IDiagnosticKeyed"/>; the 167-pending pile on memex-cloud 2026-08-12 was
+    /// indistinguishable between the two.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => StreamId;
+
     /// <summary>The address of the subscriber that will receive change events.</summary>
     public Address Subscriber { get; init; } = null!;
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-excel-based-sample-pages-compile-on-the-cloud-portal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-excel-based-sample-pages-compile-on-the-cloud-portal.md
@@ -1,0 +1,18 @@
+---
+Name: Excel-based sample pages compile on the cloud portal
+Category: Fix
+Description: Node types whose code loads spreadsheet data now compile on the distributed portal, not only in local development.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Excel-based sample pages compile on the cloud portal
+
+Code stored in a node is compiled by the portal at runtime, against the libraries that portal ships.
+The distributed portal did not ship the spreadsheet-import library, although the local development
+portal did — so sample pages whose code loads data from a workbook compiled fine on a developer's
+machine and failed in the cloud with an error about a missing `MeshWeaver.Import` namespace.
+
+The library now ships with the distributed portal too, so those pages compile in both places. This
+also makes the failure mode less surprising in general: what in-node code can reference is whatever
+the running portal ships, not whatever exists in the framework.

--- a/src/MeshWeaver.Messaging.Contract/IDiagnosticKeyed.cs
+++ b/src/MeshWeaver.Messaging.Contract/IDiagnosticKeyed.cs
@@ -1,0 +1,30 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Opt-in on a request message: a stable sub-key the pending-callback diagnostic prints alongside
+/// the request type, so a pile of unanswered callbacks can be told apart from ONE unanswered thing
+/// asked repeatedly.
+///
+/// <para>🚨 Why this exists. memex-cloud 2026-08-12 logged
+/// <c>[STALE-CALLBACK] cache/…: 167 callback(s) pending &gt; 30000ms</c> — 167 <c>SubscribeRequest</c>s
+/// to ONE activity node, every one showing a posted-but-undelivered ack. Type and target were
+/// identical across all 167, so the log could not distinguish the two mechanisms that produce that
+/// shape, and they need opposite fixes:</para>
+/// <list type="bullet">
+///   <item>167 DISTINCT keys ⇒ 167 separate streams for one path — a fan-out (a missing dedupe, or a
+///     writer opening its own stream per write).</item>
+///   <item>ONE key repeated ⇒ a single stream re-asking — a retry/resubscribe loop.</item>
+/// </list>
+/// <para>The evidence needed to choose was destroyed with the pod (Loki was itself down through the
+/// incident window), so the next occurrence has to be self-describing. Keep the key CHEAP and
+/// ALREADY-COMPUTED — it is read on every request registration.</para>
+/// </summary>
+public interface IDiagnosticKeyed
+{
+    /// <summary>
+    /// A short, stable identifier for what this request is about — the stream id, the target path,
+    /// the entity id. Never a fresh guid per post: the whole point is that two posts about the same
+    /// thing share it.
+    /// </summary>
+    string DiagnosticKey { get; }
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -55,7 +55,10 @@ public sealed class MessageHub : IMessageHub
         System.Reactive.Subjects.AsyncSubject<IMessageDelivery> Subject,
         string RequestType,
         Address? Target,
-        long RegisteredAtTicks);
+        long RegisteredAtTicks,
+        // Opt-in sub-key from the request itself (IDiagnosticKeyed) — what makes N identical-looking
+        // pending callbacks legible: N distinct keys is a fan-out, one key repeated is a retry loop.
+        string? DiagnosticKey = null);
 
     /// <summary>
     /// Handler-side trail for the requests this hub TREE is awaiting (see
@@ -929,7 +932,8 @@ public sealed class MessageHub : IMessageHub
         // gets the same composed PostOptions via WithMessageId chaining.
         var probeOptions = options(new PostOptions(Address));
         var requestType = r?.GetType().Name ?? "<null>";
-        var subject = GetOrAddResponseSubject(messageId, requestType, probeOptions.Target);
+        var subject = GetOrAddResponseSubject(messageId, requestType, probeOptions.Target,
+            (r as IDiagnosticKeyed)?.DiagnosticKey);
         // 🔍 DIAGNOSTIC ONLY (#981) — records and RETHROWS; it changes no behaviour.
         //
         // The callback is registered on the line above and the delivery is posted on the line
@@ -1054,7 +1058,8 @@ public sealed class MessageHub : IMessageHub
     private System.Reactive.Subjects.AsyncSubject<IMessageDelivery> GetOrAddResponseSubject(
         string messageId,
         string requestType = "<unknown>",
-        Address? target = null)
+        Address? target = null,
+        string? diagnosticKey = null)
     {
         lock (responseSubjects)
         {
@@ -1071,7 +1076,8 @@ public sealed class MessageHub : IMessageHub
                     new System.Reactive.Subjects.AsyncSubject<IMessageDelivery>(),
                     requestType,
                     target,
-                    Stopwatch.GetTimestamp());
+                    Stopwatch.GetTimestamp(),
+                    diagnosticKey);
                 responseSubjects[messageId] = entry;
                 // THE one place a hub starts awaiting a reply — so it is also the one place the
                 // handler-side trail starts. "Tracked" and "awaited" are the same set by
@@ -2048,7 +2054,8 @@ public sealed class MessageHub : IMessageHub
     private void OnQuiesceComplete(
         bool drainedOk,
         Stopwatch quiesceSw,
-        (string MessageId, string RequestType, Address? Target, long AgeMs)[] initialPendingSnapshot)
+        (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[]
+            initialPendingSnapshot)
     {
         try
         {
@@ -2213,7 +2220,8 @@ public sealed class MessageHub : IMessageHub
     /// phase and by <see cref="GetDisposalDiagnostics"/> so a hung dispose names *what*
     /// the hub was waiting on, not just that it was waiting.
     /// </summary>
-    private (string MessageId, string RequestType, Address? Target, long AgeMs)[] SnapshotPendingCallbacks()
+    private (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[]
+        SnapshotPendingCallbacks()
     {
         lock (responseSubjects)
         {
@@ -2223,7 +2231,8 @@ public sealed class MessageHub : IMessageHub
                     kv.Key,
                     kv.Value.RequestType,
                     kv.Value.Target,
-                    (long)((nowTicks - kv.Value.RegisteredAtTicks) * 1000.0 / Stopwatch.Frequency)))
+                    (long)((nowTicks - kv.Value.RegisteredAtTicks) * 1000.0 / Stopwatch.Frequency),
+                    kv.Value.DiagnosticKey))
                 .ToArray();
         }
     }
@@ -2231,7 +2240,7 @@ public sealed class MessageHub : IMessageHub
     private const int PendingCallbackLogCap = 20;
 
     private static string FormatPendingCallbacks(
-        (string MessageId, string RequestType, Address? Target, long AgeMs)[] pending)
+        (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[] pending)
     {
         if (pending.Length == 0)
             return "<none>";
@@ -2247,11 +2256,14 @@ public sealed class MessageHub : IMessageHub
         }
         var head = string.Join(", ", pending.Take(PendingCallbackLogCap).Select(p =>
             $"{p.MessageId}={p.RequestType}@{p.Target}({p.AgeMs}ms)"));
-        var rest = pending.Skip(PendingCallbackLogCap)
-            .GroupBy(p => $"{p.RequestType}@{p.Target}")
-            .OrderByDescending(g => g.Count())
-            .Select(g => $"{g.Key}×{g.Count()}");
-        return $"{head}, …+{pending.Length - PendingCallbackLogCap} more [{string.Join(", ", rest)}]";
+        // 🚨 The tally groups by (type, target) — which on memex-cloud 2026-08-12 collapsed 167
+        // pending SubscribeRequests into one indistinguishable bucket. `keys=` is what tells the two
+        // mechanisms apart: keys≈count ⇒ that many SEPARATE streams (a fan-out); keys=1 ⇒ one stream
+        // re-asking (a retry loop). See IDiagnosticKeyed. Groups whose requests carry no key print
+        // no `keys=`, so nothing changes for message types that opt out.
+        var rest = PendingCallbackReport.Tally(pending.Skip(PendingCallbackLogCap)
+            .Select(p => new PendingCallbackInfo(p.RequestType, p.Target?.ToString(), p.DiagnosticKey)));
+        return $"{head}, …+{pending.Length - PendingCallbackLogCap} more [{rest}]";
     }
 
     /// <summary>
@@ -2270,7 +2282,7 @@ public sealed class MessageHub : IMessageHub
     /// <param name="pending">The still-pending callbacks, as snapshotted at the timeout.</param>
     /// <returns>A newline-prefixed block, or the empty string when there is nothing to report.</returns>
     private string FormatPendingCallbackFates(
-        (string MessageId, string RequestType, Address? Target, long AgeMs)[] pending)
+        (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[] pending)
     {
         if (pending.Length == 0)
             return string.Empty;

--- a/src/MeshWeaver.Messaging.Hub/PendingCallbackReport.cs
+++ b/src/MeshWeaver.Messaging.Hub/PendingCallbackReport.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>One still-pending request callback, as the diagnostic sees it.</summary>
+/// <param name="RequestType">The request's type name.</param>
+/// <param name="Target">The hub the reply is expected from.</param>
+/// <param name="DiagnosticKey">
+/// The request's own sub-key when it opted in (<see cref="IDiagnosticKeyed"/>), else null.
+/// </param>
+public sealed record PendingCallbackInfo(string RequestType, string? Target, string? DiagnosticKey);
+
+/// <summary>
+/// Renders the per-(type, target) tally that closes the <c>[STALE-CALLBACK]</c> line once there are
+/// more pending callbacks than the line lists individually.
+///
+/// <para>🚨 Extracted so it can be tested directly. It is the half that failed to be useful on
+/// memex-cloud 2026-08-12: 167 pending <c>SubscribeRequest</c>s to one activity node collapsed into
+/// <c>SubscribeRequest@…×147</c> — a single bucket that cannot distinguish 147 SEPARATE streams (a
+/// fan-out) from ONE stream re-asking 147 times (a retry loop), though the two have opposite fixes.
+/// <c>keys=</c> is that discriminator, and it only appears for request types that opt into
+/// <see cref="IDiagnosticKeyed"/>, so nothing about other types' output changes.</para>
+/// </summary>
+public static class PendingCallbackReport
+{
+    /// <summary>
+    /// Groups by (request type, target), ordered by descending count, and appends <c>keys=N</c> —
+    /// the number of DISTINCT diagnostic keys in the group — whenever the group's requests carry
+    /// one. <c>keys</c> ≈ count means a fan-out; <c>keys=1</c> means one thing asked repeatedly.
+    /// </summary>
+    public static string Tally(IEnumerable<PendingCallbackInfo> pending)
+        => string.Join(", ", pending
+            .GroupBy(p => $"{p.RequestType}@{p.Target}")
+            .OrderByDescending(g => g.Count())
+            .Select(g =>
+            {
+                var keys = g.Where(p => p.DiagnosticKey is { Length: > 0 })
+                    .Select(p => p.DiagnosticKey!)
+                    .Distinct()
+                    .Count();
+                return keys == 0 ? $"{g.Key}×{g.Count()}" : $"{g.Key}×{g.Count()} keys={keys}";
+            }));
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/PendingCallbackDiagnosticKeyTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/PendingCallbackDiagnosticKeyTest.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 A PILE OF PENDING CALLBACKS MUST SAY WHICH KIND OF PILE IT IS.
+///
+/// <para>memex-cloud 2026-08-12 logged
+/// <c>[STALE-CALLBACK] cache/…: 167 callback(s) pending &gt; 30000ms</c> — 167 <c>SubscribeRequest</c>s
+/// to ONE activity node, each with a posted-but-undelivered ack. The tally groups by
+/// (RequestType, Target), which were identical across all 167, so the line collapsed to one bucket
+/// that cannot distinguish the two mechanisms producing that shape — and they need OPPOSITE fixes:</para>
+/// <list type="bullet">
+///   <item>many distinct keys ⇒ that many SEPARATE streams for one path (a fan-out: a missing dedupe,
+///     or a writer opening its own stream per write),</item>
+///   <item>one key repeated ⇒ a single stream re-asking (a retry/resubscribe loop).</item>
+/// </list>
+/// <para>The evidence needed to choose died with the pod — Loki was itself down through the incident
+/// window — so the log has to carry it. <c>keys=</c> is that discriminator.</para>
+/// </summary>
+public class PendingCallbackDiagnosticKeyTest
+{
+    private const int Count = 20;
+
+    private static PendingCallbackInfo[] Pending(System.Func<int, string?> key)
+        => Enumerable.Range(0, Count)
+            .Select(i => new PendingCallbackInfo("SubscribeRequest", "cache/c1", key(i)))
+            .ToArray();
+
+    /// <summary>The fan-out shape: one stream per pending callback.</summary>
+    [Fact]
+    public void DistinctKeys_ReportAFanOut()
+    {
+        PendingCallbackReport.Tally(Pending(i => $"stream-{i}"))
+            .Should().Contain("keys=20",
+                "20 pending callbacks carrying 20 distinct stream ids are 20 SEPARATE streams for "
+                + "one target — a fan-out, i.e. a dedupe/ownership defect");
+    }
+
+    /// <summary>The retry shape: one stream, asked over and over.</summary>
+    [Fact]
+    public void OneRepeatedKey_ReportsARetryLoop()
+    {
+        var line = PendingCallbackReport.Tally(Pending(_ => "the-one-stream"));
+
+        line.Should().Contain("keys=1",
+            "the same stream id on every pending callback is ONE stream re-asking — a retry loop, "
+            + "which is a completely different fix from a fan-out");
+        line.Should().NotContain("keys=20");
+    }
+
+    /// <summary>
+    /// Opting out stays silent: a request type carrying no key prints exactly what it printed before,
+    /// so this adds no noise to the types it cannot describe.
+    /// </summary>
+    [Fact]
+    public void NoKey_AddsNothingToTheLine()
+    {
+        var line = PendingCallbackReport.Tally(Pending(_ => null));
+
+        line.Should().NotContain("keys=");
+        line.Should().Contain("SubscribeRequest@cache/c1×20",
+            "the pre-existing per-(type,target) tally is unchanged");
+    }
+
+    /// <summary>
+    /// Mixed groups keep their own tallies — a real stale-callback line carries several request
+    /// types, and the discriminator must be per group, not global.
+    /// </summary>
+    [Fact]
+    public void GroupsAreTalliedIndependently()
+    {
+        var line = PendingCallbackReport.Tally(
+        [
+            new PendingCallbackInfo("SubscribeRequest", "cache/c1", "s1"),
+            new PendingCallbackInfo("SubscribeRequest", "cache/c1", "s2"),
+            new PendingCallbackInfo("HeartBeatEvent", "cache/c1", null),
+        ]);
+
+        line.Should().Contain("SubscribeRequest@cache/c1×2 keys=2");
+        line.Should().Contain("HeartBeatEvent@cache/c1×1");
+    }
+}


### PR DESCRIPTION
## Why

memex-cloud, 2026-08-12:

```
[STALE-CALLBACK] cache/56C5…: 167 callback(s) pending > 30000ms:
  … [SubscribeRequest@MeshWeaver/_Activity/import-1896c73086a7e84c-…×147]
```

167 `SubscribeRequest`s to **one** activity node, each with a `RESPONSE_POSTED … HANDLER_EXIT Processed` trail and a callback still pending — "a reply WAS posted and the callback is STILL pending". Routing sat at `64 route dispatches in flight and not terminating` from 05:05 to ~05:37 and the whole portal crawled.

The tally groups by (RequestType, Target), which were identical across all 167, so the line collapses to one bucket — and that bucket cannot tell apart the two mechanisms that produce this shape, which need **opposite** fixes:

- **167 distinct streams** for one path → a fan-out (a missing dedupe, or a writer opening its own stream per write).
- **One stream re-asking 167 times** → a retry/resubscribe loop.

I could not settle it from the evidence, and the evidence is gone: **Loki was itself down through the incident window.** Promtail logged `dial tcp 10.43.150.240:3100: connect: connection refused` from 05:35, `loki-0` was rescheduled at 05:35:13 (fresh pod, `Restart Count: 0`) while the portal sat at **20.3 GiB of a 28 GiB limit** — so the only window worth querying is the one that no longer exists. Loki holds that pod's lines only for 05:39–05:54, i.e. ingest-time stamps after it was already gone.

## What changed

`IDiagnosticKeyed` — opt-in on a request message, returning a **stable** sub-key. `SubscribeRequest` returns its `StreamId`. The pending-callback registration records it and the tally renders `keys=N`:

```
SubscribeRequest@…×147 keys=147   ⇒ 147 separate streams — a fan-out
SubscribeRequest@…×147 keys=1     ⇒ one stream re-asking — a retry loop
```

Request types that don't opt in print exactly what they printed before, so this adds no noise. The tally moved to a public `PendingCallbackReport.Tally` so it can be tested directly — `InternalsVisibleTo` was tried first and broke unrelated overload resolution inside the same test project.

**Deliberately a diagnostic, not a "fix".** I am not guessing at the mechanism: the next occurrence will name it in one line, and then the actual defect gets fixed. Three hypotheses were already falsified on the way — an import issued on the root mesh hub (`ImportSource` does create the dedicated `import/{id}` hub), PR #1239's identity-keyed remote-stream cache (`ResolveSubscribeIdentity` returns a stable `SystemUserId` for infrastructure writes), and the change-feed resubscribe loop (it carries an in-flight guard, so one stream can have at most one outstanding re-ask).

## Also in this PR (one line, same investigation)

`Memex.Portal.Distributed` now references `MeshWeaver.Import`. In-mesh sources compile against `TRUSTED_PLATFORM_ASSEMBLIES` — the publish output — so an assembly the portal does not reference is invisible to them however much the framework ships it. `Memex.Portal.Monolith` already referenced it, which is why `Northwind/Product` compiles in dev and fails on memex-cloud with `CS0234: the type or namespace name 'Import' does not exist in the namespace 'MeshWeaver'`.

## Tests

`PendingCallbackDiagnosticKeyTest` — the fan-out shape, the retry shape, the opted-out shape (line unchanged), and per-group independence. 4/4 pass.

```
dotnet build src/MeshWeaver.Messaging.Hub -c Release -warnaserror        # clean
dotnet build memex/aspire/Memex.Portal.Distributed -c Release -warnaserror  # clean
dotnet test test/MeshWeaver.Messaging.Hub.Test --filter PendingCallbackDiagnosticKeyTest  # 4 passed
```

## Related

- #1251 (merged) — unresolved mount-relative `@@` includes: 15 parked NodeTypes, each burning a serial 15 s read first.
- #1254 (merged) — the bake enumerating before shipped content had landed (237 vs 279 types on consecutive pods).
- Systemorph/Memex#35 — persists `PreWarm__BatchBake` so a helm upgrade cannot revert the bake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)