### PR TITLE
fix(graph): register Email in the static registry — the one built-in content type missing from WithGraphTypes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -497,6 +497,43 @@ Never go through a query + merge in memory + a full-node write. The index read i
 
 ---
 
+## 🚨 Creating typed nodes — everything comes from the REGISTRY, nothing from your hand
+
+Creating a node is not assembling JSON. Three registries decide whether your write is even
+*meaningful*, and the write boundary enforces all three **fail-closed**:
+
+1. **The `NodeType` must name a registered NodeType.** A write whose `NodeType` resolves to
+   nothing is refused with *"NodeType 'X' is not registered"*. There is no "just a string" node
+   type: the name is a claim that a module owns and can activate this node. (The Store contact
+   form shipped writing `NodeType: "SalesInquiry"` — a name registered nowhere — and every
+   enquiry on every mesh was refused for a month before anything executed the write.)
+
+2. **The content's `$type` must resolve in the static registry.** Cross-hub, your typed CLR
+   content serializes to JSON carrying a `$type` discriminator, and
+   `ContentDiscriminatorValidator` refuses any discriminator the mesh root's `ITypeRegistry`
+   chain cannot resolve for a built-in NodeType — because accepting it would persist an untyped
+   blob that renders empty and cannot be edited. **Never hand-assemble a `$type` string.** Use
+   the framework's own content record (`new Email { … }`, `new MarkdownContent { … }`) and let
+   serialization write the registered name; when in doubt, read the declared shape at
+   `@{NodeType}/schema/`.
+
+3. **Every content type a built-in NodeType declares via `WithContentType<T>()` MUST be in
+   `WithGraphTypes`** (the static registry of functionality). The validator's strict branch
+   assumes exactly that — an omission is invisible for as long as only in-process writers exist
+   (typed content bypasses the guard) and then refuses the first cross-hub writer. That is how
+   `Email` broke the contact form's notification phase in production (2026-08-12): registered as
+   a NodeType, missing from the registry, undetectable until a compiled plugin queued one.
+
+**And the write itself goes through the owning hub, never around it** — the canonical verbs are
+the whole surface: `CreateNodeRequest` / `CreateOrUpdateNodeRequest` for new nodes,
+`GetMeshNodeStream(path).Update(...)` for edits. The owning hub autonames, stamps, types and
+validates on its single-threaded action block. This is the same pattern **thread creation**
+uses — the thread hub mints the node, names it, and types its content; the caller only says
+what it wants. If you find yourself constructing a `$type` by hand or writing a node whose type
+you invented, you are on the wrong side of the registry.
+
+---
+
 ## Upserts (`CreateOrUpdateNodeRequest`) — single verb, no delete-then-create
 
 When the caller has the **full target shape** and wants the node to land regardless of whether it already exists (copy / move / import / agentic write-back), use the single-verb upsert:

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -459,6 +459,17 @@ public static class MeshNodeExtensions
         typeRegistry.WithType(typeof(TrackedChangeStatus), nameof(TrackedChangeStatus));
         typeRegistry.WithType(typeof(Notification), nameof(Notification));
         typeRegistry.WithType(typeof(NotificationType), nameof(NotificationType));
+        // Email — the content of the built-in "Email" NodeType (EmailNodeType). It was the ONE
+        // built-in content type missing from this list, and the omission was invisible until a
+        // CROSS-HUB writer produced one: an in-process writer (EmailInboundProcessor) carries the
+        // content typed past ContentDiscriminatorValidator, but a foreign hub's write arrives as
+        // JSON with `$type: "Email"`, which the validator then correctly refuses as unresolvable —
+        // that broke the Store contact form's notification phase in production (2026-08-12). Every
+        // content type a built-in NodeType declares via WithContentType MUST be registered here;
+        // the validator's strict branch assumes exactly that.
+        typeRegistry.WithType(typeof(Email), nameof(Email));
+        typeRegistry.WithType(typeof(EmailDirection), nameof(EmailDirection));
+        typeRegistry.WithType(typeof(EmailStatus), nameof(EmailStatus));
         typeRegistry.WithType(typeof(ApiToken), nameof(ApiToken));
         typeRegistry.WithType(typeof(MeshDataSourceConfiguration), nameof(MeshDataSourceConfiguration));
         typeRegistry.WithType(typeof(PartitionDefinition), nameof(PartitionDefinition));

