### PR TITLE
fix: a repository's green build now updates EVERY space that follows it (#1326)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-repository-update-now-reaches-every-space-not-most-of-them.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-repository-update-now-reaches-every-space-not-most-of-them.md
@@ -1,0 +1,34 @@
+---
+Name: A repository update now reaches every space, not most of them
+Category: Fix
+Description: When a repository built successfully, some spaces were quietly left on old content — always the same ones, and the more they fell behind the less likely they were to catch up. Every matching space is now updated, and any that is skipped says so by name.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A repository update now reaches every space, not most of them
+
+Spaces that follow a repository refresh themselves whenever that repository builds successfully.
+Most of them did. Some never did — and the ones that never did were always the same ones.
+
+The refresh starts by asking a simple question: which spaces follow this repository? That question
+was being answered the way a *search box* answers — with a first page of results, the most recently
+changed ones, capped at fifty. For a search that is exactly right. For "go through all of them" it
+is quietly wrong, and nothing in the answer says it was only a page.
+
+What made it stick was the ordering. Refreshing a space marks it as recently changed, so every
+space that *did* refresh moved to the front of the queue, and the ones that missed out drifted
+further towards the back. A space that fell off the end could never get back on: it simply stopped
+following the repository, while every build reported success. On one installation nine spaces out
+of forty-three had been sitting on stale content for up to a week that way — including course
+material with fixes their readers never saw.
+
+A read that needs *everything* can now say so, and this one does. The same mistake had already cost
+us once elsewhere — a build pass that saw fifty source files out of thousands — so the platform now
+also warns whenever it hands back a capped page to a caller that never asked for one, naming the
+query, rather than letting it pass for the whole set.
+
+The refresh has also learnt to account for itself. It now reports how many spaces follow the
+repository, how many it updated, and for each one it passed over, which one and why — "on a
+different branch", "already on this commit". A space that is being skipped is now something you can
+read in the log instead of something you have to notice.

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -253,15 +253,10 @@ public sealed class GitHubWebhookProcessor
     /// <paramref name="headSha"/>: the branch must match, the source must be allowed to import, and
     /// the source must not already sit on that commit.
     /// </summary>
+    /// <remarks>Expressed as "there is no reason to skip it" so the predicate and the log line
+    /// (<see cref="SkipReason"/>) can never disagree about why a Space was left behind.</remarks>
     internal static bool ConfigMatchesBuild(GitHubSyncConfig? cfg, string branch, string headSha)
-    {
-        if (cfg is null || cfg.Direction == SyncDirection.ExportOnly)
-            return false;
-        if (!string.Equals(cfg.Branch, branch, StringComparison.OrdinalIgnoreCase))
-            return false;
-        // Already imported this exact commit — a re-run of the same green build must be a no-op.
-        return !string.Equals(cfg.LastSyncCommitSha, headSha, StringComparison.OrdinalIgnoreCase);
-    }
+        => SkipReason(cfg, branch, headSha) is null;
 
     /// <summary>The distinct sync sources whose config targets <paramref name="repoUrl"/> AND
     /// matches the green build's branch, minus those already at <paramref name="headSha"/>.</summary>
@@ -270,16 +265,59 @@ public sealed class GitHubWebhookProcessor
     {
         var target = ParseSafe(repoUrl);
         return QueryConfigNodesAsSystem()
-            .Select(c => (IReadOnlyList<PushTarget>)c.Items
-                .Where(n => RepoMatches(n, target))
-                .Where(n => ConfigMatchesBuild(
-                    n.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger), branch, headSha))
-                .Select(ToPushTarget)
-                .Where(t => t is not null)
-                .Select(t => t!)
-                .DistinctBy(t => (t.SpacePath, t.SourceId))
-                .ToList());
+            .Select(c =>
+            {
+                // 🚨 Classify EVERY candidate and say what happened to it. A fan-out that reports
+                // only its winners cannot be audited: "updated 34" and "updated 34 of 43" look
+                // identical in the log, which is how #1326 stayed invisible for days. One line per
+                // skipped config, naming the reason, is what makes a future omission findable.
+                var picked = new List<PushTarget>();
+                var skipped = new List<string>();
+                foreach (var node in c.Items)
+                {
+                    if (!RepoMatches(node, target))
+                        continue;   // a different repo entirely — not this build's business
+                    var cfg = node.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger);
+                    if (SkipReason(cfg, branch, headSha) is { } reason)
+                    {
+                        skipped.Add($"{node.Path} ({reason})");
+                        continue;
+                    }
+                    if (ToPushTarget(node) is not { } pushTarget)
+                    {
+                        skipped.Add($"{node.Path} (path carries no '{GitHubSyncService.ConfigId}' segment)");
+                        continue;
+                    }
+                    picked.Add(pushTarget);
+                }
+
+                var targets = (IReadOnlyList<PushTarget>)picked
+                    .DistinctBy(t => (t.SpacePath, t.SourceId))
+                    .ToList();
+
+                logger?.LogInformation(
+                    "Green build of {Repo}@{Branch} ({Sha}): {Candidates} sync config(s) in the mesh, "
+                    + "{Selected} selected, {Skipped} skipped{SkipDetail}.",
+                    repoUrl, branch, headSha, c.Items.Count, targets.Count, skipped.Count,
+                    skipped.Count == 0 ? string.Empty : " — " + string.Join("; ", skipped));
+
+                return targets;
+            });
     }
