### PR TITLE
One package's content was installed under another package's shape

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-installing-a-plugin-keeps-the-content-the-package-ships.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-installing-a-plugin-keeps-the-content-the-package-ships.md
@@ -1,0 +1,29 @@
+---
+Name: Installing a plugin keeps the content the package ships
+Category: Fix
+Description: A package whose content type shares a name with another package's no longer installs stripped, no longer rewrites unchanged nodes on every sync, and no longer reads as another package's data.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Installing a plugin keeps the content the package ships
+
+Two packages are allowed to name a thing the same way — a reinsurance space and an accounting space
+can both have a "Currency", and a customer catalogue that ships both had twelve such names. The
+platform, though, kept one list of those names for the whole mesh, so the second package to load
+quietly took the first one's place. Whichever had been compiled most recently became "the" Currency
+for everybody.
+
+The consequences were all silent. Installing a package could store its data under the other
+package's shape: fields the other shape does not have were dropped, so a sample record could land
+with its entire content missing, and fields it does have were filled in with the other package's
+defaults. Every following sync then saw a difference that was never authored, rewrote nodes nobody
+had touched, and recompiled types that had not changed — and because the winner depended on the
+order things happened to compile, the same install produced a different result each time it ran.
+Elsewhere in the portal a page could read a record as the wrong kind of thing and render empty.
+
+Now an install writes exactly the content the package ships, and a name two packages claim is
+treated as what it is — ambiguous. Content carrying such a name is read by the part of the mesh that
+knows which package it belongs to, rather than guessed from the name, and the log names the
+collision once so it can be resolved by renaming one of the two. Repeat syncs of unchanged content
+now write nothing at all.

--- a/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 // 🚨 Namespace deliberately NOT MeshWeaver.Messaging.Serialization (where the file now lives).
 // The type used to sit in MeshWeaver.Mesh.Contract, but MeshWeaver.Mesh.Contract REFERENCES
@@ -46,18 +47,49 @@ namespace MeshWeaver.Mesh.Services;
 /// None of them ADOPT the type into a hub's <c>ITypeRegistry</c>: they deserialise to the concrete
 /// type explicitly, so a per-compile collectible identity never becomes a hub's long-lived answer for
 /// that discriminator (see <c>PolymorphicTypeInfoResolver.WarnCollectibleSerialization</c>).</para>
+///
+/// <para>🚨 <b>A discriminator is a package-local name, so the map answers only where that name is
+/// mesh-wide unique.</b> Two packages may each define a <c>Currency</c>; when both have registered,
+/// the name resolves to NEITHER (see <see cref="TryResolveByDiscriminator"/>) and the content stays
+/// a <see cref="JsonElement"/> for any hub that has not registered the type itself. The exact route
+/// — <see cref="TryResolveByNodeType"/>, keyed on the node's own NodeType path — is never ambiguous
+/// and is the durable answer for a caller that has the node in hand.</para>
 /// </summary>
 public interface IMeshContentTypeRegistry
 {
     /// <summary>
     /// Records <paramref name="contentType"/> under its short name and full name (both are valid
     /// <c>$type</c> discriminators), and — when supplied — under its <paramref name="nodeTypePath"/>.
-    /// Idempotent; last-writer-wins on a short-name collision (the same accepted risk the rest of the
-    /// framework's short-name <c>$type</c> resolution already carries).
+    /// Idempotent, and last-writer-wins for a REBUILD of the same declaration (a recompiled NodeType
+    /// mints a new CLR identity under the same assembly name).
+    ///
+    /// <para>🚨 A discriminator claimed by two DIFFERENT declarations becomes
+    /// <b>ambiguous</b> and stops resolving by name — see
+    /// <see cref="TryResolveByDiscriminator"/>.</para>
     /// </summary>
     void Register(Type contentType, string? nodeTypePath = null);
 
-    /// <summary>Resolves a <c>$type</c> discriminator (short or full name) to its CLR type.</summary>
+    /// <summary>
+    /// Resolves a <c>$type</c> discriminator (short or full name) to its CLR type — and REFUSES
+    /// (returns <c>false</c>) a discriminator two different declarations have claimed.
+    ///
+    /// <para>🚨 <b>Why refusing beats answering.</b> A dynamically-compiled content type's
+    /// discriminator is its bare CLR name, and that name is unique only inside its own package:
+    /// one customer node repo ships <c>Currency</c> four times (<c>Reinsurance/Currency</c>,
+    /// <c>ClaimsDeepfield/Currency</c>, <c>UWDeepfield/Currency</c>, <c>Ifrs17/Currency</c>) and
+    /// eleven further names twice or more. With last-writer-wins, "the" <c>Currency</c> was
+    /// whichever package's NodeType had compiled most recently — so one package's content
+    /// deserialised into ANOTHER package's CLR record, dropping every member that record does not
+    /// declare and materialising defaults it does. Which package won changed run to run, because
+    /// registration happens at each type's compile, so the SAME input produced different results
+    /// (Systemorph/MeshWeaver#1299).</para>
+    ///
+    /// <para>An unresolvable name leaves the content a <see cref="JsonElement"/> — honest,
+    /// deterministic, and recoverable by <c>ContentAs&lt;T&gt;</c> at a consumer that knows which
+    /// type it wants. A wrong answer is silent and lossy. <see cref="TryResolveByNodeType"/> stays
+    /// exact and is unaffected: a caller that knows the node's NodeType always gets the right
+    /// type.</para>
+    /// </summary>
     bool TryResolveByDiscriminator(string discriminator, out Type contentType);
 
     /// <summary>Resolves a NodeType path to its content CLR type, when one was registered.</summary>
@@ -70,39 +102,110 @@ public interface IMeshContentTypeRegistry
     /// target is passed explicitly, so the caller hub's registry need not know the type). Returns
     /// <c>null</c> when the element carries no resolvable <c>$type</c> or deserialisation fails —
     /// leaving the caller to keep the existing untyped-JsonElement warning for the genuinely
-    /// unresolvable case.
+    /// unresolvable case. An AMBIGUOUS discriminator (two declarations, see
+    /// <see cref="TryResolveByDiscriminator"/>) is one of the unresolvable cases.
     /// </summary>
     object? TryRecover(JsonElement content, JsonSerializerOptions options);
 }
 
 /// <summary>
 /// Default <see cref="IMeshContentTypeRegistry"/>: two lock-free concurrent maps
