### PR TITLE
fix: a scoped sync no longer claims the whole Space, and a force stops eating Release records (#1326)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-space-that-is-behind-no-longer-reports-itself-up-to-date.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-space-that-is-behind-no-longer-reports-itself-up-to-date.md
@@ -1,0 +1,23 @@
+---
+Name: A Space that is behind no longer reports itself up to date
+Category: Fix
+Description: GitHub sync stops claiming "Skipped (0 nodes)" for a Space that is genuinely behind, and a forced import no longer deletes release records the repo never carries.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A Space that is behind no longer reports itself up to date
+
+Updating a GitHub-synced Space could report "Imported Skipped (0 node(s))" while the Space was
+genuinely behind the repository, and keep reporting it forever — only a forced import brought the
+content across. That happened because an incremental sync, which only looks at the files a commit
+changed, still recorded that the whole Space matched the repository. Every later update trusted that
+record and skipped without checking. An incremental sync now records only what it actually looked
+at, so a Space that has fallen behind catches up on the next ordinary update.
+
+Forcing an import was also destructive in a way nobody asked for: it deleted the release records the
+platform writes for each compiled type, because those are deliberately never stored in the
+repository and the prune read their absence as a deletion. Anything your Space's sync rules exclude
+is now left alone, whatever its capitalisation. Finally, if the configured subdirectory matches
+nothing in the repository, the import stops and says so instead of quietly treating the Space as
+empty — which would previously have removed everything in it.

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -1,6 +1,7 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -168,7 +169,7 @@ public static class GitHubActivityExtensions
                         // deletes user-visible data, and "pruned N" alone left no record of WHAT.
                         if (r.PrunedPaths.Count > 0)
                             ctx.Log($"Pruned {r.PrunedPaths.Count} node(s) absent from the repo: {string.Join(", ", r.PrunedPaths)}");
-                        ctx.Log($"Imported {r.Outcome} ({r.Count} node(s)).");
+                        ctx.Log($"Imported {DescribeOutcome(r)}.");
                         return Unit.Default;
                     });
                 }, onActivityCreated));
@@ -193,11 +194,27 @@ public static class GitHubActivityExtensions
                     // deletes user-visible data, and "pruned N" alone left no record of WHAT.
                     if (r.PrunedPaths.Count > 0)
                         ctx.Log($"Pruned {r.PrunedPaths.Count} node(s) absent from the repo: {string.Join(", ", r.PrunedPaths)}");
-                    ctx.Log($"Re-imported {r.Outcome} ({r.Count} node(s)) at {commitish}.");
+                    ctx.Log($"Re-imported {DescribeOutcome(r)} at {commitish}.");
                     return Unit.Default;
                 });
             }, onActivityCreated);
     }
