### PR TITLE
The cell's output pane leads with the RESULT; the status is a footer

### DIFF
--- a/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
@@ -52,10 +52,20 @@ public static class ActivityLayoutAreas
 
     /// <summary>
     /// Area id of the script RESULT inside <see cref="Progress"/> / <see cref="Overview"/> —
-    /// the control a script returned, rendered live. Named (not auto-numbered) so the
-    /// indicator and log keep their positions and so tests address it by name.
+    /// the control a script returned, rendered live. It comes FIRST: it is what the reader
+    /// pressed Run for.
     /// </summary>
     public const string ResultArea = "Result";
+
+    /// <summary>Area id of the message log inside <see cref="Progress"/> / <see cref="Overview"/>.</summary>
+    public const string LogArea = "Log";
+
+    /// <summary>
+    /// Area id of the run's status inside <see cref="Progress"/> / <see cref="Overview"/> — the
+    /// live bar while running, the terminal "✓ Done" line afterwards. LAST, and quiet: see
+    /// <see cref="Progress"/>.
+    /// </summary>
+    public const string StatusArea = "Status";
 
     /// <summary>
     /// The control a script RETURNED, as a live stream — the missing half of #915.
@@ -116,11 +126,14 @@ public static class ActivityLayoutAreas
 
                 var stack = Controls.Stack
                     .WithStyle("padding: 16px; gap: 12px;")
-                    .WithView(BuildHeader(log, zoneId))
-                    .WithView(BuildProgressIndicator(log))
-                    .WithView(BuildLog(log, locale: host.ViewerLocale(), hasResult: result is not null));
+                    .WithView(BuildHeader(log, zoneId));
+                // Same reading order as the cell pane: what the run PRODUCED, then what it printed,
+                // then how it ended. The header already carries the status badge.
                 if (result is not null)
                     stack = stack.WithView(result, ResultArea);
+                stack = stack
+                    .WithView(BuildLog(log, locale: host.ViewerLocale(), hasResult: result is not null), LogArea)
+                    .WithView(BuildProgressIndicator(log), StatusArea);
 
                 // While running: Cancel button. Per the Activity Control Plane
                 // pattern (Doc/Architecture/ActivityControlPlane.md), cancellation
@@ -197,13 +210,18 @@ public static class ActivityLayoutAreas
     /// Compact running-progress view for embedding next to an executable Code
     /// node (or anywhere a caller wants live script feedback). Streams the same
     /// ActivityLog content as <see cref="Overview"/> but trims chrome and shows
-    /// only the live progress indicator + message log + the script's rendered
-    /// result + inline Cancel button (while running). No header, no Re-run.
+    /// only the script's rendered result + message log + run status + inline
+    /// Cancel button (while running). No header, no Re-run.
     /// Built from framework controls.
     /// <para>This IS the code cell's output pane (<c>CodeLayoutAreas.BuildContent</c>
     /// embeds it), so a script whose result is a control renders that control HERE —
-    /// see <see cref="RenderedResult"/>. Order follows a notebook cell: status,
-    /// printed lines, then the result.</para>
+    /// see <see cref="RenderedResult"/>.</para>
+    /// <para>🚨 <b>The RESULT leads; the status is a footer.</b> A cell's output pane is not a
+    /// run report — the reader pressed Run to see the grid, and "✓ Done" is metadata about how
+    /// the run ended. Rendering the status first (as an <c>H4</c>, no less) made the pane READ
+    /// as "Done" with the actual answer somewhere below, which is precisely how it was reported:
+    /// <i>"output must show control and not Done"</i>. So: result, then whatever the script
+    /// printed, then one quiet status line at the foot.</para>
     /// </summary>
     public static IObservable<UiControl?> Progress(LayoutAreaHost host, RenderingContext _)
     {
@@ -214,12 +232,12 @@ public static class ActivityLayoutAreas
                     return (UiControl?)Controls.Label(host.Localize("ui.noActivityYet"))
                         .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);");
 
-                var stack = Controls.Stack
-                    .WithStyle("gap: 8px;")
-                    .WithView(BuildProgressIndicator(log))
-                    .WithView(BuildLog(log, locale: host.ViewerLocale(), hasResult: result is not null));
+                var stack = Controls.Stack.WithStyle("gap: 8px;");
                 if (result is not null)
                     stack = stack.WithView(result, ResultArea);
+                stack = stack
+                    .WithView(BuildLog(log, locale: host.ViewerLocale(), hasResult: result is not null), LogArea)
+                    .WithView(BuildProgressIndicator(log, compact: result is not null), StatusArea);
 
                 // Inline Cancel: same content-patch pattern as the Overview's
                 // button. Only rendered while the activity is actually running
@@ -276,7 +294,15 @@ public static class ActivityLayoutAreas
     /// final message. Passing <c>null</c> as the progress value is what drives the
     /// indeterminate FluentProgress in <c>ProgressView.razor</c>.
     /// </summary>
