### PR TITLE
fix(delete): name the STAGE a delete timeout died in, and which descendant went silent

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-delete-that-times-out-now-says-what-it-was-waiting-for.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-delete-that-times-out-now-says-what-it-was-waiting-for.md
@@ -1,0 +1,26 @@
+---
+Name: A delete that times out now says what it was waiting for
+Category: Fix
+Description: When deleting a node runs out of time, the error now names the step it was stuck on, the child that never answered, and everything it had already removed.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A delete that times out now says what it was waiting for
+
+Deleting a node with a large subtree is a multi-step operation: the node is read, your permission
+is checked, its validators run, the subtree is listed, every child is asked whether it may be
+deleted, and only then is anything removed. Each of those steps has the same time budget — so when
+a delete ran out of time, all six looked identical from the outside. The message said only that the
+delete had timed out, which left no way to tell a slow database from a single child that had stopped
+responding.
+
+It now names the step. If the delete was waiting on the children, it also names the ones that never
+answered — that step asks every child at once and waits for all of them, so one unresponsive child
+stops the whole delete, and knowing which one is the entire diagnosis.
+
+The count of what had already been deleted was worse than unhelpful: it always read zero after a
+timeout, whatever had actually been removed, because the parts already deleted were discarded along
+with the timed-out step. A delete that gets partway through now reports exactly which nodes it
+removed, so "nothing happened, safe to retry" and "the subtree is half gone" are finally
+distinguishable.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2045,6 +2045,56 @@ public static class MeshExtensions
     }
 
     /// <summary>
+    /// <see cref="Exception.Data"/> key naming the delete STAGE a <see cref="TimeoutException"/>
+    /// came out of. Issue #1198: the delete pipeline bounds SIX independent stages with the same
+    /// <see cref="MeshOperationOptions.Timeout"/>, and a bare <c>.Timeout(t)</c> throws
+    /// <c>"The operation has timed out."</c> with no context — so every one of them logged as the
+    /// same indistinguishable <c>[DeleteNode] timeout</c> and the next occurrence was unreadable.
+    /// </summary>
+    private const string DeleteStageDataKey = "DeleteStage";
+
+    /// <summary>
+    /// <see cref="Exception.Data"/> key carrying the descendant paths that never answered the
+    /// pre-flight <see cref="ValidateDeleteRequest"/> fan-out. That fan-out waits for EVERY
+    /// descendant under ONE budget, so a single unresponsive per-node hub times out the whole
+    /// delete — and until now it did so anonymously.
+    /// </summary>
+    private const string DeleteUnansweredDataKey = "DeleteUnansweredPaths";
+
+    /// <summary><see cref="Exception.Data"/> key carrying the paths already removed from storage
+    /// when the operation failed.</summary>
+    private const string DeletedPathsDataKey = "DeletedPaths";
+
+    /// <summary>
+    /// A stage-naming <c>Timeout</c>. The factory runs ONLY when the timeout fires, so it can
+    /// report state accumulated up to that moment (which descendants went silent, which paths were
+    /// already deleted) — the whole point being that the single error log can say WHERE the delete
+    /// ran out of time instead of only THAT it did (issue #1198).
+    /// </summary>
+    private static IObservable<T> TimeoutAtStage<T>(
+        this IObservable<T> source, TimeSpan timeout, Func<TimeoutException> onTimeout)
+        => source.Timeout(timeout, Observable.Defer(() => Observable.Throw<T>(onTimeout())));
+
+    /// <summary>Builds the stage-tagged <see cref="TimeoutException"/> the delete pipeline throws.</summary>
+    private static TimeoutException DeleteStageTimeout(string stage, string detail)
+    {
+        var ex = new TimeoutException($"[DeleteNode:{stage}] {detail}");
+        ex.Data[DeleteStageDataKey] = stage;
+        return ex;
+    }
+
+    /// <summary>Stage names — one per bounded stage of <see cref="HandleDeleteNodeRequest"/>.</summary>
+    private static class DeleteStage
+    {
+        public const string ReadRoot = "read-root";
+        public const string CheckPermission = "check-permission";
+        public const string ValidateRoot = "validate-root";
+        public const string CollectPaths = "collect-paths";
+        public const string PreValidateDescendants = "pre-validate-descendants";
+        public const string Commit = "commit";
+    }
+
+    /// <summary>
     /// 100% reactive delete handler — no <c>await</c>, no <c>Observable.FromAsync</c> wrapping
     /// blocking <c>IMeshStorage</c> calls. Because <see cref="IMeshService.DeleteNode"/> now
     /// targets the node's own hub (via <c>new Address(path)</c>), this handler always runs on
