### PR TITLE
fix: a faulted synced query is evicted, not replayed forever (#1316)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-momentary-database-hiccup-no-longer-lasts-until-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-momentary-database-hiccup-no-longer-lasts-until-restart.md
@@ -1,0 +1,30 @@
+---
+Name: A momentary database hiccup no longer lasts until the next restart
+Category: Fix
+Description: A single slow moment reaching the database could leave one live list permanently stuck on that error — every later reader got the same stale failure until the portal was restarted. Failed lists are now retired instead of remembered.
+Icon: ArrowSync
+Order: -20260813
+---
+
+# A momentary database hiccup no longer lasts until the next restart
+
+Lists that stay live — the set of files a piece of code is built from, the members of a group, the
+items behind a picker — are kept once and shared by everyone who needs them. Building one is
+expensive, so the platform keeps the result and hands the same live list to every later reader.
+
+That sharing had a sharp edge. If the very first attempt to build a list failed — a few seconds
+where the database was slow to answer, and nothing more — the failure was kept alongside the list
+and replayed to every reader afterwards. Not retried, not re-checked: handed the identical error,
+instantly, forever. The database recovered seconds later and it made no difference. Only restarting
+the portal cleared it.
+
+The damage was quiet and out of proportion. One piece of code could no longer see which files it was
+built from, so it never looked rebuilt — and because "we could not read the files" and "the code is
+broken" were indistinguishable from the outside, it was treated as broken and held back a release.
+The files were fine. Nobody had changed anything. A few slow seconds hours earlier were still being
+replayed as the answer.
+
+A list that ends in failure is now retired rather than remembered. The reader that hit the problem
+still sees the real error — nothing is swallowed — but the next reader gets a genuine fresh attempt,
+so a moment of slowness lasts a moment. Healthy lists are untouched and keep being shared exactly as
+before.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1963,7 +1963,17 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // distinct references instead of the shared system-security cache entry.
     // Keyed on the caller's stable hub JsonSerializerOptions (one instance per
     // hub) so repeated GetQuery(id, options, …) calls reuse the same wrapper.
-    private readonly ConcurrentDictionary<(object Id, JsonSerializerOptions Options), IObservable<IEnumerable<MeshNode>>> _optionsWrappedQueries = new();
+    //
+    // 🚨 The RAW stream the wrapper closed over is stored ALONGSIDE it, and the
+    // options overload re-wraps whenever it no longer matches the current raw.
+    // Without that, EvictFaultedQuery below would drop the poisoned entry from
+    // _queries while this dictionary kept handing every caller a wrapper over the
+    // dead chain — the eviction would be invisible from the public surface. Pairing
+    // the raw with the wrapper also makes the repair race-free: there is no window
+    // in which a concurrent GetQuery re-installs a wrapper over the raw that was
+    // just evicted, because the check is against whatever raw the caller resolved.
+    private readonly ConcurrentDictionary<(object Id, JsonSerializerOptions Options),
+        (IObservable<IEnumerable<MeshNode>> Raw, IObservable<IEnumerable<MeshNode>> Wrapper)> _optionsWrappedQueries = new();
 
     // Raw builder — PRIVATE. The public surface (hub/workspace.GetQuery → the
     // internal options overload below) always injects the caller hub's
@@ -2046,11 +2056,75 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // gate lock, contending with concurrent subscribers under
                 // load.
 
+            // 🚨 EVICT ON FAULT (#1316). Everything above is exactly what makes a
+            // TERMINAL fault permanent: ReplaySubject latches OnError and replays it
+            // to every later subscriber, AutoConnect(1) never reconnects, and this
+            // dictionary keeps the poisoned chain for the life of the process. One
+            // transient upstream error therefore converts into a per-id outage that
+            // only a pod restart clears — memex-cloud 2026-08-12, where an Npgsql
+            // CONNECT timeout (15 s handshake budget) landed on
+            // `nodetype-sources:Edu/Module`. From that instant the NodeType's sources
+            // watcher re-established once a second onto an instantly-replayed
+            // terminal, `CurrentSourceVersions` could never be written, and a null
+            // snapshot classifies as gating PreWarmStatus.CompileError
+            // (DynamicTypePreWarmer.ClassifyCompileFailure) — so a momentary database
+            // blip blocked the rollout of a type whose sources were never even read.
+            //
+            // The per-PATH sibling cache already learned this exact lesson from this
+            // exact error class — see EvictFaultedEntry: "an Npgsql connect failure …
+            // replayed forever until a manual recycle". The query cache never got the
+            // treatment. This is the same discipline, one dictionary over.
+            //
+            // `Do` (not a bookkeeping Subscribe) is deliberate: subscribing here would
+            // be the AutoConnect(1) first subscriber and would connect every CAS
+            // loser's discarded chain — the leak the AutoConnect comment above exists
+            // to prevent. `Do` stays cold and runs per-subscriber, so the FIRST
+            // consumer to observe the terminal evicts, and there is no eager connect.
+            var connected = stream;
+            stream = connected.Do(_ => { }, ex => EvictFaultedQuery(id, stream, ex));
+
             var updated = current.Add(id, stream);
             if (Interlocked.CompareExchange(ref _queries, updated, current) == current)
                 return stream;
             // CAS lost — another thread won concurrently; retry the read.
         }
