### PR TITLE
fix: content-file import lost the caller's identity across the Subscribe hop

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -31,6 +31,40 @@ public static class ContentImportExtensions
         => new(hub, nodePath);
 
     /// <summary>
+    /// Snapshots the caller's <see cref="AccessContext"/> the moment a builder's <c>Post()</c> runs —
+    /// on the CALLER's thread, where the ambient <c>AsyncLocal</c> is still correct. Same capture
+    /// <c>MeshService</c> performs for every node write (<c>CreateNode</c>/<c>DeleteNode</c>/…).
+    ///
+    /// <para>🚨 Why eager. The post itself happens inside <c>Observable.Defer</c>, i.e. on the
+    /// SUBSCRIBING thread — and in every real pipeline that thread is not the caller's: a
+    /// <c>Concat</c>/<c>Merge</c> pump subscribes item N+1 from item N's completion callback, which
+    /// runs on a hub action block / PG emission thread where the caller's (or an
+    /// <c>ImpersonateAsSystem</c>) <c>AsyncLocal</c> is long gone. Reading the ambient context there
+    /// yields null, the owning hub's PostPipeline fails the delivery closed
+    /// ("AccessContext must never be null for an application post"), and the content write is
+    /// REFUSED while the node writes around it — which capture eagerly — succeed. That asymmetry is
+    /// exactly MeshWeaver.Reinsurance#46: every node landed, all 409 attachment groups were rejected.</para>
+    /// </summary>
+    internal static AccessContext? CaptureCallerContext(IMessageHub hub)
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return accessService?.Context ?? accessService?.CircuitContext;
+    }
+
+    /// <summary>
+    /// Targets the owning node's hub and pins the eagerly-captured caller identity onto the delivery,
+    /// so the post never depends on the ambient <c>AsyncLocal</c> surviving the Subscribe hop.
+    /// A null capture is left unstamped deliberately — the never-null invariant then FAILS the post
+    /// closed rather than inventing an identity (legitimate system work opts in explicitly via
+    /// <see cref="AccessService.ImpersonateAsSystem"/> / <see cref="AccessService.ImpersonateAsHub"/>).
+    /// </summary>
+    internal static PostOptions ConfigurePost(PostOptions o, Address address, AccessContext? captured)
+    {
+        o = o.WithTarget(address);
+        return captured is null ? o : o.WithAccessContext(captured);
+    }
+
+    /// <summary>
     /// Registers the <see cref="ImportContentRequest"/> + <see cref="SyncContentFilesRequest"/> handlers.
     /// Wired into <c>AddContentCollectionsInfrastructure</c> so every content-enabled node hub can
     /// receive a collection→collection import AND an inline (byte-carrying) content mirror.
@@ -297,6 +331,11 @@ public sealed class ContentImportBuilder
     /// <summary>Post the import to the owning node's hub. Cold — subscribe to run.</summary>
     public IObservable<ImportContentResponse> Post()
     {
+        // 🚨 Capture the caller's identity EAGERLY — here, on the caller's thread, where the
+        // ambient AsyncLocal is still correct — and pin it on the delivery below. The Defer's
+        // body runs at SUBSCRIBE, which in any real pipeline lands on a pump/emission thread
+        // where that AsyncLocal is gone. See ContentImportExtensions.CaptureCallerContext.
+        var captured = ContentImportExtensions.CaptureCallerContext(_hub);
         var request = new ImportContentRequest(_targetCollection, _sourcePath, _targetPath)
         {
             SourceCollection = _sourceCollection
@@ -311,9 +350,13 @@ public sealed class ContentImportBuilder
         // has the mesh hub as target (sender: Agent…)". NodeOperationIssuingHub is a no-op for
         // every non-router hub, so node/import/portal-hub callers are unchanged.
         return Observable.Defer(() => _hub.NodeOperationIssuingHub()
-            .Observe(request, o => o.WithTarget(address))
-            .Select(d => d.Message)
-            .Take(1));
+                .Observe(request, o => ContentImportExtensions.ConfigurePost(o, address, captured))
+                .Select(d => d.Message)
+                .Take(1))
+            // …and restore that identity around every emission, so a caller chaining further
+            // work inside its Subscribe callback still runs as itself (the same wrap every
+            // MeshService write primitive applies — Doc/Architecture/AccessContextPropagation).
+            .CarryAccessContext(_hub.ServiceProvider);
     }
 }
 
