### PR TITLE
test: the Orleans dynamic-compile test must honour the pre-activation wait

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDynamicCompilationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDynamicCompilationTest.cs
@@ -75,6 +75,14 @@ public class OrleansDynamicCompilationTest(ITestOutputHelper output)
             .ServiceProvider
             .GetRequiredService<IMeshService>();
 
+    /// <summary>
+    /// The silo's mesh hub — whose WORKSPACE is the view an instance activation reads the NodeType
+    /// through. Tests must wait on this view before activating an instance; see the wait below.
+    /// </summary>
+    private IMessageHub SiloMeshHub =>
+        ((InProcessSiloHandle)Cluster.Silos[0]).SiloHost.Services
+            .GetRequiredService<IMessageHub>();
+
     [Fact(Timeout = 60000)]
     public async Task ColdStart_CompileViaGetCompilationPathRequest_Succeeds()
     {
@@ -200,7 +208,15 @@ public class OrleansDynamicCompilationTest(ITestOutputHelper output)
     /// MeshNode from persistence, loads the dynamic assembly, and answers from
     /// the per-instance hub.
     /// </summary>
-    [Fact(Timeout = 60000)]
+    // Budget note: 180s, NOT 60s. The fix for this test's flake is the pre-activation wait below —
+    // this number is only about DIAGNOSABILITY. At 60s the Fact timeout exactly equalled
+    // NodeTypeEnrichmentHelpers.SlowPathTimeout and MessageHubConfiguration.RequestTimeout, so it
+    // preempted the framework's own graceful sink (the compile-in-progress overlay / a NACK) by ~1.7s
+    // and every failure of this class reported a bare "Test execution timed out" with nothing to go on
+    // — five sessions theorised from that silence. The test's own CancellationToken is already 80s, so
+    // it now fires first and produces a real message. Raising this alone would MASK the wedge; it ships
+    // with the wait, never instead of it.
+    [Fact(Timeout = 180_000)]
     public async Task Instance_OfDynamicNodeType_ActivatesAndAnswers()
     {
         var ct = new CancellationTokenSource(80.Seconds()).Token;
@@ -238,6 +254,22 @@ public class OrleansDynamicCompilationTest(ITestOutputHelper output)
             }
         };
         await SiloMeshService.CreateNode(codeNode).FirstAsync().ToTask(ct);
+
+        // 🚨 THE DOCUMENTED PRE-ACTIVATION WAIT. NodeTypeEnrichmentHelpers.cs:294-302 states the
+        // contract this test used to violate: "A test that writes to the per-NodeType hub and then
+        // activates a new instance MUST wait for the mesh hub's workspace to see the post-write state
+        // before creating the instance." Without it the activation raced the type's very FIRST compile:
+        // EnrichWithNodeType took its slow path and then sat on the 60s Phase-A no-progress budget
+        // (SlowPathTimeout) waiting for a Pending/Compiling this workspace had not yet mirrored —
+        // locally that mirror lands in ~150ms, so the flake only ever showed in CI, as a bare
+        // "Test execution timed out after 60000 milliseconds" with 58s of silence and no diagnosis.
+        // Canonical shape: CodeEditRecompileTest.WaitForMeshHubView. Subscribing here also ACTIVATES
+        // the per-NodeType hub, which is what installs the compile watcher and drives that first build
+        // — so this waits on the real condition rather than sleeping past a race.
+        await SiloMeshHub.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(TimeSpan.FromSeconds(60))
+            .Match(n => n?.Content is NodeTypeDefinition def
+                        && def.CompilationStatus == CompilationStatus.Ok);
 
         // Create an INSTANCE of the dynamic type. NodeType=<typePath> means the
         // EnrichWithNodeType slow path fires — the static lookup misses, the


### PR DESCRIPTION
## The race

`Instance_OfDynamicNodeType_ActivatesAndAnswers` created the NodeType, its source and an instance **back-to-back**, so the instance activation raced the type's very first compile.

The framework states the contract this violates, in the code the test drives (`NodeTypeEnrichmentHelpers.cs:294-302`):

> A test that writes to the per-NodeType hub and then activates a new instance **MUST** wait for the mesh hub's workspace to see the post-write state before creating the instance. See `CodeEditRecompileTest` for the canonical wait shape.

`CodeEditRecompileTest` does exactly that (`WaitForMeshHubView` before `CreateNode`). This test did not.

Lose the race and `EnrichWithNodeType` takes its slow path, then sits on the **60 s Phase-A no-progress budget** (`SlowPathTimeout`) waiting for a `Pending`/`Compiling` the mesh hub's workspace has not mirrored yet. Locally that mirror lands in ~150 ms — which is why this only ever failed in CI, and failed as a bare:

```
Test execution timed out after 60000 milliseconds
<58.4 s of total silence>
```

## The fix

Wait on the mesh hub's view of the type for `CompilationStatus.Ok` before creating the instance. This is waiting on the **real condition**, not a sleep: subscribing is also what activates the per-NodeType hub, which is what installs the compile watcher and drives that first build.

## The budget change is about diagnosability, not the fix

`[Fact(Timeout = ...)]` goes 60 s → 180 s **because at 60 s it exactly equalled `SlowPathTimeout` and `RequestTimeout`**, so it preempted the framework's own graceful sink (the compile-in-progress overlay, a NACK) by ~1.7 s. That is why five sessions in a row had only silence to reason from. The test's own `CancellationToken` is already 80 s and now fires first, with a real message.

Raising it alone would **mask** a wedge — it ships with the wait, never instead of it.

## Verification

```
DOTNET_PROCESSOR_COUNT=4 dotnet test test/MeshWeaver.Hosting.Orleans.Test \
  --filter OrleansDynamicCompilationTest        # 3/3 pass
```
(`DOTNET_PROCESSOR_COUNT=4` is the setting that reproduces CI races in this repo — CI runners have fewer cores.)

## 🚨 The bigger finding this came out of — a CI diagnostics gap, NOT fixed here

A subagent could not reproduce the failure in **12 attempts** and narrowed the cause by eliminating every other budget on the path (`FirstNodeResolutionTimeout` 30 s, `ResolveTimeout` 30 s, `InFlightOverlayGrace` 5 s, `SourceSnapshotTimeout` 30 s, `RoslynCompileTimeout` 5 min — each would produce a *different, earlier* outcome). On the way it established something that invalidates a previous conclusion:

**The silence four prior sessions diagnosed from is a logging false negative.** Commit `b676980ae` concluded from this exact fingerprint that *"the silo logs NOTHING … the request never reaches the grain."* Instrumenting a **passing** run proved the code does execute while those lines never appear: the instance grain activated and answered, `BuildSlowPath` was entered, the compile was dispatched — and `[COMPILE-TRACE]`, `[ACTIVATE]` and `[ROUTE]` produced **0 occurrences**. Across the whole of CI run 31581651413, on red *and* green runs alike, the entire `MeshWeaver.Hosting.Orleans.*` routing + grain-activation layer is invisible in test output. Wiring the xUnit logger on the silo *or* host builder does not fix it (both tested).

So the remaining sub-cause in CI — mirror never fanned out vs. compile kickoff denied under the inbound `AccessContext` — **cannot be determined until that gap is closed**. That deserves its own change, plus an assertion in the Orleans test base that a known grain-side line actually reaches output, so it cannot silently regress a sixth time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)