+
+    /// <summary>
+    /// Why a config that DOES target this repo is not being updated, or <c>null</c> when it is.
+    /// The reason strings are log copy — a skipped Space must be traceable to the exact predicate
+    /// that dropped it, never inferred from its absence.
+    /// </summary>
+    private static string? SkipReason(GitHubSyncConfig? cfg, string branch, string headSha)
+        => cfg is null ? "config content could not be read"
+            : cfg.Direction == SyncDirection.ExportOnly ? "direction is ExportOnly"
+            : !string.Equals(cfg.Branch, branch, StringComparison.OrdinalIgnoreCase)
+                ? $"branch '{cfg.Branch}' != built branch '{branch}'"
+            : string.Equals(cfg.LastSyncCommitSha, headSha, StringComparison.OrdinalIgnoreCase)
+                ? "already at this commit"
+            : null;
 
     /// <summary>Maps a config node path (<c>{space}/_GitSync</c> or <c>{space}/_GitSync/{sourceId}</c>)
     /// to the Space + source id it configures.</summary>
@@ -304,13 +342,35 @@ public sealed class GitHubWebhookProcessor
     /// silently matches nothing on an access-gated portal (the DevLogin test fallback masked
     /// exactly this). Same identity model as the write path below.
     /// </summary>
+    /// <remarks>
+    /// 🚨 TWO silent-drop guards, both of which this read shipped without and both of which cost
+    /// spaces their updates (#1326: 9 of 43 permanently stale while every webhook reported success).
+    ///
+    /// <para><b>Complete(), not a page.</b> The query carries no <c>path:</c> and no
+    /// <c>namespace:</c>, so on Postgres it is the UNPINNED shape served by the cross-schema
+    /// fan-out — which answers a request that states no limit with the 50 most recently modified
+    /// rows. This is a fan-out over EVERY configured sync source: a config that falls out of that
+    /// window is not "missing from a list", it is a Space that never syncs again. Worse, it is
+    /// self-reinforcing — a successful sync rewrites the config node (<c>RecordSeenCommit</c>), so
+    /// the spaces that DID update stay in the window and the stragglers sink further out of it,
+    /// which is exactly the "the same 9 every time, each a different number of commits behind"
+    /// signature. Same defect as #1216 one caller over.</para>
+    ///
+    /// <para><b>Initial, not just the first emission.</b> A bare <c>Take(1)</c> can capture a
+    /// pre-Initial emission and export the fan-out as an EMPTY candidate set — observed on a live
+    /// instance and already guarded this way in <c>GitHubSyncService</c>. Filtering on
+    /// <see cref="QueryChangeType.Initial"/> waits for the snapshot the fan-out is asking for.</para>
+    /// </remarks>
     private IObservable<QueryResultChange<MeshNode>> QueryConfigNodesAsSystem()
     {
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         return Observable.Using(
             () => accessService.ImpersonateAsSystem(),
             _ => meshService
-                .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
+                .Query<MeshNode>(MeshQueryRequest
+                    .FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}")
+                    .Complete())
+                .Where(c => c.ChangeType == QueryChangeType.Initial)
                 .Take(1));
     }
 

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
@@ -117,10 +117,12 @@ public class CosmosMeshQuery : IMeshQueryProvider
 
         var parsedQuery = _parser.Parse(request.Query);
 
