### PR TITLE
A one-field edit no longer blanks the fields it did not touch

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-edit-no-longer-quietly-blanks-the-fields-you-did-not-touch.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-edit-no-longer-quietly-blanks-the-fields-you-did-not-touch.md
@@ -1,0 +1,25 @@
+---
+Name: An edit no longer quietly blanks the fields you did not touch
+Category: Fix
+Description: Saving one field of a record could reset every other field to its default, with no error anywhere. Writes now say which kind of record they are editing, and refuse rather than guess.
+Icon: Sparkle
+Order: -20260813
+---
+
+# An edit no longer quietly blanks the fields you did not touch
+
+Changing one field of something in the mesh — a thread's status, a page's text, an activity's
+progress — could silently blank every other field of that record. No error, no warning, nothing in
+the log: the value you edited was saved correctly and everything around it came back empty.
+
+It happened whenever the record arrived as plain stored data rather than as a ready-made object,
+which is the normal case any time the record is read from the database or from another part of the
+mesh. The code doing the saving would try to recognise the record, fail to, and quietly start from a
+blank one — so the save wrote your single change on top of a fresh, empty record instead of on top
+of the real one. Because the blank record is a perfectly valid thing to save, nothing along the way
+had any reason to object.
+
+A save now states up front which kind of record it is editing, so there is nothing to recognise and
+nothing to guess. And when the stored data genuinely cannot be read as that kind of record, the save
+**fails and says so** — naming the item and what was actually found — instead of falling back to a
+blank one. A refused save changes nothing; the real content stays exactly as it was.

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -77,19 +77,21 @@ public static class MeshNodeExtensions
     /// <summary>
     /// Updates a MeshNode's content with a typed update function.
     /// Path-aware typed-content update wrapper that delegates to
-    /// <see cref="MeshNodeStreamHandle.Update"/>. Returns
-    /// <see cref="IObservable{MeshNode}"/>; <b>callers MUST Subscribe</b> — the cold
+    /// <see cref="MeshNodeStreamHandle.Update{TContent}(Func{MeshNode, TContent, MeshNode})"/>.
+    /// Returns <see cref="IObservable{MeshNode}"/>; <b>callers MUST Subscribe</b> — the cold
     /// observable's side effect only runs on Subscribe. See
     /// <c>Doc/Architecture/AsynchronousCalls.md</c>.
+    /// <para>🚨 Unconvertible content faults the observable rather than skipping the write. This
+    /// used to read <c>content != null ? update(node, content) : node</c> — a SILENT no-op: when
+    /// the content arrived as JSON this reported success while writing nothing at all, so the
+    /// caller's change simply vanished with no exception and no log. Absence and
+    /// "could not be read" are now distinct (see the handle's overload docs).</para>
     /// </summary>
     public static IObservable<MeshNode> UpdateMeshNode<TContent>(this IWorkspace workspace,
         string nodePath, Func<MeshNode, TContent, MeshNode> update)
         where TContent : class
-        => workspace.GetMeshNodeStream(nodePath).Update(node =>
-        {
-            var content = node.ContentAs<TContent>(workspace.Hub.JsonSerializerOptions);
-            return content != null ? update(node, content) : node;
-        });
+        => workspace.GetMeshNodeStream(nodePath)
+            .Update<TContent>((node, content) => content is null ? node : update(node, content));
 
     /// <summary>
     /// Gets the parent path for this node.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -380,6 +380,130 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     }
 
     /// <summary>
