### PR TITLE
Publish gate: answer from the recorded park, not a 90 s wait for a rebuild that already ended

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-installing-a-package-with-a-broken-type-finishes-immediately.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-installing-a-package-with-a-broken-type-finishes-immediately.md
@@ -1,0 +1,34 @@
+---
+Name: Installing a package whose type will not build no longer takes a minute and a half
+Category: Fix
+Description: When a package ships a custom type that cannot build, the install now recognises that straight away and finishes in seconds, instead of waiting out a ninety-second budget for a rebuild that was already over.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Installing a package whose type will not build no longer takes a minute and a half
+
+A package can define its own custom type and then use it for its own top-level page. Installing
+one of those means the platform has to rebuild the type before it can put the package's images and
+videos in place — publishing them any earlier would attach the page to a version of the type that
+does not exist yet, and the page would come up empty for as long as it lived.
+
+So the install waits for that rebuild. And when the rebuild fails — the package ships code with a
+mistake in it — the install is supposed to notice, skip the file publishing, and finish, leaving a
+log line naming the type at fault. The files go out on the next install, once the code is fixed.
+
+That is what happened, but only when the timing was lucky. The install checks twice, and the wait
+recognised "the rebuild is over" only by having watched it happen. The second check usually starts
+after the rebuild has already finished, so there was nothing left to watch: it sat for its full
+ninety-second budget and only then gave the answer it could have given at once. An install of a
+package with one compile error took **93 seconds**; the same install now takes **3**, and
+re-installing it without changing anything takes a tenth of a second.
+
+The wait now reads the platform's own record of the failure. When a type's build fails, the
+platform already files that away and stops rebuilding it until its code changes — precisely so a
+broken type cannot spin. The install consults that record instead of waiting to witness something
+that has already happened. Nothing was retried or given more time; a wait for an event that could
+no longer occur was replaced by the answer already on hand.
+
+Healthy packages are untouched — they publish as promptly as before — and a rebuild that is
+genuinely still running, or one this very install has just asked for, is still waited for in full.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -872,6 +872,27 @@ public static class PackageInstaller
     /// immediate, and recoverable — the assets are published by the next install once the type
     /// compiles, which for a package under auto-update is the very next poll. The log names the
     /// type so the cause is the package's compile error, not a mystery 404.</para>