+    }
+
+    /// <summary>
+    /// Drops <paramref name="id"/>'s TERMINALLY-ERRORED synced query so the next
+    /// <c>GetQuery(id, …)</c> builds a fresh chain and re-probes the providers for real,
+    /// instead of replaying the latched terminal to every future subscriber (#1316).
+    ///
+    /// <para>The subscriber that observed the fault still SEES it — this is a cache-hygiene
+    /// step, never a swallow and never a retry. Nothing re-subscribes on its own: the next
+    /// caller decides, and the callers are already paced (a NodeType sources watcher
+    /// re-establishes at 1 Hz; a render subscribes once per render). Concurrent callers cannot
+    /// multiply the re-probe either — <c>AutoConnect(1)</c> means the first of them connects
+    /// the single fresh upstream and the rest attach to its <c>Replay(1)</c>.</para>
+    ///
+    /// <para>Pair-exact, exactly like <see cref="EvictFaultedEntry"/>: a chain that some other
+    /// caller has ALREADY replaced is left alone, so a late terminal arriving from the old
+    /// chain can never evict the healthy new one. Unlike the per-path entry there is no
+    /// upstream to detach — the <c>SyncedQueryMeshNodes</c> instance is constructed INSIDE the
+    /// <c>Observable.Defer</c>, so a fresh chain builds a genuinely fresh instance with fresh
+    /// provider subscriptions, and the errored one's <c>Replay(1).RefCount()</c> has already
+    /// disposed its own upstream.</para>
+    /// </summary>
+    private void EvictFaultedQuery(object id, IObservable<IEnumerable<MeshNode>> faulted, Exception ex)
+    {
+        while (true)
+        {
+            var current = _queries;
+            if (!current.TryGetValue(id, out var found) || !ReferenceEquals(found, faulted))
+                return; // already replaced (or evicted) by another caller — never touch a newer chain
+            if (Interlocked.CompareExchange(ref _queries, current.Remove(id), current) == current)
+                break;
+        }
+
+        logger.LogWarning(ex,
+            "MeshNodeStreamCache: evicted faulted synced query '{QueryId}' — its Replay(1) had latched the "
+            + "terminal error and would have replayed it to every future subscriber for the life of the "
+            + "process. The next GetQuery('{QueryId}') opens a fresh upstream instead.", id, id);
     }
 
     public IObservable<IEnumerable<MeshNode>>? GetQuery(object id)
@@ -2070,14 +2144,39 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // calls — infrastructure callers (ImpersonateAsSystem) bypass the
         // per-user RLS wrap and rely on getting the SAME shared observable for
         // the same id (perf shortcut for SecurityService / NodeType compile
-        // watchers). GetOrAdd's factory may run more than once under a race,
-        // but each candidate wraps the same cached raw stream — losers are
-        // inert (no Subscribe), so there's no upstream leak.
-        return _optionsWrappedQueries.GetOrAdd((id, options), static (_, state) =>
-            System.Reactive.Linq.Observable.Select(state.raw, items =>
-                (IEnumerable<MeshNode>)items.Select(node => DeserializeContent(node, state.options, state.logger, state.registry)).ToArray()),
-            (raw, options, logger, registry: contentTypeRegistry));
+        // watchers). The factory may run more than once under a race, but each
+        // candidate wraps the same cached raw stream — losers are inert (no
+        // Subscribe), so there's no upstream leak.
+        //
+        // 🚨 AddOrUpdate, not GetOrAdd (#1316). After EvictFaultedQuery drops a
+        // poisoned chain, `raw` above is a NEW observable while a memoised wrapper
+        // still closes over the DEAD one. GetOrAdd would keep returning that wrapper
+        // and the eviction would never be observable from the public surface — the
+        // query would stay broken exactly as before the fix. Re-wrapping whenever the
+        // stored raw is not the caller's current raw repairs it with no race: the
+        // decision is made against the raw this caller actually resolved, so a
+        // concurrent call can never re-install a wrapper over a raw that has since
+        // been evicted (its own GetQueryRaw would have returned the replacement).
+        return _optionsWrappedQueries.AddOrUpdate(
+            (id, options),
+            static (_, state) => (state.raw, WrapWithOptions(state.raw, state.options, state.logger, state.registry)),
+            static (_, existing, state) => ReferenceEquals(existing.Raw, state.raw)
+                ? existing
+                : (state.raw, WrapWithOptions(state.raw, state.options, state.logger, state.registry)),
+            (raw, options, logger, registry: contentTypeRegistry)).Wrapper;
     }
