### PR TITLE
An export whose body is stored as plain JSON no longer renders empty (#1374)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-exported-document-no-longer-comes-out-blank.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-exported-document-no-longer-comes-out-blank.md
@@ -1,0 +1,32 @@
+---
+Name: An exported document no longer comes out blank
+Category: Fix
+Description: Some documents exported to PDF, Word or email as a cover page and a contents list with nothing after it. The export now reads every way a document body can be stored, and says so when it genuinely cannot.
+Icon: Sparkle
+Order: -20260813
+---
+
+# An exported document no longer comes out blank
+
+Exporting a document could produce a file with a cover page, a table of contents, and then nothing
+at all. The pages were there, the headings were listed, and the body was simply gone. Nothing
+failed, no error appeared, and the download completed normally — so it read like an empty document
+rather than a broken export.
+
+Which documents it hit was not obvious from looking at them. On screen they were perfectly normal:
+the text was visible, editable and searchable. The difference was invisible — how the body happened
+to be *stored*. A document written by an import, created through the API, or saved before its
+content format existed keeps its text in a slightly plainer form than one typed into the editor.
+The export recognised only the editor's form, found nothing where it looked, and carried on.
+
+Two things made this worse than a normal bug. Including child pages made losses silent rather than
+visible: a chapter with no text is skipped entirely, so a whole section could vanish from a report
+without leaving so much as a blank page behind. And the same reading step existed in three separate
+copies — one for PDF, one for Word, one for email — so all three formats were affected, and fixing
+one would not have fixed the others.
+
+There is now a single reading step, shared by all three formats, that understands every form a
+document body is stored in. Documents that used to export blank now export their text. And in the
+one case where a body genuinely cannot be read, the export writes that into its activity log naming
+the page, instead of quietly handing back an empty chapter and leaving you to wonder what you did
+wrong.

--- a/src/MeshWeaver.Markdown.Export/Ast/ExportSource.cs
+++ b/src/MeshWeaver.Markdown.Export/Ast/ExportSource.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Markdown.Export.Ast;
+
+/// <summary>
+/// Reads the markdown BODY out of an exported <see cref="MeshNode"/> — the one place every export
+/// template asks "what text does this node contribute to the document?".
+///
+/// <para>🚨 It lives here, in compiled framework code, because the three export templates
+/// (<c>ExportPdf.csx</c>, <c>ExportDocx.csx</c>, <c>ExportHtml.csx</c>) are <c>.csx</c> compiled at
+/// RUNTIME: no <c>dotnet build</c> ever type-checks them and no unit test could reach a private
+/// local function inside one. Three hand-copied extractors is how the defect below survived — and
+/// how a fix applied to one template would have drifted from the other two.</para>
+///
+/// <para><b>The defect (#1374).</b> Each copy read the body with a direct type test:</para>
+/// <code>
+/// if (node.Content is MarkdownContent mc) return mc.Content ?? "";   // ❌ trap-door
+/// </code>
+/// <para>That is correct only when the value already happens to be that CLR type. A node whose
+/// content was stored as plain JSON — an import, an MCP <c>create</c>/<c>patch</c> carrying a raw
+/// body, a document written before its content type existed — has no <c>$type</c> discriminator for
+/// the polymorphic converter to resolve, so it arrives (and STAYS, even on the node's own owning
+/// hub) a raw <see cref="JsonElement"/>. The test is simply false, the extractor returns <c>""</c>,
+/// and the export produces a cover page, a contents list and <b>no body</b> — no exception, no log
+/// line, nothing to grep, and it reads to the author as their own mistake rather than a platform
+/// bug. <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovers exactly that shape (and a
+/// same-short-named <c>MarkdownContent</c> from another dynamic-node build, by JSON round-trip).</para>
+///
+/// <para><b>Why this is a legitimate boundary read and not a routing mistake.</b> The rule's first
+/// question is whether the value should have been deserialized closer to where its type IS
+/// registered. Here it could not be: the shape that fails carries <b>no discriminator at all</b>, so
+/// no registry can type it — measured on the monolith, a <c>Markdown</c> node whose content was
+/// written as bare JSON is still a <see cref="JsonElement"/> when read from its OWN per-node hub,
+/// the very hub that declares <c>WithContentType&lt;MarkdownContent&gt;()</c>. Moving the read would
+/// change nothing. Reading stored JSON whose type cannot be resolved is the textbook case the
+/// accessor exists for.</para>
+/// </summary>
+public static class ExportSource
+{
+    /// <summary>
+    /// The node's markdown body, or <c>""</c> when it has none.
+    ///
+    /// <para>Returning <c>""</c> for a node that is genuinely not markdown-bodied is deliberate and
+    /// is what callers probe on: with <c>IncludeChildren</c> an export walks EVERY descendant, most
+    /// of which carry typed non-markdown content, and each is skipped on an empty body. Only a
+    /// node whose content is JSON-shaped — i.e. one that could have been a markdown body and could
+    /// not be read as one — is worth a log line, and that is the only case that emits one.</para>
+    /// </summary>
+    /// <param name="node">The node to read. A null node yields <c>""</c>.</param>
+    /// <param name="options">
+    /// The reading hub's <c>JsonSerializerOptions</c> (<c>Mesh.JsonSerializerOptions</c> in a
+    /// template) — the registry behind them is what resolves a <c>$type</c>.
+    /// </param>
+    /// <param name="logger">
+    /// Optional. Without it an unreadable JSON body is still returned as <c>""</c>, just without the
+    /// diagnosis — which is the state that made #1374 invisible for as long as it was.
+    /// </param>
+    public static string MarkdownOf(MeshNode? node, JsonSerializerOptions options, ILogger? logger = null)
+    {
+        if (node?.Content is null)
+            return "";
+
+        // The accessor FIRST: it covers the already-typed value, the degraded JsonElement/JsonNode,
+        // and a same-short-named MarkdownContent from another build. Deliberately without the
+        // logger — every non-markdown descendant of an IncludeChildren export lands here too, and
+        // As<T> logs an error for a typed-but-foreign value. The one genuinely diagnosable case is
+        // reported explicitly below instead, so the diagnosis survives without the storm.
+        if (node.ContentAs<MarkdownContent>(options)?.Content is { } markdown)
+            return markdown;
+
+        // A body stored as a bare string, either still typed or degraded to a JSON string.
+        if (node.Content is string s)
+            return s;
+        if (node.Content is JsonElement { ValueKind: JsonValueKind.String } je)
+            return je.GetString() ?? "";
+        if (node.Content is JsonValue jv && jv.TryGetValue<string>(out var raw))
+            return raw;
+
+        // JSON-shaped content on a node that DECLARES itself a markdown document, yet no body came
+        // out of it. That is the export silently losing its content, so say so rather than
+        // returning an empty chapter and letting the author conclude they wrote an empty document.
+        //
+        // The NodeType is what keeps this a diagnosis instead of a storm: with IncludeChildren an
+        // export walks every descendant, and a Todo or a Product whose typed content arrived as
+        // JSON is not a fault, it is simply not a chapter. Only a node that was supposed to have a
+        // body gets a line.
+        if (node.Content is JsonElement or JsonNode
+            && string.Equals(node.NodeType, MarkdownNodeType.NodeType, StringComparison.Ordinal))
+            logger?.LogWarning(
+                "Export: {Path} is a {NodeType} node whose content is JSON that yields no markdown "
+                + "body; its chapter will be empty. Content: {Raw}",
+                node.Path,
+                node.NodeType,
+                Excerpt(node.Content is JsonElement el ? el.GetRawText() : node.Content.ToString() ?? ""));
+
+        return "";
+    }
+
+    /// <summary>Head of an unreadable body, bounded — the value being logged can be megabytes.</summary>
+    private static string Excerpt(string rawJson) =>
+        rawJson.Length <= RawJsonLogLimit
+            ? rawJson
+            : $"{rawJson[..RawJsonLogLimit]}… [{rawJson.Length - RawJsonLogLimit} more chars]";
+
+    private const int RawJsonLogLimit = 512;
+}

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportDocx.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportDocx.csx
@@ -51,13 +51,15 @@ if (rootNode is null)
 
 var title = explicitTitle ?? options.Title ?? rootNode.Name ?? rootNode.Id;
 
+var jsonOptions = Mesh.JsonSerializerOptions;
+
 Log.LogInformation("Resolving branding");
 var brandingResolver = Mesh.ServiceProvider.GetRequiredService<BrandingResolver>();
 var branding = await brandingResolver.Resolve(brandPath).FirstAsync().ToTask(Ct);
 
 var chapters = new List<ExportChapter>
 {
-    new ExportChapter(title, ExtractMarkdown(rootNode), sourcePath)
+    new ExportChapter(title, ExportSource.MarkdownOf(rootNode, jsonOptions, Log), sourcePath)
 };
 if (options.IncludeChildren)
 {
@@ -79,7 +81,7 @@ if (options.IncludeChildren)
             var depth = desc.Path.Count(c => c == '/') - rootDepth;
             if (depth > options.MaxDepth) continue;
         }
-        var md = ExtractMarkdown(desc);
+        var md = ExportSource.MarkdownOf(desc, jsonOptions, Log);
         if (!string.IsNullOrWhiteSpace(md))
             chapters.Add(new ExportChapter(desc.Name ?? desc.Id, md, desc.Path));
     }