+
+    /// <summary>
+    /// One user-facing line for an import outcome.
+    ///
+    /// <para>🚨 "Skipped" is the one outcome that reports a success on evidence THIS run never
+    /// gathered: it means a prior import already recorded this exact content fingerprint, so the
+    /// short-circuit fired and the partition was never read. Rendered as
+    /// <c>Skipped (0 node(s))</c> it was indistinguishable from "checked, nothing to do" — which is
+    /// how a genuinely-behind Space read as up to date (issue #1326). Name the evidence.</para>
+    /// </summary>
+    private static string DescribeOutcome(StaticRepoImportResult result) =>
+        string.Equals(result.Outcome, "Skipped", StringComparison.OrdinalIgnoreCase)
+            ? "Skipped — an earlier FULL import already recorded this exact content at fingerprint "
+              + $"{result.Fingerprint} ({result.Partition}/_Activity/import-{result.Fingerprint}), "
+              + "so the partition was not re-read"
+            : $"{result.Outcome} ({result.Count} node(s))";
 
     /// <summary>Create a branch from a base ref on the configured repo.</summary>
     public static IObservable<string> CreateBranchOnGitHub(

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -482,6 +482,26 @@ public sealed class GitHubSyncService
     {
         return repoClient.Fetch(repoUrl, commitish, subdirectory, token).SelectMany(snapshot =>
         {
+            // 🚨 A CONFIGURED SUBDIRECTORY THAT MATCHES NOTHING IS A CONFIGURATION ERROR, NOT AN
+            // EMPTY REPO (issue #1326). The tree filter compares the configured prefix against repo
+            // paths with StringComparison.Ordinal — correct, because git paths ARE case-sensitive —
+            // so a casing/typo mismatch yields ZERO files, and an empty snapshot flows on as "the
+            // repo carries nothing": every existing node becomes absent-from-the-source and, under
+            // the default FullReplace, the import MIRRORS THE WHOLE SPACE AWAY. Refuse loudly and
+            // name the subdirectory instead. Only guarded when a subdirectory is configured — a
+            // genuinely empty repo (no subdirectory) is a legitimate first-sync state.
+            if (snapshot.Files.Count == 0 && !string.IsNullOrWhiteSpace(subdirectory))
+            {
+                var message =
+                    $"No files found under subdirectory '{subdirectory.Trim().Trim('/')}' at "
+                    + $"{Short(snapshot.CommitSha)} in {repoUrl}. Refusing to import an empty snapshot — "
+                    + "it would prune the whole Space. Check the subdirectory (including its exact "
+                    + "capitalisation — git paths are case-sensitive) on the sync source.";
+                logger?.LogWarning("[GitSync] {Space}: {Message}", spaceId, message);
+                progress?.Invoke(message, LogLevel.Error);
+                return Observable.Throw<(StaticRepoImportResult, string)>(
+                    new InvalidOperationException(message));
+            }
             // Git-diff scope: when we know the last SUCCESSFULLY-synced commit (a routine
             // webhook/update — not a force, not a first import), ask GitHub what changed between it
             // and the head and import ONLY those nodes. A null answer (no base, force, force-push,
@@ -494,8 +514,10 @@ public sealed class GitHubSyncService
             return diff.SelectMany(changedFiles =>
                 ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
                 {
+                    // 🚨 The ignore rules travel WITH the source (issue #1326): the importer's prune
+                    // needs them to tell "the repo dropped this node" from "this node never syncs".
                     var source = new InMemoryStaticRepoSource(
-                        spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs);
+                        spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs, ignore);
                     var changedNodePaths = ChangedNodePaths(changedFiles, spaceId);
                     if (changedNodePaths is not null)
                         logger?.LogInformation(

--- a/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
+++ b/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
@@ -19,15 +19,44 @@ namespace MeshWeaver.GitSync;
 /// content collection after the node upsert. Binary-safe (bytes travel intact) and mirroring, so
 /// committed content lands and stops getting wiped by a re-import.</para>
 /// </summary>
+/// <param name="partition">The Space this snapshot materializes into.</param>
+/// <param name="children">The parsed repo files as partition child nodes.</param>
+/// <param name="root">The parsed partition root, when the repo carries one.</param>
+/// <param name="contentSyncs">Git-committed content-collection assets to mirror.</param>
+/// <param name="ignore">The Space's gitignore-style sync rules (<see cref="SyncIgnore.For"/>) —
+/// the SAME matcher the export and the import already apply, now also applied to the prune via
+/// <see cref="IsExcludedFromMirror"/>. Null falls back to <see cref="SyncIgnore.Default"/>, which
+/// is what the config-less callers effectively used before.</param>
 internal sealed class InMemoryStaticRepoSource(
     string partition,
     IReadOnlyList<MeshNode> children,
     MeshNode? root,
-    IReadOnlyList<StaticContentSync>? contentSyncs = null) : IStaticRepoSource
+    IReadOnlyList<StaticContentSync>? contentSyncs = null,
+    SyncIgnore? ignore = null) : IStaticRepoSource
 {
+    private readonly SyncIgnore ignoreRules = ignore ?? SyncIgnore.For(null);
+
     public string Partition => partition;
     public bool Versioned => false;
     public IReadOnlyList<MeshNode> EnumerateSourceNodes() => children;
     public MeshNode? PartitionRoot => root;
     public IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => contentSyncs ?? [];
+
+    /// <summary>
+    /// 🚨 The prune's view of the Space's ignore rules (issue #1326). An ignored subtree is
+    /// stripped on export and skipped on import, so it is absent from the repo BY DESIGN — the
+    /// prune must not read that absence as a deletion. Without this, the default
+    /// <c>Release/</c> rule made every mesh-minted release record a permanent prune candidate and
+    /// a forced import deleted 47 of them on memex-cloud. The rules match paths relative to the
+    /// Space root, exactly as <c>GitHubSyncService.Filter</c> and <c>ParseSnapshot</c> do.
+    /// </summary>
+    public bool IsExcludedFromMirror(string nodePath)
+    {
+        if (string.IsNullOrEmpty(nodePath)) return false;
+        var prefix = partition + "/";
+        var relative = nodePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? nodePath[prefix.Length..]
+            : nodePath;
+        return ignoreRules.IsIgnored(relative);
+    }
 }

--- a/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
+++ b/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
@@ -53,10 +53,17 @@ internal sealed class InMemoryStaticRepoSource(
     public bool IsExcludedFromMirror(string nodePath)
     {
         if (string.IsNullOrEmpty(nodePath)) return false;
+        // The Space ROOT maps to the empty relative path, which SyncIgnore never ignores — the same
+        // mapping GitHubSyncService.Filter uses. Falling through with the bare partition name instead
+        // would hand the matcher a non-empty path, so a wildcard rule could "ignore" the root and make
+        // the prune-side decision disagree with export/import for a node neither of them can exclude.
+        if (string.Equals(nodePath, partition, StringComparison.OrdinalIgnoreCase))
+            return false;
         var prefix = partition + "/";
-        var relative = nodePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            ? nodePath[prefix.Length..]
-            : nodePath;
-        return ignoreRules.IsIgnored(relative);
+        // A path outside this partition is not this source's to exclude — the ignore rules are
+        // Space-relative, so matching them against a foreign absolute path would be meaningless.
+        if (!nodePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return ignoreRules.IsIgnored(nodePath[prefix.Length..]);
     }
 }

--- a/src/MeshWeaver.GitSync/NodeFileMapper.cs
+++ b/src/MeshWeaver.GitSync/NodeFileMapper.cs
@@ -41,7 +41,13 @@ public static class NodeFileMapper
     public static bool HasChildren(string nodePath, IEnumerable<string> allPaths)
     {
         var prefix = nodePath + "/";
-        return allPaths.Any(p => p.StartsWith(prefix, StringComparison.Ordinal));
+        // OrdinalIgnoreCase: these are MESH paths, where case is not a distinction (the importer's
+        // prune, the changed-path set and IsAtOrUnder all fold case). An Ordinal compare here made a
+        // child whose stored casing differed from its parent's invisible, so the parent exported as a
+        // leaf `Foo.md` while its children went to `foo/Bar.md` — the subtree lost its index on the
+        // next import. Same comparison class as the SyncIgnore matcher (issue #1326). Git-tree
+        // comparisons in the export stay Ordinal on purpose: THOSE paths really are case-sensitive.
+        return allPaths.Any(p => p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>True when a repo-relative path is the top-level <c>index.*</c> (i.e. the partition root).</summary>

--- a/src/MeshWeaver.GitSync/SyncIgnore.cs
+++ b/src/MeshWeaver.GitSync/SyncIgnore.cs
@@ -95,6 +95,14 @@ public sealed class SyncIgnore
         }
         // The match ignores the path itself and everything beneath it.
         sb.Append("(/.*)?$");
-        return new Regex(sb.ToString(), RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        // 🚨 CASE-INSENSITIVE, unlike .gitignore (issue #1326). These rules are matched against
+        // MESH node paths as well as repo file paths, and every other path comparison in the sync
+        // pipeline is OrdinalIgnoreCase (ComputePrunableNodes, ChangedNodePaths, IsAtOrUnder,
+        // the partition fold). A case-sensitive matcher here means `release/Foo` is exported and
+        // — worse, since the prune now consults these rules — `Release/` vs `release/` decides
+        // whether a node is DELETED. Path case is not a meaningful distinction in the mesh, so the
+        // matcher must not invent one.
+        return new Regex(sb.ToString(),
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
     }
 }

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -340,13 +340,23 @@ public static class StaticRepoImporter
     /// Pure + case-insensitive so the prune DECISION is unit-testable without a database. This is the
     /// per-partition policy; the per-node <see cref="SyncBehavior"/> guard above applies in every mode
     /// (a claimed node is never a candidate).
+    ///
+    /// <para>🚨 <paramref name="isExcludedFromMirror"/> is the FIFTH guard and the one that stops the
+    /// prune from eating what the source never carries BY DESIGN
+    /// (<see cref="IStaticRepoSource.IsExcludedFromMirror"/>). "Absent from the source" is only
+    /// evidence of a deletion for nodes the source WOULD have carried; for an ignored subtree
+    /// (GitSync's <c>SyncIgnore</c>, default <c>Release/</c>) absence is the normal state, and
+    /// treating it as a deletion destroyed 47 mesh-minted release records on memex-cloud
+    /// (issue #1326). Governance spares <c>_</c>-prefixed segments only, which <c>Release/</c> is
+    /// not — hence a guard of its own rather than a widened governance rule.</para>
     /// </summary>
     public static IReadOnlyList<MeshNode> ComputePrunableNodes(
         IEnumerable<MeshNode> existing,
         IEnumerable<string> sourcePaths,
         IEnumerable<string> previouslyOwnedPaths,
         IEnumerable<string> excludedRoots,
-        PartitionSyncMode mode)
+        PartitionSyncMode mode,
+        Func<string, bool>? isExcludedFromMirror = null)
     {
         if (mode == PartitionSyncMode.UpsertOnly)
             return Array.Empty<MeshNode>();
@@ -362,6 +372,7 @@ public static class StaticRepoImporter
                         && !source.Contains(t.Path)
                         && t.SyncBehavior == SyncBehavior.Include
                         && !IsGovernance(t)
+                        && isExcludedFromMirror?.Invoke(t.Path) != true
                         && !excluded.Any(root => IsAtOrUnder(t.Path, root))
                         // Additive: only prune what the source PREVIOUSLY owned — a user-added node
                         // (never in a manifest) survives. FullReplace prunes every extra.
@@ -618,12 +629,37 @@ public static class StaticRepoImporter
 
                 var lockName = $"Import {source.Partition} ({nodes.Count} nodes)";
 
+                // 🚨 THE MARKER IS A CLAIM ABOUT THE **FULL** CONTENT — so only a run that
+                // evaluated the full content may write it (issue #1326).
+                //
+                // `fingerprint` hashes EVERY source node. `changedNodePaths` scopes the run to the
+                // handful a git diff says moved; the rest are not even looked at. A scoped run that
+                // stamped `import-{fingerprint}` Succeeded therefore asserted "this partition holds
+                // exactly content F" on the evidence of a partial pass — and once written, that
+                // marker is permanent: every later import of the same repo content computes the same
+                // F, hits the short-circuit, and returns "Skipped" with 0 nodes WITHOUT EVER READING
+                // THE PARTITION. GitHubSyncService then reads "Skipped" as "the mesh already has this
+                // commit" and advances LastSyncCommitSha to the head, so the next diff base is the
+                // head and the diff is empty forever. A Space that under-imported once could never
+                // converge again — a manual update reported "Imported Skipped (0 node(s))" while
+                // genuinely behind, and only `force` (which bypasses both the diff and the marker)
+                // fixed it. That is the memex-cloud report of 2026-08-12, end to end.
+                //
+                // A scoped run therefore records its verdict on the ATTEMPT only. Nothing is lost:
+                // the attempt node carries the full log, and the next unscoped import re-evaluates
+                // the content instead of trusting a claim nobody checked. The routine webhook path
+                // is unaffected — it is scoped, so it never reached the short-circuit anyway.
+                var isScopedRun = changedNodePaths is not null;
+
                 // Terminal stamp on the LOCK — through Upsert, the repair-capable verb, so it lands on a
                 // node that may not exist yet (the early-failure path) AND on one left forked by a prior
                 // half-write. The human-readable log lives on the attempt; the lock carries the verdict
                 // plus a pointer to the attempt that produced it.
                 IObservable<int> StampLock(ActivityStatus status, string summary) =>
-                    Upsert(hub, BookkeepingNode(activityId, lockName, status,
+                    // A scoped run never touches the content-addressed marker — see isScopedRun.
+                    isScopedRun
+                    ? Observable.Return(0)
+                    : Upsert(hub, BookkeepingNode(activityId, lockName, status,
                             new LogMessage(summary, status is ActivityStatus.Succeeded
                                 ? Microsoft.Extensions.Logging.LogLevel.Information
                                 : status is ActivityStatus.Warning
@@ -694,7 +730,12 @@ public static class StaticRepoImporter
                 IObservable<StaticRepoImportResult> Reimport() =>
                     // 1. Stamp the MARKER Running (deterministic id, repair-capable Upsert). This
                     //    records that an import is under way; it does not exclude a concurrent one.
-                    Upsert(hub, BookkeepingNode(activityId, lockName, ActivityStatus.Running))
+                    //    Skipped for a scoped run, which may not write the full-content marker at
+                    //    all (see isScopedRun) — a Running stamp it never resolves would leave a
+                    //    reclaimable-but-pointless row at an id no run will ever complete.
+                    (isScopedRun
+                        ? Observable.Return(0)
+                        : Upsert(hub, BookkeepingNode(activityId, lockName, ActivityStatus.Running)))
                         // 2. Open a FRESH attempt node — the only node this run logs progress to (#919).
                         .SelectMany(_ => Upsert(hub, BookkeepingNode(
                             attemptId, $"{lockName} — attempt {DateTime.UtcNow:u}", ActivityStatus.Running)))
@@ -1066,7 +1107,8 @@ public static class StaticRepoImporter
                     // repo); Additive prunes ONLY nodes the source PREVIOUSLY owned (the prior manifest's
                     // keys) so user-added nodes survive; UpsertOnly prunes nothing. See ComputePrunableNodes.
                     var toPrune = ComputePrunableNodes(
-                        existing.Values, nodes.Select(n => n.Path), manifest.Keys, excludedRoots, syncMode);
+                        existing.Values, nodes.Select(n => n.Path), manifest.Keys, excludedRoots, syncMode,
+                        source.IsExcludedFromMirror);
 
                     // Never prune a node CREATED/changed on the server since the last sync when the
                     // policy protects it (two-way, OR prune-only protection for bidirectional spaces —
@@ -1154,7 +1196,8 @@ public static class StaticRepoImporter
                         var contentCount = embedCount + inlineCount;
                         // Persist the per-node manifest LAST (after upserts + prune) so the NEXT import's
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
-                        return WriteManifest(hub, source.Partition, nodes, hub.JsonSerializerOptions, logger).Select(_ =>
+                        return WriteManifest(hub, source.Partition, nodes, manifest, changedNodePaths,
+                            hub.JsonSerializerOptions, logger).Select(_ =>
                         {
                             // 🚨 Terminal status reflects per-file outcomes: ANY failed upsert →
                             // Warning (the ⚠ lines above pinpoint which files), all-clear →
@@ -1688,9 +1731,25 @@ public static class StaticRepoImporter
     /// <see cref="ActivityLog.ReturnValue"/> is the <c>{path → source-token}</c> map for the CURRENT source
     /// set. Read back on the next import to upsert only the delta. Best-effort: a failed manifest write only
     /// makes the next import non-incremental, never incorrect.
+    ///
+    /// <para>🚨 A SCOPED RUN MAY ONLY CLAIM WHAT IT EVALUATED (issue #1326). The map is built from the
+    /// SOURCE, but a run scoped by a git diff (<paramref name="evaluatedPaths"/>) skipped the upsert of
+    /// every existing node outside that set — so recording the source token for those nodes tells the
+    /// NEXT import "already at this content" about content that was never written. The node then stays
+    /// stale forever: each subsequent import compares it to the manifest, finds a match, and skips it.
+    /// This is the same false claim as the content-addressed marker, one layer down, and it is the one
+    /// that actually pinned the memex-cloud Spaces — a full re-import ran and still wrote 0 nodes.
+    /// Out-of-scope nodes therefore keep their PREVIOUS token (or none at all), which is exactly the
+    /// state that makes the next import look at them again.</para>
     /// </summary>
+    /// <param name="previous">The manifest this run read at its start — the tokens that are still the
+    /// only evidence about nodes this run did not evaluate.</param>
+    /// <param name="evaluatedPaths">The git-diff scope; <see langword="null"/> means the run evaluated
+    /// every source node and may claim the whole map.</param>
     private static IObservable<int> WriteManifest(
-        IMessageHub hub, string partition, IReadOnlyList<MeshNode> nodes, JsonSerializerOptions opts, ILogger? logger)
+        IMessageHub hub, string partition, IReadOnlyList<MeshNode> nodes,
+        IReadOnlyDictionary<string, string> previous, IReadOnlySet<string>? evaluatedPaths,
+        JsonSerializerOptions opts, ILogger? logger)
     {
         var map = nodes
             .Where(n => !string.IsNullOrEmpty(n.Path))
@@ -1699,6 +1758,23 @@ public static class StaticRepoImporter
                 g => g.Key,
                 g => PartitionSourceFingerprint.ComputeNodeToken(g.First(), opts),
                 StringComparer.OrdinalIgnoreCase);
+
+        if (evaluatedPaths is not null)
+        {
+            var builder = map.ToBuilder();
+            foreach (var path in map.Keys)
+            {
+                if (evaluatedPaths.Contains(path))
+                    continue;
+                // Not evaluated: report what we actually know, which is whatever the last run that
+                // DID look at this node recorded — nothing, if none ever did.
+                if (previous.TryGetValue(path, out var prior))
+                    builder[path] = prior;
+                else
+                    builder.Remove(path);
+            }
+            map = builder.ToImmutable();
+        }
 
         var node = new MeshNode(ManifestId, $"{partition}/_Activity")
         {

--- a/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
+++ b/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
@@ -65,6 +65,27 @@ public interface IStaticRepoSource
     MeshNode? PartitionRoot => null;
 
     /// <summary>
+    /// 🚨 <b>The source does not mirror this node in EITHER direction</b> — it is never exported to
+    /// the repo and never imported from it. Its absence from
+    /// <see cref="EnumerateSourceNodes"/> is therefore <b>not evidence that it was deleted</b>, and
+    /// the prune MUST skip it. Path is the node's full mesh path. Default: nothing is excluded.
+    ///
+    /// <para><b>Why this exists (issue #1326 — data loss).</b> The prune's rule was "absent from the
+    /// source ⇒ mirror it away", guarded only by governance (<c>_</c>-prefixed segments), the
+    /// per-node <see cref="SyncBehavior"/> and claimed roots. A GitSync source additionally applies
+    /// the Space's gitignore-style rules (<c>SyncIgnore</c>, default <c>Release/</c>) on BOTH the
+    /// export and the import — so an ignored subtree is absent from the repo <b>by construction</b>,
+    /// which made every such node a permanent prune candidate. Under the default
+    /// <see cref="PartitionSyncMode.FullReplace"/> a forced import duly deleted them: 47 mesh-minted
+    /// <c>Release/</c> bookkeeping records were destroyed on memex-cloud on 2026-08-12 as "absent
+    /// from the repo". The ignore rule set is the single declaration of what does not sync; the
+    /// prune was the one direction it was never applied to.</para>
+    /// </summary>
+    /// <param name="nodePath">Full mesh path of an existing node in the target partition.</param>
+    /// <returns><c>true</c> when this source deliberately never carries the node.</returns>
+    bool IsExcludedFromMirror(string nodePath) => false;
+
+    /// <summary>
     /// Optional content-collection <b>imports</b> — assets a node references through its content
     /// collection (e.g. an <c>@@content/logo.svg</c> embed) that ship in an embedded source
     /// collection (e.g. <c>DocContent</c>) and must be copied into the owning node's runtime content

--- a/test/MeshWeaver.GitSync.Test/ForcePrunePreservesIgnoredNodesTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ForcePrunePreservesIgnoredNodesTest.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// 🚨 A FORCED IMPORT MUST NOT DELETE WHAT THE REPO NEVER CARRIES BY DESIGN (issue #1326 — data loss).
+///
+/// <para>The prune's rule is "absent from the source ⇒ mirror it away", guarded by governance
+/// (<c>_</c>-prefixed segments), the per-node <see cref="SyncBehavior"/> and claimed roots. None of
+/// those cover the Space's own gitignore-style rules: <see cref="SyncIgnore"/> strips an ignored
+/// subtree on export AND skips it on import, so an ignored node is absent from the repo
+/// <b>permanently and by construction</b> — which made every one of them a standing prune candidate.
+/// Under the default <c>FullReplace</c> a force duly deleted them: on memex-cloud, 2026-08-12, a
+/// forced update of a stale Space destroyed <b>47 mesh-minted <c>Release/</c> bookkeeping records</b>
+/// as "absent from the repo". <c>Release/</c> is the SHIPPED default of
+/// <see cref="SyncIgnore.Default"/>, so this was the out-of-the-box behaviour.</para>
+///
+/// <para>Second, the ignore matcher was case-SENSITIVE (plain <c>.gitignore</c> semantics) while every
+/// other path comparison in the sync pipeline folds case — the importer's prune set, the changed-path
+/// set, <c>IsAtOrUnder</c>, the partition fold. So <c>release/</c> was not <c>Release/</c>, and a node
+/// stored with different capitalisation was exported AND deleted. Mesh paths do not distinguish case;
+/// the matcher must not invent a distinction that decides whether data is destroyed.</para>
+/// </summary>
+public class ForcePrunePreservesIgnoredNodesTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 180000)]
+    public async Task ForcedImport_KeepsReleaseRecords_IncludingUnderAMismatchedCasing()
+    {
+        await Connect();
+        var space = "GhIg" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Ignore Space");
+
+        // Ordinary content — this DOES round-trip through the repo.
+        await CreateMarkdown($"{space}/Welcome", "Welcome", "# Welcome\n\nv1.");
+
+        // Mesh-minted bookkeeping the compile pipeline appends per release. Never exported
+        // (SyncIgnore.Default ignores `Release/`), so never in the repo. The second one differs only
+        // in the casing of the ignored segment — the mesh treats those as the same subtree, and so
+        // must the matcher that decides whether they are deleted.
+        await CreateMarkdown($"{space}/Release/r1", "r1", "release record 1");
+        await CreateMarkdown($"{space}/release/r2", "r2", "release record 2");
+
+        var repo = "https://github.com/test/space-ignore-prune";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        // Export: the ignore rules strip the release records, so the repo genuinely does not carry
+        // them. That is the precondition for the bug — and it must hold for BOTH casings.
+        var pushed = await Sync.SyncToGitHub(space, UserId).Timeout(60.Seconds()).ToTask();
+        var tree = Fake.Tree(repo).Select(f => f.Path).ToImmutableList();
+        Output.WriteLine($"exported tree: {string.Join(", ", tree)}");
+        tree.Should().NotContain(p => p.Contains("Release/", StringComparison.OrdinalIgnoreCase),
+            "the ignore rules must keep release bookkeeping out of the repo in the first place");
+        await WaitForConfig(space, c => c.LastSyncCommitSha == pushed.CommitSha);
+
+        // 🚨 THE FORCE. Its purpose is to discard local edits and mirror the repo — it is the
+        // deliberate destructive path, and it is what the operator reached for when the Space would
+        // not converge. It must still not delete records the repo was never allowed to hold.
+        var forced = await Sync.ReimportAtCommit(space, "main", UserId, force: true)
+            .Timeout(120.Seconds()).ToTask();
+        Output.WriteLine($"forced import pruned: [{string.Join(", ", forced.PrunedPaths)}]");
+
+        forced.PrunedPaths.Should().NotContain(
+            p => p.Contains("/Release/", StringComparison.OrdinalIgnoreCase),
+            "a node the Space's ignore rules exclude is absent from the repo BY DESIGN — its absence "
+            + "is not evidence of a deletion, and pruning it destroys mesh-minted data the repo can "
+            + "never restore (47 Release records lost on memex-cloud)");
+        Assert.NotNull(await WaitForNode($"{space}/Release/r1"));
+        Assert.NotNull(await WaitForNode($"{space}/release/r2"));
+
+        // …and the force still does its job on ordinary content: a mesh-only node the repo does not
+        // carry (and the rules do NOT exclude) is still mirrored away. Otherwise this fix would have
+        // turned the prune off rather than taught it what "absent" means.
+        await CreateMarkdown($"{space}/MeshOnly", "MeshOnly", "# MeshOnly");
+        var second = await Sync.ReimportAtCommit(space, "main", UserId, force: true)
+            .Timeout(120.Seconds()).ToTask();
+        second.PrunedPaths.Should().Contain(p =>
+                p.EndsWith("/MeshOnly", StringComparison.OrdinalIgnoreCase),
+            "an ordinary mesh-only extra must still be pruned by a force — the guard is scoped to "
+            + "what the ignore rules exclude, not to everything");
+        Assert.NotNull(await WaitForNode($"{space}/Release/r1"));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ScopedImportMarkerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ScopedImportMarkerTest.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 A SCOPED IMPORT MAY NOT LEAVE A FULL-CONTENT "ALREADY IMPORTED" MARKER (issue #1326).
+///
+/// <para>The importer short-circuits on a content-addressed marker: a Succeeded activity at
+/// <c>{Partition}/_Activity/import-{fingerprint}</c> means "this partition already holds exactly this
+/// content", so a later run with the same fingerprint returns <c>Skipped</c> — <b>without reading the
+/// partition at all</b>. The fingerprint hashes EVERY source node.</para>
+///
+/// <para>But a git-diff-scoped run (<c>changedNodePaths</c>, the routine webhook path) only evaluates
+/// the handful of nodes the diff named. Stamping the FULL-content marker after such a run asserts
+/// completeness on the evidence of a partial pass — and it is permanent: from then on every import of
+/// that same repo content reports <c>Skipped (0 nodes)</c>, and <c>GitHubSyncService</c> reads that as
+/// "the mesh already has this commit" and advances <c>LastSyncCommitSha</c> to the head, so the next
+/// diff is empty forever. A Space that under-imported once could never converge again; only
+/// <c>force</c> — which bypasses both the diff and the marker — fixed it. That is the memex-cloud
+/// report of 2026-08-12 (<c>ThreeBody</c>: "Imported Skipped (0 node(s))" while genuinely behind).</para>
+///
+/// <para>What is asserted is CONVERGENCE, not a log string: after a scoped run that could not have
+/// seen node C, a later import of the same content must actually materialize C. Before the fix that
+/// import returned <c>Skipped</c> and C stayed missing forever.</para>
+/// </summary>
+public class ScopedImportMarkerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 240000)]
+    public async Task ScopedImport_DoesNotMakeALaterFullImportSkipTheNodesItNeverSaw()
+    {
+        var partition = "Sc" + Guid.NewGuid().ToString("N")[..8];
+        var source = new FakeRepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "A", "v1"), Page(partition, "B", "v1")],
+        };
+
+        // 1. The FIRST import is unscoped — it really did materialize the whole content, so it may
+        //    (and must) record the marker its fingerprint names.
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(120.Seconds());
+        first.Outcome.Should().Be("Imported");
+        (await Body($"{partition}/A")).Should().Contain("v1");
+        (await Body($"{partition}/B")).Should().Contain("v1");
+
+        // 2. BOTH pages change in the repo, but the git diff the webhook computed names only A. A
+        //    scoped run skips the upsert of every EXISTING node outside the scope — so B is left at
+        //    v1 while the source (and the fingerprint) say v2. That is exactly "the Space is behind":
+        //    the nodes are all there, their content is stale.
+        source.Nodes = [Page(partition, "A", "v2"), Page(partition, "B", "v2")];
+        var scoped = await StaticRepoImporter
+            .ImportSource(Mesh, source, null, null, new HashSet<string> { $"{partition}/A" })
+            .FirstAsync().Timeout(120.Seconds());
+        Output.WriteLine($"scoped run: outcome={scoped.Outcome} count={scoped.Count} "
+            + $"written=[{string.Join(", ", scoped.WrittenPaths)}]");
+        (await Body($"{partition}/B")).Should().Contain("v1",
+            "the scope excluded B, so the scoped run must have left it stale — otherwise this test is "
+            + "not exercising the under-import it exists to detect");
+
+        // 3. …and now the same content is imported WITHOUT a scope (a manual "Update", a boot import).
+        //    It must actually reconcile. Before the fix the scoped run had already stamped this exact
+        //    fingerprint Succeeded, so this returned "Skipped" and B stayed at v1 forever.
+        var full = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(120.Seconds());
+        Output.WriteLine($"unscoped run: outcome={full.Outcome} count={full.Count}");
+
+        full.Outcome.Should().NotBe("Skipped",
+            "a scoped run evaluated only part of the content, so it must not license a later full "
+            + "import to skip on its fingerprint — that marker is the 'Skipped (0 nodes) while behind' "
+            + "lie, and it is permanent once written");
+        (await Body($"{partition}/B")).Should().Contain("v2",
+            "the unscoped import must converge the partition to the source; a Space left stale by a "
+            + "scoped run has no other way back (only `force` bypassed the marker)");
+    }
+
+    /// <summary>
+    /// The complement, so the fix cannot be "never short-circuit again": an UNSCOPED import really did
+    /// evaluate the whole content, so re-importing it unchanged must still take the cheap path. Without
+    /// this, disarming the marker for every run would silently re-materialize whole partitions on every
+    /// boot — the recompile storm the fingerprint gate exists to prevent.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task UnscopedImport_StillShortCircuitsOnItsOwnFingerprint()
+    {
+        var partition = "Sk" + Guid.NewGuid().ToString("N")[..8];
+        var source = new FakeRepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "A", "v1")],
+        };
+
+        (await StaticRepoImporter.ImportSource(Mesh, source).FirstAsync().Timeout(120.Seconds()))
+            .Outcome.Should().Be("Imported");
+
+        var again = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(120.Seconds());
+        again.Outcome.Should().Be("Skipped",
+            "the previous run WAS unscoped, so its marker is honest evidence and the short-circuit "
+            + "must still fire — the fix narrows who may write the marker, not who may read it");
+    }
+
+    /// <summary>The live markdown body of a node — read through the authoritative node stream, never
+    /// the eventually-consistent query, so "still stale" is a fact and not a lag.</summary>
+    private async Task<string> Body(string path)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(30.Seconds());
+        return node.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)?.Content ?? "";
+    }
+
+    private static MeshNode Space(string partition) => new(partition)
+    {
+        Name = "Scoped Import", NodeType = "Space", State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = "# Scoped Import\n\nfixture." }
+    };
+
+    private static MeshNode Page(string partition, string id, string revision) =>
+        new(id, partition)
+        {
+            NodeType = "Markdown", Name = $"Page {id}", State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = $"# Page {id}\n\n{revision}" }
+        };
+
+    private sealed class FakeRepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; set; } = [];
+        public MeshNode? Root { get; set; }
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+    }
+}


