### PR TITLE
Restore PDF contents page numbers by measuring the print (#1309)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PixelFaithfulExport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PixelFaithfulExport.md
@@ -163,13 +163,44 @@ Every decision about *what the page looks like* happens in a composer that is pu
 
 The browser tests (`HeadlessChromiumRenderTests`, `RendererOutputTests`, `PdfHeaderLogoTests`, `DeckPixelExportScriptRelayTest`) ask the renderer's own probe and then assert **whichever contract applies to the machine**: with a browser, a real PDF — cover, contents and body on separate pages, the running header on every page but the cover, `N / M` in the footer; without one, a loud, actionable refusal. They are never skipped, and a missing browser can neither hide a regression nor redden a build. CI provisions the same browser build the image ships, as an explicit infrastructure step, so a shard cannot pass by taking the "no browser" branch.
 
-### 🚧 The one thing that did not survive: page numbers in the contents list
+## Page numbers in the contents list: measure the print, then print the measurement
 
-The document model could print `Chapter 3 ......... 12`. **The browser cannot**, and the contents list therefore carries clickable links but no page numbers.
+The contents list prints `Chapter 3 …… 12` again. **CSS still cannot produce that number**, so it is not produced in CSS: it is read out of a printed PDF and put into a second print, which is then read back and checked before it is released. `#1230` shipped without the column and `#1309` restored it this way.
 
-The reason is specific: reading a target's page from CSS needs `target-counter()` from CSS Generated Content for Paged Media, and Chromium implements no part of it — verified directly against the browser this image ships, alongside the features that *do* work (`@page` margin boxes, named pages, `counter(page)` / `counter(pages)`), which is what the rest of the furniture is built on.
+### Why nothing in the page can answer the question
 
-The alternative is a two-pass print: print once, read back from the PDF's link annotations which page each anchor landed on, inject the numbers and print again. It was rejected deliberately — it doubles the cost of every export with a contents list, and its failure mode is *silently wrong page numbers* when the inserted digits reflow the list. An honestly absent column beats a confidently wrong one, and in a PDF the clickable entry is the affordance a reader actually uses.
+Reading a target's page from CSS needs `target-counter()` from CSS Generated Content for Paged Media, and Chromium implements **no part of it** — verified directly against the browser this image ships, alongside the features that *do* work (`@page` margin boxes, named pages, `counter(page)` / `counter(pages)`), which is what the rest of the furniture is built on.
+
+Measuring in the page with script cannot be made right either, and it is worth being precise about why, because it is the approach that looks easiest. A heading's `offsetTop` divided by a content height is arithmetic over the *viewport*, and the print box is not the viewport: `break-after: avoid` moves a heading that would be stranded, `orphans`/`widows` move the line before it, a repeated `<thead>` and an unbreakable figure both consume height that no per-page constant accounts for. The result is a number that is plausible, occasionally off by one, and impossible to distinguish from a correct one by looking at it. (It would also need `script-src` in a print document whose CSP is deliberately `default-src 'none'`.)
+
+### What the PDF already knows
+
+Every contents entry is a **link annotation**, and its `GoTo` destination names the page Chromium itself put that heading on. That is not a model of the pagination — it *is* the pagination, recorded by the engine that performed it. `TocPageNumbers` reads it back with PdfPig, which the platform already carries for content indexing, so no dependency is added and the licence gate is untouched.
+
+Entries are matched to annotations positionally, and each assumption that rests on is checked rather than trusted:
+
+| Assumption | Why it holds | Checked by |
+|---|---|---|
+| One annotation per entry | An entry is a block-level (flex) `<a>`, so a title that wraps still emits one rect — an *inline* link would emit one per line and slide every later number by one | The composer test pinning the entry's structure |
+| Entries are the first internal links | The contents list is the only thing between the cover and the body; ordinary body links are `URI` actions and carry no destination page | Count must come out exactly, else refuse |
+| Annotations are in reading order | A contents list is a plain vertical stack of blocks; they are read top-down, then left-to-right | Destinations must be non-decreasing, else refuse |
+| The list precedes what it points at | `.mw-toc { break-after: page }` | Every destination must be after the last page carrying an entry, else refuse |
+
+Reading stops at the page that completes the count — usually page two — so a 500-page export parses three pages, not five hundred.
+
+### Why the second print still matches the first
+
+The number column is emitted on **both** prints and its width is a **constant** (`flex: 0 0 40pt`, the same 40pt column the document model drew). Digits cannot reflow a box whose width does not depend on them, so the measuring print and the published print are the same layout by construction — no rewrapped title, no extra line, nothing after the list moved. Sizing the column to its content (`min-width`, `fit-content`, a width derived from the page count) is precisely how a naive two-pass ends up printing numbers that are quietly wrong.
+
+**And that argument is not trusted either.** `PdfDocumentRenderer` re-reads the *published* PDF and releases it only if every destination still equals the number printed beside it. A mismatch — or a refusal at any earlier step — falls back to the numberless contents list, logs the reason and the two readings, and publishes that instead. "By construction" is exactly the reasoning that produces silently wrong page numbers; a contents list that lies about a page is worse than one that is silent about it.
+
+### What it costs
+
+Two browser invocations instead of one, and only for a document that has a contents list — the read-back is a few pages of PDF parsing and runs on the same `Process` pool as the browser, so a burst of exports bounds its parsing as well as its browsers. Documents without a contents list are printed exactly once, as before.
+
+### How it is verified
+
+The composer contract (column reserved on both prints, constant width, digits the only difference between the two documents, a mismatched list ignored outright) is pinned by `DocumentPrintComposerTests` with no browser installed. The number itself is checked end-to-end in `RendererOutputTests` against an **independent oracle**: the test finds the page whose *glyphs* carry each section's heading and requires that the number the contents list PRINTS, the page the heading is DRAWN on, and the page the link JUMPS to all agree — over a document whose sections deliberately span page boundaries, including the first and last entries. An error in the annotation reading therefore cannot also produce the expectation.
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-pdf-export-cover-contents-header.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-12-pdf-export-cover-contents-header.md
@@ -18,8 +18,11 @@ that start each chapter on a fresh page. Two things are better than before — a
 spans pages now **repeats its header row**, and a heading is no longer left stranded alone at
 the foot of a page.
 
-**One thing is gone, and it is worth naming:** entries in the table of contents no longer show
-the page they point at. They are still real links — clicking one jumps to that section — but
-the `..... 12` column is not there. Browsers provide no way to read a target's page number
+**One thing was gone, and it is worth naming:** entries in the table of contents no longer showed
+the page they point at. They were still real links — clicking one jumps to that section — but
+the `..... 12` column was not there. Browsers provide no way to read a target's page number
 while laying the document out, and guessing it would risk printing numbers that are quietly
 wrong, which is worse than not printing them.
+
+> **Since resolved.** The column came back the next day, without any guessing: see
+> [The contents list tells you the page again](../2026-08-13-the-contents-list-tells-you-the-page-again).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-contents-list-tells-you-the-page-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-contents-list-tells-you-the-page-again.md
@@ -1,0 +1,34 @@
+---
+Name: The contents list tells you the page again
+Category: Fix
+Description: Exported PDFs print the page number beside every table-of-contents entry once more — and each number is checked against the finished document before it is published.
+Icon: Sparkle
+Order: -20260813
+---
+
+# The contents list tells you the page again
+
+When PDF export moved to the browser, the table of contents kept its entries and its links but
+lost the `..... 12` column. **The page numbers are back.**
+
+Every entry now shows the page its section starts on, right-aligned at the margin the way a
+printed contents list has always looked. Clicking the entry still jumps there — the number is
+in addition to the link, not instead of it.
+
+## Why you can trust the number
+
+Browsers genuinely cannot work out, while laying a page out, which page something will land
+on. So the export does not guess. It prints the document once, reads out of that finished PDF
+which page each section actually begins on, and prints it again with those numbers filled in —
+then **reads the finished document back a second time and checks that every number is still
+right**. Only a document that passes that check is handed to you.
+
+If anything about it does not add up, the export prints the contents list without numbers
+rather than with numbers it cannot stand behind. A contents list that quietly points at the
+wrong page would be worse than one that says nothing.
+
+The number column is reserved on both prints, so filling in the digits cannot push the list
+onto another page and move everything after it — which is exactly how this sort of feature
+usually goes wrong.
+
+Documents without a table of contents are unaffected and are still printed once.

--- a/src/MeshWeaver.Markdown.Export/Ast/DocumentBuilder.cs
+++ b/src/MeshWeaver.Markdown.Export/Ast/DocumentBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using Markdig;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
@@ -103,6 +104,10 @@ public class DocumentBuilder
         var mathIndex = 0;
         var elements = ImmutableArray.CreateBuilder<DocumentElement>();
         var tocHeadings = ImmutableArray.CreateBuilder<HeadingElement>();
+        // Anchor ids must be unique across the WHOLE document, chapters included — two chapters
+        // each opening with "Overview" is the ordinary case, not a corner one. Scoped to this
+        // call, never to the instance, so two Build()s cannot suffix each other's ids.
+        var anchors = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
 
         var first = true;
         foreach (var chapter in chapters)
@@ -120,7 +125,7 @@ public class DocumentBuilder
 
             _currentNodePath = chapter.NodePath ?? _defaultNodePath;
             var doc = Markdig.Markdown.Parse(chapter.Markdown, PipelineFor(_currentNodePath));
-            WalkBlocks(doc, options, elements, tocHeadings, ref mermaidIndex, ref mathIndex);
+            WalkBlocks(doc, options, elements, tocHeadings, anchors, ref mermaidIndex, ref mathIndex);
         }
 
         return new Document(
@@ -136,6 +141,7 @@ public class DocumentBuilder
         DocumentExportOptions options,
         ImmutableArray<DocumentElement>.Builder elements,
         ImmutableArray<HeadingElement>.Builder tocHeadings,
+        ImmutableHashSet<string>.Builder anchors,
         ref int mermaidIndex,
         ref int mathIndex)
     {
@@ -152,7 +158,7 @@ public class DocumentBuilder
                         elements.Add(new PageBreakElement());
 
                     var content = ReadInlines(h.Inline);
-                    var anchor = AnchorFromInlines(content);
+                    var anchor = AnchorFromInlines(content, anchors);
                     var heading = new HeadingElement(h.Level, anchor, content);
                     elements.Add(heading);
                     if (h.Level is >= 1 and <= 3) tocHeadings.Add(heading);
@@ -196,7 +202,7 @@ public class DocumentBuilder
                 case QuoteBlock q:
                 {
                     var inner = ImmutableArray.CreateBuilder<DocumentElement>();
-                    WalkBlocks(q, options, inner, tocHeadings, ref mermaidIndex, ref mathIndex);
+                    WalkBlocks(q, options, inner, tocHeadings, anchors, ref mermaidIndex, ref mathIndex);
                     elements.Add(new BlockQuoteElement(inner.ToImmutable()));
                     break;
                 }
@@ -208,7 +214,7 @@ public class DocumentBuilder
                         if (child is ListItemBlock li)
                         {
                             var content = ImmutableArray.CreateBuilder<DocumentElement>();
-                            WalkBlocks(li, options, content, tocHeadings, ref mermaidIndex, ref mathIndex);
+                            WalkBlocks(li, options, content, tocHeadings, anchors, ref mermaidIndex, ref mathIndex);
                             items.Add(new ListItemElement(content.ToImmutable()));
                         }
                     }