-/// (discriminator → type, NodeType path → type). No mutable static state; one instance per mesh,
+/// (discriminator → claim, NodeType path → type). No mutable static state; one instance per mesh,
 /// held as a DI singleton for the process lifetime.
 /// </summary>
-public sealed class MeshContentTypeRegistry : IMeshContentTypeRegistry
+/// <param name="logger">Names an ambiguous discriminator once, with both declarations — the only
+/// place the collision is visible, and the one thing an operator needs to fix it (rename one of the
+/// two content records).</param>
+public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? logger = null)
+    : IMeshContentTypeRegistry
 {
-    private readonly ConcurrentDictionary<string, Type> _byDiscriminator = new(StringComparer.Ordinal);
+    /// <summary>
+    /// One discriminator's claim: the CLR type, WHICH declaration claimed it, and whether a second,
+    /// different declaration has since claimed the same name (making the name unusable).
+    /// </summary>
+    /// <param name="ContentType">The type the (first) declaration registered.</param>
+    /// <param name="Declaration">The declaring identity — see <see cref="DeclarationOf"/>.</param>
+    /// <param name="Ambiguous">Set once and never cleared: a later rebuild of either claimant must
+    /// not "heal" a name that two packages genuinely share.</param>
+    private sealed record DiscriminatorClaim(Type ContentType, string Declaration, bool Ambiguous);
+
+    private readonly ConcurrentDictionary<string, DiscriminatorClaim> _byDiscriminator = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, Type> _byNodeType = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// WHO declared a content type — the NodeType path when the caller knows it, otherwise the
+    /// declaring assembly's simple name. For a runtime-compiled NodeType that assembly name is
+    /// derived from the NodeType's own path (<c>NodeTypeRelease.GetSanitizedPath</c>), so it is
+    /// stable across REBUILDS of one type and differs between two types that merely share a short
+    /// name. That is exactly the distinction the ambiguity rule needs, and it needs no plumbing at
+    /// the single <c>WithContentType</c> call site.
+    /// </summary>
+    private static string DeclarationOf(Type contentType, string? nodeTypePath) =>
+        !string.IsNullOrEmpty(nodeTypePath)
+            ? "nodeType:" + nodeTypePath
+            : "assembly:" + (contentType.Assembly.GetName().Name ?? contentType.Assembly.FullName ?? "?");
 
     /// <inheritdoc />
     public void Register(Type contentType, string? nodeTypePath = null)
     {
         if (contentType is null)
             return;
-        _byDiscriminator[contentType.Name] = contentType;
-        if (contentType.FullName is { } fullName)
-            _byDiscriminator[fullName] = contentType;
+        var declaration = DeclarationOf(contentType, nodeTypePath);
+        ClaimDiscriminator(contentType.Name, contentType, declaration);
+        if (contentType.FullName is { } fullName && !string.Equals(fullName, contentType.Name, StringComparison.Ordinal))
+            ClaimDiscriminator(fullName, contentType, declaration);
         if (!string.IsNullOrEmpty(nodeTypePath))
             _byNodeType[nodeTypePath] = contentType;
+    }
+
+    private void ClaimDiscriminator(string discriminator, Type contentType, string declaration)
+    {
+        var claim = _byDiscriminator.AddOrUpdate(
+            discriminator,
+            _ => new DiscriminatorClaim(contentType, declaration, Ambiguous: false),
+            (_, previous) => previous.Ambiguous
+                // Already contested — keep it contested. A rebuild of one claimant does not make
+                // the name unique again.
+                ? previous
+                // The SAME CLR type registered again — two NodeTypes sharing one compiled record
+                // (a package's shared Source folder). One type, one answer: never ambiguous.
+                : ReferenceEquals(previous.ContentType, contentType)
+                    ? previous
+                    : string.Equals(previous.Declaration, declaration, StringComparison.Ordinal)
+                        // Same declaration, new identity: a REBUILD. The newest one is the answer.
+                        ? new DiscriminatorClaim(contentType, declaration, Ambiguous: false)
+                        : previous with { Ambiguous = true });
+        if (claim.Ambiguous && !ReferenceEquals(claim.ContentType, contentType))
+            WarnAmbiguous(discriminator, claim.Declaration, declaration);
+    }
+
+    // Once per (discriminator, second declaration): the collision is a permanent property of the
+    // installed content, so repeating it on every recompile would be noise — but staying silent
+    // would make "renders empty" unexplainable, since the refusal to resolve is deliberate.
+    private readonly ConcurrentDictionary<string, byte> _warned = new(StringComparer.Ordinal);
+
+    private void WarnAmbiguous(string discriminator, string first, string second)
+    {
+        if (logger is null || !_warned.TryAdd(discriminator + "|" + second, 0))
+            return;
+        logger.LogWarning(
+            "Content type discriminator '{Discriminator}' is claimed by two different declarations "
+            + "({First} and {Second}) — it can no longer be resolved by name, and content carrying it "
+            + "stays an untyped JsonElement on any hub that has not registered the type itself. "
+            + "Answering with one of the two would deserialise one package's content into the other's "
+            + "record (members dropped, foreign defaults materialised) and the winner would depend on "
+            + "compile order. Rename one of the two content records to make the name unique.",
+            discriminator, first, second);
     }
 
     /// <inheritdoc />
     public bool TryResolveByDiscriminator(string discriminator, out Type contentType)
     {
-        if (!string.IsNullOrEmpty(discriminator) && _byDiscriminator.TryGetValue(discriminator, out var t))
+        if (!string.IsNullOrEmpty(discriminator)
+            && _byDiscriminator.TryGetValue(discriminator, out var claim)
+            && !claim.Ambiguous)
         {
-            contentType = t;
+            contentType = claim.ContentType;
             return true;
         }
         contentType = null!;

--- a/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
@@ -175,7 +175,11 @@ public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? lo
                         // Same declaration, new identity: a REBUILD. The newest one is the answer.
                         ? new DiscriminatorClaim(contentType, declaration, Ambiguous: false)
                         : previous with { Ambiguous = true });
-        if (claim.Ambiguous && !ReferenceEquals(claim.ContentType, contentType))
+        // Warn only for a genuinely CONTESTING registration. A rebuild of a claimant that is
+        // already contested re-enters here with a new CLR identity but the SAME declaration, and
+        // warning on that would print "two different declarations (X and X)" — a misleading line
+        // about a name whose collision was already reported (Copilot review).
+        if (claim.Ambiguous && !string.Equals(claim.Declaration, declaration, StringComparison.Ordinal))
             WarnAmbiguous(discriminator, claim.Declaration, declaration);
     }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1555,22 +1555,16 @@ public static class PackageInstaller
             //   • absent      → align. Repo content files legitimately omit the discriminator (the
             //                   node's nodeType implies the content type); skipping here would
             //                   re-open the default-churn for every discriminator-less file.