### PR DESCRIPTION
Closes #1326.

The two residuals named in the retitled issue. Both turn out to be the same shape: **bookkeeping that claims more than the run which wrote it actually verified.**

## 1. `"Skipped (0 nodes)"` while the Space is genuinely behind

A git-diff-scoped run (the routine webhook path) evaluates only the nodes the diff names — but it wrote **both** pieces of *full-content* bookkeeping:

| record | what it claims | who reads it |
|---|---|---|
| `{Partition}/_Activity/import-{fingerprint}` | "this partition holds exactly this content" | the short-circuit that returns `Skipped` **without reading the partition** |
| the per-node import manifest | `{path → source token}` for the **whole source** | the upsert's per-node "unchanged, skip" gate |

Either alone pins a Space permanently:

* `GitHubSyncService` reads `Skipped` as "the mesh already has this commit" and advances `LastSyncCommitSha` to the head → the next diff is empty, forever;
* and even a **full** re-import matched the manifest and wrote 0 nodes.

Only `force` — which bypasses the diff *and* the marker — ever converged such a Space. That is the memex-cloud report end to end.

**Fix:** a scoped run records only what it evaluated — no marker, and manifest entries for out-of-scope nodes carried forward from the previous run. An **unscoped** run still writes both and still short-circuits; `UnscopedImport_StillShortCircuitsOnItsOwnFingerprint` pins that, so the fix cannot decay into "never skip again" (which would re-materialise whole partitions on every boot).

