### PR TITLE
A rolled-out pod waits for its sessions instead of cutting them off

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -36,10 +36,17 @@ spec:
       # projected token (RBAC in rbac.yaml). See Doc/Architecture/ReleaseStrategy.
       serviceAccountName: "memex-portal-sa"
       # Graceful drain budget: the host's ShutdownTimeout is 90s (Memex.Portal.Distributed
-      # Program.cs) and the preStop below sleeps 15s — the k8s default of 30s SIGKILLed the
-      # portal mid-drain on every rollout (circuits and the Orleans silo torn down abruptly).
-      # 120 is a ceiling, not a delay: a fast shutdown still exits fast.
-      terminationGracePeriodSeconds: 120
+      # Program.cs) and the preStop below waits for this pod's SESSIONS to end — the k8s default
+      # of 30s SIGKILLed the portal mid-drain on every rollout (circuits and the Orleans silo torn
+      # down abruptly). A ceiling, not a delay: a pod with no circuits still exits in seconds.
+      #
+      # 🚨 This number is now the answer to "how long may a user keep working on the OLD build
+      # after a roll?", because preStop blocks until the last circuit closes. Sized for a working
+      # session, not for a request: at 120s a rollout still cut people off mid-task, which is the
+      # complaint this closes. Grains follow the same budget for free — MessageHubGrain is
+      # [PreferLocalPlacement], so a circuit's hubs live on the pod serving that circuit, and a pod
+      # that stays alive keeps them running against the code they activated with.
+      terminationGracePeriodSeconds: {{ .Values.portal.drainSeconds | default 1800 }}
       initContainers:
         # Postgres and the portal start concurrently on a fresh install; the portal's hub
         # init FAILS (and the host aborts) if Postgres isn't yet accepting connections.
@@ -53,15 +60,33 @@ spec:
       containers:
         - image: "{{ .Values.portal.image }}"
           name: "memex-portal"
-          # On rollout, endpoint removal propagates to the ingress-nginx upstreams asynchronously —
-          # without this grace window the pod stops accepting the instant it is SIGTERMed and
-          # in-flight/new requests briefly hit a dead socket (the deploy 502 blip). Sleep first so
-          # the endpoint drains from the upstream set BEFORE the host begins shutting down.
-          # (Base image is Debian aspnet — sh exists.)
+          # Two drains, in order, and they are not the same thing:
+          #
+          #  1. 15s — the INGRESS drain. Endpoint removal reaches the ingress-nginx upstreams
+          #     asynchronously; without this window the pod stops accepting the instant it is
+          #     SIGTERMed and in-flight/new requests hit a dead socket (the deploy 502 blip).
+          #
+          #  2. /drain — the SESSION drain. This was the missing half: after those 15 seconds the
+          #     host shut down and every Blazor circuit still open on this pod died mid-sentence,
+          #     taking its grains with it ([PreferLocalPlacement] puts a circuit's hubs on the pod
+          #     serving it). New sessions already go to the new pod — it is in the Service, this
+          #     pod is not — so waiting costs the rollout nothing and costs a working user nothing.
+          #     Poll until the pod reports "drained", i.e. its last circuit closed.
+          #
+          # Bounded by terminationGracePeriodSeconds above: a forgotten open tab delays the pod's
+          # exit, it cannot block the rollout for ever — k8s SIGKILLs at the ceiling. curl is not
+          # in the base image; wget is (Debian aspnet).
           lifecycle:
             preStop:
               exec:
