### PR TITLE
fix: an unowned AiSettings seed outlived its reader and stranded a create

### DIFF
--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -346,22 +346,59 @@ public static class AiSettingsNodeType
         IWorkspace workspace, IMessageHub hub, IServiceProvider services, string user)
     {
         var defaults = BuildDefaults(services);
-        EnsureExists(hub, services, user);
-        return workspace
+        var live = workspace
             .GetQuery($"{NodeType}|{user}", $"path:{PathFor(user)} nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Select(nodes => Effective(
                 nodes.FirstOrDefault(n => string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase)),
                 defaults, hub.JsonSerializerOptions))
             .StartWith(defaults)
             .DistinctUntilChanged();
+
+        // 🚨 The create-on-absent is MERGED INTO THIS STREAM, so its lifetime is the
+        // consumer's subscription — it starts on Subscribe (not at composition time) and is
+        // DISPOSED when the consumer unsubscribes.
+        //
+        // It used to be a bare `EnsureExists(hub, services, user);` statement: a void method
+        // that subscribed its own chain. Nobody owned that subscription, so the create could
+        // still be in flight — or start — after the last reader had gone away, and on a hub
+        // that was already tearing down it stranded a CreateNodeRequest that nothing would
+        // ever answer. That is what reddened
+        // MeshWeaver.AI.Test.SkillAutocompleteTest.Autocomplete_ListsBuiltInSkills_FromCatalog
+        // on CI: the test body passed, then teardown's quiesce guard reported two pending
+        // CreateNodeRequests for Roland/_Memex/AiSettings — the outer seed plus the partition
+        // bootstrap's nested root create, the latter deferred behind a DataContextInit gate
+        // that shutdown never reopens. Owned by the subscription, both go away with it.
+        //
+        // Errors stay contained exactly as before (log + swallow) so a failed seed can never
+        // break the settings read that consumers actually subscribe for.
+        var seed = EnsureExists(hub, services, user)
+            .Select(_ => defaults)
+            .IgnoreElements()
+            .Catch<AiSettings, Exception>(ex =>
+            {
+                services.GetService<ILoggerFactory>()
+                    ?.CreateLogger(typeof(AiSettingsNodeType))
+                    .LogWarning(ex, "EnsureExists: AiSettings create-on-absent failed for {Path}", PathFor(user));
+                return Observable.Empty<AiSettings>();
+            });
+
+        return live.Merge(seed);
     }
 
-    /// <summary>Create-on-absent (with defaults); existing node untouched.</summary>
-    public static void EnsureExists(IMessageHub hub, IServiceProvider services, string user)
+    /// <summary>
+    /// Create-on-absent (with defaults); existing node untouched.
+    ///
+    /// <para>COLD — the create runs on Subscribe and is cancelled on unsubscribe, so the
+    /// caller owns its lifetime. Never re-introduce a self-subscribing <c>void</c> variant:
+    /// an unowned write outlives its reader and can strand a request on a hub that is
+    /// already shutting down. Mirrors <c>NotificationSettingsNodeType.EnsureExists</c>.</para>
+    /// </summary>
+    public static IObservable<System.Reactive.Unit> EnsureExists(
+        IMessageHub hub, IServiceProvider services, string user)
     {
         var meshService = services.GetService<IMeshService>();
         if (meshService is null)
-            return;
+            return Observable.Empty<System.Reactive.Unit>();
         var path = PathFor(user);
         // 🚨 Create-on-absent must NEVER point-read/patch the node via
         // GetMeshNodeStream(path).Update. On an ABSENT node that opens a cross-hub
@@ -374,7 +411,7 @@ public static class AiSettingsNodeType
         // only when genuinely absent through the node-lifecycle CreateNode (create-only:
         // it does not clobber an existing customised node). See
         // feedback_optional_node_query_not_access / Doc/Architecture/AsynchronousCalls.md.
-        hub.GetWorkspace()
+        return hub.GetWorkspace()
             .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType} select:path,id,name,nodeType,content")
             .Take(1)
             .Where(nodes => !nodes.Any(n =>
@@ -386,11 +423,7 @@ public static class AiSettingsNodeType
                     Name = "AI Settings",
                     Content = BuildDefaults(services)
                 }))