@@ -2153,6 +2203,18 @@ public static class MeshExtensions
         // top-level activity log on success.
         var collectedMessages = ImmutableList.CreateBuilder<LogMessage>();
 
+        // Accumulates every path this operation actually removed from storage, as it happens.
+        // 🚨 The commit's `.Timeout(...)` UNSUBSCRIBES from the fan-out, which throws away the
+        // deleted-path list HierarchicalPathDeletion attaches to its OWN error — so before this,
+        // a timed-out delete ALWAYS reported `partial-deleted=0` no matter how much of the
+        // subtree was already gone. That zero was read as "the operation made zero progress" and
+        // sent issue #1198's triage looking exclusively at the pre-commit stages.
+        var deletedProgress = ImmutableList.CreateBuilder<string>();
+        IReadOnlyList<string> SnapshotProgress()
+        {
+            lock (deletedProgress) return deletedProgress.ToImmutable();
+        }
+
         // 1. Load the root MeshNode directly from persistence — avoids
         //    activating the per-node hub at `path` (which workspace.GetMeshNodeStream
         //    would trigger via SubscribeRequest). Per-node hub cold-start
@@ -2163,6 +2225,9 @@ public static class MeshExtensions
         //    need the live per-node hub state.
         persistence.Read(path, hub.JsonSerializerOptions)
             .DefaultIfEmpty(null!)