@@ -388,6 +431,11 @@ public sealed class SyncContentFilesBuilder
     /// <summary>Post the sync to the target node's hub. Cold — subscribe to run.</summary>
     public IObservable<ImportContentResponse> Post()
     {
+        // 🚨 Eager identity capture — see ContentImportExtensions.CaptureCallerContext. Without
+        // it this post read the ambient AsyncLocal at Subscribe time, which is null on every
+        // Concat/Merge pump thread: MeshWeaver.Reinsurance#46 landed all 412 node writes and had
+        // all 409 SyncContentFilesRequest posts failed closed for a null AccessContext.
+        var captured = ContentImportExtensions.CaptureCallerContext(_hub);
         var request = new SyncContentFilesRequest(_targetCollection, _targetPath, _files.ToArray())
         {
             Mirror = _mirror,
@@ -397,8 +445,9 @@ public sealed class SyncContentFilesBuilder
         // Off-router issuing, same reason as ContentImportBuilder.Post: the router must be neither
         // end of the request/response pair (ROUTER_TRAFFIC); a non-router hub gets itself back.
         return Observable.Defer(() => _hub.NodeOperationIssuingHub()
-            .Observe(request, o => o.WithTarget(address))
-            .Select(d => d.Message)
-            .Take(1));
+                .Observe(request, o => ContentImportExtensions.ConfigurePost(o, address, captured))
+                .Select(d => d.Message)
+                .Take(1))
+            .CarryAccessContext(_hub.ServiceProvider);
     }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
@@ -299,11 +299,22 @@ post-as-System escalation. Read/query pipelines default to `false` — a null ca
 unwrapped, preserving whatever identity is ambient at emission. Flipping that default to clamp is
 blocked on migrating the ops/MCP call sites that currently depend on the leaked ambient identity.
 
-This is applied by every mesh write primitive — `MeshService.CreateNode/Update/Delete/CopyNode`, `MeshNodeStreamHandle.Update`, `IMeshNodeStreamCache.Update` — so callers keep writing the natural shape:
+This is applied by every mesh write primitive — `MeshService.CreateNode/Update/Delete/CopyNode`, `MeshNodeStreamHandle.Update`, `IMeshNodeStreamCache.Update`, and the content-file writes `hub.ImportContent(path)…Post()` / `hub.SyncContentFiles(path)…Post()` — so callers keep writing the natural shape:
 
 ```csharp
 meshService.CreateNode(node).Subscribe(_ => …);   // identity preserved across the Subscribe seam
 ```