+
+    /// <summary>
+    /// Round-trips each emitted node's Content through the caller's options — the body of the
+    /// memoised wrapper built by <see cref="GetQuery(object, JsonSerializerOptions, string[])"/>.
+    /// </summary>
+    private static IObservable<IEnumerable<MeshNode>> WrapWithOptions(
+        IObservable<IEnumerable<MeshNode>> raw,
+        JsonSerializerOptions options,
+        ILogger logger,
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? registry)
+        => System.Reactive.Linq.Observable.Select(raw, items =>
+            (IEnumerable<MeshNode>)items.Select(node => DeserializeContent(node, options, logger, registry)).ToArray());
 
     private static MeshNode DeserializeContent(
         MeshNode node, JsonSerializerOptions options, ILogger logger,

--- a/test/MeshWeaver.Query.Test/SyncedQueryFaultRecoveryTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryFaultRecoveryTest.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// Issue #1316 — a TRANSIENT upstream fault must not poison a synced query for the life of
+/// the process.
+///
+/// <para>The cached synced query is <c>Replay(1).AutoConnect(1)</c> held in
+/// <c>MeshNodeStreamCache._queries</c>. All three of those properties conspire on a fault:
+/// <c>ReplaySubject</c> LATCHES the terminal and replays it to every later subscriber,
+/// <c>AutoConnect(1)</c> never reconnects, and the dictionary entry never expired. So a single
+/// upstream error made the id permanently unreadable — recoverable only by restarting the pod.</para>
+///
+/// <para>In production this fired as an Npgsql CONNECT timeout inside
+/// <c>PostgreSqlStorageAdapter.QueryNodesUnionInnerAsync</c> while a per-NodeType hub read its
+/// source set through <c>NodeSources.GetSources</c> (id <c>nodetype-sources:Edu/Module</c>). The
+/// sources watcher then re-established once a second straight onto the replayed terminal,
+/// <c>NodeTypeDefinition.CurrentSourceVersions</c> was never written, and a NULL snapshot
+/// classifies as a gating <c>PreWarmStatus.CompileError</c>
+/// (<c>DynamicTypePreWarmer.ClassifyCompileFailure</c>) — a momentary database blip blocking the
+/// rollout of a type whose sources had never been read at all.</para>
+///
+/// <para>The per-PATH sibling cache already learned this from the same error class
+/// (<c>EvictFaultedEntry</c>: "an Npgsql connect failure … replayed forever until a manual
+/// recycle"); the query cache had no equivalent. These tests pin the eviction, and — the part
+/// that actually matters — that the eviction is visible through the PUBLIC surface, which routes
+/// through a separately-memoised options wrapper that used to keep pointing at the dead chain.</para>
+/// </summary>
+public class SyncedQueryFaultRecoveryTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// A real <see cref="IMeshQueryProvider"/> (no mocking — see the testing rules) that faults
+    /// the FIRST subscription for queries carrying <see cref="Marker"/> and answers healthily on
+    /// every later one. That is the exact shape of a transient connect timeout: the upstream is
+    /// fine, the one attempt was not.
+    ///
+    /// <para>Every non-marker query gets the well-behaved "no matches" answer — an empty
+    /// <c>Initial</c> followed by a live stream that never completes — so registering this
+    /// provider cannot disturb the rest of the mesh's own queries.</para>
+    /// </summary>
+    private sealed class FaultOnceQueryProvider : IMeshQueryProvider
+    {
+        public const string Marker = "SyncedQueryFaultProbe";
+
+        private int subscribeCount;
+
+        /// <summary>Upstream subscriptions opened for the marker query. 2 ⇒ the cache re-probed.</summary>
+        public int MarkerSubscribeCount => Volatile.Read(ref subscribeCount);
+
+        public string Name => nameof(FaultOnceQueryProvider);
+
+        public bool Matches(IReadOnlyList<string> queryNamespaces) => true;
+
+        public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request, JsonSerializerOptions options)
+        {
+            if (!request.EffectiveQueries.Any(q => q?.Contains(Marker, StringComparison.Ordinal) == true))
+                return LiveEmpty<T>();
+
+            // Defer so the counter advances per SUBSCRIPTION, not per call: the whole point is to
+            // distinguish "a new upstream was opened" from "the cached terminal was replayed".
+            return Observable.Defer(() =>
+                Interlocked.Increment(ref subscribeCount) == 1
+                    ? Observable.Throw<QueryResultChange<T>>(
+                        new TimeoutException("simulated transient Npgsql connect timeout (#1316)"))
+                    : LiveEmpty<T>());
+        }
+
+        // An empty Initial then never-completing: what a healthy provider with no matches emits.
+        private static IObservable<QueryResultChange<T>> LiveEmpty<T>()
+            => Observable
+                .Return(new QueryResultChange<T> { ChangeType = QueryChangeType.Initial, Items = [] })
+                .Concat(Observable.Never<QueryResultChange<T>>());
+
+        public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+            string basePath, string prefix, JsonSerializerOptions options,
+            AutocompleteMode mode = AutocompleteMode.RelevanceFirst, int limit = 10,
+            string? contextPath = null, string? context = null)
+            => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+        public IObservable<T?> Select<T>(string path, string property, JsonSerializerOptions options)
+            => Observable.Return<T?>(default);
+    }
+
+    private readonly FaultOnceQueryProvider provider = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IMeshQueryProvider>(provider);
+                return services;
+            });
+
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// The regression. Subscriber 1 observes the transient fault; subscriber 2 must get a real
+    /// re-probe, not the latched terminal.
+    ///
+    /// <para><c>MarkerSubscribeCount == 2</c> is the load-bearing assertion — without it a cache
+    /// that merely happened to answer from some other layer would pass. Two upstream
+    /// subscriptions means a genuinely fresh <c>SyncedQueryMeshNodes</c> was built.</para>
+    /// </summary>
+    [Fact]
+    public async Task TransientUpstreamFault_IsNotReplayedToTheNextSubscriber()
+    {
+        var workspace = Mesh.GetWorkspace();
+        var id = $"fault-recovery:{Guid.NewGuid():N}";
+        var query = $"namespace:{FaultOnceQueryProvider.Marker} scope:subtree";
+
+        // 1. The transient fault reaches the subscriber — it is surfaced, never swallowed.
+        var first = await Record.ExceptionAsync(() =>
+            workspace.GetQuery(id, query).FirstAsync().Timeout(Budget).ToTask());
+
+        first.Should().NotBeNull("the transient upstream fault must be surfaced to the subscriber");
+        provider.MarkerSubscribeCount.Should().Be(1);
+
+        // 2. The next caller must reach the (now healthy) upstream. Before the fix this replayed
+        //    the latched TimeoutException instantly and MarkerSubscribeCount stayed at 1 forever.
+        var second = await workspace.GetQuery(id, query).FirstAsync().Timeout(Budget).ToTask();
+
+        second.Should().NotBeNull();
+        provider.MarkerSubscribeCount.Should().Be(2,
+            "the faulted cache entry must be evicted so the next GetQuery opens a FRESH upstream "
+            + "instead of replaying the latched terminal");
+    }
+
+    /// <summary>
+    /// The half that the eviction alone does not buy. <c>GetQuery(id, options, …)</c> memoises the
+    /// content-deserialising wrapper separately, keyed by <c>(id, options)</c>. If that wrapper
+    /// keeps closing over the EVICTED chain, every caller on the public surface still gets the
+    /// dead stream and the eviction is unobservable — the query stays broken exactly as before.
+    ///
+    /// <para>Same shape as the test above but asserting on the cache surface the framework's own
+    /// callers use, with the caller's <c>JsonSerializerOptions</c> in play.</para>
+    /// </summary>
+    [Fact]
+    public async Task OptionsWrappedQuery_ReWrapsAfterEviction_RatherThanServingTheDeadChain()
+    {
+        var cache = Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var options = Mesh.JsonSerializerOptions;
+        var id = $"fault-recovery-wrapped:{Guid.NewGuid():N}";
+        var query = $"namespace:{FaultOnceQueryProvider.Marker} scope:subtree";
+
+        var before = provider.MarkerSubscribeCount;
+
+        var first = await Record.ExceptionAsync(() =>
+            cache.GetQuery(id, options, query).FirstAsync().Timeout(Budget).ToTask());
+        first.Should().NotBeNull();
+
+        var second = await cache.GetQuery(id, options, query).FirstAsync().Timeout(Budget).ToTask();
+
+        second.Should().NotBeNull();
+        provider.MarkerSubscribeCount.Should().Be(before + 2,
+            "the memoised options wrapper must be rebuilt over the fresh raw chain — otherwise the "
+            + "eviction is invisible from the surface every framework caller actually uses");
+    }
+}


