### PR TITLE
fix: a view's subscription accumulator must tolerate a write during its own drain (#1308)

### DIFF
--- a/src/MeshWeaver.Blazor/BlazorView.razor.cs
+++ b/src/MeshWeaver.Blazor/BlazorView.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -144,8 +145,20 @@ public class BlazorView<TViewModel, TView> : ComponentBase, IAsyncDisposable
     /// <summary>HTML element id bound from <c>ViewModel.Id</c>.</summary>
     protected string? Id { get; set; }
 
-    /// <summary>Component-lifetime disposables released in <c>DisposeAsync</c>, in addition to data-binding subscriptions.</summary>
-    protected List<IDisposable> Disposables { get; } = new();
+    /// <summary>
+    /// Component-lifetime disposables released in <c>DisposeAsync</c>, in addition to data-binding
+    /// subscriptions.
+    ///
+    /// <para>🚨 A <see cref="CompositeDisposable"/>, not a <c>List&lt;IDisposable&gt;</c>, and both
+    /// halves of that matter (issue #1308). Its <c>Add</c> is thread-safe, so a subscription
+    /// registered from a query-change callback — which arrives on a hub/pool thread, NOT the
+    /// renderer — can no longer race the enumeration in <see cref="DisposeAsync"/> that runs on the
+    /// renderer's disposal queue ("Collection was modified; enumeration operation may not
+    /// execute", which failed the whole Blazor circuit). And an <c>Add</c> that lands AFTER
+    /// disposal disposes its argument immediately instead of parking it in a list nobody will ever
+    /// drain again — the unowned-work-outliving-its-owner leak that the same race hides.</para>
+    /// </summary>
+    protected CompositeDisposable Disposables { get; } = new();
 
     private bool _viewDisposed;
 
@@ -165,9 +178,10 @@ public class BlazorView<TViewModel, TView> : ComponentBase, IAsyncDisposable
         _viewDisposed = true;
         Logger.LogDebug("Disposing area {Area}", Area);
         DisposeBindings();
-        foreach (var d in Disposables)
-            d.Dispose();
-        Disposables.Clear();
+        // Dispose (not Clear) BOTH composites: this is component teardown, not a re-bind, so the
+        // accumulators must become terminal. A late Add then disposes its argument on the spot.
+        bindings.Dispose();
+        Disposables.Dispose();
         return default;
     }
 
@@ -495,15 +509,18 @@ public class BlazorView<TViewModel, TView> : ComponentBase, IAsyncDisposable
         DataBind(ViewModel.Class, x => x.Class);
         DataBind(ViewModel.Style, x => x.Style);
     }
-    private readonly List<IDisposable> bindings = new();
+    // CompositeDisposable for the same reason as Disposables above: DataBind subscribes streams
+    // whose emissions land off the renderer, and a re-bind (BindDataAfterParameterReset) can run
+    // concurrently with one of those callbacks registering a binding.
+    private readonly CompositeDisposable bindings = new();
 
-    /// <summary>Disposes all active data-binding subscriptions registered via <c>AddBinding</c> and <c>DataBind</c>.</summary>
-    protected virtual void DisposeBindings()
-    {
-        foreach (var d in bindings)
-            d.Dispose();
-        bindings.Clear();
-    }
+    /// <summary>
+    /// Disposes all active data-binding subscriptions registered via <c>AddBinding</c> and
+    /// <c>DataBind</c>. <c>Clear</c>, not <c>Dispose</c>: this also runs on a parameter-driven
+    /// RE-BIND, after which the accumulator must still accept the new bindings. Component teardown
+    /// makes it terminal — see <see cref="DisposeAsync"/>.
+    /// </summary>
+    protected virtual void DisposeBindings() => bindings.Clear();
 
     /// <summary>
     /// Posts a <c>ClickedEvent</c> for the current area to the stream owner, stamping the circuit

