### PR TITLE
fix: storm breaker key carries payload identity, so a wide fan-out is not dropped as a loop

### DIFF
--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -124,7 +124,20 @@ public enum ChangeType
 /// Base type for messages carried over a synchronization stream.
 /// </summary>
 /// <param name="StreamId">The identifier of the stream the message belongs to.</param>
-public abstract record StreamMessage(string StreamId);
+public abstract record StreamMessage(string StreamId) : IDiagnosticKeyed
+{
+    /// <summary>
+    /// The stream id — the thing this message is ABOUT.
+    ///
+    /// <para>🚨 Load-bearing, not cosmetic. One owner hub holds a SEPARATE sync stream per
+    /// subscriber/reference, and every one of them posts to the SAME subscriber address with the
+    /// SAME message type. Without this component the hub-ingestion <c>MessageStormBreaker</c>
+    /// folds all of them into one rate bucket, so a wide, legitimate change fan-out (a bulk import
+    /// driving many streams) is indistinguishable from ONE stream in a resubscribe/repost loop —
+    /// and the breaker DROPS the fan-out's frames at ingestion. See <see cref="IDiagnosticKeyed"/>.</para>
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => StreamId;
+}
 /// <summary>
 /// Base type for stream messages that carry a versioned JSON change.
 /// </summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/ActionBlockWedgePrevention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActionBlockWedgePrevention.md
@@ -48,6 +48,18 @@ for any *future* defect: a per-hub **aggregate** backpressure breaker.
   saw was **many distinct keys** — each phantom path, each failed area is a different key — so
   no single key crossed the threshold while the *aggregate* saturated the thread. **Per-key is
   the gap.**
