### PR TITLE
The coupon list says what a coupon really unlocks

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -425,6 +425,8 @@
   "ui.iconName": "Symbolname:",
   "ui.language": "Sprache:",
   "ui.openCoupon": "Gutschein öffnen:",
+  "ui.couponUnlocksEverything": "alles",
+  "ui.couponUnlocksRedeemedOn": "das Paket, auf dem er eingelöst wird",
   "ui.typeDeleteToConfirm": "Zum Bestätigen DELETE eingeben:",
   "ui.createRelease": "Release erstellen",
   "ui.runTests": "Tests ausführen",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -425,6 +425,8 @@
   "ui.iconName": "Icon Name:",
   "ui.language": "Language:",
   "ui.openCoupon": "Open a coupon:",
+  "ui.couponUnlocksEverything": "everything",
+  "ui.couponUnlocksRedeemedOn": "the package it is used on",
   "ui.typeDeleteToConfirm": "Type DELETE to confirm:",
   "ui.createRelease": "Create Release",
   "ui.runTests": "Run Tests",

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-coupon-list-says-what-a-coupon-unlocks.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-coupon-list-says-what-a-coupon-unlocks.md
@@ -1,0 +1,26 @@
+---
+Name: The coupon list says what a coupon really unlocks
+Category: Fix
+Description: A coupon with no package list was labelled "any plugin", which read as if it opened the whole store. It never did.
+Icon: TicketDiagonal
+Order: -20260812
+---
+
+# The coupon list says what a coupon really unlocks
+
+The **Coupons** tab in Settings labelled a coupon with no package list as unlocking **"any
+plugin"**. That reads as "this code opens the whole store", and it never did: a coupon without a
+list can be *entered* on any package, but redeeming it unlocks only the package it was used on.
+An administrator reading the list could reasonably have believed a code was far more generous
+than it is — and the one code that was actually meant to open everything looked identical to a
+code that opens one thing.
+
+The column now says what happens. A coupon with no list reads **"the package it is used on"**. A
+coupon that genuinely covers everything — the Store's new *grants all* flag — reads
+**"everything"**, and says so even when it also names a list, because that flag is the thing that
+unlocks more than the list does. A coupon that names packages still lists them, unchanged.
+
+Both labels are translated, so a German administrator reads them in German.
+
+The flag itself, and the editor that lets an administrator change a coupon's package list again,
+ship with the Store package.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -425,6 +425,8 @@
   "ui.iconName": "Symbolname:",
   "ui.language": "Sprache:",
   "ui.openCoupon": "Gutschein öffnen:",
+  "ui.couponUnlocksEverything": "alles",
+  "ui.couponUnlocksRedeemedOn": "das Paket, auf dem er eingelöst wird",
   "ui.typeDeleteToConfirm": "Zum Bestätigen DELETE eingeben:",
   "ui.createRelease": "Release erstellen",
   "ui.runTests": "Tests ausführen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -425,6 +425,8 @@
   "ui.iconName": "Icon Name:",
   "ui.language": "Language:",
   "ui.openCoupon": "Open a coupon:",
+  "ui.couponUnlocksEverything": "everything",
+  "ui.couponUnlocksRedeemedOn": "the package it is used on",
   "ui.typeDeleteToConfirm": "Type DELETE to confirm:",
   "ui.createRelease": "Create Release",
   "ui.runTests": "Run Tests",

