### PR TITLE
feat(diag): imports and the startup bake report what they cost

### DIFF
--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -3,6 +3,7 @@ using MeshWeaver.AI;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Diagnostics;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -109,13 +110,22 @@ internal sealed class StaticRepoImportHostedService(
         // import, ImportAll verifies each SERVED catalog (Agent/Provider/Harness/Skill that a source
         // actually backs this run) is registered in the cross-schema search index, force-re-syncing it
         // and surfacing a startup-failure notification for any that materialized but stayed unindexed.
+        // What this import COSTS, appended to the line that already reports its outcome — no new log
+        // volume. Cumulative since the import started, so the last partition's line is the whole
+        // import's bill. The suspected driver of the memex-cloud growth (2.5 GB → 24.5 GB at
+        // 130–340 MB/min) is this path plus the sync-stream churn it causes, and until now nothing
+        // inside the process reported what one import cost — the growth was only ever inferrable from
+        // a container gauge hours later. See MemoryDelta.
+        var importMemory = MemoryDelta.Start();
+
         _subscription = StaticRepoImporter
             .ImportAll(hub, logger, syncModeOverrides, AiContentSources.ContentPartitions)
             .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
             .Subscribe(
                 r => logger?.LogInformation(
-                    "[StaticRepoImport] {Partition}: {Outcome} ({Count} node(s)).",
-                    r.Partition, r.Outcome, r.Count),
+                    "[StaticRepoImport] {Partition}: {Outcome} ({Count} node(s)) — {Memory} "
+                    + "(cumulative since import start).",
+                    r.Partition, r.Outcome, r.Count, importMemory.ToString()),
                 ex =>
                 {
                     logger?.LogWarning(ex, "[StaticRepoImport] sync-context init failed.");

--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -125,7 +125,7 @@ internal sealed class StaticRepoImportHostedService(
                 r => logger?.LogInformation(
                     "[StaticRepoImport] {Partition}: {Outcome} ({Count} node(s)) — {Memory} "
                     + "(cumulative since import start).",
-                    r.Partition, r.Outcome, r.Count, importMemory.ToString()),
+                    r.Partition, r.Outcome, r.Count, importMemory),
                 ex =>
                 {
                     logger?.LogWarning(ex, "[StaticRepoImport] sync-context init failed.");

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imports-and-startup-builds-report-what-they-cost.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imports-and-startup-builds-report-what-they-cost.md
@@ -1,0 +1,23 @@
+---
+Name: Imports and startup builds report what they cost
+Category: Feature
+Description: The log lines for a content import and the startup node-type build now include how much memory the operation used, so growth can be attributed instead of guessed.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Imports and startup builds report what they cost
+
+When a portal's memory grows, the question is always which activity caused it — and until now the only
+evidence was a chart of total memory for the whole process, read hours later. That is enough to see
+that something grew and not enough to say what grew it, which is why one recent investigation had to
+eliminate four candidate explanations one at a time from outside the process.
+
+Two operations now report their own cost on the log line they already produced: importing the content
+that ships with a release, and the startup build of the node types. Each says how much the managed
+heap and the process grew while it ran. Nothing new is logged — the numbers are appended to existing
+lines — and measuring is deliberately cheap, so it does not change what it measures.
+
+The two figures are worth reading together: memory that leaves the managed heap without leaving the
+process is a different problem from memory the program is still holding, and previously that
+distinction was invisible from inside.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -2,6 +2,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Graph;
+using MeshWeaver.Mesh.Diagnostics;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -237,6 +238,13 @@ public sealed class DynamicTypePreWarmerHostedService(
                 "DynamicTypePreWarmer: waiting for the static repo import to settle before "
                 + "enumerating — types it has not written yet would be missed by the bake");
 
+        // What the whole sweep COSTS, appended to the summary line that already exists — no new log
+        // volume. This is the measurement that turned "the bake must be leaking" into a fact on
+        // memex-cloud: the pod sat at 2.5 GB minutes after baking all 279 types, so one linked build
+        // for the fleet is cheap and the growth is elsewhere. Keep it, so nobody has to re-derive
+        // that from a container gauge. See MemoryDelta.
+        var sweepMemory = MemoryDelta.Start();
+
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         _warmSubscription = (importSettled?.Settled ?? Observable.Return(Unit.Default))
             .SelectMany(_ => DynamicTypePreWarmer
@@ -309,11 +317,12 @@ public sealed class DynamicTypePreWarmerHostedService(
                     var elapsed = DateTimeOffset.UtcNow - startedAt;
                     logger.LogInformation(
                         "DynamicTypePreWarmer: warm-up complete in {Elapsed} — compiled={Compiled} alreadyBaked={AlreadyBaked} "
-                        + "compileErrors={Errored} timedOut={TimedOut} skipped={Skipped} contentBroken={ContentBroken} faulted={Faulted}",
+                        + "compileErrors={Errored} timedOut={TimedOut} skipped={Skipped} contentBroken={ContentBroken} faulted={Faulted} "
+                        + "— {Memory}",
                         elapsed,
                         Volatile.Read(ref compiled), Volatile.Read(ref alreadyBaked), Volatile.Read(ref errored),
                         Volatile.Read(ref timedOut), Volatile.Read(ref skipped), Volatile.Read(ref contentBroken),
-                        Volatile.Read(ref faulted));
+                        Volatile.Read(ref faulted), sweepMemory.ToString());
 
                     // MarkComplete keeps a recorded regression red — completion is not absolution.
                     gate?.MarkComplete(

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -322,7 +322,7 @@ public sealed class DynamicTypePreWarmerHostedService(
                         elapsed,
                         Volatile.Read(ref compiled), Volatile.Read(ref alreadyBaked), Volatile.Read(ref errored),
                         Volatile.Read(ref timedOut), Volatile.Read(ref skipped), Volatile.Read(ref contentBroken),
-                        Volatile.Read(ref faulted), sweepMemory.ToString());
+                        Volatile.Read(ref faulted), sweepMemory);
 
                     // MarkComplete keeps a recorded regression red — completion is not absolution.
                     gate?.MarkComplete(

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -493,7 +493,7 @@ internal static class NodeTypeBatchBake
                 "BatchBake: {TypePath} → {Status}{Detail} — {Memory}",
                 o.TypePath, o.Status,
                 string.IsNullOrEmpty(o.Detail) ? "" : $" ({o.Detail})",
-                compileMemory.ToString()));
+                compileMemory));
     }
 
     private static IObservable<PreWarmOutcome> StampAndReport(

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Diagnostics;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -451,6 +452,13 @@ internal static class NodeTypeBatchBake
         ILogger? logger)
     {
         var typePath = typeNode.Path;
+        // PER-COMPILE cost, appended to the per-type line that already exists — no new log volume.
+        // This is the measurement that answers "is compilation what eats the memory?" directly rather
+        // than by elimination: one linked bake of 279 types left the pod at 2.5 GB, so the fleet is
+        // cheap in aggregate, but nothing reported what an INDIVIDUAL compile cost or whether it was
+        // returned. A type that repeatedly costs tens of MB and never gives them back is visible here
+        // and nowhere else. See MemoryDelta.
+        var compileMemory = MemoryDelta.Start();
         var compiler = mesh.ServiceProvider.GetService<IMeshNodeCompilationService>();
         if (compiler is null)
             return Observable.Return(new PreWarmOutcome(
@@ -482,9 +490,10 @@ internal static class NodeTypeBatchBake
                         "batch compile did not settle within the per-type budget")
                     : new PreWarmOutcome(typePath, PreWarmStatus.Faulted, ex.Message)))
             .Do(o => logger?.LogInformation(
-                "BatchBake: {TypePath} → {Status}{Detail}",
+                "BatchBake: {TypePath} → {Status}{Detail} — {Memory}",
                 o.TypePath, o.Status,
-                string.IsNullOrEmpty(o.Detail) ? "" : $" ({o.Detail})"));
+                string.IsNullOrEmpty(o.Detail) ? "" : $" ({o.Detail})",
+                compileMemory.ToString()));
     }
 
     private static IObservable<PreWarmOutcome> StampAndReport(

--- a/src/MeshWeaver.Mesh.Contract/Diagnostics/MemoryDelta.cs
+++ b/src/MeshWeaver.Mesh.Contract/Diagnostics/MemoryDelta.cs
@@ -48,9 +48,13 @@ public readonly record struct MemoryDelta(long ManagedAtStart, long WorkingSetAt
     /// not leave the process.
     /// </summary>
     public override string ToString() =>
+        // 🚨 Convert to MB FIRST, then let the format supply the sign. Deriving the sign from BYTES
+        // while truncating the magnitude after division rendered "-0 MB" for any negative delta under
+        // 1 MB — a sign on a zero reads as a measurement, not as rounding. The "+#;-#;0" pattern gives
+        // "+412", "-3" and a bare "0". (Copilot review, #1321.)
         string.Format(
             CultureInfo.InvariantCulture,
-            "managed {0}{1} MB, working set {2}{3} MB",
-            ManagedGrowth < 0 ? "-" : "+", Math.Abs(ManagedGrowth) / (1024 * 1024),
-            WorkingSetGrowth < 0 ? "-" : "+", Math.Abs(WorkingSetGrowth) / (1024 * 1024));
+            "managed {0:+#;-#;0} MB, working set {1:+#;-#;0} MB",
+            ManagedGrowth / (1024 * 1024),
+            WorkingSetGrowth / (1024 * 1024));
 }