+
+  🚨 "Per-key" means `(sender, target, message-type, **payload identity**)`. The fourth component
+  is not optional decoration — without it the claim above is false, because the mesh funnels
+  traffic through dispatchers where one sender talks to one target with one message type about
+  **many different things** (every sync stream an owner holds to the shared node cache; every
+  `CreateOrUpdateNodeRequest` a bulk importer sends to the mesh hub). Keyed on the routing tuple
+  alone, a wide *legitimate* fan-out is arithmetically identical to one thing looping, and the
+  breaker drops it — real writes discarded at ingestion (#1200). The identity comes from
+  `IDiagnosticKeyed.DiagnosticKey` on the message (a stream id, a node path); once a hub hop has
+  erased the payload type to `RawJson`, it comes from the envelope property `MessageDelivery.Package`
+  stamped there, so the breaker never parses a payload on the ingestion path. A message exposing no
+  identity keys on the bare tuple — the fallback is the old, stricter behaviour, never "allow".
 - The fix: a per-action-block watermark on inbound depth/rate. When one block's queue exceeds
   the watermark, **shed `[CanBeIgnored]`/failure-class messages** (never user-facing or
   lifecycle messages) to keep it draining. The breaker is keyed on the **hub**, aggregated

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-bulk-imports-no-longer-lose-content-to-the-storm-guard.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-bulk-imports-no-longer-lose-content-to-the-storm-guard.md
@@ -1,0 +1,25 @@
+---
+Name: Bulk imports no longer lose content to the storm guard
+Category: Fix
+Description: A large import or sync could have some of its writes silently discarded by the runaway-message guard; the guard now tells a wide fan-out apart from a genuine loop.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Bulk imports no longer lose content to the storm guard
+
+The platform carries a safety guard that watches for runaway message loops and cuts them off
+before they can freeze a workspace. The guard judged traffic only by who sent it, who it was for,
+and what kind of message it was — it could not see *what each message was about*. A large import or
+sync sends thousands of writes that share all three of those, one per page or record, so the guard
+mistook the whole batch for a single message repeating itself and discarded part of it.
+
+The result was content that simply never appeared: an import would report itself finished while
+some of its pages, or some of its progress log, were missing, with nothing in the interface to say
+anything had been dropped.
+
+The guard now also considers which page, node or stream each message concerns. Thousands of writes
+to thousands of different places are recognised as normal work and pass through untouched, while a
+genuine loop — the same one thing repeating thousands of times a second — is still stopped just as
+before. As a bonus, when the guard does fire it now names the exact item that was looping, so the
+underlying cause can be found instead of guessed at.

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -14,8 +14,16 @@ namespace MeshWeaver.Mesh;
 /// </summary>
 /// <param name="Node">The MeshNode to create</param>
 [CreateNodePermission]
-public record CreateNodeRequest(MeshNode Node) : IRequest<CreateNodeResponse>
+public record CreateNodeRequest(MeshNode Node) : IRequest<CreateNodeResponse>, IDiagnosticKeyed
 {
+    /// <summary>
+    /// The path of the node being created — so a bulk fan-out (N creates for N DISTINCT paths from
+    /// one importer to the mesh hub) is told apart from ONE create retried in a loop. Both the
+    /// pending-callback diagnostic and the ingestion storm breaker key on it; without it the whole
+    /// fan-out is one bucket and the breaker drops it. See <see cref="IDiagnosticKeyed"/>.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => Node is { } node ? node.Path : string.Empty;
+
     /// <summary>
     /// The user or system requesting the creation.
     /// </summary>
@@ -216,8 +224,14 @@ public class CreateNodesPermissionAttribute() : RequiresPermissionAttribute(Perm
 /// </summary>
 /// <param name="Path">The path of the node to delete</param>
 [RequiresPermission(Permission.Delete)]
-public record DeleteNodeRequest(string Path) : IRequest<DeleteNodeResponse>
+public record DeleteNodeRequest(string Path) : IRequest<DeleteNodeResponse>, IDiagnosticKeyed
 {
+    /// <summary>
+    /// The path being deleted — tells a wide prune (N distinct paths) apart from one delete
+    /// retried in a loop. See <see cref="IDiagnosticKeyed"/>.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => Path ?? string.Empty;
+
     /// <summary>
     /// If true, also delete all descendant nodes.
     /// </summary>
@@ -361,8 +375,15 @@ public enum NodeDeletionRejectionReason
 /// Both checks run through the standard permission pipeline.</para>
 /// </summary>
 [CreateOrUpdateNodePermission]
-public record CreateOrUpdateNodeRequest(MeshNode Node) : IRequest<CreateOrUpdateNodeResponse>
+public record CreateOrUpdateNodeRequest(MeshNode Node) : IRequest<CreateOrUpdateNodeResponse>, IDiagnosticKeyed
 {
+    /// <summary>
+    /// The path being upserted. This is THE bulk verb — <c>StaticRepoImporter</c> issues one per
+    /// source node from a single import hub to a single mesh hub, so without this component the
+    /// entire import is one storm-breaker bucket. See <see cref="IDiagnosticKeyed"/>.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => Node is { } node ? node.Path : string.Empty;
+
     /// <summary>Optional JSON Patch payload (Json.Patch.JsonPatch) to apply to
     /// the existing node. When null, <see cref="Node"/> is the full instance
     /// to upsert. Typed as <c>object?</c> so the patch type is owned by the
@@ -459,8 +480,14 @@ public class CreateOrUpdateNodePermissionAttribute() : RequiresPermissionAttribu
 /// </summary>
 /// <param name="SourcePath">The path to copy from.</param>
 /// <param name="TargetPath">The path to copy to.</param>
-public record CopyNodeRequest(string SourcePath, string TargetPath) : IRequest<CopyNodeResponse>
+public record CopyNodeRequest(string SourcePath, string TargetPath) : IRequest<CopyNodeResponse>, IDiagnosticKeyed
 {
+    /// <summary>
+    /// The target path — the thing being produced. Tells a wide copy fan-out apart from one copy
+    /// retried in a loop. See <see cref="IDiagnosticKeyed"/>.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => TargetPath ?? string.Empty;
+
     /// <summary>If <c>true</c>, copies all descendant nodes (subtree) under the source.</summary>
     public bool IncludeDescendants { get; init; } = true;
 
@@ -530,7 +557,14 @@ public enum NodeCopyRejectionReason
 /// <param name="SourcePath">The current path of the node</param>
 /// <param name="TargetPath">The new path for the node</param>
 [MoveNodePermission]
-public record MoveNodeRequest(string SourcePath, string TargetPath) : IRequest<MoveNodeResponse>;
+public record MoveNodeRequest(string SourcePath, string TargetPath) : IRequest<MoveNodeResponse>, IDiagnosticKeyed
+{
+    /// <summary>
+    /// The source path — the node being moved. Tells a wide move fan-out apart from one move
+    /// retried in a loop. See <see cref="IDiagnosticKeyed"/>.
+    /// </summary>
+    string IDiagnosticKeyed.DiagnosticKey => SourcePath ?? string.Empty;
+}
 
 /// <summary>
 /// Custom permission attribute for MoveNodeRequest.

--- a/src/MeshWeaver.Messaging.Contract/IDiagnosticKeyed.cs
+++ b/src/MeshWeaver.Messaging.Contract/IDiagnosticKeyed.cs
@@ -18,9 +18,32 @@ namespace MeshWeaver.Messaging;
 /// <para>The evidence needed to choose was destroyed with the pod (Loki was itself down through the
 /// incident window), so the next occurrence has to be self-describing. Keep the key CHEAP and
 /// ALREADY-COMPUTED — it is read on every request registration.</para>
+///
+/// <para>🚨 The key is ALSO load-bearing, not merely diagnostic: the hub-ingestion
+/// <c>MessageStormBreaker</c> keys its per-second rate counters on
+/// <c>(sender, target, type, DiagnosticKey)</c>. Without the fourth component the two mechanisms
+/// above are indistinguishable to the breaker too — and it does not merely mislabel them, it
+/// DROPS the fan-out, because N legitimate writes to N distinct things fold into one bucket and
+/// cross the per-key bar. Every message type whose traffic can be wide (one sender → one target,
+/// many things) must carry this. See <c>MessageStormBreaker.ShouldDrop</c>.</para>
 /// </summary>
 public interface IDiagnosticKeyed
 {
+    /// <summary>
+    /// Delivery-property name under which <c>MessageDelivery.Package(...)</c> stamps
+    /// <see cref="DiagnosticKey"/> onto the ENVELOPE, immediately before the payload type is erased
+    /// to <see cref="RawJson"/> for transport.
+    ///
+    /// <para>🚨 This is what keeps the key readable after a hub hop. A cross-hub delivery reaches
+    /// the receiving hub's ingestion gate UNDESERIALIZED — the storm breaker sees
+    /// <c>type=RawJson</c> and cannot look inside without parsing the payload on the hottest path
+    /// in the hub. Stamping at <c>Package</c> costs one interface check next to a full JSON
+    /// serialize that is already happening, and the envelope's properties survive both the
+    /// in-process router hop and the gRPC/SignalR wire (the same mechanism that carries
+    /// <c>PostOptions.RequestId</c> for response correlation).</para>
+    /// </summary>
+    public const string DeliveryProperty = "DiagnosticKey";
+
     /// <summary>
     /// A short, stable identifier for what this request is about — the stream id, the target path,
     /// the entity id. Never a fresh guid per post: the whole point is that two posts about the same

--- a/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
@@ -188,7 +188,18 @@ public abstract record MessageDelivery : IMessageDelivery
                 return this;
             var serialized = JsonSerializer.Serialize(message, options ?? fallbackOptions);
             var rawJson = new RawJson(serialized);
-            return WithMessage(rawJson);
+            var packaged = WithMessage(rawJson);
+            // 🚨 Carry the payload's IDENTITY across the type erasure. From here on the delivery
+            // is `type=RawJson` and nothing downstream can tell WHAT it is about without parsing
+            // the payload — which the receiving hub's storm breaker runs far too hot to do (it
+            // sees every inbound delivery, before the turn loop). Stamping the already-computed
+            // DiagnosticKey onto the envelope here is free next to the Serialize above, and the
+            // envelope's properties survive the router hop and the wire. Without it, N legitimate
+            // cross-hub writes to N DISTINCT things collapse into one storm-breaker bucket and get
+            // dropped as if they were one thing looping (#1200).
+            return message is IDiagnosticKeyed keyed && keyed.DiagnosticKey is { Length: > 0 } key
+                ? packaged.SetProperty(IDiagnosticKeyed.DeliveryProperty, key)
+                : packaged;
         }
         catch (Exception e)
         {

--- a/src/MeshWeaver.Messaging.Hub/MessageStormBreaker.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageStormBreaker.cs
@@ -355,19 +355,31 @@ public sealed class MessageStormBreaker
         };
     }
 
+    /// <summary>
+    /// TryGetValue + TryAdd rather than <c>GetOrAdd</c>: the live-key count must only be
+    /// incremented by the caller that actually INSERTED, and <c>GetOrAdd</c>'s factory can also run
+    /// for a racing loser.
+    ///
+    /// <para>🚨 The retry loop is required, not defensive padding. Returning the locally-built
+    /// counter when <c>TryAdd</c> loses would hand back an instance that is NOT in the dictionary
+    /// whenever the winner's entry is evicted (window roll / sweep) in the gap before the re-read —
+    /// this delivery would then be counted on an orphan nobody else can see, so a storming key's
+    /// count and cooldown would silently reset. Loop until we either observe a published counter or
+    /// publish ours; each pass strictly makes progress (find or insert).</para>
+    /// </summary>
     private Counter GetOrAddCounter(StormKey key, long now)
     {
-        // TryGetValue + TryAdd rather than GetOrAdd: the live-key count must only be incremented
-        // by the caller that actually INSERTED (GetOrAdd's factory can run for a racing loser).
-        if (counters.TryGetValue(key, out var existing))
-            return existing;
-        var fresh = new Counter(now);
-        if (counters.TryAdd(key, fresh))
+        while (true)
         {
-            Interlocked.Increment(ref liveKeys);
-            return fresh;
+            if (counters.TryGetValue(key, out var existing))
+                return existing;
+            var fresh = new Counter(now);
+            if (counters.TryAdd(key, fresh))
+            {
+                Interlocked.Increment(ref liveKeys);
+                return fresh;
+            }
         }
-        return counters.TryGetValue(key, out var raced) ? raced : fresh;
     }
 
     private void RemoveCounter(StormKey key)
@@ -382,6 +394,14 @@ public sealed class MessageStormBreaker
     /// above <see cref="DefaultMaxTrackedKeys"/> and run at most once per window by a single
     /// thread, so the O(n) pass costs at most one traversal of a bounded map per second and the
     /// live set tracks RECENT traffic instead of growing with everything the hub ever saw.
+    ///
+    /// <para>🚨 Staleness is the ONLY criterion — a <c>Tripped</c> counter is swept like any other.
+    /// Exempting tripped keys would break the bound this method exists to provide: a key that
+    /// storms once and is never seen again would live for the hub's lifetime. It is also
+    /// unnecessary, because "stale" means NO message for a full window+cooldown, which a storming
+    /// key can never be (every message restamps its window) and which is strictly past the
+    /// cooldown. Dropping such a counter is behaviourally identical to the self-heal its next
+    /// message would perform anyway: a fresh counter starts at 1 and the message passes.</para>
     /// </summary>
     private void SweepStaleKeys(long now)
     {
@@ -398,7 +418,7 @@ public sealed class MessageStormBreaker
             var counter = pair.Value;
             bool stale;
             lock (counter.Gate)
-                stale = !counter.Tripped && counter.WindowStartTicks < staleBefore;
+                stale = counter.WindowStartTicks < staleBefore;
             if (stale)
                 RemoveCounter(pair.Key);
         }

--- a/src/MeshWeaver.Messaging.Hub/MessageStormBreaker.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageStormBreaker.cs
@@ -22,11 +22,26 @@ namespace MeshWeaver.Messaging;
 /// unbounded loop can saturate a hub again.</para>
 ///
 /// <para><b>The discriminator is per-key RATE, not total volume.</b> A loop emits
-/// thousands per second of ONE identical <c>(sender, target, message-type)</c> tuple;
-/// real traffic is DIVERSE tuples each at a modest rate. The breaker keys every inbound
-/// message by that tuple and counts per-key occurrences in a 1-second window. Only a
-/// single key sustaining a rate no legitimate caller can reach trips — high-volume
-/// diverse traffic passes untouched because no single key crosses the bar.</para>
+/// thousands per second of ONE identical
+/// <c>(sender, target, message-type, payload-identity)</c> key; real traffic is DIVERSE keys each
+/// at a modest rate. The breaker keys every inbound message by that tuple and counts per-key
+/// occurrences in a 1-second window. Only a single key sustaining a rate no legitimate caller can
+/// reach trips — high-volume diverse traffic passes untouched because no single key crosses the
+/// bar.</para>
+///
+/// <para><b>🚨 The payload-identity component is what makes that claim TRUE (#1200).</b> The
+/// routing tuple alone is not a loop signature: the mesh funnels traffic through dispatchers where
+/// ONE sender talks to ONE target with ONE message type ABOUT MANY DIFFERENT THINGS — every sync
+/// stream an owner hub holds open to the shared mesh-node cache posts
+/// <c>DataChangedEvent</c>/<c>RawJson</c> over that one tuple, and a bulk importer issues one
+/// <c>CreateOrUpdateNodeRequest</c> per source node from one hub to the mesh hub. Keyed on the
+/// tuple alone, a wide LEGITIMATE fan-out is arithmetically identical to one thing looping, so the
+/// breaker crossed the bar and <see cref="ShouldDrop"/> DISCARDED real writes at ingestion — data
+/// loss, not mitigation. The key therefore carries the payload's own identity
+/// (<see cref="IDiagnosticKeyed.DiagnosticKey"/> — a stream id, a node path), read O(1) from the
+/// already-typed message or, once a hub hop has erased the type to <c>RawJson</c>, from the
+/// envelope property <c>Package</c> stamped there. A message that exposes no identity keys exactly
+/// as before — the fallback is the OLD behaviour, never "always allow".</para>
 ///
 /// <para><b>It is a LOUD diagnostic tripwire, never a silent swallow.</b> On a trip it
 /// logs ONE <c>Error</c> naming the offending tuple and observed rate (so the root loop
@@ -39,9 +54,11 @@ namespace MeshWeaver.Messaging;
 /// (one per hub). It dies with the hub — no static state, nothing to clear for test
 /// isolation.</para>
 ///
-/// <para><b>Cost.</b> O(1) per message: one <see cref="ConcurrentDictionary{TKey,TValue}"/>
-/// lookup and a short per-key lock. No per-message LINQ or allocation beyond the
-/// (bounded, self-evicting) per-key counter.</para>
+/// <para><b>Cost.</b> O(1) per message: one type check to read the payload identity (NEVER a
+/// payload parse — the identity is either an already-computed property on the typed message or a
+/// string already sitting on the envelope), one <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// lookup and a short per-key lock. No per-message LINQ or allocation beyond the (bounded,
+/// self-evicting) per-key counter.</para>
 ///
 /// <para><b>Visibility.</b> Public like its owner <see cref="MessageService"/> (a
 /// framework type, not app API) — apps never construct or call it; <see cref="MessageService"/>
@@ -59,7 +76,7 @@ public sealed class MessageStormBreaker
 
     /// <summary>
     /// Default per-key trip threshold: messages of ONE identical
-    /// <c>(sender, target, type)</c> tuple within a single window.
+    /// <c>(sender, target, type, payload-identity)</c> key within a single window.
     ///
     /// <para><b>Justification.</b> A storm is a CPU-bound resubscribe/repost loop —
     /// the observed cadences were ~1ms/cycle for the DeliveryFailure⟷ShutdownRequest
@@ -93,6 +110,24 @@ public sealed class MessageStormBreaker
     /// </summary>
     public const int DefaultAggregateWatermark = 10_000;
 
+    /// <summary>
+    /// Soft cap on the number of per-key counters kept alive at once.
+    ///
+    /// <para><b>Why a cap exists at all.</b> Before the payload-identity component the key space
+    /// was bounded by construction (peers × message types), so the opportunistic "evict on the
+    /// next message for an idle key" was enough. With the payload identity in the key, a hub that
+    /// sees many distinct paths/streams over its lifetime would accumulate one counter per thing
+    /// it EVER saw, because a key that never receives a second message is never revisited and so
+    /// never evicted. That is a leak on the hottest path in the hub.</para>
+    ///
+    /// <para>Crossing this cap arms a single inline sweep (at most one per window) that removes
+    /// counters idle for longer than window+cooldown. The live set is then bounded by RECENT
+    /// traffic — roughly rate × (window + cooldown + sweep interval) — instead of by all-time
+    /// traffic, and it drains on its own with no timer, no background thread and no static state.
+    /// Nothing about detection changes: a key idle for seconds is by definition not storming.</para>
+    /// </summary>
+    public const int DefaultMaxTrackedKeys = 10_000;
+
     private readonly int threshold;
     private readonly long windowTicks;
     private readonly long cooldownTicks;
@@ -115,6 +150,12 @@ public sealed class MessageStormBreaker
     // exception for concurrent mutation (an instance field, never static).
     private readonly ConcurrentDictionary<StormKey, Counter> counters = new();
 
+    // Live counter count + last-sweep stamp for the bounded key space (see DefaultMaxTrackedKeys).
+    // counters.Count would take every bucket lock, so the live size is tracked alongside.
+    private readonly int maxTrackedKeys;
+    private int liveKeys;
+    private long lastSweepTicks;
+
     // Surfaced for deterministic tests: emits once per trip transition (the same
     // moment the Error is logged). Hot observable; a test subscribes and asserts.
     private readonly Subject<StormTrip> trips = new();
@@ -126,6 +167,9 @@ public sealed class MessageStormBreaker
             Stopwatch.GetTimestamp, Stopwatch.Frequency, aggregateWatermark)
     {
     }
+
+    /// <summary>Number of per-key counters currently held (see <see cref="DefaultMaxTrackedKeys"/>).</summary>
+    public int TrackedKeyCount => Volatile.Read(ref liveKeys);
 
     /// <summary>
     /// Test/tuning constructor — explicit threshold/window/cooldown and an injectable
@@ -141,11 +185,13 @@ public sealed class MessageStormBreaker
     /// <param name="nowTicks">Injectable monotonic clock returning the current time in ticks; enables deterministic time control in tests.</param>
     /// <param name="ticksPerSecond">Ticks-per-second of the injected <paramref name="nowTicks"/> clock.</param>
     /// <param name="aggregateWatermark">Inbound-queue-depth watermark above which sheddable traffic is shed for aggregate overload.</param>
+    /// <param name="maxTrackedKeys">Soft cap on live per-key counters before an inline stale sweep is armed; see <see cref="DefaultMaxTrackedKeys"/>.</param>
     public MessageStormBreaker(
         ILogger logger, Address address,
         int threshold, TimeSpan window, TimeSpan cooldown,
         Func<long> nowTicks, long ticksPerSecond,
-        int aggregateWatermark = DefaultAggregateWatermark)
+        int aggregateWatermark = DefaultAggregateWatermark,
+        int maxTrackedKeys = DefaultMaxTrackedKeys)
     {
         this.logger = logger;
         this.address = address;
@@ -156,6 +202,7 @@ public sealed class MessageStormBreaker
         this.cooldownSeconds = cooldown.TotalSeconds;
         this.nowTicks = nowTicks;
         this.aggregateWatermark = aggregateWatermark;
+        this.maxTrackedKeys = maxTrackedKeys;
     }
 
     /// <summary>
@@ -198,8 +245,15 @@ public sealed class MessageStormBreaker
             return false;
 
         var now = nowTicks();
-        var key = new StormKey(delivery.Sender, delivery.Target, type.Name);
-        var counter = counters.GetOrAdd(key, _ => new Counter(now));
+        var key = new StormKey(delivery.Sender, delivery.Target, type.Name,
+            ResolvePayloadKey(delivery, message));
+
+        // Bounded key space: arm at most one inline stale sweep per window once the live set
+        // crosses the cap. One volatile read on the live path when we are under it.
+        if (Volatile.Read(ref liveKeys) > maxTrackedKeys)
+            SweepStaleKeys(now);
+
+        var counter = GetOrAddCounter(key, now);
 
         // When set inside the lock, the trip side effects (Error log + Trips.OnNext) run
         // AFTER the lock is released — never call out to a subscriber while holding the
@@ -227,7 +281,7 @@ public sealed class MessageStormBreaker
                 // next message — at zero cost to the live path.
                 if (previousCount == 0 && !counter.Tripped)
                 {
-                    counters.TryRemove(key, out _);
+                    RemoveCounter(key);
                     return false;
                 }
             }
@@ -268,21 +322,105 @@ public sealed class MessageStormBreaker
         return false;
     }
 
+    /// <summary>
+    /// The payload's own identity, resolved WITHOUT deserializing anything. Two sources, in the
+    /// order the type erasure happens:
+    /// <list type="number">
+    ///   <item>the typed message itself, when it opts in via <see cref="IDiagnosticKeyed"/> (an
+    ///     already-computed stream id / node path — one interface check);</item>
+    ///   <item>the envelope property that <c>MessageDelivery.Package</c> stamped, for a delivery
+    ///     that crossed a hub boundary and now arrives as <see cref="RawJson"/> — the ONLY case
+    ///     where the type is gone, so the property lookup is paid only there.</item>
+    /// </list>
+    /// <c>null</c> ⇒ this message exposes no identity, and the key degrades to exactly the
+    /// pre-#1200 <c>(sender, target, type)</c> tuple. That is deliberate: the fallback is the old,
+    /// stricter behaviour (fail CLOSED), never "let it through".
+    /// </summary>
+    private static string? ResolvePayloadKey(IMessageDelivery delivery, object message)
+    {
+        if (message is IDiagnosticKeyed keyed)
+            return keyed.DiagnosticKey is { Length: > 0 } key ? key : null;
+        if (message is not RawJson)
+            return null;
+        if (!delivery.Properties.TryGetValue(IDiagnosticKeyed.DeliveryProperty, out var value))
+            return null;
+        // In-process the value is the string we stamped; across a JSON wire hop it arrives as a
+        // JsonElement, whose ToString() is the string content (same read PatchDataResponse's
+        // RequestId correlation uses).
+        return value switch
+        {
+            string s => s.Length > 0 ? s : null,
+            null => null,
+            _ => value.ToString() is { Length: > 0 } s ? s : null
+        };
+    }
+
+    private Counter GetOrAddCounter(StormKey key, long now)
+    {
+        // TryGetValue + TryAdd rather than GetOrAdd: the live-key count must only be incremented
+        // by the caller that actually INSERTED (GetOrAdd's factory can run for a racing loser).
+        if (counters.TryGetValue(key, out var existing))
+            return existing;
+        var fresh = new Counter(now);
+        if (counters.TryAdd(key, fresh))
+        {
+            Interlocked.Increment(ref liveKeys);
+            return fresh;
+        }
+        return counters.TryGetValue(key, out var raced) ? raced : fresh;
+    }
+
+    private void RemoveCounter(StormKey key)
+    {
+        if (counters.TryRemove(key, out _))
+            Interlocked.Decrement(ref liveKeys);
+    }
+
+    /// <summary>
+    /// Inline, amortized eviction of counters that have been IDLE longer than one window plus the
+    /// cooldown — by definition not storming, so removing them cannot affect detection. Armed only
+    /// above <see cref="DefaultMaxTrackedKeys"/> and run at most once per window by a single
+    /// thread, so the O(n) pass costs at most one traversal of a bounded map per second and the
+    /// live set tracks RECENT traffic instead of growing with everything the hub ever saw.
+    /// </summary>
+    private void SweepStaleKeys(long now)
+    {
+        var last = Interlocked.Read(ref lastSweepTicks);
+        if (now - last < windowTicks)
+            return;
+        // One sweeper: the loser of this exchange simply skips (the winner is already sweeping).
+        if (Interlocked.CompareExchange(ref lastSweepTicks, now, last) != last)
+            return;
+
+        var staleBefore = now - (windowTicks + cooldownTicks);
+        foreach (var pair in counters)
+        {
+            var counter = pair.Value;
+            bool stale;
+            lock (counter.Gate)
+                stale = !counter.Tripped && counter.WindowStartTicks < staleBefore;
+            if (stale)
+                RemoveCounter(pair.Key);
+        }
+    }
+
     private void OnTripped(StormKey key, int observedCount)
     {
         Interlocked.Increment(ref tripCount);
 
-        // LOUD, once per trip: name the offending tuple and the observed per-window rate
-        // so the root loop is found and fixed. This is a tripwire, not a silent swallow.
+        // LOUD, once per trip: name the offending key — INCLUDING what the messages were about —
+        // and the observed per-window rate, so the root loop is found and fixed. The payload
+        // identity is the half that turns "something between these two hubs is looping" into a
+        // pointer at the exact stream/path. This is a tripwire, not a silent swallow.
         logger.LogError(
-            "MESSAGE STORM detected in hub {Address}: the tuple (sender={Sender}, target={Target}, type={Type}) "
-            + "exceeded {Threshold} messages within {Window:0.##}s (observed {Observed} in-window). "
-            + "Dropping this key at ingestion for {Cooldown:0.##}s to keep the hub responsive — "
-            + "this indicates an UNBOUNDED retry/resubscribe/repost loop somewhere; find and fix it.",
-            address, key.Sender, key.Target, key.TypeName,
+            "MESSAGE STORM detected in hub {Address}: the key (sender={Sender}, target={Target}, type={Type}, "
+            + "about={PayloadKey}) exceeded {Threshold} messages within {Window:0.##}s (observed {Observed} "
+            + "in-window). Dropping this key at ingestion for {Cooldown:0.##}s to keep the hub responsive — "
+            + "this indicates an UNBOUNDED retry/resubscribe/repost loop on that ONE thing; find and fix it.",
+            address, key.Sender, key.Target, key.TypeName, key.PayloadKey ?? "(unidentified)",
             threshold, windowSeconds, observedCount, cooldownSeconds);
 
-        try { trips.OnNext(new StormTrip(key.Sender, key.Target, key.TypeName, observedCount)); }
+        try { trips.OnNext(new StormTrip(key.Sender, key.Target, key.TypeName, observedCount, key.PayloadKey)); }
         catch { /* a faulting test subscriber must never wedge the hot path */ }
     }
 
@@ -369,13 +507,30 @@ public sealed class MessageStormBreaker
         try { aggregateSheds.OnCompleted(); } catch { /* ignore */ }
         aggregateSheds.Dispose();
         counters.Clear();
+        Interlocked.Exchange(ref liveKeys, 0);
     }
 