-            .Subscribe(
-                _ => { },
-                ex => services.GetService<ILoggerFactory>()
-                    ?.CreateLogger(typeof(AiSettingsNodeType))
-                    .LogWarning(ex, "EnsureExists: AiSettings create-on-absent failed for {Path}", path));
+            .Select(_ => System.Reactive.Unit.Default);
     }
 
     /// <summary>


### PR DESCRIPTION
## Symptom

`MeshWeaver.AI.Test.SkillAutocompleteTest.Autocomplete_ListsBuiltInSkills_FromCatalog` — **3 failures on `main` in one morning** (runs `31569022680`, `31574636901`, `31577766913`), the most frequent single contributor to the current intermittent-red cluster.

It is **not an assertion failure**. The test body passes (start `07:45:18.862`, end `07:45:19.083`); teardown then throws:

```
System.InvalidOperationException : SkillAutocompleteTest left Observe subscriptions pending
past the Quiescing budget. Pending callbacks at dispose:
Hub mesh/…: 2 pending callback(s) after 0.50s:
  cb1=CreateNodeRequest(690ms), cb2=CreateNodeRequest(171ms)
  cb1: … CREATE_CHAIN_SUBSCRIBED path=Roland/_Memex/AiSettings
       → BOOTSTRAP_PERM_AWAIT partition=Roland user=system-security (+189ms)
       → BOOTSTRAP_PERM_VERDICT authorized=True (+512ms)   ⇒ no reply, ever
  cb2: … RECEIVED runLevel=Quiescing → DEFERRED gates=[DataContextInit]
```

## Mechanism

`AiSettingsNodeType.Observe` opened with a bare statement — `EnsureExists(hub, services, user);` — and `EnsureExists` was `void` and **subscribed its own chain**. The create-on-absent write had no owner, so:

- it fired at **composition** time (building the observable sufficed; nobody had to subscribe), and
- **nothing could cancel it**, so it could still be in flight — or start — after the last reader was gone, including on a hub already tearing down.

`cb1` is that seed. The test mesh has no `Roland` partition root, so `EnsurePartitionBootstrap` heals it, and the heal issues `cb2`, a **nested** root create. By then the mesh is Quiescing, so `cb2` parks behind `DataContextInit` — a gate shutdown never reopens. `cb1`'s chain therefore neither emits, faults, nor completes, no response is posted, the 500 ms quiesce budget expires, and the guard fails the class.

On a loaded CI runner the 512 ms permission fold **alone** overruns the 500 ms budget — which is exactly why this reproduces there and not locally.

## Fix

The seed is **merged into the stream it serves**, so its lifetime is the consumer's subscription: it starts on `Subscribe` (not at composition) and is disposed when the consumer unsubscribes. `EnsureExists` now returns a cold `IObservable<Unit>` and no longer self-subscribes — matching its sibling `NotificationSettingsNodeType.EnsureExists`, which already had this shape.

Error handling is unchanged (log + swallow), so a failed seed still cannot break the settings read that consumers actually subscribe for.

## Not papered over

The trace also exposes two deeper holes, filed as #1270 — neither is reachable from here once the seed cannot outlive its reader:

1. `DataContext.OpenInitializationGate` returns **without opening the gate** when the hub is shutting down, stranding anything already deferred behind it.
2. The nested creates in `EnsurePartitionBootstrap` ride an unbounded `meshService.CreateNode`; the advertised `MeshOperationOptions.Timeout` is dead code (no `.Timeout(` anywhere in `MeshService.cs`).

## Verification

- `dotnet build src/MeshWeaver.AI -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `SkillAutocompleteTest` green after the change (`Total: 1, Failed: 0`)
- Full `MeshWeaver.AI.Test` assembly green

No What's New entry: the user-visible behaviour of the settings read is unchanged — this fixes a teardown-scoped leak in how the seed's lifetime is owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