### PR DESCRIPTION
Closes #1316.

## What the limit actually was

Not a query that was slow, and not a connection another operation was holding. The
Npgsql failure in the report is at **`PoolingDataSource.OpenNewConnector` → `NpgsqlConnector.ConnectAsync`** — the physical connect
(TCP/TLS/auth) exceeding its 15 s budget, which Npgsql only reaches when the pool is *below*
`MaxPoolSize`. So the pool was not exhausted; one handshake was slow.

The bound that was actually reached is a **cache with no eviction**. `MeshNodeStreamCache._queries`
holds each synced query as `Replay(1).AutoConnect(1)` in a dictionary that never expires an entry:

- `ReplaySubject` (backing `Replay(1)`) **latches** a terminal and replays it to every later subscriber,
- `AutoConnect(1)` connects once and **never reconnects**,
- the dictionary entry lives for the life of the process.

So the transient 15 s connect timeout became a **permanent** per-id outage clearable only by
restarting the pod. That is why the report shows the watcher re-establishing and failing again and
again: every re-establish re-subscribed to an instantly-replayed terminal.

## Why it mattered more than a log line

The poisoned id was `nodetype-sources:Edu/Module` — the NodeType's own source set, read through
`NodeSources.GetSources`. With it dead, `NodeTypeDefinition.CurrentSourceVersions` could never be
written, and a **null** snapshot classifies as a gating `PreWarmStatus.CompileError`
(`DynamicTypePreWarmer.ClassifyCompileFailure`). A few slow seconds against the database therefore
blocked the rollout of a type whose sources had never been read at all.