--- a/src/MeshWeaver.Mesh.Contract/Diagnostics/MemoryDelta.cs
+++ b/src/MeshWeaver.Mesh.Contract/Diagnostics/MemoryDelta.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Globalization;
+
+namespace MeshWeaver.Mesh.Diagnostics;
+
+/// <summary>
+/// A start-to-finish memory measurement for ONE named operation, so an existing log line can say
+/// what that operation COST instead of leaving the growth to be inferred from a container metric
+/// hours later.
+///
+/// <para>🚨 Why this exists. memex-cloud 2026-08-12: a portal pod went from 2.5 GB to 24.5 GB
+/// (RSS 23.6 GB — real anonymous memory, not page cache) at 130–340 MB/min. Four candidate
+/// explanations were eliminated one by one from OUTSIDE the process — the collectible-ALC lifecycle
+/// (bounded, proven by NodeTypeRecompileAlcLeakTest), the LSP workspace cache (per NodeType, disposed
+/// on version change), the batch bake (279 types for 2.5 GB), page cache (RSS says otherwise) —
+/// because nothing inside the process ever reported what any single operation cost. Growth
+/// correlated with GitSync re-imports and sync-stream churn, but correlation from a container gauge
+/// cannot name a culprit.</para>
+///
+/// <para><b>Deliberately cheap, and it adds NO log volume.</b> <see cref="GC.GetTotalMemory(bool)"/>
+/// is called with <c>forceFullCollection: false</c> — it never provokes a collection — and
+/// <see cref="Environment.WorkingSet"/> is one read. Both are taken once per operation, and the
+/// result is appended to log lines that already existed, because `Information` lines ship to Loki
+/// and that is not free.</para>
+///
+/// <para><b>Read it as a hint, not an accountant.</b> The managed figure is un-collected heap at two
+/// instants, so a GC between them can make a real allocation look free or a quiet operation look
+/// negative. What it is good for is the shape: an operation that repeatedly costs tens or hundreds of
+/// MB and never gives it back is the one to investigate, and that is exactly what was missing.</para>
+/// </summary>
+/// <param name="ManagedAtStart">Managed heap bytes when the operation began.</param>
+/// <param name="WorkingSetAtStart">Process working set bytes when the operation began.</param>
+public readonly record struct MemoryDelta(long ManagedAtStart, long WorkingSetAtStart)
+{
+    /// <summary>Takes the opening measurement. Cheap enough to call per operation, not per item.</summary>
+    public static MemoryDelta Start() => new(GC.GetTotalMemory(false), Environment.WorkingSet);
+
+    /// <summary>Managed-heap growth since <see cref="Start"/>, in bytes (can be negative).</summary>
+    public long ManagedGrowth => GC.GetTotalMemory(false) - ManagedAtStart;
+
+    /// <summary>Working-set growth since <see cref="Start"/>, in bytes (can be negative).</summary>
+    public long WorkingSetGrowth => Environment.WorkingSet - WorkingSetAtStart;
+
+    /// <summary>
+    /// Renders both deltas for a log line, signed and in MB — e.g.
+    /// <c>"managed +412 MB, working set +1183 MB"</c>. Signed on purpose: a NEGATIVE managed delta
+    /// next to a POSITIVE working set is the signature of memory that left the managed heap and did
+    /// not leave the process.
+    /// </summary>
+    public override string ToString() =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "managed {0}{1} MB, working set {2}{3} MB",
+            ManagedGrowth < 0 ? "-" : "+", Math.Abs(ManagedGrowth) / (1024 * 1024),
+            WorkingSetGrowth < 0 ? "-" : "+", Math.Abs(WorkingSetGrowth) / (1024 * 1024));
+}

