### PR TITLE
fix: a ShuttingDown NACK is a recycling node, not a missing one

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-restarting-node-is-no-longer-reported-as-missing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-a-restarting-node-is-no-longer-reported-as-missing.md
@@ -1,0 +1,19 @@
+---
+Name: A restarting node is no longer reported as missing
+Category: Fix
+Description: Reading a node while it restarts now retries and answers correctly, instead of reporting that the node does not exist.
+Icon: Sparkle
+Order: -20260812
+---
+
+# A restarting node is no longer reported as missing
+
+Nodes restart routinely — after their code is rebuilt, after a recycle, after an update. A read that
+arrived during one of those restarts got an answer meaning "this node is restarting, ask again", but
+the read turned that into the same answer it uses for "there is no such node". Whatever asked then
+behaved as though the node had been deleted: a page reported missing content, a check concluded
+something was gone when it was merely coming back.
+
+Such a read now asks once more, which lands on the restarted node and gets a real answer. If the node
+is genuinely gone, that second answer says so. And if it is still restarting, the reader is told that
+plainly rather than being handed a wrong answer it cannot distinguish from deletion.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1492,7 +1492,14 @@ public static class MeshNodeStreamExtensions
             // path emits null and the outer observer disposes, but the inner
             // Subscribe keeps the hub-level callback registered, surfacing as
             // a "pending callback at dispose" Quiescing-watchdog failure.
-            IDisposable? innerSubscription = null;
+            // One re-probe only: a ShuttingDown answered twice is surfaced, never collapsed to null.
+            var reProbed = 0;
+            // SerialDisposable, not a bare IDisposable: the ShuttingDown re-probe below REPLACES this
+            // subscription, and assigning into a SerialDisposable that has already been disposed
+            // disposes the newcomer immediately — so a teardown racing the re-probe cannot leak the
+            // second hub-level callback (which is the very "pending callback at dispose" failure the
+            // note above exists to prevent).
+            var innerSubscription = new SerialDisposable();
 
             void EmitOnce(MeshNode? node)
             {
@@ -1573,99 +1580,150 @@ public static class MeshNodeStreamExtensions
                     EmitError(new TimeoutException(message));
             });
 
