### PR TITLE
fix: HtmlView honours Style/Class instead of silently dropping them

### DIFF
--- a/src/MeshWeaver.Blazor/Components/HtmlView.razor
+++ b/src/MeshWeaver.Blazor/Components/HtmlView.razor
@@ -46,9 +46,25 @@ else
     /// surrounding <c>FluentStack</c>. A wrapper interposed on all of those turns inline runs into block
     /// boxes, collapses gapped siblings into one child, and makes <c>flex: 1</c> inert. Most of that code
     /// lives in mesh nodes that no build and no test ever renders, so the breakage would surface only in a
-    /// running portal. NOT ONE of those call sites sets <c>Style</c> or <c>Class</c>, so gating on the
-    /// declaration leaves every one of them byte-identical while the next author who writes
-    /// <c>Controls.Html(svg).WithStyle("width:100%")</c> gets an element that actually carries it.</para>
+    /// running portal. A balanced-paren scan of <c>src/</c>, <c>samples/</c>, <c>content/</c>, <c>memex/</c>
+    /// for <c>Controls.Html</c> / <c>Controls.Title</c> / <c>new HtmlControl</c> followed by a
+    /// <c>.WithStyle</c>/<c>.WithClass</c> chain finds just THREE — a textarea in the Todo sample and the
+    /// two version-page titles in <c>VersionLayoutArea</c>. All three were asking for a style that was
+    /// being dropped, and all three now get it. Every other call site is untouched, while the next author
+    /// who writes <c>Controls.Html(svg).WithStyle("width:100%")</c> gets an element that carries it.</para>
+    ///
+    /// <para>⚠️ Do not confuse <c>Controls.Title(text, n)</c> with <c>Controls.H1</c>…<c>H6</c> when
+    /// reasoning about that blast radius. Only <c>Title</c> is an <c>HtmlControl</c> (it emits
+    /// <c>&lt;h{n}&gt;</c> markup); <c>H1</c>…<c>H6</c> are <c>LabelControl</c>
+    /// (<c>Label(data).WithTypo(Typography.Hn)</c>) and render through <c>Label.razor</c>, which already
+    /// applies <c>Style</c>. The ~100 <c>Controls.H2(...).WithStyle("margin: 0")</c> call sites across the
+    /// portal therefore have nothing to do with this view and are completely unaffected.</para>
+    ///
+    /// <para>For the two <c>Controls.Title</c> sites the wrapper carries the style, so a declared
+    /// <c>margin</c> applies to the wrapper while the <c>&lt;h{n}&gt;</c> keeps its own UA margin inside
+    /// it. That is strictly better than dropping the style, but the author's literal intent would need the
+    /// style ON the heading — which means giving <c>Title</c> its own control/view rather than borrowing
+    /// <c>HtmlControl</c>. Left as a follow-up: it changes a public factory's return type.</para>
     /// </summary>
     private bool HasStyling => ViewModel.Style is not null || ViewModel.Class is not null;
 

--- a/src/MeshWeaver.Blazor/Components/HtmlView.razor
+++ b/src/MeshWeaver.Blazor/Components/HtmlView.razor
@@ -6,6 +6,15 @@
         @Html
     </div>
 }
