### PR TITLE
fix(query): the live change feed no longer bypasses row-level security (#1250)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-live-list-can-no-longer-flash-a-node-you-cannot-open.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-live-list-can-no-longer-flash-a-node-you-cannot-open.md
@@ -1,0 +1,28 @@
+---
+Name: A live list can no longer flash a node you cannot open
+Category: Fix
+Description: A live search or catalog list could briefly show a node the viewer has no permission to read — including its content — when someone else edited it, before dropping it again on the next update.
+Icon: Sparkle
+Order: -20260812
+---
+
+# A live list can no longer flash a node you cannot open
+
+A list that stays live — a search page, a catalog, a folder view — is built twice over: once when
+the page loads, from the full answer to your query, and then continuously, as changes come through.
+The load side has always applied your permissions, so a node you may not read simply is not in it.
+
+The live side did not. It admitted whatever had just been written under the area you were watching,
+checking only whether it matched your search words and filters — never whether you were allowed to
+see it. So when someone edited a node you have no access to, and that node sat under an area your
+list covered, it appeared in your list as a new row, carrying its name and its content. The next
+update took it back out again, because that frame was rebuilt from the permission-checked answer.
+A row you were never entitled to, visible for as long as nothing else changed.
+
+The live side now shows only what the permission-checked read returns, for every update, not just
+the first one. Nothing else about live lists changes: an edit to something you *can* see still
+arrives immediately.
+
+This affected portals backed by the in-memory, SQLite, or file-system stores. On PostgreSQL — which
+every hosted portal uses — the main content queries are served by a different, unaffected component,
+so the exposure there was limited to scoped queries over attached records.

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -858,10 +858,14 @@ public class MeshQuery : IMeshQueryCore
     ///
     /// <para>🚨 An <c>Added</c> for a path that is ALREADY live is NOT dropped — it flows through
     /// exactly like an <c>Updated</c>. Dropping it was the terminal dropped-update of issue #889:
-    /// two providers legitimately race the same write (the pedestrian
-    /// <c>StorageAdapterMeshQueryProvider</c> supplements its re-query with the change
-    /// notification's raw entity and usually emits FIRST; the per-schema PostgreSQL delegate
-    /// re-queries storage and emits the authoritative row a beat LATER — both as <c>Added</c>).
+    /// two providers legitimately race the same write and both announce it as <c>Added</c>, at
+    /// different times and with different content. (The #889 instance was the pedestrian
+    /// <c>StorageAdapterMeshQueryProvider</c> supplementing its re-query with the change
+    /// notification's raw entity and emitting FIRST, while the per-schema PostgreSQL delegate
+    /// re-queried storage and emitted the authoritative row a beat LATER. #1250 deleted that
+    /// supplement — the pedestrian now only ever emits what its own read returned — so that
+    /// particular race is retired, but the merge still fans in independent providers and the
+    /// contract below is what keeps their races safe.)
     /// The old dedup forwarded whichever arrived first and DISCARDED the second — discarding the
     /// authoritative content correction. When the raced write was the LAST write touching the
     /// query (PaywallRealGateShapeTests' buyer grant), no later change ever healed the snapshot:

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -208,9 +208,10 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                 var (matched, parsedQuery, _) = collected;
 
                 // Satellite paths and partition roots are not content-query results.
-                // 🚨 The rules live in IsExcludedFromResults — one predicate, documented there —
-                // precisely so the LIVE path (ProcessBatch's notification supplement) applies the
-                // same set. Duplicating them here is how the two drifted apart (#1193).
+                // 🚨 The rules live in IsExcludedFromResults — one predicate, documented there.
+                // This read is now the SOLE source of rows for both the Initial snapshot and every
+                // live delta (#1250 removed the live path's parallel admission of raw notification
+                // entities), so applying them here applies them everywhere.
                 IEnumerable<object> matchedNodes =
                     matched.Where(n => !IsExcludedFromResults(n, parsedQuery));
 
@@ -328,12 +329,12 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
     }
 
     /// <summary>