+
+> **Eager capture is half the contract, and the half that is easy to forget.** A primitive that only
+> wraps its result with `CarryAccessContext` still reads the ambient `AsyncLocal` when its
+> `Observable.Defer` body runs — i.e. on the **subscribing** thread. The two content-import builders
+> shipped that way and were the last write primitives without an eager snapshot: an import that built
+> its operations under `ImpersonateAsSystem` and then drained them through a `Concat` pump had every
+> node write land (those capture eagerly) and every content write failed closed for a null
+> `AccessContext` (MeshWeaver.Reinsurance#46 — 412 applied, 409 refused, one call site). Snapshot the
+> context where the caller calls you; pin it on the post with `o.WithAccessContext(captured)`; wrap
+> the result with `CarryAccessContext`. All three, or the primitive is not identity-safe.
+> Pinned by `ContentImportAccessContextTest`.
 
 Phase 2 then happens again from the Subscribe callback's thread, under the right identity. The chain continues.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imported-files-no-longer-go-missing-from-their-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imported-files-no-longer-go-missing-from-their-page.md
@@ -1,0 +1,20 @@
+---
+Name: Imported files no longer go missing from their page
+Category: Fix
+Description: An import that created pages now also attaches their files, instead of silently leaving every attachment behind.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Imported files no longer go missing from their page
+
+An import could finish looking successful — every page created — while none of the files that
+belong to those pages were attached. On a large demo import, all 412 pages landed and all 409
+groups of documents were rejected, so the pages opened with nothing on them.
+
+The cause was that the framework lost track of who was performing the import once the work moved
+between threads, and a file write with no known author is refused rather than attributed to the
+wrong person. Page writes already remembered the author; file writes did not.
+
+Both now record the caller up front, so imports attach their files as the person who ran them. If
+you were affected, simply run the import again — it is idempotent and will attach the missing files.

--- a/test/MeshWeaver.Content.Test/ContentImportAccessContextTest.cs
+++ b/test/MeshWeaver.Content.Test/ContentImportAccessContextTest.cs
@@ -1,0 +1,219 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Regression pin for the content-file import losing the CALLER'S IDENTITY
+/// (MeshWeaver.Reinsurance#46, "Demo setup loading failed"): the demo wrote all 412 of its nodes
+/// and had all 409 of its attachment groups REFUSED —
+/// <c>"AccessContext must never be null for an application post … message=SyncContentFilesRequest"</c>.
+///
+/// <para><b>The defect.</b> Every other framework write primitive (<c>IMeshService.CreateNode</c> and
+/// friends, <c>MeshNodeStreamHandle.Update</c>) snapshots <c>AccessService.Context</c> EAGERLY, on the
+/// caller's thread, and pins it on the delivery. The two content-import builders did neither: their
+/// <c>Post()</c> was a bare <c>hub.Observe(request, o =&gt; o.WithTarget(address))</c> inside an
+/// <c>Observable.Defer</c>, so the identity was read at SUBSCRIBE time — from whatever thread the
+/// pipeline happened to subscribe on. In any real import that is a <c>Concat</c>/<c>Merge</c> pump or a
+/// storage emission thread, where the caller's (or an <c>ImpersonateAsSystem</c>) <c>AsyncLocal</c> is
+/// gone. Node writes therefore landed and content writes were failed closed, in the same run, from the
+/// same call site — the asymmetry the issue reports.</para>
+///
+/// <para><b>What this test pins.</b> The write is BUILT with a specific caller ambient and SUBSCRIBED on
+/// another thread that does not carry that identity. The identity that reaches the wire must still be
+/// the caller's — not the ambient identity of the subscribing thread (here the xUnit host's standing
+/// DevLogin admin, which <c>CircuitContext</c> resolves to on every thread). A single-threaded version
+/// of this test would pass with or without the fix and prove nothing: the thread hop IS the defect.</para>
+/// </summary>
+public class ContentImportAccessContextTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly TimeSpan StepTimeout = 30.Seconds();
+
+    /// <summary>
+    /// The caller. Deliberately NOT <see cref="TestUsers.Admin"/> ("Roland"), the xUnit host's standing
+    /// identity: <c>CircuitContext</c> falls back to it on any thread with no context of its own, so
+    /// "the caller" and "whatever the subscribing thread carries" stay distinguishable.
+    /// </summary>
+    private static readonly AccessContext Importer = new()
+    {
+        ObjectId = "content-importer",
+        Name = "Content Importer"
+    };
+
+    // Not valid UTF-8 — the pack documents an import attaches are binaries.
+    private static readonly byte[] PackDocument =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0x21];
+
+    private readonly string _contentRoot = Path.Combine(
+        Path.GetTempPath(), "ContentImportAccessContextTest", Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// The identity each outgoing <see cref="SyncContentFilesRequest"/> delivery actually carries.
+    /// Recorded by a post-pipeline step on the issuing hub AFTER the rest of the chain has run
+    /// (<c>AddPipeline</c> nests outer-first, so recording the value <c>next(d)</c> RETURNS is what
+    /// sees the final resolved identity — exactly what the receiving node hub will authorise against).
+    /// A <see cref="ReplaySubject{T}"/> so the assertion can attach after the post; an instance field,
+    /// never static.
+    /// </summary>
+    private readonly ReplaySubject<string?> _stampedIdentities = new();
+
+    /// <summary>The read-only source collection the collection→collection import copies FROM.</summary>
+    private string SourceDir => Path.Combine(_contentRoot, "_source");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(SourceDir);
+        File.WriteAllBytes(Path.Combine(SourceDir, "asset.bin"), PackDocument);
+
+        // base.ConfigureMesh adds PublicAdminAccess, so BOTH candidate identities are authorised to
+        // write. Authorisation is not what this test discriminates on — attribution is.
+        return base.ConfigureMesh(builder)
+            .ConfigureDefaultNodeHub(config => config
+                .AddContentCollections()
+                .AddFileSystemContentCollection("ImportSource", _ => SourceDir)
+                // Mirror the portal: a per-node writable "content" collection on disk.
+                .AddContentCollection(_ => new ContentCollectionConfig
+                {
+                    Name = ContentCollectionsExtensions.DefaultCollectionName,
+                    SourceType = "FileSystem",
+                    BasePath = Path.Combine(_contentRoot, config.Address.ToString()),
+                    IsEditable = true,
+                    ExposeInChildren = true
+                }));
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (Directory.Exists(_contentRoot))
+        {
+            try { Directory.Delete(_contentRoot, recursive: true); }
+            catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SyncContentFiles_CarriesTheCallersIdentity_WhenSubscribeLandsOnAnotherThread()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (access.ImpersonateAsSystem())
+        {
+            await NodeFactory.CreateNode(new MeshNode("CtxSpace") { NodeType = "Space", Name = "Ctx Space" })
+                .Should().Within(StepTimeout).Emit();
+        }
+
+        var client = GetClient(c => ConfigureClient(c)
+            .AddPostPipeline(p => p.AddPipeline((delivery, next) =>
+            {
+                var posted = next(delivery);
+                if (posted.Message is SyncContentFilesRequest)
+                    _stampedIdentities.OnNext(posted.AccessContext?.ObjectId);
+                return posted;
+            })));
+
+        // BUILD the write with the caller ambient — the moment the framework must snapshot.
+        IObservable<ImportContentResponse> write;
+        using (access.SwitchAccessContext(Importer))
+        {
+            write = client.SyncContentFiles("CtxSpace")
+                .To(ContentCollectionsExtensions.DefaultCollectionName, "packs")
+                .Add("pack.bin", PackDocument)
+                .Mirror(false)
+                .Post();
+        }
+
+        // SUBSCRIBE from another thread. The scope above is disposed, so this thread carries no
+        // Context of its own — precisely the pump/emission thread the production pipeline subscribes
+        // on. The post happens HERE (the observable is cold), which is why a lazy read loses the user.
+        var ct = TestContext.Current.CancellationToken;
+        string? ambientAtSubscribe = null;
+        string? identityInsideSubscriberCallback = null;
+        var response = await Task.Run(() =>
+        {
+            ambientAtSubscribe = access.Context?.ObjectId;
+            return write
+                .Do(_ => identityInsideSubscriberCallback = access.Context?.ObjectId)
+                .FirstAsync()
+                .Timeout(StepTimeout)
+                .ToTask(ct);
+        }, ct);
+
+        ambientAtSubscribe.Should().NotBe(Importer.ObjectId,
+            because: "the hop must be real — if the caller's AsyncLocal still flowed to the " +
+                     "subscribing thread the test would pass with or without the fix and prove " +
+                     "nothing about the capture");
+
+        var stamped = await _stampedIdentities.FirstAsync().Timeout(StepTimeout).ToTask(ct);
+        stamped.Should().Be(Importer.ObjectId,
+            because: "SyncContentFilesBuilder.Post captures the caller EAGERLY and pins it on the " +
+                     "delivery, so the owning node hub authorises the write as the caller. Without " +
+                     $"that capture the post carried the subscribing thread's ambient identity " +
+                     $"('{TestUsers.Admin.ObjectId}' here, a null AccessContext in production — the " +
+                     "failed-closed delivery of MeshWeaver.Reinsurance#46)");
+
+        identityInsideSubscriberCallback.Should().Be(Importer.ObjectId,
+            because: "the returned observable is CarryAccessContext-wrapped, so a caller chaining " +
+                     "further work inside its Subscribe callback still runs as itself — the same " +
+                     "contract every MeshService write primitive honours");
+
+        response.Success.Should().BeTrue($"the content sync must land (error: {response.Error})");
+        response.FilesImported.Should().Be(1, "the one supplied pack document is written");
+
+        var landed = Directory.GetFiles(_contentRoot, "pack.bin", SearchOption.AllDirectories);
+        landed.Should().HaveCount(1, "the attachment lands in the node's content collection");
+        File.ReadAllBytes(landed[0]).SequenceEqual(PackDocument)
+            .Should().BeTrue("the bytes are written stream-to-stream, not through the text API");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ImportContent_CarriesTheCallersIdentity_WhenSubscribeLandsOnAnotherThread()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (access.ImpersonateAsSystem())
+        {
+            await NodeFactory.CreateNode(new MeshNode("ImpSpace") { NodeType = "Space", Name = "Imp Space" })
+                .Should().Within(StepTimeout).Emit();
+        }
+
+        var client = GetClient(c => ConfigureClient(c)
+            .AddPostPipeline(p => p.AddPipeline((delivery, next) =>
+            {
+                var posted = next(delivery);
+                if (posted.Message is ImportContentRequest)
+                    _stampedIdentities.OnNext(posted.AccessContext?.ObjectId);
+                return posted;
+            })));
+
+        IObservable<ImportContentResponse> import;
+        using (access.SwitchAccessContext(Importer))
+        {
+            import = client.ImportContent("ImpSpace")
+                .From("ImportSource")
+                .To(ContentCollectionsExtensions.DefaultCollectionName, "imported")
+                .Post();
+        }
+
+        var ct = TestContext.Current.CancellationToken;
+        var response = await Task.Run(
+            () => import.FirstAsync().Timeout(StepTimeout).ToTask(ct), ct);
+
+        var stamped = await _stampedIdentities.FirstAsync().Timeout(StepTimeout).ToTask(ct);
+        stamped.Should().Be(Importer.ObjectId,
+            because: "ContentImportBuilder.Post carries the same eager capture — the collection→" +
+                     "collection import is the second half of the same defect, and a caller that " +
+                     "subscribes off its own thread must still import as itself");
+
+        response.Success.Should().BeTrue($"the collection import must land (error: {response.Error})");
+    }
+}