-            try
+            // The read is issued through a local function so the ShuttingDown arm below can
+            // re-issue it ONCE against a fresh activation. Declared here rather than inlined so
+            // there is exactly one copy of the register-before-post ordering.
+            void Issue()
             {
-                // 🚨 Register the response subject BEFORE posting. Observe<TResponse> pre-registers the
-                // callback (WithMessageId) and only then posts — see MessageHub.Observe(object, options):
-                // "registering the subject BEFORE posting avoids the race where a synchronously-handled
-                // response arrives before the subscription is in place."
-                //
-                // The previous Post(request) + Observe(delivery) ordering registered the subject AFTER the
-                // post. The hub DROPS any response whose requestId has no registered subject yet ("No
-                // subject found for response ... treating as processed", HandleCallbacks). A WARM owning
-                // per-node hub answers in sub-millisecond time, so under thread-pool contention a
-                // preemption between Post and Observe let the reply land before the subject existed -> the
-                // reply was dropped and this read hung to its timeout. That was the intermittent bulk flake
-                // in WorkspaceCacheEvictionTest (ReadNode -> GetMeshNode), proven deterministically by
-                // GetMeshNode_WarmOwner_DropsResponse_WhenSubjectRegisteredAfterPost.
-                innerSubscription = issuingHub
-                    .Observe<GetDataResponse>(
-                        new GetDataRequest(new MeshNodeReference()),
-                        o => o.WithTarget(new Address(path)))
-                    .Subscribe(
-                        d =>
-                        {
-                            try
+                try
+                {
+                    // 🚨 Register the response subject BEFORE posting. Observe<TResponse> pre-registers the
+                    // callback (WithMessageId) and only then posts — see MessageHub.Observe(object, options):
+                    // "registering the subject BEFORE posting avoids the race where a synchronously-handled
+                    // response arrives before the subscription is in place."
+                    //
+                    // The previous Post(request) + Observe(delivery) ordering registered the subject AFTER the
+                    // post. The hub DROPS any response whose requestId has no registered subject yet ("No
+                    // subject found for response ... treating as processed", HandleCallbacks). A WARM owning
+                    // per-node hub answers in sub-millisecond time, so under thread-pool contention a
+                    // preemption between Post and Observe let the reply land before the subject existed -> the
+                    // reply was dropped and this read hung to its timeout. That was the intermittent bulk flake
+                    // in WorkspaceCacheEvictionTest (ReadNode -> GetMeshNode), proven deterministically by
+                    // GetMeshNode_WarmOwner_DropsResponse_WhenSubjectRegisteredAfterPost.
+                    innerSubscription.Disposable = issuingHub
+                        .Observe<GetDataResponse>(
+                            new GetDataRequest(new MeshNodeReference()),
+                            o => o.WithTarget(new Address(path)))
+                        .Subscribe(
+                            d =>
                             {
-                                if (d.Message is GetDataResponse resp)
+                                try
                                 {
-                                    // A null-Data response carrying an Error is an application-level
-                                    // read-validator verdict (INodeValidator → GetDataResponse{Error},
-                                    // e.g. NodeHidden / a policy filter — see
-                                    // MeshDataSource.AddReadValidatorPipeline). The documented contract is
-                                    // that such a filtered node is INVISIBLE to the reader → resolve to
-                                    // null (indistinguishable from "not found", which is the point of
-                                    // hiding). A *genuine* access denial is enforced at the delivery layer
-                                    // (AccessControlPipeline → DeliveryFailure{ErrorType.Unauthorized}) and
-                                    // surfaces via the OnError branch below — it never arrives as a
-                                    // GetDataResponse{Error}. Log the verdict so it isn't entirely silent.
-                                    if (resp.Data is null && !string.IsNullOrEmpty(resp.Error))
+                                    if (d.Message is GetDataResponse resp)
                                     {
-                                        hub.ServiceProvider.GetService<ILoggerFactory>()
-                                            ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
-                                            ?.LogDebug("GetMeshNode read-validator filtered {Path}: {Error}", path, resp.Error);
-                                        EmitOnce(null);
-                                        return;
+                                        // A null-Data response carrying an Error is an application-level
+                                        // read-validator verdict (INodeValidator → GetDataResponse{Error},
+                                        // e.g. NodeHidden / a policy filter — see
+                                        // MeshDataSource.AddReadValidatorPipeline). The documented contract is
+                                        // that such a filtered node is INVISIBLE to the reader → resolve to
+                                        // null (indistinguishable from "not found", which is the point of
+                                        // hiding). A *genuine* access denial is enforced at the delivery layer
+                                        // (AccessControlPipeline → DeliveryFailure{ErrorType.Unauthorized}) and
+                                        // surfaces via the OnError branch below — it never arrives as a
+                                        // GetDataResponse{Error}. Log the verdict so it isn't entirely silent.
+                                        if (resp.Data is null && !string.IsNullOrEmpty(resp.Error))
+                                        {
+                                            hub.ServiceProvider.GetService<ILoggerFactory>()
+                                                ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
+                                                ?.LogDebug("GetMeshNode read-validator filtered {Path}: {Error}", path, resp.Error);
+                                            EmitOnce(null);
+                                            return;
+                                        }
+                                        MeshNode? node = resp.Data as MeshNode;
+                                        if (node == null && resp.Data is JsonElement je)
+                                            node = je.Deserialize<MeshNode>(hub.JsonSerializerOptions);
+                                        EmitOnce(node);
                                     }
-                                    MeshNode? node = resp.Data as MeshNode;
-                                    if (node == null && resp.Data is JsonElement je)
-                                        node = je.Deserialize<MeshNode>(hub.JsonSerializerOptions);
-                                    EmitOnce(node);
+                                    else
+                                    {
+                                        // Unexpected response â€” node not found / no handler.
+                                        EmitOnce(null);
+                                    }
                                 }
-                                else
+                                catch (Exception ex)
                                 {
-                                    // Unexpected response â€” node not found / no handler.
+                                    var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                                        ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
+                                    logger?.LogDebug(ex, "GetMeshNode callback failed for {Path}", path);
                                     EmitOnce(null);
                                 }
-                            }
-                            catch (Exception ex)
+                            },
+                            ex =>
                             {
+                                // Access denial (ErrorType.Unauthorized) is a real error the
+                                // caller — and ultimately the user — must see: surface it.
+                                // Genuine not-found (routing NotFound) stays a null emission,
+                                // the documented contract. Without this, a denied read was
+                                // indistinguishable from a missing node and silently fell back.
+                                if (ex is DeliveryFailureException dfe
+                                    && dfe.Failure?.ErrorType == ErrorType.Unauthorized)
+                                {
+                                    EmitError(ex);
+                                    return;
+                                }
                                 var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
                                     ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
-                                logger?.LogDebug(ex, "GetMeshNode callback failed for {Path}", path);
+
+                                // 🚨 SHUTTING DOWN IS NOT ABSENCE. ErrorType.ShuttingDown's own contract
+                                // (Events.cs) is "retry-worthy, never terminal … the sender must read this as
+                                // 'ask again', not 'gone'", and routing mints it deliberately INSTEAD of
+                                // NotFound for a live-but-recycling address (MonolithRoutingService:
+                                // `isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound`). Collapsing
+                                // it into the same null a genuine not-found emits threw that distinction away
+                                // and told the caller the node does not exist while it was merely recycling.
+                                //
+                                // Field evidence: ThreadAgentIntegrationTest on CI — the ACME/ProductLaunch
+                                // instance hub self-recycled via the overlay self-heal watcher, its parked
+                                // GetDataRequest was NACKed ShuttingDown (9d8880c68), and the test failed with
+                                // "ACME/ProductLaunch node should exist" 6.4s into a 60s budget. Before that
+                                // NACK existed the same race HUNG for 60s; the symptom migrated from a stall
+                                // to a confident wrong answer.
+                                //
+                                // Re-issue ONCE inside the caller's remaining budget. This is not a
+                                // retry-to-paper-over: the re-probe lands on a FRESH activation (a
+                                // SubscribeRequest/GetDataRequest creates one on arrival) and terminates
+                                // authoritatively — if the node is genuinely gone, routing answers NotFound and
+                                // we emit null; if it is still shutting down, we surface the error rather than
+                                // lie. Exactly the reasoning MeshNodeStreamCache.IsTransientOwnerFailure already
+                                // applies on the live-stream path, where "is shutting down" is classified
+                                // transient for this same reason.
+                                if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
+                                {
+                                    if (Interlocked.Exchange(ref reProbed, 1) == 0
+                                        && !cts.IsCancellationRequested)
+                                    {
+                                        logger?.LogDebug(
+                                            "GetMeshNode: {Path} NACKed ShuttingDown — the address is recycling, "
+                                            + "not absent. Re-probing once within the remaining budget.", path);
+                                        Issue();
+                                        return;
+                                    }
+                                    EmitError(new InvalidOperationException(
+                                        $"GetMeshNode('{path}'): the owning hub answered ShuttingDown twice — "
+                                        + "the address is recycling, NOT absent. Surfacing rather than "
+                                        + "returning null, which the caller cannot tell apart from "
+                                        + "'node not found'. Retry the read.", ex));
+                                    return;
+                                }
+
+                                logger?.LogDebug(ex, "GetMeshNode delivery failed for {Path}", path);
                                 EmitOnce(null);
-                            }
-                        },
-                        ex =>
-                        {
-                            // Access denial (ErrorType.Unauthorized) is a real error the
-                            // caller — and ultimately the user — must see: surface it.
-                            // Genuine not-found (routing NotFound) stays a null emission,
-                            // the documented contract. Without this, a denied read was
-                            // indistinguishable from a missing node and silently fell back.
-                            if (ex is DeliveryFailureException dfe
-                                && dfe.Failure?.ErrorType == ErrorType.Unauthorized)
-                            {
-                                EmitError(ex);
-                                return;
-                            }
-                            var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
-                                ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
-                            logger?.LogDebug(ex, "GetMeshNode delivery failed for {Path}", path);
-                            EmitOnce(null);
-                        });
+                            });
+                }
+                catch (Exception ex)
+                {
+                    var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
+                    logger?.LogDebug(ex, "GetMeshNode post failed for {Path}", path);
+                    EmitOnce(null);
+                }
             }
