### PR TITLE
fix: batch the import activity log per phase — the O(n²) CPU burner throttling memex-cloud

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imports-no-longer-burn-cpu-on-their-own-progress-log.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-imports-no-longer-burn-cpu-on-their-own-progress-log.md
@@ -1,0 +1,23 @@
+---
+Name: Imports no longer burn CPU on their own progress log
+Category: Fix
+Description: Large repository imports are dramatically cheaper, so the portal stays responsive while one is running.
+Icon: Sparkle
+Order: -20260812
+---
+
+# Imports no longer burn CPU on their own progress log
+
+While a large import was running, the portal could slow to a crawl — pages that took seconds to
+appear, chats that stalled mid-answer — and it got worse the bigger the import was.
+
+The cause was the import's own progress log. Every file it kept, pruned or failed to write was
+recorded as a separate update to the import's activity record, and each of those updates re-read and
+re-compared the entire record. So the hundredth line cost a hundred times what the first one did, and
+a single import on one portal ended up rewriting hundreds of megabytes just to describe what it had
+done. That work was competing with everything else the portal had to do.
+
+The import now records each stage once, with all of that stage's lines together. The activity log
+still names every file it kept and every node it pruned — nothing is lost from the audit trail — but
+the cost no longer grows with the size of the import. The one visible difference is that progress now
+appears stage by stage rather than file by file.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
@@ -98,15 +98,38 @@ internal static class NodeTypeCompilationActivity
     }
 
     /// <summary>
-    /// Append an Information-level <see cref="LogMessage"/> to the activity
+    /// Append a single <see cref="LogMessage"/> (Information-level by default) to the activity
     /// log so callers can see progress in real time. No-op when
     /// <paramref name="activityPath"/> is null. Best-effort: failures log and
     /// swallow — observability must never break a compile.
+    ///
+    /// <para>🚨 ONE write per call, and a write is <b>O(size of the whole activity node)</b>: the
+    /// patcher <c>SerializeToNode</c>s the entire content and diffs every element on EVERY update.
+    /// So N appends to one activity cost <b>O(N²)</b> CPU + allocation. Never call this in a loop —
+    /// collect the messages and use <see cref="AppendLogs"/> (per phase) or <see cref="Complete"/>
+    /// (terminal). The per-item shape burned 719 MB of serialisation on a single memex-cloud import
+    /// activity (5,239 writes over a 141 kB node) and was half of the CFS throttling on that pod.</para>
     /// </summary>
     public static void AppendLog(IMessageHub hub, string? activityPath, string message, ILogger logger,
-        Microsoft.Extensions.Logging.LogLevel level = Microsoft.Extensions.Logging.LogLevel.Information)
+        Microsoft.Extensions.Logging.LogLevel level = Microsoft.Extensions.Logging.LogLevel.Information) =>
+        AppendLogs(hub, activityPath, [new LogMessage(message, level)], logger);
+
+    /// <summary>
+    /// Append MANY <see cref="LogMessage"/>s to the activity log in a <b>SINGLE</b>
+    /// <c>stream.Update</c> — the batched form of <see cref="AppendLog"/>, and the one to use for
+    /// anything that produces a line PER ITEM (per imported file, per pruned node, per diagnostic).
+    /// No-op when <paramref name="activityPath"/> is null or there is nothing to append.
+    /// Best-effort: failures log and swallow — observability must never break the work it observes.
+    ///
+    /// <para>Why batching is not a micro-optimisation: each <c>Update</c> re-serialises the WHOLE
+    /// activity node to compute its patch, so appending N lines one at a time is O(N²) in CPU and
+    /// allocation while appending them together is O(N). Emitting one line per phase instead of one
+    /// per item is the deliberate trade — coarser live progress, bounded cost.</para>
+    /// </summary>
+    public static void AppendLogs(
+        IMessageHub hub, string? activityPath, IReadOnlyList<LogMessage> messages, ILogger logger)
     {
-        if (string.IsNullOrEmpty(activityPath)) return;
+        if (string.IsNullOrEmpty(activityPath) || messages.Count == 0) return;
         try
         {
             // Set the property on the activity's stream — GetMeshNodeStream
@@ -125,7 +148,7 @@ internal static class NodeTypeCompilationActivity
                             {
                                 Content = log with
                                 {
-                                    Messages = log.Messages.Add(new LogMessage(message, level))
+                                    Messages = log.Messages.AddRange(messages)
                                 }
                             }
                             : current!)

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -896,7 +896,8 @@ public static class StaticRepoImporter
                         {
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: skip claimed {Path}", source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
+                            return Observable.Return(
+                                (Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null, Log: (LogMessage?)null));
                         }
 
                         // 🅶 Git-diff scope: when the caller supplied the changed-path set (a webhook /
@@ -923,12 +924,14 @@ public static class StaticRepoImporter
                                 logger?.LogDebug(
                                     "[StaticRepoImport] {Partition}: outside git-diff scope, {Path} is server-newer — counted preserved.",
                                     source.Partition, path);
-                                return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null));
+                                return Observable.Return(
+                                    (Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null, Log: (LogMessage?)null));
                             }
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: outside git-diff scope, skipping {Path}",
                                 source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
