### PR TITLE
fix(iopool): Drain() must join BLOCKING leaves too — it was reporting a join it never did

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -20,6 +20,12 @@ public sealed class IoPool : IIoPool, IDisposable
     // in-flight leaves unwind promptly — the join then knows they will release their gate permits.
     private readonly CancellationTokenSource _poolCts = new();
     private int _inFlight;
+
+    // 🚨 Idle signal for BLOCKING leaves, which hold no gate permit — see Drain(). Set while no
+    // blocking leaf is running, so the join has something real to wait on instead of polling.
+    // A ManualResetEventSlim here is consistent with this file being the ONE sanctioned home for
+    // such a primitive: IoPool IS the boundary between the turn-based schedulers and blocking I/O.
+    private readonly ManualResetEventSlim _blockingIdle = new(initialState: true);
     private volatile bool _disposed;
 
     // Teardown safety net for the drain join: cancellation makes in-flight leaves release in ms,
@@ -127,14 +133,16 @@ public sealed class IoPool : IIoPool, IDisposable
                     // _inFlight increments only once the scheduler grants a slot —
                     // so CurrentInFlight reflects actually-running blocking work,
                     // capped at the scheduler's MaximumConcurrencyLevel.
-                    Interlocked.Increment(ref _inFlight);
+                    if (Interlocked.Increment(ref _inFlight) == 1)
+                        _blockingIdle.Reset();
                     try
                     {
                         return work(cts.Token);
                     }
                     finally
                     {
-                        Interlocked.Decrement(ref _inFlight);
+                        if (Interlocked.Decrement(ref _inFlight) == 0)
+                            _blockingIdle.Set();
                     }
                 }, cts.Token)
                 .ContinueWith(t =>
@@ -228,8 +236,10 @@ public sealed class IoPool : IIoPool, IDisposable
     /// last running leaf has released, then we release them back so the pool stays usable/idempotent.
     /// </remarks>
     /// <returns>
-    /// The number of leaves that did NOT unwind within the drain budget — permits that could not be
-    /// re-acquired because a leaf ignored its cancellation token. <c>0</c> means the join is REAL:
+    /// The number of leaves that did NOT unwind within the drain budget — gate permits that could not
+    /// be re-acquired because an async leaf ignored its cancellation token, PLUS any blocking leaf
+    /// (<see cref="InvokeBlocking{T}"/>) still running, which holds no permit and so is counted
+    /// separately. <c>0</c> means the join is REAL:
     /// no pool thread is still running when this returns. Anything else means teardown is about to
     /// proceed over live work (the use-after-unload SIGSEGV precondition) — the caller must surface
     /// it, never swallow it: a drain that silently gives up is how "disposal completed" becomes a
@@ -247,7 +257,26 @@ public sealed class IoPool : IIoPool, IDisposable
         }
         if (acquired > 0)
             _gate.Release(acquired);
-        return _maxConcurrency - acquired;
+        var gateResidual = _maxConcurrency - acquired;
+
+        // 🚨 BLOCKING LEAVES HOLD NO GATE PERMIT — so the gate join above joins NOTHING for them, and
+        // this method returned 0 ("the join is REAL: no pool thread is still running") while a
+        // Roslyn compile or a file read was still executing. That is precisely the use-after-unload
+        // precondition Drain exists to rule out, and it was reachable on every node read
+        // (CachingStorageAdapter routes through InvokeBlocking on the FileSystem pool). The existing
+        // guard test only exercised Invoke, which DOES take a permit, so this went untested.
+        // Repro: IoPoolTest.Drain_joins_InvokeBlocking_leaves_too.
+        //
+        // Join them on their own idle signal, bounded by the SAME budget — no new timeout, no poll.
+        // Re-read the counter when the wait expires: a leaf that finished between the signal reset
+        // and our wait would otherwise be reported as surviving.
+        if (!_blockingIdle.Wait(DrainTimeout))
+        {
+            var stillRunning = Volatile.Read(ref _inFlight);
+            return gateResidual + stillRunning;
+        }
+
+        return gateResidual;
     }
 
     /// <summary>
@@ -262,6 +291,7 @@ public sealed class IoPool : IIoPool, IDisposable
         Drain();
         _poolCts.Dispose();
         _gate.Dispose();
+        _blockingIdle.Dispose();
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -146,6 +146,45 @@ public class IoPoolTest
         pool.CurrentInFlight.Should().Be(0);
     }
 