+    /// 🚨 <b>THE typed write.</b> Applies <paramref name="update"/> to the node's content read as
+    /// <typeparamref name="TContent"/> — <b>the caller names the type</b>, so nothing has to guess
+    /// which CLR type a <c>$type</c> discriminator means.
+    ///
+    /// <para><b>Why this exists.</b> The untyped <see cref="Update(Func{MeshNode, MeshNode})"/> hands
+    /// the lambda a <see cref="MeshNode"/> and every writer then re-derives the content type itself,
+    /// overwhelmingly as <c>node.Content as TContent ?? new TContent()</c>. That idiom is a silent
+    /// data-loss bug: whenever the content arrives as JSON the cast yields <c>null</c>, the
+    /// <c>?? new()</c> materialises a DEFAULT record, and the write persists those defaults over
+    /// every field the caller never meant to touch (the CheckInbox / AppendUserInput
+    /// Status-reset class). Making the type a TYPE ARGUMENT removes the guess at the root:
+    /// <see cref="MeshNodeContentExtensions.ContentAs{T}"/> converts a typed instance, a degraded
+    /// <see cref="JsonElement"/>, an as-written <c>JsonNode</c>, or a same-named record from another
+    /// build — all into the <typeparamref name="TContent"/> the caller asked for, with no
+    /// name→Type lookup anywhere.</para>
+    ///
+    /// <para>🚨 <b>Unconvertible content FAILS THE WRITE — it never writes a default.</b>
+    /// <see cref="MeshNodeContentExtensions.ContentAs{T}"/> returns <c>null</c> for unconvertible
+    /// content because a READ must stay bad-data tolerant; a WRITE must not, or the caller's own
+    /// content is what gets destroyed. So a node whose Content is present but cannot be read as
+    /// <typeparamref name="TContent"/> faults the returned observable with a
+    /// <see cref="MeshNodeStreamException"/> (<see cref="MeshNodeErrorCode.Deserialization"/>)
+    /// carrying the node path, the actual runtime type and a JSON excerpt — the write does not
+    /// happen.</para>
+    ///
+    /// <para>Content that is simply ABSENT (<c>Content is null</c>) is not an error and not
+    /// representable here — use the
+    /// <see cref="Update{TContent}(Func{MeshNode, TContent, MeshNode})"/> overload, whose
+    /// <c>null</c> means exactly and only "no content yet".</para>
+    /// </summary>
+    /// <typeparam name="TContent">The content type the caller knows this node carries.</typeparam>
+    /// <param name="update">Receives the current content, returns the replacement.</param>
+    public IObservable<MeshNode> Update<TContent>(Func<TContent, TContent> update)
+        where TContent : class
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        return Update(node => node with { Content = update(RequireContent<TContent>(node)) });
+    }
+
+    /// <summary>
+    /// The typed write for a lambda that also needs the <see cref="MeshNode"/> itself (to set
+    /// Name/NodeType/… alongside Content, or to create the content when there is none yet).
+    /// Same contract as <see cref="Update{TContent}(Func{TContent, TContent})"/> with one
+    /// difference, and it is the important one:
+    ///
+    /// <para>🚨 <b><c>null</c> means ABSENT, never "could not be read".</b> A node with no content
+    /// yields <c>null</c> so the caller can initialise it; content that is PRESENT but not
+    /// convertible to <typeparamref name="TContent"/> faults the observable with
+    /// <see cref="MeshNodeStreamException"/> instead of quietly arriving as <c>null</c>. Conflating
+    /// the two is what turns "the content did not deserialise" into "the content was empty, write
+    /// a fresh one" — the write that destroys the real record.</para>
+    /// </summary>
+    /// <typeparam name="TContent">The content type the caller knows this node carries.</typeparam>
+    /// <param name="update">Receives the node and its content (<c>null</c> only when absent).</param>
+    public IObservable<MeshNode> Update<TContent>(Func<MeshNode, TContent?, MeshNode> update)
+        where TContent : class
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        return Update(node => update(node, ResolveContent<TContent>(node)));
+    }
+
+    /// <summary>
+    /// Content as <typeparamref name="TContent"/> for a WRITE: <c>null</c> only when Content is
+    /// absent; unconvertible content throws (see the overload docs).
+    /// </summary>
+    private TContent? ResolveContent<TContent>(MeshNode node) where TContent : class
+    {
+        if (node.Content is null)
+            return null;
+        // No logger: an unconvertible value here is about to become an exception carrying the same
+        // diagnosis, so ContentAs's LogError would only duplicate it at a level the caller cannot
+        // suppress. The failing read IS the thrown error.
+        var content = node.ContentAs<TContent>(_jsonOptions);
+        return content ?? throw new MeshNodeStreamException(
+            BuildTypedWriteError<TContent>(node,
+                $"content is {Describe(node.Content)} and could not be read as "
+                + $"'{typeof(TContent).Name}'"));
+    }
+
+    /// <summary>Content as <typeparamref name="TContent"/>, required to be present.</summary>
+    private TContent RequireContent<TContent>(MeshNode node) where TContent : class
+        => ResolveContent<TContent>(node)
+           ?? throw new MeshNodeStreamException(
+               BuildTypedWriteError<TContent>(node,
+                   $"the node has no content to update as '{typeof(TContent).Name}'"));
+
+    private MeshNodeError BuildTypedWriteError<TContent>(MeshNode node, string what) =>
+        new(MeshNodeErrorCode.Deserialization,
+            node.Path ?? _path ?? "<own>",
+            $"Update<{typeof(TContent).Name}> refused to write: {what}. The write was NOT applied — "
+            + "writing a default-valued record here would persist those defaults over every field "
+            + "the caller never touched.",
+            ContentExcerpt(node.Content));
+
+    // Assembly-qualified on purpose: a dynamic node assembly compiles without a namespace, so the
+    // bare type name is identical on both sides of a cross-assembly mismatch and only the assembly
+    // identity makes it diagnosable.
+    private static string Describe(object? content) =>
+        content is null
+            ? "absent"
+            : content is JsonElement or System.Text.Json.Nodes.JsonNode
+                ? $"untyped JSON ({content.GetType().Name})"
+                : $"a {content.GetType().FullName} ({content.GetType().Assembly.GetName().Name})";
+
+    private const int TypedWriteExcerptLimit = 400;
+
+    private static string? ContentExcerpt(object? content)
+    {
+        if (content is null)
+            return null;
+        var raw = content switch
+        {
+            JsonElement je => je.GetRawText(),
+            System.Text.Json.Nodes.JsonNode jn => jn.ToJsonString(),
+            _ => null,
+        };
+        return raw is null
+            ? null
+            : raw.Length <= TypedWriteExcerptLimit
+                ? raw
+                : raw[..TypedWriteExcerptLimit] + "…";
+    }
+
+    /// <summary>
     /// Applies <paramref name="update"/> to the targeted MeshNode and returns an
     /// <see cref="IObservable{MeshNode}"/> that emits the post-update node on the first
     /// emission past the pre-update snapshot. <b>Caller MUST Subscribe</b> â€” the cold
