### PR TITLE
fix: the plugin gate no longer reports node counts it never took, and names the stage that failed (#1360)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-failed-plugin-check-no-longer-reports-counts-it-never-took.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-failed-plugin-check-no-longer-reports-counts-it-never-took.md
@@ -1,0 +1,28 @@
+---
+Name: A failed plugin check no longer reports counts it never took
+Category: Fix
+Description: When a plugin's automated check broke part-way through, the summary printed "0 items" — indistinguishable from a plugin that genuinely contained nothing, and it named the wrong step. It now says which step failed and admits when nothing was counted.
+Icon: ClipboardTaskListLtr
+Order: -20260813
+---
+
+# A failed plugin check no longer reports counts it never took
+
+Every plugin goes through an automated check before it ships: its contents are installed into a
+throw-away workspace, each of its types is built, its views are rendered, and the whole thing is
+installed a second time to prove that repeating it changes nothing.
+
+When any part of that broke, the summary said the same thing regardless: the plugin's name, the
+label **install**, and *0 items, 0 types*. Both halves of that could be wrong. The failure might
+have happened long after the install finished — while building a type, or rendering a view — and the
+zeros were never a measurement at all, just the empty defaults of a result the check gave up on.
+
+That combination is worse than no information, because it reads as a confident statement: this
+plugin installed nothing. On at least one occasion a plugin that had installed perfectly well —
+proven by the very next run, which installed all of it — was reported that way, and the failure was
+put down to background noise instead of being investigated.
+
+The summary now names the step that actually failed — fetching, installing, or the per-type
+checks — and where no count was ever taken it says so plainly instead of printing zeros. A broken
+check still fails the plugin, exactly as before. It simply no longer claims to have measured
+something it did not.

--- a/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateSummaryTest.cs
@@ -213,4 +213,45 @@ public class GateSummaryTest
             "Tests host: Store/Catalog/GateProbe — the probe instance the gate created for this check",
             summary, StringComparison.Ordinal);
     }