> Note: the manifest half was only visible *after* fixing the marker — with the marker fixed the re-import ran and still wrote 0 nodes. The issue named the marker; the manifest is the layer under it and is what actually kept the Spaces stale.

## 2. Force-prune ate `Release` records — data loss

The prune's rule is "absent from the source ⇒ mirror it away", guarded by governance (`_`-prefixed segments), `SyncBehavior` and claimed roots. None of those cover the Space's own ignore rules — and `SyncIgnore` strips a subtree on export *and* skips it on import, so an ignored node is absent from the repo **by construction**. Every one of them was a standing prune candidate, and `Release/` is the shipped default of `SyncIgnore.Default`. A force destroyed 47 of them on memex-cloud.

`IStaticRepoSource` gains `IsExcludedFromMirror`; `ComputePrunableNodes` takes it as a fifth guard; the GitSync source answers it from the Space's own `SyncIgnore`. An ordinary mesh-only extra is still pruned (asserted).

## Did `AddIfUnderPrefix` have other victims?

Yes — but not the ones the issue expected, and the reported call site is **not** where the damage was.

**Fixed (same class, real victims):**
* **`SyncIgnore`'s matcher was case-sensitive** while every other path comparison in the pipeline folds case (`ComputePrunableNodes`, `ChangedNodePaths`, `IsAtOrUnder`, the partition fold). Now that the prune consults it, `Release/` vs `release/` decided whether data was **deleted**.
* **`NodeFileMapper.HasChildren`** compared mesh paths `Ordinal`, so a child whose stored casing differed from its parent's was invisible: the parent exported as a leaf `Foo.md` while its children went to `foo/Bar.md`, and the subtree lost its index on re-import.

