### PR TITLE
docs(release): the roll policy — serve fast, never disturb

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
@@ -86,6 +86,39 @@ invisible to `VersionSelect`). When a symptom points at core behaviour, **check 
 first** — comparing the deployment's tag against the newest tag in the registry costs one command and
 forecloses a long, wrong hunt.
 
+## 🎯 The roll policy — serve fast, never disturb
+
+**The aim of every roll: the user never notices.** No slow first hit, no dropped circuit, no
+"transient hub error", no page that pays a compile because an image moved underneath it. The
+contract, in five rules — grain = an activated per-node hub; silo = a portal process of one image
+generation; bake = pre-compiling every dynamic NodeType for the NEW framework fingerprint:
+
+1. **An ACTIVE grain is never torn down.** As long as there is activity on a grain, it keeps
+   serving where it is. Deactivation is for idle grains only; a roll must not become a mass
+   eviction of pages people are looking at.
+2. **Bake FIRST, and until the bake is finished every new grain is allocated on an OLD silo.**
+   The new generation earns traffic by having every assembly warm; while it is still baking, the
+   old generation — whose assemblies are all warm by definition — keeps taking all placements.
+3. **A failed bake means NO switch.** The old silos keep serving indefinitely; a broken new
+   generation is a non-event for users, not an outage. (This is the readiness gate with teeth:
+   fail closed toward the OLD generation, never toward a cold or broken new one.)
+4. **Only a successful AND finished bake opens the new generation** — from that moment, new grain
+   allocations go to the new silos. Old silos drain naturally as their grains go idle (rule 1),
+   then retire.
+5. **A recycled grain re-hashes** — recycling is the explicit way to move a grain onto the new
+   generation early. Everything else transitions smoothly: activity-pinned on the old silo until
+   idle, re-placed on the new one on its next activation.
+
+**Where reality stands against this (2026-08-12):** the roll is a single-Deployment rolling update
+— the old pod is torn down grains-and-all (rule 1 violated: every active hub dies with its pod);
+the image bake contributes zero assemblies (`alreadyBaked=0` —
+[#1347](https://github.com/Systemorph/MeshWeaver/issues/1347)), so the new pod boots cold and the
+76-second prewarm sweep races the first visitors (rules 2–4 approximated only by the readiness
+gate, which is currently off); and the sweep warms the most user-visible types (the
+`Store/Coupon → Store/Order → Store/Plugin` cycle trio) LAST. The policy above is the target the
+bake, the readiness gate, and a two-generation silo topology are building toward — see
+[#1348](https://github.com/Systemorph/MeshWeaver/issues/1348).
+
 ## Update policy
 
 The policy is a **single boolean on each install record** — `Package.AutoUpdate` — not a three-state


### PR DESCRIPTION
## What

Writes the zero-disruption roll policy into `Doc/Architecture/ReleaseToProductionPipeline` as the stated aim, directly after the image-roll section:

1. an **active grain is never torn down** — deactivation is for idle grains only;
2. **bake first** — until the bake finishes, every new grain allocates on an **old** silo;
3. a **failed bake means no switch** — fail closed toward the old generation;
4. only a **successful, finished** bake opens the new generation for new allocations;
5. a **recycled grain re-hashes** early; everything else transitions smoothly.

The section honestly names where reality stands today (single-Deployment rolling update kills grains with the pod; the image bake contributes zero — #1347; the prewarm sweep warms the `Store/*` cycle trio last) and points at #1348 for the implementation shape.

## Why

2026-08-12: /SST/Subscribe "took forever with many redirects" after a roll — cold hub activations racing a 280-type recompile the image bake should have pre-paid. The policy needs to live where the next person reads about rolls, not in a chat transcript.

## Tested

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)