That null-snapshot classification is deliberately fail-closed ("a real regression cannot hide behind
'not seeded'") and is **left as-is** — this change removes what was making the snapshot null. Both
were the "two distinct defects" 58a1ceb6b named when it closed #1310/#1312/#1313 and left #1316 open.

## The fix

The per-**path** sibling cache in this same file already learned this from this exact error class —
`EvictFaultedEntry`: *"an Npgsql connect failure fell through both predicates and replayed forever
until a manual recycle."* The **query** cache never got the treatment. This is that discipline, one
dictionary over.

- `EvictFaultedQuery` drops the entry **pair-exact** (never a chain another caller already replaced),
  so the next `GetQuery(id, …)` builds a fresh `SyncedQueryMeshNodes` with fresh provider subscriptions.
  No upstream to detach, unlike the path cache: the instance is constructed *inside* the
  `Observable.Defer`, and the errored chain's `Replay(1).RefCount()` already disposed its own upstream.
- Attached with **`Do`, not a bookkeeping `Subscribe`** — subscribing would be the `AutoConnect(1)`
  first subscriber and would connect every CAS loser's discarded chain, the exact leak the existing
  `AutoConnect` comment exists to prevent.
- `_optionsWrappedQueries` now stores the raw **alongside** the wrapper and re-wraps when they diverge
  (`AddOrUpdate`, not `GetOrAdd`). Without this the eviction is invisible from the public surface: the
  memoised wrapper kept closing over the dead chain, so every framework caller would still get the
  poisoned stream.

**No band-aid**: no timeout raised, no pool enlarged, no retry added. The subscriber that hits the
fault still sees it; nothing re-subscribes on its own. Callers are already paced (the sources watcher
at 1 Hz), and concurrent callers cannot multiply the re-probe — `AutoConnect(1)` means the first
connects the single fresh upstream and the rest attach to its `Replay(1)`.

## Verification — fail-before / pass-after

`SyncedQueryFaultRecoveryTest` registers a real `IMeshQueryProvider` (no mocking) that faults only
its **first** subscription and is healthy afterwards — the shape of a transient connect timeout.

| | before | after |
|---|---|---|
| `TransientUpstreamFault_IsNotReplayedToTheNextSubscriber` | FAIL — `TimeoutException` replayed to subscriber 2 | PASS |
| `OptionsWrappedQuery_ReWrapsAfterEviction_RatherThanServingTheDeadChain` | FAIL — same | PASS |

`Failed: 2, Passed: 0` → `Failed: 0, Passed: 2`. The load-bearing assertion is the provider's
**subscribe count reaching 2**: that is what proves a genuinely fresh upstream was opened rather than
a cached terminal served.

Built `-c Release -warnaserror` clean: `MeshWeaver.Hosting`, `MeshWeaver.Documentation`,
`MeshWeaver.Query.Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)