-            //   • string      → align only when it MATCHES the peer's discriminator.
+            //   • string      → align only when it NAMES the peer's type (see NamesPeerType — the
+            //                   peer's serialized discriminator OR its CLR short/full name, because
+            //                   a runtime-compiled type serializes without a discriminator at all).
             //   • non-string  → malformed; skip alignment entirely (raw compare → the malformed
             //                   value shows as a change instead of being silently repaired).
             var hasDiscriminator = el.TryGetProperty("$type", out var it);
             if (hasDiscriminator && it.ValueKind != JsonValueKind.String)
                 return candidate;
             var candidateType = hasDiscriminator ? it.GetString() : null;
-            var peerType = JsonSerializer.SerializeToNode(peer, options)
-                    is System.Text.Json.Nodes.JsonObject peerNode
-                && peerNode.TryGetPropertyValue("$type", out var pt)
-                && pt is System.Text.Json.Nodes.JsonValue pv
-                && pv.TryGetValue<string>(out var pts)
-                ? pts
-                : null;
-            if (candidateType is not null
-                && !string.Equals(candidateType, peerType, StringComparison.Ordinal))
+            if (candidateType is not null && !NamesPeerType(candidateType, peer, options))
                 return candidate;
 
             // Deserialize WITHOUT tolerating unknown members: with the ambient Skip handling, a