-                command: ["sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - >-
+                    sleep 15;
+                    while ! wget -q -T 5 -O /dev/null http://127.0.0.1:8080/drain 2>/dev/null; do
+                      sleep 5;
+                    done
           envFrom:
             - configMapRef:
                 name: "memex-portal-config"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -144,6 +144,14 @@ ollama:
 # swaps whatever else on the machine is already running them at its next restart.
 portal:
   image: "ghcr.io/systemorph/memex-portal-ai:latest"
+  # How long a rolled-out pod may keep serving the sessions it already has. The container's preStop
+  # drains the ingress (15s) and then waits on /drain until its last Blazor circuit closes, so this
+  # is the ceiling on "how long may someone keep working on the OLD build after a roll" — not a
+  # delay: a pod with no circuits exits in seconds. It also bounds how long a second silo lives
+  # alongside the new one, which matters because both hold their own set of compiled NodeType
+  # assemblies. 30 minutes covers a working session; lower it where memory is tighter than
+  # continuity.
+  drainSeconds: 1800
 migration:
   image: "ghcr.io/systemorph/memex-migration:latest"
 

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using MeshWeaver.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -136,6 +137,41 @@ public static class ServiceDefaults
         app.MapHealthChecks("/alive", new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
 
         app.MapVersionEndpoint();
+        app.MapDrainEndpoint();
+
+        return app;
+    }
+
+    /// <summary>
+    /// <c>/drain</c> — "may this pod stop without cutting anyone off?" Answers <b>200 drained</b>
+    /// when no Blazor circuit is live here, <b>503</b> with the count while sessions remain.
+    ///
+    /// <para>The container's <c>preStop</c> polls it, so a rollout stops SIGTERMing a pod that is
+    /// still serving people. Until now preStop was a flat <c>sleep 15</c> — enough to drain the
+    /// ingress upstream, nothing more — and fifteen seconds after the replacement went ready every
+    /// circuit on the old pod died mid-sentence, along with the grains they had activated
+    /// (<c>MessageHubGrain</c> is <c>[PreferLocalPlacement]</c>, so a circuit's hubs live on the pod
+    /// serving it). With a 6-hourly self-update poller, that arrived unannounced.</para>
+    ///
+    /// <para>It reports, it does not decide: the ceiling stays
+    /// <c>terminationGracePeriodSeconds</c>, so a pod with a forgotten open tab cannot block a
+    /// rollout forever. No session, no state, no auth — infrastructure, exactly like
+    /// <c>/health</c> and <c>/alive</c> beside it.</para>
+    /// </summary>
+    public static WebApplication MapDrainEndpoint(this WebApplication app)
+    {
+        app.MapGet("/drain", (IServiceProvider services) =>
+        {
+            // GetService, not GetRequired: a host without Blazor (a worker, a test host) has no
+            // tracker and is trivially drained — never a 500 that a preStop would read as "keep
+            // waiting" and then hard-kill at the grace ceiling anyway.
+            var tracker = services.GetService<ActiveCircuitTracker>();
+            var live = tracker?.Count ?? 0;
+            return live == 0
+                ? Results.Text("drained", "text/plain")
+                : Results.Text($"{live} circuit(s) still open", "text/plain",
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+        }).AllowAnonymous();
 
         return app;
     }

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -50,6 +50,11 @@ public static class BlazorHostingExtensions
                 .AddScoped<IMenuItemsProvider, MenuItemsProvider>()
                 .AddScoped<CircuitAccessHandler>()
                 .AddScoped<CircuitHandler>(sp => sp.GetRequiredService<CircuitAccessHandler>())
+                // The pod's "is anyone still working here" signal — see ActiveCircuitTracker. The
+                // TRACKER is a singleton (the shutdown decision is process-wide); the HANDLER is
+                // scoped, because Blazor resolves circuit handlers per circuit.
+                .AddSingleton<ActiveCircuitTracker>()
+                .AddScoped<CircuitHandler, CircuitDrainHandler>()
                 .AddMeshMcp()
             )
             .ConfigureHub(hub => hub.AddBlazor(clientConfig));

--- a/src/MeshWeaver.Hosting.Blazor/CircuitDrainHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitDrainHandler.cs
@@ -1,0 +1,27 @@
+using MeshWeaver.Hosting;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+
+namespace MeshWeaver.Hosting.Blazor;
+
+/// <summary>
+/// The <see cref="CircuitHandler"/> that feeds <see cref="ActiveCircuitTracker"/>. Deliberately
+/// separate from <c>CircuitAccessHandler</c>: that one carries per-circuit identity and is scoped to
+/// the circuit, while this one only ticks a process-wide counter. Keeping them apart means the
+/// shutdown signal cannot be broken by a change to identity handling, and vice versa.
+/// </summary>
+public sealed class CircuitDrainHandler(ActiveCircuitTracker tracker) : CircuitHandler
+{
+    /// <inheritdoc />
+    public override Task OnCircuitOpenedAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        tracker.Opened();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task OnCircuitClosedAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        tracker.Closed();
+        return Task.CompletedTask;
+    }
+}