-    public static UiControl BuildProgressIndicator(ActivityLog log)
+    /// <param name="log">The activity log to render the status of.</param>
+    /// <param name="compact">
+    /// True when the caller renders this as a FOOTER under a result the reader actually came for
+    /// (see <see cref="Progress"/>). The terminal line then drops to small print instead of an
+    /// <c>H4</c> — a heading-sized "✓ Done" is what made the pane read as a status report with
+    /// the answer hidden underneath. The RUNNING bar is unaffected: while a run is in flight it
+    /// is the only content there is.
+    /// </param>
+    public static UiControl BuildProgressIndicator(ActivityLog log, bool compact = false)
     {
         var latest = log.Messages.Count > 0 ? log.Messages[^1].Message : null;
 
@@ -299,8 +325,10 @@ public static class ActivityLayoutAreas
         };
 
         var text = string.IsNullOrEmpty(latest) ? $"{glyph} {label}" : $"{latest}\n{glyph} {label}";
-        return Controls.H4(text)
-            .WithStyle($"color: {StatusColor(log.Status)}; white-space: pre-wrap; margin: 0;");
+        var style = $"color: {StatusColor(log.Status)}; white-space: pre-wrap; margin: 0;";
+        return compact
+            ? Controls.Label(text).WithStyle(style + " font-size: 0.8rem;")
+            : Controls.H4(text).WithStyle(style);
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -361,11 +361,13 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
         var root = (StackControl)(await stream.GetControlStream(reference.Area!)
             .Should().Within(60.Seconds()).Match(c => c is StackControl s
                 && s.Areas.Any(a => IsArea(a, ActivityLayoutAreas.ResultArea))))!;
-        var order = root.Areas.Select(a => a.Area?.ToString() ?? "").ToList();
-        order.FindIndex(a => a.EndsWith("/" + ActivityLayoutAreas.ResultArea, StringComparison.Ordinal))
+        // Positions via IsArea, which accepts a bare id as well as the rendered "Progress/…"
+        // prefix — the same tolerance the rest of this test uses, so a change of rendering root
+        // cannot turn the ORDER assertion into a "not found" (-1) that reads as a wrong position.
+        root.Areas.FindIndex(a => IsArea(a, ActivityLayoutAreas.ResultArea))
             .Should().Be(0, "the result leads the output pane");
-        order.FindIndex(a => a.EndsWith("/" + ActivityLayoutAreas.StatusArea, StringComparison.Ordinal))
-            .Should().Be(order.Count - 1, "the status is the pane's footer, never its headline");
+        root.Areas.FindIndex(a => IsArea(a, ActivityLayoutAreas.StatusArea))
+            .Should().Be(root.Areas.Count - 1, "the status is the pane's footer, never its headline");
         var resultArea = root.Areas.First(a => IsArea(a, ActivityLayoutAreas.ResultArea)).Area!.ToString()!;
 
         // …and it is the LIVE control tree: the returned Stack's child renders as the markdown

--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -179,18 +179,20 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(activityPath), reference);
 
-        // The Progress root is a Stack: [0] the status indicator, [1] the message
-        // log — the control-based shape ActivityLayoutAreas.Progress renders since
-        // the hand-rolled messages HTML was replaced by controls (BuildLog /
-        // BuildProgressIndicator). The old assertion demanded an HtmlControl and
-        // burned its full 30 s wait on every run — one of the hidden AI.Test
-        // failures masked by the CI 6-minute kill.
+        // The Progress root is a Stack of NAMED areas — Result (when the script returned a
+        // control), Log, Status — the control-based shape ActivityLayoutAreas.Progress renders
+        // since the hand-rolled messages HTML was replaced by controls (BuildLog /
+        // BuildProgressIndicator). The old assertion demanded an HtmlControl and burned its full
+        // 30 s wait on every run — one of the hidden AI.Test failures masked by the CI 6-minute
+        // kill. Addressed by NAME, never by index: the order is a product decision that has moved
+        // once already (the status went from first to last) and index assertions turn that into
+        // unrelated red.
         var rootControl = (StackControl)(await stream.GetControlStream(reference.Area!)
             .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count >= 2))!;
 
         // Terminal indicator: a Succeeded activity renders a "✓ Done" status line,
         // never a spinner (pinned control-shape: ActivityProgressViewTest).
-        var indicatorArea = rootControl.Areas[0].Area!.ToString()!;
+        var indicatorArea = AreaNamed(rootControl, ActivityLayoutAreas.StatusArea);
         try
         {
             await stream.GetControlStream(indicatorArea)
@@ -240,7 +242,7 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
 
         // The captured output line renders as one of the log rows' message labels
         // (BuildLog: one horizontal [level-tag, message] row per LogMessage).
-        var logArea = rootControl.Areas[1].Area!.ToString()!;
+        var logArea = AreaNamed(rootControl, ActivityLayoutAreas.LogArea);
         var logStack = (StackControl)(await stream.GetControlStream(logArea)
             .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count >= 1))!;
         await logStack.Areas
@@ -352,11 +354,18 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(activityPath), reference);
 