--- a/src/MeshWeaver.Blazor/Components/MeshNodeCollectionView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshNodeCollectionView.razor.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -20,7 +21,12 @@ public partial class MeshNodeCollectionView : BlazorView<MeshNodeCollectionContr
 {
     private List<MeshNode> _items = [];
     private bool _isLoading = true;
-    private readonly List<IDisposable> _subscriptions = new();
+    // 🚨 CompositeDisposable, registered in the base's Disposables so component teardown makes it
+    // terminal (issue #1308). Two defects in the List<IDisposable> this replaces: DeleteItem
+    // re-runs LoadItems from the DeleteNode observable's callback — off the renderer — so the
+    // clear-then-refill raced a renderer-thread LoadItems ("Collection was modified"); and nothing
+    // ever disposed the list on component teardown, so every query subscription outlived the view.
+    private readonly CompositeDisposable _subscriptions = new();
 
     /// <summary>
     /// Tears down prior per-query subscriptions and starts a fresh live subscription for
@@ -29,13 +35,23 @@ public partial class MeshNodeCollectionView : BlazorView<MeshNodeCollectionContr
     protected override void BindData()
     {
         base.BindData();
+        // Idempotent: Disposables is a set-like composite in effect — re-adding the same instance
+        // across re-binds is harmless because the base disposes each entry exactly once, and the
+        // composite is only ever disposed at teardown.
+        if (!_registeredForDisposal)
+        {
+            _registeredForDisposal = true;
+            Disposables.Add(_subscriptions);
+        }
         LoadItems();
     }
 
+    private bool _registeredForDisposal;
+
     private void LoadItems()
     {
-        // Tear down any prior live subscriptions before re-binding.
-        foreach (var s in _subscriptions) s.Dispose();
+        // Tear down any prior live subscriptions before re-binding. Clear (not Dispose) — the
+        // composite must stay usable for the fresh per-query subscriptions below.
         _subscriptions.Clear();
 
         _isLoading = true;

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -73,7 +74,14 @@ public partial class MeshSearchView : IDisposable
     // releases its entry so the next result batch can re-ask; see RecordDeleteOutcome.
     private readonly HashSet<string> _permissionRequested =
         new(StringComparer.OrdinalIgnoreCase);
-    private readonly List<IDisposable> _affordanceSubscriptions = new();
+    // 🚨 CompositeDisposable, not List<IDisposable> — issue #1308. ResolveDeletePermissions runs
+    // straight off the result stream's emission (ApplyResults is called from the query
+    // subscription's OnNext, on a hub/pool thread — NOT inside InvokeAsync), so it registers
+    // probes concurrently with Dispose() enumerating them on the renderer's disposal queue. That
+    // threw "Collection was modified; enumeration operation may not execute" out of Dispose and
+    // failed the whole Blazor circuit. Add is thread-safe here, and an Add that lands after
+    // disposal disposes the probe immediately rather than leaking it.
+    private readonly CompositeDisposable _affordanceSubscriptions = new();
     // The card whose trash is armed for confirmation (two-step delete; null = none armed).
     private string? _pendingDeletePath;
     // The keyboard-highlighted result path (Arrow Up/Down). Distinct from the SelectedPath param.
@@ -1134,7 +1142,14 @@ public partial class MeshSearchView : IDisposable
         ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
     private ImmutableDictionary<string, IDisposable> _treeLevelSubscriptions =
         ImmutableDictionary<string, IDisposable>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
-    private ImmutableList<IDisposable> _treeProbeSubscriptions = ImmutableList<IDisposable>.Empty;
+    // 🚨 CompositeDisposable for the same reason as _affordanceSubscriptions: ProbeTreeChildCounts
+    // is called from the tree-level query subscription's OnNext (off the renderer), so the plain
+    // read-modify-write this replaces raced DisposeTreeSubscriptions on the renderer thread. That
+    // one never threw — an ImmutableList cannot — it silently LOST the probe, which is the same
+    // defect wearing the quieter of its two faces: an unowned subscription outliving its reader.
+    // (_treeLevelSubscriptions and _treeSearchSubscription below stay as they are: both are
+    // written only from InitializeTree / the folder-click and search handlers, all on the renderer.)
+    private readonly CompositeDisposable _treeProbeSubscriptions = new();
     private IDisposable? _treeSearchSubscription;
     private ImmutableList<NamespaceTreeItem>? _treeSearchItems;
     private bool _treeSearchLoading;
@@ -1196,14 +1211,17 @@ public partial class MeshSearchView : IDisposable
         InitializeTree();
     }
 
+    /// <summary>
+    /// Tears down the tree's live subscriptions. Also runs on <see cref="ResetTree"/>, so the probe
+    /// accumulator is CLEARED (disposes its contents, stays usable) rather than disposed; only
+    /// <see cref="Dispose"/> makes it terminal.
+    /// </summary>
     private void DisposeTreeSubscriptions()
     {
         foreach (var subscription in _treeLevelSubscriptions.Values)
             subscription.Dispose();
         _treeLevelSubscriptions = _treeLevelSubscriptions.Clear();
-        foreach (var probe in _treeProbeSubscriptions)
-            probe.Dispose();
-        _treeProbeSubscriptions = ImmutableList<IDisposable>.Empty;
+        _treeProbeSubscriptions.Clear();
         _treeSearchSubscription?.Dispose();
         _treeSearchSubscription = null;
     }
@@ -1317,7 +1335,7 @@ public partial class MeshSearchView : IDisposable
                     ns, new TreeLevel(false, NamespaceTreeBuilder.BuildLevel(ns, nodes, countMap)));
                 StateHasChanged();
             }));