-    /// The result-set exclusions this provider applies to EVERY emission — the snapshot
-    /// (<see cref="RunQueryNodes"/>) and the live change feed
-    /// (<see cref="ProcessBatch{T}"/>'s notification supplement) alike.
+    /// The result-set exclusions this provider applies to EVERY emission. They live in
+    /// <see cref="RunQueryNodes"/> — the single read behind the Initial snapshot AND every live
+    /// delta (<see cref="ProcessBatch{T}"/> only diffs that read's output).
     ///
-    /// <para>🚨 <b>One predicate, both paths (#1193).</b> The snapshot used to own these rules
-    /// inline while the live path's write-lag supplement admitted any notified entity on
+    /// <para>🚨 <b>One predicate, one path (#1193, #1250).</b> The snapshot used to own these rules
+    /// inline while the live path ran a parallel admission of raw change-notification entities on
     /// <c>_evaluator.Matches</c> alone — and <c>Matches</c> is <c>true</c> for EVERY node when the
     /// query carries no filter and no free-text term (a bare <c>path:X scope:descendants</c>
     /// catalog listing is exactly that shape). So a write to a node the snapshot deliberately
@@ -345,7 +346,10 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
     /// writes: it landed inside a <c>path:{root} scope:descendants</c> subscription and turned
     /// <c>SearchResultStormTest</c>'s exact re-render count into a coin flip. The add-then-remove
     /// of an unchanged node is self-evidently wrong — nothing about it changed between the two
-    /// frames; only which code path judged it did.</para>
+    /// frames; only which code path judged it did. #1193 taught that admission to apply these
+    /// exclusions; #1250 deleted the admission outright, because the SAME shape also bypassed
+    /// row-level security (<c>Matches</c> performs no permission check) and covered no real
+    /// write lag.</para>
     ///
     /// <para><b>1. Satellite paths.</b> Match PG's table separation: a NON-satellite content query
     /// must not return satellite nodes. On PG these live in separate per-prefix tables (the
@@ -1324,13 +1328,46 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                         // subscribers attaching during the debounce gap saw the
                         // pre-write Replay(1) snapshot. Trade throughput (one
                         // RunQuery per change vs batched) for correctness.
+                        //
+                        // 🚨🚨 THE NOTIFICATION IS A TRIGGER, NEVER A RESULT ROW (#1250).
+                        // The notification's raw `Entity` is deliberately discarded: RunQuery is
+                        // the ONLY source of rows, so every emission — Initial and every live
+                        // delta alike — carries exactly what the (RLS-filtered, when this is the
+                        // secured IMeshQueryProvider surface) read returned.
+                        //
+                        // This used to "supplement" the re-query with `change.Entity` whenever
+                        // `_evaluator.Matches` accepted it, to cover a supposed write lag. It
+                        // could never do that, and it was a row-level-security BYPASS:
+                        //  • Matches() consults ONLY the query's filter and free-text term
+                        //    (QueryEvaluator.Matches) — no permission check of any kind. A write
+                        //    under the subscription's base path to a node the subscriber cannot
+                        //    read was injected into their result set as an `Added` carrying the
+                        //    node AND its Content, and nothing downstream re-filtered it
+                        //    (MeshQuery.TryFilterDuplicateLiveChange forwards duplicate Addeds by
+                        //    design). The next re-query took it back out as `Removed` — a flicker
+                        //    of data the caller was never entitled to.
+                        //  • There was no write lag to cover. EVERY adapter that populates
+                        //    `Entity` commits to the store BEFORE publishing
+                        //    (InMemoryStorageAdapter.Write, SqliteStorageAdapter.Write,
+                        //    PostgreSqlStorageAdapter.Write/PublishChanges,
+                        //    SnowflakeStorageAdapter.Write; FileSystemChangeWatcher notifies with
+                        //    the node it just READ back). Conversely every source whose
+                        //    notification can outrun row visibility — PG's LISTEN/NOTIFY
+                        //    (PostgreSqlChangeListener), the Cosmos change feed, the Snowflake
+                        //    poller — passes `Entity = null`, so the supplement could not fire
+                        //    for them even in principle.
+                        //  • Whenever the supplement DID change the outcome, the re-query was the
+                        //    one that was right: the row it re-added was one the read had
+                        //    excluded by RLS, by satellite-table routing (#1193), by a path
+                        //    filter, or past the load cap. It also raced the per-schema PG
+                        //    delegate over the same write, which is the provider race #889
+                        //    documents in MeshQuery.TryFilterDuplicateLiveChange.
                         disposables.Add(
                             changeBuffer
-                                .Select(n => RunQuery()
-                                    .Select(newResults => (batch: (IList<DataChangeNotification>)new[] { n }, newResults)))
+                                .Select(_ => RunQuery())
                                 .Concat()
                                 .Subscribe(
-                                    t => ProcessBatch(t.batch, t.newResults, currentItems, parsedQuery, observer),
+                                    newResults => ProcessBatch(newResults, currentItems, parsedQuery, observer),
                                     ex => observer.OnError(ex)));
 
                         lock (earlyLock)