@@ -229,7 +235,7 @@ public class DocumentBuilder
                     elements.AddRange(ResolveArea(areaInfo));
                     break;
                 case ContainerBlock container2:
-                    WalkBlocks(container2, options, elements, tocHeadings, ref mermaidIndex, ref mathIndex);
+                    WalkBlocks(container2, options, elements, tocHeadings, anchors, ref mermaidIndex, ref mathIndex);
                     break;
             }
         }
@@ -362,7 +368,21 @@ public class DocumentBuilder
         return sb.ToString();
     }
 
-    private static string AnchorFromInlines(ImmutableArray<InlineElement> inlines)
+    /// <summary>
+    /// The id a heading carries and its contents entry links to — slugified from the heading text
+    /// and then made UNIQUE within the document.
+    ///
+    /// <para>🚨 Uniqueness is not cosmetic. Two sections legitimately called "Overview" slugify to
+    /// the same <c>overview</c>, and an HTML fragment reference resolves to the FIRST element with
+    /// that id — so the second entry's link jumped to the first section, and the PDF link
+    /// annotation recorded that wrong destination too. It was invisible while the contents list
+    /// printed no page numbers; the page-number read-back (#1309) refuses a document whose
+    /// destinations run backwards, which is how it surfaced. Disambiguating with a numeric suffix
+    /// is what every markdown renderer does, so an author's expectation is unchanged.</para>
+    /// </summary>
+    private static string AnchorFromInlines(
+        ImmutableArray<InlineElement> inlines,
+        ImmutableHashSet<string>.Builder taken)
     {
         var sb = new System.Text.StringBuilder();
         foreach (var i in inlines)
@@ -372,7 +392,18 @@ public class DocumentBuilder
                 foreach (var c in l.Content)
                     if (c is TextInline tt) sb.Append(tt.Text);
         }
-        return Slugify(sb.ToString());
+
+        var slug = Slugify(sb.ToString());
+        // An empty heading (or one made only of punctuation) has no slug to make unique; give it
+        // a stable generated one rather than an id of "" that nothing can link to.
+        if (slug.Length == 0)
+            slug = "section";
+
+        var candidate = slug;
+        for (var suffix = 2; !taken.Add(candidate); suffix++)
+            candidate = slug + "-" + suffix.ToString(CultureInfo.InvariantCulture);
+
+        return candidate;
     }
 
     private static string Slugify(string s)

--- a/src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj
+++ b/src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj
@@ -10,6 +10,12 @@
          to strip what mail clients cannot render. Same parser the Blazor MarkdownHtmlRenderer
          uses for the identical walk, so the two agree on what a placeholder div is. -->
     <PackageReference Include="HtmlAgilityPack" />