-    /// <summary>The loop signature a storm is detected on.</summary>
-    private readonly record struct StormKey(Address Sender, Address? Target, string TypeName);
+    /// <summary>
+    /// The loop signature a storm is detected on: WHO → WHOM, WHAT KIND of message, and — the
+    /// component #1200 was missing — WHICH THING it was about. Without the last one, N messages
+    /// about N different things are indistinguishable from N messages about the SAME thing, and a
+    /// legitimate fan-out gets dropped as a loop.
+    /// </summary>
+    /// <param name="Sender">Sending address.</param>
+    /// <param name="Target">Target address, if any.</param>
+    /// <param name="TypeName">Runtime type name of the message (or <c>RawJson</c> after a hub hop).</param>
+    /// <param name="PayloadKey">The payload's own identity, or <c>null</c> when it exposes none.</param>
+    private readonly record struct StormKey(
+        Address Sender, Address? Target, string TypeName, string? PayloadKey);
 
     /// <summary>Emitted on each trip transition (carries the offending loop signature).</summary>
-    public readonly record struct StormTrip(Address Sender, Address? Target, string TypeName, int ObservedCount);
+    /// <param name="Sender">Sending address of the storming key.</param>
+    /// <param name="Target">Target address of the storming key.</param>
+    /// <param name="TypeName">Message type name of the storming key.</param>
+    /// <param name="ObservedCount">In-window count observed at the trip transition.</param>
+    /// <param name="PayloadKey">What the storming messages were ABOUT (stream id / node path), or <c>null</c> when the type exposes no identity.</param>
+    public readonly record struct StormTrip(
+        Address Sender, Address? Target, string TypeName, int ObservedCount, string? PayloadKey = null);
 
     /// <summary>
     /// Per-key window counter. A small class (not a struct) so the