@@ -393,6 +517,9 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     ///     cached remote stream so the patch routes to the owning per-node hub via
     ///     the data sync protocol.</description></item>
     /// </list>
+    /// <para>🚨 Prefer the typed <see cref="Update{TContent}(Func{TContent, TContent})"/> whenever
+    /// the lambda reads Content: it names the type instead of re-deriving it, and it fails loudly
+    /// rather than letting a <c>Content as T ?? new T()</c> write defaults over real fields.</para>
     /// </summary>
     public IObservable<MeshNode> Update(Func<MeshNode, MeshNode> update)
     {

--- a/test/MeshWeaver.Hosting.Monolith.Test/TypedContentUpdateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/TypedContentUpdateTest.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Pins <c>MeshNodeStreamHandle.Update&lt;TContent&gt;</c> — the typed write where the CALLER
+/// names the content type, so nothing has to resolve a <c>$type</c> discriminator to a CLR type.
+///
+/// <para>The untyped <c>Update(node =&gt; …)</c> leaves every writer to re-derive the content type
+/// itself, and the idiom that spread through the codebase is
+/// <c>node.Content as TContent ?? new TContent()</c>. That is a silent data-loss bug: when content
+/// arrives as JSON (file-system / Postgres / any cross-hub read) the cast is <c>null</c>, the
+/// <c>?? new()</c> materialises a DEFAULT record, and the write persists those defaults over every
+/// field the caller never touched. <see cref="UntypedUpdate_WithTheAsOrDefaultIdiom_SilentlyWritesDefaultsOverRealFields"/>
+/// reproduces exactly that; the two <c>Update&lt;TContent&gt;</c> tests pin the cure.</para>
+///
+/// <para>And the cure must not trade one silent failure for another: a node whose content is
+/// PRESENT but unreadable as <typeparamref name="TContent"/> must <b>fail the write loudly</b>,
+/// never arrive as <c>null</c> for the caller to <c>?? new()</c> again. That is
+/// <see cref="TypedUpdate_UnconvertibleContent_FaultsAndLeavesTheNodeUntouched"/>.</para>
+/// </summary>
+public class TypedContentUpdateTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    /// <summary>Creates a Markdown node and returns its activated per-node workspace.</summary>
+    private async Task<(string Path, IWorkspace Workspace)> CreateNodeAsync(string id, object? content)
+    {
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = id,
+            NodeType = "Markdown",
+            Content = content,
+        }).Should().Emit();
+
+        // Per-node hubs activate lazily — any inbound message brings the hub up.
+        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull("the GetDataRequest above must have activated the hub");
+        return (path, nodeHub!.GetWorkspace());
+    }
+
+    /// <summary>
+    /// Content with NO <c>$type</c> discriminator — the "as-written DOM" shape
+    /// (<c>ObjectAsExtensions</c> case 2): application code and repo content files build content as
+    /// a plain JSON object, and it is forwarded verbatim until something re-types it. With no
+    /// discriminator the polymorphic reader has nothing to resolve, so it hands back a bare
+    /// <see cref="JsonElement"/> — and that is precisely when <c>Content as T</c> starts returning
+    /// <c>null</c>.
+    /// <para>Note what this fixture is NOT: a JsonElement of a type the hub DOES know. Those are
+    /// re-typed on the way in, which is why the <c>as T ?? new T()</c> idiom looks safe in most
+    /// tests and still destroys data in the field. It is also deliberately not an UNREGISTERED
+    /// <c>$type</c>: <c>ContentDiscriminatorValidator</c> rejects those at Create, so that shape
+    /// cannot reach a stored node in the first place.</para>
+    /// </summary>
+    private const string UnresolvableContentJson =
+        """{"content":"# real","prerenderedHtml":"<h1>real</h1>"}""";
+
+    /// <summary>
+    /// 🚨 THE DEFECT, reproduced with no mocks and no Roslyn: unresolvable JSON content, the
+    /// <c>as T ?? new T()</c> idiom, and a write that destroys a field the caller never named.
+    /// Passes before and after — it documents WHY the typed overload exists, and it is the exact
+    /// input <see cref="TypedUpdate_UnresolvableJsonContent_ConvertsAndPreservesUntouchedFields"/>
+    /// survives.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task UntypedUpdate_WithTheAsOrDefaultIdiom_SilentlyWritesDefaultsOverRealFields()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        var stored = JsonSerializer.Deserialize<JsonElement>(UnresolvableContentJson);
+        var (path, workspace) = await CreateNodeAsync("untyped-idiom", stored);
+
+        // The idiom, verbatim as it appears across the codebase.
+        await workspace.GetMeshNodeStream(path)
+            .Update(node =>
+            {
+                var c = node.Content as MarkdownContent ?? new MarkdownContent { Content = "" };
+                return node with { Content = c with { Content = "# edited" } };
+            })
+            .FirstAsync().ToTask();
+
+        var after = await workspace.GetMeshNodeStream(path)
+            .Where(n => n.ContentAs<MarkdownContent>(options)?.Content == "# edited")
+            .FirstAsync().Timeout(10.Seconds()).ToTask();
+
+        after.ContentAs<MarkdownContent>(options)!.PrerenderedHtml.Should().BeNull(
+            "this is the defect: `as T` was null on unresolvable JSON content, `?? new T()` "
+            + "supplied a DEFAULT record, and the write persisted that default over "
+            + "PrerenderedHtml — a field the caller never mentioned.");
+    }
+
+    /// <summary>
+    /// The cure, on the SAME input: the caller names the type, so the content is converted by
+    /// <c>ContentAs&lt;T&gt;</c> — no name→Type lookup anywhere — and the field the lambda does not
+    /// touch survives the write.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TypedUpdate_UnresolvableJsonContent_ConvertsAndPreservesUntouchedFields()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        var stored = JsonSerializer.Deserialize<JsonElement>(UnresolvableContentJson);
+        var (path, workspace) = await CreateNodeAsync("typed-unresolvable", stored);
+
+        await workspace.GetMeshNodeStream(path)
+            .Update<MarkdownContent>(c => c with { Content = "# edited" })
+            .FirstAsync().ToTask();
+
+        var after = await workspace.GetMeshNodeStream(path)
+            .Where(n => n.ContentAs<MarkdownContent>(options)?.Content == "# edited")
+            .FirstAsync().Timeout(10.Seconds()).ToTask();
+
+        after.ContentAs<MarkdownContent>(options)!.PrerenderedHtml.Should().Be("<h1>real</h1>",
+            "Update<TContent> read the unresolvable JSON AS MarkdownContent, so the untouched "
+            + "field round-tripped instead of being replaced by a default — the same input the "
+            + "untyped idiom destroys");
+    }
+
+    /// <summary>
+    /// The typed write also handles content that is ALREADY a typed instance of a statically
+    /// registered type — the common case — without a round-trip surprise.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TypedUpdate_JsonContent_ConvertsAndPreservesUntouchedFields()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        var stored = JsonSerializer.SerializeToElement(
+            new MarkdownContent { Content = "# real", PrerenderedHtml = "<h1>real</h1>" },
+            typeof(MarkdownContent), options);
+        var (path, workspace) = await CreateNodeAsync("typed-json", stored);
+
+        await workspace.GetMeshNodeStream(path)
+            .Update<MarkdownContent>(c => c with { Content = "# edited" })
+            .FirstAsync().ToTask();
+
+        var after = await workspace.GetMeshNodeStream(path)
+            .Where(n => n.ContentAs<MarkdownContent>(options)?.Content == "# edited")
+            .FirstAsync().Timeout(10.Seconds()).ToTask();
+
+        var content = after.ContentAs<MarkdownContent>(options)!;
+        content.Content.Should().Be("# edited");
+        content.PrerenderedHtml.Should().Be("<h1>real</h1>",
+            "Update<TContent> read the JsonElement AS MarkdownContent, so the untouched field "
+            + "round-tripped instead of being replaced by a default");
+    }
+
+    /// <summary>
+    /// 🚨 The loud-failure contract. <c>ContentAs&lt;T&gt;</c> returns null for unconvertible
+    /// content because a READ must be bad-data tolerant. A WRITE must not: a null there would let
+    /// the caller write a fresh default over the real record. So the write faults, and the node is
+    /// left exactly as it was.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TypedUpdate_UnconvertibleContent_FaultsAndLeavesTheNodeUntouched()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        // A typed value of a DIFFERENTLY-named type: ContentAs<MarkdownContent> returns null for
+        // this by contract (probe-dispatch call sites depend on that), so it is precisely the case
+        // a write must refuse rather than "recover".
+        var (path, workspace) = await CreateNodeAsync(
+            "typed-wrong", new Comment { Text = "not markdown content" });
+
+        var act = () => workspace.GetMeshNodeStream(path)
+            .Update<MarkdownContent>(c => c with { Content = "# edited" })
+            .FirstAsync().ToTask();
+
+        var ex = await act.Should().ThrowAsync<MeshNodeStreamException>(
+            "a write whose content cannot be read as the named type must fail loudly, never write "
+            + "a default-valued record over the caller's real content");
+        ex.Which.Error.Code.Should().Be(MeshNodeErrorCode.Deserialization);
+        ex.Which.Error.Path.Should().Be(path);
+
+        // …and the node is untouched: the refusal happened BEFORE any write.
+        var after = await workspace.GetMeshNodeStream(path).FirstAsync().Timeout(10.Seconds()).ToTask();
+        after.ContentAs<Comment>(options)!.Text.Should().Be("not markdown content",
+            "the refused write must not have replaced the real content");
+    }
+
+    /// <summary>
+    /// 🚨 The same refusal on the CROSS-HUB write path. Most writes in the mesh are not own-hub
+    /// writes — they route through <c>IMeshNodeStreamCache</c> to the owning per-node hub, and that
+    /// path invokes the update lambda on the cache's serial queue, several hops from the caller. A
+    /// guarantee that only holds on the own path is not a guarantee: a lambda exception swallowed
+    /// there would report success while writing nothing, or worse, write the default.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TypedUpdate_UnconvertibleContent_FaultsOnTheCrossHubPathToo()
+    {
+        var (path, _) = await CreateNodeAsync(
+            "typed-wrong-remote", new Comment { Text = "not markdown content" });
+
+        // The MESH workspace is NOT the node's owner — this write routes through the cache.
+        var foreign = Mesh.GetWorkspace();
+        var act = () => foreign.GetMeshNodeStream(path)
+            .Update<MarkdownContent>(c => c with { Content = "# edited" })
+            .FirstAsync().ToTask();
+
+        var ex = await act.Should().ThrowAsync<MeshNodeStreamException>(
+            "the refusal must survive the cache's serial queue and the remote write path");
+        ex.Which.Error.Code.Should().Be(MeshNodeErrorCode.Deserialization);
+    }
+
+    /// <summary>
+    /// Absence is NOT an error and is distinguishable from "could not be read": the node+content
+    /// overload passes <c>null</c> only when the node genuinely has no content, so a caller can
+    /// initialise it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TypedUpdate_AbsentContent_YieldsNullSoTheCallerCanInitialise()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        var (path, workspace) = await CreateNodeAsync("typed-absent", content: null);
+
+        var sawNull = false;
+        await workspace.GetMeshNodeStream(path)
+            .Update<MarkdownContent>((node, content) =>
+            {
+                sawNull = content is null;
+                return node with { Content = new MarkdownContent { Content = "# created" } };
+            })
+            .FirstAsync().ToTask();
+
+        sawNull.Should().BeTrue("null must mean ABSENT — the one case a caller may initialise");
+
+        var after = await workspace.GetMeshNodeStream(path)
+            .Where(n => n.ContentAs<MarkdownContent>(options) is not null)
+            .FirstAsync().Timeout(10.Seconds()).ToTask();
+        after.ContentAs<MarkdownContent>(options)!.Content.Should().Be("# created");
+    }
+}