+            .TimeoutAtStage(opts.Timeout, () => DeleteStageTimeout(
+                DeleteStage.ReadRoot,
+                $"storage did not return the node at '{path}' within {opts.Timeout.TotalSeconds:0}s"))
             .SelectMany(rootNode =>
             {
                 if (rootNode is null)
@@ -2180,6 +2245,10 @@ public static class MeshExtensions
                 //    hub when fan-out fires a non-recursive DeleteNodeRequest at
                 //    each leaf's address — never load all descendant nodes upfront.
                 return CheckDeletePermissionForNode(hub, senderUserId, rootNode, logger)
+                    .TimeoutAtStage(opts.Timeout, () => DeleteStageTimeout(
+                        DeleteStage.CheckPermission,
+                        $"the effective-permission fold for '{path}' did not settle within "
+                        + $"{opts.Timeout.TotalSeconds:0}s (user '{senderUserId}')"))
                     .SelectMany(denied =>
                     {
                         if (denied)
@@ -2194,6 +2263,10 @@ public static class MeshExtensions
                         }
 
                         return RunDeletionValidatorsWithWarningsObs(hub, rootNode, capturedRequest, request.AccessContext)
+                            .TimeoutAtStage(opts.Timeout, () => DeleteStageTimeout(
+                                DeleteStage.ValidateRoot,
+                                $"the INodeValidator chain for '{path}' did not complete within "
+                                + $"{opts.Timeout.TotalSeconds:0}s"))
                             .SelectMany(vresult =>
                             {
                                 if (vresult.Error is { Length: > 0 } err)
@@ -2341,8 +2414,23 @@ public static class MeshExtensions
                                         return DeleteSubtreeUntilDrained(
                                                 meshHub, storage, path, collected.ToDelete,
                                                 capturedRequest, executionContext,
-                                                recentlyDeleted, logger, collectedMessages)
-                                            .Timeout(opts.Timeout)
+                                                recentlyDeleted, logger, collectedMessages,
+                                                deletedProgress)
+                                            .TimeoutAtStage(opts.Timeout, () =>
+                                            {
+                                                var done = SnapshotProgress();
+                                                var ex = DeleteStageTimeout(
+                                                    DeleteStage.Commit,
+                                                    $"the bottom-up delete of '{path}' did not drain within "
+                                                    + $"{opts.Timeout.TotalSeconds:0}s — {done.Count} of "
+                                                    + $"{collected.ToDelete.Count} planned path(s) were already "
+                                                    + "removed from storage");
+                                                // Carry the REAL progress: the timeout discards the fan-out's
+                                                // own bookkeeping, and reporting 0 here is what made #1198 look
+                                                // like a pre-commit failure.
+                                                ex.Data[DeletedPathsDataKey] = done;
+                                                return ex;
+                                            })
                                             // 5. Post-deletion side effects for the ROOT node — e.g.
                                             //    dropping the backing partition store when a
                                             //    partition-owning Space root is deleted. The subtree
@@ -2447,7 +2535,13 @@ public static class MeshExtensions
                 ex =>
                 {
                     var isTimeout = ex is TimeoutException;
-                    var partial = ex.Data["DeletedPaths"] as IReadOnlyList<string>
+                    var partial = ex.Data[DeletedPathsDataKey] as IReadOnlyList<string>
+                        ?? Array.Empty<string>();
+                    // Which of the pipeline's six bounded stages ran out of time. Unset means the
+                    // exception came from somewhere that is not one of them (a nested Timeout — e.g.
+                    // a leaf's own ValidateDeleteRequest read — surfacing through this handler).
+                    var stage = ex.Data[DeleteStageDataKey] as string ?? "unattributed";
+                    var unanswered = ex.Data[DeleteUnansweredDataKey] as IReadOnlyList<string>
                         ?? Array.Empty<string>();
                     // "Node not found" pulled from the inner DeliveryFailureException —
                     // when the subscribe call hits a non-existent owner address the
@@ -2484,16 +2578,34 @@ public static class MeshExtensions
                     else if (isUnauthorized)
                         logger.LogWarning(
                             "[DeleteNode] permission-denied path={Path}: {Reason}", path, ex.Message);
+                    else if (isTimeout)
+                        // 🚨 stage= is the whole point of issue #1198: six stages share one budget,
+                        // and only two of them can leave the subtree untouched. unanswered= names the
+                        // descendant hubs that went silent when it was the pre-flight fan-out — that
+                        // stage waits for EVERY descendant under a single timeout, so one wedged
+                        // per-node hub stops the whole delete and used to do it anonymously.
+                        logger.LogError(ex,
+                            "[DeleteNode] timeout path={Path} stage={Stage} partial-deleted={Partial} "
+                            + "unanswered={Unanswered}",
+                            path, stage, partial.Count,
+                            unanswered.Count == 0
+                                ? "-"
+                                : string.Join(", ", unanswered.Take(20))
+                                  + (unanswered.Count > 20 ? $" (+{unanswered.Count - 20} more)" : ""));
                     else
                         logger.LogError(ex, "[DeleteNode] {Kind} path={Path} partial-deleted={Partial}",
-                            isTimeout ? "timeout" : (isNotFound ? "not-found" : "unexpected"), path, partial.Count);
+                            isNotFound ? "not-found" : "unexpected", path, partial.Count);
                     var failMsgs = collectedMessages.ToImmutable()
                         .Add(new LogMessage(
                             isNotFound ? $"Node not found at path '{path}'" : ex.Message,
                             LogLevel.Error));
                     PostFailed(
                         isTimeout
-                            ? $"Delete of '{path}' exceeded {opts.Timeout.TotalSeconds:0}s timeout"
+                            // The stage detail rides along so the CALLER sees it too — the response
+                            // is what a user, an agent or a test reads, and "exceeded 30s" alone is
+                            // exactly as unreadable there as it was in the log.
+                            ? $"Delete of '{path}' exceeded {opts.Timeout.TotalSeconds:0}s timeout "
+                              + $"in stage '{stage}': {ex.Message}"
                             : (isNotFound
                                 ? $"Node not found at path '{path}'"
                                 : (isUnauthorized
@@ -2563,7 +2675,10 @@ public static class MeshExtensions
                     RootExists: true,
                     empty.Add(path),
                     descendants.Any(d => IsDirectChildOf(d, path))))
-                .Timeout(timeout);
+                .TimeoutAtStage(timeout, () => DeleteStageTimeout(
+                    DeleteStage.CollectPaths,
+                    $"the storage enumeration of children under '{path}' did not answer within "
+                    + $"{timeout.TotalSeconds:0}s"));
         }
 
         return storage.ListDescendantPaths(path)
@@ -2576,7 +2691,10 @@ public static class MeshExtensions
                 logger.LogDebug("[DeleteNode] collected path={Path} total={Count}", path, set.Count);
                 return (RootExists: true, set, false);
             })
-            .Timeout(timeout);
+            .TimeoutAtStage(timeout, () => DeleteStageTimeout(
+                DeleteStage.CollectPaths,
+                $"the storage enumeration of the subtree under '{path}' did not answer within "
+                + $"{timeout.TotalSeconds:0}s"));
     }
 
     /// <summary>
@@ -2617,10 +2735,11 @@ public static class MeshExtensions
         AccessContext? callerAccessContext,
         RecentlyDeletedRegistry? recentlyDeleted,
         ILogger logger,
-        ImmutableList<LogMessage>.Builder collectedMessages)
+        ImmutableList<LogMessage>.Builder collectedMessages,
+        ImmutableList<string>.Builder deletedProgress)
         => RunDeletePass(
             meshHub, storage, rootPath, plannedPaths, baseRequest, callerAccessContext,
-            recentlyDeleted, logger, collectedMessages,
+            recentlyDeleted, logger, collectedMessages, deletedProgress,
             pass: 1, deletedSoFar: ImmutableList<string>.Empty);
 
     private static IObservable<IReadOnlyList<string>> RunDeletePass(
@@ -2633,6 +2752,7 @@ public static class MeshExtensions
         RecentlyDeletedRegistry? recentlyDeleted,
         ILogger logger,
         ImmutableList<LogMessage>.Builder collectedMessages,
+        ImmutableList<string>.Builder deletedProgress,
         int pass,
         ImmutableList<string> deletedSoFar)
     {
@@ -2650,14 +2770,14 @@ public static class MeshExtensions
 
         return FanOutDeleteSubtree(
                 meshHub, storage, rootPath, toDelete, baseRequest, callerAccessContext,
-                logger, collectedMessages, rootAlreadyDeleted: pass > 1)
+                logger, collectedMessages, deletedProgress, rootAlreadyDeleted: pass > 1)
             .Catch<IReadOnlyList<string>, Exception>(ex =>
             {
                 // Fold this pass's partial deletions into the accumulated total so
                 // the caller's failure response reports every path actually removed.
-                var passDeleted = ex.Data["DeletedPaths"] as IReadOnlyList<string>
+                var passDeleted = ex.Data[DeletedPathsDataKey] as IReadOnlyList<string>
                     ?? Array.Empty<string>();
-                ex.Data["DeletedPaths"] = (IReadOnlyList<string>)deletedSoFar.AddRange(passDeleted);
+                ex.Data[DeletedPathsDataKey] = (IReadOnlyList<string>)deletedSoFar.AddRange(passDeleted);
                 return Observable.Throw<IReadOnlyList<string>>(ex);
             })
             .SelectMany(deletedPaths =>
@@ -2696,7 +2816,7 @@ public static class MeshExtensions
                         return RunDeletePass(
                             meshHub, storage, rootPath, survivorSet, baseRequest,
                             callerAccessContext, recentlyDeleted, logger, collectedMessages,
-                            pass + 1, acc);
+                            deletedProgress, pass + 1, acc);
                     });
             });
     }