-            catch (Exception ex)
-            {
-                var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
-                    ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
-                logger?.LogDebug(ex, "GetMeshNode post failed for {Path}", path);
-                EmitOnce(null);
-            }
+
+            Issue();
 
             return Disposable.Create(() =>
             {
-                innerSubscription?.Dispose();
+                innerSubscription.Dispose();
                 cts.Dispose();
             });
         });

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1636,7 +1636,7 @@ public static class MeshNodeStreamExtensions
                                     }
                                     else
                                     {
-                                        // Unexpected response â€” node not found / no handler.
+                                        // Unexpected response — node not found / no handler.
                                         EmitOnce(null);
                                     }
                                 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeShuttingDownIsNotAbsentTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeShuttingDownIsNotAbsentTest.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A RECYCLING NODE IS NOT A MISSING NODE.
+///
+/// <para><see cref="ErrorType.ShuttingDown"/> has an explicit contract (Events.cs): "retry-worthy,
+/// never terminal … the sender must read this as 'ask again', not 'gone'". Routing mints it
+/// DELIBERATELY instead of NotFound for a live-but-recycling address
+/// (<c>MonolithRoutingService</c>: <c>isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound</c>),
+/// and the live-stream path honours that — <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>
+/// classifies "is shutting down" as transient.</para>
+///
+/// <para><b>The read primitive did not.</b> <c>GetMeshNode</c>'s OnError arm surfaced only
+/// <see cref="ErrorType.Unauthorized"/> and collapsed everything else — ShuttingDown included — into
+/// the same <c>null</c> a genuine not-found emits. So a caller was told the node does not exist while
+/// it was merely recycling, with no way to tell the two apart.</para>
+///
+/// <para><b>Field evidence.</b> <c>ThreadAgentIntegrationTest</c> on CI: the <c>ACME/ProductLaunch</c>
+/// instance hub self-recycled via the overlay self-heal watcher, its parked <c>GetDataRequest</c> was
+/// NACKed ShuttingDown, and the test failed on "ACME/ProductLaunch node should exist" 6.4 s into a
+/// 60 s budget. Before that NACK existed (9d8880c68) the same race HUNG for the full 60 s — the
+/// symptom migrated from a stall into a confident wrong answer, which is worse.</para>
+///
+/// <para>The sibling <c>DeferredDeliveryNackedOnDisposeTest</c> pins that the NACK is produced and
+/// carries ShuttingDown. This pins what the READER does with it.</para>
+/// </summary>
+public class GetMeshNodeShuttingDownIsNotAbsentTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private static readonly Address RecyclingAddress = new("recycling", "node");
+
+    /// <summary>
+    /// Counts how many <c>GetDataRequest</c>s reach the address, so the re-probe is not merely
+    /// inferred from the outcome — the count IS the assertion that it happened exactly once.
+    /// </summary>
+    private int _reads;
+
+    [Fact(Timeout = 120_000)]
+    public async Task ShuttingDownNack_IsSurfaced_NeverCollapsedToNull()
+    {
+        // A hub that ALWAYS answers as one caught mid-recycle — the exact DeliveryFailure shape
+        // routing mints for a shutting-down address (MonolithRoutingService:
+        // `isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound`). Always, so the test is
+        // deterministic: there is no millisecond window to lose, unlike the production race.
+        var recycling = Mesh.GetHostedHub(
+            RecyclingAddress,
+            c => c.WithHandler<GetDataRequest>((hub, delivery) =>
+            {
+                Interlocked.Increment(ref _reads);
+                hub.Post(
+                    new DeliveryFailure(delivery)
+                    {
+                        ErrorType = ErrorType.ShuttingDown,
+                        Message = $"Hub {RecyclingAddress} is shutting down — cannot read. "
+                                  + "The address may reactivate (recycle / restart); retry to get "
+                                  + "the authoritative answer."
+                    },
+                    o => o.ResponseFor(delivery));
+                return delivery.Processed();
+            }));
+        recycling.Should().NotBeNull();
+
+        var read = Mesh
+            .GetMeshNode(RecyclingAddress.ToString(), TimeSpan.FromSeconds(30))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        // The whole point: a caller must NOT be handed null. Null is what "node not found" means, and
+        // a recycling node is present — that conflation is what made the CI failure claim a node in
+        // the test's own fixture did not exist.
+        var failure = await Assert.ThrowsAnyAsync<Exception>(() => read);
+
+        Output.WriteLine($"surfaced: {failure.GetType().Name}: {failure.Message}");
+        failure.Message.Should().Contain("ShuttingDown",
+            "the error must name the classification, so the next reader knows to retry rather than "
+            + "concluding the node is gone");
+        failure.Message.Should().Contain("NOT absent",
+            "…and must say explicitly that this is not absence — the misreading this exists to stop");
+
+        // Exactly TWO reads: the original plus ONE re-probe. Not one (that would mean the transient
+        // was surfaced without giving the address its documented chance to reactivate) and not three
+        // or more (that would be a retry loop, which this repo bans — the re-probe is bounded and
+        // terminates on the second answer, whatever it is).
+        Volatile.Read(ref _reads).Should().Be(2,
+            "ShuttingDown earns exactly one re-probe against a fresh activation — bounded, not a loop");
+    }
+}