+                            return Observable.Return(
+                                (Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null, Log: (LogMessage?)null));
                         }
 
                         // Incremental skip: unchanged since the last import (same source token) AND the
@@ -950,11 +953,13 @@ public static class StaticRepoImporter
                                 logger?.LogDebug(
                                     "[StaticRepoImport] {Partition}: unchanged in repo, {Path} is server-newer — counted preserved.",
                                     source.Partition, path);
-                                return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null));
+                                return Observable.Return(
+                                    (Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null, Log: (LogMessage?)null));
                             }
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: unchanged, skipping {Path}", source.Partition, path);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null));
+                            return Observable.Return(
+                                (Imported: 0, Failed: 0, Preserved: 0, Written: (string?)null, Log: (LogMessage?)null));
                         }
 
                         // Two-way conflict resolution: a node changed on the SERVER since the last sync
@@ -967,9 +972,14 @@ public static class StaticRepoImporter
                             logger?.LogInformation(
                                 "[StaticRepoImport] {Partition}: two-way — preserving server-newer {Path} (not overwritten).",
                                 source.Partition, path);
-                            NodeTypeCompilationActivity.AppendLog(hub, activityPath,
-                                $"↩ Kept local change to {path} (newer on the server — commit to sync it back).", logger!);
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null));
+                            // 🚨 The activity line RIDES ALONG with the result instead of being written
+                            // here. A per-item stream.Update re-serialises the whole activity node, so
+                            // one write per kept/failed file is O(n²) — see the phase-level AppendLogs
+                            // below and NodeTypeCompilationActivity.AppendLogs.
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Written: (string?)null,
+                                Log: (LogMessage?)new LogMessage(
+                                    $"↩ Kept local change to {path} (newer on the server — commit to sync it back).",
+                                    Microsoft.Extensions.Logging.LogLevel.Information)));
                         }
 
                         var materialized = Materialize(sourceNode);
@@ -1001,16 +1011,17 @@ public static class StaticRepoImporter
                         // Failed and continue. The Failed tally drives the terminal Warning status
                         // below — the activity never reports a green Succeeded while hiding failures.
                         return Upsert(hub, materialized)
-                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0, Written: (string?)path))
-                            .Catch<(int Imported, int Failed, int Preserved, string? Written), Exception>(ex =>
+                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0, Written: (string?)path,
+                                Log: (LogMessage?)null))
+                            .Catch<(int Imported, int Failed, int Preserved, string? Written, LogMessage? Log), Exception>(ex =>
                             {
                                 logger?.LogWarning(ex,
                                     "[StaticRepoImport] {Partition}: upsert of {Path} failed (continuing).",
                                     source.Partition, path);
-                                NodeTypeCompilationActivity.AppendLog(hub, activityPath,
-                                    $"⚠ Failed to import {path}: {ex.Message}", logger!,
-                                    Microsoft.Extensions.Logging.LogLevel.Warning);
-                                return Observable.Return((Imported: 0, Failed: 1, Preserved: 0, Written: (string?)null));
+                                return Observable.Return((Imported: 0, Failed: 1, Preserved: 0, Written: (string?)null,
+                                    Log: (LogMessage?)new LogMessage(
+                                        $"⚠ Failed to import {path}: {ex.Message}",
+                                        Microsoft.Extensions.Logging.LogLevel.Warning)));
                             });
                     })
                     .ToObservable()