@@ -107,12 +109,9 @@ return new RenderedDocument(
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     bytes);
 
-static string ExtractMarkdown(MeshNode node)
-{
-    if (node.Content is MarkdownContent mc) return mc.Content ?? "";
-    if (node.Content is string s) return s;
-    return "";
-}
+// 🚨 There is no local ExtractMarkdown — the body extraction is ExportSource.MarkdownOf, in
+// COMPILED framework code. See ExportPdf.csx for why (#1374): a `node.Content is MarkdownContent`
+// test is false for a body stored as plain JSON, and the export silently loses it.
 
 // The portal's public origin — a resolved area's links are dead without one once the file leaves
 // this machine. Same key order as ExportPdf.csx and the HTML export.

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportHtml.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportHtml.csx
@@ -30,6 +30,7 @@ using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown;
 using MeshWeaver.Markdown.Export;
+using MeshWeaver.Markdown.Export.Ast;
 using MeshWeaver.Markdown.Export.Configuration;
 using MeshWeaver.Markdown.Export.Email;
 using MeshWeaver.Markdown.Export.Html;
@@ -72,7 +73,7 @@ var title = explicitTitle
 // One markdown body for the whole export: the node's own, plus each requested descendant as a
 // section. Composing ONCE (rather than per chapter) means the area resolution and the sanitising
 // pass each run a single time over the finished document.