@@ -1372,8 +1409,13 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
         });
     }
 
+    /// <summary>
+    /// Diffs one re-query snapshot against the live result set and emits the Added / Updated /
+    /// Removed deltas. <b>The re-query is the ONLY source of result rows</b> — see the note on the
+    /// live pipeline in <see cref="ObserveQueryInternal{T}"/> for why the change notification's raw
+    /// entity is deliberately not admitted here (#1250).
+    /// </summary>
     private void ProcessBatch<T>(
-        IList<DataChangeNotification> batch,
         List<(string? Path, T Item)> newResults,
         Dictionary<string, T> currentItems,
         ParsedQuery parsedQuery,
@@ -1383,31 +1425,6 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
         foreach (var (path, item) in newResults)
             if (!string.IsNullOrEmpty(path))
                 newItems[path] = item;
-
-        var changesByPath = batch
-            .GroupBy(c => c.Path, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
-
-        // Supplement re-query results with entities from notifications
-        // that haven't appeared in the store yet (write lag).
-        //
-        // 🚨 An admitted entity must pass the SAME result-set exclusions the re-query applies
-        // (IsExcludedFromResults) — `_evaluator.Matches` is not enough. Matches() consults only
-        // the query's filter and free-text term, so for a bare `path:X scope:descendants`
-        // listing (neither present) it returns true for EVERY notified node, satellites and
-        // partition roots included. Admitting one produced a phantom structural `Added` that
-        // the next re-query immediately took back out as `Removed` — see IsExcludedFromResults.
-        // A Deleted notification still removes unconditionally: dropping a path that is gone can
-        // never be wrong, and an excluded path was never in the set to begin with.
-        foreach (var (path, change) in changesByPath)
-        {
-            if (change.Entity is not T directMatch || !_evaluator.Matches(directMatch, parsedQuery))
-                continue;
-            if (change.Kind == DataChangeKind.Deleted)
-                newItems.Remove(path);
-            else if (!IsExcludedFromResults(directMatch, parsedQuery))
-                newItems[path] = directMatch;
-        }
 
         var addedItems = new List<T>();
         var updatedItems = new List<T>();

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -346,7 +346,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
     /// writes: it landed inside a <c>path:{root} scope:descendants</c> subscription and turned
     /// <c>SearchResultStormTest</c>'s exact re-render count into a coin flip. The add-then-remove
     /// of an unchanged node is self-evidently wrong — nothing about it changed between the two
-    /// frames; only which code path judged it did. #1193 taught that admission to apply these
+    /// frames; only which code path judged it did. #1193 made that admission apply these
     /// exclusions; #1250 deleted the admission outright, because the SAME shape also bypassed
     /// row-level security (<c>Matches</c> performs no permission check) and covered no real
     /// write lag.</para>

--- a/test/MeshWeaver.Hosting.Monolith.Test/SearchResultStormTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SearchResultStormTest.cs
@@ -213,10 +213,11 @@ public class SearchResultStormTest(ITestOutputHelper output) : MonolithMeshTestB
     /// as <c>Removed</c> — a phantom row that flashes into a live search grid, and two re-renders of
     /// the whole result list that nothing in the result set justifies.</para>
     ///
-    /// <para>#1193 taught that supplement the snapshot's exclusions; #1250 deleted it outright once
-    /// the same shape turned out to bypass row-level security as well (<c>Matches</c> performs no
-    /// permission check) and to cover no real write lag. The invariant this test pins is unchanged —
-    /// it is now held by construction, because the re-query is the live path's only source of rows.</para>
+    /// <para>#1193 made that supplement apply the snapshot's exclusions; #1250 deleted the
+    /// supplement outright, once the same shape turned out to bypass row-level security as well
+    /// (<c>Matches</c> performs no permission check) and to cover no real write lag. The invariant
+    /// this test pins is unchanged — it is now held by construction, because the re-query is the
+    /// live path's only source of rows.</para>
     ///
     /// <para>The storm test hit it because a <c>MonotonicWriteGuard</c> resolution writes a
     /// <c>{path}/_Activity/write-conflict-{n}</c> satellite, and whether the 25-update storm produced

--- a/test/MeshWeaver.Hosting.Monolith.Test/SearchResultStormTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SearchResultStormTest.cs
@@ -213,6 +213,11 @@ public class SearchResultStormTest(ITestOutputHelper output) : MonolithMeshTestB
     /// as <c>Removed</c> — a phantom row that flashes into a live search grid, and two re-renders of
     /// the whole result list that nothing in the result set justifies.</para>
     ///
+    /// <para>#1193 taught that supplement the snapshot's exclusions; #1250 deleted it outright once
+    /// the same shape turned out to bypass row-level security as well (<c>Matches</c> performs no
+    /// permission check) and to cover no real write lag. The invariant this test pins is unchanged —
+    /// it is now held by construction, because the re-query is the live path's only source of rows.</para>
+    ///
     /// <para>The storm test hit it because a <c>MonotonicWriteGuard</c> resolution writes a
     /// <c>{path}/_Activity/write-conflict-{n}</c> satellite, and whether the 25-update storm produced
     /// a conflict at all was timing. This test does not race anything: it WRITES the satellite

--- a/test/MeshWeaver.Security.Test/LiveQueryRowLevelSecurityTest.cs
+++ b/test/MeshWeaver.Security.Test/LiveQueryRowLevelSecurityTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Row-level security must hold on the LIVE leg of a secure query, not just on its
+/// Initial snapshot (issue #1250).
+///
+/// <para>A live <c>IMeshService.Query&lt;MeshNode&gt;</c> subscription is served by
+/// <c>StorageAdapterMeshQueryProvider.ObserveQueryInternal</c>: the Initial payload comes from an
+/// RLS-filtered read, and every later frame comes from a re-query on the same filtered read. The
+/// re-query used to be SUPPLEMENTED with the raw entity carried on the storage adapter's change
+/// notification, admitted on <c>QueryEvaluator.Matches</c> (filter + free text) alone — a predicate
+/// that performs no permission check whatsoever. A write under the subscription's base path to a
+/// node the subscriber cannot read was therefore emitted to them as an <c>Added</c>, carrying the
+/// node AND its <c>Content</c>.</para>
+///
+/// <para>The subscriber picks the base path freely — the query need not be over anything they can
+/// read, because an RLS-filtered Initial over an unreadable path simply comes back empty. So the
+/// exposure needed nothing but a live subscription plus a same-process write.</para>
+///
+/// <para>This test pins the invariant end-to-end with real access control: every frame a secure
+/// subscription emits — Initial, Added, Updated, Removed — contains only nodes the subscriber is
+/// entitled to read, and the legitimate live delta still arrives.</para>
+/// </summary>
+public class LiveQueryRowLevelSecurityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Subscriber = "eve";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
+
+    protected override async Task SetupAccessRightsAsync()
+    {
+        // Grant the test runner Admin on TestPartition so the System-impersonated seed writes
+        // land deterministically (same rationale as SyncedQueryPerUserIsolationTest: TestData is
+        // a statically seeded partition, so routing the first write through a non-System identity
+        // races PartitionWriteGuard's cold-partition provisioning).
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(
+                    AssignmentNodeFactory.UserRole(
+                        Mesh.Address.ToFullString(), "Admin", TestPartition))
+                .Should().Emit();
+        }
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task LiveSecureQuery_WriteToADeniedSibling_IsNeverEmittedToTheSubscriber()
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var ns = $"{TestPartition}/live_rls_{Guid.NewGuid().AsString()}";
+        var readablePath = $"{ns}/readable";
+        var deniedPath = $"{ns}/denied";
+        const string secretText = "TOP-SECRET-PAYLOAD-1250";
+
+        // Seed: one node the subscriber may read (explicit Editor grant on that node only),
+        // and NO grant anywhere else under the namespace.
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode("readable", ns)
+            {
+                Name = "v1",
+                NodeType = "Markdown",
+                Content = MarkdownContent.Parse("visible", "", readablePath)
+            }).Should().Emit();
+
+            await meshService.CreateNode(
+                    AssignmentNodeFactory.UserRole(Subscriber, "Editor", readablePath))
+                .Should().Emit();
+        }
+
+        await Mesh.GetEffectivePermissions(readablePath, Subscriber)
+            .Should().Match(p => p.HasFlag(Permission.Read));
+        await Mesh.GetEffectivePermissions(deniedPath, Subscriber)
+            .Should().Match(p => p == Permission.None);
+
+        // The live SECURE subscription, taken as the subscriber. UserId is stamped explicitly so
+        // the provider's identity resolution cannot pick up the test runner's ambient admin.
+        var request = MeshQueryRequest.FromQuery($"namespace:{ns}") with { UserId = Subscriber };
+        var seen = new ConcurrentQueue<QueryResultChange<MeshNode>>();
+        var hot = meshService.Query<MeshNode>(request).Replay();
+        using var collector = hot.Subscribe(seen.Enqueue);
+        using var conn = hot.Connect();
+
+        var initial = await hot.Should().Within(20.Seconds())
+            .Match(c => c.ChangeType == QueryChangeType.Initial);
+        initial.Items.Select(n => n.Path).Should().Contain(readablePath,
+            "the subscriber has an explicit Read grant on this node");
+
+        // 1. Write the node the subscriber may NOT read. On the pre-#1250 code this notification's
+        //    raw entity was injected straight into the live result set as an Added.
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode("denied", ns)
+            {
+                Name = "Denied",
+                NodeType = "Markdown",
+                Content = MarkdownContent.Parse(secretText, "", deniedPath)
+            }).Should().Emit();
+        }
+
+        // 2. Then touch the node the subscriber MAY read. The live pipeline is Concat-serialised
+        //    per notification, so the denied write's frame is fully processed BEFORE this one's —
+        //    seeing "v2" is a deterministic barrier, not a sleep.
+        using (accessService.ImpersonateAsSystem())
+        {
+            await Mesh.GetMeshNodeStream(readablePath)
+                .Update(n => n with { Name = "v2" })
+                .Should().Within(20.Seconds()).Emit();
+        }
+
+        // The legitimate live delta must still arrive — the fix must not go the other way and
+        // silence the live leg.
+        await hot.Should().Within(20.Seconds())
+            .Match(c => c.ChangeType is QueryChangeType.Added or QueryChangeType.Updated
+                        && c.Items.Any(n => n.Path == readablePath && n.Name == "v2"));
+
+        // The security invariant: no frame — of any change type — ever carried the denied node.
+        var leaked = seen.SelectMany(c => c.Items.Select(n => (c.ChangeType, Node: n)))
+            .Where(x => x.Node.Path == deniedPath)
+            .ToArray();
+
+        leaked.Should().BeEmpty(
+            "a live secure subscription must never emit a node the subscriber cannot read; " +
+            "leaked as: " + string.Join(", ", leaked.Select(x => x.ChangeType)));
+
+        seen.SelectMany(c => c.Items)
+            .Select(n => (n.Content as MarkdownContent)?.Content)
+            .Should().NotContain(secretText,
+                "the denied node's CONTENT must never reach an unentitled subscriber");
+    }
+}