--- a/test/MeshWeaver.Messaging.Hub.Test/MessageStormBreakerTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MessageStormBreakerTest.cs
@@ -37,12 +37,21 @@ public class MessageStormBreakerTest
         => new MessageDelivery<object>(sender ?? Sender, target ?? Target, message, JsonOptions);
 
     // A plain message type with no [CanBeIgnored] / lifecycle exemption — the storm-prone
-    // path (stands in for SubscribeRequest / RawJson and friends).
+    // path (stands in for SubscribeRequest / RawJson and friends). It exposes NO payload
+    // identity, so it exercises the fail-closed fallback: keyed on the routing tuple alone.
     private record StormableMessage(int Seq = 0);
 
     // [CanBeIgnored] fire-and-forget control traffic — must be exempt from the breaker.
     [CanBeIgnored]
     private record IgnorableControlMessage(int Seq = 0);
+
+    // Stands in for the real wide-traffic shapes — DataChangedEvent (StreamId),
+    // CreateOrUpdateNodeRequest (node path): ONE sender, ONE target, ONE message type, but each
+    // message is ABOUT a different thing.
+    private record KeyedMessage(string About) : IDiagnosticKeyed
+    {
+        public string DiagnosticKey => About;
+    }
 
     [Fact]
     public void Trips_AndDrops_WhenOneKeyExceedsThresholdInWindow()
