### PR TITLE
Compiled code is filed under the name it is looked up by (#1368)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-compiled-code-is-filed-under-the-name-it-is-looked-up-by.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-compiled-code-is-filed-under-the-name-it-is-looked-up-by.md
@@ -1,0 +1,34 @@
+---
+Name: Compiled code is filed under the name it is looked up by
+Category: Fix
+Description: After compiling code that lives inside the portal, the portal sometimes wrote down the wrong location for the result. Later it looked there, found nothing, and quietly fell back to a blank configuration — so the page rendered empty and the pre-update readiness check called a perfectly good build missing.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Compiled code is filed under the name it is looked up by
+
+Code that lives inside the portal is compiled by the portal itself, and the result is filed away so
+that everything which needs it later — opening a page, activating content, checking before an update
+that everything still builds — can fetch the same result instead of compiling it again.
+
+Filing it away means writing down two things: the compiled code, and a note saying where it was put.
+The note has to match. If it does not, every later lookup goes to an empty shelf.
+
+Two different parts of the portal write that note, and one of them was writing the wrong location. It
+recorded where the content stood *at the moment it finished writing* rather than where the compiled
+result had actually been filed — and those drift apart, because the act of recording the compile
+moves the content on. Which of the two wrote last was decided by nothing more than timing, so the
+same compile could produce a correct note or a broken one on different runs of the same code.
+
+When the broken note won, nothing announced it. The compile had genuinely succeeded, and everything
+you could see said so: the status read fine, the timestamp was fresh, the build was real and sitting
+exactly where it had been put. Only the note pointed elsewhere. What you saw instead was a page for
+that content rendering empty — the portal had looked for the compiled code, not found it, and fallen
+back to a configuration that does nothing, without saying why. The check that runs before a platform
+update was misled the same way: it asked whether each piece of in-portal code had a usable build,
+followed the note, found the empty shelf, and reported a healthy build as missing.
+
+Both writers now record the location the result was actually filed under. A note that cannot be
+trusted to point at the thing it names is worse than no note at all, so this is also now pinned by a
+test that reads the note and insists the shelf it names is not empty.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -140,7 +140,7 @@ internal static class NodeTypeContractHandler
                                         hubPath, requestedReleasePath, localPath);
                                     return compilationService.GetConfigurationsFromExistingAssembly(localPath!, hubPath)
                                         .Select(result => new ResolvedResponse(BuildResponseFromLocal(
-                                            hubPath, node, localPath!, release.AssemblyCollection,
+                                            hubPath, releaseVersion, localPath!, release.AssemblyCollection,
                                             release.AssemblyContentPath, result), false));
                                 });
                         });
@@ -176,7 +176,7 @@ internal static class NodeTypeContractHandler
                                 .SelectMany(result => SurfaceActivityLog(
                                     hub, def.LastCompilationActivityPath, result,
                                     res => BuildResponseFromLocal(
-                                        hubPath, node, localPath!, def.LatestAssemblyCollection,
+                                        hubPath, compileVersion, localPath!, def.LatestAssemblyCollection,
                                         def.LatestAssemblyPath, res)))
                                 .Select(response => new ResolvedResponse(response, false));
                         });
@@ -244,7 +244,24 @@ internal static class NodeTypeContractHandler
                                     // populate them (Null store).
                                     LatestAssemblyCollection = response.Collection ?? def.LatestAssemblyCollection,
                                     LatestAssemblyPath = response.ContentPath ?? def.LatestAssemblyPath,