@@ -1591,6 +1585,37 @@ public static class PackageInstaller
         {
             return candidate;                       // schema drift / unknown member — raw compare
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="discriminator"/> (an element's <c>$type</c>) names
+    /// <paramref name="peer"/>'s type — the same-type guard in front of the alignment.
+    ///
+    /// <para>🚨 The peer's SERIALIZED <c>$type</c> is not sufficient evidence on its own. A
+    /// runtime-compiled content type is deliberately never adopted into a long-lived per-hub
+    /// <c>ITypeRegistry</c> (a per-compile collectible identity would poison later resolutions and
+    /// pin the assembly), so <c>ObjectPolymorphicConverter.Write</c> emits such a value with NO
+    /// discriminator at all. Reading "no <c>$type</c>" as "a different type" skipped the alignment
+    /// for exactly the packages whose content types are dynamic, and the raw compare then found the
+    /// one and only difference — the <c>$type</c> member the element carries and the typed peer does
+    /// not — so the node was rewritten on every re-install (<c>Underwriting/Rulebook/*</c>, 40
+    /// nodes per run, allow-listed as known debt since). The discriminator IS the type's short or
+    /// full CLR name by construction, so the peer's own name is the authoritative fallback.</para>
+    /// </summary>
+    private static bool NamesPeerType(string discriminator, object peer, JsonSerializerOptions options)
+    {
+        var peerType = peer.GetType();
+        if (string.Equals(discriminator, peerType.Name, StringComparison.Ordinal)
+            || string.Equals(discriminator, peerType.FullName, StringComparison.Ordinal))
+            return true;
+        // A peer whose hub DID register it may carry an explicit collection name that differs from
+        // the CLR name — honour that too.
+        return JsonSerializer.SerializeToNode(peer, options)
+                is System.Text.Json.Nodes.JsonObject peerNode
+            && peerNode.TryGetPropertyValue("$type", out var pt)
+            && pt is System.Text.Json.Nodes.JsonValue pv
+            && pv.TryGetValue<string>(out var pts)
+            && string.Equals(discriminator, pts, StringComparison.Ordinal);
     }
 
     // The node's scalar fields, applying the incoming's non-null values over the current (mirrors
@@ -2321,7 +2346,7 @@ public static class PackageInstaller
             return null;
         }
         var (id, ns) = NodeFileMapper.FromRelativePath(file.RelativePath);
-        return parsed with
+        return AsAuthored(parsed, file, logger) with
         {
             Id = id,
             Namespace = ns,
@@ -2331,6 +2356,55 @@ public static class PackageInstaller
             MainNode = parsed.MainNode ?? (string.IsNullOrEmpty(ns) ? id : $"{ns}/{id}"),
             State = MeshNodeState.Active,
         };
+    }
+
+    /// <summary>
+    /// The node with the content the FILE declares, whenever the parse materialised a
+    /// RUNTIME-COMPILED (collectible-assembly) content type.
+    ///
+    /// <para>🚨 An install must write what the package says, and for a dynamically-compiled content
+    /// type the parse cannot know it guessed right. Such a type's <c>$type</c> discriminator is its
+    /// bare CLR name, and that name is unique only inside its own package — one customer node repo
+    /// ships <c>Currency</c> in four packages and eleven further names in two or more. The mesh-wide
+    /// content-type map answers by name, so the deserialiser hands the installer whichever
+    /// package's record compiled most recently, and materialising it is destructive both ways:
+    /// members the foreign record does not declare are DROPPED (<c>Reinsurance/Samples/AlpinaCedent</c>
+    /// installed with its whole content stripped to <c>{}</c>), and defaults it does declare are
+    /// INJECTED (<c>Ifrs17/Currency/*</c> gained <c>code</c>/<c>decimalPlaces</c> from
+    /// <c>ClaimsDeepfield</c>'s record). The unchanged-check then compares an authored file against
+    /// a foreign materialisation, finds a difference, and rewrites the node on EVERY install — with
+    /// the set of rewritten nodes varying run to run, because which package won the name depends on
+    /// compile order (Systemorph/MeshWeaver#1299).</para>
+    ///
+    /// <para>The authored element is written instead, and the OWNING hub — the one place the node's
+    /// own NodeType is known — types it on read. Statically-registered content
+    /// (<see cref="NodeTypeDefinition"/>, markdown, access assignments) is a real, process-unique
+    /// registration rather than a name guess, so it stays typed: the installer's own ordering and
+    /// compile-trigger logic reads <c>Content is NodeTypeDefinition</c>.</para>
+    /// </summary>
+    // Internal for the InstallAuthoredContentTest pin (InternalsVisibleTo).
+    internal static MeshNode AsAuthored(MeshNode parsed, PackageFile file, ILogger? logger)
+    {
+        if (parsed.Content is null || !parsed.Content.GetType().Assembly.IsCollectible)
+            return parsed;
+        try
+        {
+            using var doc = JsonDocument.Parse(file.Content);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("content", out var authored))
+                return parsed with { Content = authored.Clone() };
+        }
+        catch (JsonException)
+        {
+            // Unreachable in practice — a file that produced a typed content parsed as JSON once
+            // already. Fall through rather than invent a content shape.
+        }
+        logger?.LogWarning(
+            "[PackageInstaller] {Path} materialised the runtime-compiled content type {Type}, and the "
+            + "file's authored content could not be re-read — installing the materialised value, which "
+            + "may carry another package's defaults.",
+            file.RelativePath, parsed.Content.GetType().Name);
+        return parsed;
     }
 
     // Each write is System-impersonated INDIVIDUALLY — an ambient whole-pipeline impersonation
@@ -2375,7 +2449,7 @@ public static class PackageInstaller
 
         var (id, ns) = NodeFileMapper.FromRelativePath(rel);
         var rebasedNs = string.IsNullOrEmpty(ns) ? partition : $"{partition}/{ns}";
