### PR TITLE
fix(portal): bound the outbound-email watch with terminal-status negations

### DIFF
--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -31,17 +31,26 @@ public sealed class OutboundEmailSender(
     ILogger<OutboundEmailSender>? logger = null) : IHostedService, IDisposable
 {
     /// <summary>
-    /// The live watch query. 🚨 It must NOT filter <c>content.status:New</c>: <see cref="EmailStatus.New"/>
-    /// is the enum DEFAULT (0) and the serializer OMITS it from the stored JSON, so that filter never
-    /// matches a freshly queued email — the exact trap <see cref="InvitationEmailSender"/> documents for
-    /// <c>content.status:Pending</c>, and the reason the Store contact form's notification sat queued
-    /// forever on memex (2026-08-12: the query with the status clause returned 0 rows, without it 1).
-    /// Status is filtered IN CODE by <c>Send</c> (a read fills the omitted default back in), and the
-    /// New → Sending claim guards double-send. <c>content.direction:Outbound</c> IS safe: Outbound is
-    /// not the default, so it always serializes — see <c>OutboundEmailWatchQueryTest</c>.
+    /// The live watch query. 🚨 It must NOT match <c>content.status:New</c> POSITIVELY:
+    /// <see cref="EmailStatus.New"/> is the enum DEFAULT (0) and the serializer OMITS it from the
+    /// stored JSON, so that filter never matches a freshly queued email — the exact trap
+    /// <see cref="InvitationEmailSender"/> documents for <c>content.status:Pending</c>, and the
+    /// reason the Store contact form's notification sat queued forever on memex (2026-08-12: the
+    /// query with the positive status clause returned 0 rows, without it 1).
+    ///
+    /// <para>NEGATIONS are the shape that both avoids the trap and keeps the live set BOUNDED:
+    /// a negation on an omitted field never excludes (verified live — <c>-content.status:New</c>
+    /// still returned the status-omitted email), so New-queued mail always matches, while
+    /// explicitly stamped <c>Sending</c>/<c>Sent</c>/<c>Failed</c> mail drops out of the set as it
+    /// is processed instead of accumulating forever (the Copilot review's growth concern on the
+    /// unfiltered form). Status is additionally re-checked IN CODE by <c>Send</c>, and the
+    /// New → Sending claim guards double-send. <c>content.direction:Outbound</c> is a safe
+    /// positive match: Outbound is not the default, so it always serializes — see
+    /// <c>OutboundEmailWatchQueryTest</c>.</para>
     /// </summary>
     public const string WatchQuery =
-        $"nodeType:{EmailNodeType.NodeType} content.direction:Outbound";
+        $"nodeType:{EmailNodeType.NodeType} content.direction:Outbound "
+        + "-content.status:Sending -content.status:Sent -content.status:Failed";
 
     private readonly CompositeDisposable subscriptions = new();
     private IServiceScope? scope;

--- a/test/Memex.Portal.Shared.Test/OutboundEmailWatchQueryTest.cs
+++ b/test/Memex.Portal.Shared.Test/OutboundEmailWatchQueryTest.cs
@@ -9,27 +9,45 @@ namespace Memex.Portal.Shared.Test;
 /// Pins the shape of <see cref="OutboundEmailSender.WatchQuery"/> against the omitted-default
 /// serialization trap that stranded the Store contact form's notification email on memex
 /// (2026-08-12): <see cref="EmailStatus.New"/> is the enum default, the serializer omits default
-/// values from stored JSON, so a query filtering <c>content.status:New</c> matches NOTHING that is
-/// actually new — proven live (the status-filtered query returned 0 rows while the unfiltered one
-/// returned the queued email). <see cref="InvitationEmailSender"/> documents the identical rule
-/// for <c>content.status:Pending</c>; this test makes the rule enforceable rather than a comment.
+/// values from stored JSON, so a query POSITIVELY matching <c>content.status:New</c> matches
+/// NOTHING that is actually new — proven live (the status-filtered query returned 0 rows while
+/// the unfiltered one returned the queued email). NEGATIONS are safe AND keep the live set
+/// bounded: a negation on an omitted field never excludes (also proven live —
+/// <c>-content.status:New</c> still returned the status-omitted email), while explicitly stamped
+/// terminal states drop out instead of accumulating forever.
 /// </summary>
 public class OutboundEmailWatchQueryTest
 {
     [Fact]
-    public void WatchQuery_MustNotFilterOnStatus_TheDefaultIsOmittedFromStoredJson()
+    public void WatchQuery_MustNotPositivelyMatchStatus_TheDefaultIsOmittedFromStoredJson()
     {
-        Assert.DoesNotContain("status", OutboundEmailSender.WatchQuery);
-        Assert.Contains("content.direction:Outbound", OutboundEmailSender.WatchQuery);
-        Assert.Contains($"nodeType:{EmailNodeType.NodeType}", OutboundEmailSender.WatchQuery);
+        // The trap: a positive match on the omittable default. Negated clauses are fine —
+        // strip them before asserting nothing positive remains.
+        var withoutNegations = OutboundEmailWatchQueryTestHelpers.StripNegatedClauses(
+            OutboundEmailSender.WatchQuery);
+        Assert.DoesNotContain("content.status", withoutNegations);
+        Assert.Contains("content.direction:Outbound", withoutNegations);
+        Assert.Contains($"nodeType:{EmailNodeType.NodeType}", withoutNegations);
+    }
+
+    /// <summary>The bounded shape: every non-New status is negated away, so processed mail drops
+    /// out of the live set instead of re-emitting forever, while New — stored with the status
+    /// OMITTED, which no negation excludes — always matches.</summary>
+    [Fact]
+    public void WatchQuery_NegatesEveryTerminalStatus_SoTheLiveSetStaysBounded()
+    {
+        Assert.Contains("-content.status:Sending", OutboundEmailSender.WatchQuery);
+        Assert.Contains("-content.status:Sent", OutboundEmailSender.WatchQuery);
+        Assert.Contains("-content.status:Failed", OutboundEmailSender.WatchQuery);
     }
 
     /// <summary>
     /// The reasoning the query shape rests on, pinned so an enum reorder cannot silently
-    /// invalidate it: <c>New</c> IS the omittable default (which is why the query must not filter
-    /// on status), and <c>Outbound</c> is NOT the direction default (which is why filtering on
-    /// direction is safe — a queued outbound email always serializes it). If either assertion
-    /// fails, the watch query above has to be rethought, not just this test.
+    /// invalidate it: <c>New</c> IS the omittable default (which is why no positive status match
+    /// can ever see queued mail, and why the negations cannot exclude it), and <c>Outbound</c> is
+    /// NOT the direction default (which is why the positive direction match is safe — a queued
+    /// outbound email always serializes it). If either assertion fails, the watch query above has
+    /// to be rethought, not just this test.
     /// </summary>
     [Fact]
     public void TheDefaults_AreWhatTheQueryShapeAssumes()
@@ -37,4 +55,14 @@ public class OutboundEmailWatchQueryTest
         Assert.Equal(EmailStatus.New, default(EmailStatus));
         Assert.NotEqual(EmailDirection.Outbound, default(EmailDirection));
     }
+}
+
+internal static class OutboundEmailWatchQueryTestHelpers
+{
+    /// <summary>Removes every <c>-negated:clause</c> token so a test can assert on the POSITIVE
+    /// clauses alone.</summary>
+    public static string StripNegatedClauses(string query) =>
+        string.Join(' ',
+            query.Split(' ', System.StringSplitOptions.RemoveEmptyEntries)
+                .Where(token => !token.StartsWith('-')));
 }


### PR DESCRIPTION
Follow-up to #1344, addressing both Copilot findings there:

- **Growth**: the unfiltered watch re-emitted every outbound email ever. The query now negates the terminal states — `-content.status:Sending -content.status:Sent -content.status:Failed` — so processed mail drops out of the live set. Safe against the omitted-default trap because **a negation on an omitted field never excludes** (verified live on memex: `-content.status:New` still returned the status-omitted queued email — omitted fields pass all negations).
- **Test over-constraint**: the test now forbids only a POSITIVE `content.status` match (the actual trap), requires the three terminal negations, and keeps the enum-defaults pin.

`Memex.Portal.Shared.Test`: 302 passed. Release build `-p:CIRun=true -warnaserror`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)