--- a/src/MeshWeaver.Hosting/ActiveCircuitTracker.cs
+++ b/src/MeshWeaver.Hosting/ActiveCircuitTracker.cs
@@ -1,0 +1,54 @@
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Counts the LIVE Blazor circuits this process is serving — the signal a shutting-down pod uses
+/// to decide whether anyone is still working on it.
+///
+/// <para><b>Why this exists.</b> A rollout is surge-first (<c>maxUnavailable: 0</c>): the new pod
+/// serves before the old one is removed, so HTTP never breaks. What DOES break is every session on
+/// the old pod — k8s deletes it as soon as the replacement is ready, and the container's
+/// <c>preStop</c> was a flat <c>sleep 15</c>, which drains the ingress upstream and nothing else.
+/// Fifteen seconds later the silo goes down and every circuit on it dies mid-sentence. That is the
+/// "the demo just crashed" report, and with a 6-hourly self-update poller it arrives
+/// unannounced.</para>
+///
+/// <para>Grain placement is already on the right side of this: <c>MessageHubGrain</c> is
+/// <c>[PreferLocalPlacement]</c>, so a circuit's hubs activate on the pod serving that circuit. Keep
+/// the pod alive and its work keeps running; the only thing that kills it is the pod going away. So
+/// the drain question is exactly "does this pod still have circuits?" — this counter answers it, and
+/// <c>/drain</c> exposes the answer to the preStop hook.</para>
+///
+/// <para>Singleton and process-wide on purpose: circuits are scoped, the pod's shutdown decision is
+/// not. Interlocked, because circuit open/close arrive on many threads.</para>
+/// </summary>
+public sealed class ActiveCircuitTracker
+{
+    private int count;
+
+    /// <summary>Live circuits right now. Never negative.</summary>
+    public int Count => Volatile.Read(ref count);
+
+    /// <summary>True when no circuit is left — the pod is free to stop without cutting anyone off.</summary>
+    public bool Drained => Count == 0;
+
+    /// <summary>Records a circuit opening. Called by the Blazor circuit handler that feeds it.</summary>
+    public void Opened() => Interlocked.Increment(ref count);
+
+    /// <summary>
+    /// Records a circuit closing. Clamped at zero: a double-close (Blazor can report a circuit
+    /// closed after a connection-down that already ended it) must never push the count negative —
+    /// a negative count reads as "drained" forever after, which would hand back the very kill this
+    /// exists to prevent.
+    /// </summary>
+    public void Closed()
+    {
+        int observed, updated;
+        do
+        {
+            observed = Volatile.Read(ref count);
+            if (observed == 0) return;
+            updated = observed - 1;
+        }
+        while (Interlocked.CompareExchange(ref count, updated, observed) != observed);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/ActiveCircuitTrackerTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ActiveCircuitTrackerTest.cs
@@ -1,0 +1,85 @@
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// The pod's "may I stop?" counter. It decides whether a rolled-out pod waits for its users or cuts
+/// them off, so the two failure directions are not symmetric: over-counting delays a pod's exit
+/// (bounded by <c>terminationGracePeriodSeconds</c>), while UNDER-counting hands back the abrupt
+/// kill this exists to prevent.
+/// </summary>
+public class ActiveCircuitTrackerTest
+{
+    [Fact]
+    public void FreshTracker_IsDrained()
+    {
+        var tracker = new ActiveCircuitTracker();
+
+        tracker.Count.Should().Be(0);
+        tracker.Drained.Should().BeTrue("a pod nobody is connected to may stop immediately");
+    }
+
+    [Fact]
+    public void OpenAndClose_MoveTheCount()
+    {
+        var tracker = new ActiveCircuitTracker();
+
+        tracker.Opened();
+        tracker.Opened();
+        tracker.Count.Should().Be(2);
+        tracker.Drained.Should().BeFalse("two people are working here");
+
+        tracker.Closed();
+        tracker.Drained.Should().BeFalse("one is still working");
+
+        tracker.Closed();
+        tracker.Drained.Should().BeTrue("the last circuit closed — now it may stop");
+    }
+
+    /// <summary>
+    /// Blazor can report a circuit closed after a connection-down already ended it. Unclamped, the
+    /// second close would push the count to -1, and -1 != 0 reads as "still busy" — the pod would
+    /// then hang until the grace ceiling on EVERY roll. Worse in the other direction: a stray close
+    /// before an open would make a busy pod read as drained and stop on top of live sessions.
+    /// </summary>
+    [Fact]
+    public void DoubleClose_CannotDriveTheCountNegative()
+    {
+        var tracker = new ActiveCircuitTracker();
+
+        tracker.Opened();
+        tracker.Closed();
+        tracker.Closed();
+        tracker.Closed();
+
+        tracker.Count.Should().Be(0);
+        tracker.Drained.Should().BeTrue();
+
+        // …and the counter still works afterwards: a clamp that leaked would make the NEXT circuit
+        // invisible, so the pod would stop while someone was on it.
+        tracker.Opened();
+        tracker.Drained.Should().BeFalse("a new circuit after a double-close still counts");
+    }
+
+    /// <summary>Circuits open and close on many threads; the count is the shutdown decision.</summary>
+    [Fact]
+    public void ConcurrentOpensAndCloses_SettleExactly()
+    {
+        var tracker = new ActiveCircuitTracker();
+        const int perThread = 1_000;
+
+        Parallel.For(0, 8, _ =>
+        {
+            for (var i = 0; i < perThread; i++) tracker.Opened();
+        });
+        tracker.Count.Should().Be(8 * perThread);
+
+        Parallel.For(0, 8, _ =>
+        {
+            for (var i = 0; i < perThread; i++) tracker.Closed();
+        });
+        tracker.Count.Should().Be(0, "every open was matched — no lost update in either direction");
+        tracker.Drained.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
First step of #1340.

## The kill

A rollout is surge-first (`maxUnavailable: 0`), so HTTP never breaks. But the moment the new pod goes ready, k8s deletes the old one — and `preStop` was a flat `sleep 15`. That sleep drains the **ingress upstream** and nothing else: fifteen seconds later the host shuts down and every Blazor circuit still open on that pod dies mid-sentence, taking its grains with it. With a 6-hourly self-update poller, it arrives unannounced. That is the "the demo just crashed" report.

## What was already right

`MessageHubGrain` is `[PreferLocalPlacement]`, so a circuit's hubs activate **on the pod serving that circuit**. Keep the pod alive and its work keeps running against the code it activated with. The missing piece was never placement — it was that nothing could answer the shutdown question, *"is anyone still working here?"*

## The change

| | |
|---|---|
| `ActiveCircuitTracker` | counts live circuits. Lives in `MeshWeaver.Hosting` — a plain counter, so the ServiceDefaults endpoint reads it without depending on the Blazor hosting assembly |
| `CircuitDrainHandler` | feeds it. Deliberately separate from `CircuitAccessHandler`, so the shutdown signal can't break when identity handling changes |
| `/drain` | `200 drained` / `503 <n> circuit(s) still open`, beside `/health` and `/alive` |
| `preStop` | two stages: 15s for the ingress upstream (unchanged — a different problem), then poll `/drain` until the last circuit closes |
| `portal.drainSeconds` (default **1800**) | the ceiling on how long someone may keep working on the OLD build |

A forgotten tab delays one pod's exit; it can never block a rollout, because k8s SIGKILLs at the ceiling. The ceiling is a **value**, not a constant, because it also bounds how long two silos hold two sets of compiled NodeType assemblies — and there is a known retained-assembly leak in core, so that window has a cost.

## The clamp is load-bearing

Blazor can report a circuit closed after a connection-down already ended it. Unclamped, the second close drives the count to −1, and −1 ≠ 0 reads as *"still busy"* — every roll would then hang to the ceiling. In the other direction a stray close would make a busy pod read as drained and stop on top of live sessions. `ActiveCircuitTrackerTest` pins both, plus the concurrent case (8×1000 opens/closes settling exactly).

## Scope

This removes the abrupt kill **within one Deployment**. It does not give #1340's full model — old silo alive until an explicit recycle, new activations placed on the new build — which needs the blue/green half and the three prerequisites listed there (expand/contract migrations, grain-state round-tripping, memory during the overlap).

Verified: `helm template` renders `terminationGracePeriodSeconds: 1800` and the two-stage `preStop`; `ActiveCircuitTrackerTest` 4/4; `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Blazor`, `Memex.Portal.ServiceDefaults` and `Memex.Portal.Distributed` all build `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)