### PR DESCRIPTION
## The defect

The two content-file write primitives — `hub.ImportContent(path)…Post()` and
`hub.SyncContentFiles(path)…Post()` — posted their request as a bare

```csharp
Observable.Defer(() => hub.NodeOperationIssuingHub()
    .Observe(request, o => o.WithTarget(address)) …)
```

with **no eager `AccessContext` capture, no `o.WithAccessContext(...)`, and no `CarryAccessContext`
wrap**. Every other framework write primitive does all three (`MeshService.CreateNode/CreateNodes/
CreateOrUpdateNode/DeleteNode/CopyNode`, `MeshNodeStreamHandle.Update`, `IMeshNodeStreamCache.Update`
— `src/MeshWeaver.Hosting/MeshService.cs:126-280`).

Because the post sits inside `Observable.Defer`, the identity was read **at Subscribe time, on the
subscribing thread**. In any real import that thread is a `Concat`/`Merge` pump or a storage-emission
thread: it subscribes item N+1 from item N's completion callback, where the caller's (or an
`ImpersonateAsSystem`) `AsyncLocal` is long gone. `UserServicePostPipeline` then resolves no context
and — correctly — fails the delivery closed.

That produces a **silent, partial** import: node writes land (they capture eagerly) and content
writes are refused, from the same call site, in the same run.