### PR DESCRIPTION
## The defect

`MeshNode.Content` is `object?`, so every writer of the untyped `GetMeshNodeStream(path).Update(node => …)` has to re-derive the content type itself. The idiom that spread through the codebase is:

```csharp
var c = node.Content as TContent ?? new TContent();
return node with { Content = c with { Field = newValue } };
```

Whenever content arrives as JSON — the as-written DOM, a storage round-trip, a cross-hub read — the cast is `null`, `?? new()` materialises a **default** record, and the write persists those defaults over every field the caller never named. There is no exception and no log, because a default-valued record is a perfectly valid thing to save. This is the family behind the CheckInbox / AppendUserInput silent-Status-reset failures.

## The fix — the write names its type

The root of the guessing is that the write never says *which* type it is writing. So say it:

```csharp
stream.Update<MeshThread>(t => t with { Status = Executing });
stream.Update<MeshThread>((node, t) => node with { Name = …, Content = t with { … } });
```

The caller supplies `TContent`; `ContentAs<TContent>` does the conversion (typed instance, degraded `JsonElement`, as-written `JsonNode`, or a same-named record from another build). **No name→Type lookup is consulted anywhere on the write path** — there is nothing left to guess.

Both shapes are warranted by the call sites. Of the **127** `Update` lambdas in `src/` that read content: **34** are content-only, **15** need the node (5 set content *plus* other node fields, 10 are guard/early-return shapes).

