### PR TITLE
fix(#1379): a NodeType definition must not claim the content-type key its instances read

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-node-no-longer-shows-you-its-type-instead-of-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-node-no-longer-shows-you-its-type-instead-of-itself.md
@@ -1,0 +1,32 @@
+---
+Name: A node no longer shows you its type instead of itself
+Category: Fix
+Description: Just after a package's type was rebuilt, some of its nodes served the type's own definition in place of their content — so pages read as empty and a paid install reported there was nothing to install.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A node no longer shows you its type instead of itself
+
+Every node says what kind of thing it is, and the platform keeps one list of what each kind's
+content looks like — so that a page rendering a node knows what shape to expect. Entries in that
+list were being written by two different things: by a node of that kind, which knows the right
+answer, and by the kind's own definition, which does not. Whichever wrote last won.
+
+When the definition wrote last, every node of that kind started reading back as **a copy of its own
+type definition** rather than its content. Nothing looked broken from the outside: the node kept its
+name, its address and its version, no error was logged, and the substitution held for as long as the
+process ran. Pages simply showed nothing, and anything that asked a node a question about itself got
+an answer that belonged to something else.
+
+The visible cost was on the Store. A purchase whose package was in that state read its own
+declaration, found a type definition where the list of things to install should have been, and
+concluded there was nothing to install — leaving a buyer charged, entitled, marked delivered, and
+holding an empty space. It happened only in the moments right after a package's type was rebuilt,
+which is why it looked random; a platform update rebuilds every type at once, so the window opened
+for everything simultaneously.
+
+Only the nodes themselves describe their content now, and the definition no longer overwrites what
+they said. Alongside that, content is never reshaped into a type it says it is not: if the two ever
+disagree again, the platform declines to answer and says so, instead of handing back a confident
+wrong one.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
@@ -30,12 +30,31 @@ internal class MeshNodeHubFactory(
                 // through — MonolithRoutingService and MessageHubGrain — so stamping here covers
                 // both hosts; the transient probe hubs stamp their own.
                 //
-                // For a NodeType DEFINITION node, `NodeType` is the literal "NodeType" and the
-                // semantically-correct value is the node's own Path — that is the type every
-                // instance of it will declare.
-                var nodeTypePath = string.Equals(enriched.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal)
-                    ? enriched.Path
-                    : enriched.NodeType;
+                // 🚨 The stamp names the type whose CONFIGURATION IS BEING APPLIED — always
+                // `enriched.NodeType`, never the node's own Path. A NodeType DEFINITION node
+                // (`NodeType` == the literal "NodeType") is the case that makes the distinction
+                // load-bearing, and it used to be special-cased to `enriched.Path` on the reasoning
+                // that the node's path "is the type every instance of it will declare". The KEY was
+                // right and the VALUE cannot be: a definition node's hub applies
+                // NodeTypeNodeType's configuration — `WithContentType<NodeTypeDefinition>()` — and
+                // never loads the compiled assembly of the type it declares, so the only thing it
+                // can publish under its own path is NodeTypeDefinition. That is the answer to a
+                // DIFFERENT question than the one the key asks: every read seam resolves by
+                // `node.NodeType`, so the entry at `Store/Plugin` is what an INSTANCE of
+                // Store/Plugin gets, and its content is PluginContent.
+                //
+                // MeshContentTypeRegistry.Register is last-writer-wins per key, so a definition
+                // node cold-activating after an instance overwrote the instance's correct entry,
+                // and the degrade seams then recovered instance content as the type's own
+                // definition — at its unchanged Version, on every read, for the rest of the process
+                // (Systemorph/MeshWeaver#1379: a paid Store package whose fulfilment read the
+                // declaration, got a NodeTypeDefinition, and reported "nothing to install").
+                // Instances and the schema probes already write the correct entry under exactly
+                // this key, so dropping the special case loses nothing; the literal "NodeType" that
+                // a definition node now stamps is itself a correct entry — a node whose NodeType is
+                // "NodeType" does carry NodeTypeDefinition content.
+                // Repro: NodeTypePathRegistrationTest.ActivatingANodeTypeDefinition_DoesNotClaimItsOwnPathForItsInstances.
+                var nodeTypePath = enriched.NodeType;
 
                 var defaultConfig = meshConfiguration.DefaultNodeHubConfiguration;
                 var nodeConfig = enriched.HubConfiguration;

--- a/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
@@ -269,14 +269,55 @@ public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? lo
             return null;
         // Exact first: keyed on the node's own NodeType, so a name two packages share is not a
         // problem to be refused — each package's nodes resolve to their own type.
+        //
+        // 🚨 …but only when the content's OWN discriminator does not contradict it. Materialize
+        // deserialises to whatever type it is handed, and System.Text.Json ignores members that
+        // type does not declare and materialises defaults for the ones it does — so feeding it a
+        // mismatched type SUCCEEDS and returns a plausible, wrong object. That is what turned one
+        // bad registry entry into Systemorph/MeshWeaver#1379: an instance served its NodeType's
+        // NodeTypeDefinition as its own content, silently, on every read. The entry that caused it
+        // is fixed at the writer (MeshNodeHubFactory), but "the map said so" must never again be
+        // enough on its own to reshape content — an unresolvable read is honest and recoverable,
+        // a wrongly-typed one is neither.
         if (nodeTypePath is not null
             && TryResolveByNodeType(nodeTypePath, out var exact)
+            && DiscriminatorAdmits(content, exact)
             && Materialize(content, exact, options) is { } recovered)
             return recovered;
         // Then the name route, for a node with no NodeType or a type not yet activated in this
         // process. It still refuses a contested name — that refusal is what keeps a wrong answer
         // from being silently lossy.
         return TryRecover(content, options);
+    }
+
+    /// <summary>
+    /// True when <paramref name="content"/>'s own <c>$type</c> does not CONTRADICT
+    /// <paramref name="candidate"/> — the guard that stops the NodeType route from reshaping content
+    /// into a type its own discriminator disagrees with.
+    ///
+    /// <para><b>Absent is not contradicting.</b> Content written without a <c>$type</c> (a plain
+    /// JSON object) has nothing to disagree with, and the NodeType route is then the only answer
+    /// available — so it is admitted, exactly as before.</para>
+    ///
+    /// <para><b>The comparison is on the SHORT name, deliberately.</b> That is the framework's
+    /// existing recovery rule (<c>ObjectAsExtensions.As&lt;T&gt;</c>: "recover ONLY when the runtime
+    /// type has the SAME short name … a DIFFERENTLY-named type must stay null"), and it is what
+    /// keeps the whole point of the exact route intact: two packages that each ship a
+    /// <c>Currency</c> both carry <c>"$type":"Currency"</c>, each resolves to its OWN package's
+    /// CLR type through its own NodeType key, and both match here. A rebuild into a new collectible
+    /// assembly, and a declaration that moved namespace, match too — only a genuinely different
+    /// record name is refused.</para>
+    /// </summary>
+    private static bool DiscriminatorAdmits(JsonElement content, Type candidate)
+    {
+        if (!content.TryGetProperty("$type", out var typeProp)
+            || typeProp.ValueKind != JsonValueKind.String
+            || typeProp.GetString() is not { Length: > 0 } discriminator)
+            return true;
+
+        var lastDot = discriminator.LastIndexOf('.');
+        var shortName = lastDot >= 0 ? discriminator[(lastDot + 1)..] : discriminator;
+        return string.Equals(shortName, candidate.Name, StringComparison.Ordinal);
     }
 
     private static object? Materialize(JsonElement content, Type contentType, JsonSerializerOptions options)

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathRegistrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathRegistrationTest.cs
@@ -4,6 +4,7 @@ using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
@@ -140,5 +141,72 @@ public class NodeTypePathRegistrationTest(ITestOutputHelper output) : MonolithMe
 
         node.ContentAs<StampedProduct>(Mesh.JsonSerializerOptions)?.Name.Should().Be("Gadget",
             "a cross-hub read must yield the real content, not a blank record");
+    }
+
+    /// <summary>
+    /// 🚨 A NodeType DEFINITION node must never claim its OWN path in the content-type registry.
+    ///
+    /// <para><b>The key belongs to the instances, not to the definition.</b> Every read seam
+    /// resolves by <c>node.NodeType</c>, so the entry at path <c>P</c> answers the question "what
+    /// CLR type is the content of a node whose NodeType is <c>P</c>?". For a definition node at
+    /// <c>P</c> the answer that its own activation can supply is <see cref="NodeTypeDefinition"/> —
+    /// the content type of the <c>NodeType</c> configuration it is running — and that is the answer
+    /// to a DIFFERENT question. Instances of <c>P</c> carry the type <c>P</c> declares
+    /// (<c>PluginContent</c>, <c>StampedProduct</c>, …), which the definition node's hub never even
+    /// loads: it applies <see cref="NodeTypeNodeType"/>'s configuration, not the compiled one.</para>
+    ///
+    /// <para><b>Why the wrong entry is silent and not merely absent.</b>
+    /// <c>MeshContentTypeRegistry.Register</c> is last-writer-wins per key, so a definition node
+    /// activating AFTER an instance overwrites the instance's correct entry. The degrade seams
+    /// (<c>MeshNodeStreamCache.ConvertContentJsonElementToTyped</c>,
+    /// <c>MeshNodeTypeSource.ResolveJsonElementContent</c>) then hand
+    /// <c>TryRecoverForNodeType(node.NodeType, …)</c> an instance's JSON and get
+    /// <see cref="NodeTypeDefinition"/> back — System.Text.Json ignores the members it does not
+    /// know and materialises defaults for the rest, so the recovery SUCCEEDS and the instance
+    /// serves its type's definition as its own content, at its unchanged Version, on every read.
+    /// That is Systemorph/MeshWeaver#1379: a paid Store package whose fulfilment read the
+    /// declaration, found a <see cref="NodeTypeDefinition"/>, and reported "nothing to install".</para>
+    ///
+    /// <para>The ordering here is FIXED, not raced: the definition node activates second, which is
+    /// the order that exposes the overwrite. In production the order is whichever hub cold-activates
+    /// last, which is why the symptom was intermittent (~1 gate run in 20) rather than constant.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ActivatingANodeTypeDefinition_DoesNotClaimItsOwnPathForItsInstances()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+
+        var id = $"declared-{Guid.NewGuid():N}";
+        var definitionPath = $"{TestPartition}/{id}";
+
+        // A NodeType definition node exactly as a dynamic type is persisted: NodeType is the
+        // literal "NodeType", Content is a NodeTypeDefinition. No sources / configuration, so no
+        // compile is kicked off — this test is about the registration, not about Roslyn.
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Declared Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition { Description = "a type whose instances are not definitions" },
+        }).Should().Emit();
+
+        // Activate the definition node's own hub — this applies NodeTypeNodeType's configuration
+        // and therefore runs its WithContentType<NodeTypeDefinition>().
+        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(definitionPath)))
+            .Should().Emit();
+
+        // THE ASSERTION: the definition's own path is the key its INSTANCES read. Nothing the
+        // definition node's hub knows may be published under it.
+        registry.TryResolveByNodeType(definitionPath, out var claimed).Should().BeFalse(
+            $"the definition node's activation must not claim '{definitionPath}' — that key answers "
+            + "'what is the content type of a node whose NodeType is this?', and the only answer this "
+            + "hub can give is NodeTypeDefinition, which is the content type of the DEFINITION, not of "
+            + $"its instances. Claimed: {claimed?.FullName ?? "(none)"}");
+
+        // …and the entry that IS correct must still be written: a definition node read through a
+        // degrade seam resolves by its own NodeType, the literal "NodeType".
+        registry.TryResolveByNodeType(MeshNode.NodeTypePath, out var forDefinitions).Should().BeTrue(
+            "a node whose NodeType is the literal 'NodeType' does carry NodeTypeDefinition content — "
+            + "that entry is the correct one and must not be lost by fixing the wrong one");
+        forDefinitions.Should().Be(typeof(NodeTypeDefinition));
     }
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MeshContentTypeRegistryTest.cs
@@ -292,6 +292,68 @@ public class MeshContentTypeRegistryTest
             .GetType().Should().Be(scenario, "an unregistered path falls back rather than failing");
     }
 