-        // Override limit from request if provided
+        // Override limit from request if provided. A NON-POSITIVE request limit is the framework's
+        // "return every match" encoding (MeshQueryRequest.NoLimit) — it must clear the in-query
+        // limit rather than become a `TOP -1` (invalid) or a `count >= -1` early return (one row).
         if (request.Limit.HasValue)
         {
-            parsedQuery = parsedQuery with { Limit = request.Limit };
+            parsedQuery = parsedQuery with { Limit = request.Limit is > 0 ? request.Limit : null };
         }
 
         // Strip $type filters — all items in the nodes container are MeshNodes,

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -376,6 +376,16 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         };
         var clippedByDefault = query.Limit is null;
 
+        // 🚨 Fetch ONE row past the default so the warning below can state truncation as a FACT.
+        // "rows == the limit" does not mean rows were dropped — a query with exactly
+        // DefaultFanOutLimit matches is complete — and a warning that cries truncation on a
+        // complete result trains readers to ignore it, which is how the next real one gets missed.
+        // The probe row is read but never yielded, so the caller's result is unchanged; the cost is
+        // one row on a query that already scanned every partition schema. Only for the default
+        // clip: a stated limit is the caller's own paging (no claim to make) and NoLimit is already
+        // int.MaxValue (where +1 would overflow).
+        var fetchLimit = clippedByDefault ? limit + 1 : limit;
+
         _logger?.LogInformation(
             "[CrossSchema] search_across_schemas(where='{Where}', user='{User}', order='{Order}', limit={Limit})",
             filterClause, userId, orderBy, limit);
@@ -389,7 +399,7 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         cmd.Parameters.Add(new NpgsqlParameter("@p_where", string.IsNullOrEmpty(filterClause) ? "" : filterClause));
         cmd.Parameters.Add(new NpgsqlParameter("@p_user", (object?)userId ?? DBNull.Value));
         cmd.Parameters.Add(new NpgsqlParameter("@p_order", orderBy));
-        cmd.Parameters.Add(new NpgsqlParameter("@p_limit", limit));
+        cmd.Parameters.Add(new NpgsqlParameter("@p_limit", fetchLimit));
 
         // ⏱️ TIMED, because this is the expensive shape and nothing used to measure it.
         // search_across_schemas builds a UNION ALL over EVERY row of public.searchable_schemas,
@@ -402,6 +412,8 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var rows = 0;
         var firstRowMs = -1L;
+        // Set only when the probe row exists — i.e. matches were genuinely dropped.
+        var truncated = false;
         await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
         // 🚨 try/FINALLY, not a call after the loop. A caller that stops enumerating early — a
         // `.Take(n)`, a `break`, a cancellation, or a throw out of ReadMeshNode — disposes the
@@ -412,6 +424,12 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         {
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
             {
+                // The probe row proves there was more, and is NOT part of the answer.
+                if (rows == limit)
+                {
+                    truncated = true;
+                    break;
+                }
                 if (rows++ == 0)
                     firstRowMs = sw.ElapsedMilliseconds;
                 yield return ReadMeshNode(reader, options);
@@ -429,13 +447,17 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             // the window and the stragglers sink further. #1216 (batch bake saw 50 of thousands of
             // Code nodes) and #1326 (9 of 43 Spaces never re-synced while the webhook reported
             // success) are the same line of code seen twice. Say so, and name the cure.
-            if (clippedByDefault && rows >= DefaultFanOutLimit)
+            //
+            // `truncated` is a FACT, not an inference from the row count: it is set only when a row
+            // beyond the limit actually existed. A query with exactly DefaultFanOutLimit matches is
+            // complete and stays silent.
+            if (truncated)
                 _logger?.LogWarning(
-                    "[CrossSchema] TRUNCATED at the default fan-out limit of {Limit} rows "
-                    + "(where='{Where}', order='{Order}'). The caller stated no limit, so this result "
-                    + "is a PAGE — the most recently modified matches — not the complete set, and "
-                    + "there is no way for it to tell. If the caller enumerates the result as the "
-                    + "whole set, it must say MeshQueryRequest.Complete().",
+                    "[CrossSchema] TRUNCATED at the default fan-out limit of {Limit} rows — matches "
+                    + "beyond it were DROPPED (where='{Where}', order='{Order}'). The caller stated no "
+                    + "limit, so this result is a PAGE — the most recently modified matches — not the "
+                    + "complete set, and there is no way for it to tell. If the caller enumerates the "
+                    + "result as the whole set, it must say MeshQueryRequest.Complete().",
                     DefaultFanOutLimit, filterClause, orderBy);
         }
     }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -361,7 +361,20 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             ? $"{PostgreSqlSqlGenerator.MapSelector(query.OrderBy.Property)} {(query.OrderBy.Descending ? "DESC" : "ASC")}"
             : "n.last_modified DESC";
 