+
+    // ── counts that were never taken must not be printed as zeros (#1360) ─────────────────────
+
+    [Fact]
+    public void PipelineThrewBeforeTheInstallReported_SummaryDoesNotClaimZeroNodes()
+    {
+        // Systemorph/MeshWeaver#1360: a wait inside the install timed out AFTER the nodes were
+        // written — the identical snapshot wrote 34 nodes on the very next run — and the gate
+        // printed `[FAIL] Essentials (0 node(s), 0 type(s))`. "Its hub vanished mid-install" and
+        // "it legitimately had nothing to install" rendered as the SAME line, which is exactly why
+        // the signature was filed away as harness noise. The failure must still fail; it must not
+        // claim a measurement nobody took.
+        var report = new GateReport([
+            new PackageResult("Essentials")
+            {
+                CountsMeasured = false,
+                InstallError = "[install] TimeoutException: The operation has timed out.",
+            }
+        ]);
+
+        var summary = Summarize(report);
+
+        Assert.Contains("counts unavailable", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("(0 node(s), 0 type(s))", summary, StringComparison.Ordinal);
+        // The stage is part of the verdict: `install:` used to label a fetch failure, a compile
+        // failure and an idempotence re-install failure alike.
+        Assert.Contains("[install] TimeoutException", summary, StringComparison.Ordinal);
+        Assert.False(report.Success, "a package whose pipeline threw is still RED");
+    }
+
+    [Fact]
+    public void MeasuredRun_StillPrintsTheCounts()
+    {
+        // The new flag defaults to true, so every real result keeps its counts — this pins that
+        // the #1360 change did not quietly hide the numbers from healthy runs.
+        var summary = Summarize(Report(Type("Store/Catalog",
+            CheckOutcome.Passed, CheckOutcome.Passed, CheckOutcome.Passed)));
+
+        Assert.Contains("(97 node(s), 1 type(s))", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("counts unavailable", summary, StringComparison.Ordinal);
+    }
 }

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -67,6 +67,20 @@ public sealed record PackageResult(string Id)
     /// <summary>Total nodes the package carried.</summary>
     public int NodeCount { get; init; }
 
+    /// <summary>
+    /// Whether <see cref="NodeCount"/> / <see cref="NodeTypes"/> are a MEASUREMENT. False when the
+    /// package pipeline threw before the install reported, in which case both are defaults and
+    /// printing them asserts a count nobody took.
+    ///
+    /// <para>🚨 Why this exists (#1360). A wait inside the install timed out AFTER the nodes had
+    /// been written — the identical snapshot wrote 34 nodes on the very next run — and the gate
+    /// reported <c>[FAIL] Essentials (0 node(s), 0 type(s))</c>. "Its hub vanished mid-install" and
+    /// "it legitimately had nothing to install" rendered as the same line, which is exactly why the
+    /// signature was filed away as harness noise. A failure still FAILS; it just may not claim to
+    /// have counted anything.</para>
+    /// </summary>
+    public bool CountsMeasured { get; init; } = true;
+
     /// <summary>Install failure detail; null when the install succeeded.</summary>
     public string? InstallError { get; init; }
 
@@ -154,7 +168,9 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
         foreach (var package in Packages)
         {
             output.WriteLine($"[{Label(package, verdict)}] {package.Id} " +
-                             $"({package.NodeCount} node(s), {package.NodeTypes.Count} type(s))");
+                             (package.CountsMeasured
+                                 ? $"({package.NodeCount} node(s), {package.NodeTypes.Count} type(s))"
+                                 : "(counts unavailable — the pipeline threw before the install reported)"));
             if (package.InstallError is not null)
                 output.WriteLine($"    install{Debt(verdict, package.Id, "install")}: {package.InstallError}");
             if (package.IdempotenceError is not null)

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -108,9 +108,22 @@ public static class PluginGateRunner
     {
         var source = new NodeRepoPackageSource(
             (_, _, _, _) => Observable.Return(snapshot), repoUrl: "local");
+        // 🚨 WHICH STAGE FAILED is part of the verdict. The catch at the bottom wraps the WHOLE
+        // pipeline — fetch, install, every NodeType compile/render/Tests gate, the idempotence
+        // re-install — and used to label every one of them `install:` on a PackageResult built
+        // from scratch, so `NodeCount` defaulted to 0 and `NodeTypes` to empty. That is how
+        // Systemorph/MeshWeaver#1360 read as harness noise: `[FAIL] Essentials (0 node(s), 0
+        // type(s)) / install: TimeoutException` was produced by a wait that did not complete
+        // AFTER the nodes had been written (the same snapshot wrote 34 nodes on the re-run), yet
+        // the line is indistinguishable from a package that genuinely installed nothing. The
+        // counts were never measured — printing them as zeros asserts a measurement that was
+        // never taken. Packages run strictly sequentially (Concat in RunPackages), so a captured
+        // stage marker is exact.
+        var stage = "fetch";
         return source.FetchPackageFiles(package, "HEAD")
             .SelectMany(files =>
             {
+                stage = "install";
                 options.Output.WriteLine($"── {package.Id}: installing {files.Count} file(s)…");
                 var types = DiscoverNodeTypes(package, files);
                 // The authorizing principal is EXPLICIT — see GateMesh.AuthorizingUserId. Passing
@@ -122,6 +135,7 @@ public static class PluginGateRunner
                         authorizingUserId: GateMesh.AuthorizingUserId)
                     .SelectMany(install =>
                     {
+                        stage = "checks";
                         options.Output.WriteLine(
                             $"── {package.Id}: installed ({install.Written} written, " +
                             $"{install.Unchanged} unchanged); checking {types.Count} NodeType(s)…");
@@ -159,7 +173,10 @@ public static class PluginGateRunner
             })
             .Catch((Exception ex) => Observable.Return(new PackageResult(package.Id)
             {
-                InstallError = $"{ex.GetType().Name}: {ex.Message}",
+                // Named for the stage that actually threw, and marked as NOT a measurement so
+                // WriteSummary prints "counts unavailable" instead of a fabricated "0 node(s)".
+                CountsMeasured = false,
+                InstallError = $"[{stage}] {ex.GetType().Name}: {ex.Message}",
             }));
     }
 


### PR DESCRIPTION
Partial for #1360 — **the issue stays open** for its load-bearing half (see "What this does NOT fix").

## What the trace actually says

I pulled the failing run behind #1360: **MeshWeaver.Plugins run 31645120599, attempt 1**, job "Compile + render node repos". (The run's top-level conclusion reads `success` because the job was re-run — attempt 1 has to be requested explicitly.)

```
22:03:44.045  ── Essentials: installing 36 file(s)…
22:03:46.382  warn: JsonSynchronizationStream Stream Q-PDrHPxdUC4kWg5HolW2Q: resubscribe failed.
              DeliveryFailureException: Hub Essentials is shutting down (RunLevel=DisposeHostedHubs)
              — cannot process RawJson; the address may reactivate (recycle / restart). Rejecting now.
              [ ×4 in 11 ms, then 28.043 seconds of TOTAL log silence ]
22:04:14.437  ── Feedback: installing 12 file(s)…
22:04:49.222  [FAIL] Essentials (0 node(s), 0 type(s))
                  install: TimeoutException: The operation has timed out.
22:04:49.229  GATE FAILED — install: Essentials — 1 new failure(s), 0 stale allow entr(ies).
```

The green re-run, same pinned image digest, same 36 files: `── Essentials: installed (34 written, 0 unchanged)` in **0.768 s**.

Two things follow, and both contradict the issue's opening hypothesis:

1. **The harness did not tear anything down.** `PluginGateRunner.Run` attaches `.Finally(harness.Dispose)` to the whole pipeline and `RunPackages` folds packages through `Concat`, so the harness dies strictly after the last package — and empirically 10 more packages installed and passed over the following 35 s. The disposal was **scoped to Essentials**.
2. **The counts were never measured.** The identical snapshot wrote 34 nodes on the very next run. `0 node(s), 0 type(s)` are the empty defaults of a `PackageResult` the pipeline gave up on.

## The reporting defect (what this PR fixes)

`TestPackage`'s bottom `.Catch` wraps the **whole** pipeline — fetch, install, every NodeType compile/render/Tests gate, the idempotence re-install — and labelled all of them `install:` on a `PackageResult` constructed with only `InstallError` set. So `install:` means "an exception escaped somewhere in this package", not "the install failed", and the zeros assert a measurement nobody took. `InstanceComboVerifier` lifts the same label into the image-promotion verdict, so a race can fail a candidate image under a cause that never happened.

That ambiguity is precisely what let this signature be filed away as noise, and it is item 3 of the issue's "what would settle it".

- **`PackageResult.CountsMeasured`** (default `true`) records whether the counts are a measurement. `WriteSummary` prints `(counts unavailable — the pipeline threw before the install reported)` instead of fabricated zeros.
- **The error text is prefixed with the stage that actually threw** — `[fetch]` / `[install]` / `[checks]`. Packages run strictly sequentially (`Concat`), so the captured marker is exact.

A broken check **still fails the package**, exactly as before — nothing is made tolerant of the signature, which the issue explicitly rules out. The `GateRunReport` wire contract is unchanged.

## What this does NOT fix

The non-termination itself. On the evidence the trigger was **not** a host shutdown and **not** disposal being blind to installs — it was a *targeted, by-design* recycle of the Essentials root hub 2.34 s into its own install, which killed the shared `GetMeshNodeStream` handle's subscription. `PackageInstaller.RootRetypeReconciled()` waits on exactly that handle behind a bare, uncaught `.Timeout(30 s)`; its sibling stage (`SyncPackageContent`) already carries the recycle-aware `IsRootRecycling` + `RootTeardownSettled` re-ask, and these two stages do not.

Two things I could **not** establish from the log, so I have not written code against them:

- **Who issued the disposal.** The gate runs at `LogLevel.Warning`, and both candidates (`NodeTypeRebindWatcher`'s self-`DisposeRequest`, `SettleRetypedRoot`) log at Information. Zero hits for `QUIESCE`, `watchdog`, `Disposal`, or an `ErrorType.ShuttingDown` token anywhere in the run.
- **Why the shared handle stayed silent for 28 s** rather than riding the recycle out as `IsTransientOwnerFailure` intends.

Re-running the gate with the log level at Information would name the disposer directly. #1360 stays open for that half.

Related and worth reading together: #1362 is the same defect *class* one layer down — a hub recycle silently invalidating a reactive wait with nobody telling the waiter — fixed in #1364.

## Verification

`GateSummaryTest` gains two pins: counts-unavailable on a thrown pipeline (and the package still RED), and counts still printed on a measured run. `MeshWeaver.PluginTester.Test` 35/35 before, 37/37 after. `dotnet build -c Release -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)