@@ -120,6 +129,157 @@ public class MessageStormBreakerTest
             breaker.ShouldDrop(Delivery(new StormableMessage(i))).Should().BeFalse();
 
         breaker.TripCount.Should().Be(1, "self-heal must not log a second trip");
+    }
+
+    /// <summary>
+    /// 🚨 The #1200 defect. A bulk import drives ONE sender → ONE target with ONE message type
+    /// over thousands of DISTINCT things (every mesh-node path it writes, every sync stream those
+    /// writes open). Keyed on the routing tuple alone that whole legitimate fan-out is one bucket,
+    /// crosses the per-key bar, and the breaker DISCARDS real writes at ingestion — imported
+    /// content silently missing, which is data loss, not mitigation.
+    ///
+    /// <para>RED before the payload-identity component (every message folds into one key and the
+    /// breaker trips); GREEN after (each thing is counted on its own key, all far under the bar).</para>
+    /// </summary>
+    [Fact]
+    public void WideFanOut_OneTuple_ManyDistinctPayloadKeys_NeverTrips()
+    {
+        var breaker = CreateBreaker();
+        var trips = new List<MessageStormBreaker.StormTrip>();
+        using var _ = breaker.Trips.Subscribe(trips.Add);
+
+        // 40x the per-key threshold in TOTAL volume through a SINGLE (sender, target, type)
+        // tuple — the cross-hub dispatcher shape — but every message is about a different path.
+        const int distinctPaths = Threshold * 40;
+        for (var i = 0; i < distinctPaths; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage($"UWDeepfield/Content/node-{i}")))
+                .Should().BeFalse(
+                    "a write to a DISTINCT path is not a loop, however many of them one importer issues");
+
+        trips.Should().BeEmpty("a wide fan-out over one tuple must never be mistaken for a storm");
+        breaker.TripCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The guard itself is unchanged: concentrate the SAME volume on ONE thing and it still trips —
+    /// and the trip now names WHICH thing, which is what turns "something between these two hubs
+    /// is looping" into a pointer at the offending stream/path.
+    /// </summary>
+    [Fact]
+    public void RepeatedSamePayloadKey_StillTrips_AndNamesTheThing()
+    {
+        var breaker = CreateBreaker();
+        var trips = new List<MessageStormBreaker.StormTrip>();
+        using var _ = breaker.Trips.Subscribe(trips.Add);
+
+        const string looping = "UWDeepfield/_Activity/import-f2bb979af363573d";
+        for (var i = 0; i < Threshold; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage(looping))).Should().BeFalse();
+
+        breaker.ShouldDrop(Delivery(new KeyedMessage(looping))).Should().BeTrue(
+            "one thing repeated past the per-key bar IS the loop the breaker exists to stop");
+
+        trips.Should().ContainSingle();
+        trips[0].PayloadKey.Should().Be(looping, "the trip must name what the storm was about");
+        trips[0].TypeName.Should().Be(nameof(KeyedMessage));
+
+        // And the fan-out running ALONGSIDE the loop keeps flowing — the drop is scoped to the
+        // one storming thing, not to everything that shares its sender/target/type.
+        for (var i = 0; i < Threshold; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage($"UWDeepfield/Content/other-{i}")))
+                .Should().BeFalse("healthy traffic on the same tuple is untouched by another key's trip");
+    }
+
+    /// <summary>
+    /// A cross-hub delivery reaches the receiving hub's ingestion gate UNDESERIALIZED — the
+    /// breaker sees <c>type=RawJson</c> and must not parse the payload on the hottest path in the
+    /// hub. <c>Package</c> stamps the identity onto the ENVELOPE right before it erases the type,
+    /// so discrimination survives the hop: the same fan-out that would fold into one key after
+    /// packaging still counts per thing.
+    /// </summary>
+    [Fact]
+    public void PackagedDelivery_KeepsPayloadIdentity_AcrossTheTypeErasure()
+    {
+        var breaker = CreateBreaker();
+        var trips = new List<MessageStormBreaker.StormTrip>();
+        using var _ = breaker.Trips.Subscribe(trips.Add);
+
+        // Post-Package the message really is RawJson — the state the cache hub saw in #1200.
+        var packagedSample = Delivery(new KeyedMessage("about/one")).Package();
+        packagedSample.Message.Should().BeOfType<RawJson>("Package erases the payload type");
+
+        const int distinctPaths = Threshold * 40;
+        for (var i = 0; i < distinctPaths; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage($"UWDeepfield/Content/node-{i}")).Package())
+                .Should().BeFalse("the envelope carries the identity the erased payload no longer shows");
+
+        trips.Should().BeEmpty();
+
+        // ...while a packaged LOOP on one thing still trips, still named.
+        for (var i = 0; i <= Threshold; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage("looping/stream")).Package());
+
+        trips.Should().ContainSingle();
+        trips[0].TypeName.Should().Be(nameof(RawJson), "after the hop the type really is RawJson");
+        trips[0].PayloadKey.Should().Be("looping/stream");
+    }
+
+    /// <summary>
+    /// The fallback is FAIL-CLOSED, never "allow". A message exposing no identity (and a packaged
+    /// delivery whose sender stamped none) keys on exactly the pre-#1200
+    /// <c>(sender, target, type)</c> tuple and trips exactly as it always did.
+    /// </summary>
+    [Fact]
+    public void NoPayloadIdentity_FallsBackToTheRoutingTuple_AndStillTrips()
+    {
+        var breaker = CreateBreaker();
+        var trips = new List<MessageStormBreaker.StormTrip>();
+        using var _ = breaker.Trips.Subscribe(trips.Add);
+
+        // Distinct CONTENT (Seq differs) but no IDiagnosticKeyed → one key, exactly as before.
+        for (var i = 0; i < Threshold; i++)
+            breaker.ShouldDrop(Delivery(new StormableMessage(i))).Should().BeFalse();
+        breaker.ShouldDrop(Delivery(new StormableMessage(Threshold))).Should().BeTrue(
+            "an unidentifiable payload must keep the old, stricter behaviour — never be waved through");
+
+        trips.Should().ContainSingle();
+        trips[0].PayloadKey.Should().BeNull("nothing identified this payload; the key degrades to the tuple");
+
+        // Same for a packaged one: Package stamps nothing when the message opts out.
+        var breaker2 = CreateBreaker();
+        for (var i = 0; i < Threshold; i++)
+            breaker2.ShouldDrop(Delivery(new StormableMessage(i)).Package()).Should().BeFalse();
+        breaker2.ShouldDrop(Delivery(new StormableMessage(Threshold)).Package()).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The payload component makes the key space unbounded in principle (one counter per thing the
+    /// hub ever saw), so the live set must track RECENT traffic, not all-time traffic. Crossing the
+    /// soft cap arms one inline sweep per window that drops counters idle beyond window+cooldown —
+    /// no timer, no background thread, no static state, and no effect on detection (an idle key is
+    /// by definition not storming).
+    /// </summary>
+    [Fact]
+    public void TrackedKeys_AreBounded_ByRecentTrafficNotAllTimeTraffic()
+    {
+        const int cap = 10;
+        var breaker = new MessageStormBreaker(NullLogger.Instance, new Address("host", "1"),
+            Threshold, Window, Cooldown, () => _now, TicksPerSecond, maxTrackedKeys: cap);
+
+        // A burst of one-shot keys — the shape that used to accumulate forever.
+        const int oneShotKeys = 500;
+        for (var i = 0; i < oneShotKeys; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage($"burst/node-{i}"))).Should().BeFalse();
+
+        breaker.TrackedKeyCount.Should().Be(oneShotKeys, "each distinct thing is counted on its own key");
+
+        // They go quiet. Past window+cooldown the next message arms the sweep and they are gone.
+        _now += (long)((Window.TotalSeconds + Cooldown.TotalSeconds) * TicksPerSecond) + 1;
+        breaker.ShouldDrop(Delivery(new KeyedMessage("later/node"))).Should().BeFalse();
+
+        breaker.TrackedKeyCount.Should().Be(1,
+            "counters idle past window+cooldown are swept, so the live set follows recent traffic");
+        breaker.TripCount.Should().Be(0, "sweeping idle keys must not look like — or mask — a storm");
     }
 
     [Fact]

--- a/test/MeshWeaver.Messaging.Hub.Test/MessageStormBreakerTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MessageStormBreakerTest.cs
@@ -282,6 +282,42 @@ public class MessageStormBreakerTest
         breaker.TripCount.Should().Be(0, "sweeping idle keys must not look like — or mask — a storm");
     }
 