-        var limit = query.Limit ?? 50;
+        // 🚨 THREE cases, and conflating the last two is how spaces go silently stale.
+        //   • no limit stated  → DefaultFanOutLimit. An unanchored UNION over every partition
+        //     schema needs SOME bound, and a search wants a page anyway.
+        //   • MeshQueryRequest.NoLimit (non-positive) → the caller declared this an ENUMERATION,
+        //     so return every match. `LIMIT 0` / `LIMIT -1` must never reach SQL; the largest INT
+        //     is `LIMIT ALL` in practice and needs no change to the stored function.
+        //   • a positive limit → honour it.
+        var limit = query.Limit switch
+        {
+            null => DefaultFanOutLimit,
+            <= 0 => int.MaxValue,
+            var stated => stated.Value,
+        };
+        var clippedByDefault = query.Limit is null;
 
         _logger?.LogInformation(
             "[CrossSchema] search_across_schemas(where='{Where}', user='{User}', order='{Order}', limit={Limit})",
@@ -407,8 +420,32 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         finally
         {
             LogFanOutTiming("search_across_schemas", sw.ElapsedMilliseconds, firstRowMs, rows, limit);
+
+            // 🚨 A DEFAULT that clipped must never be silent. The caller stated no limit, so it
+            // cannot distinguish "these are all the matches" from "these are the 50 most recently
+            // modified matches" — and because the order is `last_modified DESC`, the rows that fall
+            // off are precisely the ones that have gone longest without being touched. That makes
+            // the omission self-reinforcing: processing a row refreshes it, so the winners stay in
+            // the window and the stragglers sink further. #1216 (batch bake saw 50 of thousands of
+            // Code nodes) and #1326 (9 of 43 Spaces never re-synced while the webhook reported
+            // success) are the same line of code seen twice. Say so, and name the cure.
+            if (clippedByDefault && rows >= DefaultFanOutLimit)
+                _logger?.LogWarning(
+                    "[CrossSchema] TRUNCATED at the default fan-out limit of {Limit} rows "
+                    + "(where='{Where}', order='{Order}'). The caller stated no limit, so this result "
+                    + "is a PAGE — the most recently modified matches — not the complete set, and "
+                    + "there is no way for it to tell. If the caller enumerates the result as the "
+                    + "whole set, it must say MeshQueryRequest.Complete().",
+                    DefaultFanOutLimit, filterClause, orderBy);
         }
     }
+
+    /// <summary>
+    /// Rows returned to a cross-schema query that states NO limit. A page size for a search, never
+    /// a completeness guarantee — see the truncation warning in
+    /// <c>QueryAcrossSchemasAsync</c> and <c>MeshQueryRequest.Complete()</c>.
+    /// </summary>
+    internal const int DefaultFanOutLimit = 50;
 
     /// <summary>Elapsed above which a cross-schema fan-out is logged as a Warning, not Debug.</summary>
     internal const long SlowFanOutMs = 1000;

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -452,7 +452,10 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
         // explicit `limit:N`. Smaller wins so a request-level cap can't be
         // bypassed by a higher in-query limit, and an explicit in-query limit
         // still applies when no request cap is set.