+else if (HasStyling)
+{
+    @* The author set Style and/or Class, so they asked for a box to hang it on. HtmlControl has no
+       element of its own — the fragment IS the output — so the only way to honour the request is to
+       wrap. See HasStyling for why this is conditional rather than unconditional. *@
+    <div style="@Style" class="@Class">
+        @Html
+    </div>
+}
 else
 {
     @Html
@@ -14,6 +23,34 @@ else
 @code
 {
     private MarkupString? Html { get; set; }
+
+    /// <summary>
+    /// Whether the author declared <c>Style</c> or <c>Class</c> on this control — and therefore whether
+    /// the fragment gets a wrapper element to carry them.
+    ///
+    /// <para>Read from <c>ViewModel</c> (the DECLARATION) rather than from the bound <c>Style</c>/<c>Class</c>
+    /// fields (the RESOLVED values) on purpose: either may be a <c>JsonPointerReference</c> that resolves a
+    /// frame or more after the first render, and gating on the resolved value would render the fragment
+    /// bare, then restructure the DOM around it when the pointer lands. The declaration is known at bind
+    /// time and never changes for a given view-model, so the box is stable from the first frame. Gating on
+    /// the declaration also loses nothing: <c>BindData</c> feeds these fields from exactly these two
+    /// properties, so a resolved value can only be non-null when the declaration was.</para>
+    ///
+    /// <para>🚨 Why not wrap unconditionally. <c>HtmlControl</c> renders its data as a raw fragment with no
+    /// element of its own, and ~400 call sites across <c>src/</c>, <c>samples/</c> and the in-mesh node
+    /// trees rely on that: <c>BlazorViewRegistry.FallbackHtml</c> emits bare encoded TEXT for every
+    /// unrecognised control, <c>Northwind.LayoutTemplates.GrowthPercentage</c> emits an inline
+    /// <c>&lt;span&gt;</c>, several settings tabs emit multiple top-level siblings that are meant to be
+    /// separate gapped children of their stack, and <c>Todo/Source/TodoLayoutAreas</c> writes
+    /// <c>flex: 1</c> onto the fragment's OWN root because that root is the direct flex child of the
+    /// surrounding <c>FluentStack</c>. A wrapper interposed on all of those turns inline runs into block
+    /// boxes, collapses gapped siblings into one child, and makes <c>flex: 1</c> inert. Most of that code
+    /// lives in mesh nodes that no build and no test ever renders, so the breakage would surface only in a
+    /// running portal. NOT ONE of those call sites sets <c>Style</c> or <c>Class</c>, so gating on the
+    /// declaration leaves every one of them byte-identical while the next author who writes
+    /// <c>Controls.Html(svg).WithStyle("width:100%")</c> gets an element that actually carries it.</para>
+    /// </summary>
+    private bool HasStyling => ViewModel.Style is not null || ViewModel.Class is not null;
 
     protected override void BindData()
     {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-content-blocks-no-longer-ignore-the-width-you-set.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-content-blocks-no-longer-ignore-the-width-you-set.md
@@ -1,0 +1,28 @@
+---
+Name: Content blocks no longer ignore the width you set
+Category: Fix
+Description: A block of ready-made content — a chart, a diagram, an embedded image — silently discarded any width, spacing or styling its author gave it, so a chart asked to fill its column could still render as a sliver a few percent wide.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Content blocks no longer ignore the width you set
+
+Most things on a page are built from the portal's own building blocks — a table, a button, a stack
+of cards — and each of those has always honoured the size and styling its author asks for. There is
+one more building block for content that is already finished and just needs placing on the page: a
+chart drawn elsewhere, a diagram, an embedded picture, a formatted note.
+
+That one quietly threw the styling away. An author could set a width, a margin or a colour on it and
+nothing at all would happen — no warning, no error, no hint that the instruction had been dropped.
+The most visible consequence was charts: a chart placed in a column and told to fill it would
+instead shrink to whatever size it happened to be drawn at, sometimes only a few percent of the
+space, squeezed into a corner of an otherwise empty column. The obvious fix — telling it to be full
+width — was exactly the instruction being discarded, so the problem looked unfixable rather than
+merely broken.
+
+These blocks now carry their styling like everything else, so a width or a margin set on one takes
+effect. Blocks whose author set no styling are placed exactly as before: that matters because such a
+block is dropped into the page as-is, and quietly boxing every one of them would have shifted
+existing layouts — turning side-by-side items into stacked ones, or adding line breaks around short
+pieces of inline text. Nothing changes unless the author asked for it.

--- a/src/MeshWeaver.Layout/HtmlControl.cs
+++ b/src/MeshWeaver.Layout/HtmlControl.cs
@@ -4,8 +4,18 @@
     /// Represents an HTML control with customizable properties.
     /// </summary>
     /// <remarks>
-    /// For more information, visit the 
-    /// <a href="https://www.fluentui-blazor.net/html">Fluent UI Blazor HTML documentation</a>.
+    /// <para>Unlike every other control, this one has no element of its own: <c>Data</c> is emitted as a raw
+    /// fragment, so whatever elements it contains become the direct children of the surrounding container.
+    /// That is deliberate — an inline <c>&lt;span&gt;</c> stays inline, several top-level siblings stay
+    /// several children of the parent stack, and a root carrying <c>flex: 1</c> is genuinely the flex child
+    /// that rule applies to.</para>
+    /// <para>Setting <see cref="UiControl.Style"/> or <see cref="UiControl.Class"/> opts out of that: the
+    /// fragment is then wrapped in a <c>&lt;div&gt;</c> carrying them, because there is otherwise no element
+    /// to put them on. Set them when the content needs a box of its own (e.g.
+    /// <c>Controls.Html(svg).WithStyle("width: 100%")</c> to stop a raw <c>&lt;svg&gt;</c> collapsing to its
+    /// intrinsic size as a flex child); leave them unset to keep the bare fragment.</para>
+    /// <para>For more information, visit the
+    /// <a href="https://www.fluentui-blazor.net/html">Fluent UI Blazor HTML documentation</a>.</para>
     /// </remarks>
     /// <param name="Data">The data associated with the HTML control.</param>
     public record HtmlControl(object Data)

--- a/src/MeshWeaver.Layout/HtmlControl.cs
+++ b/src/MeshWeaver.Layout/HtmlControl.cs
@@ -4,16 +4,22 @@
     /// Represents an HTML control with customizable properties.
     /// </summary>
     /// <remarks>
-    /// <para>Unlike every other control, this one has no element of its own: <c>Data</c> is emitted as a raw
-    /// fragment, so whatever elements it contains become the direct children of the surrounding container.
-    /// That is deliberate — an inline <c>&lt;span&gt;</c> stays inline, several top-level siblings stay
-    /// several children of the parent stack, and a root carrying <c>flex: 1</c> is genuinely the flex child
-    /// that rule applies to.</para>
-    /// <para>Setting <see cref="UiControl.Style"/> or <see cref="UiControl.Class"/> opts out of that: the
-    /// fragment is then wrapped in a <c>&lt;div&gt;</c> carrying them, because there is otherwise no element
-    /// to put them on. Set them when the content needs a box of its own (e.g.
+    /// <para><b>By default this control contributes no element of its own</b> — <c>Data</c> is emitted as a
+    /// raw fragment, so whatever elements it contains become the direct children of the surrounding
+    /// container. That is deliberate: an inline <c>&lt;span&gt;</c> stays inline, several top-level siblings
+    /// stay several children of the parent stack, and a root carrying <c>flex: 1</c> is genuinely the flex
+    /// child that rule applies to.</para>
+    /// <para><b>It is a default, not an invariant — two things opt into a wrapping <c>&lt;div&gt;</c>:</b></para>
+    /// <list type="bullet">
+    /// <item><description>Setting <see cref="UiControl.Style"/> or <see cref="UiControl.Class"/>, because
+    /// there is otherwise no element to put them on. Set them when the content needs a box of its own (e.g.
     /// <c>Controls.Html(svg).WithStyle("width: 100%")</c> to stop a raw <c>&lt;svg&gt;</c> collapsing to its
-    /// intrinsic size as a flex child); leave them unset to keep the bare fragment.</para>
+    /// intrinsic size as a flex child); leave them unset to keep the bare fragment.</description></item>
+    /// <item><description>Registering a click handler (<c>WithClickAction</c>), which needs an element to
+    /// attach to. That wrapper has always been there and carries Style/Class too.</description></item>
+    /// </list>
+    /// <para>So the bare fragment is what you get when the control is non-clickable AND has no Style or
+    /// Class; anything else introduces exactly one <c>&lt;div&gt;</c> around the fragment.</para>
     /// <para>For more information, visit the
     /// <a href="https://www.fluentui-blazor.net/html">Fluent UI Blazor HTML documentation</a>.</para>
     /// </remarks>

--- a/test/MeshWeaver.Hosting.Blazor.Test/ControlStyleRenderingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ControlStyleRenderingTest.cs
@@ -35,7 +35,11 @@ namespace MeshWeaver.Hosting.Blazor.Test;
 ///
 /// <para><b>Coverage and its edges.</b> Rendered here: <c>ButtonView</c> (the reported control, both
 /// <c>WithStyle</c> overloads plus <c>WithClass</c>), <c>IconView</c> and <c>BadgeView</c> as
-/// representatives of the sibling views that shared the omission. The form-input views
+/// representatives of the sibling views that shared the omission, and <c>HtmlView</c>, which had the
+/// same hole in its NON-clickable branch only — with the twist that <c>HtmlControl</c> has no element of
+/// its own, so honouring Style means introducing one. It may therefore do so only when the author asked
+/// for it; the two "bare fragment" tests below are the guard on that and are as load-bearing as the
+/// positive ones. The form-input views
 /// (Checkbox/Switch/Combobox/Listbox/RadioGroup/Search) forward <c>ComputedStyle</c> — the
 /// <c>FormComponentBase</c> fold of Style+Width+Height — and are not rendered here because they need a
 /// live pointer stream. <c>SpacerView</c> is deliberately NOT fixed: <c>FluentSpacer</c> exposes no
@@ -168,6 +172,78 @@ public class ControlStyleRenderingTest(ITestOutputHelper output) : MonolithMeshT
         // later appends further declarations to it.
         html.Should().NotContain("style=\"button",
             because: "Controls.Button must not seed the style slot with the class token \"button\" — #742");
+    }
+
+    /// <summary>
+    /// <c>HtmlControl</c> is the same omission in its non-clickable branch: the clickable branch wrapped
+    /// the fragment in a <c>&lt;div style class&gt;</c>, the non-clickable one emitted the bare fragment and
+    /// dropped both. So <c>Controls.Html(svg).WithStyle("width: 100%")</c> — the obvious fix for a raw
+    /// <c>&lt;svg&gt;</c> collapsing to its intrinsic size as a flex child — did nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task HtmlControl_StyleAndClass_ReachTheDom()
+    {
+        var html = await RenderAsync<HtmlView>(
+            Controls.Html("<svg viewBox=\"0 0 10 10\"></svg>").WithStyle("width: 100%").WithClass(ClassValue));
+
+        html.Should().Contain("width: 100%",
+            because: "a styled HtmlControl must get an element that carries the style — it has none of its own");
+        html.Should().Contain(ClassValue,
+            because: "Class is dropped by the same markup omission as Style");
+        html.Should().Contain("<svg",
+            because: "wrapping must not swallow or escape the fragment itself");
+    }
+
+    /// <summary>Only <c>Class</c> set — the wrapper is not conditional on <c>Style</c> alone.</summary>
+    [Fact]
+    public async Task HtmlControl_ClassOnly_ReachesTheDom()
+    {
+        var html = await RenderAsync<HtmlView>(Controls.Html("<span>x</span>").WithClass(ClassValue));
+
+        html.Should().Contain(ClassValue,
+            because: "Class alone must also produce the element that carries it");
+    }
+
+    /// <summary>
+    /// 🚨 THE BACKWARDS-COMPATIBILITY GUARD. <c>HtmlControl</c> emits a RAW fragment — it has no element of
+    /// its own — and ~400 call sites depend on that. <c>BlazorViewRegistry.FallbackHtml</c> emits bare
+    /// encoded text for every unrecognised control; <c>Northwind.LayoutTemplates.GrowthPercentage</c> emits
+    /// an inline <c>&lt;span&gt;</c>; the settings tabs emit several top-level siblings meant to be separate
+    /// gapped children of their stack; <c>Todo/Source/TodoLayoutAreas</c> writes <c>flex: 1</c> onto the
+    /// fragment's own root precisely because that root is the direct flex child of the enclosing
+    /// <c>FluentStack</c>. Wrapping unconditionally would turn inline runs into block boxes, collapse gapped
+    /// siblings into one child, and make that <c>flex: 1</c> inert — and most of those call sites live in
+    /// mesh nodes that no build and no test renders, so it would surface only in a running portal.
+    ///
+    /// <para>Hence: an UNSTYLED HtmlControl must still emit the bare fragment and nothing else. If someone
+    /// later "simplifies" the view to always wrap, this test is what stops it.</para>
+    /// </summary>
+    [Fact]
+    public async Task HtmlControl_WithoutStyleOrClass_EmitsTheBareFragment()
+    {
+        const string fragment = "<span>inline</span>";
+
+        var html = await RenderAsync<HtmlView>(Controls.Html(fragment));
+
+        html.Should().Be(fragment,
+            because: "an unstyled HtmlControl is a raw fragment — no wrapper element may be introduced, or "
+                   + "inline content becomes a block and a fragment root's own flex rules stop applying");
+    }
+
+    /// <summary>
+    /// The multi-root case stated explicitly: several top-level siblings must stay several siblings of the
+    /// parent container, not be collapsed into one child (which would drop the container's gaps between
+    /// them).
+    /// </summary>
+    [Fact]
+    public async Task HtmlControl_MultiRootFragment_StaysMultiRoot()
+    {
+        const string fragment = "<div>label</div><div>value</div>";
+
+        var html = await RenderAsync<HtmlView>(Controls.Html(fragment));
+
+        html.Should().Be(fragment,
+            because: "the settings tabs pass sibling elements expecting them to be siblings in the stack");
     }
 
     private sealed class StaticHostLifetime : Microsoft.Extensions.Hosting.IHostApplicationLifetime

--- a/test/MeshWeaver.Hosting.Blazor.Test/ControlStyleRenderingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ControlStyleRenderingTest.cs
@@ -246,6 +246,59 @@ public class ControlStyleRenderingTest(ITestOutputHelper output) : MonolithMeshT
             because: "the settings tabs pass sibling elements expecting them to be siblings in the stack");
     }
 