## Evidence

`Systemorph/MeshWeaver.Reinsurance#46` ("Demo setup loading failed") is exactly this shape — 412
writes applied (every node), 409 failed (every attachment group), with:

```
⚠ 409 write(s) failed — first: files → ReinsuranceDemo/Cedents/Adriatica:
AccessContext must never be null for an application post — no identity, no delivery.
hub=ReinsuranceDemo/Setup, message=SyncContentFilesRequest,
target=ReinsuranceDemo/Cedents/Adriatica was posted with no AccessContext
(no Context, no CircuitContext).
```

Both builders were affected, not just `SyncContentFiles`.

Two in-framework callers had already worked around it per-callsite by wrapping each `Post()` in
`Observable.Using(() => access.ImpersonateAsSystem(), …)` — `StaticRepoImporter.AsSystem` and
`PackageInstaller.SyncPackageContent`. Those keep working unchanged (their `Post()` is invoked
inside the impersonation scope, so the eager capture now snapshots System). Every caller that did
**not** know to hand-roll that wrapper was silently broken.

## The fix

`src/MeshWeaver.ContentCollections/ContentImportExtensions.cs` — both `Post()` methods now do what
`MeshService` does:

1. `CaptureCallerContext(hub)` — eager snapshot of `AccessService.Context ?? CircuitContext` on the
   caller's thread, at `Post()`;