+    <!-- Reads the printed PDF back to recover the page each contents entry landed on: Chromium
+         implements no part of CSS `target-counter`, so the browser's own link annotations are the
+         only truthful source for a contents page number (#1309, TocPageNumbers). Already in this
+         project's graph via MeshWeaver.ContentCollections — declared here because this project now
+         uses the API directly. -->
+    <PackageReference Include="UglyToad.PdfPig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrint.css
+++ b/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrint.css
@@ -180,8 +180,23 @@ body {
     margin: 0 0 10pt 0;
 }
 
+/* 🚨 An entry never straddles a page break, and that is a correctness rule, not typography.
+ * A title caught by the break fragments, and Chromium emits one link annotation PER FRAGMENT —
+ * so one entry contributes two rects, the positional match in TocPageNumbers sees more links
+ * than there are entries, and the whole contents list loses its numbers to an avoidable
+ * refusal. Keeping the entry whole keeps the one-annotation-per-entry invariant it rests on.
+ *
+ * Measured, not assumed: sliding a contents list past a page break in 8pt steps, 10 of 15
+ * layouts printed 15 annotations for 14 entries without this rule and exactly 14 with it.
+ *
+ * 🚨 REPRODUCING IT NEEDS A TITLE OF FOUR OR MORE LINES. `orphans` and `widows` both default
+ * to 2, so a two- or three-line entry cannot be split at all — every half would breach one of
+ * them. Anyone who tests this rule with an ordinary wrapped title will see no difference and
+ * conclude it does nothing. It is not decoration; delete it and a long enough heading silently
+ * costs the document its page numbers. (Copilot review, #1372.) */
 .mw-toc-entry {
     margin: 0;
+    break-inside: avoid;
 }
 
 /* Each entry is a row: the title takes the slack, the page number sits in a column at the

--- a/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrint.css
+++ b/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrint.css
@@ -33,8 +33,9 @@
 /* Every other page: the running header and footer live in @page margin boxes.
  *
  * Chromium implements margin boxes and the `page`/`pages` counters (verified against the
- * browser this image ships). It does NOT implement `target-counter`, which is why the
- * contents list carries links rather than page numbers — see the doc page. */
+ * browser this image ships). It does NOT implement `target-counter`, so the contents list's
+ * page numbers cannot come from CSS at all — they are read back out of a first print and put
+ * into a second one. See TocPageNumbers and the `.mw-toc-page` rule below. */
 @page mw-doc {
     margin: 2cm;
 
@@ -183,9 +184,40 @@ body {
     margin: 0;
 }
 
+/* Each entry is a row: the title takes the slack, the page number sits in a column at the
+ * right margin — the same shape the document model drew (a relative title item plus a
+ * constant 40pt right-aligned page-number item).
+ *
+ * 🚨 The column's width is a CONSTANT, and that is the load-bearing detail of the whole
+ * feature. Chromium implements no part of `target-counter`, so the numbers can only be read
+ * back out of a first print and put into a second one (see TocPageNumbers). That is only
+ * sound if adding the digits cannot move anything: a box whose width does not depend on its
+ * content reflows nothing, so the second print has the pagination the first one measured.
+ * Sizing this column to the digits — `min-width`, `fit-content`, a width derived from the
+ * page count — would quietly break that and is the reason a naive two-pass prints numbers
+ * that are wrong. `tabular-nums` keeps the digits on a common grid so the column reads as a
+ * column; `baseline` alignment keeps the number on the FIRST line of an entry that wraps.
+ * `width` repeats what `flex-basis` already says, deliberately: it is the size the box falls
+ * back to if the flex context is ever lost (a future stylesheet edit, a different engine), and
+ * a constant width is the one property here that must not silently become content-dependent. */
 .mw-toc-entry a {
     color: inherit;
     text-decoration: none;
+    display: flex;
+    align-items: baseline;
+    gap: 6pt;
+}
+
+.mw-toc-text {
+    flex: 1 1 auto;
+}
+
+.mw-toc-page {
+    flex: 0 0 40pt;
+    width: 40pt;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }
 
 .mw-toc-1 { font-size: 12pt; font-weight: 700; padding-left: 0; }

--- a/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrintComposer.cs
+++ b/src/MeshWeaver.Markdown.Export/Pdf/DocumentPrintComposer.cs
@@ -53,9 +53,31 @@ public static partial class DocumentPrintComposer
     /// </summary>
     internal const string ContentsHeading = "Contents";
 
+    /// <summary>
+    /// What the reserved page-number column holds on the MEASURING print — a zero-width space,
+    /// spelled as an escape so it survives any editor that would otherwise eat an invisible
+    /// character.
+    ///
+    /// <para>Not an empty string: an inline box with no content generates no line box, so the
+    /// reserved column would not sit on the baseline the numbered print then puts a digit on, and
+    /// the two prints would not be the pixel-for-pixel same layout that the measurement relies
+    /// on.</para>
+    /// </summary>
+    internal const string ReservedColumnFiller = "\u200b";
+
     /// <summary>Composes the print document for <paramref name="document"/>.</summary>
+    /// <param name="document">The document model to lay out.</param>
+    /// <param name="tocPageNumbers">
+    /// The page each contents entry points at, in entry order, as read back out of a first print by
+    /// <see cref="TocPageNumbers"/>. Leave it defaulted for the measuring print: the number column
+    /// is then reserved but left blank.
+    ///
+    /// <para>🚨 A list of the wrong length is IGNORED rather than partially applied — a contents
+    /// list whose numbers have slipped by one entry is exactly the silent lie this feature exists
+    /// not to print.</para>
+    /// </param>
     /// <returns>A complete, self-contained HTML document.</returns>
-    public static string Compose(Document document)
+    public static string Compose(Document document, ImmutableArray<int> tocPageNumbers = default)
     {
         ArgumentNullException.ThrowIfNull(document);
 
@@ -63,7 +85,7 @@ public static partial class DocumentPrintComposer
             (TitleToken, MarkupNode.Text(document.Title).Render()),
             (StylesToken, ComposeStyles(document)),
             (CoverToken, ComposeCover(document)),
-            (TocToken, ComposeToc(document)),
+            (TocToken, ComposeToc(document, tocPageNumbers)),
             (BodyToken, ComposeBody(document)));
     }
 
@@ -176,28 +198,46 @@ public static partial class DocumentPrintComposer
 
     // ── Table of contents ───────────────────────────────────────────────────────────────
 
-    private static string ComposeToc(Document document)
+    private static string ComposeToc(Document document, ImmutableArray<int> pageNumbers)
     {
         if (!document.Options.TableOfContents || document.TocHeadings.Length == 0)
             return string.Empty;
+
+        // Partial numbering is not a thing: either every entry carries a number that was read back
+        // out of a print of THIS document, or none does.
+        var numbered = !pageNumbers.IsDefault && pageNumbers.Length == document.TocHeadings.Length;
 
         var toc = MarkupNode.El("section")
             .With("class", "mw-toc")
             .Add(MarkupNode.El("div").With("class", "mw-toc-title").Add(MarkupNode.Text(ContentsHeading)));
 
-        // Each entry is a real internal link, which Chromium turns into a PDF link annotation —
-        // so the contents list navigates. It carries no page NUMBER: Chromium implements neither
-        // `target-counter` nor any other way to read a target's page from CSS, and the two-pass
-        // alternative (print, read back where each anchor landed, print again) can silently
-        // publish wrong numbers when the inserted digits reflow the list. See the doc page.
-        foreach (var heading in document.TocHeadings)
+        // Each entry is a real internal link, which Chromium turns into a PDF link annotation. That
+        // annotation does double duty: it is what makes the contents list navigate, AND it is what
+        // the page number is read back from — Chromium implements no part of `target-counter`, so
+        // the browser's own pagination in the printed PDF is the only truthful source (#1309).
+        //
+        // 🚨 The page-number cell is emitted on BOTH passes and its width is a CONSTANT (see
+        // DocumentPrint.css). The measuring print therefore has exactly the pagination of the
+        // numbered one — digits cannot reflow a box whose width does not depend on them — which is
+        // what makes the number read off the first print still true of the second. The renderer
+        // re-reads the numbered print and verifies that anyway; belt and braces, because the whole
+        // point is to never publish a number nobody checked.
+        for (var i = 0; i < document.TocHeadings.Length; i++)
         {
+            var heading = document.TocHeadings[i];
             var level = Math.Clamp(heading.Level, 1, 6);
             toc = toc.Add(MarkupNode.El("p")
                 .With("class", $"mw-toc-entry mw-toc-{level.ToString(CultureInfo.InvariantCulture)}")
                 .Add(MarkupNode.El("a")
                     .With("href", "#" + heading.AnchorId)
-                    .Add(MarkupNode.Text(PlainText(heading.Content)))));
+                    .Add(MarkupNode.El("span")
+                        .With("class", "mw-toc-text")
+                        .Add(MarkupNode.Text(PlainText(heading.Content))))
+                    .Add(MarkupNode.El("span")
+                        .With("class", "mw-toc-page")
+                        .Add(MarkupNode.Text(numbered
+                            ? pageNumbers[i].ToString(CultureInfo.InvariantCulture)
+                            : ReservedColumnFiller)))));
         }
 
         return toc.Render();

--- a/src/MeshWeaver.Markdown.Export/Pdf/PdfDocumentRenderer.cs
+++ b/src/MeshWeaver.Markdown.Export/Pdf/PdfDocumentRenderer.cs
@@ -1,5 +1,8 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Markdown.Export.Pixel;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
 using Document = MeshWeaver.Markdown.Export.Model.Document;
 
 namespace MeshWeaver.Markdown.Export.Pdf;