--- a/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
@@ -86,8 +86,16 @@ public static class CouponAdminSettingsTab
     {
         /// <summary>The coupon code (the node id).</summary>
         public string Code { get; init; } = string.Empty;
-        /// <summary>The plugin allow-list, comma-joined; "any plugin" when the list is empty
-        /// (an empty list is valid everywhere and grants the redeemed-on plugin).</summary>
+        /// <summary>
+        /// What the coupon unlocks: the package list comma-joined; the <c>grantsAll</c> label when
+        /// the coupon covers everything; the empty-list label otherwise.
+        ///
+        /// <para>🚨 It used to read <b>"any plugin"</b> for an empty list, which described
+        /// behaviour the Store never had. An empty list means the coupon may be REDEEMED anywhere
+        /// and grants only the package it was redeemed ON — the opposite of "unlocks any plugin"
+        /// (Systemorph/MeshWeaver.Plugins#321). "Unlocks everything" is the coupon's own
+        /// <c>grantsAll</c> flag, and now has its own label.</para>
+        /// </summary>
         public string Unlocks { get; init; } = string.Empty;
         /// <summary>The effective price: "free" when the coupon carries none (or 0), else the
         /// discounted amount with currency.</summary>
@@ -106,7 +114,13 @@ public static class CouponAdminSettingsTab
     /// own class; a foreign hub may still deliver it typed, a query a <c>JsonElement</c>, a
     /// builder a <c>JsonNode</c>). Pure.
     /// </summary>
-    public static CouponRow ToRow(MeshNode node, JsonSerializerOptions options)
+    /// <param name="localize">
+    /// Resolves the two <see cref="CouponRow.Unlocks"/> labels for the viewer's language. Optional
+    /// so the projection stays a pure function callable without a host (its tests do exactly that);
+    /// callers that HAVE a host must pass <c>host.Localize</c>, or a German admin reads English.
+    /// </param>
+    public static CouponRow ToRow(
+        MeshNode node, JsonSerializerOptions options, Func<string, string>? localize = null)
     {
         var content = ElementOf(node, options);
         var plugins = content is { } c && c.TryGetProperty("plugins", out var p)
@@ -114,6 +128,8 @@ public static class CouponAdminSettingsTab
             ? p.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String)
                 .Select(e => e.GetString()!).ToArray()
             : [];
+        var grantsAll = content is { } g && g.TryGetProperty("grantsAll", out var ga)
+                        && ga.ValueKind == JsonValueKind.True;
         var price = ReadDecimal(content, "price");
         var currency = ReadString(content, "currency") ?? "CHF";
         var validFrom = ReadString(content, "validFrom");
@@ -124,7 +140,13 @@ public static class CouponAdminSettingsTab
         return new CouponRow
         {
             Code = node.Id,
-            Unlocks = plugins.Length == 0 ? "any plugin" : string.Join(", ", plugins),
+            // grantsAll wins the cell: it is the one thing that unlocks more than the list names.
+            // An empty list is NOT "any plugin" — see CouponRow.Unlocks.
+            Unlocks = grantsAll
+                ? Label(localize, "ui.couponUnlocksEverything", "everything")
+                : plugins.Length == 0
+                    ? Label(localize, "ui.couponUnlocksRedeemedOn", "the package it is used on")
+                    : string.Join(", ", plugins),
             Price = price is null or 0m ? "free" : $"{currency} {price:0.##}",
             Valid = (validFrom, validUntil) switch
             {
@@ -137,6 +159,12 @@ public static class CouponAdminSettingsTab
             Notes = ReadString(content, "notes") ?? "",
         };
     }
+
+    // The localized label, or the English fallback when this projection was called without a host
+    // (its unit tests). Never CultureInfo.CurrentUICulture — a layout-area render hops the hub
+    // scheduler and an ambient culture does not survive it.
+    private static string Label(Func<string, string>? localize, string key, string english) =>
+        localize?.Invoke(key) is { Length: > 0 } localized && localized != key ? localized : english;
 
     private static string DatePart(string isoTimestamp) =>
         isoTimestamp.Length >= 10 ? isoTimestamp[..10] : isoTimestamp;
@@ -227,7 +255,7 @@ public static class CouponAdminSettingsTab
 
         var rows = coupons.Values
             .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
-            .Select(n => ToRow(n, options))
+            .Select(n => ToRow(n, options, key => host.Localize(key)))
             .ToImmutableArray();
 
         // Rows bind INLINE — a per-render UpdateData under a fresh id would accumulate orphaned

--- a/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/CouponAdminSettingsTab.cs
@@ -253,9 +253,12 @@ public static class CouponAdminSettingsTab
         if (coupons.IsEmpty)
             return Controls.Markdown(host.Localize("ui.mdNoCoupons"));
 
+        // One delegate for the whole grid, not one per row: this projection re-runs on every
+        // snapshot of a live query, so a per-row closure is an allocation per coupon per frame.
+        var localize = (Func<string, string>)(key => host.Localize(key));
         var rows = coupons.Values
             .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
-            .Select(n => ToRow(n, options, key => host.Localize(key)))
+            .Select(n => ToRow(n, options, localize))
             .ToImmutableArray();
 
         // Rows bind INLINE — a per-render UpdateData under a fresh id would accumulate orphaned

--- a/test/MeshWeaver.PluginCatalog.Test/CouponAdminSettingsTabTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CouponAdminSettingsTabTest.cs
@@ -59,16 +59,56 @@ public class CouponAdminSettingsTabTest
         Assert.Equal("4 / 10", row.Redeemed);
     }
 