+    /// <summary>
+    /// A key that TRIPPED and then went silent must be swept too. Exempting tripped counters would
+    /// break the bound outright — a one-off storm's key would live for the hub's lifetime — and it
+    /// buys nothing: "stale" means no message for a full window+cooldown, which an actively
+    /// storming key can never be (every message restamps its window) and which is already past the
+    /// cooldown, so dropping it is identical to the self-heal its next message would do anyway.
+    /// </summary>
+    [Fact]
+    public void TrackedKeys_Sweep_AlsoReleases_TrippedThenIdleKeys()
+    {
+        const int cap = 10;
+        var breaker = new MessageStormBreaker(NullLogger.Instance, new Address("host", "1"),
+            Threshold, Window, Cooldown, () => _now, TicksPerSecond, maxTrackedKeys: cap);
+
+        // Storm ONE key past the bar so its counter is left Tripped...
+        for (var i = 0; i <= Threshold; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage("looping/stream")));
+        breaker.TripCount.Should().Be(1);
+
+        // ...and push the live set over the cap with keys that then all go quiet.
+        for (var i = 0; i < 100; i++)
+            breaker.ShouldDrop(Delivery(new KeyedMessage($"burst/node-{i}")));
+        breaker.TrackedKeyCount.Should().Be(101);
+
+        // Everything goes silent past window+cooldown; the next message arms the sweep.
+        _now += (long)((Window.TotalSeconds + Cooldown.TotalSeconds) * TicksPerSecond) + 1;
+        breaker.ShouldDrop(Delivery(new KeyedMessage("later/node"))).Should().BeFalse();
+
+        breaker.TrackedKeyCount.Should().Be(1,
+            "the tripped-then-idle key is released like any other stale counter");
+
+        // And the formerly-storming key flows again — sweeping it is a self-heal, not an amnesty
+        // that hides a live storm (a still-storming key can never be stale in the first place).
+        breaker.ShouldDrop(Delivery(new KeyedMessage("looping/stream"))).Should().BeFalse();
+    }
+
     [Fact]
     public void LifecycleAndControlMessages_AreNeverDropped()
     {


### PR DESCRIPTION
Closes #1200

## The defect

`MessageStormBreaker` keys its per-second rate counters on `(Sender, Target, TypeName)` — **no
component identifying what the message is about**. Its own justifying comment claims real traffic
is "DIVERSE tuples". That is false wherever the mesh funnels traffic through a dispatcher: **one
sender talks to one target with one message type about MANY DIFFERENT THINGS.**

- Every sync stream an owner hub holds open to the shared mesh-node cache posts
  `DataChangedEvent` (→ `RawJson` once the router packages it) over that single tuple.
- A bulk importer sends one `CreateOrUpdateNodeRequest` per source node from one import hub to the
  one mesh hub.

Keyed on the routing tuple alone, a wide **legitimate** fan-out is arithmetically identical to one
thing looping. The guard therefore crosses its bar on ordinary bulk work and `ShouldDrop`
**discards real writes at ingestion** — imported content and progress-log lines silently missing.

**That is data loss, not mitigation.** The issue text credits the guard with "mitigating" the
storm and rates the impact "low"; it is backwards. The trip is the guard eating legitimate traffic,
and the reason nobody could tell is the same missing component: with no payload identity in the
key or the log line, "N things fanning out" and "one thing looping" produce an identical message.

**The issue's stated cause is refuted.** It blames router-identity miswiring (#1140). Its own log
disproves that: `sender=UWDeepfield/_Activity/import-…-f4dc71b1` is the import **attempt node's own
per-node hub** (the fresh-per-run node `StaticRepoImporter` logs progress to), not the router. The
router appears only as the hub that *packages and forwards* the frames — which is exactly why the
cache hub sees them as `type=RawJson`.

## The fix

The key gains a fourth component: the payload's own identity, resolved **without ever parsing a
payload on the ingestion path** (the breaker sees every inbound delivery, before the turn loop — a
per-message parse would be its own performance defect).

| Where the message is | Where the identity comes from | Cost |
|---|---|---|
| Typed, in-process | `IDiagnosticKeyed.DiagnosticKey` — an already-computed property | one interface check |
| `RawJson`, after a hub hop erased the type | envelope property stamped by `MessageDelivery.Package` | one property lookup, only for `RawJson` |
| Exposes no identity | `null` → key degrades to **exactly the old tuple** | — |

`IDiagnosticKeyed` already existed for the pending-callback diagnostic, for precisely this
"N distinct things vs one thing repeated" ambiguity — this makes it load-bearing. It is now
implemented by `StreamMessage` (`StreamId`, covering `DataChangedEvent`, `PatchDataChangeRequest`,
`UnsubscribeRequest`, `StreamErrorEvent`) and by the node-lifecycle verbs
`Create`/`CreateOrUpdate`/`Delete`/`Copy`/`Move` (the node path).

`Package()` is the one seam where the type is erased for a cross-hub hop, and it is already doing a
full `JsonSerializer.Serialize` — stamping the key there is free by comparison, and delivery
properties already survive both the in-process router hop and the gRPC/SignalR wire (the same
mechanism that carries `PostOptions.RequestId`).

**No band-aid**: threshold (2000), window (1 s) and cooldown (2 s) are untouched, no exemption
list, no widened bound. A genuine single-thing loop still trips exactly as before — and the `Error`
now names *which* stream/path was looping instead of only which two hubs were talking.

### Bounded key space

The payload component makes the key space unbounded in principle: the existing eviction only fires
when a key is *touched again* after an idle window, so a key seen once would live forever. Crossing
a soft cap of 10 000 live counters arms **one inline sweep per window** that drops counters idle
beyond window+cooldown. The live set then tracks *recent* traffic instead of everything the hub
ever saw — no timer, no background thread, no static state, and no effect on detection (a key idle
for seconds is by definition not storming).

## Tests

Deterministic, injected logical clock — no sleeps, no wall-clock races
(`MessageStormBreakerTest`):

1. `WideFanOut_OneTuple_ManyDistinctPayloadKeys_NeverTrips` — **the bug.** 40× the threshold through
   ONE tuple, each message about a different path → must not trip.
2. `RepeatedSamePayloadKey_StillTrips_AndNamesTheThing` — the guard is intact; the trip names the
   thing; and a fan-out running *alongside* the loop keeps flowing (the drop is scoped to the one
   storming key, not to everything sharing its sender/target/type).
3. `PackagedDelivery_KeepsPayloadIdentity_AcrossTheTypeErasure` — the same fan-out survives
   `Package()`; a packaged loop still trips, reported as `type=RawJson` with the payload named.
4. `NoPayloadIdentity_FallsBackToTheRoutingTuple_AndStillTrips` — the fallback is **fail-closed**.
5. `TrackedKeys_AreBounded_ByRecentTrafficNotAllTimeTraffic` — 500 one-shot keys are swept.

**Red-before proof** (payload component neutered, everything else identical):

```
Failed WideFanOut_OneTuple_ManyDistinctPayloadKeys_NeverTrips
  Expected value to be false because a write to a DISTINCT path is not a loop,
  however many of them one importer issues, but found True.
Failed RepeatedSamePayloadKey_StillTrips_AndNamesTheThing
  Expected "UWDeepfield/_Activity/import-f2bb979af363573d" …, but found <null>.
Failed PackagedDelivery_KeepsPayloadIdentity_AcrossTheTypeErasure
Failed TrackedKeys_AreBounded_ByRecentTrafficNotAllTimeTraffic
Failed: 4, Passed: 6
```

## Local verification (CI parity)

- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → **0 Errors, 0 Warnings**
  (re-run after merging current `main`).
- `MeshWeaver.Messaging.Hub.Test` → 191/191
- `MeshWeaver.Data.Test` → 311/311
- `MeshWeaver.Hosting.Monolith.Test` → 582 passed / 3 pre-existing skips
- `MeshWeaver.Documentation.Test` → 20/20

What's New entry included (`Category: Fix` — a user notices imported content going missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