-        var effectiveLimit = MinLimit(request.Limit, firstParsed.Limit);
+        // Non-positive means "no clip" (MeshQueryRequest.NoLimit) — NOT "stop after zero rows".
+        // Folded away here so the row loop below only ever sees a real cap; without it a
+        // Complete() request returned exactly one row (`count >= -1` is true immediately).
+        var effectiveLimit = MinLimit(Positive(request.Limit), Positive(firstParsed.Limit));
         var effectiveUserId = GetEffectiveUserId(request);
         await foreach (var node in _adapter.QueryNodesAsync(
             parsedList, options, effectiveUserId, activityUserId: activityUserId,
@@ -481,6 +484,14 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
             (var v, null) => v,
             ({ } x, { } y) => Math.Min(x, y)
         };
+
+    /// <summary>
+    /// A stated limit only counts when it is a real cap. Non-positive is the framework's "return
+    /// every match" encoding (<see cref="MeshQueryRequest.NoLimit"/>), which is the SAME thing as
+    /// "no limit stated" for a row-count guard — collapsing them here keeps every downstream
+    /// comparison honest.
+    /// </summary>
+    private static int? Positive(int? limit) => limit is > 0 ? limit : null;
 
     /// <summary>
     /// Native reactive autocomplete. The PG execute-query (<c>_adapter.QueryNodesAsync</c> — the

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -883,13 +883,16 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
         // this shape and resolved 50 Code nodes out of thousands). A request that states no limit at
         // all still gets the fan-out's default: an unanchored UNION over every partition schema
         // needs SOME bound, and changing that default is a separate decision.
-        // 🚨 POSITIVE limits only. `Limit <= 0` means "do not clip" upstream —
-        // MeshQuery.ClipMergedInitial applies a limit only `if (effectiveLimit is int limit &&
-        // limit > 0)` — but propagated into SQL a zero becomes a literal `LIMIT 0`, i.e. ZERO ROWS
-        // returned for a caller that asked for everything. That is the same silent-empty-result
-        // failure this very PR exists to fix (#1216: discovery that cannot see rows reports the
-        // content as missing), so it must not be re-introduced one layer down.
-        if (request.Limit is > 0)
+        // 🚨 Propagate the request limit WHATEVER its sign, including the non-positive "no clip"
+        // encoding (MeshQueryRequest.NoLimit). It used to be dropped for `<= 0` because a zero
+        // reached SQL as a literal `LIMIT 0` — ZERO ROWS for a caller that asked for everything —
+        // but silently substituting the fan-out's default of 50 instead is the bug in the other
+        // direction, and the one that shipped: #1326 left 9 of 43 Spaces permanently stale because
+        // the webhook's `nodeType:GitHubSyncConfig` fan-out got a page it could not distinguish
+        // from the whole set. The translation now happens where the SQL is written —
+        // PostgreSqlSqlGenerator emits no LIMIT clause and PostgreSqlCrossSchemaQueryProvider
+        // passes int.MaxValue — so neither `LIMIT 0` nor `LIMIT -1` can be produced here.
+        if (request.Limit is not null)
             queryForSql = queryForSql with { Limit = request.Limit };
 
         var userId = GetEffectiveUserId(request);

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
@@ -338,7 +338,11 @@ public class PostgreSqlSqlGenerator
                 "ELSE 0 END) DESC, n.last_modified DESC NULLS LAST");
         }
 
-        if (query.Limit.HasValue)
+        // 🚨 POSITIVE limits only. A non-positive limit is the framework's "no clip" encoding
+        // (MeshQueryRequest.NoLimit; MeshQuery.ClipMergedInitial only clips when limit > 0) — emit
+        // NO LIMIT clause for it. `LIMIT -1` is a syntax error and `LIMIT 0` returns nothing, and
+        // both would surface as an empty result for a caller that asked for everything.
+        if (query.Limit is > 0)
             sql.Append($" LIMIT {query.Limit.Value}");
 
         return (sql.ToString(), parameters);
@@ -721,7 +725,8 @@ public class PostgreSqlSqlGenerator
                 "ELSE 0 END) DESC, last_modified DESC NULLS LAST";
         }
 
-        if (query.Limit.HasValue)
+        // Positive limits only — see the sibling overload above.
+        if (query.Limit is > 0)
             sql += $" LIMIT {query.Limit.Value}";
 
         return (sql, parameters);

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -424,7 +424,11 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
         // parsedQuery.Limit is the per-query limit:N hint and is still honoured
         // separately if no request-level limit was set.
         var skip = request.Skip ?? 0;
-        int? limit = request.Limit ?? parsedQuery.Limit;
+        // Non-positive is "no clip" (MeshQueryRequest.NoLimit), i.e. no load cap either — never a
+        // cap of `skip - 1`, which downstream would read as "load almost nothing".
+        int? limit = request.Limit is > 0 ? request.Limit
+            : request.Limit is null && parsedQuery.Limit is > 0 ? parsedQuery.Limit
+            : null;
         return limit is int l ? skip + l : null;
     }
 

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
@@ -185,8 +185,37 @@ public record MeshQueryRequest
 
     /// <summary>
     /// Maximum number of results to return (takes precedence over limit in query string).
