### PR TITLE
ci: stop MeshWeaver.FutuRe.Test walking into a CoreCLR background-GC bug

### DIFF
--- a/test/MeshWeaver.FutuRe.Test/MeshWeaver.FutuRe.Test.csproj
+++ b/test/MeshWeaver.FutuRe.Test/MeshWeaver.FutuRe.Test.csproj
@@ -3,6 +3,17 @@
     <ProjectGuid>{d7a2e1f3-8c4b-4e9d-b5a6-3f1c2d8e7a9b}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+    <!-- 🚨 STOP STEPPING ON A CoreCLR BUG. This project's recurring `exit=139` (SIGSEGV) in CI was
+         root-caused in #613 to a background-GC fault — a null MethodTable in `background_sweep`,
+         explicitly NOT teardown and NOT ALC unload. Every completed test passes and the process then
+         segfaults at/near exit, which reds whichever PR happens to be running (it took out #1265
+         while nothing in that diff touches this project).
+         `background_sweep` only exists when background (concurrent) GC is enabled, so disabling it
+         here removes the faulting path. The runtime bug is upstream and unfixed — this does not fix
+         it, it stops this project walking into it. Scoped to this one test project deliberately: if
+         the same signature appears elsewhere, move it to test/Directory.Build.props rather than
+         sprinkling it. Verified in the generated runtimeconfig.json ("System.GC.Concurrent": false). -->
+    <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

`MeshWeaver.FutuRe.Test exit=139` (SIGSEGV) recurs in CI and reds whichever PR is running. It killed **#1265** today — a PR whose diff (observability chart values + the log watcher) does not touch this project.

It is already root-caused. **#613** was closed with the diagnosis in its title: *"a CoreCLR background-GC fault (null MethodTable in `background_sweep`) — not teardown, not ALC unload"*. The signature matches every sighting: all completed tests pass, then the process segfaults at/near exit.

## What this does

`background_sweep` only exists when background (concurrent) GC is enabled, so this project sets `ConcurrentGarbageCollection=false` and the faulting path is gone from its test host.

Verified rather than assumed — the generated runtimeconfig.json:

```json
"configProperties": {
  "System.GC.Concurrent": false,
```

## What this does NOT do

**It does not fix the runtime bug.** That is upstream and unfixed; this stops one test project stepping on it. Said plainly in the csproj comment too, so nobody later reads it as "the segfault was fixed".

Scoped to this one project on purpose rather than `test/Directory.Build.props` — if the same signature appears elsewhere, move it up rather than sprinkling GC settings across projects. The cost is blocking GC pauses in this test host, which is not a meaningful trade for a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)