@@ -2732,8 +2852,19 @@ public static class MeshExtensions
         AccessContext? callerAccessContext,
         ILogger logger,
         ImmutableList<LogMessage>.Builder collectedMessages,
+        ImmutableList<string>.Builder deletedProgress,
         bool rootAlreadyDeleted = false)
     {
+        // 🚨 Record each commit AS IT LANDS, not at the end. The caller bounds this whole fan-out
+        // with one Timeout, and a timeout UNSUBSCRIBES — discarding the deleted-path list
+        // HierarchicalPathDeletion only attaches to its own OnError. Without this sink a timed-out
+        // delete reports partial-deleted=0 however much of the subtree it removed, which is
+        // exactly the false "zero progress" reading in issue #1198.
+        void RecordDeleted(string deleted)
+        {
+            lock (deletedProgress) deletedProgress.Add(deleted);
+        }
+
         return HierarchicalPathDeletion.DeleteSubtree(
             rootPath,
             descendantPaths.Remove(rootPath),
@@ -2763,7 +2894,8 @@ public static class MeshExtensions
                                 if (removed)
                                     changeFeed?.Publish(MeshChangeEvent.Deleted(path));
                             })
-                            .Select(_ => path);
+                            .Select(_ => path)
+                            .Do(RecordDeleted);
 
                     return storage.DeleteAndPublish(path, changeFeed)
                         .Do(_ =>
@@ -2798,7 +2930,8 @@ public static class MeshExtensions
                                 logger.LogDebug(ex,
                                     "[DeleteNode] best-effort hub disposal failed for {Path}", path);
                             }