+    ///
+    /// <para>🚨 <b>Leaving this unset does NOT mean "everything".</b> An UNPINNED query (no
+    /// <c>path:</c>, no <c>namespace:</c>) is served on Postgres by the cross-schema fan-out, which
+    /// answers a request that states no limit with a PAGE — the most recently modified rows, capped
+    /// at a default — and the caller cannot tell a page from the whole set. Say
+    /// <see cref="Complete"/> when the read is an ENUMERATION rather than a search.</para>
     /// </summary>
     public int? Limit { get; init; }
+
+    /// <summary>
+    /// The <see cref="Limit"/> value that means "no clip — return every match". Non-positive, which
+    /// is what the merge layer has always treated as unbounded; the storage providers translate it
+    /// to an unbounded SQL fetch rather than a literal <c>LIMIT -1</c>.
+    /// </summary>
+    public const int NoLimit = -1;
+
+    /// <summary>
+    /// Declares this read an ENUMERATION, not a page: every match must come back, because the
+    /// caller iterates the result as the complete set.
+    ///
+    /// <para>🚨 Use it wherever a MISSING row silently changes behaviour rather than merely
+    /// shortening a list — a fan-out over every configured sync source, a bake over every NodeType,
+    /// a reconciliation. Both production incidents in this family had the same shape: the query
+    /// stated no limit, the cross-schema fan-out substituted its default and ordered by
+    /// <c>last_modified DESC</c>, and the rows that fell off the end were exactly the ones that had
+    /// gone longest without being processed — so the omission was self-reinforcing and invisible.
+    /// #1216 baked 237 NodeTypes against 50 Code nodes; #1326 left 9 of 43 Spaces permanently stale
+    /// while the webhook reported success.</para>
+    /// </summary>
+    /// <returns>A copy of this request that must not be truncated.</returns>
+    public MeshQueryRequest Complete() => this with { Limit = NoLimit };
 
     /// <summary>
     /// Context for visibility filtering. When set, nodes with this context

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CompleteEnumerationFanOutTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CompleteEnumerationFanOutTests.cs
@@ -1,0 +1,128 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 AN UNPINNED CROSS-SCHEMA QUERY ANSWERS WITH A PAGE, AND THE CALLER CANNOT TELL.
+///
+/// <para><c>PostgreSqlCrossSchemaQueryProvider</c> serves every query that carries no
+/// <c>path:</c> and no <c>namespace:</c> by UNION-ing every partition schema, ordering by
+/// <c>last_modified DESC</c> and clipping at a default row count. That is right for a search and
+/// catastrophic for an ENUMERATION — and the two are the same call, so the mistake is invisible at
+/// the call site and invisible in the result.</para>
+///
+/// <para><b>Twice in production.</b> #1216: the batch bake's global <c>nodeType:Code</c> fetch
+/// resolved 50 Code nodes for 237 pending types, and 169 types compiled against nothing. #1326: the
+/// GitHub webhook's <c>nodeType:GitHubSyncConfig</c> fan-out saw 50 of the mesh's configs, so 9 of
+/// 43 Spaces never re-synced while every delivery reported success. Both are self-reinforcing:
+/// processing a row rewrites it, which refreshes <c>last_modified</c>, which keeps the rows that
+/// DID get processed inside the window and pushes the stragglers further out — so the same
+/// handful stays stale forever and the set never heals.</para>
+///
+/// <para>This pins the cure: <see cref="MeshQueryRequest.NoLimit"/> (what
+/// <c>MeshQueryRequest.Complete()</c> sets) means EVERY match, a stated positive limit means that
+/// many, and only a caller that states nothing gets the page. The 50-row page is asserted too — it
+/// is the behaviour the enumeration callers have to opt out of, so it must not drift silently.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class CompleteEnumerationFanOutTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+    private readonly JsonSerializerOptions _options = new();
+
+    /// <summary>
+    /// Rows per partition. Two partitions ⇒ 66, comfortably above
+    /// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> — at or below it the test
+    /// reproduces nothing.
+    /// </summary>
+    private const int RowsPerPartition = 33;
+
+    private const int TotalRows = 2 * RowsPerPartition;
+
+    /// <summary>The two seeded partitions. The stored-procedure fan-out resolves its own schema
+    /// list from <c>public.searchable_schemas</c>; the parameter is part of the shared signature.
+    /// </summary>
+    private static readonly string[] Schemas = ["alpha", "beta"];
+
+    /// <summary>A node type nothing else in the fixture writes, so the fan-out's result set is
+    /// exactly what this test seeded.</summary>
+    private const string ProbeNodeType = "FanOutEnumerationProbe";
+
+    [Fact(Timeout = 120000)]
+    public async Task UnpinnedFanOut_PagesByDefault_ButReturnsEveryMatchWhenTheCallerDeclaresCompleteness()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        var partitionDef = new PartitionDefinition
+        {
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+
+        await SeedAsync("alpha", "Alpha", partitionDef, ct);
+        await SeedAsync("beta", "Beta", partitionDef, ct);
+
+        var cross = new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource)
+        {
+            SyncTtl = System.TimeSpan.Zero
+        };
+        await cross.SyncSearchableSchemasAsync(ct);
+
+        var parser = new QueryParser();
+        var parsed = parser.Parse($"nodeType:{ProbeNodeType}");
+
+        // 1. No limit stated → a PAGE. Documented, not accidental: an unanchored UNION over every
+        //    partition schema needs a bound, and a search wants one anyway.
+        var page = await cross.QueryAcrossSchemasAsync(parsed, _options, Schemas, ct: ct).Collect(ct)
+            .Should().Within(60.Seconds()).Emit();
+        output.WriteLine($"default page: {page.Count} of {TotalRows}");
+        page.Count.Should().Be(PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit,
+            "a query that states no limit is served the default page — which is precisely why an "
+            + "enumeration must say Complete() rather than trust the absence of a limit");
+
+        // 2. Complete() → EVERY match. This is the assertion that fails before the fix: NoLimit is
+        //    non-positive, and the provider used to fold every non-positive value into `?? 50`
+        //    (after PostgreSqlPartitionedMeshQuery had already refused to propagate it at all).
+        var complete = await cross
+            .QueryAcrossSchemasAsync(parsed with { Limit = MeshQueryRequest.NoLimit }, _options, Schemas, ct: ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        output.WriteLine($"complete: {complete.Count} of {TotalRows}");
+        complete.Count.Should().Be(TotalRows,
+            "MeshQueryRequest.NoLimit declares the read an enumeration — every match must come back, "
+            + "or a fan-out over sync sources silently stops updating the Spaces that sank out of "
+            + "the last_modified window (#1326)");
+        complete.Select(n => n.Path).Distinct().Count().Should().Be(TotalRows,
+            "the complete set must be the union of both partitions, not one partition twice");
+
+        // 3. A stated POSITIVE limit is still honoured — Complete() must not have turned the
+        //    limit into a no-op for everyone else.
+        var ten = await cross
+            .QueryAcrossSchemasAsync(parsed with { Limit = 10 }, _options, Schemas, ct: ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        ten.Count.Should().Be(10, "an explicit positive limit still clips");
+    }
+
+    private async Task SeedAsync(
+        string schema, string ns, PartitionDefinition partitionDef, System.Threading.CancellationToken ct)
+    {
+        var (_, adapter) = await _fixture.CreateSchemaAdapterAsync(
+            schema, partitionDef with { Namespace = ns, Schema = schema });
+
+        for (var i = 0; i < RowsPerPartition; i++)
+            await adapter.WriteAsync(
+                new MeshNode($"Probe{i:D2}", ns)
+                {
+                    Name = $"Probe {i:D2}",
+                    NodeType = ProbeNodeType,
+                    State = MeshNodeState.Active
+                },
+                _options, ct);
+    }
+}


