### PR TITLE
test: two flakes that asserted before their real condition was established

### DIFF
--- a/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
+++ b/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
@@ -1272,10 +1272,23 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             address, reference);
 
+        // 🚨 `**Area not found**` is a TRANSIENT frame, never a terminal verdict — do not
+        // latch it. A global `WithRenderer(_ => true, RenderMenus)` runs on every hub, so
+        // `applicable.Count` is always >= 1 and LayoutDefinition emits its not-found
+        // placeholder SYNCHRONOUSLY for an area whose real renderer has not registered yet
+        // (the instance hub re-registers its layout after a cold compile / activation).
+        // `x is not null` accepts that placeholder, so on a loaded CI runner the first frame
+        // won this race and the test read the placeholder as the answer — which is how
+        // EuropeRe_AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution went red on CI
+        // while passing on every local run. Wait for the REAL condition (a frame that is not
+        // the placeholder) instead of the first non-null one; the existing timeout still
+        // bounds a renderer that genuinely never appears.
+        // Same lesson already recorded in tools/MeshWeaver.PluginTester/AreaProbe.cs.
         var control = await stream
             .GetControlStream(reference.Area!)
             .Should().Within(Math.Max(timeoutSeconds, ActivationBudgetSeconds).Seconds())
-            .Match(x => x is not null, $"{areaName} should render at {addressPath}");
+            .Match(x => x is not null && !IsAreaNotFound(x),
+                $"{areaName} should render at {addressPath} (not the 'Area not found' placeholder)");
 
         if (unwrap)
         {
@@ -1294,7 +1307,8 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
                 control = await stream
                     .GetControlStream(childKey)
                     .Should().Within(timeoutSeconds.Seconds())
-                    .Match(x => x is not null && (!waitForData || HasNonTrivialData(x)));
+                    .Match(x => x is not null && !IsAreaNotFound(x)
+                                && (!waitForData || HasNonTrivialData(x)));
                 Output.WriteLine($"  Ã¢â€ â€™ {control?.GetType().Name}");
             }
         }
@@ -1308,6 +1322,21 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
 
         return control;
     }
+
+    /// <summary>
+    /// True for the framework's <c>**Area not found**</c> placeholder
+    /// (<c>LayoutDefinition.BuildNotFoundControl</c>).
+    ///
+    /// <para>🚨 This frame is TRANSIENT, not a verdict. Every hub carries a global
+    /// <c>WithRenderer(_ => true, RenderMenus)</c>, so the composed stream always has an
+    /// applicable renderer and LayoutDefinition emits the placeholder immediately for an area
+    /// whose real renderer has not registered yet. Any wait of the shape
+    /// <c>Match(x => x is not null)</c> can therefore latch it on a loaded runner — the whole
+    /// reason this helper exists. Treat it as "keep waiting", never as the rendered control.</para>
+    /// </summary>
+    private static bool IsAreaNotFound(UiControl? control)
+        => control is MarkdownControl md
+           && (md.Markdown?.ToString() ?? "").Contains("**Area not found**", StringComparison.Ordinal);
 
     /// <summary>
     /// Checks if a control has meaningful data (not all zeros).

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -403,6 +403,23 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
                     }
                 })
             .Should().Within(30.Seconds()).Emit();