### PR DESCRIPTION
## The defect

`GetMeshNode`'s OnError arm surfaced only `ErrorType.Unauthorized` and collapsed everything else — **`ShuttingDown` included** — into the same `null` a genuine not-found emits:

```csharp
if (ex is DeliveryFailureException dfe && dfe.Failure?.ErrorType == ErrorType.Unauthorized)
{ EmitError(ex); return; }
logger?.LogDebug(ex, "GetMeshNode delivery failed for {Path}", path);
EmitOnce(null);            // ← ShuttingDown landed here
```

So a caller was told the node **does not exist** while it was merely recycling, with no way to tell the two apart.

That contradicts the error type's own contract (`Events.cs`): *"retry-worthy, never terminal … the sender must read this as 'ask again', not 'gone'."* Routing mints it **deliberately instead of** NotFound for a live-but-recycling address (`MonolithRoutingService`: `isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound`), and the live-stream path already honours it — `MeshNodeStreamCache.IsTransientOwnerFailure` classifies `"is shutting down"` as transient for exactly this reason. **`GetMeshNode` was the outlier** that erased a distinction the rest of the stack maintains.

## Field evidence

`ThreadAgentIntegrationTest` on CI (run 31585103880) failed with:

```
Expected value not to be <null> because ACME/ProductLaunch node should exist in test data.
```