### PR DESCRIPTION
Part of #1326 — asks #1 (per-space outcome logging) and #2 (root-cause the non-matching spaces). Asks #3 and #4 are a different mechanism and are left open, so this deliberately does **not** auto-close the issue.

## First, a correction to the framing

**A `push` event imports nothing, by design.** `GitHubWebhookProcessor.ProcessPush` logs and returns
0 — the sync is CI-gated, and the trigger is a green `workflow_run`. So "push webhooks are live" is
not the premise that matters; the 34 spaces that *did* update were updated by the build-completion
path, and that path works. The question is only why the same 9 never were.

## Root cause

`QueryConfigNodesAsSystem` asks "which spaces follow this repository?" with an **unpinned**
`nodeType:GitHubSyncConfig` query and **no stated limit**. On Postgres an unpinned query is served
by `PostgreSqlCrossSchemaQueryProvider`, which answers a limitless request with a **page**:

```csharp
var orderBy = query.OrderBy != null ? … : "n.last_modified DESC";
var limit = query.Limit ?? 50;      // ← one global LIMIT over the UNION of every partition schema
```

The repo filter runs in C# *after* that clip, so configs that fell outside the 50 most recently
modified rows were never even considered — and the result is indistinguishable from the complete
set.

**Why it is always the same 9, and why they never recover.** The order is `last_modified DESC`, and
a successful sync *rewrites the config node* (`RecordSeenCommit` / `RecordLastSync`). So every space
that updated moves to the front of the window and every space that missed out sinks further out of
it. The omission is self-reinforcing and completely silent — which matches the reported pattern
exactly: a fixed set of stragglers, each a different number of commits behind depending on when it
fell off.