-var markdown = new StringBuilder(ExtractMarkdown(rootNode));
+var markdown = new StringBuilder(ExportSource.MarkdownOf(rootNode, jsonOptions, Log));
 
 if (isDeck)
 {
@@ -113,7 +114,8 @@ if (isDeck)
     Log.LogInformation("Deck email export: {Count} slides", slides.Count);
     foreach (var slide in slides)
     {
-        var slideMarkdown = slide.ContentAs<SlideContent>(jsonOptions)?.Content ?? ExtractMarkdown(slide);
+        var slideMarkdown = slide.ContentAs<SlideContent>(jsonOptions)?.Content
+                            ?? ExportSource.MarkdownOf(slide, jsonOptions, Log);
         if (string.IsNullOrWhiteSpace(slideMarkdown)) continue;
         if (markdown.Length > 0) markdown.AppendLine().AppendLine();
         markdown.Append(slideMarkdown);
@@ -137,7 +139,7 @@ else if (options.IncludeChildren)
             var depth = desc.Path.Count(c => c == '/') - rootDepth;
             if (depth > options.MaxDepth) continue;
         }
-        var body = ExtractMarkdown(desc);
+        var body = ExportSource.MarkdownOf(desc, jsonOptions, Log);
         if (string.IsNullOrWhiteSpace(body)) continue;
         markdown.AppendLine().AppendLine();
         markdown.Append("## ").AppendLine(desc.Name ?? desc.Id);
@@ -177,12 +179,9 @@ return new RenderedDocument(
     "text/html",
     bytes);
 
-static string ExtractMarkdown(MeshNode node)
-{
-    if (node.Content is MarkdownContent mc) return mc.Content ?? "";
-    if (node.Content is string s) return s;
-    return "";
-}
+// 🚨 There is no local ExtractMarkdown — the body extraction is ExportSource.MarkdownOf, in
+// COMPILED framework code. See ExportPdf.csx for why (#1374): a `node.Content is MarkdownContent`
+// test is false for a body stored as plain JSON, and the export silently loses it.
 
 static string Sanitize(string s)
 {

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
@@ -218,7 +218,7 @@ else
     effectiveOptions = options;
 chapters = new List<ExportChapter>
     {
-        new ExportChapter(title, ExtractMarkdown(rootNode), sourcePath)
+        new ExportChapter(title, ExportSource.MarkdownOf(rootNode, jsonOptions, Log), sourcePath)
     };
     if (options.IncludeChildren)
     {
@@ -238,7 +238,7 @@ chapters = new List<ExportChapter>
                 var depth = desc.Path.Count(c => c == '/') - rootDepth;
                 if (depth > options.MaxDepth) continue;
             }
-            var md = ExtractMarkdown(desc);
+            var md = ExportSource.MarkdownOf(desc, jsonOptions, Log);
             if (!string.IsNullOrWhiteSpace(md))
                 chapters.Add(new ExportChapter(desc.Name ?? desc.Id, md, desc.Path));
         }
@@ -279,12 +279,12 @@ return new RenderedDocument(
     "application/pdf",
     bytes);
 
-static string ExtractMarkdown(MeshNode node)
-{
-    if (node.Content is MarkdownContent mc) return mc.Content ?? "";
-    if (node.Content is string s) return s;
-    return "";
-}
+// 🚨 There is no local ExtractMarkdown any more — the body extraction is
+// ExportSource.MarkdownOf, in COMPILED framework code. `node.Content is MarkdownContent` was the
+// trap-door: a body stored as plain JSON carries no $type, so it stays a raw JsonElement even on
+// its own hub, the test is false, and the export prints a cover page, a contents list and NO body,
+// silently (#1374). Three .csx copies of that test is how it survived — nothing in this file is
+// type-checked by dotnet build, so only a compiled, unit-tested helper can be trusted to stay fixed.
 
 // The portal's public origin. A resolved layout area can carry links, and a link with no origin is
 // dead the moment the PDF leaves this machine — the reader has no page to resolve it against.
@@ -303,7 +303,7 @@ static string ExtractSlideMarkdown(MeshNode node, JsonSerializerOptions options)
 {
     var slide = node.ContentAs<SlideContent>(options);
     if (slide?.Content is { } content) return content;
-    return ExtractMarkdown(node);
+    return ExportSource.MarkdownOf(node, options);
 }
 
 static string Sanitize(string s)

--- a/test/MeshWeaver.Hosting.Monolith.Test/ExportUntypedContentTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ExportUntypedContentTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Messaging;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// #1374 — a document whose body was stored as plain JSON must still EXPORT its body.
+///
+/// <para>The three export templates extracted the body with <c>node.Content is MarkdownContent</c>.
+/// That test is true only when the value already happens to be that CLR type. A body written as
+/// bare JSON — an import, an MCP <c>create</c>/<c>patch</c> carrying a raw content object, a
+/// document older than its content type — has no <c>$type</c> for the polymorphic converter to
+/// resolve, so it stays a raw <see cref="JsonElement"/>: not degraded in transit but STORED that
+/// way, and therefore still a <c>JsonElement</c> when read from the node's own per-node hub, the
+/// very hub that declares <c>WithContentType&lt;MarkdownContent&gt;()</c>. The test was false, the
+/// extractor returned <c>""</c>, and the export produced a cover page, a contents list and no
+/// body — no exception, nothing logged, nothing to grep, and it reads to the author as their own
+/// empty document rather than as a platform bug.</para>
+///
+/// <para>Asserted on the RENDERED ARTEFACT, not the document model: the bug is that a real reader
+/// opens a real file and finds it empty, and only the file can say that did not happen. Both
+/// formats are covered because both templates carried the same extractor — PDF through the
+/// headless-browser print, DOCX through the OpenXml writer.</para>
+/// </summary>
+public class ExportUntypedContentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Single contiguous words: PDF text extraction keeps them intact.</summary>
+    private const string BodyToken = "ZANZIBARWIDGET";
+    private const string ChildToken = "QUOKKAENGINE";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMarkdownExport();
+
+    [Fact(Timeout = 180000)]
+    public async Task Pdf_export_of_a_document_stored_as_untyped_json_still_carries_its_body()
+    {
+        var doc = await SeedDocumentStoredAsUntypedJson();
+
+        var rendered = await Export(doc, ExportFormat.Pdf);
+
+        rendered.MimeType.Should().Be("application/pdf");
+        using var pdf = PdfDocument.Open(rendered.Content);
+        var text = string.Join("\n", pdf.GetPages().Select(p => p.Text));
+        Output.WriteLine($"PDF pages={pdf.NumberOfPages}\n{text}");
+
+        text.Should().Contain(BodyToken,
+            "the document's own body must reach the page — its absence is the whole of #1374");
+        text.Should().Contain(ChildToken,
+            "a descendant chapter stored the same way must not be dropped either");
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task Docx_export_of_a_document_stored_as_untyped_json_still_carries_its_body()
+    {
+        var doc = await SeedDocumentStoredAsUntypedJson();
+
+        var rendered = await Export(doc, ExportFormat.Docx);
+
+        rendered.MimeType.Should().Be(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        // Word stores the body as XML inside the package; the token has to be IN it.
+        using var package = System.IO.Packaging.Package.Open(
+            new System.IO.MemoryStream(rendered.Content), System.IO.FileMode.Open, System.IO.FileAccess.Read);
+        var part = package.GetPart(new Uri("/word/document.xml", UriKind.Relative));
+        using var reader = new System.IO.StreamReader(part.GetStream(), Encoding.UTF8);
+        var xml = await reader.ReadToEndAsync();
+
+        xml.Should().Contain(BodyToken, "the DOCX body must carry the document's own text");
+        xml.Should().Contain(ChildToken, "and its descendant chapter's text");
+    }
+
+    /// <summary>
+    /// Seeds a document plus one child, both with content written as bare JSON — no <c>$type</c>,
+    /// which is what makes the content unresolvable by every registry there is. The child covers
+    /// the <c>IncludeChildren</c> path, where an empty body is silently SKIPPED rather than
+    /// rendered blank, so a lost chapter leaves no trace at all.
+    /// </summary>
+    private async Task<string> SeedDocumentStoredAsUntypedJson()
+    {
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Untyped Export Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space()
+        }).Should().Emit();
+
+        var doc = $"{space}/Report";
+        await NodeFactory.CreateNode(MeshNode.FromPath(doc) with
+        {
+            Name = "Report",
+            NodeType = MarkdownNodeType.NodeType,
+            Content = JsonSerializer.SerializeToElement(
+                new { content = $"# Report\n\nThe body mentions {BodyToken} exactly once." })
+        }).Should().Emit();
+
+        await NodeFactory.CreateNode(MeshNode.FromPath($"{doc}/Appendix") with
+        {
+            Name = "Appendix",
+            NodeType = MarkdownNodeType.NodeType,
+            Content = JsonSerializer.SerializeToElement(
+                new { content = $"# Appendix\n\nThe appendix mentions {ChildToken}." })
+        }).Should().Emit();
+
+        // Precondition: the content really is untyped where the export reads it. Without this the
+        // test could pass on a re-typed value and prove nothing about the defect.
+        var read = await Mesh.GetMeshNode(doc, TimeSpan.FromSeconds(20)).Should().Within(30.Seconds()).Emit();
+        read!.Content.Should().BeOfType<JsonElement>(
+            "the stored shape carries no $type, so no registry — not even the node's own hub — can type it");
+
+        return doc;
+    }
+
+    private async Task<RenderedDocument> Export(string doc, ExportFormat format)
+    {
+        var dispatch = await Mesh
+            .Observe<ExportDocumentResponse>(
+                new ExportDocumentRequest(doc, new DocumentExportOptions
+                {
+                    Format = format,
+                    IncludeChildren = true,
+                    CoverPage = false,
+                    TableOfContents = false
+                }),
+                o => o.WithTarget(new Address(doc)))
+            .Should().Within(30.Seconds()).Emit();
+
+        dispatch.Message.Error.Should().BeNullOrEmpty("the export should start successfully");
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var terminal = await workspace
+            .GetMeshNodeStream(dispatch.Message.ActivityPath)
+            .Select(node => node?.Content as ActivityLog)
+            .Should().Within(2.Minutes())
+            .Match(log => log is not null && log.Status != ActivityStatus.Running);
+
+        terminal!.Status.Should().Be(ActivityStatus.Succeeded,
+            because: "the export should render without errors. Messages:\n  "
+                     + string.Join("\n  ", terminal.Messages.Select(m => $"[{m.LogLevel}] {m.Message}")));
+
+        var rendered = terminal.ReturnValue!.Value.Deserialize<RenderedDocument>(Mesh.JsonSerializerOptions);
+        rendered.Should().NotBeNull();
+        rendered!.Content.Should().NotBeNull().And.NotBeEmpty();
+        return rendered;
+    }
+}