2. `o.WithAccessContext(captured)` on the delivery, so it survives the cross-hub post;
3. `.CarryAccessContext(hub.ServiceProvider)` on the returned cold observable, so a caller chaining
   work inside its Subscribe callback still runs as itself.

**No band-aid**: a null capture is deliberately left unstamped, so the never-null invariant still
fails the post closed rather than inventing an identity. Legitimate system work keeps opting in
explicitly via `ImpersonateAsSystem` / `ImpersonateAsHub`.

## Test

`test/MeshWeaver.Content.Test/ContentImportAccessContextTest.cs` — two tests (one per builder) that
BUILD the write with a specific caller ambient and SUBSCRIBE from another thread that carries a
different identity, then assert the identity that reaches the wire is the caller's. The thread hop is
the whole defect, so a single-threaded version would pass either way.

Verified red before the change / green after:

```
# before (src reverted to HEAD)
Failed!  - Failed: 2, Passed: 0
  Expected value to be "content-importer" … but found "Roland"   ← the subscribing thread's identity
# after
Passed!  - Failed: 0, Passed: 2
```

## Cross-repo

Fixes the framework half of `Systemorph/MeshWeaver.Reinsurance#46`. GitHub cannot auto-close across
repos, so that issue stays open: **once this ships, the demo import must be re-run** — it is
idempotent and will attach the 1320 pack documents it previously dropped. No change is needed in the
Reinsurance repo itself; impersonating inside each `Observable.Defer` there would have repaired one
caller and left every other `SyncContentFiles`/`ImportContent` caller broken.

## Also

- `Doc/Architecture/AccessContextPropagation` — the primitive list now includes the content-file
  writes, plus a note that eager capture is the half of the contract that is easy to forget.
- What's New entry (`Category: Fix`).