--- a/test/MeshWeaver.Graph.Test/EmailContentDiscriminatorTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmailContentDiscriminatorTest.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Domain;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins that <c>Email</c> — the content type of the built-in <c>Email</c> NodeType — is registered
+/// in the STATIC registry (<c>WithGraphTypes</c>), so a CROSS-HUB write of an email node passes
+/// <see cref="ContentDiscriminatorValidator"/>.
+///
+/// <para><b>The production failure this fixes (2026-08-12).</b> The Store contact form's submit
+/// pipeline (a compiled plugin) queued its notification emails as ordinary mesh writes:
+/// <c>Content = new Email {…}</c>, serialized across the hub boundary as JSON carrying
+/// <c>$type: "Email"</c>. Every OTHER built-in content type (MarkdownContent, Comment,
+/// Notification, the security types…) is registered in <c>WithGraphTypes</c>; <c>Email</c> alone
+/// was not — so the validator's strict built-in branch correctly refused the write, and the form's
+/// "Notifying our team" phase failed on every mesh. The omission was invisible for as long as only
+/// IN-PROCESS writers (EmailInboundProcessor) created email nodes, because typed in-process content
+/// bypasses the guard entirely. The contract this test pins: <b>every content type a built-in
+/// NodeType declares via <c>WithContentType</c> must be in the static registry</b> — the
+/// validator's strict branch assumes exactly that.</para>
+/// </summary>
+public class EmailContentDiscriminatorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private ContentDiscriminatorValidator Guard =>
+        Mesh.ServiceProvider.GetServices<INodeValidator>()
+            .OfType<ContentDiscriminatorValidator>()
+            .Single();
+
+    private static MeshNode EmailNode(string discriminator) => new("mail-0", "Sales/inq-1/_Email")
+    {
+        NodeType = EmailNodeType.NodeType,
+        Name = "Email to a@b.c",
+        // The exact degraded shape a cross-hub write arrives in: a raw JsonElement whose $type
+        // is whatever the WRITING hub's registry named the CLR type.
+        Content = JsonSerializer.Deserialize<JsonElement>(
+            $$"""
+            {"$type":"{{discriminator}}","direction":"Outbound","status":"New",
+             "to":"a@b.c","from":"c@d.e","subject":"s","body":"<p>b</p>"}
+            """),
+    };
+
+    [Fact(Timeout = 30000)]
+    public async Task ACrossHubEmailWrite_CarryingTheEmailDiscriminator_IsAccepted()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<ITypeRegistry>();
+        registry.TryGetType(nameof(Email), out var definition).Should().BeTrue(
+            "Email is the content type of a built-in NodeType, so it must be in the static "
+            + "registry like every other built-in content type — its absence is what broke the "
+            + "contact form's notification phase in production");
+        definition!.Type.Should().Be(typeof(Email));
+
+        var result = await Guard
+            .Validate(new NodeValidationContext
+            { Operation = NodeOperation.Create, Node = EmailNode(nameof(Email)) })
+            .Should().Emit();
+
+        result.IsValid.Should().BeTrue(
+            "a cross-hub writer (a compiled plugin queueing a notification) serializes the typed "
+            + $"Email as JSON with $type 'Email'; the guard must resolve it, got: {result.ErrorMessage}");
+    }
+
+    /// <summary>The guard itself stays armed: a discriminator that names NOTHING is still refused
+    /// on the same node type — registering Email must not have widened the gate.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task ABogusDiscriminatorOnAnEmailNode_StaysRefused()
+    {
+        var result = await Guard
+            .Validate(new NodeValidationContext
+            { Operation = NodeOperation.Create, Node = EmailNode("EmailContent") })
+            .Should().Emit();
+
+        result.IsValid.Should().BeFalse(
+            "'EmailContent' is registered nowhere — the untypeable-blob guard must keep refusing it");
+        result.ErrorMessage.Should().Contain("EmailContent");
+    }
+}


### PR DESCRIPTION
## What

`WithGraphTypes` registers every built-in content type (MarkdownContent, Comment, Notification, the security types…) — except **`Email`**, the content of the built-in `Email` NodeType. Registered here now, with `EmailDirection`/`EmailStatus`.

## Why

The omission was invisible for as long as only **in-process** writers created email nodes (typed content bypasses `ContentDiscriminatorValidator`). The first **cross-hub** writer — the Store contact form's compiled submit pipeline, whose `new Email {…}` content crosses the hub boundary as JSON with `$type: "Email"` — was refused by the guard in production (2026-08-12): *"'$type': 'Email' is not a registered content type for the built-in NodeType 'Email'"*. The guard was right; the registry was incomplete. Contract: **every content type a built-in NodeType declares via `WithContentType<T>()` must be in the static registry** — the validator's strict branch assumes exactly that.

## How tested

`EmailContentDiscriminatorTest` (MeshWeaver.Graph.Test, MonolithMeshTestBase):
- the mesh registry resolves `Email`, and a cross-hub email write carrying `$type: "Email"` **passes** the guard — verified non-vacuous by reverting the registration (the test fails);
- a bogus discriminator (`EmailContent`) on the same node type **stays refused** — the gate did not widen.

Release build with `-p:CIRun=true -warnaserror`: clean. Both tests green on current main.

## Docs

`CqrsAndContentAccess.md` gains a prominent section — *Creating typed nodes: everything comes from the REGISTRY, nothing from your hand* — the registered-NodeType rule, the static-registry `$type` rule, and the canonical create/update-on-the-owning-hub pattern (as thread creation does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)