@@ -1020,6 +1031,9 @@ public static class StaticRepoImporter
                     // (GitHubSyncService → ReleaseAffectedNodeTypes) keys off exactly this list.
                     // Collected in ONE materialization pass (not per-element immutable Adds), so a
                     // large first import stays linear.
+                    // The per-file activity LINES ride along the same way, for the same reason plus a
+                    // sharper one: written one at a time they cost O(n²) (every stream.Update
+                    // re-serialises the whole activity node), so the phase writes them together below.
                     .ToList()
                     .Select(results => (
                         Imported: results.Sum(x => x.Imported),
@@ -1028,10 +1042,23 @@ public static class StaticRepoImporter
                         Written: results
                             .Where(x => x.Written is not null)
                             .Select(x => x.Written!)
-                            .ToImmutableList()));
+                            .ToImmutableList(),
+                        Logs: results
+                            .Where(x => x.Log is not null)
+                            .Select(x => x.Log!)
+                            .ToArray()));
 
                 return upserted.SelectMany(count =>
                 {
+                    // 🚨 PHASE LOG, not per item. Every per-file line the upsert phase produced (the
+                    // "↩ Kept local change" conflicts and the "⚠ Failed to import" diagnostics) lands
+                    // in ONE stream.Update. Written per item this was the portal's biggest CPU burner:
+                    // an Update re-serialises the WHOLE activity node to diff it, so n appends cost
+                    // O(n²) — 5,239 writes over a 141 kB node = 719 MB serialised on ONE memex-cloud
+                    // import, and 51% CFS throttling on the pod. Batching makes it O(n). The accepted
+                    // cost is coarser live progress: you see the phase, not each file.
+                    NodeTypeCompilationActivity.AppendLogs(hub, activityPath, count.Logs, logger!);
+
                     // Prune per the partition's PartitionSyncMode. In every mode the guards hold: a
                     // pruned node is absent from the source AND still Include AND not governance
                     // (_Policy/_Access/_Activity) AND not under a claimed subtree. The MODE narrows the
@@ -1059,13 +1086,9 @@ public static class StaticRepoImporter
                         if (keptFromPrune.Length > 0)
                             toPrune = toPrune.Where(n => !policy.PreservesFromPruneOf(n)).ToArray();
                         foreach (var kept in keptFromPrune)
-                        {
                             logger?.LogInformation(
                                 "[StaticRepoImport] {Partition}: keeping server-added {Path} (not pruned).",
                                 source.Partition, kept.Path);
-                            NodeTypeCompilationActivity.AppendLog(hub, activityPath,
-                                $"↩ Kept {kept.Path} (added on the server — commit to sync it back).", logger!);
-                        }
                     }
 
                     // Collect the actually-pruned PATHS (not just a count): a pruned Source/Test
@@ -1075,7 +1098,9 @@ public static class StaticRepoImporter
                     // #604): a prune is a destructive act on user data, and an aggregate count alone
                     // made a deleted node indistinguishable from a bug ("my page vanished and nothing
                     // says why"). The activity log is the diagnosis surface, so the deletion must be
-                    // as auditable as the "⚠ Failed to import …" lines already are.
+                    // as auditable as the "⚠ Failed to import …" lines already are. It is named ONCE
+                    // PER PHASE, not once per node: the pruned paths are collected here and appended
+                    // in a single Update below (a per-node append is O(n²) — see the upsert phase).
                     var pruned = toPrune.Count == 0
                         ? Observable.Return(ImmutableList<string>.Empty)
                         : toPrune
@@ -1085,8 +1110,6 @@ public static class StaticRepoImporter
                                     logger?.LogInformation(
                                         "[StaticRepoImport] {Partition}: pruned {Path} (absent from the source).",
                                         source.Partition, t.Path);
-                                    NodeTypeCompilationActivity.AppendLog(hub, activityPath,
-                                        $"🗑 Pruned {t.Path} (absent from the repo).", logger!);
                                     return (string?)t.Path;
                                 })
                                 .Catch<string?, Exception>(ex =>
@@ -1104,9 +1127,23 @@ public static class StaticRepoImporter
                             .Select(list => list.ToImmutableList());
 
                     return pruned.SelectMany(prunedPaths =>
+                    {
+                        // 🚨 PHASE LOG #2 — the prune phase's whole audit trail (every kept server
+                        // addition + every pruned path) in ONE Update, same O(n) reason as above.
+                        NodeTypeCompilationActivity.AppendLogs(hub, activityPath,
+                            keptFromPrune
+                                .Select(kept => new LogMessage(
+                                    $"↩ Kept {kept.Path} (added on the server — commit to sync it back).",
+                                    Microsoft.Extensions.Logging.LogLevel.Information))
+                                .Concat(prunedPaths.Select(p => new LogMessage(
+                                    $"🗑 Pruned {p} (absent from the repo).",
+                                    Microsoft.Extensions.Logging.LogLevel.Information)))
+                                .ToArray(),
+                            logger!);
+
                         // Sync content-collection files (the assets behind @@content/<file> embeds)
                         // collection→collection into each owning node — AFTER the node upsert.
-                        SyncContentImports(hub, source, logger).SelectMany(embedCount =>
+                        return SyncContentImports(hub, source, logger).SelectMany(embedCount =>
                         // Mirror inline (byte-carrying) content into each owning node's content
                         // collection — the git-committed {Space}/content/** binaries a GitSync import
                         // supplies. Binary-safe + mirroring (writes what the repo has, prunes what the
@@ -1157,7 +1194,8 @@ public static class StaticRepoImporter
                                 PrunedPaths = prunedPaths,
                             };
                         });
-                        })));
+                        }));
+                    });
                 });
             })
             .Catch<StaticRepoImportResult, Exception>(ex =>

--- a/test/MeshWeaver.Graph.Test/StaticRepoImportActivityWriteCountTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaticRepoImportActivityWriteCountTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The import's activity log must cost <b>O(number of items)</b>, not O(items²).
+///
+/// <para>Every <c>stream.Update</c> on an activity node re-serialises that node's WHOLE content to
+/// compute its patch, so a per-item <c>AppendLog</c> over n items serialises 1 + 2 + … + n copies of
+/// a growing document. On memex-cloud that shape produced <b>5,239 writes and ~719 MB serialised for
+/// ONE import activity</b> (141 kB of content), ~7.1 GB across 25,579 activity nodes, and was the
+/// dominant term in the pod's 51%-of-CFS-periods throttling. Not one non-import node appeared in the
+/// top 20 — the importer's per-item logging was the burner.</para>
+///
+/// <para>The fix is to append <b>once per PHASE</b> (upsert phase, prune phase) with an
+/// <c>AddRange</c>-style call instead of once per item, so the number of writes an import makes is
+/// independent of how many items that phase handled. The deliberate, accepted cost is coarser live
+/// progress: a long import shows per-phase progress, not per-file.</para>
+///
+/// <para>What is asserted is the WRITE COUNT — the activity node's own revision counter
+/// (<see cref="MeshNode.Version"/>, "+1 per real modification") — never the log text, so the test
+/// cannot be satisfied by rewording a message. RED before the batching fix (writes grew 1:1 with the
+/// item count), GREEN after (identical for both sizes).</para>
+/// </summary>
+public class StaticRepoImportActivityWriteCountTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Item counts that must produce the SAME number of activity writes.</summary>
+    private const int SmallImport = 4;
+    private const int LargeImport = 16;
+
+    /// <summary>
+    /// 🚨 THE REGRESSION GUARD. Two imports whose conflict phase keeps 4 and 16 nodes respectively
+    /// must write the activity log the same number of times. Before batching, each kept node cost its
+    /// own <c>stream.Update</c> (and each of those re-serialised the whole, by then larger, node), so
+    /// the counts differed by exactly the item delta — the O(n²) shape.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task ImportActivityWrites_DoNotGrowWithTheNumberOfItemsInAPhase()
+    {
+        var small = await ActivityWritesForConflictPhase(SmallImport);
+        var large = await ActivityWritesForConflictPhase(LargeImport);
+
+        Output.WriteLine(
+            $"activity writes: {SmallImport} kept items -> {small}; {LargeImport} kept items -> {large}");
+
+        large.Should().Be(small,
+            "the import must log its conflict phase in ONE write regardless of how many items it "
+            + $"handled — {LargeImport} items cost {large} writes vs {small} for {SmallImport}, i.e. the "
+            + "per-item AppendLog is back and every one of those writes re-serialises the whole "
+            + "activity node (O(n²) CPU — the memex-cloud CFS-throttling burner)");
+
+        // …and the absolute figure stays a small constant: opening line, root line, one phase line,
+        // terminal summary. A test that only compared the two sizes would still pass if BOTH grew.
+        large.Should().BeLessThan(LargeImport,
+            "the write count is per-phase, so it must stay well under the per-item count");
+    }
+
+    /// <summary>
+    /// Runs a two-step import into a fresh partition and returns how many times the SECOND import's
+    /// attempt-activity node was written.
+    /// <list type="number">
+    ///   <item>import <paramref name="items"/> nodes (creates them);</item>
+    ///   <item>re-import the same paths with CHANGED content under a two-way policy whose baseline is
+    ///     <see cref="DateTimeOffset.MinValue"/> — so every live node counts as "newer on the server"
+    ///     and every one of them takes the <c>↩ Kept local change</c> branch.</item>
+    /// </list>
+    /// Step 2 writes no content at all (everything is preserved), so the attempt node's revisions are
+    /// exactly the import's own logging — the quantity under test, isolated.
+    /// </summary>
+    private async Task<long> ActivityWritesForConflictPhase(int items)
+    {
+        var partition = "Wc" + Guid.NewGuid().ToString("N")[..8];
+        var source = new FakeRepoSource(partition)
+        {
+            Root = new MeshNode(partition)
+            {
+                Name = "Write Count", NodeType = "Space", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "# Write Count\n\nfixture." }
+            },
+            Nodes = Pages(partition, items, "v1")
+        };
+
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(120.Seconds());
+        first.Outcome.Should().Be("Imported");
+        first.Count.Should().Be(items, "the first import must actually materialize the fixture");
+
+        var beforeAttempts = await AttemptIds(partition);
+
+        // Same paths, different content → new fingerprint (no short-circuit) and a REAL conflict on
+        // every node (past the unchanged-token skip, which logs nothing).
+        source.Nodes = Pages(partition, items, "v2");
+        var conflicted = await StaticRepoImporter.ImportSource(
+                Mesh, source, null,
+                new ImportConflictPolicy(PreserveServerNewer: true, Since: DateTimeOffset.MinValue))
+            .FirstAsync().Timeout(120.Seconds());
+        conflicted.Preserved.Should().Be(items,
+            "every node must take the kept-local-change branch — that is the phase being measured");
+
+        // The second import opens exactly one fresh attempt node — that is the one being measured.
+        var attemptPath = Assert.Single(
+            (await AttemptIds(partition)).Except(beforeAttempts, StringComparer.Ordinal).ToArray());
+
+        // The terminal write is the LAST one the import makes (the per-path write queue is serial),
+        // so a non-Running status means every earlier write has landed and Version is final.
+        var attempt = await Mesh.GetWorkspace().GetMeshNodeStream(attemptPath)
+            .Where(n => n.ContentAs<ActivityLog>(Mesh.JsonSerializerOptions)
+                is { Status: not ActivityStatus.Running })
+            .FirstAsync().Timeout(60.Seconds());
+
+        return attempt!.Version;
+    }
+
+    /// <summary>The per-run attempt nodes under the partition's <c>_Activity</c> namespace.</summary>
+    private async Task<IReadOnlyList<string>> AttemptIds(string partition)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var change = await meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{partition}/_Activity scope:children nodeType:{ActivityNodeType.NodeType}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .FirstAsync().Timeout(30.Seconds());
+        // The lock is `import-{fingerprint}`; an attempt is that id plus a per-run suffix, and its
+        // Name carries "attempt" (StaticRepoImporter.Import). Manifests are separate ids.
+        return change.Items
+            .Where(n => n.Name?.Contains("attempt", StringComparison.Ordinal) == true)
+            .Select(n => n.Path)
+            .ToArray();
+    }
+
+    private static List<MeshNode> Pages(string partition, int count, string revision) =>
+        Enumerable.Range(0, count)
+            .Select(i => new MeshNode($"Page{i}", partition)
+            {
+                NodeType = "Markdown", Name = $"Page {i}", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = $"# Page {i}\n\n{revision}" }
+            })
+            .ToList();
+
+    private sealed class FakeRepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; set; } = [];
+        public MeshNode? Root { get; set; }
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+    }
+}


