### PR TITLE
The course-index reads go through the unified query — a hub-scoped synced query is subtree-local

### DIFF
--- a/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
@@ -310,7 +310,7 @@ public static class EducationLayoutAreas
     // A query stream reports Initial/Reset as the FULL result but Added/Updated/Removed as ONLY the changed
     // items — so the rail folds the changes instead of re-rendering from a delta, which would blank every
     // page the delta does not mention the moment someone adds or renames one.
-    private static ImmutableDictionary<string, MeshNode> ApplyQueryChange(
+    internal static ImmutableDictionary<string, MeshNode> ApplyQueryChange(
         ImmutableDictionary<string, MeshNode> nodes, QueryResultChange<MeshNode> change)
         => change.ChangeType switch
         {

--- a/src/MeshWeaver.Graph/Education/EducationNavigationProvider.cs
+++ b/src/MeshWeaver.Graph/Education/EducationNavigationProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using MeshWeaver.Layout.Composition;
@@ -74,15 +75,29 @@ public sealed class EducationNavigationProvider : INodeNavigationProvider
 
         var hub = host.Hub;
         var courseSlug = CourseProgress.CourseSlug(root);
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return null;
+
+        // 🚨 Both reads go through IMeshService.Query — the UNIFIED query — never hub.GetQuery.
+        // A hub-scoped synced query is SUBTREE-LOCAL on a running (Orleans-hosted) mesh: asked from
+        // a lesson's hub for `path:{course} scope:subtree`, it answers from the lesson's own
+        // snapshot and returns (nearly) nothing, so the provider silently declined and every course
+        // page fell back to the one-branch child list — on live memex only, because the Monolith
+        // test host's synced queries see the whole store. The reader shell's rail
+        // (EducationLayoutAreas.CourseNavStream) uses this same unified read and demonstrably
+        // returns the full course from a lesson hub in production; same family as the live compile
+        // trace in MeshWeaver#1311 and the record-page fix in MeshWeaver.Plugins#430.
 
         // The learner's visit markers decorate the index (✓ on visited lessons). Starts empty so
         // a slow or absent record can never hold the menu back.
         var visitedStream = string.IsNullOrEmpty(viewer)
             ? Observable.Return(NoLessons)
-            : hub.GetQuery(
-                    $"course-progress:{viewer}:{courseSlug}",
-                    $"path:{CourseProgress.VisitedPath(viewer, courseSlug)} scope:descendants select:path,id")
-                .Select(markers => CourseProgress.VisitedSlugs(markers))
+            : meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    $"path:{CourseProgress.VisitedPath(viewer, courseSlug)} scope:descendants"))
+                .Scan(ImmutableDictionary<string, MeshNode>.Empty, EducationLayoutAreas.ApplyQueryChange)
+                .Select(markers => CourseProgress.VisitedSlugs(markers.Values))
                 .Catch((Exception _) => Observable.Return(NoLessons))
                 .StartWith(NoLessons);
 
@@ -93,7 +108,8 @@ public sealed class EducationNavigationProvider : INodeNavigationProvider
         // upsert of a self-describing marker, so there is no read-modify-write to race.
         var visitWrite = PrepareVisitWrite(host, viewer, root, courseSlug, currentPath);
 
-        // ONE subtree query per course, shared by every page of it (synced + RLS-wrapped).
+        // The course subtree, folded from the query's change feed (Initial/Reset carry the full
+        // result, Added/Updated/Removed only the delta — the same fold the reader shell uses).
         // Defer wraps a per-subscription flag: the first CLAIMED index this page renders arms the
         // visit write — once per page open, and only after CourseProgress.VisitDwell so a page the
         // reader merely paged through is never marked read. Leaving CANCELS the dwell: the
@@ -101,11 +117,11 @@ public sealed class EducationNavigationProvider : INodeNavigationProvider
         return Observable.Defer(() =>
         {
             var recorded = false;
-            return hub.GetQuery(
-                    $"edu-course-index:{root}",
-                    $"path:{root} scope:subtree is:main select:path,id,name,order,nodeType,icon")
+            return meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{root} scope:subtree is:main"))
+                .Scan(ImmutableDictionary<string, MeshNode>.Empty, EducationLayoutAreas.ApplyQueryChange)
                 .CombineLatest(visitedStream, (nodes, visited) =>
-                    DecorateVisited(BuildNavigation(root, nodes.ToList(), currentPath), visited))
+                    DecorateVisited(BuildNavigation(root, nodes.Values.ToList(), currentPath), visited))
                 .Do(navigation =>
                 {
                     if (navigation is null || recorded || visitWrite is null)


### PR DESCRIPTION
## What broke

Deployed #1302 to memex and rendered `/ThinkInStreams/01-TheCombinatorialTrap`: the rail fell back to the one-branch child list. `EducationNavigationProvider`'s `hub.GetQuery` is a hub-scoped synced query — on the running Orleans-hosted mesh it answers from the asking hub's **own subtree snapshot**, so `path:{course} scope:subtree` asked from a lesson hub returns (nearly) nothing and the provider silently declines. Monolith test hosts see the whole store through the same call, which is why all tests passed. Same live-only scoping family as #1311 (compile source snapshot) and MeshWeaver.Plugins#430 (record-page reads).

## Fix

Both provider reads (course subtree + visit markers) now go through `IMeshService.Query` with the change-feed fold the reader shell's rail already uses (`EducationLayoutAreas.ApplyQueryChange`, widened to internal) — the read path that demonstrably returns the full course from a lesson hub in production (verified on memex today via the Learn rail payload).

## Noted, not fixed here

`CourseNavigationProvider` (MeshWeaver.Courses) reads through `hub.GetQuery` identically and carries the same latent behaviour; no core-Courses course is deployed, so it is not hot — it should follow this pattern when touched.

Unit tests unchanged and green (11) — they pin the pure model; the defect lived in the read path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)