+    /// <summary>
+    /// 🚨 The exact route must not reshape content into a type its OWN <c>$type</c> contradicts.
+    ///
+    /// <para><see cref="MeshContentTypeRegistry.Register"/> is last-writer-wins on the NodeType key,
+    /// so one wrong writer poisons the entry for every reader — and because
+    /// System.Text.Json ignores members the target does not declare and materialises defaults for
+    /// the ones it does, deserialising into the wrong record SUCCEEDS. The recovery then returns a
+    /// plausible, wrong object rather than failing, which is exactly how Systemorph/MeshWeaver#1379
+    /// stayed invisible: a <c>Store/Plugin</c> instance served its type's
+    /// <c>NodeTypeDefinition</c> as its own content, at its unchanged Version, on every read, and
+    /// the paid install reported "nothing to install".</para>
+    ///
+    /// <para>The poisoning writer is fixed at its source (<c>MeshNodeHubFactory</c> no longer stamps
+    /// a definition node's own path). This pins the invariant that keeps the NEXT such mismatch
+    /// loud: an unresolvable read leaves a <see cref="JsonElement"/> the consumer's
+    /// <c>ContentAs&lt;T&gt;</c> can still recover and the seams already warn about; a wrongly-typed
+    /// one is silent and lossy.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TryRecoverForNodeType_RefusesATypeTheContentsOwnDiscriminatorContradicts()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var declaration = EmitTypeWithProperty("Store_Plugin_Declaration", "PluginContent", "Id");
+        var foreign = EmitTypeWithProperty("Graph_Definition", "NodeTypeDefinition", "Description");
+
+        // The poisoned entry: the key belongs to Store/Plugin's INSTANCES, the value does not.
+        registry.Register(foreign, "Store/Plugin");
+
+        var element = JsonSerializer.Deserialize<JsonElement>("""{"$type":"PluginContent","Id":"pack-1"}""");
+
+        registry.TryRecoverForNodeType("Store/Plugin", element, JsonSerializerOptions.Default)
+            .Should().BeNull(
+                "the content says it is a PluginContent — materialising it as a NodeTypeDefinition "
+                + "would succeed and be silently wrong, which is worse than not answering");
+
+        // The same guard must NOT cost the exact route its purpose: once the correct writer wins,
+        // a discriminator two packages share still resolves through the NodeType key.
+        registry.Register(declaration, "Store/Plugin");
+        registry.TryRecoverForNodeType("Store/Plugin", element, JsonSerializerOptions.Default)!
+            .GetType().Should().Be(declaration);
+    }
+
+    /// <summary>
+    /// Content written WITHOUT a <c>$type</c> has nothing to contradict, so the NodeType route stays
+    /// the only answer available and must still give it. Pinned separately because the obvious way
+    /// to write the guard above — "require a matching discriminator" — would silently stop typing
+    /// every such node.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TryRecoverForNodeType_StillResolvesContentThatCarriesNoDiscriminator()
+    {
+        var registry = new MeshContentTypeRegistry();
+        var scenario = EmitTypeWithProperty("SST_Untagged", "Scenario", "Code");
+        registry.Register(scenario, "SST/Scenario");
+
+        var element = JsonSerializer.Deserialize<JsonElement>("""{"Code":"base"}""");
+
+        var recovered = registry.TryRecoverForNodeType("SST/Scenario", element, JsonSerializerOptions.Default);
+        recovered!.GetType().Should().Be(scenario, "an absent discriminator contradicts nothing");
+        scenario.GetProperty("Code")!.GetValue(recovered).Should().Be("base");
+    }
+
     /// <summary>A type with one settable string property — enough to prove the payload round-trips.</summary>
     private static Type EmitTypeWithProperty(string assemblyName, string typeName, string propertyName)
     {


### PR DESCRIPTION
Closes #1379.

## What was wrong

A per-node instance intermittently served its NodeType's `NodeTypeDefinition` as its own
`Content` — `Path`, `NodeType` and `MainNode` all correct, `Version` never advancing, persistent
for the rest of the process, and identical on both the authoritative stream and the synced query.

It is a **read-side aliasing, not a write** — which is exactly why the Version never moved, and
why the recycle in the issue's trace is a red herring as a *cause*: it only re-orders two
activations. The stale-assembly self-heal is correct and is untouched here.

`MeshNodeHubFactory` stamps `NodeTypePathHolder` so that the `WithContentType` inside a NodeType's
configuration records its content type under an exact, mesh-unique key (#1299's exact route). For
a NodeType **definition** node it stamped the node's **own path**:

```csharp
var nodeTypePath = string.Equals(enriched.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal)
    ? enriched.Path        // ← "Store/Plugin"
    : enriched.NodeType;
```

The reasoning in the comment — *"that is the type every instance of it will declare"* — got the
**key** right and the **value** cannot be. A definition node's hub applies `NodeTypeNodeType`'s
configuration, `WithContentType<NodeTypeDefinition>()`, and never loads the compiled assembly of
the type it declares. So the only thing it can publish under `Store/Plugin` is
`NodeTypeDefinition` — while that key answers a different question: every read seam resolves by
`node.NodeType`, so the entry at `Store/Plugin` is what an **instance** of Store/Plugin gets, and
its content is `PluginContent`.

`MeshContentTypeRegistry.Register` is last-writer-wins per key, so a definition hub cold-activating
after an instance overwrote the instance's correct entry. The degrade seams (`MeshNodeStreamCache`,
`MeshNodeTypeSource.ResolveJsonElementContent`, `EnsureTypedContent`) then recovered instance
content through `TryRecoverForNodeType(node.NodeType, …)` and got the definition back — **silently**,
because System.Text.Json ignores members the target does not declare and materialises defaults for
the ones it does, so deserialising into the wrong record *succeeds*.

Downstream, `ContentAs<PluginContent>` correctly declines a differently-named type, the paid
fulfilment read no declaration, and the buyer was charged, entitled, stamped delivered, and holding
nothing.

## The change

- **`MeshNodeHubFactory`** stamps `enriched.NodeType` unconditionally — the type whose
  configuration is actually being applied. Instances and both schema probes already write the
  correct entry under that same key, so the special case only ever published a wrong one. The
  literal `"NodeType"` a definition node now stamps is itself a correct entry: a node whose
  NodeType *is* `"NodeType"` does carry `NodeTypeDefinition` content.
- **`TryRecoverForNodeType`** refuses a type the content's own `$type` contradicts. The bad entry
  is fixed at its writer, but *"the map said so"* must not be enough on its own to reshape content:
  an unresolvable read stays a `JsonElement` that `ContentAs<T>` can still recover and the seams
  already warn loudly about, where a wrongly-typed one is silent and lossy. The comparison is on the
  **short name**, matching `ObjectAsExtensions.As<T>`'s existing rule — so two packages that each
  ship a `Currency` are unaffected (#1299's whole point is preserved), a rebuild into a new
  collectible assembly matches, and absent `$type` contradicts nothing and still resolves.

## Verification

Fail-before / pass-after, and a measured rate rather than a single green run.

**Deterministic pin** — `NodeTypePathRegistrationTest.ActivatingANodeTypeDefinition_DoesNotClaimItsOwnPathForItsInstances`
fixes the activation order (definition second), so it is not a race. Red before, naming the
claimant:

```
Expected value to be false because the definition node's activation must not claim
'TestData/declared-…' … Claimed: MeshWeaver.Graph.Configuration.NodeTypeDefinition, but found True.
```

Green after. It also asserts the *correct* entry (`"NodeType"` → `NodeTypeDefinition`) still gets
written, so a naive "just drop the stamp" fix does not pass.

**Measured rate**, `mw-plugin-test` over Store + Essentials staged exactly as the `plugin-gate` job
stages them (~9 s/run, default log level — `MW_LOG_LEVEL=Information` closes the window):

| | runs | gate failures | of which #1379's signature | of which a distinct 15 s residual |
|---|---|---|---|---|
| before | 60 | 2 (3.3%) | **1** (`got 'NodeTypeDefinition'`) | 1 |
| after | 130 | **0** | **0** | 0 |

Both before-failures are `GATE FAILED — tests: Store/Catalog` paid fulfilment, but they are **not**
the same defect and I am not claiming both:

- run 1 — `'PaidPack…' carries content that did not read as a package declaration (got
  'NodeTypeDefinition')`. This is #1379, and it is what this PR fixes: **1/60 → 0/130**.
- run 37 — `'PaidPack…' did not answer within 15s — the package's own hub is not serving its node`.
  That is Plugins#456's `DeclarationReadBudget` elapsing, a serving/activation delay rather than a
  content-typing fault. **This PR does not target it**, and 0 occurrences in 130 runs is too few to
  say anything about a 1-in-60 event either way.

**Regression net** (all green): `MeshContentTypeRegistryTest` 14/14 including the two new ones,
`TypedContentUpdateTest` 6/6 (notably `UntypedUpdate_WithTheAsOrDefaultIdiom_IsRescuedByTheExactContentTypeRoute`,
the case most exposed to the new guard), `ReimportTypedContentRecoveryTest` 5/5,
`NodeTypePathRegistrationTest` 3/3, `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest`.

`dotnet build -c Release -warnaserror` clean for both touched projects (`MeshWeaver.Graph`,
`MeshWeaver.Messaging.Hub`), DLL mtimes confirmed newer than the edits.

## Not in this PR

**#1371 does not share this root**, and the evidence is decisive rather than circumstantial: if
#1379 had degraded the package node's content, `ContentAs<PluginContent>` returns null →
`HasInstallableContent == false` → `NothingToInstall`, which writes **no manifest at all**. #1371's
defining observation is a manifest that *was* written. Same reasoning rules out Plugins#456 as its
fix — #456's failure mode also ends in no manifest. Details in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