### PR DESCRIPTION
## The live production CPU burner

`memex-cloud` sits at **51% of CFS periods throttled**. The dominant term is the static-repo
importer writing its own progress log **once per item**.

`NodeTypeCompilationActivity.AppendLog` does **one `stream.Update` per message**, and
`StaticRepoImporter` called it per pruned / kept / failed node at four sites. Each `stream.Update`
runs `CreateSingleObjectPatch`, which **`SerializeToNode`s the entire node content (O(n)) and diffs
all n elements (O(n))** — on *every* write. Over n appends that is **O(n²)** CPU and allocation.

Live attribution, by node path:

| path | writes | content | est. serialised |
|---|---:|---:|---:|
| `AgenticEngineering/_Activity/import-69f6248b…` | **5,239** | 141 kB | **719 MB** |
| `UWDeepfield/_Activity/import-af545232…` | 2,581 | 114 kB | 288 MB |
| `MeshWeaver/_Activity/import-1d1a65…` | 637 | 204 kB | 127 MB |

230,674 writes / ~7.1 GB serialised across 25,579 activity nodes; **no non-import node in the top
20**. Downstream: ~7.8 cores demanded against a 6-core quota → CFS throttling → turns, timers and
`Dequeue` all slip together (thread-pool delay #1284, routing pile-up #1172). No deadlock.

**The patch *output* was never the problem.** `PatchExtensions.DiffArray` is element-wise, so an
append walks the equal prefix and emits a single O(1) `add` op. The cost is on the **input** side of
the patcher — which is exactly why replacing the patch library in #1292 (1.2× faster diff, 17–19%
fewer allocations) did not move the needle: the dominant cost is re-serialising a growing document.