-                        });
+                        })
+                        .Do(RecordDeleted);
                 }
 
                 // Descendant: fan-out via per-node hub. The leaf hub re-enters
@@ -2830,7 +2963,8 @@ public static class MeshExtensions
                         var reason = failResp?.Error ?? "Unknown error";
                         return Observable.Throw<string>(new InvalidOperationException(
                             $"Delete failed for '{path}': {reason}"));
-                    });
+                    })
+                    .Do(RecordDeleted);
             });
     }
 
@@ -2866,6 +3000,16 @@ public static class MeshExtensions
             .ToArray();
         if (descendants.Length == 0)
             return Observable.Return<(string, string, NodeDeletionRejectionReason)?>(null);
+
+        // 🚨 Who has NOT answered yet. This fan-out waits for EVERY descendant under ONE
+        // timeout, so a single unresponsive per-node hub times out the whole delete with the
+        // subtree untouched — and the operator's only evidence used to be an anonymous
+        // "[DeleteNode] timeout … partial-deleted=0" (issue #1198). Read exclusively from the
+        // timeout factory below, so a healthy fan-out pays one dictionary removal per leaf.
+        // Method-local (never static), and concurrent because Merge answers on many threads.
+        var unanswered = new System.Collections.Concurrent.ConcurrentDictionary<string, byte>(
+            descendants.Select(p => new KeyValuePair<string, byte>(p, 0)),
+            StringComparer.OrdinalIgnoreCase);
 
         var perPath = descendants.Select(p => meshHub
             // 🚨 Stamp the caller's AccessContext on every ValidateDeleteRequest.
@@ -2906,7 +3050,10 @@ public static class MeshExtensions
                     "[DeleteNode] pre-validate descendant failed {Path}", p);
                 return Observable.Return<(string, string, NodeDeletionRejectionReason)?>(
                     (p, ex.Message, NodeDeletionRejectionReason.ValidationFailed));
-            }));
+            })
+            // Answered — pass or fail, the leaf spoke. Whatever is LEFT in the map when the
+            // stage times out is the set of hubs that did not.
+            .Do(answer => unanswered.TryRemove(p, out _)));
 
         // Collect every descendant's outcome; emit the first non-null failure
         // (or null when all pass). Merge — not Concat — so independent
@@ -2916,7 +3063,23 @@ public static class MeshExtensions
             .Where(r => r.HasValue)
             .Take(1)
             .DefaultIfEmpty(null)