+    // 🚨 REPRO for the #613 family: Drain()'s contract says "0 means the join is REAL: no pool
+    // thread is still running when this returns", and every teardown orchestrator
+    // (MonolithMeshTestBase, MeshTeardownExtensions, HubTestBase) trusts that return value before
+    // it disposes the Autofac scope and unloads the collectible node ALCs. But the join is
+    // implemented by re-acquiring the SemaphoreSlim gate — and InvokeBlocking NEVER takes a gate
+    // permit (it dispatches on the LimitedConcurrencyLevelTaskScheduler and only bumps _inFlight).
+    // So for a blocking leaf the permits are free immediately, Drain returns 0, and teardown
+    // proceeds over live work. Deterministic: the leaf below ignores its cancellation token, which
+    // is EXACTLY the case Drain's non-zero return is documented to report.
+    [Fact]
+    public void Drain_joins_InvokeBlocking_leaves_too()
+    {
+        using var pool = new IoPool(2);
+        using var entered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        pool.InvokeBlocking(_ =>
+        {
+            entered.Set();
+            release.Wait(Timeout10);   // deliberately ignores the token — the reportable case
+            return 0;
+        }).Subscribe(_ => { }, _ => { });
+
+        entered.Wait(Timeout5, TestContext.Current.CancellationToken).Should().BeTrue();
+        pool.CurrentInFlight.Should().Be(1, "a running blocking leaf must be visible as in-flight");
+
+        var leaked = pool.Drain();
+
+        // Either the drain JOINED (in-flight back to 0) or it must REPORT the survivor. Reporting
+        // 0 while a leaf still runs is the lie teardown acts on.
+        if (leaked == 0)
+            pool.CurrentInFlight.Should().Be(0,
+                "Drain returned 0 — 'the join is REAL' — so no pool thread may still be running. " +
+                "A blocking leaf survives the drain unseen because InvokeBlocking takes no gate " +
+                "permit, so re-acquiring the gate joins nothing.");
+
+        release.Set();
+    }
+
     [Fact]
     public void Invoke_is_cold_no_work_runs_until_subscribe()
     {


### PR DESCRIPTION
## The defect

`Drain()` joins by cancelling the pool token and re-acquiring all `_maxConcurrency` gate permits. But **`InvokeBlocking` never takes a gate permit** — it dispatches on the limited-concurrency scheduler and only bumps `_inFlight`, which `Drain` never read. So the permits were free instantly and it returned **0**, whose documented meaning is:

> `0` means the join is REAL: no pool thread is still running when this returns.

…while a blocking leaf was still executing.

**That is precisely the precondition `Drain()` exists to rule out.** Its own summary:

> Called before a collectible node `AssemblyLoadContext` is unloaded so no pool thread is still executing (or about to dereference) that ALC's compiled types when it is torn down (the teardown use-after-unload SIGSEGV).

Roslyn emit, assembly load and file reads *are* the blocking leaves. And it is reachable on every node read — `CachingStorageAdapter` routes them through `InvokeBlocking` on the FileSystem pool (cap 256).

It went untested because the existing guard (`IoPoolTest`) exercises `Invoke`, which **does** take a permit.

## The repro

`IoPoolTest.Drain_joins_InvokeBlocking_leaves_too` — on main today:

```
Expected value to be 0 because Drain returned 0 — 'the join is REAL' — so no pool thread
may still be running. A blocking leaf survives the drain unseen because InvokeBlocking
takes no gate permit, so re-acquiring the gate joins nothing., but found 1.
```

With this fix: **13/13 in the class.**

## The fix

Blocking leaves maintain a `ManualResetEventSlim` around the counter they already keep, and `Drain` waits on it under the **same** budget — no new timeout, no polling. If the wait expires the counter is re-read, so a leaf that finished inside the race window isn't reported as surviving. The residual is **added to the return value**, so a survivor reaches the caller instead of being silently counted as zero — which is the contract the return value already documented.

(A `ManualResetEventSlim` here is consistent with this file being the one sanctioned home for such a primitive: `IoPool` *is* the boundary between the turn-based schedulers and blocking I/O.)

## 🚨 Scope, stated honestly

**This does not fix `FutuRe.Test exit=139`.** That crash was reproduced locally with dumps (2 in 15 runs with `DOTNET_gcConcurrent=1`, 0 in 12 with concurrent GC off) and resolves to:

```
SVR::gc_heap::background_ephemeral_sweep() + 344
SVR::gc_heap::background_sweep()          + 1368
SVR::gc_heap::gc1()                       + 520
SVR::gc_heap::bgc_thread_function()       + 204
```

faulting at `ldr w12, [x11]` with `x11 == 0` — **the swept object's MethodTable pointer is exactly zero**, `si_addr=0x0`, translation fault on read. Instruction-for-instruction the arm64 equivalent of #613's recorded x64 fingerprint, on a different arch, a different GC flavour (SVR vs WKS) and a different runtime build. Safe managed code cannot zero an object header — the crashing process ships **no** native libraries and no `unsafe` code — and a freed collectible `LoaderAllocator` yields a non-null *unmapped* pointer, not zero.

So this is a genuine CoreCLR bug, and this PR is a real defect found while auditing for it.

## Related follow-ups from the same audit (not in this PR)

- `MonolithMeshTestBase.DisposeAsync` omits teardown **phase 0** (`ActivityTracker.WhenIdle`) — the phase added specifically to stop this segfault is not on the path `FutuRe.Test` takes. And `ActivityTracker.Track()` has exactly one caller in the tree, so the NodeType compile isn't tracked either.
- `NodeAssemblyLoadContext.Dispose` waits 5 s on `_pins`, times out, and proceeds to `Unload()` **silently** — the one case it exists to catch is invisible.
- `Workspace.EvictForPath` parks a materialised stream in `_evictedRemoteStreams` **without disposing it** on every mesh change event; reaped only when subscribers hit zero for 10 minutes, or at workspace disposal. A path with any live subscriber therefore parks a new stream per change event and never reaps one — a strong candidate for #1324's growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)