## 🚨 The cure must not trade one silent failure for another

`ContentAs<T>` returns `null` for unconvertible content because a **read** must stay bad-data tolerant. A **write** must not, or the caller's own content is what gets destroyed. So:

- Content **present but unreadable** as `TContent` faults the observable with `MeshNodeStreamException(Deserialization)` — naming the path, the actual runtime type (assembly-qualified, because dynamic node assemblies compile without namespaces) and a JSON excerpt — **and the write does not happen**.
- `null` reaches the lambda **only** when content is genuinely absent, so "not set yet" and "could not be read" can never be conflated again.

Also fixes a live silent no-op in `workspace.UpdateMeshNode<TContent>`, which read `content != null ? update(node, content) : node` — reporting success while writing nothing at all whenever content arrived as JSON.

## Verification

- **Tests** (`TypedContentUpdateTest`, 6/6 green) run the defect and the cure on **one** input: the untyped idiom loses `prerenderedHtml`; `Update<MarkdownContent>` keeps it. The refusal is pinned on **both** write paths — own-hub and cross-hub through the cache's serial queue — because a guarantee that holds on only one of them is not a guarantee.
- **Full solution**, CI flags (`-c Release -warnaserror`): 162 projects, 0 warnings, 0 errors. A full build (not just the touched projects) because new public overloads can rebind existing call sites solution-wide.
- **Plugin-gate determinism** — the bar #1306 set — re-verified against the real `MeshWeaver.Reinsurance` checkout: **6 consecutive runs of one binary, byte-identical reports** (`sha 669d33bc…`), 11 packages / 150 NodeTypes, **0 new failures**. (The gate's red verdict on that checkout is a *stale* allow entry — `Underwriting idempotence` now passes, which is #1306's own fix — not a regression.)

## Not in this PR

This is the write half of removing content-type guessing. The read seams (`ObjectPolymorphicConverter`, `MeshNodeStreamCache`, `MeshNodeStreamHandle.EnsureTypedContent`, `MeshNodeTypeSource`) still consult the mesh-wide `IMeshContentTypeRegistry`; migrating callers to `ContentAs<T>`/`Update<TContent>` is what makes that deletable. Analysis and the measured cost are reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