@@ -13,19 +16,38 @@ namespace MeshWeaver.Markdown.Export.Pdf;
 /// licence MeshWeaver cannot ship under (issue #1230). The replacement is the engine the portal
 /// already runs for pixel-faithful deck export, so the product keeps ONE PDF back end instead of
 /// two, and the page furniture is expressed in CSS Paged Media rather than in a fluent drawing
-/// API. Every feature the document model provided is reproduced — cover page, table of contents,
-/// running header and footer, page numbering, page-break rules — with one named exception: the
-/// contents list carries links but no page numbers, because Chromium implements no way to read a
-/// target's page from CSS. See <c>Doc/Architecture/PixelFaithfulExport</c>.</para>
+/// API. Cover page, table of contents, running header and footer, page numbering and the
+/// page-break rules are all reproduced.</para>
 ///
-/// <para>Cold and reactive: composing and printing both happen on <b>Subscribe</b>, and the
-/// browser itself is a <c>Process</c> leaf bounded by <c>IIoPool</c>'s <c>Process</c> pool inside
-/// <see cref="IPixelPdfRenderer"/>. There is no <c>Task</c> in the signature and no
-/// <c>Observable.FromAsync</c> anywhere on the path.</para>
+/// <para><b>Contents page numbers: measure the print, then print the measurement.</b> Chromium
+/// implements no part of <c>target-counter</c>, so nothing in the page can name the page a heading
+/// landed on (#1309). A print CAN: every contents entry is a link annotation carrying the
+/// destination page the browser itself chose. So a document with a contents list is printed twice —
+/// once to measure, once to publish — and the second print is then RE-MEASURED and released only if
+/// it still agrees. The measuring print already reserves the number column at a constant width, so
+/// the digits cannot reflow anything and the two prints are the same layout by construction; the
+/// verification is there because "by construction" is exactly the argument that produces silently
+/// wrong page numbers. When either step cannot stand behind a number, the export falls back to the
+/// contents list it has had since #1230 — links, no numbers — and says why in the log. A contents
+/// list that lies about a page is worse than one that is silent about it.</para>
+///
+/// <para>Cold and reactive: composing, printing and reading back all happen on <b>Subscribe</b>.
+/// The browser is a <c>Process</c> leaf bounded by <c>IIoPool</c>'s <c>Process</c> pool inside
+/// <see cref="IPixelPdfRenderer"/>, and the read-back — parsing a couple of pages of PDF — is a CPU
+/// leaf that goes through the same pool, so a burst of exports bounds its parsing as well as its
+/// browsers. There is no <c>Task</c> in the signature and no <c>Observable.FromAsync</c> anywhere
+/// on the path.</para>
 /// </summary>
 /// <param name="browser">The browser leaf that prints a self-contained HTML document.</param>
-public sealed class PdfDocumentRenderer(IPixelPdfRenderer browser)
+/// <param name="ioPools">Pool registry; the read-back runs on the same pool as the browser.</param>
+/// <param name="logger">Records a refusal to number the contents list, with its reason.</param>
+public sealed class PdfDocumentRenderer(
+    IPixelPdfRenderer browser,
+    IoPoolRegistry ioPools,
+    ILogger<PdfDocumentRenderer>? logger = null)
 {
+    private IIoPool Pool => ioPools.Get(IoPoolNames.Process);
+
     /// <summary>
     /// Produces the PDF for <paramref name="document"/>.
     ///
@@ -33,7 +55,72 @@ public sealed class PdfDocumentRenderer(IPixelPdfRenderer browser)
     /// browser this fails with <see cref="PixelRendererUnavailableException"/> rather than
     /// returning a document that silently lost its formatting.</para>
     /// </summary>
-    public IObservable<byte[]> Render(Document document) =>
+    public IObservable<byte[]> Render(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
         // Defer keeps the composition cold too — nothing runs until someone subscribes.
-        Observable.Defer(() => browser.Render(DocumentPrintComposer.Compose(document)));
+        return Observable.Defer(() =>
+        {
+            var entries = document.Options.TableOfContents ? document.TocHeadings.Length : 0;
+            var measuring = browser.Render(DocumentPrintComposer.Compose(document));
+
+            // No contents list, nothing to number: ONE print, exactly as before. The second print
+            // is the price of the numbers and is only paid by the documents that show them.
+            return entries == 0 ? measuring : measuring.SelectMany(measured => Publish(document, measured, entries));
+        });
+    }
+
+    /// <summary>
+    /// Reads the contents pages out of the measuring print and, when they are trustworthy, prints
+    /// the document again with them — releasing that second print only if re-reading it agrees.
+    /// </summary>
+    private IObservable<byte[]> Publish(Document document, byte[] measured, int entries) =>
+        Pool.InvokeBlocking(_ => TocPageNumbers.Resolve(measured, entries))
+            .SelectMany(lookup =>
+            {
+                if (!lookup.Resolved)
+                {
+                    logger?.LogWarning(
+                        "Contents page numbers were not printed for '{Title}': {Reason}. The contents "
+                        + "list still links to each section.", document.Title, lookup.Refusal);
+                    return Observable.Return(measured);
+                }
+
+                return browser.Render(DocumentPrintComposer.Compose(document, lookup.Pages))
+                    .SelectMany(published => Verify(document, measured, published, lookup.Pages, entries));
+            });
+
+    /// <summary>
+    /// The gate on publication: the numbered print must still put every heading on the page its
+    /// contents entry claims.
+    ///
+    /// <para>This is what makes the two-pass honest rather than hopeful. The numbers were measured
+    /// on a DIFFERENT print, and the only thing that makes them true of this one is that the two
+    /// paginate identically — so that is asserted against the printed artefact, not assumed from
+    /// the stylesheet. A mismatch releases the measuring print (which claims nothing) and names the
+    /// disagreement.</para>
+    /// </summary>
+    private IObservable<byte[]> Verify(
+        Document document,
+        byte[] measured,
+        byte[] published,
+        ImmutableArray<int> printedPages,
+        int entries) =>
+        Pool.InvokeBlocking(_ => TocPageNumbers.Resolve(published, entries))
+            .Select(check =>
+            {
+                if (check.Resolved && check.Pages.SequenceEqual(printedPages))
+                    return published;
+
+                logger?.LogWarning(
+                    "Contents page numbers were withdrawn from '{Title}': the print carrying them "
+                    + "paginates differently from the one they were measured on ({Reason}). Printed "
+                    + "{Printed}, re-read {Reread}.",
+                    document.Title,
+                    check.Refusal ?? "pagination shifted",
+                    string.Join(", ", printedPages),
+                    check.Resolved ? string.Join(", ", check.Pages) : "nothing");
+                return measured;
+            });
 }