--- a/test/MeshWeaver.Data.Test/MemoryDeltaTest.cs
+++ b/test/MeshWeaver.Data.Test/MemoryDeltaTest.cs
@@ -61,7 +61,12 @@ public class MemoryDeltaTest
         rendered.Should().Contain("managed");
         rendered.Should().Contain("working set");
         rendered.Should().Contain("MB");
-        rendered.Should().MatchRegex(@"managed [+-]\d+ MB, working set [+-]\d+ MB");
+        rendered.Should().MatchRegex(@"managed [+-]?\d+ MB, working set [+-]?\d+ MB");
+
+        // A delta under 1 MB must render a bare "0", never "-0" — a sign on a zero reads as a
+        // measurement rather than as rounding. (Copilot review, #1321.)
+        new MemoryDelta(GC.GetTotalMemory(false) + 512 * 1024, Environment.WorkingSet + 512 * 1024)
+            .ToString().Should().NotContain("-0 MB");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/MemoryDeltaTest.cs
+++ b/test/MeshWeaver.Data.Test/MemoryDeltaTest.cs
@@ -1,0 +1,80 @@
+using System;
+using MeshWeaver.Mesh.Diagnostics;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the two properties that make <see cref="MemoryDelta"/> usable in a log line: it must never
+/// provoke a collection (it is called on hot-ish paths and inside a bake), and its rendering must be
+/// SIGNED — a negative managed delta beside a positive working set is the signature of memory that
+/// left the managed heap and did not leave the process, which is precisely the shape the memex-cloud
+/// growth turned out to have (RSS 23.6 GB with the managed heap far smaller).
+/// </summary>
+public class MemoryDeltaTest
+{
+    /// <summary>
+    /// It must read the heap WITHOUT forcing a collection. `GC.GetTotalMemory(true)` would make this
+    /// probe change the thing it measures and add a full GC to every import and bake.
+    /// </summary>
+    [Fact]
+    public void Start_DoesNotForceACollection()
+    {
+        var before = GC.CollectionCount(GC.MaxGeneration);
+
+        var probe = MemoryDelta.Start();
+        _ = probe.ManagedGrowth;
+        _ = probe.WorkingSetGrowth;
+        _ = probe.ToString();
+
+        GC.CollectionCount(GC.MaxGeneration).Should().Be(before,
+            "the probe must observe memory, never collect it — otherwise measuring an import would "
+            + "itself cost a full gen-2 GC on every partition");
+    }
+
+    /// <summary>Growth is measured from the captured start, so a real allocation shows up.</summary>
+    [Fact]
+    public void ManagedGrowth_CountsAllocationsSinceStart()
+    {
+        var probe = MemoryDelta.Start();
+
+        // ~8 MB, held live across the measurement so no collection can hide it.
+        var held = new byte[8 * 1024 * 1024];
+        held[0] = 1;
+        var grown = probe.ManagedGrowth;
+
+        grown.Should().BeGreaterThan(4 * 1024 * 1024,
+            "an 8 MB live allocation must be visible; a probe that cannot see one is not worth the "
+            + "log line");
+        GC.KeepAlive(held);
+    }
+
+    /// <summary>
+    /// The rendering must carry SIGNS and name both figures — the whole diagnostic value is in
+    /// comparing them, and an unsigned number silently reads as growth when it may be a release.
+    /// </summary>
+    [Fact]
+    public void ToString_IsSignedAndNamesBothFigures()
+    {
+        var rendered = MemoryDelta.Start().ToString();
+
+        rendered.Should().Contain("managed");
+        rendered.Should().Contain("working set");
+        rendered.Should().Contain("MB");
+        rendered.Should().MatchRegex(@"managed [+-]\d+ MB, working set [+-]\d+ MB");
+    }
+
+    /// <summary>
+    /// A delta taken against a HIGHER start renders negative rather than wrapping or throwing — the
+    /// release case has to be legible, since "managed went down while working set went up" is the
+    /// finding that distinguishes a native/unreturned-to-OS problem from a managed leak.
+    /// </summary>
+    [Fact]
+    public void NegativeGrowth_RendersWithAMinus()
+    {
+        var impossiblyHighStart = new MemoryDelta(long.MaxValue / 2, long.MaxValue / 2);
+
+        impossiblyHighStart.ManagedGrowth.Should().BeLessThan(0);
+        impossiblyHighStart.ToString().Should().MatchRegex(@"managed -\d+ MB, working set -\d+ MB");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
@@ -91,7 +91,13 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
         // stream is what does that (the compile watcher is installed from the hub's init hook).
         var first = await WhenCompiled(TypePath, d => d.CompilationStatus == CompilationStatus.Ok, null);
         var lastSucceeded = first.LastCompileSucceededAt;
-        Output.WriteLine($"initial compile settled at {lastSucceeded:HH:mm:ss.fff} — contexts: {LiveContexts()}");
+        FullyCollect();
+        // Baseline AFTER the first compile, so the comparison is recompile-to-recompile and does not
+        // charge the steady-state cost of having one built type to the recompiles.
+        var managedBaseline = AfterCollectionBytes();
+        Output.WriteLine(
+            $"initial compile settled at {lastSucceeded:HH:mm:ss.fff} — contexts: {LiveContexts()}, "
+            + $"managed baseline = {managedBaseline / (1024 * 1024)} MB");
 
         for (var i = 1; i <= Recompiles; i++)
         {
@@ -122,12 +128,18 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
             lastSucceeded = settled.LastCompileSucceededAt;
 
             FullyCollect();
-            Output.WriteLine($"after recompile {generation}: live contexts = {LiveContexts()}");
+            Output.WriteLine(
+                $"after recompile {generation}: live contexts = {LiveContexts()}, "
+                + $"managed = {AfterCollectionBytes() / (1024 * 1024)} MB");
         }
 
         FullyCollect();
         var live = LiveContexts();
+        var managedGrowth = AfterCollectionBytes() - managedBaseline;
         Output.WriteLine($"FINAL live contexts for {TypePath} after {Recompiles} recompiles: {live}");
+        Output.WriteLine(
+            $"FINAL managed growth over {Recompiles} recompiles: "
+            + $"{managedGrowth / (1024 * 1024)} MB ({managedGrowth / Recompiles / (1024 * 1024)} MB per recompile)");
 
         // ≤2, not ==1: the newest build is legitimately live, and one predecessor may still be
         // inside its unload (a pin drained, the LoaderAllocator awaiting the next GC). What must
@@ -136,7 +148,29 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
         live.Should().BeLessThanOrEqualTo(2,
             $"every superseded DynamicNode_ context must be collectable after unload; {live} alive "
             + $"after {Recompiles} recompiles means a generation is pinned per rebuild");
+
+        // 🚨 BYTES, not just context counts. Contexts unloading proves the ALC bookkeeping is right;
+        // it does NOT prove a recompile hands its memory back — Roslyn compilations, metadata and
+        // symbol graphs are ordinary managed objects that outlive an unloaded context if anything
+        // still references them. On memex-cloud the process grew 130–340 MB/min while contexts stayed
+        // bounded, which is exactly the gap this assertion closes.
+        //
+        // 32 MB/recompile is a ceiling, not a target: a trivial `config => config` type compiles to a
+        // few KB of IL, so anything approaching this bound means per-compile state is being retained.
+        // Measured after three aggressive blocking collections, so transient allocation is excluded.
+        var perRecompile = managedGrowth / Recompiles;
+        perRecompile.Should().BeLessThan(32 * 1024 * 1024,
+            $"a recompile of a trivial type must return its memory; {perRecompile / (1024 * 1024)} MB "
+            + $"retained per recompile ({managedGrowth / (1024 * 1024)} MB over {Recompiles}) means "
+            + "compile state survives the context that owned it");
     }
+
+    /// <summary>
+    /// Managed bytes with a full collection forced FIRST — the opposite choice from
+    /// <c>MemoryDelta</c>, which must never collect because it runs in production. Here the question
+    /// is what SURVIVES collection, so paying for the collection is the point.
+    /// </summary>
+    private static long AfterCollectionBytes() => GC.GetTotalMemory(forceFullCollection: true);
 
     /// <summary>
     /// 🚨 THE SAME LOOP, BUT WITH A LIVE INSTANCE HUB — which is the shape production actually runs.

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
@@ -136,6 +136,22 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
         FullyCollect();
         var live = LiveContexts();
         var managedGrowth = AfterCollectionBytes() - managedBaseline;
+
+        // WHERE the bytes went. The contexts unload (above), so the retained memory belongs to
+        // ordinary managed objects — and the leading suspect is per-compile BOOKKEEPING: every compile
+        // mints {typePath}/_Activity/compile-<timestamp> plus a compile-state node, and a mesh node
+        // means a per-node hub with its own DI container and sync streams. If these counts climb with
+        // the recompiles, that is the retainer; if they are flat, the bytes are Roslyn state and the
+        // hunt moves there. Diagnostic output, deliberately not asserted — it names the direction for
+        // issue #1324 rather than pinning a number nobody has justified yet.
+        var hubs = System.Text.RegularExpressions.Regex
+            .Matches(Mesh.GetDisposalDiagnostics(), @"deferred=\d+").Count;
+        var activities = await Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{TypePath}/_Activity"))
+            .Should().Within(30.Seconds()).Emit();
+        Output.WriteLine(
+            $"WHERE: live hubs = {hubs}, compile-activity nodes under {TypePath}/_Activity = "
+            + $"{activities?.Items?.Count ?? -1} after {Recompiles} recompiles");
         Output.WriteLine($"FINAL live contexts for {TypePath} after {Recompiles} recompiles: {live}");
         Output.WriteLine(
             $"FINAL managed growth over {Recompiles} recompiles: "


### PR DESCRIPTION
## Why

The memex-cloud growth — 2.5 GB → 24.5 GB, **RSS 23.6 GB**, 130–340 MB/min — had to be narrowed entirely from **outside** the process. Four candidate explanations were eliminated one at a time:

- the collectible-ALC lifecycle (bounded at 2 contexts across N recompiles — proven by `NodeTypeRecompileAlcLeakTest`, #1272),
- the LSP workspace cache (keyed per NodeType, disposed on version change),
- the batch bake (279 types for 2.5 GB),
- page cache (RSS says otherwise).

All of that because **nothing inside the process ever reported what a single operation cost**. A container gauge shows that something grew; it cannot name what grew it.

## What this adds

`MemoryDelta` — a two-field readonly struct: managed heap + working set at `Start()`, signed growth on read. Both figures deliberately: memory that leaves the managed heap **without leaving the process** is a different problem from memory the program still holds, and that distinction was invisible from inside.

Wired into two operations, on log lines that **already existed** — so this adds **zero** log volume (`Information` lines ship to Loki, and that is not free):

```
[StaticRepoImport] Doc: Imported (412 node(s)) — managed +118 MB, working set +263 MB (cumulative since import start).
DynamicTypePreWarmer: warm-up complete in 00:01:09 — compiled=261 … — managed +1204 MB, working set +2011 MB
```

Those two were chosen because they are the suspected driver and the exonerated one: the import path (plus the sync-stream churn it causes) is where the growth correlates, and the bake is what the numbers already cleared.

## Cheap by construction

`GC.GetTotalMemory(forceFullCollection: **false**)` — it must never provoke a collection, or measuring an import would itself cost a gen-2 GC per partition — plus one `Environment.WorkingSet` read, once per operation, never per item.

## Tests

`MemoryDeltaTest`:
- **collection count unchanged** across `Start()` + both reads + `ToString()` — the probe observes, never collects;
- an 8 MB live allocation is visible (a probe that can't see one isn't worth the log line);
- the rendering is **signed** and names both figures, in both directions.

4/4 pass.

## Honest about its limits

Stated in the type's own doc comment: it is two instants of un-collected heap, so a GC in between can flatter or slander any single reading. What it is for is the **shape** — an operation that repeatedly costs tens or hundreds of MB and never returns it. That is precisely the evidence this investigation lacked, and why it took a day of elimination to get as far as "the import/sync-stream path".

## Related

- #1272 — the repro that eliminated the ALC explanation.
- #1262 — the `keys=` discriminator, which will name the 167-subscribe fan-out on the same path.
- #613 (reopened) — the `exit=139` segfault, which may share a root cause with this growth: a dispose that returns before the work it started has finished would both retain the object graph (growth) and leave the GC walking a heap whose owner is gone (the crash). Under investigation separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)