-        _treeProbeSubscriptions = _treeProbeSubscriptions.Add(probeSubscription);
+        _treeProbeSubscriptions.Add(probeSubscription);
     }
 
     private void OnTreeFolderHeaderClick(string folderPath, bool lazy)
@@ -1879,15 +1897,20 @@ public partial class MeshSearchView : IDisposable
     }
 
     /// <summary>
-    /// Disposes all reactive subscriptions (search results, navigation, tree, affordance) held by this view.
+    /// Disposes all reactive subscriptions (search results, navigation, tree, affordance) held by
+    /// this view. Every step is idempotent and none of them enumerates a collection another thread
+    /// can be writing — which is what makes this safe against the live result stream still
+    /// emitting while the circuit tears down (issue #1308).
     /// </summary>
     public void Dispose()
     {
         _reactiveSubscription?.Dispose();
         DisposeTreeSubscriptions();
         _navSubscription?.Dispose();
-        foreach (var sub in _affordanceSubscriptions)
-            sub.Dispose();
-        _affordanceSubscriptions.Clear();
+        // Dispose, not Clear: teardown is terminal here, so a probe registered by an in-flight
+        // ApplyResults or ProbeTreeChildCounts after this point is disposed on arrival instead of
+        // being retained forever.
+        _treeProbeSubscriptions.Dispose();
+        _affordanceSubscriptions.Dispose();
     }
 }

--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -4,6 +4,7 @@
 @using MeshWeaver.Blazor.Components.Monaco
 @using MeshWeaver.Mesh.Services.LanguageServer
 @using System.Text.Json
+@using System.Reactive.Disposables
 @using System.Reactive.Linq
 @using Microsoft.Extensions.Logging
 @using Microsoft.Extensions.DependencyInjection
@@ -29,7 +30,11 @@
 
 @code {
     private MonacoEditorView? editorRef;
-    private List<IDisposable> subscriptions = new();
+    // CompositeDisposable, not List<IDisposable> (#1308): the value binding below is subscribed
+    // to a stream whose emissions arrive off the renderer, so a re-bind or a teardown could be
+    // draining this while an emission registers into it. Add is thread-safe, and an Add after
+    // Dispose releases its argument instead of stranding a live subscription on a dead component.
+    private readonly CompositeDisposable subscriptions = new();
     private bool isUpdatingFromStream = false;
 
     private string BoundValue = "";
@@ -80,19 +85,11 @@
         BindData();
     }
 
-    private void DisposeSubscriptions()
-    {
-        foreach (var sub in subscriptions)
-        {
-            sub.Dispose();
-        }
-        subscriptions.Clear();
-    }
+    // Clear, not Dispose: OnParametersSet re-binds through here, after which the accumulator must
+    // still accept the fresh subscriptions. Dispose() below makes it terminal.
+    private void DisposeSubscriptions() => subscriptions.Clear();
 