--- a/src/MeshWeaver.Markdown.Export/Pdf/TocPageNumbers.cs
+++ b/src/MeshWeaver.Markdown.Export/Pdf/TocPageNumbers.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Actions;
+using UglyToad.PdfPig.Annotations;
+// MeshWeaver has an AnnotationType of its own (tracked-change kinds) that a global using brings
+// into scope here; alias the PDF one so the two can never be confused.
+using PdfAnnotationType = UglyToad.PdfPig.Annotations.AnnotationType;
+
+namespace MeshWeaver.Markdown.Export.Pdf;
+
+/// <summary>
+/// The page each contents entry points at, <b>read back out of a printed PDF</b> rather than
+/// computed.
+///
+/// <para><b>Why measure the PDF instead of the page.</b> Printing `Chapter 3 …… 12` from CSS needs
+/// <c>target-counter()</c>, and Chromium implements no part of it (issue #1309). Measuring in the
+/// page with script — heading <c>offsetTop</c> divided by a content height — cannot be made right:
+/// the print box is not the viewport, and <c>break-after: avoid</c>, <c>orphans</c>/<c>widows</c>,
+/// repeated table headers and unbreakable figures all move a heading to a page arithmetic does not
+/// predict. The PDF, by contrast, already contains the answer: every contents entry is a link
+/// annotation whose <c>GoTo</c> destination names the page the browser actually put the heading on.
+/// That is the browser's own pagination, not a model of it.</para>
+///
+/// <para><b>Identification is positional, and every assumption it makes is checked.</b> A contents
+/// entry is a block-level <c>&lt;a&gt;</c>, so Chromium emits exactly one annotation per entry even
+/// when the title wraps; the contents list is the only thing between the cover and the body, so its
+/// entries are the FIRST internal links in the document. Reading stops at the page that completes
+/// the count — usually page two — so a 500-page export parses three pages, not five hundred.</para>
+///
+/// <para>Three structural facts are then asserted, and any one of them failing REFUSES rather than
+/// guesses: the count must come out exactly, destinations must be non-decreasing (entries are in
+/// document order, so their targets are too), and every destination must lie after the last page
+/// carrying a contents entry (headings live in the body, which follows the list). A contents list
+/// that quietly points at the wrong page is worse than one that prints no page at all — so a
+/// refusal is a first-class outcome here, carrying the reason for the log.</para>
+/// </summary>
+public static class TocPageNumbers
+{
+    /// <summary>
+    /// Resolves the destination page of each of the first <paramref name="entryCount"/> internal
+    /// links in <paramref name="pdf"/>.
+    /// </summary>
+    /// <param name="pdf">A printed PDF — normally one this renderer just produced.</param>
+    /// <param name="entryCount">How many contents entries the document was composed with.</param>
+    public static TocPageLookup Resolve(byte[] pdf, int entryCount)
+    {
+        ArgumentNullException.ThrowIfNull(pdf);
+        if (entryCount <= 0)
+            return TocPageLookup.Refused("the document has no contents entries");
+
+        using var document = PdfDocument.Open(pdf);
+
+        var pages = ImmutableArray.CreateBuilder<int>(entryCount);
+        var lastSourcePage = 0;
+
+        foreach (var page in document.GetPages())
+        {
+            // Document order within a page: top-down, then left-to-right. A contents list is a
+            // plain vertical stack of blocks, so this IS its reading order.
+            var links = page.ExperimentalAccess.GetAnnotations()
+                .Where(a => a.Type == PdfAnnotationType.Link)
+                .Select(a => (Annotation: a, Destination: DestinationPage(a)))
+                .Where(l => l.Destination > 0)
+                .OrderByDescending(l => l.Annotation.Rectangle.Top)
+                .ThenBy(l => l.Annotation.Rectangle.Left)
+                .ToArray();
+
+            if (links.Length == 0)
+                continue;
+
+            if (pages.Count + links.Length > entryCount)
+                return TocPageLookup.Refused(
+                    $"page {page.Number.ToString(CultureInfo.InvariantCulture)} carries more internal "
+                    + "links than the contents list has remaining entries, so the entries cannot be "
+                    + "matched to them positionally");
+
+            foreach (var link in links)
+                pages.Add(link.Destination);
+            lastSourcePage = page.Number;
+
+            if (pages.Count == entryCount)
+                break;
+        }
+
+        if (pages.Count != entryCount)
+            return TocPageLookup.Refused(
+                $"found {pages.Count.ToString(CultureInfo.InvariantCulture)} internal links for "
+                + $"{entryCount.ToString(CultureInfo.InvariantCulture)} contents entries");
+
+        var resolved = pages.MoveToImmutable();
+
+        for (var i = 1; i < resolved.Length; i++)
+            if (resolved[i] < resolved[i - 1])
+                return TocPageLookup.Refused(
+                    "contents destinations are not in document order "
+                    + $"({string.Join(", ", resolved)})");
+
+        if (resolved[0] <= lastSourcePage)
+            return TocPageLookup.Refused(
+                $"the first contents destination (page {resolved[0].ToString(CultureInfo.InvariantCulture)}) "
+                + $"is not after the contents list itself (page {lastSourcePage.ToString(CultureInfo.InvariantCulture)})");
+
+        if (resolved[^1] > document.NumberOfPages)
+            return TocPageLookup.Refused(
+                $"a contents destination (page {resolved[^1].ToString(CultureInfo.InvariantCulture)}) "
+                + $"is past the end of the document ({document.NumberOfPages.ToString(CultureInfo.InvariantCulture)} pages)");
+
+        return TocPageLookup.Of(resolved);
+    }
+
+    /// <summary>
+    /// The one-based page an annotation jumps to <b>within this document</b>, or <c>0</c> when it
+    /// is not such a jump.
+    ///
+    /// <para>Deliberately <c>GoToAction</c> and not its base <c>AbstractGoToAction</c>: the
+    /// remote and embedded variants (<c>GoToR</c>, <c>GoToE</c>) carry a page number too, but it
+    /// numbers a page in ANOTHER file. An external <c>URI</c> link — an ordinary markdown link in
+    /// the body — has no destination at all. Neither can enter the positional match.</para>
+    /// </summary>
+    private static int DestinationPage(Annotation annotation) =>
+        annotation.Action is GoToAction { Destination: { } destination }
+            ? destination.PageNumber
+            : 0;
+}
+
+/// <summary>
+/// Either the page number for every contents entry, or the reason they could not be established.
+///
+/// <para>A refusal is not an error: the export still produces a PDF, with the contents list it has
+/// always had since #1230 — links, no numbers. What it must never do is print a number nobody
+/// checked, so the reason travels to the caller for the log rather than being swallowed.</para>
+/// </summary>
+public readonly record struct TocPageLookup
+{
+    private TocPageLookup(ImmutableArray<int> pages, string? refusal)
+    {
+        Pages = pages;
+        Refusal = refusal;
+    }
+
+    /// <summary>The one-based page of each contents entry, in entry order. Empty when refused.</summary>
+    public ImmutableArray<int> Pages { get; }
+
+    /// <summary>Why the numbers could not be established, or <c>null</c> when they were.</summary>
+    public string? Refusal { get; }
+
+    /// <summary>True when <see cref="Pages"/> carries a checked number for every entry.</summary>
+    public bool Resolved => Refusal is null && !Pages.IsDefaultOrEmpty;
+
+    internal static TocPageLookup Of(ImmutableArray<int> pages) => new(pages, null);
+
+    internal static TocPageLookup Refused(string reason) => new(ImmutableArray<int>.Empty, reason);
+}