+    /// <summary>
+    /// ⚠️ <c>Controls.Title(text, n)</c> is an <c>HtmlControl</c> — it emits <c>&lt;h{n}&gt;</c> markup
+    /// (<c>Controls.cs</c>: <c>Html($"&lt;h{headerSize}&gt;{text}&lt;/h{headerSize}&gt;")</c>) — so it went
+    /// through the same silent drop, and the two <c>VersionLayoutArea</c> title call sites are two of the
+    /// only three places in the tree affected by this change.
+    ///
+    /// <para><b>Do not confuse it with <c>Controls.H1</c>…<c>H6</c>.</b> Those are <c>LabelControl</c>
+    /// (<c>Label(data).WithTypo(Typography.Hn)</c>) and render through <c>Label.razor</c>, which already
+    /// applies <c>Style</c> — so the ~100 <c>Controls.H2(...).WithStyle("margin: 0")</c> call sites across
+    /// the portal never had this bug and are untouched here. The two factories look interchangeable and
+    /// are not; the sibling test below pins the <c>Title</c> half so the distinction stays visible.</para>
+    ///
+    /// <para>The style lands on the wrapper, not on the <c>&lt;h{n}&gt;</c>, so a declared <c>margin</c>
+    /// adds to the heading's own UA margin rather than replacing it. Strictly better than dropping it;
+    /// the author's literal intent needs <c>Title</c> to have its own control/view, which is the tracked
+    /// follow-up rather than this change.</para>
+    /// </summary>
+    [Fact]
+    public async Task TitleControl_IsAnHtmlControl_SoItsStyleNowReachesAWrapper()
+    {
+        var html = await RenderAsync<HtmlView>(Controls.Title("Section", 2).WithStyle("margin: 0 0 8px 0;"));
+
+        html.Should().Contain("margin: 0 0 8px 0",
+            because: "Controls.Title is an HtmlControl, so its style went through the same silent drop");
+        html.Should().Contain("<h2>Section</h2>",
+            because: "the heading element itself must survive the wrapper unchanged");
+    }
+
+    /// <summary>An unstyled title keeps the bare <c>&lt;h2&gt;</c> — no wrapper, exactly as today.</summary>
+    [Fact]
+    public async Task TitleControl_WithoutStyle_IsStillABareHeading()
+    {
+        var html = await RenderAsync<HtmlView>(Controls.Title("Section", 2));
+
+        html.Should().Be("<h2>Section</h2>",
+            because: "the great majority of titles set no style and must be untouched");
+    }
+
+    /// <summary>
+    /// The guard on the paragraph above: <c>Controls.H2</c> is a <c>LabelControl</c>, NOT an
+    /// <c>HtmlControl</c>, and its Style already worked. If someone ever re-implements <c>H1</c>…<c>H6</c>
+    /// on top of <c>Controls.Title</c>, this test fails and the ~100 heading call sites' blast radius has
+    /// to be re-reasoned rather than silently changing.
+    /// </summary>
+    [Fact]
+    public void HeadingFactories_AreLabelControls_NotHtmlControls()
+    {
+        Controls.H2("Section").Should().BeOfType<LabelControl>(
+            because: "Controls.H1..H6 are Label(data).WithTypo(...) and render through Label.razor");
+        Controls.Title("Section", 2).Should().BeOfType<HtmlControl>(
+            because: "Controls.Title emits raw <hN> markup and is the one heading factory this view sees");
+    }
+
     private sealed class StaticHostLifetime : Microsoft.Extensions.Hosting.IHostApplicationLifetime
     {
         public CancellationToken ApplicationStarted { get; } = new(canceled: true);


### PR DESCRIPTION
## The defect

`HtmlView.razor`'s non-clickable branch emitted the bare fragment with no wrapper element:

```razor
@if (ViewModel.IsClickable)
{
    <div @onclick="OnClick" style="@Style" class="@Class">@Html</div>
}
else
{
    @Html          ← no wrapper element, no Style, no Class
}
```

`Style` and `Class` are public API on `UiControl` and are bound for **every** control by
`BlazorView.BindData` (`BlazorView.razor.cs:494-496`) — so an author could set them and this view
**silently discarded** them unless the control happened to be clickable. No error, no log, no fallback.
`Controls.Html(x).WithStyle("width: 100%")` did nothing.

Same defect class as #742 (`ButtonView` / `IconView` / `BadgeView`), which is why the fix and its tests
live alongside those in `ControlStyleRenderingTest`.

**Driving case:** raw `<svg>` emitted via `Controls.Html(...)` becomes a direct flex child of its
`FluentStack` and collapses toward its intrinsic size — the Reinsurance charts at ~6% of column width.
The obvious author fix was the exact instruction being dropped, which made it look unfixable rather
than merely broken. **This PR is the platform fix only** — the charts themselves are being moved onto
framework chart controls separately (Reinsurance PR #52); nothing here chases that symptom.

## Wrapping strategy: conditional, gated on the declaration

The fragment is wrapped in a `<div style class>` **only when the author declared `Style` or `Class`**.
Otherwise the bare fragment is emitted exactly as today.

### Why not unconditional — consumer evidence

`HtmlControl` is the one control with no element of its own: `Data` is emitted as a raw fragment, and
**~416 call sites** depend on that (334 in `src/`, 82 in `samples/` + `content/` + `memex/`). Four
concrete shapes in the tree break under an unconditional wrapper:

| Call site | Fragment | What a wrapper does |
|---|---|---|
| `src/MeshWeaver.Blazor/BlazorViewRegistry.cs:214` (`FallbackHtml`) | bare HTML-encoded **text**, no element at all | inline text run → block box, for **every unrecognised control anywhere in the portal** |
| `samples/Northwind/.../LayoutTemplates.cs:43` (`GrowthPercentage`) | `<span style='color:green'>+12%</span>` | inline → block: a line break where there was none |
| `ContentIndexSettingsTab.BuildChunkPanel` | three top-level siblings into a `gap:6px` stack | three gapped flex children collapse into **one**, dropping the gaps |
| `samples/Graph/Data/ACME/Project/Todo/Source/TodoLayoutAreas.cs:117` | `<h1 style="margin: 0; flex: 1; min-width: 200px;">` | 🚨 the `flex: 1` is on the fragment's **own root** precisely because that root IS the direct flex child of the enclosing `FluentStack`. A wrapper interposes a non-grow block and makes it **inert** |

The last is decisive: a call site that provably depends on the bare-fragment behaviour today. It lives
in `samples/Graph/Data/.../Source/` — **in-mesh source, compiled at runtime, rendered by no build and
no test** — so that regression would surface only in a running portal.

### Why gate on the declaration, not the resolved value

`HasStyling` reads `ViewModel.Style`/`ViewModel.Class` (the declaration) rather than the bound
`Style`/`Class` fields (the resolved values). Either may be a `JsonPointerReference` that resolves a
frame or more after the first render; gating on the resolved value would render the fragment bare and
then restructure the DOM around it when the pointer lands. The declaration is known at bind time and
never changes for a given view-model, so the box is stable from frame one. Nothing is lost: `BindData`
feeds those fields from exactly those two properties, so a resolved value can only be non-null when the
declaration was.

### "Never silently ignored again"

With the conditional wrapper there is no case where honouring `Style` is impossible — a `<div>` can
always carry it — so there is nothing to log or throw about. The contract is made explicit in the XML
docs on `HtmlControl` (bare fragment by default; setting Style/Class opts into a box) and pinned by the
tests below.

## ⚠️ Behaviour change: exactly three call sites — and a scare that turned out to be nothing

Reviewer-relevant, because I got this wrong first and the correction is the second commit.

I initially claimed *"not one call site sets Style or Class on an HtmlControl."* Then I found ~100
`Controls.H2(...).WithStyle("margin: 0")` sites and assumed they were `HtmlControl`s, because
`Controls.Title` is one. **They are not**, and a test I wrote to pin the supposed consequence failed
with `Unable to cast LabelControl to HtmlControl`:

```csharp
Controls.Title(text, n) -> HtmlControl   // emits raw <hN> markup — this view renders it
Controls.H1..H6(data)   -> LabelControl  // Label(data).WithTypo(Hn) — Label.razor already applies Style
```

`Label.razor` applies `Style="@Style"` in both branches, so those ~100 heading sites never had this bug
and are **untouched**. `HeadingFactories_AreLabelControls_NotHtmlControls` now pins that distinction, so
re-implementing `H1..H6` on top of `Title` fails loudly instead of silently widening the blast radius.

A balanced-paren scan (multi-line aware) for `Controls.Html` / `Controls.Title` / `new HtmlControl`
followed by a `.WithStyle`/`.WithClass` chain, across `src/ samples/ content/ memex/`, finds **three**
real call sites — the true blast radius:

| Call site | Style | Effect |
|---|---|---|
| `samples/Todo/.../TodoLayoutAreas.cs:1717` | `WithMarginBottom("8px")` on a `<textarea>` fragment | gains its 8px bottom margin |
| `src/MeshWeaver.Graph/VersionLayoutArea.cs:153` | `margin: 0 0 16px 0` on `Controls.Title(…, 2)` | gains 16px below the version-page title |
| `src/MeshWeaver.Graph/VersionLayoutArea.cs:443` | `margin: 0 0 16px 0` on `Controls.Title(…, 2)` | as above |

All three were asking for a style that was being dropped; all three now get it. For the two `Title`
sites the style lands on the wrapper, so the declared margin adds to the `<h2>`'s own UA margin rather
than replacing it — strictly better than dropping it, but the author's literal intent needs `Title` to
have its own control/view instead of borrowing `HtmlControl`. **Left as a follow-up**: it changes a
public factory's return type, including for in-mesh callers.

## Tests — verified by falsification

Seven tests added to `ControlStyleRenderingTest`, which renders through the **real** `HtmlRenderer`
against a real monolith mesh and asserts on emitted HTML (asserting `control.Style` proves nothing —
the value was always set correctly; the markup dropped it).

I reverted `HtmlView.razor` to the pre-fix markup and re-ran the first four:

```
Failed  HtmlControl_ClassOnly_ReachesTheDom
Failed  HtmlControl_StyleAndClass_ReachTheDom
Failed! - Failed: 2, Passed: 2, Total: 4
```

- The two **positive** tests fail without the fix → they genuinely pin the bug.
- The two **backwards-compatibility** guards pass **with and without** the fix → they assert today's
  markup is unchanged, so they are real guards, not tautologies:
  - `HtmlControl_WithoutStyleOrClass_EmitsTheBareFragment` — asserts `html.Should().Be(fragment)`
    exactly, for `<span>inline</span>`. **This is the backwards-compatibility assertion**: an unstyled
    `HtmlControl` emits markup byte-identical to today, no wrapper introduced.
  - `HtmlControl_MultiRootFragment_StaysMultiRoot` — `<div>label</div><div>value</div>` stays two
    siblings, so a parent stack's gaps are not collapsed.

Plus `TitleControl_IsAnHtmlControl_SoItsStyleNowReachesAWrapper`,
`TitleControl_WithoutStyle_IsStillABareHeading`, and
`HeadingFactories_AreLabelControls_NotHtmlControls`.

With the fix: `Passed! - Failed: 0, Passed: 13, Total: 13`.

## Verification

| Check | Result |
|---|---|
| `dotnet build src/MeshWeaver.Layout -c Release -warnaserror` | 0 Warning(s), 0 Error(s) |
| `dotnet build src/MeshWeaver.Blazor -c Release -warnaserror` | 0 Warning(s), 0 Error(s) |
| `dotnet build test/MeshWeaver.Hosting.Blazor.Test -c Release -warnaserror` | 0 Warning(s), 0 Error(s) |
| `ControlStyleRenderingTest` (13) | Passed |
| `DocumentationLinkIntegrityTest` (What's New note added) | Passed |

What's New entry added (`Category: Fix`).

---

# 📋 Audit: `Style` / `Class` across all Blazor control views — **information only, NOT fixed here**

Requested alongside the fix so the owner can decide whether the third bucket warrants a follow-up.
**Nothing below is changed by this PR.**

**72 control views examined** — every `.razor` under `src/MeshWeaver.Blazor/Components/` (incl.
`Monaco/`) whose `@inherits` resolves to `BlazorView<,>` or a subclass; code-behinds checked for all.

Base-class facts: `BlazorView.BindData` (`BlazorView.razor.cs:485-497`) binds `Id`/`Class`/`Style` for
every control view. `SkinnedView.cs:40-46` repeats the same three binds. `FormComponentBase.cs:60-70`
folds Style+Width+Height into `ComputedStyle`, which form views are supposed to emit instead of `Style`.

## 🔴 Bucket 3 — silently drops it (25)

### Drops **both** Style and Class (17)

| View | Evidence |
|---|---|
| `AppearanceView` | root `<div style="max-width: 500px;">` (l.6) — literal; `@Style`/`@Class` never appear |
| `CatalogView` | `style="@ContainerStyle"` (l.5) where `ContainerStyle` is a literal in the code-behind (l.27) |
| `CollaborativeMarkdownView` | root `class="collab-md-container @ViewModeClass"` (l.11) — private computed class, not `Class` |
| `CommentableView` | root `class="commentable-wrapper"` (l.7); renders `ViewModel.Areas` children, so nothing downstream carries the container's own Style either |
| `DialogView` | `style="@GetDialogStyle()"` (l.9) composes only `--dialog-width`/`--dialog-height` from `Size` |
| `ExportDocumentView` | root `class="export-document-view" style="max-width: 720px;"` (l.16) — literal |
| `LayoutAreaDefinitionView` | root `<a class="card layout-area-card …">` (l.4) — fixed classes, no style attribute |
| `MarkdownEditorView` | root `class="collaborative-editor-container"` (l.25); no `@Style`/`@Class` in file |
| `MeshNodeCardView` | literal `style="text-decoration: none; …"` (l.12, 18) + `<FluentCard Class="mesh-node-card" Style="cursor: pointer; …">` (l.60) |
| `MeshNodeContentEditorView` | root `class="mesh-node-content-editor" style="display: flex; …"` (l.16) — literal |
| `MeshNodePickerView` | ⚠️ inherits `FormComponentBase` yet root is `<div class="mesh-node-picker…">` (l.6) with no `ComputedStyle` — drops Style, Class, **Width and Height** |
| `MeshNodeRoleEditorView` | branch roots literal `style="display: flex; align-items: center; gap: 8px;"` (l.15) |
| `MeshNodeThumbnailView` | `<FluentCard Class="mesh-node-thumbnail" Style="min-width: 320px; …">` (l.4) — both params present but hard-coded, shadowing the bound values |
| `NavLink` | `class="menu-item-link@(IsActive…)"` (l.6) / `Class="@(IsActive ? "active" : null)"` (l.21) — `Class` overwritten by active-state token; `Style` never appears |
| `NodeExportView` | root `class="node-export-view" style="max-width: 800px;"` (l.11) — literal |
| `NodeImportView` | root `class="node-import-view" style="max-width: 800px;"` (l.9) — literal |
| `Monaco/DiffEditorView` | root `style="height: @(ViewModel?.Height ?? "500px"); width: 100%;"` (l.8) reads `ViewModel.Height` directly; `CssClass` fixed |

### Drops **Class** only (Style works) (8)

| View | Evidence |
|---|---|
| `EditorView` | `<div style="@Style">` (l.4); inner `class="form-group"` fixed; `@Class` never emitted |
| `Label` | both branches set `Style="@Style"` (l.13, 26) on `FluentLabel`; `Class` never passed though the param exists |
| `LayoutAreaView` | `class="layout-area-container @(IsContentLoaded…) …" style="@Style"` (l.5) — `@Class` not merged |
| `MarkdownView` | `<article class="markdown-body" … style="…; @Style">` (l.3) — class list fixed |
| `MeshNodeCollectionView` | `<div class="mesh-node-collection" style="@Style">` (l.8) |
| `NumberFieldView` | `@ComputedStyle` applied correctly (l.8), but inner input uses `class="@appearanceClass"` (l.60), a local value |
| `TabsView` | `<FluentTabs … Style="@Style">` (l.4-10); `FluentTabs` accepts `Class`, not passed |
| `ThreadMessageBubbleView` | `class="thread-msg-bubble @(IsUser…)" style="@Style"` (l.6) — `@Class` not merged |

## 🟡 Bucket 4 — unclear (1)

| View | Why |
|---|---|
| `NamedAreaView` | renders real markup in the not-yet-loaded branch (`class="skeleton-placeholder"` l.37, `FluentStack` with conditional literal Style l.50) but in the loaded branch emits only `<DispatchView ViewModel="@RootControl">` (l.72) — a *different* control applying its own Style. The NamedArea's own Style/Class are never rendered, but whether they are *meant* to (there is no steady-state element to carry them) is a design call I could not settle from the code. |

## 🟢 Bucket 1 — applies Style and Class (39)

`BadgeView`, `BodyContentView`, `ButtonView`, `CardView`, `Checkbox`, `Combobox`, `ComparisonBarsView`,
`DataGridView`, `DateTimeView`*, `DocumentSourceView`, `FooterView`, `HeaderView`, `HighlightView`,
**`HtmlView`** (this PR — conditional wrapper), `IconView`, `ItemTemplate`, `KpiStripView`,
`LayoutGridItemView`, `LayoutGridView`, `LayoutStackView`, `LayoutView`, `Listbox`, `MainView`,
`MenuItemView`*, `NavGroup`, `NavMenuView`, `ProgressView`, `RadioGroupView`, `SearchView`,
`SelectView`*, `SplitterPane`, `SplitterView`, `Switch`, `TabView`, `TextAreaView`, `TextFieldView`,
`ToolbarView`, `TowerView`, `VideoView`.

Mechanism is `Class="@Class"` + `Style="@Style"` on a Fluent component, or `class="… @Class"
style="@Style"` on a plain element; the form inputs (`Checkbox`, `Combobox`, `Listbox`,
`RadioGroupView`, `SearchView`, `Switch`, `TextFieldView`, `NumberFieldView`) correctly use
`ComputedStyle`.

\* Three caveats worth a look, on a different axis (Style/Class are fine):

- `SelectView` and `DateTimeView` are `FormComponentBase` views that pass `Style` instead of
  `ComputedStyle` → the bound **`Width`/`Height` are dropped**.
- `MenuItemView` re-binds `DataBind(Skin.Style, x => x.Style)` (l.127) **after** the base bound
  `ViewModel.Style`, so the skin wins and a null skin style nulls the field. Coherent with
  `MenuItemControl.WithStyle(object)` routing into the skin, but the inherited
  `WithStyle(Func<StyleBuilder,…>)` overload writes the control's Style and is clobbered.

## ⚪ Bucket 2 — deliberately N/A (7)

| View | Reason |
|---|---|
| `SpacerView` | `FluentSpacer` exposes no Style/Class parameter (the case the existing test doc-comment already calls out) |
| `ContainerView` | emits no element of its own — a `foreach` over children rendering one `DispatchView` each (l.3-11). ⚠️ Consequence worth noting: a container control's own Style/Class therefore have no effect anywhere |
| `DispatchView` | pure dispatcher — the dispatched concrete view applies Style/Class |
| `EditFormView` | re-dispatches the **same** ViewModel (l.17) after the skin was popped; the terminal view applies it |
| `PropertyView` | `<dt>`/`<dd>` chrome plus `<DispatchView ViewModel="@ViewModel">` (l.13) — same control, terminal view applies it |
| `RedirectView` | renders no markup; `OnInitializedAsync` navigates |
| `SlideShowView` | renders no visible chrome by design — registers a JS keydown listener only |

## ⚠️ Outside the four buckets — never bound at all (3)

`SearchBoxView`, `MeshSearchView` and `Monaco/CodeEditorView` are **registered as control views** in
`BlazorViewRegistry.cs` (l.144, 147, 134) but derive from plain `ComponentBase` and take
`[Parameter] ViewModel/Stream/Area` by hand. `Style`/`Class` are therefore not merely dropped in
markup — they are never bound. Strictly outside the bucket definitions, but the same user-visible
defect.

## Counts

| Bucket | Count |
|---|---|
| 🔴 Silently drops (17 both + 8 Class-only) | **25** |
| 🟡 Unclear | 1 |
| 🟢 Applies both | 39 |
| ⚪ Deliberately N/A | 7 |
| **Total control views examined** | **72** |
| ⚠️ Registered as views but never bind Style/Class | 3 (separate) |

Whether bucket 3 warrants a systemic follow-up is the owner's call — several of the 17 are
single-purpose views whose box is genuinely fixed by design, but `MeshNodePickerView` (drops
Width/Height too) and the 8 Class-only drops look like plain omissions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