+    ///
+    /// <para>🚨 <b>"A rebuild has run" is a RECORDED fact, not something this wait may insist on
+    /// WITNESSING</b> (#1277 — the same shape as #1114/#1168, one caller further out). The
+    /// <c>Compiled</c> latch below only turns true on an emission that shows the type
+    /// Pending/Compiling. An install touches this gate TWICE — once from
+    /// <see cref="SettleRetypedRoot"/> while the rebuild is still running, and once from
+    /// <see cref="SyncPackageContent"/> a moment later — and by the second call the compile is
+    /// over. With nothing left to emit, the fold could never reach <c>Settled</c> and the answer
+    /// came only from <see cref="RootTypeSettleTimeout"/> elapsing: measured on
+    /// <c>StaleStampRootBindingTest</c>, the first call answered in 3.2 s and the second burned
+    /// the whole 90 s — a 93 s install of a package the installer had ALREADY decided to skip.
+    /// So the fold also consults <see cref="NodeTypeCompileParkRegistry"/>, which is precisely the
+    /// process's record of "no compile is coming for this type until its source changes". Nothing
+    /// is retried and no bound moves; a wait for an event that provably cannot occur is replaced
+    /// by the answer already in hand.</para>
+    ///
+    /// <para>The park is honoured only while NO release request is outstanding
+    /// (<c>RequestedReleaseAt &gt; LastReleaseRequestHandledAt</c> — the release watcher's own
+    /// trigger predicate, and the watcher un-parks before promoting it to Pending). A queued
+    /// retry means a compile IS coming, so the wait stays a wait — the short-circuit can never
+    /// jump ahead of a rebuild this very install asked for.</para>
     /// </summary>
     private static IObservable<bool> MayPublishIntoRoot(
         IMessageHub hub, string rootPath, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
@@ -880,18 +901,31 @@ public static class PackageInstaller
         if (declaredType is null)
             return Observable.Return(true);
 
-        // Fold the type's stream into "has a compile been in flight since we started?" so a
-        // rebuild that ends WITHOUT a loadable build is recognised as a final answer instead of
-        // waited out to the cap.
+        var options = hub.JsonSerializerOptions;
+        // Absent on a host without AddGraph (a unit-test hub): the fold then behaves exactly as
+        // the pre-#1277 two-phase wait did.
+        var parkRegistry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>();
+
+        // Fold the type's stream into "is the answer known yet?" — the type has a loadable build,
+        // or a rebuild we WITNESSED has ended without one, or the process has already RECORDED
+        // that no rebuild is coming.
         return hub.GetWorkspace().GetMeshNodeStream(declaredType)
             .Where(node => node is not null)
             .Scan((Compiled: false, Loadable: false, Settled: false), (state, node) =>
             {
-                var inFlight = node.Content is NodeTypeDefinition def
-                    && def.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling;
+                // ContentAs, never `is NodeTypeDefinition`: a cross-hub mirror snapshot is
+                // routinely un-materialized JSON, and a CLR type test blinds this to an in-flight
+                // compile (the same reason NodeTypeEnrichmentHelpers.IsCompileInFlight reads it
+                // this way).
+                var def = node.ContentAs<NodeTypeDefinition>(options);
+                var inFlight = def?.CompilationStatus
+                    is CompilationStatus.Pending or CompilationStatus.Compiling;
                 var compiled = state.Compiled || inFlight;
                 var loadable = node.HasLoadableBuild();
-                return (compiled, loadable, loadable || (compiled && !inFlight));
+                var parked = !inFlight
+                    && !ReleaseRequestOutstanding(def)
+                    && parkRegistry?.IsParked(declaredType) == true;
+                return (compiled, loadable, loadable || parked || (compiled && !inFlight));
             })
             .Where(state => state.Settled)
             .Take(1)
@@ -910,6 +944,18 @@ public static class PackageInstaller
                         rootPath, declaredType);
             });
     }
+
+    /// <summary>
+    /// Whether a release request has been flipped on the NodeType and not yet handled — the exact
+    /// predicate <c>NodeTypeCompilationHelpers.InstallReleaseRequestWatcher</c> dispatches on. It
+    /// is the one state in which a PARKED type is nonetheless about to recompile (the watcher
+    /// un-parks before promoting the request to <c>Pending</c>), so the parked short-circuit in
+    /// <see cref="MayPublishIntoRoot"/> must stand down while it holds.
+    /// </summary>
+    private static bool ReleaseRequestOutstanding(NodeTypeDefinition? def) =>
+        def?.RequestedReleaseAt is { } requested
+        && (def.LastReleaseRequestHandledAt is null
+            || requested > def.LastReleaseRequestHandledAt.Value);
 
     /// <summary>
     /// Activates the roots this install just wrote, so a freshly installed package is not dark

--- a/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
@@ -247,6 +247,22 @@ public class StaleStampRootBindingTest(ITestOutputHelper output) : MonolithMeshT
         installMs.Should().BeLessThan(30_000,
             "the install must not post into a root it cannot activate and then wait out the hub's "
             + $"whole request timeout — it did exactly that before the fix (60.9 s); took {installMs}ms");