--- a/test/MeshWeaver.Markdown.Export.Test/ExportSourceTests.cs
+++ b/test/MeshWeaver.Markdown.Export.Test/ExportSourceTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Markdown.Export.Ast;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Markdown.Export.Test;
+
+/// <summary>
+/// The contract of the export's body extraction (#1374).
+///
+/// <para>Every one of these shapes is a real way a markdown body arrives on a running mesh, and
+/// the extractor the three export templates used to carry — <c>node.Content is MarkdownContent</c>
+/// — is correct for exactly the FIRST of them. For the rest it returned <c>""</c>, which the
+/// templates then rendered as an empty chapter: a cover page, a contents list and no body, with no
+/// exception and no log line. This suite exists because that extractor lived three times over
+/// inside <c>.csx</c> text that <c>dotnet build</c> never type-checks and no test could reach.</para>
+/// </summary>
+public class ExportSourceTests
+{
+    /// <summary>How the mesh writes content: camelCase, case-insensitive on the way back.</summary>
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    private const string Body = "# Title\n\nBody text.";
+
+    private static MeshNode NodeWith(object? content, string nodeType = "Markdown") =>
+        MeshNode.FromPath("Space/Doc") with { NodeType = nodeType, Content = content };
+
+    [Fact]
+    public void Typed_content_is_read()
+    {
+        var node = NodeWith(new MarkdownContent { Content = Body });
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    /// <summary>
+    /// 🚨 THE regression. A body stored as plain JSON has no <c>$type</c> for the polymorphic
+    /// converter to resolve, so nothing can re-type it — measured on the monolith, a node in this
+    /// shape is still a <see cref="JsonElement"/> when read from its OWN per-node hub, the hub that
+    /// declares <c>WithContentType&lt;MarkdownContent&gt;()</c>. The direct type test is simply
+    /// false and the export loses the entire document body in silence.
+    /// </summary>
+    [Fact]
+    public void A_body_stored_as_untyped_json_is_still_read()
+    {
+        var content = JsonSerializer.SerializeToElement(new { content = Body });
+        var node = NodeWith(content);
+
+        // The precondition that made this invisible: the trap-door reads the node as having no body.
+        (node.Content is MarkdownContent).Should().BeFalse(
+            "this is exactly the shape the old `node.Content is MarkdownContent` test missed");
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    /// <summary>The as-written DOM: application code builds content as a <see cref="JsonObject"/>.</summary>
+    [Fact]
+    public void A_body_built_as_a_json_object_is_read()
+    {
+        var node = NodeWith(new JsonObject { ["content"] = Body });
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    [Fact]
+    public void A_bare_string_body_is_read()
+    {
+        ExportSource.MarkdownOf(NodeWith(Body), Options).Should().Be(Body);
+    }
+
+    /// <summary>A bare-string body that went through JSON and came back as a JSON string.</summary>
+    [Fact]
+    public void A_string_body_degraded_to_a_json_string_is_read()
+    {
+        var node = NodeWith(JsonSerializer.SerializeToElement(Body));
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    [Fact]
+    public void A_string_body_carried_as_a_json_node_is_read()
+    {
+        var node = NodeWith(JsonValue.Create(Body));
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    /// <summary>
+    /// Every recompile of a dynamic NodeType mints a new collectible assembly, so "the same" record
+    /// has a different CLR identity per build. Recovery is by JSON round-trip on the SHORT name.
+    /// </summary>
+    [Fact]
+    public void A_same_named_content_type_from_another_build_is_recovered()
+    {
+        var node = NodeWith(new ForeignBuild.MarkdownContent(Body));
+
+        ExportSource.MarkdownOf(node, Options).Should().Be(Body);
+    }
+
+    /// <summary>
+    /// Not every node is markdown-bodied, and with <c>IncludeChildren</c> an export walks EVERY
+    /// descendant. "No body" has to stay a quiet, ordinary answer — the templates skip such a node
+    /// — or the fix would trade a silent empty export for a log storm.
+    /// </summary>
+    [Fact]
+    public void Typed_content_of_another_kind_has_no_body_and_says_nothing()
+    {
+        var log = new CapturingLogger();
+
+        ExportSource.MarkdownOf(NodeWith(new SomeOtherContent("x")), Options, log).Should().BeEmpty();
+
+        log.Entries.Should().BeEmpty("a non-markdown descendant is the ordinary case, not a fault");
+    }
+
+    [Fact]
+    public void No_content_has_no_body()
+    {
+        ExportSource.MarkdownOf(NodeWith(null), Options).Should().BeEmpty();
+        ExportSource.MarkdownOf(null, Options).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The one case worth a log line: a node that DECLARES itself a markdown document, whose
+    /// content is json — so it could have been a body — and could not be read as one. Silence here
+    /// is what made #1374 look like an authoring mistake.
+    /// </summary>
+    [Fact]
+    public void Json_content_on_a_markdown_node_that_is_not_a_body_is_reported()
+    {
+        var log = new CapturingLogger();
+        var node = NodeWith(JsonSerializer.SerializeToElement(new { slides = new[] { "a", "b" } }));
+
+        ExportSource.MarkdownOf(node, Options, log).Should().BeEmpty();
+
+        log.Entries.Should().ContainSingle()
+            .Which.Should().Contain("Space/Doc").And.Contain("chapter will be empty");
+    }
+
+    /// <summary>
+    /// …and the counterweight that keeps that line a diagnosis rather than a storm. With
+    /// <c>IncludeChildren</c> an export walks EVERY descendant, and a typed content node whose
+    /// value arrived as JSON is the ordinary case, not a fault — one log line per descendant of a
+    /// large subtree would drown the very message above.
+    /// </summary>
+    [Fact]
+    public void Json_content_on_a_node_that_is_not_a_document_says_nothing()
+    {
+        var log = new CapturingLogger();
+        var node = NodeWith(JsonSerializer.SerializeToElement(new { title = "Ship it", done = false }), "Todo");
+
+        ExportSource.MarkdownOf(node, Options, log).Should().BeEmpty();
+
+        log.Entries.Should().BeEmpty("a Todo is not a chapter that went missing");
+    }
+
+    private sealed record SomeOtherContent(string Name);
+
+    /// <summary>Stands in for the same record compiled into a different dynamic-node assembly.</summary>
+    private static class ForeignBuild
+    {
+        internal sealed record MarkdownContent(string Content);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(formatter(state, exception));
+    }
+}


### PR DESCRIPTION
Closes #1374.

All three export templates read a node's markdown body with a direct type test:

```csharp
if (node.Content is MarkdownContent mc) return mc.Content ?? "";
if (node.Content is string s) return s;
```

## What actually goes wrong

The failing shape is not a transport degradation — it is how the body is **stored**. A document
written by an import, created through the API, or saved before its content type existed keeps its
body as bare JSON with **no `$type`**, so there is no discriminator for the polymorphic converter to
resolve. Measured on the monolith: such a node is still a `JsonElement` when read from its **own**
per-node hub — the hub that declares `WithContentType<MarkdownContent>()`.

So the test is false, the extractor returns `""`, and the export produces **a cover page, a contents
list and no body**. No exception, nothing logged, nothing to grep, and it reads to the author as
their own empty document.

**Fail-before, on the artefact** (both new e2e tests, red on `main`'s templates):

- DOCX: `<w:body><w:sectPr>…</w:sectPr></w:body>` — the body element is *empty*.
- PDF: the only extractable text on the page is the running footer, `1 / 1`.

## Routing mistake, or a legitimate boundary read?

The rule says to ask first, so: **legitimate boundary read.** The shape that fails carries no
discriminator at all, so no registry anywhere can type it — which is why it survives a read on the
owning hub. Moving the work would change nothing; registering the type where the read happens would
change nothing. Reading stored JSON whose type cannot be resolved is the case the accessor exists
for. (The other direction of the rule *was* already honoured next door: `ExtractSlideMarkdown` in
the same file has used `ContentAs<SlideContent>` all along. Only the markdown path was left behind.)

## The fix, and why it moves out of the `.csx`

The extraction is now `ExportSource.MarkdownOf` in **compiled** framework code, going through
`node.ContentAs<MarkdownContent>(options)` — which recovers a degraded `JsonElement`/`JsonNode` and
a same-short-named `MarkdownContent` from another dynamic-node build.

Moving it is half the fix. Three hand-copied extractors living inside runtime-compiled `.csx` text
is *why this survived*: `dotnet build` never type-checked them, and no unit test could reach a
private local function inside one. There is now one implementation, covered by 11 unit tests over
every shape a body arrives in — typed, untyped `JsonElement`, `JsonObject`, bare string, JSON
string, `JsonValue`, a foreign same-named build, and the two "no body" cases.

## A second, quieter loss

With `IncludeChildren`, a chapter with an empty body is **skipped**, not rendered blank — so a whole
section could vanish from a report leaving no trace at all. The e2e covers a descendant stored the
same way.

A node that *declares itself* a Markdown document and yields no body now writes a warning naming the
path into the export's activity log. Node types that are not documents stay silent on purpose: an
export walks every descendant, and a Todo whose typed content arrived as JSON is the ordinary case —
one line per descendant would drown the message that matters.

## Sibling sweep

Asked for, and reported rather than widened into this PR:

| Surface | Trap-door casts of `Content`/`Payload` |
|---|---|
| `.csx` export templates | **6** (3 files × `is MarkdownContent` + `is string`) — fixed here |
| NodeType `configuration` JSON-string lambdas | **0** across 42 lambdas scanned |
| In-mesh `samples/**/Source/*.cs` (never compiled by CI) | **34**, across 12 files — see the issue thread |

The in-mesh 34 split cleanly, and only one half is this defect:

- **10 casts in 4 files have no fallback at all** — the exact silent-null shape. Three of them
  (`ArticleLayoutAreas.cs` in ACME, Northwind and Cornerstone) carry a **character-for-character
  copy of the extractor this PR is about**, so an article stored as plain JSON renders as an empty
  article view. The fourth is `ReportsCatalogLayoutAreas.cs`.
- **24 casts in 8 files hand-roll `ContentAs`** — `is XContent` then `is JsonElement` + a manual
  `Deserialize`. Functionally covers the JSON cases; misses the same-short-named-type recovery that
  matters once a dynamic NodeType is recompiled into a fresh collectible assembly.

Left for their own change — sample content, not the export path, and folding them in would put
untested in-mesh edits in a PR about the export. Full listing on the issue.

## Verification

- 2 new e2e tests over the **rendered artefact** (PDF via PdfPig, DOCX via the OpenXml package) —
  red before, green after. Each asserts its precondition (`Content` really is a `JsonElement` where
  the export reads it) so it cannot pass on a re-typed value and prove nothing.
- 11 new unit tests on `ExportSource`.
- `MeshWeaver.Markdown.Export.Test` 110/110 · the 8 export e2e suites in
  `MeshWeaver.Hosting.Monolith.Test` 18/18 · `DocumentationLinkIntegrityTest` green.
- `-c Release -warnaserror` clean on `MeshWeaver.Markdown.Export` and both test projects.

## Overlap with #1372

None. #1372 touches `Ast/DocumentBuilder.cs`; this touches `Ast/ExportSource.cs` (new), the three
templates, and two test files it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