**Deliberately left `Ordinal`:**
* the git-tree comparisons in the export (`OctokitGitHubRepoClient.Push`: under-prefix / preserved / exportPaths) — those paths *really are* case-sensitive, and folding them would delete a differently-cased blob;
* the read-side prefix filters (`Fetch`, `AddIfUnderPrefix`, `ReadWorktree`) — loosening the read while the write stays strict would create a duplicate tree on the next export.

Instead, the read side now **fails loudly**: a configured subdirectory that matches nothing aborts the import naming the subdirectory. Previously it flowed on as an empty snapshot and, under the default `FullReplace`, **would have mirrored the whole Space away** — the most serious latent case of the same "empty is not evidence" bug, and exactly what a case-mismatched subdirectory would have triggered.

Finally, a `Skipped` outcome now names the evidence that licensed it (fingerprint + marker node) instead of rendering as `Skipped (0 node(s))`, which was indistinguishable from "checked, nothing to do".

## Verification

**Fail-before proven for each guard, by reverting it in isolation:**
* prune guard off → the force prunes `GhIg…/release/r2, GhIg…/Release/r1` (the exact reported loss, both casings);
* marker/manifest fix off → the unscoped re-import returns `Skipped` / writes 0 and `Page B` stays at `v1`.

Release builds, `-warnaserror`, one project per invocation. `MeshWeaver.GitSync.Test` 161/161 · `MeshWeaver.Graph.Test` 1094/1094 · `MeshWeaver.Documentation.Test` 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