-    public void Dispose()
-    {
-        DisposeSubscriptions();
-    }
+    public void Dispose() => subscriptions.Dispose();
 
     private void BindData()
     {

--- a/src/MeshWeaver.Blazor/Components/Monaco/NotebookEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/NotebookEditorView.razor
@@ -6,6 +6,7 @@
 @using MeshWeaver.Data
 @using System.Collections.Immutable
 @using System.Text.Json
+@using System.Reactive.Disposables
 @using System.Reactive.Linq
 @using System.Reactive.Threading.Tasks
 @using FluentAppearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
@@ -105,7 +106,8 @@
     private int executionCounter = 0;
     private bool isRunningAll = false;
     private IJSObjectReference? jsModule;
-    private List<IDisposable> subscriptions = new();
+    // CompositeDisposable, not List<IDisposable> — see CodeEditorView (#1308).
+    private readonly CompositeDisposable subscriptions = new();
 
     // Bound values from ViewModel
     private bool BoundReadonly = false;
@@ -478,11 +480,7 @@
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var sub in subscriptions)
-        {
-            sub.Dispose();
-        }
-        subscriptions.Clear();
+        subscriptions.Dispose();
 
         if (jsModule != null)
         {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-search-view-disposal-drops-circuit.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-search-view-disposal-drops-circuit.md
@@ -1,0 +1,17 @@
+---
+Name: Closing a search page no longer drops the connection
+Category: Fix
+Description: Navigating away from search while results were still arriving could disconnect the page.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Closing a search page no longer drops the connection
+
+Leaving a search or catalog page at the moment fresh results arrived could break the page's
+connection to the server, showing the reconnecting overlay for no reason. Tidying up the page's live
+subscriptions collided with results still coming in.
+
+Views now tear their subscriptions down in a way that tolerates late arrivals, so leaving a page is
+never disruptive. The same change also stops a subscription that arrives during teardown from being
+left running for a page that is already gone.

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshNodePickerDebounceOwnershipTest.cs
@@ -52,7 +52,9 @@ public class MeshNodePickerDebounceOwnershipTest
 
         public void Initialize() => OnInitialized();
 
-        public IReadOnlyList<IDisposable> Owned => Disposables;
+        // IEnumerable, not IReadOnlyList: BlazorView.Disposables is a CompositeDisposable (#1308),
+        // which is an ICollection<IDisposable>. The assertions below only enumerate.
+        public IEnumerable<IDisposable> Owned => Disposables;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Blazor.Test/ViewDisposalConcurrencyTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ViewDisposalConcurrencyTest.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor;
+using MeshWeaver.Blazor.Components;
+using MeshWeaver.Layout;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// #1308 — a view's subscription accumulator must tolerate a registration that arrives WHILE the
+/// view is being disposed, because in this framework one routinely does.
+///
+/// <para><b>The production failure.</b> <c>MeshSearchView.Dispose()</c> threw
+/// <c>InvalidOperationException: Collection was modified; enumeration operation may not execute</c>
+/// out of the renderer's disposal queue, which fails the whole Blazor circuit (the user's
+/// connection drops). The accumulator was a plain <c>List&lt;IDisposable&gt;</c> and the writer was
+/// not the renderer: <c>ApplyResults</c> is called straight from the result stream's <c>OnNext</c>,
+/// on a hub/pool thread, and it calls <c>ResolveDeletePermissions</c>, which registers a permission
+/// probe. Circuit teardown and a query emission are independent events, so nothing ordered them.</para>
+///
+/// <para><b>Both halves are the same defect.</b> Throwing is the loud face. The quiet face is a
+/// registration that lands just after the drain and is retained by a list nobody will ever read
+/// again — an unowned subscription outliving its owner, which is how a dead circuit keeps a live
+/// mesh subscription. A fix that only stopped the throw would leave that in place, so both are
+/// pinned below.</para>
+///
+/// <para><b>Not a lock.</b> Idempotent, concurrency-safe disposal here is a property of the
+/// accumulator (<see cref="CompositeDisposable"/>), not mutual exclusion bolted around it.</para>
+/// </summary>
+public class ViewDisposalConcurrencyTest
+{
+    /// <summary>
+    /// Drives <see cref="BlazorView{TViewModel,TView}"/>'s REAL disposal path without a renderer —
+    /// this test is about accumulator behaviour, not markup. Reuses the shape
+    /// <c>MeshNodePickerDebounceOwnershipTest</c> established.
+    /// </summary>
+    private sealed class Probe : MeshNodePickerView
+    {
+        [SetsRequiredMembers]
+        public Probe()
+        {
+            ViewModel = new MeshNodePickerControl(new object());
+            Logger = NullLogger<MeshNodePickerView>.Instance;
+        }
+
+        /// <summary>Registers a component-lifetime disposable, exactly as component code does.</summary>
+        public void Register(IDisposable d) => Disposables.Add(d);
+
+        /// <summary>The live accumulator contents.</summary>
+        public IEnumerable<IDisposable> Owned => Disposables;
+    }
+
+    /// <summary>
+    /// The deterministic repro. A disposable that registers another one as it is being disposed
+    /// reproduces the exact failing operation — the accumulator is mutated while it is being
+    /// drained — with no thread scheduling to sample. Against the <c>List&lt;IDisposable&gt;</c>
+    /// this replaces, the enumerator's version check throws precisely the production exception.
+    /// </summary>
+    [Fact]
+    public async Task RegisteringWhileDisposalDrains_DoesNotThrow()
+    {
+        var probe = new Probe();
+        var lateRegistered = new BooleanDisposable();
+
+        probe.Register(Disposable.Create(() => probe.Register(lateRegistered)));
+        probe.Register(new BooleanDisposable());
+
+        var dispose = async () => await probe.DisposeAsync();
+
+        await dispose.Should().NotThrowAsync(
+            "a registration arriving during the drain is the normal case for a view whose "
+            + "subscriptions emit off the renderer — it must not fail the circuit");
+    }
+
+    /// <summary>
+    /// The quiet half: after teardown the accumulator is TERMINAL, so a registration that loses the
+    /// race is disposed on arrival instead of being parked forever. Fails against the predecessor,
+    /// which appended to a list that <c>DisposeAsync</c> had already walked past and cleared.
+    /// </summary>
+    [Fact]
+    public async Task RegisteringAfterDisposal_DisposesImmediately_RatherThanLeaking()
+    {
+        var probe = new Probe();
+        await probe.DisposeAsync();
+
+        var late = new BooleanDisposable();
+        probe.Register(late);
+
+        late.IsDisposed.Should().BeTrue(
+            "the view is gone; a subscription registered after teardown has no owner left to "
+            + "release it, so the accumulator must release it on arrival");
+        probe.Owned.Should().BeEmpty("a disposed accumulator must not retain anything");
+    }
+
+    /// <summary>Disposal is idempotent — the renderer may drain a component more than once.</summary>
+    [Fact]
+    public async Task DisposalIsIdempotent()
+    {
+        var probe = new Probe();
+        var tracked = new BooleanDisposable();
+        probe.Register(tracked);
+
+        await probe.DisposeAsync();
+        var second = async () => await probe.DisposeAsync();
+
+        await second.Should().NotThrowAsync();
+        tracked.IsDisposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The genuine cross-thread shape, as a regression guard: writers hammering the accumulator
+    /// while the renderer thread disposes it. This cannot PROVE the defect (a race can always be
+    /// missed), which is why the deterministic repro above carries that burden — but it is the
+    /// only assertion that exercises the actual concurrency, and it must never throw.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentRegistrationDuringDisposal_NeverThrows()
+    {
+        var probe = new Probe();
+        for (var i = 0; i < 200; i++)
+            probe.Register(new BooleanDisposable());
+
+        using var start = new ManualResetEventSlim(false);
+        Exception? writerFault = null;
+
+        var writer = Task.Run(() =>
+        {
+            start.Wait(TimeSpan.FromSeconds(10));
+            try
+            {
+                for (var i = 0; i < 2_000; i++)
+                    probe.Register(new BooleanDisposable());
+            }
+            catch (Exception ex)
+            {
+                writerFault = ex;
+            }
+        });
+
+        var disposer = Task.Run(async () =>
+        {
+            start.Wait(TimeSpan.FromSeconds(10));
+            await probe.DisposeAsync();
+        });
+
+        start.Set();
+        await Task.WhenAll(writer, disposer).WaitAsync(TimeSpan.FromSeconds(30));
+
+        writerFault.Should().BeNull("registering a subscription must never fault, disposal or not");
+        probe.Owned.Should().BeEmpty(
+            "every registration either made it into the drain or was disposed on arrival — "
+            + "nothing may be left holding a mesh subscription for a dead view");
+    }
+
+    /// <summary>
+    /// A type-level guard over the whole component surface. The reported crash was in
+    /// <c>MeshSearchView</c>, but the shape — a bare <c>List&lt;IDisposable&gt;</c> accumulating
+    /// subscriptions that a stream callback can append to — was copied across several views and
+    /// into the base class. A per-site fix would leave the next copy to be found in production, so
+    /// the pattern itself is what is pinned here.
+    /// </summary>
+    [Fact]
+    public void NoComponentAccumulatesDisposablesInABareList()
+    {
+        var offenders = typeof(BlazorView<,>).Assembly
+            .GetTypes()
+            .SelectMany(t => t.GetFields(
+                BindingFlags.Instance | BindingFlags.Public
+                | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            .Where(f => IsBareDisposableList(f.FieldType))
+            .Select(f => $"{f.DeclaringType!.FullName}.{f.Name}")
+            .OrderBy(n => n)
+            .ToArray();
+
+        offenders.Should().BeEmpty(
+            "a subscription accumulator must be a CompositeDisposable: its Add is thread-safe "
+            + "against a concurrent drain, and an Add after disposal releases its argument "
+            + "instead of stranding it. A List<IDisposable> gives neither, and both faces of "
+            + "that showed up in production as #1308");
+    }
+
+    private static bool IsBareDisposableList(Type t) =>
+        t.IsGenericType
+        && (t.GetGenericTypeDefinition() == typeof(List<>)
+            || t.GetGenericTypeDefinition() == typeof(System.Collections.Immutable.ImmutableList<>))
+        && t.GetGenericArguments()[0] == typeof(IDisposable);
+}


### PR DESCRIPTION
Fixes #1308.

## Root: **ordering** — work outliving its owner, in an accumulator that cannot survive it

`MeshSearchView.Dispose()` threw `Collection was modified; enumeration operation may not execute` out of the renderer's disposal queue, which fails the whole Blazor circuit (the user's connection drops).

The accumulator was a plain `List<IDisposable>`, and **the writer is not the renderer**:

`MeshQuery.Query<MeshNode>(…).Subscribe(change => … ApplyResults())` → `ApplyResults` → `ResolveDeletePermissions` → `_affordanceSubscriptions.Add(sub)`

`ApplyResults` is called *directly* from the query subscription's `OnNext`, on a hub/pool thread — not inside `InvokeAsync`. Circuit teardown and a query emission are independent events, so nothing ordered them.

## Both faces are the same defect

| | |
|---|---|
| **Loud** | enumerate-while-mutating → `InvalidOperationException` → circuit dropped (the reported crash) |
| **Quiet** | a registration landing just *after* the drain is retained by a list nobody will read again — a live mesh subscription owned by a dead view |

A fix that only stopped the throw would leave the leak in place, so both are addressed. `_treeProbeSubscriptions` is the pure-quiet case: same off-renderer writer, but an `ImmutableList` read-modify-write, so it never threw — it silently *lost* the probe.

## Change

Every subscription accumulator becomes a `CompositeDisposable`: thread-safe `Add`, and an `Add` after `Dispose` releases its argument on arrival instead of stranding it.

**Not a lock** — no `SemaphoreSlim`, no `lock` around anything awaitable. Idempotent, concurrency-safe disposal here is a property of the accumulator, not mutual exclusion bolted around it. `CompositeDisposable` is already used across the codebase (`MeshNodeStreamCache`, `PostgreSqlPartitionedMeshQuery`).

Sites:
- `BlazorView.Disposables` + `.bindings` — the base **every** view inherits; `MeshSearchView`'s field is a copy of this pattern
- `MeshSearchView._affordanceSubscriptions` (reported crash) and `._treeProbeSubscriptions`
- `MeshNodeCollectionView._subscriptions` — raced by `DeleteItem`'s off-renderer callback re-running `LoadItems`, **and never disposed at component teardown at all** (now registered in `Disposables`)
- `CodeEditorView` / `NotebookEditorView`

`Clear` vs `Dispose` is deliberate: a re-bind `Clear`s (the accumulator must stay usable), teardown `Dispose`s (it must become terminal).

Left alone, and stated in-code: `_treeLevelSubscriptions` and `_treeSearchSubscription` are written only from `InitializeTree` / the folder-click and search handlers — all renderer-thread.

## Verification

- `ViewDisposalConcurrencyTest` — the **deterministic** repro is a disposable that registers another during the drain: the exact failing operation (mutation during enumeration) with no thread scheduling to sample. Plus post-dispose release, idempotency, a concurrent hammer (regression guard), and a type-level guard.
- The type-level guard **failed before the fix naming 2 remaining offenders** (the Monaco views) after I had converted the first three — it is what found them, and it will fail on the next copy of this pattern.
- `MeshWeaver.Hosting.Blazor.Test` full suite: **351/351**. `MeshWeaver.Blazor` + `MeshWeaver.Hosting.Blazor` `-c Release -warnaserror --no-incremental`: 0 warnings, 0 errors.

One API note: `BlazorView.Disposables` changes from `List<IDisposable>` to `CompositeDisposable`. `.Add`/`.Clear`/`foreach` are unaffected; the one place that needed a touch was a test exposing it as `IReadOnlyList<IDisposable>` (now `IEnumerable<IDisposable>`). No in-mesh source references `Disposables` (`grep content/ samples/` clean).

## Relationship to the sibling issues

Investigated together with #1300 and #1317. **They do not share a root** — see the #1317 PR for the comparison.
