### PR TITLE
fix(portal): outbound-email watch query must not filter on the omitted default status

### DIFF
--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -30,6 +30,19 @@ public sealed class OutboundEmailSender(
     EmailOptions options,
     ILogger<OutboundEmailSender>? logger = null) : IHostedService, IDisposable
 {
+    /// <summary>
+    /// The live watch query. 🚨 It must NOT filter <c>content.status:New</c>: <see cref="EmailStatus.New"/>
+    /// is the enum DEFAULT (0) and the serializer OMITS it from the stored JSON, so that filter never
+    /// matches a freshly queued email — the exact trap <see cref="InvitationEmailSender"/> documents for
+    /// <c>content.status:Pending</c>, and the reason the Store contact form's notification sat queued
+    /// forever on memex (2026-08-12: the query with the status clause returned 0 rows, without it 1).
+    /// Status is filtered IN CODE by <c>Send</c> (a read fills the omitted default back in), and the
+    /// New → Sending claim guards double-send. <c>content.direction:Outbound</c> IS safe: Outbound is
+    /// not the default, so it always serializes — see <c>OutboundEmailWatchQueryTest</c>.
+    /// </summary>
+    public const string WatchQuery =
+        $"nodeType:{EmailNodeType.NodeType} content.direction:Outbound";
+
     private readonly CompositeDisposable subscriptions = new();
     private IServiceScope? scope;
 
@@ -65,10 +78,10 @@ public sealed class OutboundEmailSender(
             var emailSender = sp.GetRequiredService<IEmailSender>();
             var jsonOptions = hub.JsonSerializerOptions;
 
-            // Live query: any outbound mail awaiting send. Emits the current set on change.
+            // Live query: any outbound mail. Emits the current set on change; Send filters to
+            // New and claims (New → Sending) before dispatching, so already-sent nodes are no-ops.
             subscriptions.Add(query
-                .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                    $"nodeType:{EmailNodeType.NodeType} content.direction:Outbound content.status:New"), jsonOptions)
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(WatchQuery), jsonOptions)
                 .Select(change => change.Items)
                 .Subscribe(
                     items =>

--- a/test/Memex.Portal.Shared.Test/OutboundEmailWatchQueryTest.cs
+++ b/test/Memex.Portal.Shared.Test/OutboundEmailWatchQueryTest.cs
@@ -1,0 +1,40 @@
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the shape of <see cref="OutboundEmailSender.WatchQuery"/> against the omitted-default
+/// serialization trap that stranded the Store contact form's notification email on memex
+/// (2026-08-12): <see cref="EmailStatus.New"/> is the enum default, the serializer omits default
+/// values from stored JSON, so a query filtering <c>content.status:New</c> matches NOTHING that is
+/// actually new — proven live (the status-filtered query returned 0 rows while the unfiltered one
+/// returned the queued email). <see cref="InvitationEmailSender"/> documents the identical rule
+/// for <c>content.status:Pending</c>; this test makes the rule enforceable rather than a comment.
+/// </summary>
+public class OutboundEmailWatchQueryTest
+{
+    [Fact]
+    public void WatchQuery_MustNotFilterOnStatus_TheDefaultIsOmittedFromStoredJson()
+    {
+        Assert.DoesNotContain("status", OutboundEmailSender.WatchQuery);
+        Assert.Contains("content.direction:Outbound", OutboundEmailSender.WatchQuery);
+        Assert.Contains($"nodeType:{EmailNodeType.NodeType}", OutboundEmailSender.WatchQuery);
+    }
+
+    /// <summary>
+    /// The reasoning the query shape rests on, pinned so an enum reorder cannot silently
+    /// invalidate it: <c>New</c> IS the omittable default (which is why the query must not filter
+    /// on status), and <c>Outbound</c> is NOT the direction default (which is why filtering on
+    /// direction is safe — a queued outbound email always serializes it). If either assertion
+    /// fails, the watch query above has to be rethought, not just this test.
+    /// </summary>
+    [Fact]
+    public void TheDefaults_AreWhatTheQueryShapeAssumes()
+    {
+        Assert.Equal(EmailStatus.New, default(EmailStatus));
+        Assert.NotEqual(EmailDirection.Outbound, default(EmailDirection));
+    }
+}


### PR DESCRIPTION
## What

`OutboundEmailSender`'s live query drops `content.status:New` — `EmailStatus.New` is the enum default, the serializer omits defaults from stored JSON, so the filter matched nothing that was actually new. Status is filtered in code by `Send` (which also does the New → Sending claim), exactly as `InvitationEmailSender` already documents and does for the identical `content.status:Pending` trap. The query keeps `content.direction:Outbound` — Outbound is not the direction default, so it always serializes.

## Why

The Store contact form's notification email sat queued forever on memex (2026-08-12): the enquiry recorded, the email node landed at `Sales/…/_Email/mail-0`, and the sender never saw it. Proven live over MCP: `nodeType:Email content.direction:Outbound content.status:New` → 0 rows; drop the status clause → 1 row (the queued email).

## How tested

`OutboundEmailWatchQueryTest` pins the query shape (no status reference) AND the enum defaults it rests on (`New` is the omittable status default, `Outbound` is not the direction default — an enum reorder fails the test instead of silently breaking the watch). Full `Memex.Portal.Shared.Test`: 301 passed. Release build with `-p:CIRun=true -warnaserror`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)