### PR DESCRIPTION
Closes #1250.

## The bypass

`StorageAdapterMeshQueryProvider`'s live pipeline re-queries storage on every change
notification, then **supplemented** that re-query with the notification's raw `Entity`,
admitting it on `QueryEvaluator.Matches` alone. `Matches` consults only the query's filter
and free-text term (`QueryEvaluator.cs:32-47`) — **no permission check of any kind**.

The snapshot leg is RLS-filtered (`CollectMatched` → `ValidateRead`). The live leg was not.
So on the **secure** surface — `IMeshQueryProvider.Query`, which `MeshQuery.Query<T>` and
therefore `IMeshService.Query<T>` / `workspace.GetQuery` route to — a write under a live
subscription's base path to a node the subscriber cannot read was emitted to them as an
`Added` **carrying the node and its `Content`**.

Nothing downstream re-filtered it: `MeshQuery.TryFilterDuplicateLiveChange` forwards duplicate
`Added`s by design (#889).

**The subscriber picks the base path freely.** The query need not be over anything they can
read — an RLS-filtered Initial over an unreadable path simply comes back empty. The exposure
needed nothing but a live subscription plus a same-process write under it.

**It was not necessarily transient.** The injected node is written into `currentItems`, so it
stays in the caller's result set — and on screen — until the next in-scope change emits a
`Removed`. On a quiet subtree that is indefinite.

## Who was exposed

`AddSingleton<IMeshQueryProvider>` (not `TryAdd`) — this provider is always in the merge,
alongside any native one. Exposure is the intersection of "the adapter populates `Entity`"
and "this provider serves the query shape":

| Backend | `Entity` on the feed | Defer | Exposure |
|---|---|---|---|
| **In-memory** | yes (`InMemoryStorageAdapter:131`) | none | **every live secure query** |
| **SQLite** | yes (`SqliteStorageAdapter:161`) | none | **every live secure query** |
| **File system** | yes (`FileSystemChangeWatcher:201-202`) | none | **every live secure query** |
| **PostgreSQL** | yes, in-process (`:463`, `:579`) | `DeferToNativeProvider = true` | **scoped SATELLITE reads only** — `_Access`, `_Thread`, `_Activity`, `_Comment`, satellite `nodeType:` filters, `source:activity|accessed` (`DefersToNativeProvider` returns false for exactly those) |
| **Snowflake** | yes (`:485`) | `= true` | same satellite residue as PG |
| **Cosmos** | never (`Updated(path, null)`) | n/a | not reachable via this path |

So hosted PostgreSQL portals were **not** clear of this: the shapes the pedestrian still
serves there are the access grants, threads, activities and comments — a live
`path:{space}/_Thread scope:children` or a thread-list subscription would flash a satellite
the viewer has no grant on. Unscoped and scoped-primary content queries on PG go to
`PostgreSqlPartitionedMeshQuery`, which has no supplement.

## Which fix, and why

**Branch taken: delete the supplement.** The issue left open whether to lift `ProcessBatch`
into the reactive chain so `ValidateRead` applies. That is unnecessary — the supplement is
dead code for its stated purpose. Verified across every adapter and change source:

- **Every source that populates `Entity` commits to the store BEFORE publishing.**
  `InMemoryStorageAdapter.Write` (`AddOrUpdate` → `OnNext`), `SqliteStorageAdapter.Write`
  (`ExecuteNonQuery` → `OnNext`), `PostgreSqlStorageAdapter.Write` (`await WriteAsyncCore`
  → `OnNext`) and `PublishChanges` (post-commit), `SnowflakeStorageAdapter.Write` (same
  shape). `FileSystemChangeWatcher` is the strongest case: it notifies with the node it just
  **read back out of the adapter**. In every one of them the re-query that the notification
  triggers is guaranteed to see the row.
- **Every source whose notification can outrun row visibility passes `Entity = null`** —
  `PostgreSqlChangeListener:130` (the LISTEN/NOTIFY path the supplement's own comment cited as
  its justification), `CosmosChangeFeedProcessor:149`, `SnowflakeChangeFeedPoller:177-179`, and
  the `Deleted` legs of the SQL adapters. The supplement could not fire for them in principle.
- **The `Deleted` branch was already non-load-bearing.** Only the in-memory adapter carries a
  tombstone entity; PG/SQLite/Snowflake deletes pass `null`, so delete propagation has always
  come from the re-query alone on every real backend.
- **Whenever the supplement DID change the outcome, the re-query was the one that was right.**
  The row it re-added had been excluded by RLS, by satellite-table routing (#1193), by a path
  filter, or clipped past the load cap. It could also install an *older* notification entity
  over a newer re-queried row.

The notification is now strictly a **trigger**: `RunQuery` is the only source of rows, so
every frame — Initial and every live delta — carries exactly what the (RLS-filtered, on the
secured surface) read returned. The `Concat` serialisation and ordering are untouched; only
the tuple carrying the notification alongside the snapshot is gone.

This also **retires the #889 provider race** documented at
`MeshQuery.TryFilterDuplicateLiveChange`: the pedestrian no longer emits a raw-entity `Added`
ahead of the per-schema PostgreSQL delegate's authoritative row. The forward-duplicates
contract stays (independent providers can still race), with the doc updated to say so.

## Test

`test/MeshWeaver.Security.Test/LiveQueryRowLevelSecurityTest.cs` — `MonolithMeshTestBase`,
real access control, no mocking. A subscriber holds an Editor grant on **one child only**;
they open a live **secure** subscription over the parent namespace; a denied sibling is then
written, followed by a touch of the readable node.

- **Red on `main`:** `Expected collection to be empty … leaked as: Added, Removed, but found
  2 item(s)` — exactly the add-then-remove flicker the issue predicts.
- **Green with the fix:** no frame of any change type carries the denied node, and its content
  string never appears in any emission.
- The positive half is asserted too: the live `Updated` for the readable node still arrives.
- No sleep. The denied write is ordered before the readable one and the pipeline is
  `Concat`-serialised, so observing the readable node's `v2` frame is a deterministic barrier
  proving the denied node's frame has already been fully processed. No "exactly N events"
  assertion — the check filters on emission shape.

## Verification

Release + `-warnaserror`, per project: `MeshWeaver.Hosting`, `MeshWeaver.Documentation`,
`MeshWeaver.Security.Test`, `MeshWeaver.Hosting.Monolith.Test` — all `0 Warning(s) 0 Error(s)`.

| Suite | Result |
|---|---|
| `MeshWeaver.Security.Test` (full) | 399 / 399 |
| `MeshWeaver.Query.Test` | 388 / 388 |
| `MeshWeaver.Persistence.Test` | 617 / 617 |
| `MeshWeaver.Hosting.Test` | 145 / 145 |
| `MeshWeaver.Documentation.Test` (WhatsNew + link integrity) | 2 / 2 |
| Monolith `SearchResultStormTest` + `ObserveQueryFreshnessTest` | 11 / 11 |

`SearchResultStormTest.CatalogSubscription_SatelliteWriteUnderTheRoot_NeverEntersTheResultSet`
(#1193's regression pin) still passes — the invariant it guards is now held by construction.

What's New: `Category: Fix` —
`2026-08-12-a-live-list-can-no-longer-flash-a-node-you-cannot-open.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
