### PR TITLE
feat(self-update): trigger an immediate check on a green build of the platform repo

### DIFF
--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -12,6 +12,9 @@ merge to main ─▶ "Build and Test" (green) ─▶ images job builds+pushes  m
    memex install                       prod install                      external install
    SelfUpdateHostedService polls ACR (its OWN workload identity) every 6h, per its OWN Admin/UpdatePolicy,
    and PATCHes its OWN portal+migration Deployments via its OWN in-cluster ServiceAccount token.
+   Where the GitHub webhook is wired, a green build of SelfUpdate:BuildTriggerRepository (default
+   Systemorph/MeshWeaver) additionally triggers ONE immediate check via the BuildCompletion node —
+   the poll stays as the fallback for installs without the webhook.
 ```
 
 **Why** — prod must not know about the (potentially many) installs, and a central CI service principal

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -2,6 +2,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Threading;
@@ -68,7 +69,9 @@ public class SelfUpdateHostedService : IHostedService
             // re-subscribed when the admin ACTUALLY changes the policy (human-rare) — not a storm.
             .Select(content => content.Policy == UpdatePolicyKind.None
                 ? Observable.Empty<Unit>()                            // None => never poll
-                : Observable.Interval(_options.PollInterval).StartWith(-1L)
+                : Observable.Merge(
+                        Observable.Interval(_options.PollInterval).StartWith(-1L),
+                        BuildCompletionTicks())
                     .SelectMany(_ => RunOnce(content)
                         .Catch((Exception ex) =>
                         {
@@ -136,6 +139,52 @@ public class SelfUpdateHostedService : IHostedService
         return workspace.GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
             .Select(node => UpdatePolicyNodeType.Parse(node, jsonOptions));
     }
+
+    /// <summary>
+    /// Ticks once per NEW green build of <see cref="SelfUpdateOptions.BuildTriggerRepository"/> —
+    /// the event-driven complement to the interval. The <c>BuildCompletion</c> node is a FACT the
+    /// GitHub webhook writes; on an install without the webhook the query never yields and the
+    /// interval still drives everything. Throttled so a burst of workflow completions coalesces
+    /// into one check. This is a THIRD mesh touch, and the standing invariant applies: it may never
+    /// gate or kill the poller — a fault re-establishes the watch silently at the polling cadence,
+    /// and <see cref="RunOnce"/> still lists ACR itself, so a spurious tick costs one cheap tag
+    /// list and can never cause a wrong roll.
+    /// </summary>
+    protected virtual IObservable<long> BuildCompletionTicks()
+    {
+        var parts = (_options.BuildTriggerRepository ?? "")
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+            return Observable.Empty<long>();
+
+        var path = BuildCompletion.PathFor(parts[0], parts[1]);
+        return Observable
+            .Defer(() => NewBuildEvents(_hub
+                .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}", $"path:{path}")
+                .Select(nodes => nodes?.FirstOrDefault())))
+            .Throttle(TimeSpan.FromMinutes(1))
+            .Select(_ => -2L)
+            .RetryWhen(ResubscribeAfterPollInterval("build-completion watch"));
+    }
+
+    /// <summary>
+    /// Turns a live read of one node into "a NEW write happened while we were watching": the
+    /// replayed current state (or its absence) is baseline, never an event — a pod start must not
+    /// look like a fresh build — and every subsequent version change is one event. Pure and static,
+    /// so the distinction is pinned by a unit test rather than re-derived from Rx operator lore.
+    /// </summary>
+    public static IObservable<Unit> NewBuildEvents(IObservable<MeshNode?> node) =>
+        node.Scan(
+                (Baselined: false, Version: 0L, IsEvent: false),
+                (state, current) => current is null
+                    ? (true, state.Version, false)                 // absent baseline (or deleted)
+                    : !state.Baselined
+                        ? (true, current.Version, false)           // replayed current state
+                        : current.Version != state.Version
+                            ? (true, current.Version, true)        // a NEW green build
+                            : (true, current.Version, false))
+            .Where(s => s.IsEvent)
+            .Select(_ => Unit.Default);
 
     /// <summary>Retry signal for <c>RetryWhen</c>: log the fault and resubscribe after one poll
     /// interval (delayed, Rx-composed — no hot loop).</summary>

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateOptions.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateOptions.cs
@@ -36,6 +36,16 @@ public record SelfUpdateOptions
     /// <summary>How often the running install polls the registry ("a few times a day").</summary>
     public TimeSpan PollInterval { get; init; } = TimeSpan.FromHours(6);
 
+    /// <summary>
+    /// The repository ("owner/repo") whose green builds trigger an IMMEDIATE check, on top of the
+    /// interval. The platform image is built by this repo's CD, so reacting to its
+    /// <c>BuildCompletion</c> node (written by the GitHub webhook — see
+    /// <c>Doc/Architecture/PluginUpdateOnGreenBuild</c>) turns "up to a PollInterval late" into
+    /// "minutes after the image lands". On an install without the webhook the stream simply never
+    /// emits and the interval still drives everything. Empty disables the trigger.
+    /// </summary>
+    public string BuildTriggerRepository { get; init; } = "Systemorph/MeshWeaver";
+
     /// <summary>The policy seeded onto <c>Admin/UpdatePolicy</c> when it doesn't exist yet, and the
     /// fallback used before the policy node's first live emission.</summary>
     public UpdatePolicyKind DefaultPolicy { get; init; } = UpdatePolicyKind.Continuous;

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
@@ -79,6 +79,14 @@ startup) and patches its **own** portal + migration Deployments per the `Admin/U
 `Continuous` (the platform default, newest build-numbered tag), `Stable` (newest clean release), or
 `None` (manual only). See [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy).
 