-        return parsed with
+        return AsAuthored(parsed, file, logger) with
         {
             Id = id,
             Namespace = rebasedNs,

--- a/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
@@ -1,10 +1,12 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text.Json;
 using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.Messaging.Hub.Test;
@@ -152,6 +154,61 @@ public class MeshContentTypeRegistryTest
         registry.TryResolveByNodeType("ClaimsDeepfield/Currency", out var b).Should().BeTrue();
         b.Should().BeSameAs(claims);
         registry.TryResolveByDiscriminator("Currency", out _).Should().BeFalse();
+    }
+
+    /// <summary>Captures the warning lines so the collision report can be asserted on.</summary>
+    private sealed class CapturingLogger : ILogger<MeshContentTypeRegistry>
+    {
+        public List<string> Warnings { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+                Warnings.Add(formatter(state, exception));
+        }
+    }
+
+    /// <summary>The collision is reported once, naming both declarations — the only place it is
+    /// visible, and what an operator needs in order to rename one of the two records.</summary>
+    [Fact(Timeout = 30000)]
+    public void TheCollisionIsReportedOnce_NamingBothDeclarations()
+    {
+        var logger = new CapturingLogger();
+        var registry = new MeshContentTypeRegistry(logger);
+
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));
+        registry.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+
+        logger.Warnings.Should().ContainSingle().Which
+            .Should().Contain("Currency")
+            .And.Contain("Ifrs17_Currency")
+            .And.Contain("ClaimsDeepfield_Currency");
+    }
+
+    /// <summary>
+    /// A REBUILD of a claimant whose name is already contested must not report the collision again
+    /// — it would print "two different declarations (X and X)", a misleading line about a name whose
+    /// collision was already reported, on every recompile.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void RebuildOfAContestedClaimant_DoesNotReportItAgain()
+    {
+        var logger = new CapturingLogger();
+        var registry = new MeshContentTypeRegistry(logger);
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));
+        registry.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+        logger.Warnings.Clear();
+
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));
+
+        logger.Warnings.Should().BeEmpty(
+            "a rebuild is the same declaration — there is no new collision to report");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
@@ -1,0 +1,172 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.Json;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the AMBIGUITY rule of the mesh-wide <c>$type</c> → CLR-Type map
+/// (<see cref="MeshContentTypeRegistry"/>).
+///
+/// <para>A runtime-compiled content type's discriminator is its bare CLR name, and that name is
+/// unique only inside its own package. One customer node repo ships <c>Currency</c> in four
+/// packages (<c>Reinsurance</c>, <c>ClaimsDeepfield</c>, <c>UWDeepfield</c>, <c>Ifrs17</c>) and
+/// eleven more names in two or more. Under the original last-writer-wins rule the map answered
+/// with whichever package's record had compiled most recently, so one package's content
+/// deserialised into another package's record — members dropped, foreign defaults materialised —
+/// and WHICH package won changed run to run. That is what made the plugin gate's install
+/// unchanged-check nondeterministic on one image digest (Systemorph/MeshWeaver#1299).</para>
+///
+/// <para>The types here are built with <see cref="AssemblyBuilder"/> because that is the shape
+/// under test: production never passes a <c>nodeTypePath</c>, so the declaring identity IS the
+/// assembly's simple name — which, for a compiled NodeType, is derived from the NodeType path
+/// and is therefore stable across rebuilds and distinct between two types that merely share a
+/// short name.</para>
+/// </summary>
+public class MeshContentTypeRegistryTest
+{
+    /// <summary>A CLR type named <paramref name="typeName"/> in its own assembly — the shape a
+    /// compiled NodeType produces (assembly name = the sanitized NodeType path).</summary>
+    private static Type EmitType(string assemblyName, string typeName)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName(assemblyName), AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule(assemblyName);
+        return module.DefineType(typeName, TypeAttributes.Public | TypeAttributes.Class)
+            .CreateType();
+    }
+
+    [Fact(Timeout = 30000)]
+    public void UniqueDiscriminator_Resolves()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var scenario = EmitType("SST_Scenario", "Scenario");
+
+        registry.Register(scenario);
+
+        registry.TryResolveByDiscriminator("Scenario", out var resolved).Should().BeTrue();
+        resolved.Should().BeSameAs(scenario);
+    }
+
+    /// <summary>🚨 The defect: two packages, one short name. The map must stop answering.</summary>
+    [Fact(Timeout = 30000)]
+    public void TwoDeclarationsOfOneName_StopResolving()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var ifrs17 = EmitType("Ifrs17_Currency", "Currency");
+        var claims = EmitType("ClaimsDeepfield_Currency", "Currency");
+
+        registry.Register(ifrs17);
+        registry.TryResolveByDiscriminator("Currency", out _)
+            .Should().BeTrue("one claimant — the name is still unique");
+
+        registry.Register(claims);
+
+        registry.TryResolveByDiscriminator("Currency", out _)
+            .Should().BeFalse(
+                "answering with either package's record would deserialise the other package's " +
+                "content into it, and which one wins would depend on compile order");
+    }
+
+    /// <summary>Order must not matter — the contested name is refused whichever registered first.</summary>
+    [Fact(Timeout = 30000)]
+    public void ContestedName_IsRefusedRegardlessOfRegistrationOrder()
+    {
+        var forward = new MeshContentTypeRegistry();
+        forward.Register(EmitType("Ifrs17_Currency", "Currency"));
+        forward.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+
+        var reverse = new MeshContentTypeRegistry();
+        reverse.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+        reverse.Register(EmitType("Ifrs17_Currency", "Currency"));
+
+        forward.TryResolveByDiscriminator("Currency", out _).Should().BeFalse();
+        reverse.TryResolveByDiscriminator("Currency", out _).Should().BeFalse();
+    }
+
+    /// <summary>A third claimant cannot "heal" the name back into resolvability.</summary>
+    [Fact(Timeout = 30000)]
+    public void ContestedName_StaysContestedAfterAFurtherRegistration()
+    {
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));
+        registry.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));   // a rebuild of the first
+
+        registry.TryResolveByDiscriminator("Currency", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A RECOMPILE of one NodeType mints a new collectible identity under the SAME assembly name.
+    /// That is not a collision — the newest build is the right answer, exactly as before.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void RebuildOfTheSameDeclaration_ResolvesToTheNewestBuild()
+    {
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(EmitType("SST_Scenario", "Scenario"));
+        var rebuilt = EmitType("SST_Scenario", "Scenario");
+
+        registry.Register(rebuilt);
+
+        registry.TryResolveByDiscriminator("Scenario", out var resolved).Should().BeTrue(
+            "a rebuild is the same declaration, not a second claimant");
+        resolved.Should().BeSameAs(rebuilt);
+    }
+
+    /// <summary>
+    /// Two NodeTypes that share ONE compiled record (a package's shared <c>Source</c> folder)
+    /// register the very same CLR type twice. One type means one answer — never ambiguous.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void SameTypeRegisteredFromTwoNodeTypes_StaysResolvable()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var shared = EmitType("SST_Shared", "Filing");
+
+        registry.Register(shared, "SST/Filing");
+        registry.Register(shared, "SST/StandReModel");
+
+        registry.TryResolveByDiscriminator("Filing", out var resolved).Should().BeTrue();
+        resolved.Should().BeSameAs(shared);
+    }
+
+    /// <summary>The exact NodeType route is unaffected — it never guessed from a name.</summary>
+    [Fact(Timeout = 30000)]
+    public void NodeTypeRoute_StaysExactForBothClaimants()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var ifrs17 = EmitType("Ifrs17_Currency", "Currency");
+        var claims = EmitType("ClaimsDeepfield_Currency", "Currency");
+
+        registry.Register(ifrs17, "Ifrs17/Currency");
+        registry.Register(claims, "ClaimsDeepfield/Currency");
+
+        registry.TryResolveByNodeType("Ifrs17/Currency", out var a).Should().BeTrue();
+        a.Should().BeSameAs(ifrs17);
+        registry.TryResolveByNodeType("ClaimsDeepfield/Currency", out var b).Should().BeTrue();
+        b.Should().BeSameAs(claims);
+        registry.TryResolveByDiscriminator("Currency", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The recovery seam degrades to "unresolvable" for a contested name rather than handing back
+    /// a foreign record — the JsonElement the caller then keeps is honest and deterministic.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TryRecover_RefusesAContestedDiscriminator()
+    {
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(EmitType("Ifrs17_Currency", "Currency"));
+        registry.Register(EmitType("ClaimsDeepfield_Currency", "Currency"));
+
+        var element = JsonSerializer.Deserialize<JsonElement>("""{"$type":"Currency"}""");
+
+        registry.TryRecover(element, JsonSerializerOptions.Default).Should().BeNull();
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallAuthoredContentTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallAuthoredContentTest.cs
@@ -1,0 +1,95 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins <see cref="PackageInstaller.AsAuthored"/>: an install writes the content the FILE declares
+/// whenever the parse materialised a RUNTIME-COMPILED content type.
+///
+/// <para>🚨 A dynamically-compiled content type's <c>$type</c> discriminator is its bare CLR name,
+/// and that name is unique only inside its own package — one customer node repo ships
+/// <c>Currency</c> in four packages. The deserialiser therefore hands the installer whichever
+/// package's record the mesh-wide map last learned, and materialising it is destructive both ways:
+/// members the foreign record does not declare are dropped (an installed sample cedent lost its
+/// entire content), and defaults it does declare are injected. The unchanged-check then compares an
+/// authored file against a foreign materialisation and rewrites the node on every install, with the
+/// rewritten set varying run to run (Systemorph/MeshWeaver#1299).</para>
+/// </summary>
+public class InstallAuthoredContentTest
+{
+    /// <summary>A content type in a COLLECTIBLE assembly — the shape a compiled NodeType produces
+    /// and the only shape whose name-based resolution is a guess.</summary>
+    private static object EmitCollectibleContent()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("ClaimsDeepfield_Currency"), AssemblyBuilderAccess.RunAndCollect);
+        var type = assembly.DefineDynamicModule("ClaimsDeepfield_Currency")
+            .DefineType("Currency", TypeAttributes.Public | TypeAttributes.Class)
+            .CreateType();
+        return Activator.CreateInstance(type)!;
+    }
+
+    private static PackageFile File(string json) =>
+        new("Ifrs17/Currency/CHF.json", json);
+
+    private const string AuthoredJson =
+        """{"$type":"MeshNode","id":"CHF","nodeType":"Ifrs17/Currency","content":{"$type":"Currency","code":"CHF"}}""";
+
+    [Fact(Timeout = 30000)]
+    public void RuntimeCompiledContent_IsReplacedByTheAuthoredElement()
+    {
+        var parsed = new MeshNode("CHF", "Ifrs17/Currency") { Content = EmitCollectibleContent() };
+
+        var authored = PackageInstaller.AsAuthored(parsed, File(AuthoredJson), null);
+
+        authored.Content.Should().BeOfType<JsonElement>(
+            "a runtime-compiled content type can only have been resolved by a name that is not " +
+            "unique across packages — the install must write what the file says");
+        ((JsonElement)authored.Content!).GetProperty("code").GetString().Should().Be("CHF",
+            "the authored members must survive, including ones the materialised record dropped");
+    }
+
+    /// <summary>
+    /// Statically-registered content is a real, process-unique registration rather than a name
+    /// guess — and the installer's own ordering and compile-trigger logic reads
+    /// <c>Content is NodeTypeDefinition</c>, so it must stay typed.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void StaticallyRegisteredContent_StaysTyped()
+    {
+        var content = new Graph.Configuration.NodeTypeDefinition { Description = "a type" };
+        var parsed = new MeshNode("Currency", "Ifrs17") { Content = content };
+
+        PackageInstaller.AsAuthored(parsed, File(AuthoredJson), null).Content
+            .Should().BeSameAs(content);
+    }
+
+    [Fact(Timeout = 30000)]
+    public void ContentlessNode_IsUntouched()
+    {
+        var parsed = new MeshNode("CHF", "Ifrs17/Currency");
+
+        PackageInstaller.AsAuthored(parsed, File(AuthoredJson), null).Content.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A file whose authored content cannot be re-read leaves the node exactly as parsed — the
+    /// installer never invents a content shape, it only ever prefers the authored one.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void UnreadableAuthoredContent_LeavesTheParsedValue()
+    {
+        var content = EmitCollectibleContent();
+        var parsed = new MeshNode("CHF", "Ifrs17/Currency") { Content = content };
+
+        PackageInstaller.AsAuthored(parsed, File("not json at all"), null).Content
+            .Should().BeSameAs(content);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallSignatureAlignmentTest.cs
@@ -195,6 +195,69 @@ public class InstallSignatureAlignmentTest(ITestOutputHelper output) : MonolithM
                 "a discriminator-less file with only materialized-default differences is unchanged");
     }
 
+    /// <summary>A content type deliberately NOT registered on any hub — so
+    /// <c>ObjectPolymorphicConverter.Write</c> serializes it with no <c>$type</c> at all, exactly as
+    /// it does for every runtime-compiled NodeType content record (those are never adopted into a
+    /// long-lived per-hub registry).</summary>
+    private record UnregisteredContent
+    {
+        public string Label { get; init; } = string.Empty;
+    }
+
+    /// <summary>
+    /// 🚨 The peer serializes WITHOUT a discriminator, and that must not read as "a different type".
+    /// The guard used to compare the element's <c>$type</c> against the peer's SERIALIZED <c>$type</c>
+    /// only — null for any runtime-compiled record — so alignment was skipped for exactly the
+    /// packages whose content types are dynamic, and the raw compare then found the one and only
+    /// difference: the <c>$type</c> member itself. That rewrote 40 <c>Underwriting/Rulebook/*</c>
+    /// nodes on every re-install (Systemorph/MeshWeaver#1299).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void PeerSerializedWithoutDiscriminator_StillAligns_AndReadsUnchanged()
+    {
+        var current = Node(Element("""{"$type":"UnregisteredContent","label":"x"}"""));
+        var incoming = Node(new UnregisteredContent { Label = "x" });
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeTrue(
+                "the element's $type names the peer's CLR type — a peer whose hub never registered " +
+                "it simply serializes without a discriminator, which is not a type difference");
+    }
+
+    /// <summary>The same, with the sides swapped — the guard runs on whichever side is the element.</summary>
+    [Fact(Timeout = 30000)]
+    public void TypedCurrentSerializedWithoutDiscriminator_VsElementIncoming_IsUnchanged()
+    {
+        var current = Node(new UnregisteredContent { Label = "x" });
+        var incoming = Node(Element("""{"$type":"UnregisteredContent","label":"x"}"""));
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeTrue();
+    }
+
+    /// <summary>A real value change is still detected once the discriminator no longer blocks alignment.</summary>
+    [Fact(Timeout = 30000)]
+    public void PeerWithoutDiscriminator_RealValueChange_IsStillDetected()
+    {
+        var current = Node(Element("""{"$type":"UnregisteredContent","label":"x"}"""));
+        var incoming = Node(new UnregisteredContent { Label = "y" });
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse("label x → y is a real change the relaxed guard must not mask");
+    }
+
+    /// <summary>A DIFFERENT $type is still a type difference — the fallback names the peer's type,
+    /// it does not accept any discriminator.</summary>
+    [Fact(Timeout = 30000)]
+    public void PeerWithoutDiscriminator_DifferentContentType_IsStillDetected()
+    {
+        var current = Node(Element("""{"$type":"SomeOtherContent","label":"x"}"""));
+        var incoming = Node(new UnregisteredContent { Label = "x" });
+
+        PackageInstaller.IsUnchanged(current, incoming, Mesh.JsonSerializerOptions)
+            .Should().BeFalse("a differing $type IS a real change — alignment only applies same-type");
+    }
+
     /// <summary>
     /// A MALFORMED (non-string) discriminator skips alignment entirely: the raw compare shows the
     /// malformed value as a change instead of the alignment silently stripping and repairing it.


### PR DESCRIPTION
Closes #1299.

Both defects in that issue have **one root**, and it is not in the gate — the gate was reporting
something real, exactly as the issue says.

## The root: a mesh-wide map keyed by a name that is not mesh-wide unique

A runtime-compiled content type's `$type` discriminator is its bare CLR name.
`MeshContentTypeRegistry` — the process-wide `$type` → CLR-Type map that lets a hub re-type content
its own frozen options cannot resolve — mapped that name **last-writer-wins across the whole mesh**.

Names are only unique *inside* a package. The MeshWeaver.Reinsurance repo declares:

| Discriminator | Claimed by |
|---|---|
| `Currency` | Reinsurance, ClaimsDeepfield, UWDeepfield, Ifrs17 |
| `Cedent` | Reinsurance, ClaimsDeepfield, UWDeepfield |
| `LineOfBusiness` | Reinsurance, UWDeepfield, Ifrs17 |
| `Scenario` · `Treaty` · `Broker` · `Underwriter` · `AmountType` · `ExposureProfile` · `YieldCurve` · `EngineDescriptor` · `UWDeepfieldHome` | two packages each |

So "the" `Currency` was whichever package's NodeType had compiled most recently.

## What that produced — three symptoms, one cause

**1. Installs wrote the wrong shape, and lost data.** `PackageInstaller` parses a package file with
the hub's serializer, so content materialised as the *foreign* record. Members it does not declare
were **dropped** — `Reinsurance/Samples/AlpinaCedent` installed with its entire content stripped to
`{}` — and defaults it does declare were **injected**: `Ifrs17/Currency/*` gained
`code`/`decimalPlaces` from ClaimsDeepfield's record. Reproduced with `MW_INSTALL_DIFF=1`:

```
[DIFF] Ifrs17/Currency/CHF  scalars=True lens=48/20
  cur(Currency): {"$type":"Currency","code":"","decimalPlaces":2}   ← ClaimsDeepfield's record
  inc(Currency): {"$type":"Currency"}                                ← Ifrs17's own record
```

**2. Defect 1 of the issue** — the unchanged-check then compares an authored file against a foreign
materialisation, finds a difference that was never authored, and rewrites the node on *every*
install. Measured locally on `main` (67e2aed): Ifrs17 10, Reinsurance 75, SST 25, Underwriting 40.

**3. Defect 2 of the issue** — and the result is **nondeterministic on identical input**, because
which package wins the name depends on the order the types happen to compile. That is the
"same digest, 2 failures then 3, Reinsurance 80 nodes then 77", and it is what made the #1205 and
#1273 attributions wrong. It is also visible here: the same repo produced Reinsurance **12** on the
PR's CI run and **75** locally.

A fourth, independent contributor to the same check is fixed alongside it (see below); it is
deterministic and is the `Underwriting idempotence` allow entry.

## The fix, at each level it broke

**`MeshContentTypeRegistry` refuses a contested name.** A discriminator claimed by two *different*
declarations stops resolving by name; the content stays a `JsonElement` — honest, deterministic and
recoverable by `ContentAs<T>` at a consumer that knows which type it wants. A wrong answer is silent
and lossy; no answer is neither. The declaring identity is the type's **assembly name**, which for a
compiled NodeType is derived from its NodeType path (`NodeTypeRelease.GetSanitizedPath`), so a
**rebuild** of one type is still last-writer-wins and two packages sharing a name are not — no
plumbing needed at the single `WithContentType` call site. `TryResolveByNodeType` is exact and
untouched. The collision is logged **once**, naming both declarations, so it can be resolved by
renaming one record:

```
Content type discriminator 'Currency' is claimed by two different declarations
(assembly:DynamicNode_ClaimsDeepfield_Currency and assembly:DynamicNode_Ifrs17_Currency) — …
```

**`PackageInstaller` installs the content the FILE declares** whenever the parse materialised a
runtime-compiled (collectible-assembly) type. Deciding a content type from a name that is not
mesh-wide unique is a guess the installer has no business making; the owning hub — the one place the
node's own NodeType is known — types it on read. Statically-registered content stays typed (the
installer's own ordering reads `Content is NodeTypeDefinition`).

**The same-type guard no longer reads "the peer serialized without a `$type`" as "a different
type".** A runtime-compiled type is deliberately never adopted into a long-lived per-hub registry,
so `ObjectPolymorphicConverter.Write` emits it with **no discriminator at all** — which skipped the
alignment for exactly the dynamic-typed packages and left the `$type` member itself as the only
difference:

```
[DIFF] Underwriting/Rulebook/Caps/Cyber  lens=153/124 firstDiff@2
  cur(JsonElement):        {"$type":"CapacityCapContent","aliases":["cyber"],…}
  inc(CapacityCapContent): {"aliases":["cyber"],…}
```

The discriminator IS the type's CLR short/full name by construction, so the peer's own name is the
fallback.

## No band-aid

No window was widened, nothing is retried, no allow entry was added. The one bound left in place
(`RootTypeSettleTimeout` &c.) was not touched. `Reinsurance`/`SST` are **not** on any allow list —
the ratchet only shrinks (see below).

## Verified

**Determinism (the bar the issue sets).** The `mw-plugin-test` gate run against a real
MeshWeaver.Reinsurance checkout — 1483 nodes, 152 NodeTypes, 11 packages — **six consecutive times
with the same binary on the same checkout** (four before merging main, two after, on the tree CI
builds). All six verdicts byte-identical:

| Run | Ifrs17 | Reinsurance | SST | Underwriting | `[DIFF]` lines |
|---|---|---|---|---|---|
| before | RED (10) | RED (75) | RED (25) | RED (40) | 150 |
| 1 · 2 · 3 · 4 · 5 · 6 | PASS | PASS | PASS | PASS | **0** |

Every package now passes; **zero** nodes are rewritten by a re-install of an unchanged snapshot.
The only remaining red is `ReinsuranceDemo install` — the pre-existing, documented cross-repo
dependency (`Training/Tour` ships in MeshWeaver.Plugins), already on that repo's allow list.

**Unit pins** (all new): `MeshContentTypeRegistryTest` (8) drives two `AssemblyBuilder` types that
share a short name — contested name refused, refusal order-independent, a rebuild still resolves,
one type registered from two NodeTypes stays resolvable, the NodeType route stays exact.
`InstallAuthoredContentTest` (4) pins the authored-content rule and that static content stays typed.
`InstallSignatureAlignmentTest` gains 4 for the discriminator-less peer, including that a real value
change and a genuinely different `$type` are still detected.

**Suites**: MeshWeaver.Messaging.Hub.Test 208/208 · MeshWeaver.PluginCatalog.Test 267/267 ·
ReimportTypedContentRecoveryTest 5/5 (the other consumer of the discriminator route).
`dotnet build -c Release -warnaserror --no-incremental`, one project at a time: `0 Error(s)`.

## Follow-up for MeshWeaver.Reinsurance (one line, not in this repo)

With this fix, `Underwriting idempotence` in that repo's `plugin-gate.allow` **now passes** and is
therefore STALE — and a stale entry fails the gate, which is the ratchet doing its job. Running the
gate with the repo's own allow file gives:

```
[PASS] Underwriting (108 node(s), 8 type(s))
STALE allow entry (now passing — remove it): Underwriting idempotence
GATE FAILED — stale allow entr(ies): Underwriting idempotence — 0 new failure(s), 1 stale allow entr(ies).
```

**0 new failures.** Deleting that one line from `plugin-gate.allow` is what finishes unblocking
MeshWeaver.Reinsurance#52; that PR itself needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