-        // The result hangs off the Progress root under its OWN named area, after the status
-        // indicator and the log — a notebook cell's reading order.
+        // The result hangs off the Progress root under its OWN named area, and it comes FIRST —
+        // ahead of the log and the status footer. The reader pressed Run to see the control;
+        // "✓ Done" is metadata about how the run ended, which is why a pane that led with it read
+        // as "Done" with the answer buried ("output must show control and not Done").
         var root = (StackControl)(await stream.GetControlStream(reference.Area!)
             .Should().Within(60.Seconds()).Match(c => c is StackControl s
                 && s.Areas.Any(a => IsArea(a, ActivityLayoutAreas.ResultArea))))!;
+        var order = root.Areas.Select(a => a.Area?.ToString() ?? "").ToList();
+        order.FindIndex(a => a.EndsWith("/" + ActivityLayoutAreas.ResultArea, StringComparison.Ordinal))
+            .Should().Be(0, "the result leads the output pane");
+        order.FindIndex(a => a.EndsWith("/" + ActivityLayoutAreas.StatusArea, StringComparison.Ordinal))
+            .Should().Be(order.Count - 1, "the status is the pane's footer, never its headline");
         var resultArea = root.Areas.First(a => IsArea(a, ActivityLayoutAreas.ResultArea)).Area!.ToString()!;
 
         // …and it is the LIVE control tree: the returned Stack's child renders as the markdown
@@ -372,15 +381,26 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
 
         // The log says nothing: "This run produced no output." beside a rendered result would
         // contradict the very thing under it.
-        var logArea = root.Areas[1].Area!.ToString()!;
-        await stream.GetControlStream(logArea)
+        await stream.GetControlStream(AreaNamed(root, ActivityLayoutAreas.LogArea))
             .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count == 0);
+
+        // …and the status footer is small print, not the H4 headline it used to be.
+        await stream.GetControlStream(AreaNamed(root, ActivityLayoutAreas.StatusArea))
+            .Should().Within(30.Seconds()).Match(c => c is LabelControl l
+                && l.Typo is null
+                && (l.Style?.ToString() ?? "").Contains("0.8rem"));
     }
 
     /// <summary>Area ids are rendered PREFIXED with their parent's path ("Progress/Result").</summary>
     private static bool IsArea(NamedAreaControl area, string name) =>
         area.Area?.ToString() is { } a
         && (a == name || a.EndsWith("/" + name, StringComparison.Ordinal));
+
+    /// <summary>The rendered area id of the Progress root's <paramref name="name"/> slot.</summary>
+    private static string AreaNamed(StackControl root, string name) =>
+        root.Areas.FirstOrDefault(a => IsArea(a, name))?.Area!.ToString()
+        ?? throw new Xunit.Sdk.XunitException(
+            $"the Progress root has no '{name}' area — it rendered [{string.Join(", ", root.Areas.Select(a => a.Area))}]");
 
     // ── (iv) the SatelliteAccessRule defect, pinned at the rule ────────────
 


### PR DESCRIPTION
## The report

> "still shows Done => you can show this status at bottom. but output must show control and not Done!!"

#1264 made the returned control render. It rendered it **under** an `H4` "✓ Done", so the pane still *read* as a status report with the answer somewhere below — which is the same complaint one layer up.

## The change

`Progress` (the code cell's output pane) now renders **[Result, Log, Status]**:

- the **result leads** — it is what the reader pressed Run for;
- then whatever the script printed;
- then **one quiet status line at the foot**: the terminal badge drops from `H4` to 0.8rem small print when it sits under a result.

The **running** bar is deliberately untouched — while a run is in flight it is the only content there is, so it stays as-is. `Overview` follows the same order; its header already carries a status badge, so nothing is lost there.

## Named areas, and why

The three slots are now named areas — `Result`, `Log`, `Status` — and the tests address them **by name**. This order is a product decision that has now moved once; index-based assertions (`Areas[0]` = indicator, `Areas[1]` = log) turn the next move into unrelated red, which is exactly what this PR had to repair in `CodeCellOutputCaptureTest`.

`Progress_Renders_The_Control_A_Script_Returned` now pins the ORDER itself — result at index 0, status last — plus the footer's small-print styling, so a regression fails on the thing that was actually reported rather than on an incidental index.

## Verified live

The previous fix is confirmed running on `memex.meshweaver.cloud` (reflection on the loaded assembly: `ResultArea = Result`), and a fresh run of `ThinkInStreams/01-TheCombinatorialTrap/Source/CaseCount` renders `Progress/Result` with its H4, six-row DataGrid and markdown. This PR is the ordering on top of that.

⚠️ Unrelated, found while verifying and worth its own issue: the image tagged `3.0.0-rc1.ci.3103` (`f748d16`) ships `/app` binaries built from `b99c744` — 38 commits earlier. The portal self-updated onto it and ran pre-fix code while every tag and tick said otherwise.

Tests: `MeshWeaver.AI.Test` CodeCellOutputCaptureTest 6/6, `MeshWeaver.Graph.Test` Activity* 71/71, full `dotnet build -c Release -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)