-            .Timeout(timeout);
+            .TimeoutAtStage(timeout, () =>
+            {
+                var pending = unanswered.Keys
+                    .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var ex = DeleteStageTimeout(
+                    DeleteStage.PreValidateDescendants,
+                    $"{pending.Length} of {descendants.Length} descendant(s) of '{rootPath}' did not "
+                    + $"answer ValidateDeleteRequest within {timeout.TotalSeconds:0}s, so the delete "
+                    + "was refused with the subtree untouched"
+                    + (pending.Length == 0
+                        ? string.Empty
+                        : $": {string.Join(", ", pending.Take(10))}"
+                          + (pending.Length > 10 ? $" (+{pending.Length - 10} more)" : string.Empty)));
+                ex.Data[DeleteUnansweredDataKey] = (IReadOnlyList<string>)pending;
+                return ex;
+            });
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A TIMED-OUT DELETE MUST SAY WHERE IT TIMED OUT — issue #1198.
+///
+/// <para>memex-cloud logged exactly one line for a delete that never finished:
+/// <c>[DeleteNode] timeout path=KmuBasics/Buchungsjournal partial-deleted=0</c>. That line names
+/// the KIND of failure and nothing else, and the delete pipeline bounds FIVE independent stages
+/// with the same <see cref="MeshOperationOptions.Timeout"/> — so it could equally have been the
+/// root read, the permission fold, the root validators, the storage enumeration, the pre-flight
+/// descendant fan-out, or the commit. Worse, <c>partial-deleted=0</c> was not evidence of
+/// anything: the commit's <c>Timeout</c> UNSUBSCRIBES from the fan-out, discarding the
+/// deleted-path list, so a timed-out delete reported ZERO however much of the subtree it had
+/// already removed. Both halves of that line are pinned here.</para>
+///
+/// <para>The stall is produced by a real, registered <see cref="INodeValidator"/> that never
+/// emits for one specific node — the framework-legal way for a per-node hub to go silent, which
+/// is precisely the shape the fan-out cannot survive: it posts
+/// <see cref="ValidateDeleteRequest"/> at EVERY descendant and waits for ALL of them under ONE
+/// budget, so one unresponsive hub refuses the whole delete.</para>
+/// </summary>
+public class DeleteTimeoutStageDiagnosticsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The whole pipeline's budget. Small enough that a stage timeout is the fastest thing in the
+    /// test, generous enough that node creation on a cold CI agent is nowhere near it.
+    /// </summary>
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>A node whose validators never answer, on ANY delete leg.</summary>
+    private const string SilentSuffix = "-silent";
+
+    /// <summary>A node whose validators answer the pre-flight but never the cascade leg.</summary>
+    private const string CommitStallSuffix = "-stallcommit";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(s => s
+                .AddSingleton(new MeshOperationOptions { Timeout = OperationTimeout })
+                .AddSingleton<INodeValidator, StallingDeleteValidator>());
+
+    /// <summary>
+    /// A per-node hub that goes silent during the PRE-FLIGHT fan-out. Nothing is deleted, so the
+    /// old log line was right about <c>partial-deleted=0</c> and useless about everything else.
+    /// The response must now name the stage AND the descendant that did not answer — without the
+    /// latter, an operator staring at a 400-node subtree has no way to find the wedged hub.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task PreFlightFanOut_TimesOut_NamesTheStageAndTheSilentDescendant()
+    {
+        var space = $"{TestPartition}/prevalidate";
+        var silent = $"{space}/child{SilentSuffix}";
+        await NodeFactory.CreateNode(new MeshNode("prevalidate", TestPartition)
+        { Name = "Space", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode($"child{SilentSuffix}", space)
+        { Name = "Silent", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        var response = (await Mesh
+            .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
+                o => o.WithTarget(new Address(space)))
+            .Should().Within(60.Seconds()).Emit()).Message;
+
+        Output.WriteLine($"error: {response.Error}");
+
+        response.Success.Should().BeFalse("the silent descendant never answered the pre-flight");
+        response.Error.Should().Contain("pre-validate-descendants",
+            "the failure must name WHICH of the pipeline's five bounded stages ran out of time — "
+            + "naming only the kind ('timeout') is what made #1198 unreadable");
+        response.Error.Should().Contain(silent,
+            "the fan-out waits for every descendant under one budget, so the ONE hub that went "
+            + "silent is the entire diagnosis — it must be named, not counted");
+    }
+
+    /// <summary>
+    /// 🚨 The other half: a commit that times out must report the paths it ALREADY deleted.
+    /// Reporting 0 is not merely imprecise — it is the reading that sent #1198's triage to the
+    /// pre-commit stages, because "partial-deleted=0" was taken to mean "made zero progress".
+    /// Here a healthy sibling is genuinely removed before the stalled leaf holds up the cascade.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task CommitTimesOut_ReportsThePathsItAlreadyDeleted_NotZero()
+    {
+        var space = $"{TestPartition}/commitstall";
+        var healthy = $"{space}/healthy";
+        var stalled = $"{space}/child{CommitStallSuffix}";
+        await NodeFactory.CreateNode(new MeshNode("commitstall", TestPartition)
+        { Name = "Space", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("healthy", space)
+        { Name = "Healthy", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode($"child{CommitStallSuffix}", space)
+        { Name = "Stalled", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+
+        var response = (await Mesh
+            .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
+                o => o.WithTarget(new Address(space)))
+            .Should().Within(60.Seconds()).Emit()).Message;
+
+        Output.WriteLine($"error: {response.Error}");
+        Output.WriteLine($"affected: {string.Join(", ", response.Log?.AffectedPaths ?? [])}");
+
+        response.Success.Should().BeFalse("the stalled leaf never completed its own delete");
+        response.Error.Should().Contain("commit",
+            "the stage name distinguishes 'nothing was touched' from 'the subtree is half gone' — "
+            + "which is the difference between a retry and an investigation");
+        (response.Log?.AffectedPaths ?? []).Should().Contain(healthy,
+            "the healthy sibling WAS deleted before the cascade stalled; a timeout that discards "
+            + "that fact reports partial-deleted=0 over a half-deleted subtree (#1198)");
+    }
+
+    /// <summary>
+    /// Never emits for the node under test — the framework-legal way to make one per-node hub go
+    /// silent. <c>RunDeletionValidatorsObs</c> runs validators via <c>Concat</c>, so a validator
+    /// that does not complete means the hub posts no <see cref="ValidateDeleteResponse"/> at all.
+    ///
+    /// <para>The two legs are told apart by <see cref="DeleteNodeRequest.CascadeRootPath"/>: the
+    /// pre-flight runs against a FABRICATED <c>DeleteNodeRequest(path)</c> that carries none,
+    /// while a cascade leaf's own delete carries the original root.</para>
+    /// </summary>
+    private sealed class StallingDeleteValidator : INodeValidator
+    {
+        public IReadOnlyCollection<NodeOperation> SupportedOperations { get; } = [NodeOperation.Delete];
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+        {
+            var path = context.Node.Path ?? string.Empty;
+            var isCascadeLeg = context.Request is DeleteNodeRequest { CascadeRootPath: not null };
+            var stall = path.EndsWith(SilentSuffix, StringComparison.OrdinalIgnoreCase)
+                        || (isCascadeLeg
+                            && path.EndsWith(CommitStallSuffix, StringComparison.OrdinalIgnoreCase));
+            return stall
+                ? Observable.Never<NodeValidationResult>()
+                : Observable.Return(NodeValidationResult.Valid());
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
@@ -17,7 +17,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 ///
 /// <para>memex-cloud logged exactly one line for a delete that never finished:
 /// <c>[DeleteNode] timeout path=KmuBasics/Buchungsjournal partial-deleted=0</c>. That line names
-/// the KIND of failure and nothing else, and the delete pipeline bounds FIVE independent stages
+/// the KIND of failure and nothing else, and the delete pipeline bounds SIX independent stages
 /// with the same <see cref="MeshOperationOptions.Timeout"/> — so it could equally have been the
 /// root read, the permission fold, the root validators, the storage enumeration, the pre-flight
 /// descendant fan-out, or the commit. Worse, <c>partial-deleted=0</c> was not evidence of
@@ -76,7 +76,7 @@ public class DeleteTimeoutStageDiagnosticsTest(ITestOutputHelper output) : Monol
 
         response.Success.Should().BeFalse("the silent descendant never answered the pre-flight");
         response.Error.Should().Contain("pre-validate-descendants",
-            "the failure must name WHICH of the pipeline's five bounded stages ran out of time — "
+            "the failure must name WHICH of the pipeline's six bounded stages ran out of time — "
             + "naming only the kind ('timeout') is what made #1198 unreadable");
         response.Error.Should().Contain(silent,
             "the fan-out waits for every descendant under one budget, so the ONE hub that went "


### PR DESCRIPTION
Refs #1198. **Diagnostics only — this does NOT close the issue**, and it corrects the issue's
central piece of evidence.

## `partial-deleted=0` was never evidence of anything

The issue reads `[DeleteNode] timeout path=KmuBasics/Buchungsjournal partial-deleted=0` as "the
operation made zero progress", and the triage used that to narrow the failure to the pre-commit
stages. That reading does not hold. The commit is wrapped in `.Timeout(opts.Timeout)`, a timeout
**unsubscribes**, and the deleted-path list is attached only to the exception
`HierarchicalPathDeletion` raises *itself*. The freshly-constructed `TimeoutException` carries no
`Data`, so `partial-deleted` printed `0` for **every** timeout regardless of how much of the
subtree was already gone. The commit stage was never excluded.

## What the log could not say

`HandleDeleteNodeRequest` bounds **six** independent stages with the same
`MeshOperationOptions.Timeout` — and three of them had no bound at all, so a wedge there produced
no `[DeleteNode]` line whatsoever (only the caller's request timed out). Every bounded one threw
`new TimeoutException()` → `"The operation has timed out."` → one indistinguishable log line.

## What changed

- **Every stage is bounded and named**: `read-root`, `check-permission`, `validate-root`,
  `collect-paths`, `pre-validate-descendants`, `commit`. The three previously-unbounded stages
  (root read, permission fold, root validators) now fail loudly *inside the budget the operation
  already declares* instead of hanging silently. **No budget was raised.**
- **The fan-out names who went silent.** `PreValidateDescendantsObs` posts `ValidateDeleteRequest`
  at *every* descendant and waits for *all* of them under **one** timeout — so a single
  unresponsive per-node hub refuses the whole delete. It now tracks which paths have answered and,
  on timeout, reports the ones that did not (first 10 in the message, first 20 in the log line).
- **`partial-deleted` is truthful.** A sink records each path as its delete commits, so the commit
  timeout carries the real set. The response's `AffectedPaths` is fixed by the same change:
  "nothing happened, safe to retry" and "the subtree is half gone" are finally distinguishable.
- **The caller sees it too** — the response `Error` carries the stage and the detail, not just the
  log.

Real output from the two new tests:

```
Delete of 'TestData/prevalidate' exceeded 15s timeout in stage 'pre-validate-descendants':
  [DeleteNode:pre-validate-descendants] 1 of 1 descendant(s) of 'TestData/prevalidate' did not
  answer ValidateDeleteRequest within 15s, so the delete was refused with the subtree untouched:
  TestData/prevalidate/child-silent

Delete of 'TestData/commitstall' exceeded 15s timeout in stage 'commit':
  [DeleteNode:commit] the bottom-up delete of 'TestData/commitstall' did not drain within 15s
  — 1 of 3 planned path(s) were already removed from storage
affected: TestData/commitstall/healthy          ← was empty, and partial-deleted=0
```

## Why the root cause is not fixed here

Two stages fit the single line we have, and with `partial-deleted` proven uninformative the commit
stage is a third. Choosing between them from one occurrence would be a guess, and the plausible
fixes differ in kind (a per-leaf report for an unresponsive descendant vs. a stalled storage
enumeration vs. a leaf hub wedged mid-commit). The next occurrence now names the stage and the
silent hub — exactly the evidence that decision needs. **#1198 stays open** with that note.

Deliberately NOT done: no timeout raised, no validation made optional, no retry, no watchdog.

## Test

`test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs` — the stall is a real
registered `INodeValidator` that never emits for one node, which is the framework-legal way to make
a single per-node hub go silent (validators run through `Concat`, so that hub posts no
`ValidateDeleteResponse` at all).

1. **Pre-flight fan-out** → the response names `pre-validate-descendants` **and** the silent
   descendant's full path.
2. **Commit** → a healthy sibling is genuinely deleted before the stalled leaf holds up the
   cascade, and the failure reports that sibling in `AffectedPaths` instead of the old zero.

Both bounded by the mesh operation timeout; no sleeps, no polling. Green locally
(`-c Release -warnaserror`, 2/2 passed, 30 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