+    /// <summary>
+    /// 🚨 An EMPTY list is not "any plugin". It means the coupon may be REDEEMED anywhere and
+    /// grants only the package it was redeemed ON — the old label promised the opposite, and read
+    /// as if the coupon unlocked the whole store (Systemorph/MeshWeaver.Plugins#321).
+    /// </summary>
     [Fact]
-    public void ToRow_EmptyAllowList_ReadsAsAnyPlugin_AndZeroPriceIsFree()
+    public void ToRow_EmptyList_SaysItUnlocksTheRedeemedOnPackage_NotAnyPlugin()
     {
         var row = CouponAdminSettingsTab.ToRow(Coupon("OPEN",
             """{"$type":"CouponContent","price":0,"validUntil":"2026-12-31T00:00:00+00:00"}"""), Options);
-        Assert.Equal("any plugin", row.Unlocks);
+        Assert.Equal("the package it is used on", row.Unlocks);
+        Assert.DoesNotContain("any", row.Unlocks, StringComparison.OrdinalIgnoreCase);
         Assert.Equal("free", row.Price);
         Assert.Equal("until 2026-12-31", row.Valid);
         Assert.Equal("0", row.Redeemed);
         Assert.Equal("", row.Notes);
+    }
+
+    /// <summary>
+    /// "Unlocks everything" is the coupon's own <c>grantsAll</c> flag, and it wins the cell — it is
+    /// the one thing that unlocks more than the list names.
+    /// </summary>
+    [Fact]
+    public void ToRow_GrantsAll_SaysEverything_EvenBesideAList()
+    {
+        Assert.Equal("everything", CouponAdminSettingsTab.ToRow(Coupon("UNLOCKALL",
+            """{"$type":"CouponContent","grantsAll":true}"""), Options).Unlocks);
+        Assert.Equal("everything", CouponAdminSettingsTab.ToRow(Coupon("UNLOCKALL",
+            """{"$type":"CouponContent","grantsAll":true,"plugins":["Chess"]}"""), Options).Unlocks);
+        Assert.Equal("Chess", CouponAdminSettingsTab.ToRow(Coupon("JUSTCHESS",
+            """{"$type":"CouponContent","grantsAll":false,"plugins":["Chess"]}"""), Options).Unlocks);
+    }
+
+    /// <summary>
+    /// The labels resolve through the viewer's catalog when a host supplied one — the projection
+    /// stays pure and falls back to English only when called without one (as these tests do).
+    /// </summary>
+    [Fact]
+    public void ToRow_Labels_ComeFromTheLocalizer_WhenOneIsSupplied()
+    {
+        string German(string key) => key switch
+        {
+            "ui.couponUnlocksEverything" => "alles",
+            "ui.couponUnlocksRedeemedOn" => "das Paket, auf dem er eingelöst wird",
+            _ => key,
+        };
+        Assert.Equal("alles", CouponAdminSettingsTab.ToRow(Coupon("A",
+            """{"grantsAll":true}"""), Options, German).Unlocks);
+        Assert.Equal("das Paket, auf dem er eingelöst wird", CouponAdminSettingsTab.ToRow(Coupon("B",
+            """{"plugins":[]}"""), Options, German).Unlocks);
     }
 
     [Fact]