This is the same line of code as **#1216** (the batch bake resolving 50 `Code` nodes for 237 pending
types), seen from a second caller. That is what makes it a framework fix and not a one-line patch at
the call site.

## The fix

**1. An explicit way to say "this is an enumeration, not a page."**
`MeshQueryRequest.Complete()` / `MeshQueryRequest.NoLimit`. The merge layer already treated a
non-positive limit as "do not clip" (`ClipMergedInitial` clips only when `limit > 0`); the storage
providers now *translate* it instead of mistranslating it:

| provider | before | after |
|---|---|---|
| `PostgreSqlSqlGenerator` | could emit `LIMIT -1` (syntax error) | no `LIMIT` clause |
| `PostgreSqlCrossSchemaQueryProvider` | `query.Limit ?? 50` folded it to 50 | `int.MaxValue` |
| `PostgreSqlMeshQuery` | `count >= -1` returned one row | folded away before the guard |
| `StorageAdapterMeshQueryProvider` | load cap of `skip - 1` | no cap |
| `CosmosMeshQuery` | `TOP -1` | no `TOP` |

`PostgreSqlPartitionedMeshQuery` now propagates the request limit **whatever its sign**. Refusing to
propagate `<= 0` (added by #1216) avoided a literal `LIMIT 0`; substituting the fan-out's default of
50 instead is the bug in the other direction, and the one that shipped.

**2. A default that clipped is no longer silent.** The cross-schema provider warns — naming the
query — whenever it hands back exactly the default page to a caller that stated no limit. This is
the generalisation of the issue's ask #1: the *next* caller to make this mistake is findable instead
of invisible.

**3. The fan-out itself.** It says `Complete()`, and it waits for the **merged Initial** rather than
whatever emission arrives first (`MeshQuery` emits exactly one merged Initial once every provider
has reported; a bare `Take(1)` can capture a pre-Initial empty snapshot — the hazard
`GitHubSyncService` already guards against three files over).

**4. Per-space outcome logging** (issue ask #1, literally). The fan-out now reports how many configs
exist in the mesh, how many it selected, and for every one it passed over, its path and the exact
predicate that dropped it — `branch 'main' != built branch 'release'`, `already at this commit`,
`direction is ExportOnly`. `ConfigMatchesBuild` is re-expressed as "there is no reason to skip it"
so the predicate and the log line cannot drift apart.

## Verification

`CompleteEnumerationFanOutTests` — 66 probe rows across two partition schemas, against a real
Postgres:

```
default page: 50 of 66     ← no limit stated: a page, as documented
complete:     66 of 66     ← Complete(): every match
limit 10:     10           ← a stated positive limit still clips
```

**Fail-before verified** by reverting only the provider translation (`query.Limit ?? DefaultFanOutLimit`):
the `Complete()` leg fails with `2201W: LIMIT must not be negative` — i.e. before this change there
was no way for a caller to ask for the whole set at all.

- `MeshWeaver.Hosting.PostgreSql.Test` — 697/698 (1 pre-existing skip)
- `MeshWeaver.GitSync.Test` — 160/160
- `dotnet build -c Release -warnaserror` clean for every touched project

## Not fixed here

The issue's asks #3 (`"Imported Skipped (0 node(s))"` while genuinely behind) and #4 (force-prune
deleting mesh-minted `Release` records) are a different mechanism — the content-fingerprint marker
at `{space}/_Activity/import-{hash}` and `ComputePrunableNodes` — and are left for a separate
change. Notably `Release/` is spared today only by `SyncIgnore.Default`, not by the prune's
governance rule (`_`-prefixed segments), so under `FullReplace` a force *is* free to remove those
nodes; that is the thread to pull for #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