…having logged, 190 ms earlier:

```
Could not lease the NodeType assembly context for ACME/ProductLaunch
  ---> HubDisposingException: Hub ACME/ProductLaunch is shutting down — cannot create '/MeshNode'.
       The address may reactivate (recycle / restart); retry to get the authoritative answer.
```

The instance hub self-recycled via the overlay self-heal watcher, its parked `GetDataRequest` was NACKed `ShuttingDown` (`9d8880c68`), and the read reported absence 6.4 s into a 60 s budget.

**The symptom had migrated, not been fixed.** Before that NACK existed this same race hung for the full 60 s (documented at `MonolithMeshTestBase.cs:1058-1066`, naming this test). Afterwards it fails fast with a confident wrong answer — worse, because a stall is at least visibly a stall.

## The fix

Re-issue **once**, inside the caller's remaining budget:

- Not a retry-to-paper-over: the re-probe lands on a **fresh activation** (a `GetDataRequest` creates one on arrival) and **terminates authoritatively** — genuinely gone answers `NotFound` and we emit `null`; still shutting down surfaces an error naming the classification.
- **Never a silent `null`** the caller cannot distinguish from absence — the same principle as the existing `Unauthorized` arm and `GetMeshNodeAccessSurfacingTest`.
- The inner subscription became a `SerialDisposable`, so a teardown racing the re-probe cannot leak the second hub-level callback (the "pending callback at dispose" failure that code's own comment exists to prevent).

## Test

`GetMeshNodeShuttingDownIsNotAbsentTest` — a hub that **always** NACKs `ShuttingDown`, so it is deterministic rather than a millisecond race:

- the error is surfaced, naming `ShuttingDown` and "NOT absent";
- the handler is invoked **exactly twice** — not once (the transient never got its documented chance to reactivate) and not three or more (a retry loop, which this repo bans).

```
dotnet build src/MeshWeaver.Mesh.Contract -c Release -warnaserror   # clean
dotnet test test/MeshWeaver.Hosting.Monolith.Test --filter GetMeshNodeShuttingDownIsNotAbsentTest   # 1 passed, 432 ms
```

Sibling to `DeferredDeliveryNackedOnDisposeTest`, which pins that the NACK is *produced* and carries `ShuttingDown`; this pins what the **reader** does with it.

## Provenance

Root-caused by a subagent investigating why `ThreadAgentIntegrationTest` and `SkillAutocompleteTest` reddened unrelated PRs. It also established that the `SkillAutocompleteTest` failure was **already fixed** on main by #1269 (`a531e432d`) — those runs predated it, which is the "merge main before you investigate" case. Ruled out along the way, with evidence: banned async in this path (none), lost `AccessContext` (a denial arrives as `Unauthorized`, which is handled), and a homegrown request/response racing a watcher (the racing request is the sanctioned `GetDataRequest`; the watcher race is real but the culprit is the read primitive's misclassification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)