+On installs where the GitHub webhook is wired, the poll is only the fallback: the poller also
+watches the platform repo's `BuildCompletion` node (`Admin/_Build/Systemorph.MeshWeaver` — the same
+fact [plugin updates](/Doc/Architecture/PluginUpdateOnGreenBuild) react to) and runs one immediate
+check when a green build lands, so a roll follows CI by minutes instead of by up to a poll
+interval. `SelfUpdate:BuildTriggerRepository` names the repo (empty disables); an install without
+the webhook simply never sees the node and keeps polling. The watch may never gate or kill the
+poller — a fault re-establishes it silently, same discipline as the policy read.
+
 So the hop is automated *by policy*, and it still fails silently in two ways worth remembering: a
 `None`-policy install never moves, and a commit whose CD run never completed has no selectable
 version tag to move **to** (only the moving `main` pointer and the per-run staging tag, both

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateBuildTriggerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateBuildTriggerTest.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Subjects;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the one distinction the self-update build trigger lives on
+/// (<see cref="SelfUpdateHostedService.NewBuildEvents"/>): the replayed current state of the
+/// <c>BuildCompletion</c> node — or its absence — is BASELINE, and only a version change observed
+/// while watching is an event. Getting this wrong in the "replay" direction makes every pod start
+/// look like a fresh green build; getting it wrong in the "absence" direction misses the first
+/// build after the webhook is wired.
+/// </summary>
+public class SelfUpdateBuildTriggerTest
+{
+    private static MeshNode Node(long version) =>
+        new("Systemorph.MeshWeaver", "Admin/_Build/Systemorph.MeshWeaver") { Version = version };
+
+    private static (Subject<MeshNode?> Input, List<Unit> Events) Watch()
+    {
+        var input = new Subject<MeshNode?>();
+        var events = new List<Unit>();
+        SelfUpdateHostedService.NewBuildEvents(input).Subscribe(events.Add);
+        return (input, events);
+    }
+
+    [Fact]
+    public void ReplayedCurrentState_IsBaseline_NotAnEvent()
+    {
+        var (input, events) = Watch();
+        input.OnNext(Node(5));
+        Assert.Empty(events);
+
+        input.OnNext(Node(6));
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void AbsentNode_ThenFirstWrite_IsAnEvent()
+    {
+        var (input, events) = Watch();
+        input.OnNext(null);
+        Assert.Empty(events);
+
+        input.OnNext(Node(1));
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void UnchangedVersionReEmission_IsNotAnEvent()
+    {
+        var (input, events) = Watch();
+        input.OnNext(Node(5));
+        input.OnNext(Node(5));
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void EverySubsequentBuild_IsOneEvent()
+    {
+        var (input, events) = Watch();
+        input.OnNext(Node(5));
+        input.OnNext(Node(6));
+        input.OnNext(Node(7));
+        input.OnNext(Node(8));
+        Assert.Equal(3, events.Count);
+    }
+}


### PR DESCRIPTION
## What changed

The self-updater's tick source now merges a **BuildCompletion watch** with the poll interval: when the GitHub webhook records a green build of `SelfUpdate:BuildTriggerRepository` (default `Systemorph/MeshWeaver`), the poller runs one immediate check instead of waiting up to a PollInterval (daily on AKS). Plugin content was already event-driven via the same node (`PluginUpdateOnGreenBuild`); this gives the image the same path, using `BuildCompletion` exactly as its docs anticipate ('a third consumer can be added later without touching either').

- `SelfUpdateHostedService.NewBuildEvents` (pure, public): the replayed current state of the node — or its absence — is **baseline**; only a version change observed while watching is an event. A pod start can never look like a fresh build.
- Throttled 1 min so a burst of workflow completions coalesces; ticks route into the existing `RunOnce`, which still lists ACR itself — a spurious tick costs one tag list and can never cause a wrong roll.
- Wedges-to-zero: the watch is a third mesh touch and may never gate or kill the poller — faults re-establish it silently at the polling cadence (`RetryWhen`, same pattern as the policy read #611). Installs without the webhook simply keep polling.
- `SelfUpdateOptions.BuildTriggerRepository` — empty disables.

## Why

Each instance handles its own updates; with webhooks per instance this turns 'rolls happen eventually' into 'rolls happen minutes after CI goes green', and the daily poll remains the fallback.

## How tested

`dotnet build -c Release -p:CIRun=true -warnaserror` clean on Memex.Portal.Shared; `SelfUpdate*` filter: 7/7 green — the 3 existing poller-resilience tests plus 4 new `NewBuildEvents` pins (replay-is-baseline, absent-then-first-write-is-event, unchanged-re-emission, N-builds-N-events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)