-                                    LastCompiledVersion = curr.Version,
+                                    // 🚨 The version the BYTES are stored under — never curr.Version.
+                                    // LastCompiledVersion is one half of the IAssemblyStore key
+                                    // (nodeTypePath, version); the response echoes that key's version
+                                    // precisely "so the consumer's cache key matches what was actually
+                                    // compiled". curr.Version is the node's version at WRITE-BACK time,
+                                    // which has advanced past the upload (every compile-status write
+                                    // bumps it) and, on a hydrate, was never the upload version at all.
+                                    //
+                                    // Stamping it re-pointed the record at a store key holding no bytes,
+                                    // and this handler races the activity write-back (ApplyCompileSuccess,
+                                    // which stamps correctly) — so whether the record ended up valid was
+                                    // decided by scheduling. Whoever lost, the readers all use this field
+                                    // as the store key: activation (MeshDataSource / EnrichWithNodeType)
+                                    // then misses and falls back to the DEFAULT config — no
+                                    // MeshNodeReference reducer, the instance page renders nothing — and
+                                    // NodeTypeBakeStatus reports a baked type as having no bytes.
+                                    // Issue #1368.
+                                    LastCompiledVersion = ResolvedStoreVersion(response, def, curr),
                                     // 🚨 A FRESH compile's success write must be COMPLETE —
                                     // stamp the framework version the build ran against,
                                     // exactly like the activity write-back (RunCompile).
@@ -508,9 +525,18 @@ internal static class NodeTypeContractHandler
     /// NodeTypeDefinition. The local path is what <c>MessageHubGrain</c> still
     /// needs to <c>Assembly.LoadFrom</c> during Stage 1.
     /// </summary>
+    /// <param name="storeVersion">
+    /// 🚨 The version the bytes were RESOLVED under — the second half of the
+    /// <c>(nodeTypePath, version)</c> store key that <see cref="ResolveAssembly"/> just hit.
+    /// It is emphatically NOT <c>node.Version</c>: a hydrate serves an assembly uploaded at some
+    /// EARLIER node version, and the node has advanced since (every compile-status write bumps
+    /// it). Echoing the live node version made the caller's write-back re-point
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/> at a store key with no bytes — see
+    /// the write-back note in <see cref="Handle"/> for what that costs.
+    /// </param>
     private static GetCompilationPathResponse BuildResponseFromLocal(
         string hubPath,
-        MeshNode node,
+        long storeVersion,
         string localPath,
         string? collection,
         string? contentPath,
@@ -537,7 +563,7 @@ internal static class NodeTypeContractHandler
             Success: true,
             AssemblyLocation: localPath,
             Collection: collection,
-            Version: node.Version.ToString(),
+            Version: storeVersion.ToString(),
             Error: null,
             HubConfiguration: matchingConfig?.HubConfiguration,
             Log: result.Log)
@@ -545,6 +571,24 @@ internal static class NodeTypeContractHandler
             ContentPath = contentPath
         };
     }