+
+        // 🚨 The helper write is only ACKED at this point — that ack says the owner accepted the
+        // patch, NOT that the edit has reached the shared `nodetype-sources:{tornPath}` query the
+        // COMPILE reads. Triggering the release before it has makes the compile consume the
+        // PRE-EDIT helper (Answer() still present): Roslyn succeeds, the type settles Ok, and the
+        // watcher stamps LastReleaseRequestHandledAt — so the trigger is spent and nothing ever
+        // recompiles. The wait below then burns its full 120 s against a type that is permanently
+        // Ok, which is exactly this test's CI failure: a TimeoutException at the tornFailure wait
+        // after 120 s of total silence (no compile of TornType logged at all).
+        //
+        // Gate on the REAL condition — IsDirty is derived from CurrentSourceVersions, which
+        // InstallSourcesWatcher folds from the SAME shared query the compile reads. Once it is
+        // true, that query cannot hand the compile the pre-edit source. Canonical pattern:
+        // CodeEditRecompileTest ("Observe the NodeType getting DIRTY from the source change
+        // BEFORE triggering the release").
+        await WhenDefinition(tornPath, d => d.IsDirty, TimeSpan.FromSeconds(30));
+
         await workspace.GetMeshNodeStream(tornPath).Update(curr =>
             {
                 if (curr?.Content is not NodeTypeDefinition def) return curr!;


### PR DESCRIPTION
Two **independent** races from the current main-red cluster. They are not one bug in two places — they are grouped because both are test-side synchronisation gaps with no production component, and both are fixed the same way: **wait on the real condition instead of on whatever arrived first.**

## 1. `FutuReAnalysisTest` latched a transient `**Area not found**` frame

`EuropeRe_AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution` (run `31573558342`).

Every hub carries a global `WithRenderer(_ => true, RenderMenus)`, so `LayoutDefinition` **always** has an applicable renderer and emits its `**Area not found**` placeholder *synchronously* for an area whose real renderer has not registered yet (the instance hub re-registers its layout after activation / a cold compile). `GetControl` waited with:

```csharp
.Match(x => x is not null)
```

— which the placeholder satisfies. On a loaded runner the placeholder won the race and the test read it as the answer. The reported failure was `Expected "**Area not found**"`, accompanied by a burst of `No node found at 'Admin/Menu/{Default,Node,Mesh}'` — that part is **unrelated background noise**; those nodes are deliberately never seeded (`MenuPresentationOverlay`: *"There is deliberately NO seeded catalog"*).

Worth flagging how invisible this was: on the **healthy** path `KeyMetrics` renders a `StackControl`, so the test's `if (control is MarkdownControl md)` body — the only place it inspects content — is dead code. **That assertion ran only when the placeholder had been latched.**

**Fix:** a new `IsAreaNotFound` helper, applied at the top-level wait and in the unwrap loop. This *strengthens* the wait; the existing timeout still bounds a renderer that genuinely never appears. Same lesson already recorded in `tools/MeshWeaver.PluginTester/AreaProbe.cs`.

## 2. `DynamicTypePreWarmerTest` triggered a release against stale sources

`RegressedType_ThatRebuildsAfterTheContentConverges_IsRetracted_ButARealBreakStillGates` (run `31572467193`): `TimeoutException` after 120 s, with **no compile of TornType logged at all**.

The test rewrites the helper source and then *immediately* flips `RequestedReleaseAt`. But `.Emit()` on a cross-hub write returns on the owner's **ack** — it does not mean the edit has reached the shared `nodetype-sources:{tornPath}` query that the **compile** reads. So the compile can consume the pre-edit helper (`Answer()` still present) → Roslyn succeeds → the type settles `Ok` → the watcher stamps `LastReleaseRequestHandledAt`, spending the trigger → **nothing ever recompiles**. The 120 s wait for `Error` then expires against a permanently-`Ok` type.

That matches the signature exactly: total silence for 120 s (compile *success* is logged at Information, which the CI capture drops).

Ruled out along the way:
- the park registry is **exact-path keyed**, so parking `StaysBroken` cannot suppress `TornType`;
- a release trigger landing mid-compile is **held, not dropped** (#185 moved the high-water advance to the commit path).

**Fix:** gate on `IsDirty` before triggering. `IsDirty` derives from `CurrentSourceVersions`, which `InstallSourcesWatcher` folds from the *same shared query the compile reads* — once true, that query cannot hand the compile the pre-edit source. This is the repo's canonical pattern, lifted from `CodeEditRecompileTest`.

## No band-aids

Neither fix widens a timeout, adds a sleep, adds a retry, or weakens an assertion. Both replace "first thing that showed up" with the actual condition.

## Verification

- `DynamicTypePreWarmerTest` — **10/10 green**, 37 s (the CI failure was a 120.9 s timeout)
- `FutuReAnalysisTest.EuropeRe_AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution` — green
- `dotnet build -c Release -warnaserror` on both test projects individually — **0 Warning(s), 0 Error(s)**

Caveat stated plainly: both races are CI-load-dependent and do **not** reproduce locally (both tests pass on this machine before and after). The mechanism for each is established from the code path and the CI trace, and each fix closes the specific gap identified.

No What's New entry: test-only, no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)