+
+        // 🅿️ The same install AGAIN — the RECORDED-fact case in its purest form (#1277). Nothing
+        // changed, so no release is requested and NOTHING will ever emit on the type's stream
+        // again. A publish gate that insists on WITNESSING a rebuild has nothing left to witness
+        // and can only end on its 90 s cap; one that reads NodeTypeCompileParkRegistry answers
+        // from state the process already holds. This is the half the first install cannot pin: it
+        // still sees a live compile on its way past, which is exactly why the regression was
+        // bimodal rather than constant.
+        var again = System.Diagnostics.Stopwatch.StartNew();
+        await Install(id, broken);
+        var againMs = again.ElapsedMilliseconds;
+        Output.WriteLine($"re-install of the broken package returned at +{againMs}ms");
+        againMs.Should().BeLessThan(15_000,
+            "a re-install of a package whose NodeType is PARKED compiles nothing at all, so the "
+            + "publish gate must answer from the recorded park rather than wait out its settle "
+            + $"budget; took {againMs}ms");
     }
 
     /// <summary>Installs the fixture package through the standard installer.</summary>


### PR DESCRIPTION
`StaleStampRootBindingTest.SelfTypedRootWhoseTypeNeverCompiles_SkipsThePublishPromptly`
took **93 213 ms** against its 30 s budget on unmodified `main`. Reproduced locally; the
log pins it to the millisecond:

```
13:18:10.775  compile of ShopC/Front fails (CS0103)
13:18:10.850  ShopC/Front PARKED  → NodeTypeParkedException, enrichment overlays
13:18:11.143  MayPublishIntoRoot #1 answers false   (from SettleRetypedRoot)
13:19:41.147  MayPublishIntoRoot #2 answers false   (from SyncPackageContent)
```

**90.004 s** between the two answers — `RootTypeSettleTimeout` exactly.

## Mechanism

`MayPublishIntoRoot` folds the NodeType's stream into *"has a compile been in flight
since we subscribed?"* and only treats a rebuild as finished once it has **witnessed**
one. An install touches the gate twice:

- `SettleRetypedRoot` subscribes while the rebuild is still running → settles in 3.2 s.
- `SyncPackageContent` subscribes a moment later, when the compile is **over**. Nothing
  more is ever emitted, `Settled` can never become true, and the verdict comes only from
  the `.Timeout(90 s)` → `.Catch(→ false)`.

This is answer **(i)** to the question in the issue: a second caller on the #1114/#1168
path that #1168 did not reach. #1168 taught `WaitForCompileSettled` to consult
`NodeTypeCompileParkRegistry`; `PackageInstaller`'s own hand-rolled wait was never
taught the same thing. It also explains the bimodality — whether the second subscription
lands inside a live compile is a race, and main's own CI run won it.

## Fix

The fold also reads `NodeTypeCompileParkRegistry` — the process's record of *"no compile
is coming for this type until its source changes"*. A deterministic compile error parks
on the **first** failure, and the park is written **before** the terminal `Error` status,
so it is already visible on that emission. No bound moves, nothing is retried: a wait for
an event that provably cannot occur is replaced by the answer already in hand.

The short-circuit stands down while a release request is outstanding
(`RequestedReleaseAt > LastReleaseRequestHandledAt` — the release watcher's own trigger
predicate; the watcher un-parks *before* promoting it to `Pending`), so it can never jump
ahead of a rebuild this very install asked for.

The in-flight read also moves from `is NodeTypeDefinition` to `ContentAs<T>`: an
un-materialized mirror snapshot is the normal shape off a sync stream, and the CLR test
was blind to a compile in flight on exactly those emissions.

## Measured

| | before | after |
|---|---|---|
| broken package, install | 93 213 ms | **3 223 ms** |
| broken package, re-install (nothing changes) | ~90 000 ms | **102 ms** |
| healthy self-typed root | 683 ms | 683 ms |
| whole test class | 93 s + | **5 s** |

The re-install assertion is new, and is the recorded-fact case in its purest form: nothing
changes, so no compile is requested and nothing will ever emit on the type's stream again
— a gate that insists on witnessing a rebuild has nothing left to witness.

Not done: the 30 s budget is untouched, no timeout was widened, and no retry/watchdog was
added.

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)