+
+    /// <summary>
+    /// The <see cref="IAssemblyStore"/> key version that <see cref="NodeTypeDefinition.LastCompiledVersion"/>
+    /// must name after a successful resolve: the one the response echoes
+    /// (<see cref="GetCompilationPathResponse.Version"/> — set by the upload on a fresh compile, by
+    /// the resolved store key on a hydrate). Falls back to the value already persisted (still a
+    /// valid key — the bytes it names are exactly what we just served) and only then to the node's
+    /// own version, which is the last-resort guess used when nothing produced a store reference.
+    ///
+    /// <para>🚨 Never stamp the live node version directly. It is the one value guaranteed to be
+    /// WRONG whenever the node advanced after the upload, and it silently converts a healthy
+    /// record into one whose store key holds no bytes (issue #1368).</para>
+    /// </summary>
+    private static long ResolvedStoreVersion(
+        GetCompilationPathResponse response, NodeTypeDefinition def, MeshNode curr)
+        => long.TryParse(response.Version, out var v) && v > 0
+            ? v
+            : def.LastCompiledVersion ?? curr.Version;
 
     private static GetCompilationPathResponse Fail(string? version, string error, ActivityLog? log = null) =>
         new(Success: false,

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -586,9 +586,16 @@ internal static class NodeTypeContractHandler
     /// </summary>
     private static long ResolvedStoreVersion(
         GetCompilationPathResponse response, NodeTypeDefinition def, MeshNode curr)
-        => long.TryParse(response.Version, out var v) && v > 0
-            ? v
-            : def.LastCompiledVersion ?? curr.Version;
+        // The path and the version are ONE reference, so they must come from ONE source.
+        // LatestAssemblyPath above takes response.ContentPath and falls back to the persisted
+        // value when the producer uploaded nothing (memory:// compile, no configurations, Null
+        // store, unreadable bytes). Taking the version from the response while the PATH fell
+        // back to def would pair the retained bytes with a key that was never theirs — the same
+        // record-names-an-empty-shelf defect, just reached the other way round.
+        => !string.IsNullOrEmpty(response.ContentPath)
+           && long.TryParse(response.Version, out var v) && v > 0
+            ? v                                        // path came from the response: take its key
+            : def.LastCompiledVersion ?? curr.Version; // path retained: retain its key
 
     private static GetCompilationPathResponse Fail(string? version, string error, ActivityLog? log = null) =>
         new(Success: false,

--- a/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
@@ -25,15 +27,20 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>NodeTypeEnrichmentHelpers</c> only fires when an INSTANCE of the type is activated. A
 /// NodeType with no live instances therefore stays stale (and <c>compile</c> / CreateRelease
 /// up-to-date checks report it clean) — a runtime <c>MissingMethodException</c> timebomb — until
-/// an operator manually rebuilds it.</para>
+/// an operator manually rebuilds it. The fix is the owner-side, level-triggered kickoff in
+/// <c>NodeTypeCompilationHelpers.InstallCompileWatcher</c>.</para>
 ///
-/// <para><b>The fix</b> adds an owner-side, level-triggered kickoff in
-/// <c>NodeTypeCompilationHelpers.InstallCompileWatcher</c>: when the NodeType's own hub observes
-/// a settled Ok/Error state whose cached assembly is framework-stale, it flips
-/// <see cref="CompilationStatus.Pending"/> so the compile watcher rebuilds it against the CURRENT
-/// framework. This test forces the framework-stale shape on the NodeType (NO instance activated),
-/// then requires the NodeType to re-stamp the CURRENT framework version on its own. Before the fix
-/// nothing rebuilds and the wait for convergence times out.</para>
+/// <para>🚨 <b>The stale RECORD is only half the trigger — the other half is the STORE, and
+/// getting that wrong is what made this test a flake (issue #1368).</b> Since "Don't rebuild what
+/// the share already has" the kickoff asks <see cref="IAssemblyStore"/> before rebuilding, because
+/// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> only says which framework the last
+/// WRITE-BACK came from — not whether bytes for the LIVE framework exist. The store answers the
+/// question that matters: its key carries the live framework tag, so a hit IS a usable build.
+/// A real self-update changes that tag, so every previously-cached DLL becomes invisible to the
+/// live lookup — the record AND the store go stale together. A test that forges only the record
+/// leaves genuine live-framework bytes on the volume, and the correct response to THAT state is
+/// to decline the rebuild. The two cases below therefore pin BOTH directions of the contract, and
+/// each one arranges the store to match the record it forges.</para>
 /// </summary>
 public class FrameworkStaleProactiveRebuildTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -48,11 +55,94 @@ public class FrameworkStaleProactiveRebuildTest(ITestOutputHelper output) : Mono
         => base.ConfigureMesh(builder).AddGraph();
 
     private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private IAssemblyStore AssemblyStore => Mesh.ServiceProvider.GetRequiredService<IAssemblyStore>();
 
+    /// <summary>
+    /// #464: the record is framework-stale AND the store holds no bytes for the live framework —
+    /// the true post-self-update state. The NodeType's OWN hub must rebuild it, with no instance
+    /// activated and no user click.
+    /// </summary>
     [Fact(Timeout = 180_000)]
     public async Task FrameworkStaleNodeType_ProactivelyRebuilds_WithoutInstanceActivation()
     {
-        var typeId = $"ProactiveStale{Guid.NewGuid():N}";
+        var (nodeTypePath, realFv, baselineSucceededAt) = await CompileBaselineType("ProactiveStale");
+        var workspace = Mesh.GetWorkspace();
+
+        // Make the store MISS for the live framework, exactly as a self-update does. The store key
+        // embeds the framework tag (FileSystemAssemblyStore.FrameworkTag), so after a framework
+        // change every cached DLL still on the volume carries the OLD tag and the live-tag lookup
+        // finds nothing. We cannot change the running process's tag, so we remove the cached bytes
+        // — observationally identical through IAssemblyStore, which is all the kickoff can see.
+        EvictFromAssemblyStore(nodeTypePath);
+
+        var bogusFv = await ForceFrameworkStale(nodeTypePath);
+
+        // The NodeType's OWN hub must proactively rebuild and re-stamp the CURRENT framework
+        // version — Status back to Ok, a usable assembly, and a STRICTLY NEWER
+        // LastCompileSucceededAt than the baseline (proving a genuine fresh compile, not a
+        // replayed old Ok) — WITHOUT any instance activation. Before the fix nothing re-drives
+        // the stale-Ok type, so this times out.
+        var rebuilt = await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.CompiledFrameworkVersion == realFv
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && d.LastCompileSucceededAt is { } s && s > baselineSucceededAt);
+        Output.WriteLine($"NodeType proactively rebuilt against the current framework version (was '{bogusFv}').");
+
+        // The rebuild must leave a record whose store key names REAL bytes — see
+        // AssertRecordNamesStoredBytes for why this is the assertion that matters.
+        await AssertRecordNamesStoredBytes(nodeTypePath, rebuilt, "after the proactive rebuild");
+    }
+
+    /// <summary>
+    /// The other direction, and the one that was silently unpinned: the record is framework-stale
+    /// but the store ALREADY holds a build for the LIVE framework — a peer replica or a bake
+    /// service compiled it without this hub seeing the write-back. Rebuilding here is not merely
+    /// wasted work: with two images live at once each pod rebuilds to stamp its own version, sees
+    /// the other's stamp, and rebuilds back — a recompile storm across the pods currently serving
+    /// production. The kickoff must DECLINE.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task FrameworkStaleRecord_WithLiveFrameworkBytesInStore_DoesNotRebuild()
+    {
+        var (nodeTypePath, _, _) = await CompileBaselineType("StaleRecordFreshBytes");
+        var workspace = Mesh.GetWorkspace();
+
+        // NO eviction — the baseline compile's bytes stay in the store under the live framework
+        // tag. That is the whole premise, so assert it rather than assume it: a vacuous version of
+        // this test (bytes actually absent) would pass for the wrong reason.
+        var baseline = await workspace.GetMeshNodeStream(nodeTypePath).Should().Within(30.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition { CompilationStatus: CompilationStatus.Ok });
+        await AssertRecordNamesStoredBytes(nodeTypePath, baseline, "before forging the stale record");
+
+        var bogusFv = await ForceFrameworkStale(nodeTypePath);
+
+        // No rebuild: the node must stay settled Ok carrying the forged stamp. There is no
+        // positive signal for "a decision to do nothing", so this is the sanctioned bounded
+        // negative observation — but it is NOT vacuous: the assertion above proves the store hit
+        // the kickoff relies on is real, and the sibling test proves the same kickoff DOES fire
+        // when the store misses. Any Pending/Compiling flip, or a re-stamped framework version,
+        // fails this immediately.
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Where(n => n.Content is NodeTypeDefinition d
+                && (d.CompilationStatus != CompilationStatus.Ok
+                    || d.CompiledFrameworkVersion != bogusFv))
+            .Should().NotEmit(20.Seconds(),
+                "the assembly store already holds a build for the live framework, so the "
+                + "framework-stale kickoff must decline instead of storming a rebuild");
+        Output.WriteLine("Framework-stale kickoff correctly declined — the store already had live-framework bytes.");
+    }
+
+    /// <summary>
+    /// Creates a NodeType with a trivial source file and waits for its first build to settle Ok,
+    /// returning the path, the REAL (live) framework version it stamped, and its success time.
+    /// </summary>
+    private async Task<(string Path, string RealFrameworkVersion, DateTimeOffset SucceededAt)>
+        CompileBaselineType(string prefix)
+    {
+        var typeId = $"{prefix}{Guid.NewGuid():N}";
         var nodeTypePath = $"type/{typeId}";
 
         var source = $$"""
@@ -84,56 +174,89 @@ public class FrameworkStaleProactiveRebuildTest(ITestOutputHelper output) : Mono
             Content = new CodeConfiguration { Code = source, Language = "csharp" }
         }).Should().Emit();
 
-        var workspace = Mesh.GetWorkspace();
-
-        // 1. Baseline: wait for the first-build compile to settle Ok with a usable build, and
-        //    capture the REAL (live) framework version it stamped.
         await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
             .Should().Within(90.Seconds()).Emit();
-        var okNode = await workspace.GetMeshNodeStream(nodeTypePath)
+        var okNode = await Mesh.GetWorkspace().GetMeshNodeStream(nodeTypePath)
             .Should().Within(60.Seconds())
             .Match(n => n.Content is NodeTypeDefinition d
                 && d.CompilationStatus == CompilationStatus.Ok
                 && d.LastCompileSucceededAt is not null
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && !string.IsNullOrEmpty(d.CompiledFrameworkVersion));
-        var baselineDef = (NodeTypeDefinition)okNode.Content!;
-        var realFv = baselineDef.CompiledFrameworkVersion!;
-        var baselineSucceededAt = baselineDef.LastCompileSucceededAt!.Value;
-        Output.WriteLine($"Baseline compile Ok — real framework version '{realFv}', succeededAt {baselineSucceededAt:O}.");
+        var def = (NodeTypeDefinition)okNode.Content!;
+        Output.WriteLine(
+            $"Baseline compile Ok for {nodeTypePath} — real framework version "
+            + $"'{def.CompiledFrameworkVersion}', succeededAt {def.LastCompileSucceededAt!.Value:O}, "
+            + $"store key v{def.LastCompiledVersion}, assembly '{def.LatestAssemblyPath}'.");
+        return (nodeTypePath, def.CompiledFrameworkVersion!, def.LastCompileSucceededAt!.Value);
+    }
 
-        // 2. Force the framework-stale shape: stamp a bogus CompiledFrameworkVersion while leaving
-        //    Status=Ok and the assembly fields intact — exactly what a binary redeploy leaves
-        //    behind. NO instance of the type is ever activated, so the reactive enrichment
-        //    self-heal never runs: only the proactive OWNER-side kickoff can recover this.
+    /// <summary>
+    /// Stamps a bogus <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> while leaving
+    /// Status=Ok and the assembly fields intact — what a binary redeploy leaves behind. NO instance
+    /// of the type is ever activated, so the reactive enrichment self-heal never runs: only the
+    /// proactive OWNER-side kickoff can act on this.
+    /// </summary>
+    private async Task<string> ForceFrameworkStale(string nodeTypePath)
+    {
+        var workspace = Mesh.GetWorkspace();
         var bogusFv = $"STALE-{Guid.NewGuid():N}";
         await workspace.GetMeshNodeStream(nodeTypePath)
             .Update(curr => curr.Content is NodeTypeDefinition d
                 ? curr with { Content = d with { CompiledFrameworkVersion = bogusFv } }
                 : curr)
             .Should().Emit();
-        // 🚧 Barrier: confirm the bogus stamp actually LANDED before waiting for convergence.
-        // GetMeshNodeStream replays the latest snapshot, so without this the convergence Match
-        // below could match the pre-stamp baseline Ok (still carrying realFv) and pass without
-        // any rebuild — masking a disabled kickoff. Observing bogusFv proves the stale state is
-        // the current one, so realFv can only reappear via a genuine recompile.
+        // 🚧 Barrier: confirm the bogus stamp actually LANDED before waiting on what follows.
+        // GetMeshNodeStream replays the latest snapshot, so without this a convergence Match could
+        // match the pre-stamp baseline Ok (still carrying the real framework version) and pass
+        // without any rebuild — masking a disabled kickoff.
         await workspace.GetMeshNodeStream(nodeTypePath)
             .Should().Within(20.Seconds())
             .Match(n => n.Content is NodeTypeDefinition d && d.CompiledFrameworkVersion == bogusFv);
-        Output.WriteLine($"Forced framework-stale (bogus framework version '{bogusFv}').");
+        Output.WriteLine($"Forced framework-stale on {nodeTypePath} (bogus framework version '{bogusFv}').");
+        return bogusFv;
+    }
 
-        // 3. The NodeType's OWN hub must proactively rebuild and re-stamp the CURRENT framework
-        //    version — Status back to Ok, a usable assembly, and a STRICTLY NEWER
-        //    LastCompileSucceededAt than the baseline (proving a genuine fresh compile, not a
-        //    replayed old Ok) — WITHOUT any instance activation. Before the fix nothing re-drives
-        //    the stale-Ok type, so this times out.
-        await workspace.GetMeshNodeStream(nodeTypePath)
-            .Should().Within(90.Seconds())
-            .Match(n => n.Content is NodeTypeDefinition d
-                && d.CompilationStatus == CompilationStatus.Ok
-                && d.CompiledFrameworkVersion == realFv
-                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
-                && d.LastCompileSucceededAt is { } s && s > baselineSucceededAt);
-        Output.WriteLine("NodeType proactively rebuilt against the current framework version.");
+    /// <summary>
+    /// 🚨 The record's <see cref="NodeTypeDefinition.LastCompiledVersion"/> is one half of the
+    /// <see cref="IAssemblyStore"/> key <c>(nodeTypePath, version)</c>; it MUST name bytes that
+    /// exist. When it does not, every consumer that resolves an assembly through it misses:
+    /// activation falls back to the default config (no MeshNodeReference reducer — the instance
+    /// page renders nothing), the bake gate files a baked type as having no bytes, and the
+    /// framework-stale kickoff's store probe wrongly concludes a rebuild is needed.
+    ///
+    /// <para>This is the regression pin for issue #1368, where the <c>GetCompilationPathRequest</c>
+    /// write-back stamped the node's CURRENT version instead of the version the upload used, and
+    /// raced the activity write-back (which stamps correctly) for the last word.</para>
+    /// </summary>
+    private async Task AssertRecordNamesStoredBytes(string nodeTypePath, MeshNode node, string when)
+    {
+        var def = (NodeTypeDefinition)node.Content!;
+        def.LastCompiledVersion.Should().NotBeNull(
+            $"the compile write-back must record the assembly-store key version ({when})");
+        var resolved = await AssemblyStore
+            .TryGetAssemblyPath(nodeTypePath, def.LastCompiledVersion!.Value)
+            .Should().Within(30.Seconds()).Emit();
+        resolved.Should().NotBeNullOrEmpty(
+            $"LastCompiledVersion={def.LastCompiledVersion} must name assembly-store bytes that "
+            + $"exist ({when}); the record points at '{def.LatestAssemblyPath}'");
+        Output.WriteLine($"Store key v{def.LastCompiledVersion} resolves to '{resolved}' ({when}).");
+    }
+
+    /// <summary>
+    /// Removes this NodeType's cached assemblies from the filesystem assembly store, reproducing
+    /// what a framework-tag change does to the live lookup (see the class remarks).
+    /// </summary>
+    private void EvictFromAssemblyStore(string nodeTypePath)
+    {
+        var store = (FileSystemAssemblyStore)AssemblyStore;
+        var typeId = nodeTypePath.Split('/').Last();
+        var dirs = Directory.EnumerateDirectories(store.RootDirectory, $"*{typeId}*").ToList();
+        dirs.Should().NotBeEmpty(
+            $"the baseline compile must have cached '{nodeTypePath}' under {store.RootDirectory} — "
+            + "without bytes to evict this test's premise is not established");
+        foreach (var dir in dirs)
+            Directory.Delete(dir, recursive: true);
+        Output.WriteLine($"Evicted {dirs.Count} assembly-store director(ies) for {nodeTypePath}.");
     }
 }


### PR DESCRIPTION
Closes #1368.

## Neither hypothesis in the issue survived

**Not a bounded wait.** The test already waits on a condition, not on elapsed time. The 90 s expiry was a symptom: the node received exactly **one** emission in the whole window — byte-identical on all three PRs (`Last of 1 emission(s)`, `LastCompiledVersion = 4`, `Version = 8`). Nothing was late. The framework-stale kickoff looked at the state, logged

```
Framework-stale kickoff SKIPPED … the assembly store already holds a build for
the live framework — nothing to rebuild
```

and, having consumed its `Take(1)`, never looked again. There is no bound here to widen.

**Not today's bake work.** #1357 / #1361 / #1363 / #1343 are all innocent. The two commits that matter are `5c86076bb` (2026-07-28, the store probe) and #145 (2026-07-02, the defect).

## Two writers, one field, different values

`LastCompiledVersion` is one half of the `IAssemblyStore` key `(nodeTypePath, version)`. Two places write it:

| writer | value | correct? |
|---|---|---|
| `NodeTypeCompilationHelpers.ApplyCompileSuccess` | `result.Version` — the version the upload used | ✅ and its own comment says why it must be: *"A different version here would point activation at a store key that has no bytes"* |
| `NodeTypeContractHandler` (`GetCompilationPathRequest` write-back) | `curr.Version` — the node's version at write-back time | ❌ since #145 |

The node has advanced past the upload by write-back time (every compile-status write bumps it), and on a hydrate that version was never the upload version at all. Whichever landed last won, so whether a compile left a valid record was decided by **scheduling** — which is exactly why contention moved it and a quiet `main` kept producing the other outcome.

## The test was the detector, wired backwards

Since `5c86076bb` the kickoff asks the store before rebuilding, keyed by `LastCompiledVersion`:

- record **correct** → probe hits the real bytes → kickoff rightly declines → **test RED**
- record **corrupt** → probe misses an empty key → kickoff fires → **test GREEN**

It was green only when the record was broken. It is the only test that reads this field as a store key and asserts on the consequence, which is why it was over-represented among the failures.

## What it costs in production

Every reader uses this field as the store key: activation (`MeshDataSource`, `NodeTypeEnrichmentHelpers`) — which on a miss falls back to the default config, no `MeshNodeReference` reducer, so **the instance page renders empty** — the MCP compile tool, and `NodeTypeBakeStatus.HasBytes`, **the pre-update bake gate**, which files a genuinely baked type as having no bytes.

## The fix

Both writers now record the version the bytes were filed under. `BuildResponseFromLocal` echoes the store key it resolved with instead of the live node version, and the write-back takes the version off the response — which the contract already defines as *"echoed so the consumer's cache key matches what was actually compiled"*.

## The test

Its fixture could not express the state it claimed. A real self-update changes the framework tag the store key embeds, so record and store go stale **together**; forging only the record leaves genuine live-framework bytes on the volume, and declining to rebuild is then the *correct* answer. Both directions are now pinned, each arranging the store to match the record it forges:

- record stale + **no** live-framework bytes ⇒ rebuilds (the #464 defect)
- record stale + live-framework bytes ⇒ declines (the recompile-storm guard — previously unpinned, and the behaviour this test had been calling a failure)

Both also assert the record's store key names bytes that exist: the regression pin for the defect above.

## Verification

- **fail-before**, unconstrained, 3 s: `LastCompiledVersion=6 must name assembly-store bytes that exist; the record points at '…/v4-…dll'`
- **pass-after**: green unconstrained *and* under `DOTNET_PROCESSOR_COUNT=4`
- the **old** test under `DOTNET_PROCESSOR_COUNT=4` reproduced CI byte-for-byte before any change
- regression sweep `Compile|NodeType|SelfHeal|PreWarm|Bake|StaleActivation`: **142/142**
- `MeshWeaver.Graph` and `MeshWeaver.Hosting.Monolith.Test` clean under `-c Release -warnaserror`

## The other two sightings do NOT share this root

- **`LayoutAreaRetrievalTest`** on #1364 failed with `the data stream for this reference completed without ever producing a value — its owner is shutting down`. That string is the NACK **#1364 itself introduces**; it is that PR's own diff surfacing on a shutdown race, not shared contention. Passes locally under 4 cores.
- **`StaleActivationDurableFirstSeedTest`** failed on a version count (`expected 2 … found 3` — an extra activation write-back) against a **`Markdown`** node, so this fix cannot touch it. It passed in the sweep; I could not reproduce its failure and make no claim about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