@@ -87,7 +127,7 @@ public class CouponAdminSettingsTabTest
             { NodeType = "Store/Coupon", Content = null };
         var row = CouponAdminSettingsTab.ToRow(empty, Options);
         Assert.Equal("N2", row.Code);
-        Assert.Equal("any plugin", row.Unlocks);
+        Assert.Equal("the package it is used on", row.Unlocks);
         Assert.Equal("free", row.Price);
     }
 


### PR DESCRIPTION
The label half of **Systemorph/MeshWeaver.Plugins#321**. The code it describes lives in the Store
package (**Systemorph/MeshWeaver.Plugins#422**); the *label* is here, so it ships separately.

## What was wrong

`CouponAdminSettingsTab.cs:127` rendered an empty package list as **"any plugin"**:

```csharp
Unlocks = plugins.Length == 0 ? "any plugin" : string.Join(", ", plugins),
```

That reads as *"this code opens the whole store"*, and the Store has never behaved that way. An
empty list means the coupon may be **entered** on any package — but redeeming it grants only the
package it was used on (`CouponRedemption.GrantTargets`). The label promised the exact opposite of
what the code does, and an administrator scanning the grid had no way to tell a genuinely-generous
code from a one-package one: they printed the same words.

## What it says now

| coupon | before | after |
|---|---|---|
| no list | `any plugin` | `the package it is used on` |
| `grantsAll: true` | `any plugin` (or the list) | `everything` |
| `grantsAll: true` + a list | the list | `everything` |
| a list | the list | the list — unchanged |

`grantsAll` wins the cell deliberately: it is the one thing that unlocks more than the list names,
so showing the list there would understate the coupon.

## Localization

Both labels resolve through the viewer's catalog — `ui.couponUnlocksEverything` and
`ui.couponUnlocksRedeemedOn`, added to `strings.en.json` **and** `strings.de.json` ("alles" / "das
Paket, auf dem er eingelöst wird").

`ToRow` stays a **pure** function: the localizer arrives as an optional `Func<string,string>`,
because the projection has no `LayoutAreaHost` and its unit tests call it directly. The one caller
that *has* a host passes `host.Localize`, so a German admin reads German. Never
`CultureInfo.CurrentUICulture` — a layout-area render hops the hub scheduler and an ambient culture
does not survive it.

The other five cells in this grid (`free`, `always`, `until …`, the currency default) are
pre-existing English literals and are left alone — widening this into a full localization pass of
the tab would bury the one-line semantic fix that the issue is about.

## Reading `grantsAll`

By SHAPE, like every other field here — `Store/Coupon` is a dynamically compiled node type, so this
assembly never sees it as a class. Absent property ⇒ `false`, which is what every coupon written
before the flag existed always meant.

## Verified

* `dotnet test test/MeshWeaver.PluginCatalog.Test --filter CouponAdminSettingsTabTest` — **7/7**
  (the empty-list case renamed to say what it now asserts, plus two new cases: `grantsAll` wins the
  cell even beside a list, and the labels come from the localizer when one is supplied)
* `dotnet test test/MeshWeaver.Messaging.Hub.Test --filter LocalizationTest` — **33/33** (no
  language is missing either new key)
* `dotnet test test/MeshWeaver.Documentation.Test --filter WhatsNewEntryIntegrity` — **1/1**
* `dotnet build -c Release -warnaserror` on `MeshWeaver.PluginCatalog`, `MeshWeaver.Messaging.Hub`
  and `MeshWeaver.Documentation` — **0 warnings, 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