## The fix — batch per phase

- **New `NodeTypeCompilationActivity.AppendLogs(...)`** writes N messages in **one** `Update`
  (`Messages.AddRange`). `AppendLog` becomes the one-message call into it, and its doc comment now
  states the cost model so the per-item shape does not come back.
- **`StaticRepoImporter.Run`** carries each per-file line along with its per-file result tuple —
  the same trick `WrittenPaths` already used — and appends the whole **upsert phase** in one write.
  The **prune phase** likewise appends its kept-from-prune + pruned lines in one write once the
  deletes have settled.
- **`Complete` was not the right vehicle on its own.** It writes the *terminal* status, so folding
  the phase lines into it would defer every line past the prune, content-sync and manifest-write
  phases — no live progress at all. The phase-level append sits alongside it.

Nothing leaves the audit trail: every kept and every pruned path is still **named** on the activity
log (issue #604's requirement), and still lands before the terminal status — the per-path write
queue is serial, so a reader that sees a non-Running status has already seen every line.

**Accepted cost (owner's call):** per-item live progress during a long import is replaced by
per-phase progress. The satellite-node design that would keep per-item progress alters the
`ActivityLog` contract, its readers and the GUI, and was deliberately deferred as a separate change.

No band-aids: no quota change, no scheduler hop, no recursion-depth bound, no throttle/debounce on
the writes. The work itself is gone, not moved.

## Verification — before / after write counts

New test `StaticRepoImportActivityWriteCountTest` runs a real import into a fresh partition, then
re-imports the same paths under a two-way policy so every node takes the "kept local change" branch
— a phase that writes **no content at all**, so the attempt-activity node's revisions are exactly
the import's own logging. It asserts on **`MeshNode.Version`** (the node's own "+1 per real
modification" counter), never on log text, so a reworded message cannot satisfy it.

| items in the phase | activity writes **before** | **after** |
|---:|---:|---:|
| 4 | 8 | **5** |
| 16 | 20 | **5** |

Writes grew 1:1 with the item count; they are now a constant (opening line, root line, one phase
line, terminal summary). Fail-before/pass-after was verified by reverting the `src/` diff, rebuilding
and re-running: RED with `4 -> 8; 16 -> 20`, GREEN with `4 -> 5; 16 -> 5`.

Extrapolating the measured production shape: the 5,239-write / 719 MB activity becomes a handful of
writes, and the ~7.1 GB of serialisation across the 25,579 activity nodes collapses by the same
order.

## Test runs (local, this branch)

- `MeshWeaver.Graph.Test` — **1060 passed, 0 failed** (includes the new test)
- `MeshWeaver.GitSync.Test` — **160 passed, 0 failed** (covers the prune/preserve paths and the
  "activity log NAMES the pruned node" assertion of #604)
- `MeshWeaver.Documentation.Test` — `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph`, `MeshWeaver.Graph.Test`,
  `MeshWeaver.Documentation`

What's New entry: `Category: Fix` — users notice imports being far cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