--- a/src/MeshWeaver.Markdown.Export/README.md
+++ b/src/MeshWeaver.Markdown.Export/README.md
@@ -9,7 +9,7 @@ Pipeline: `Markdig AST` → `Document` model → { print HTML + CSS Paged Media 
 Features:
 
 - **Embedded layout areas** (`@@("…/area/Foo/…")`) resolved to real document structure — see below.
-- Table of contents (built from document heading structure; PDF entries are links, without page numbers — see the doc page).
+- Table of contents (built from document heading structure; PDF entries are links AND carry the page each section starts on — read back out of a first print, then verified against the published one, because CSS cannot name a target's page. See the doc page).
 - Page break rules (before H1, between subtree children, explicit `\newpage` / `<!-- pagebreak -->`).
 - Branded cover page, running header, and running footer (with `N / M` page numbers in PDF) resolved from a `CorporateIdentity` mesh node.
 - MeshWeaver annotations become native Word comments and tracked changes in DOCX.

--- a/test/MeshWeaver.Markdown.Export.Test/DocumentBuilderTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/DocumentBuilderTests.cs
@@ -98,4 +98,53 @@ public class DocumentBuilderTests
         doc.Elements.OfType<ChapterBreakElement>().Should().ContainSingle()
             .Which.Title.Should().Be("Chapter 2");
     }
+
+    /// <summary>
+    /// Two sections may share a title, and their anchors must not.
+    ///
+    /// <para>An HTML fragment reference resolves to the FIRST element carrying the id, so a
+    /// duplicate made the second contents entry jump to the first section — in the rendered page
+    /// and in the exported PDF's link annotation alike. It went unnoticed while the contents list
+    /// printed no page numbers; reading those numbers back out of the print (#1309) exposed it as
+    /// a set of destinations that ran backwards.</para>
+    /// </summary>
+    [Fact]
+    public void Headings_that_share_a_title_still_get_distinct_anchors()
+    {
+        var doc = new DocumentBuilder().Build(
+            "T",
+            "# Introduction\n\n## Overview\n\n# Methods\n\n## Overview\n\n## Overview",
+            new DocumentExportOptions(),
+            BrandingOptions.Default);
+
+        var anchors = doc.TocHeadings.Select(h => h.AnchorId).ToArray();
+
+        anchors.Should().Equal("introduction", "overview", "methods", "overview-2", "overview-3");
+        anchors.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Anchors_are_unique_across_chapters_too()
+    {
+        // Two chapters each opening with "Overview" is the ordinary case for a compiled document,
+        // so the uniqueness scope has to be the document and not one chapter's walk.
+        var doc = new DocumentBuilder().Build(
+            "Book",
+            [("Chapter 1", "# Overview"), ("Chapter 2", "# Overview")],
+            new DocumentExportOptions { IncludeChildren = true },
+            BrandingOptions.Default);
+
+        doc.TocHeadings.Select(h => h.AnchorId).Should().Equal("overview", "overview-2");
+    }
+
+    [Fact]
+    public void A_heading_with_no_slug_still_gets_a_usable_anchor()
+    {
+        // "###" or a heading of pure punctuation slugifies to nothing; an id of "" is one nothing
+        // can link to, and two of them would collide with each other.
+        var doc = new DocumentBuilder().Build(
+            "T", "# ---\n\n# +++", new DocumentExportOptions(), BrandingOptions.Default);
+
+        doc.TocHeadings.Select(h => h.AnchorId).Should().Equal("section", "section-2");
+    }
 }

--- a/test/MeshWeaver.Markdown.Export.Test/DocumentPrintComposerTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/DocumentPrintComposerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Immutable;
 using System.Linq;
 using HtmlAgilityPack;
 using MeshWeaver.Markdown.Export.Ast;
@@ -43,12 +45,15 @@ public class DocumentPrintComposerTests
     private static string Compose(
         DocumentExportOptions? options = null,
         BrandingOptions? branding = null,
-        string? markdown = null)
-        => DocumentPrintComposer.Compose(new DocumentBuilder().Build(
-            "Quarterly Report 2026",
-            markdown ?? SampleMarkdown,
-            options ?? new DocumentExportOptions(),
-            branding ?? Brand));
+        string? markdown = null,
+        ImmutableArray<int> tocPageNumbers = default)
+        => DocumentPrintComposer.Compose(
+            new DocumentBuilder().Build(
+                "Quarterly Report 2026",
+                markdown ?? SampleMarkdown,
+                options ?? new DocumentExportOptions(),
+                branding ?? Brand),
+            tocPageNumbers);
 
     private static HtmlDocument Parse(string html)
     {
@@ -138,6 +143,92 @@ public class DocumentPrintComposerTests
         => Parse(Compose(new DocumentExportOptions { TableOfContents = false }))
             .DocumentNode.SelectSingleNode("//section[@class='mw-toc']")
             .Should().BeNull();
+
+    // ── Contents page numbers (#1309) ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Contents_entries_print_the_page_number_supplied_for_each_of_them()
+    {
+        var numbers = Parse(Compose(tocPageNumbers: [7, 9]))
+            .DocumentNode.SelectNodes("//span[@class='mw-toc-page']")
+            .Select(n => n.InnerText)
+            .ToArray();
+
+        numbers.Should().Equal("7", "9");
+    }
+
+    [Fact]
+    public void The_number_column_is_reserved_even_when_there_is_no_number_to_print()
+    {
+        // The measuring print has to occupy the same box the numbered one will, or the digits
+        // would reflow the list and the page they were measured on would stop being the page
+        // they end up describing.
+        var cells = Parse(Compose())
+            .DocumentNode.SelectNodes("//span[@class='mw-toc-page']");
+
+        cells.Should().HaveCount(2, "one reserved cell per contents entry");
+        cells.Select(c => c.InnerText).Should().AllBe("\u200b", "an empty inline box has no line box");
+    }
+
+    [Fact]
+    public void The_numbered_print_differs_from_the_measuring_print_ONLY_in_the_digits()
+    {
+        // The property the whole two-pass rests on, asserted as a property: swap the digits back
+        // out and the two documents are byte-identical — so nothing else about the layout, and in
+        // particular nothing about the amount of content, changed between the prints.
+        var measuring = Compose();
+        var numbered = Compose(tocPageNumbers: [7, 9]);
+
+        numbered
+            .Replace(">7</span>", ">\u200b</span>", StringComparison.Ordinal)
+            .Replace(">9</span>", ">\u200b</span>", StringComparison.Ordinal)
+            .Should().Be(measuring);
+    }
+
+    [Fact]
+    public void The_number_column_has_a_constant_width_that_the_digits_cannot_change()
+    {
+        // A column sized to its content — min-width, fit-content, a width derived from the page
+        // count — is exactly how a two-pass prints numbers that are quietly wrong: the digits
+        // widen the column, the title rewraps, the list grows a line and everything after it
+        // moves a page. So the rule is read out and checked on its own, not searched for in the
+        // whole document where a comment could satisfy it.
+        var html = Compose();
+        var start = html.IndexOf(".mw-toc-page {", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(-1, "the reserved column needs a rule of its own");
+        var rule = html[start..(html.IndexOf('}', start) + 1)];
+
+        rule.Should().Contain("flex: 0 0 40pt").And.Contain("width: 40pt");
+        rule.Should().NotContain("min-width").And.NotContain("max-width").And.NotContain("fit-content");
+    }
+
+    [Fact]
+    public void A_page_number_list_that_does_not_match_the_entry_count_is_ignored_entirely()
+    {
+        // Off-by-one numbering is worse than none: every entry after the slip would point at the
+        // wrong section with total confidence. Partial application is therefore not an option.
+        var oneShort = Parse(Compose(tocPageNumbers: [7]))
+            .DocumentNode.SelectNodes("//span[@class='mw-toc-page']");
+
+        oneShort.Select(c => c.InnerText).Should().AllBe("\u200b");
+    }
+
+    [Fact]
+    public void A_contents_entry_is_one_block_level_link_so_a_wrapped_title_stays_one_annotation()
+    {
+        // Identification of an entry in the printed PDF is positional, and it holds because
+        // Chromium emits ONE link annotation per entry. That is a consequence of the entry being
+        // a block-level (flex) box: an inline link wrapping onto a second line would emit two
+        // rects and slide every later entry's number by one.
+        var html = Compose();
+
+        html.Should().Contain(".mw-toc-entry a {").And.Contain("display: flex;");
+
+        var link = Parse(html).DocumentNode.SelectSingleNode("//p[contains(@class,'mw-toc-entry')]/a");
+        link.ChildNodes.Where(n => n.NodeType == HtmlNodeType.Element)
+            .Select(n => n.GetAttributeValue("class", ""))
+            .Should().Equal("mw-toc-text", "mw-toc-page");
+    }
 
     // ── Running header and footer ───────────────────────────────────────────────────────
 

--- a/test/MeshWeaver.Markdown.Export.Test/DocumentPrintComposerTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/DocumentPrintComposerTests.cs
@@ -230,6 +230,24 @@ public class DocumentPrintComposerTests
             .Should().Equal("mw-toc-text", "mw-toc-page");
     }
 
+    [Fact]
+    public void A_contents_entry_never_straddles_a_page_break()
+    {
+        // The other half of one-annotation-per-entry. Being a block box stops a WRAPPED title
+        // emitting a rect per line; this stops a title CAUGHT BY A PAGE BREAK emitting a rect
+        // per fragment, which would push the link count past the entry count and cost the whole
+        // list its numbers. Measured: sliding a contents list past a break in 8pt steps, 10 of
+        // 15 layouts printed 15 annotations for 14 entries without the rule and 14 with it —
+        // but only with titles of FOUR or more lines, since orphans/widows (2 by default) make a
+        // shorter entry unsplittable. That is why this is pinned here rather than left to a
+        // browser test nobody could make fail on purpose.
+        var html = Compose();
+        var start = html.IndexOf(".mw-toc-entry {", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(-1);
+
+        html[start..(html.IndexOf('}', start) + 1)].Should().Contain("break-inside: avoid");
+    }
+
     // ── Running header and footer ───────────────────────────────────────────────────────
 
     [Fact]

--- a/test/MeshWeaver.Markdown.Export.Test/PdfHeaderLogoTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/PdfHeaderLogoTests.cs
@@ -57,7 +57,7 @@ public class PdfHeaderLogoTests : IDisposable
 
         var browser = Browser();
         var executable = await browser.Probe().FirstAsync().ToTask();
-        var renderer = new PdfDocumentRenderer(browser);
+        var renderer = new PdfDocumentRenderer(browser, pools);
 
         if (executable is null)
         {
@@ -90,7 +90,7 @@ public class PdfHeaderLogoTests : IDisposable
 
         var browser = Browser();
         var executable = await browser.Probe().FirstAsync().ToTask();
-        var renderer = new PdfDocumentRenderer(browser);
+        var renderer = new PdfDocumentRenderer(browser, pools);
 
         if (executable is null)
         {

--- a/test/MeshWeaver.Markdown.Export.Test/RendererOutputTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/RendererOutputTests.cs
@@ -87,7 +87,9 @@ public class RendererOutputTests : IDisposable
         contents.Should().Contain("2 / " + pdfDoc.NumberOfPages);
         // #1309: the contents list names the page, not just the link. Both sections are on the
         // one body page here, so both entries read 3 — and 3 is where the body actually starts.
-        contents.Should().Contain("Report3").And.Contain("Details3");
+        // Whitespace is stripped so the assertion does not depend on whether the extractor puts
+        // a gap between an entry's title and its number.
+        Packed(contents).Should().Contain("Report3").And.Contain("Details3");
 
         var body = string.Join("\n", pdfDoc.GetPages().Skip(2).Select(p => p.Text));
         body.Should().Contain("executive").And.Contain("Column A").And.Contain("var answer = 42;");
@@ -159,9 +161,8 @@ public class RendererOutputTests : IDisposable
         landsOn.Should().Contain(p => p > 3 + 1,
             "a section that begins two or more pages in is what proves a boundary was crossed");
 
-        // 1. What the contents list PRINTS. Whitespace is stripped so the assertion does not
-        //    depend on whether the extractor puts a gap between the title and its number.
-        var contents = new string(pdfDoc.GetPage(2).Text.Where(c => !char.IsWhiteSpace(c)).ToArray());
+        // 1. What the contents list PRINTS.
+        var contents = Packed(pdfDoc.GetPage(2).Text);
         for (var i = 0; i < headings.Length; i++)
             contents.Should().Contain(headings[i] + landsOn[i].ToString(CultureInfo.InvariantCulture),
                 $"the contents entry for '{headings[i]}' must print the page it starts on");
@@ -227,6 +228,14 @@ public class RendererOutputTests : IDisposable
         docx[0].Should().Be((byte)'P');
         docx[1].Should().Be((byte)'K');
     }
+
+    /// <summary>
+    /// Extracted page text with every space removed, so an assertion pairing a contents entry
+    /// with its page number ("Details" immediately followed by "3") does not depend on whether
+    /// the PDF text extractor chooses to put a gap across the column that separates them.
+    /// </summary>
+    private static string Packed(string pageText) =>
+        new(pageText.Where(c => !char.IsWhiteSpace(c)).ToArray());
 
     public void Dispose() => pools.Dispose();
 }

--- a/test/MeshWeaver.Markdown.Export.Test/RendererOutputTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/RendererOutputTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -57,7 +58,7 @@ public class RendererOutputTests : IDisposable
 
         var browser = new HeadlessChromiumPdfRenderer(
             new PixelRenderingOptions { NoSandbox = OperatingSystem.IsLinux() }, pools);
-        var renderer = new PdfDocumentRenderer(browser);
+        var renderer = new PdfDocumentRenderer(browser, pools);
 
         if (await browser.Probe().FirstAsync().ToTask() is null)
         {
@@ -84,9 +85,99 @@ public class RendererOutputTests : IDisposable
         contents.Should().Contain("Contents").And.Contain("Details");
         contents.Should().Contain("Draft", "every page after the cover carries the running header");
         contents.Should().Contain("2 / " + pdfDoc.NumberOfPages);
+        // #1309: the contents list names the page, not just the link. Both sections are on the
+        // one body page here, so both entries read 3 — and 3 is where the body actually starts.
+        contents.Should().Contain("Report3").And.Contain("Details3");
 
         var body = string.Join("\n", pdfDoc.GetPages().Skip(2).Select(p => p.Text));
         body.Should().Contain("executive").And.Contain("Column A").And.Contain("var answer = 42;");
+    }
+
+    /// <summary>
+    /// #1309: every page number the contents list prints is the page that section actually
+    /// starts on — across page boundaries, for the first entry and for the last.
+    ///
+    /// <para><b>The oracle is independent of the mechanism.</b> The renderer works out the numbers
+    /// from the printed PDF's link annotations; this test works them out from the printed PDF's
+    /// TEXT — the page whose glyphs contain that section's (unique) heading. So an error in the
+    /// annotation reading cannot also produce the expectation, which is the failure mode that makes
+    /// "assert the number 12 appears somewhere" worthless. All three are then required to agree:
+    /// what the contents list PRINTS, where the heading is DRAWN, and where the link JUMPS.</para>
+    ///
+    /// <para>The document is built so that this is a real test of pagination and not of a one-page
+    /// body: one section is long enough to run over several pages, so the numbers are neither
+    /// consecutive nor all equal, and a section boundary falls mid-page.</para>
+    /// </summary>
+    [Fact]
+    public async Task Contents_page_numbers_name_the_page_each_section_actually_starts_on()
+    {
+        // Distinctive one-word headings: each must appear on exactly one BODY page, so the text
+        // oracle is unambiguous, and none may collide with the filler.
+        string[] headings = ["Alphaville", "Bravissimo", "Charliehorse", "Deltawing", "Echoplex"];
+        int[] paragraphs = [6, 22, 3, 14, 2];
+
+        var markdown = string.Join("\n\n", headings.Select((h, i) =>
+            $"# {h}\n\n" + string.Join("\n\n", Enumerable.Range(0, paragraphs[i])
+                .Select(p => $"Filler {p} for the section. " + string.Concat(
+                    Enumerable.Repeat("lorem ipsum dolor sit amet ", 12))))));
+
+        var doc = new DocumentBuilder().Build(
+            "Boundary Report",
+            markdown,
+            new DocumentExportOptions { CoverPage = true, TableOfContents = true },
+            BrandingOptions.Default with { Name = "Contoso", HeaderText = "Draft" });
+
+        var browser = new HeadlessChromiumPdfRenderer(
+            new PixelRenderingOptions { NoSandbox = OperatingSystem.IsLinux() }, pools);
+        var renderer = new PdfDocumentRenderer(browser, pools);
+
+        if (await browser.Probe().FirstAsync().ToTask() is null)
+        {
+            var render = async () => await renderer.Render(doc).FirstAsync().ToTask();
+            (await render.Should().ThrowAsync<PixelRendererUnavailableException>())
+                .WithMessage("*headless Chromium*");
+            return;
+        }
+
+        var pdf = await renderer.Render(doc).FirstAsync().ToTask();
+        using var pdfDoc = UglyToad.PdfPig.PdfDocument.Open(pdf);
+
+        // Page 1 cover, page 2 contents, body from page 3 — asserted rather than assumed, because
+        // every expectation below is stated in terms of it.
+        pdfDoc.GetPage(2).Text.Should().Contain("Contents");
+        pdfDoc.GetPage(3).Text.Should().NotContain("Contents", "the contents list fits one page");
+        pdfDoc.NumberOfPages.Should().BeGreaterThan(headings.Length + 2,
+            "the body must span more pages than it has sections, or nothing here crosses a boundary");
+
+        // The oracle: the first body page whose glyphs carry this heading.
+        var landsOn = headings.Select(h => Enumerable.Range(3, pdfDoc.NumberOfPages - 2)
+            .First(p => pdfDoc.GetPage(p).Text.Contains(h, StringComparison.Ordinal))).ToArray();
+
+        landsOn.Should().OnlyHaveUniqueItems("each heading starts exactly one section")
+            .And.BeInAscendingOrder();
+        landsOn[0].Should().Be(3, "the first section starts on the first body page");
+        landsOn.Should().Contain(p => p > 3 + 1,
+            "a section that begins two or more pages in is what proves a boundary was crossed");
+
+        // 1. What the contents list PRINTS. Whitespace is stripped so the assertion does not
+        //    depend on whether the extractor puts a gap between the title and its number.
+        var contents = new string(pdfDoc.GetPage(2).Text.Where(c => !char.IsWhiteSpace(c)).ToArray());
+        for (var i = 0; i < headings.Length; i++)
+            contents.Should().Contain(headings[i] + landsOn[i].ToString(CultureInfo.InvariantCulture),
+                $"the contents entry for '{headings[i]}' must print the page it starts on");
+
+        // 2. Where the link JUMPS — the same reading the renderer used, re-run on the published PDF.
+        var lookup = TocPageNumbers.Resolve(pdf, headings.Length);
+        lookup.Resolved.Should().BeTrue(lookup.Refusal ?? "resolved");
+        lookup.Pages.Should().Equal(landsOn);
+
+        // And the read-back REFUSES rather than improvises when the document it is given does not
+        // match the count it was told to expect — the guard that turns a mis-identification into
+        // a contents list with no numbers instead of one with wrong ones.
+        var tooMany = TocPageNumbers.Resolve(pdf, headings.Length + 1);
+        tooMany.Resolved.Should().BeFalse();
+        tooMany.Refusal.Should().Contain("internal links");
+        TocPageNumbers.Resolve(pdf, 0).Resolved.Should().BeFalse();
     }
 
     /// <summary>
@@ -101,7 +192,7 @@ public class RendererOutputTests : IDisposable
         if (await browser.Probe().FirstAsync().ToTask() is null)
             return;
 
-        var renderer = new PdfDocumentRenderer(browser);
+        var renderer = new PdfDocumentRenderer(browser, pools);
         var options = new DocumentExportOptions { CoverPage = false, TableOfContents = false };
 
         var portrait = UglyToad.PdfPig.PdfDocument.Open(await renderer


### PR DESCRIPTION
Closes #1309.

`#1230` replaced QuestPDF with the headless browser and reached parity on everything but one item: contents entries kept their links and lost the `..... 12` column. Chromium implements no part of CSS `target-counter`, so nothing *in the page* can name the page a heading landed on.

**The print can.** Every contents entry is a link annotation whose `GoTo` destination is the page the browser itself chose — not a model of the pagination but *the* pagination, recorded by the engine that performed it. `TocPageNumbers` reads it back with PdfPig, which is already in this project's graph (via `MeshWeaver.ContentCollections`) and already carried by the licence gate, so **no dependency is added** and `check-licenses.py` is untouched.

## The objection in #1309, answered

#1309 rejected a two-pass because its failure mode is *silently wrong* numbers when the inserted digits reflow the list, and set the bar at failing **loudly**. Both halves:

1. **The digits cannot reflow anything.** The number column is emitted on **both** prints at a **constant** width (`flex: 0 0 40pt` — the same 40pt right-aligned column the document model drew), so the measuring print and the published print are the same layout by construction. Sizing the column to its content (`min-width`, `fit-content`, a width derived from the page count) is precisely how a naive two-pass goes wrong.
2. **That argument is not trusted anyway.** The renderer re-reads the **published** PDF and releases it only if every destination still equals the number printed beside it.

Any refusal — count mismatch, destinations out of document order, a destination not after the contents list, or a verification disagreement — falls back to the numberless list of #1230 and logs the reason with both readings. A contents list that lies about a page is worse than one that is silent about it.

## Why not the other approaches

| Approach | Why not |
|---|---|
| Measure in the page with script (`offsetTop` / content height) | Arithmetic over the *viewport*; the print box is not the viewport. `break-after: avoid`, `orphans`/`widows`, a repeated `<thead>` and unbreakable figures all move a heading to a page no per-page constant predicts — plausible numbers, occasionally off by one, indistinguishable from correct ones by eye. Also needs `script-src` in a document whose CSP is deliberately `default-src 'none'`. |
| Post-process the PDF (stamp numbers into the produced file) | Exact for *measuring*, which is why measuring is done exactly this way. Writing needs a PDF writer that faithfully round-trips an existing document; PdfPig has none, and adding one is a new dependency and a new licence decision. |
| Pure two-pass, no verification | The thing #1309 rejected, and rightly. |

## Cost

One extra browser print, paid **only** by documents that have a contents list (measured: 3.1 s vs 1.4 s for the same document without one). Reading stops at the page that completes the count, so a 50-page export parses two pages and the read-back costs ~1 ms. The read-back is a CPU leaf and goes through `IIoPool`'s `Process` pool — the same pool as the browser — so a burst of exports bounds its parsing as well as its browsers. Cold and reactive throughout: no `Task`, no `Observable.FromAsync`.

## A real bug the refusal check caught

Two headings sharing a title slugified to the **same** anchor, so the second contents entry jumped to the **first** section — in the rendered page and in the PDF's link annotation alike. It predates #1230 and was invisible only because there was no number to expose it; the "destinations must be in document order" check surfaced it as `3, 3, 4, 6, 4, 8, 11`. Fixed at the root: anchors are made unique per document (`overview`, `overview-2`), which is what every markdown renderer does.

## Verification

Verified the way #1230's parity table was — by rendering PDFs and **looking** at them — and then by assertion.

**By eye** (rasterised, real renderer):
- A 10-page report: first entry, a section spanning three pages, a heading landing **mid-page**, and the last entry on the last page. Every printed number matches the section's first page and the running footer.
- A wrapping contents title with duplicate section names: the number sits on the entry's first line; the two `Overview` entries now read 4 and 7.
- A 46-entry contents list spanning **two** pages: numbered correctly across its own page break, body starting at page 4.

**By assertion**: `RendererOutputTests` pins it against an **independent oracle** — the page whose *glyphs* carry the heading — and requires all three to agree: what the list **prints**, where the heading is **drawn**, and where the link **jumps**. An error in the annotation reading therefore cannot also produce the expectation. `DocumentPrintComposerTests` pins the composer contract with no browser installed (column reserved on both prints, constant width, digits the only difference between the two documents, a mismatched list ignored outright).

Local: `MeshWeaver.Markdown.Export.Test` 109/109, `MeshWeaver.Documentation.Test` 20/20, monolith export tests 16/16, `-c Release -warnaserror` clean on the touched projects and their dependents, licence gate green.

## Not included (from #1309's "Related, NOT fixed")

The two pre-existing defects that issue names — `ReadInlinesInto` rendering `~~strike~~` as bold+strike, and the export `.csx` templates using `node.Content is MarkdownContent` — are unrelated to the contents column and are left for their own change so they are not buried in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
