### PR TITLE
fix: trap-door content casts in in-mesh sample source (#1383)

### DIFF
--- a/samples/Graph/Data/ACME/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/ACME/Article/Source/ArticleLayoutAreas.cs
@@ -51,8 +51,12 @@ public static class ArticleLayoutAreas
         container = container.WithView(
             Controls.Html($"<h1 style=\"margin: 0 0 8px 0;\">{System.Web.HttpUtility.HtmlEncode(node.Name ?? "Article")}</h1>"));
 
-        // Metadata bar: authors, published date, tags
-        var mdContent = node.Content as MarkdownContent;
+        // Metadata bar: authors, published date, tags.
+        // ContentAs, never `as`: a node whose content was stored as bare JSON (an import, an MCP
+        // create/patch carrying a raw body) has no $type for the polymorphic converter to resolve,
+        // so it arrives — and stays, even on this article's OWN hub — a raw JsonElement. `as` is
+        // then silently null and the whole header vanishes with no exception and no log line.
+        var mdContent = node.ContentAs<MarkdownContent>(host.Hub.JsonSerializerOptions);
         var metaParts = new List<string>();
 
         if (mdContent?.Authors?.Count > 0)
@@ -95,8 +99,10 @@ public static class ArticleLayoutAreas
                 $"<img src=\"{imgSrc}\" alt=\"\" style=\"max-width: 100%; border-radius: 8px; margin-bottom: 24px;\" />"));
         }
 
-        // Markdown body content
-        var rawContent = GetMarkdownContent(node);
+        // Markdown body content. MarkdownBody.Of is the framework's single reader — shared with the
+        // export templates (ExportSource.MarkdownOf) precisely so this extractor is not hand-copied
+        // into every sample space again.
+        var rawContent = MarkdownBody.Of(node, host.Hub.JsonSerializerOptions);
         if (!string.IsNullOrEmpty(rawContent))
         {
             container = container.WithView(Controls.Markdown(rawContent));
@@ -122,22 +128,5 @@ public static class ArticleLayoutAreas
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
             return (UiControl?)MeshNodeThumbnailControl.FromNode(node, hubPath);
         });
-    }
-
-    /// <summary>
-    /// Extracts markdown content from a MeshNode.
-    /// </summary>
-    private static string GetMarkdownContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return string.Empty;
-
-        if (node.Content is MarkdownContent markdownContent)
-            return markdownContent.Content;
-
-        if (node.Content is string stringContent)
-            return stringContent;
-
-        return string.Empty;
     }
 }

--- a/samples/Graph/Data/ACME/Project/Todo/Source/TodoLayoutAreas.cs
+++ b/samples/Graph/Data/ACME/Project/Todo/Source/TodoLayoutAreas.cs
@@ -12,72 +12,29 @@ using MeshWeaver.Domain;
 public static class TodoLayoutAreas
 {
     /// <summary>
-    /// Extracts Todo from MeshNode content, handling various serialization formats
-    /// and cross-assembly type mismatches.
+    /// The node's Todo content. <c>ContentAs</c> is the framework accessor that every branch of the
+    /// hand-rolled extractor this replaced was trying to be — and it is strictly better at each:
+    ///
+    /// <list type="bullet">
+    /// <item>the already-typed value — same;</item>
+    /// <item>a degraded <c>JsonElement</c> (and <c>JsonNode</c>, which the hand-rolled version
+    ///   missed: application code builds content as a <c>JsonObject</c> and a change notification
+    ///   forwards that shape verbatim);</item>
+    /// <item>a same-short-named <c>Todo</c> from another build — every recompile of this NodeType
+    ///   mints a new collectible assembly, so "the same" record has a different CLR identity per
+    ///   build. The hand-rolled version reached for this with a <c>GetType().Name</c> probe and an
+    ///   UNGUARDED <c>JsonSerializer.Serialize(object)</c>, which routes through the polymorphic
+    ///   converter's <c>GetOrAddType</c> and adopts the foreign type into this hub's registry as a
+    ///   read side effect; the accessor serializes as the concrete runtime type, whose
+    ///   collectible-assembly guard formats the discriminator WITHOUT registering.</item>
+    /// </list>
+    ///
+    /// <para>It also reads with the HUB's options (the registry behind them is what resolves a
+    /// <c>$type</c>) instead of a locally-invented <c>JsonSerializerOptions</c>, and it diagnoses
+    /// through the logger instead of a bare <c>catch</c> plus <c>Console.WriteLine</c>.</para>
     /// </summary>
-    private static Todo? ExtractTodo(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return null;
-
-        var options = new System.Text.Json.JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
-        };
-
-        // Direct type match
-        if (node.Content is Todo todo)
-            return todo;
-
-        // JsonElement - deserialize to Todo
-        if (node.Content is System.Text.Json.JsonElement json)
-        {
-            try
-            {
-                return System.Text.Json.JsonSerializer.Deserialize<Todo>(json.GetRawText(), options);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Dictionary - convert to JSON then deserialize
-        if (node.Content is System.Collections.IDictionary dict)
-        {
-            try
-            {
-                var jsonStr = System.Text.Json.JsonSerializer.Serialize(dict);
-                return System.Text.Json.JsonSerializer.Deserialize<Todo>(jsonStr, options);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Fallback: Content might be a Todo from a different assembly
-        // Serialize to JSON and deserialize to local Todo type
-        var contentTypeName = node.Content.GetType().Name;
-        if (contentTypeName == "Todo" || contentTypeName.EndsWith(".Todo"))
-        {
-            try
-            {
-                var jsonStr = System.Text.Json.JsonSerializer.Serialize(node.Content);
-                System.Console.WriteLine($"[ExtractTodo] Fallback serialization: {jsonStr.Substring(0, Math.Min(200, jsonStr.Length))}...");
-                return System.Text.Json.JsonSerializer.Deserialize<Todo>(jsonStr, options);
-            }
-            catch (Exception ex)
-            {
-                System.Console.WriteLine($"[ExtractTodo] Fallback failed: {ex.Message}");
-                return null;
-            }
-        }
-
-        // Try GetContent as last resort
-        return node.GetContent<Todo>();
-    }
+    private static Todo? ExtractTodo(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<Todo>(host.Hub.JsonSerializerOptions);
 
     /// <summary>
     /// Details view showing the Todo item with status, metadata, and action buttons.
@@ -87,7 +44,7 @@ public static class TodoLayoutAreas
     {
         return host.Workspace.GetStream<MeshNode>()
             .Select(nodes => nodes?.FirstOrDefault())
-            .Select(node => BuildTodoDetails(host, ExtractTodo(node)));
+            .Select(node => BuildTodoDetails(host, ExtractTodo(host, node)));
     }
 
     private static UiControl BuildTodoDetails(LayoutAreaHost host, Todo? todo)
@@ -393,7 +350,7 @@ public static class TodoLayoutAreas
     }
 
     private static UiControl BuildThumbnail(LayoutAreaHost host, MeshNode? node, string hubPath)
-        => BuildThumbnail(host, node, ExtractTodo(node), hubPath);
+        => BuildThumbnail(host, node, ExtractTodo(host, node), hubPath);
 
     private static UiControl BuildThumbnail(LayoutAreaHost host, MeshNode? node, Todo? todo, string hubPath)
     {

--- a/samples/Graph/Data/Cornerstone/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/Cornerstone/Article/Source/ArticleLayoutAreas.cs
@@ -51,8 +51,12 @@ public static class ArticleLayoutAreas
         container = container.WithView(
             Controls.Html($"<h1 style=\"margin: 0 0 8px 0;\">{System.Web.HttpUtility.HtmlEncode(node.Name ?? "Article")}</h1>"));
 
-        // Metadata bar: authors, published date, tags
-        var mdContent = node.Content as MarkdownContent;
+        // Metadata bar: authors, published date, tags.
+        // ContentAs, never `as`: a node whose content was stored as bare JSON (an import, an MCP
+        // create/patch carrying a raw body) has no $type for the polymorphic converter to resolve,
+        // so it arrives — and stays, even on this article's OWN hub — a raw JsonElement. `as` is
+        // then silently null and the whole header vanishes with no exception and no log line.
+        var mdContent = node.ContentAs<MarkdownContent>(host.Hub.JsonSerializerOptions);
         var metaParts = new List<string>();
 
         if (mdContent?.Authors?.Count > 0)
@@ -95,8 +99,10 @@ public static class ArticleLayoutAreas
                 $"<img src=\"{imgSrc}\" alt=\"\" style=\"max-width: 100%; border-radius: 8px; margin-bottom: 24px;\" />"));
         }
 
-        // Markdown body content
-        var rawContent = GetMarkdownContent(node);
+        // Markdown body content. MarkdownBody.Of is the framework's single reader — shared with the
+        // export templates (ExportSource.MarkdownOf) precisely so this extractor is not hand-copied
+        // into every sample space again.
+        var rawContent = MarkdownBody.Of(node, host.Hub.JsonSerializerOptions);
         if (!string.IsNullOrEmpty(rawContent))
         {
             container = container.WithView(Controls.Markdown(rawContent));
@@ -122,22 +128,5 @@ public static class ArticleLayoutAreas
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
             return (UiControl?)MeshNodeThumbnailControl.FromNode(node, hubPath);
         });
-    }
-
-    /// <summary>
-    /// Extracts markdown content from a MeshNode.
-    /// </summary>
-    private static string GetMarkdownContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return string.Empty;
-
-        if (node.Content is MarkdownContent markdownContent)
-            return markdownContent.Content;
-
-        if (node.Content is string stringContent)
-            return stringContent;
-
-        return string.Empty;
     }
 }

--- a/samples/Graph/Data/Cornerstone/Pricing/Source/PricingLayoutAreas.cs
+++ b/samples/Graph/Data/Cornerstone/Pricing/Source/PricingLayoutAreas.cs
@@ -60,31 +60,17 @@ public static class PricingLayoutAreas
     }
 
     /// <summary>
-    /// Extracts Pricing from a MeshNode, handling both typed content and JsonElement.
+    /// The node's pricing content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JsonElement
+    /// branch: the accessor covers the already-typed value AND the degraded JsonElement/JsonNode AND
+    /// a same-short-named <c>Pricing</c> from another build (every recompile of a dynamic NodeType
+    /// mints a new collectible assembly, so "the same" record has a different CLR identity per
+    /// build — the case the hand-rolled version had no round-trip to recover, leaving every pricing
+    /// view blank after a recompile with nothing to grep). It also reads with the HUB's options
+    /// rather than a locally-invented <c>JsonSerializerOptions</c>, so the registry behind them can
+    /// resolve the content's <c>$type</c>, and it logs instead of swallowing in a bare <c>catch</c>.
     /// </summary>
-    private static Pricing? ExtractPricing(MeshNode? node)
-    {
-        if (node?.Content is null)
-            return null;
-
-        if (node.Content is Pricing pricing)
-            return pricing;
-
-        if (node.Content is JsonElement json)
-        {
-            try
-            {
-                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                return JsonSerializer.Deserialize<Pricing>(json.GetRawText(), options);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        return null;
-    }
+    private static Pricing? ExtractPricing(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<Pricing>(host.Hub.JsonSerializerOptions);
 
     /// <summary>
     /// Overview view showing pricing header details.
@@ -101,7 +87,7 @@ public static class PricingLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes?.FirstOrDefault();
-            var pricing = ExtractPricing(node);
+            var pricing = ExtractPricing(host, node);
 
             if (pricing is null)
             {
@@ -428,7 +414,7 @@ public static class PricingLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes?.FirstOrDefault();
-            var pricing = ExtractPricing(node);
+            var pricing = ExtractPricing(host, node);
 
             if (pricing is null)
             {
@@ -510,7 +496,7 @@ public static class PricingLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes?.FirstOrDefault();
-            var pricing = ExtractPricing(node);
+            var pricing = ExtractPricing(host, node);
 
             if (pricing is null)
             {

--- a/samples/Graph/Data/FutuRe/GroupAnalysis/Source/FutuReDataLoader.cs
+++ b/samples/Graph/Data/FutuRe/GroupAnalysis/Source/FutuReDataLoader.cs
@@ -35,38 +35,24 @@ public static class FutuReDataLoader
         var buPath = segments.Length > 1 ? $"{segments[0]}/{segments[1]}" : segments[0];
 
         // BU node lookup goes through the per-node MeshNodeReference reducer (authoritative,
-        // no read-side index lag). CSV I/O stays on a separate Observable.FromAsync at the
-        // file boundary. Both compose into the final tuple.
+        // no read-side index lag). CSV I/O stays on the bounded FileSystem IoPool at the file
+        // boundary. Both compose into the final tuple.
         //
         // Cross-ALC type-identity is fragile here: BusinessUnit gets compiled into
         // FutuRe_BusinessUnit's NodeAssemblyLoadContext while this loader lives in
-        // FutuRe_LocalAnalysis's ALC, so `Content is BusinessUnit` returns false even
-        // though the runtime types match by full name. We probe by JsonElement first
-        // (the deserialized-to-JSON path), then by reflection (`Currency` property)
-        // for the cross-ALC custom-type case, before falling back to CHF.
+        // FutuRe_LocalAnalysis's ALC, so `Content is BusinessUnit` returns false even though the
+        // runtime types match by full name. ContentAs<T> is precisely the accessor for that: it
+        // covers the already-typed value, the degraded JsonElement/JsonNode (the
+        // deserialized-to-JSON path), AND the same-short-named foreign type by JSON round-trip —
+        // which is what the hand-rolled casing probe plus a reflected `Currency` property were
+        // approximating, one shape at a time and with no diagnosis when all of them missed.
+        var buOptions = hub.JsonSerializerOptions;
         var buCurrencyObs = hub.GetMeshNode(buPath, TimeSpan.FromSeconds(10))
             .Select(buNode =>
             {
-                if (buNode?.Content is JsonElement json
-                    && json.ValueKind == JsonValueKind.Object)
-                {
-                    // Mesh stream serialisation may emit either casing depending on
-                    // JsonSerializerOptions; probe both.
-                    if (json.TryGetProperty("currency", out var val)
-                        && val.ValueKind == JsonValueKind.String)
-                        return val.GetString() ?? "CHF";
-                    if (json.TryGetProperty("Currency", out var val2)
-                        && val2.ValueKind == JsonValueKind.String)
-                        return val2.GetString() ?? "CHF";
-                }
-                if (buNode?.Content is BusinessUnit bu)
-                    return bu.Currency;
-                if (buNode?.Content is { } content)
-                {
-                    var prop = content.GetType().GetProperty("Currency");
-                    if (prop?.GetValue(content) is string s && !string.IsNullOrEmpty(s))
-                        return s;
-                }
+                if (buNode.ContentAs<BusinessUnit>(buOptions)?.Currency is { Length: > 0 } currency)
+                    return currency;
+
                 // Fallback by hub address — every BU's local currency is known statically;
                 // this keeps the local Analysis dashboard labelling correct when the
                 // cross-hub MeshNode lookup fails (e.g. BU hub not yet activated, or
@@ -274,12 +260,13 @@ public static class FutuReDataLoader
             : segments[0];
 
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery(
                     $"nodeType:FutuRe/LineOfBusiness namespace:{buNamespace}/LineOfBusiness state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToLineOfBusiness)
+                .Select(node => ConvertToLineOfBusiness(node, options))
                 .Where(lob => lob != null)
                 .Cast<LineOfBusiness>()
                 .OrderBy(lob => lob.Order));
@@ -295,11 +282,12 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<AmountType>> LoadAmountTypes(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/AmountType namespace:FutuRe/AmountType state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToAmountType)
+                .Select(node => ConvertToAmountType(node, options))
                 .Where(a => a != null)
                 .Cast<AmountType>()
                 .OrderBy(a => a.Order));
@@ -311,11 +299,12 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<Currency>> LoadCurrencies(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/Currency namespace:FutuRe/Currency state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToCurrency)
+                .Select(node => ConvertToCurrency(node, options))
                 .Where(c => c != null)
                 .Cast<Currency>()
                 .OrderBy(c => c.Order));
@@ -327,11 +316,12 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<Country>> LoadCountries(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/Country namespace:FutuRe/Country state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToCountry)
+                .Select(node => ConvertToCountry(node, options))
                 .Where(c => c != null)
                 .Cast<Country>()
                 .OrderBy(c => c.Order));
@@ -343,12 +333,13 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<TransactionMapping>> LoadTransactionMappingsFromNodes(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
 
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/TransactionMapping namespace:FutuRe scope:descendants"))
             .Select(change => change.Items
-                .Select(ConvertToTransactionMapping)
+                .Select(node => ConvertToTransactionMapping(node, options))
                 .Where(m => m != null)
                 .Cast<TransactionMapping>());
     }
@@ -359,11 +350,12 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<ExchangeRate>> LoadExchangeRates(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/ExchangeRate namespace:FutuRe/ExchangeRate state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToExchangeRate)
+                .Select(node => ConvertToExchangeRate(node, options))
                 .Where(fx => fx != null)
                 .Cast<ExchangeRate>()
                 .OrderBy(fx => fx.Order));
@@ -375,11 +367,12 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<BusinessUnit>> LoadBusinessUnits(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/BusinessUnit namespace:FutuRe state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToBusinessUnit)
+                .Select(node => ConvertToBusinessUnit(node, options))
                 .Where(bu => bu != null)
                 .Cast<BusinessUnit>());
     }
@@ -390,12 +383,13 @@ public static class FutuReDataLoader
     public static IObservable<IEnumerable<LineOfBusiness>> LoadLinesOfBusinessFromNodes(IWorkspace workspace)
     {
         var meshQuery = workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = workspace.Hub.JsonSerializerOptions;
 
         return meshQuery
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery("nodeType:FutuRe/LineOfBusiness namespace:FutuRe/LineOfBusiness state:Active"))
             .Select(change => change.Items
-                .Select(ConvertToLineOfBusiness)
+                .Select(node => ConvertToLineOfBusiness(node, options))
                 .Where(lob => lob != null)
                 .Cast<LineOfBusiness>()
                 .OrderBy(lob => lob.Order));
@@ -404,152 +398,110 @@ public static class FutuReDataLoader
     // ---------------------------------------------------------------
     // MeshNode → Record Converters
     // ---------------------------------------------------------------
+    //
+    // 🚨 Every one of these reads the node's content through ContentAs<T>(hub options) — NEVER
+    // `Content is T` plus a hand-rolled JsonElement branch. That hand-rolled shape was correct for
+    // the two cases it enumerated and silently wrong for the one that bites hardest HERE: a
+    // same-short-named record from another build. These converters run in FutuRe/GroupAnalysis's
+    // NodeAssemblyLoadContext while BusinessUnit, LineOfBusiness et al. are compiled into their OWN
+    // NodeTypes' ALCs, and every recompile mints a fresh collectible assembly — so a content value
+    // the owning hub's registry DID resolve arrives typed as a foreign CLR identity, fails
+    // `Content is T`, is not a JsonElement either, and fell through to `null`. The row then simply
+    // vanished from the cube with no exception and no log line. ContentAs recovers exactly that by
+    // JSON round-trip (and the degraded JsonElement/JsonNode, and the already-typed value).
+    //
+    // The node-level overlays below are NOT fallbacks for a failed cast — they are the node's own
+    // identity (Id / Name / Order) taking precedence over, or standing in for, what the content
+    // carries, exactly as the JSON branch did.
 
-    private static TransactionMapping? ConvertToTransactionMapping(MeshNode node)
+    private static TransactionMapping? ConvertToTransactionMapping(MeshNode node, JsonSerializerOptions options)
     {
-        if (node.Content is TransactionMapping tm)
-            return tm;
-        if (node.Content is not JsonElement json)
+        var mapping = node.ContentAs<TransactionMapping>(options);
+        if (mapping is null)
             return null;
 
-        return new TransactionMapping
-        {
-            Id = GetString(json, "id") ?? node.Id,
-            BusinessUnit = GetString(json, "businessUnit") ?? string.Empty,
-            LocalLineOfBusiness = GetString(json, "localLineOfBusiness") ?? string.Empty,
-            LocalLineOfBusinessName = GetString(json, "localLineOfBusinessName") ?? string.Empty,
-            GroupLineOfBusiness = GetString(json, "groupLineOfBusiness") ?? string.Empty,
-            GroupLineOfBusinessName = GetString(json, "groupLineOfBusinessName") ?? string.Empty,
-            Percentage = GetDouble(json, "percentage")
-        };
+        return string.IsNullOrEmpty(mapping.Id) ? mapping with { Id = node.Id } : mapping;
     }
 
-    private static LineOfBusiness? ConvertToLineOfBusiness(MeshNode node)
+    private static LineOfBusiness? ConvertToLineOfBusiness(MeshNode node, JsonSerializerOptions options)
     {
-        if (node.Content is LineOfBusiness lob)
-            return lob;
-        if (node.Content is not JsonElement json)
+        var lob = node.ContentAs<LineOfBusiness>(options);
+        if (lob is null)
             return null;
 
-        return new LineOfBusiness
-        {
-            SystemName = node.Id,
-            DisplayName = node.Name ?? node.Id,
-            Description = GetString(json, "description"),
-            Order = node.Order ?? GetInt(json, "order"),
-            ProductExamples = GetString(json, "productExamples")
-        };
-    }
-
-    private static AmountType? ConvertToAmountType(MeshNode node)
-    {
-        if (node.Content is AmountType at)
-            return at;
-        if (node.Content is not JsonElement json)
-            return null;
-
-        return new AmountType
-        {
-            SystemName = GetString(json, "systemName") ?? node.Id,
-            DisplayName = GetString(json, "displayName") ?? node.Name ?? node.Id,
-            Order = GetInt(json, "order"),
-            Sign = GetInt(json, "sign"),
-            HasActuals = GetBool(json, "hasActuals")
-        };
-    }
-
-    private static Currency? ConvertToCurrency(MeshNode node)
-    {
-        if (node.Content is Currency c)
-            return c;
-        if (node.Content is not JsonElement json)
-            return null;
-
-        return new Currency
-        {
-            Id = GetString(json, "id") ?? node.Id,
-            Name = GetString(json, "name") ?? node.Name ?? node.Id,
-            Symbol = GetString(json, "symbol"),
-            DecimalPlaces = GetInt(json, "decimalPlaces"),
-            Order = GetInt(json, "order")
-        };
-    }
-
-    private static Country? ConvertToCountry(MeshNode node)
-    {
-        if (node.Content is Country co)
-            return co;
-        if (node.Content is not JsonElement json)
-            return null;
-
-        return new Country
-        {
-            Id = GetString(json, "id") ?? node.Id,
-            Name = GetString(json, "name") ?? node.Name ?? node.Id,
-            Alpha3Code = GetString(json, "alpha3Code"),
-            Region = GetString(json, "region"),
-            Order = GetInt(json, "order")
-        };
-    }
-
-    private static ExchangeRate? ConvertToExchangeRate(MeshNode node)
-    {
-        if (node.Content is ExchangeRate fx)
-            return fx;
-        if (node.Content is not JsonElement json)
-            return null;
-
-        return new ExchangeRate
+        return lob with
         {
             SystemName = node.Id,
             DisplayName = node.Name ?? node.Id,
-            FromCurrency = GetString(json, "fromCurrency") ?? string.Empty,
-            ToCurrency = GetString(json, "toCurrency") ?? string.Empty,
-            PlanRate = GetDouble(json, "planRate"),
-            ActualRate = GetDouble(json, "actualRate"),
-            Order = node.Order ?? GetInt(json, "order")
+            Order = node.Order ?? lob.Order
         };
     }
 
-    private static BusinessUnit? ConvertToBusinessUnit(MeshNode node)
+    private static AmountType? ConvertToAmountType(MeshNode node, JsonSerializerOptions options)
     {
-        if (node.Content is BusinessUnit bu)
-            return bu;
-        if (node.Content is not JsonElement json)
+        var amountType = node.ContentAs<AmountType>(options);
+        if (amountType is null)
             return null;
 
-        return new BusinessUnit
+        return amountType with
         {
-            Id = GetString(json, "id") ?? node.Id,
-            Name = GetString(json, "name") ?? node.Name ?? node.Id,
-            Description = GetString(json, "description"),
-            Currency = GetString(json, "currency") ?? "USD",
-            Region = GetString(json, "region"),
-            Icon = GetString(json, "icon") ?? "Building"
+            SystemName = string.IsNullOrEmpty(amountType.SystemName) ? node.Id : amountType.SystemName,
+            DisplayName = string.IsNullOrEmpty(amountType.DisplayName)
+                ? node.Name ?? node.Id
+                : amountType.DisplayName
         };
     }
 
-    // ---------------------------------------------------------------
-    // JSON Helpers
-    // ---------------------------------------------------------------
+    private static Currency? ConvertToCurrency(MeshNode node, JsonSerializerOptions options)
+    {
+        var currency = node.ContentAs<Currency>(options);
+        if (currency is null)
+            return null;
 
-    private static string? GetString(JsonElement json, string property) =>
-        json.TryGetProperty(property, out var val) && val.ValueKind == JsonValueKind.String
-            ? val.GetString()
-            : null;
+        return currency with
+        {
+            Id = string.IsNullOrEmpty(currency.Id) ? node.Id : currency.Id,
+            Name = string.IsNullOrEmpty(currency.Name) ? node.Name ?? node.Id : currency.Name
+        };
+    }
 
-    private static int GetInt(JsonElement json, string property) =>
-        json.TryGetProperty(property, out var val) && val.ValueKind == JsonValueKind.Number
-            ? val.GetInt32()
-            : 0;
+    private static Country? ConvertToCountry(MeshNode node, JsonSerializerOptions options)
+    {
+        var country = node.ContentAs<Country>(options);
+        if (country is null)
+            return null;
 
-    private static double GetDouble(JsonElement json, string property) =>
-        json.TryGetProperty(property, out var val) && val.ValueKind == JsonValueKind.Number
-            ? val.GetDouble()
-            : 0.0;
+        return country with
+        {
+            Id = string.IsNullOrEmpty(country.Id) ? node.Id : country.Id,
+            Name = string.IsNullOrEmpty(country.Name) ? node.Name ?? node.Id : country.Name
+        };
+    }
 
-    private static bool GetBool(JsonElement json, string property) =>
-        json.TryGetProperty(property, out var val) &&
-        (val.ValueKind == JsonValueKind.True || val.ValueKind == JsonValueKind.False)
-            && val.GetBoolean();
+    private static ExchangeRate? ConvertToExchangeRate(MeshNode node, JsonSerializerOptions options)
+    {
+        var fx = node.ContentAs<ExchangeRate>(options);
+        if (fx is null)
+            return null;
+
+        return fx with
+        {
+            SystemName = node.Id,
+            DisplayName = node.Name ?? node.Id,
+            Order = node.Order ?? fx.Order
+        };
+    }
+
+    private static BusinessUnit? ConvertToBusinessUnit(MeshNode node, JsonSerializerOptions options)
+    {
+        var bu = node.ContentAs<BusinessUnit>(options);
+        if (bu is null)
+            return null;
+
+        return bu with
+        {
+            Id = string.IsNullOrEmpty(bu.Id) ? node.Id : bu.Id,
+            Name = string.IsNullOrEmpty(bu.Name) ? node.Name ?? node.Id : bu.Name
+        };
+    }
 }

--- a/samples/Graph/Data/Northwind/Article/Source/ArticleLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Article/Source/ArticleLayoutAreas.cs
@@ -51,8 +51,12 @@ public static class ArticleLayoutAreas
         container = container.WithView(
             Controls.Html($"<h1 style=\"margin: 0 0 8px 0;\">{System.Web.HttpUtility.HtmlEncode(node.Name ?? "Article")}</h1>"));
 
-        // Metadata bar: authors, published date, tags
-        var mdContent = node.Content as MarkdownContent;
+        // Metadata bar: authors, published date, tags.
+        // ContentAs, never `as`: a node whose content was stored as bare JSON (an import, an MCP
+        // create/patch carrying a raw body) has no $type for the polymorphic converter to resolve,
+        // so it arrives — and stays, even on this article's OWN hub — a raw JsonElement. `as` is
+        // then silently null and the whole header vanishes with no exception and no log line.
+        var mdContent = node.ContentAs<MarkdownContent>(host.Hub.JsonSerializerOptions);
         var metaParts = new List<string>();
 
         if (mdContent?.Authors?.Count > 0)
@@ -95,8 +99,10 @@ public static class ArticleLayoutAreas
                 $"<img src=\"{imgSrc}\" alt=\"\" style=\"max-width: 100%; border-radius: 8px; margin-bottom: 24px;\" />"));
         }
 
-        // Markdown body content
-        var rawContent = GetMarkdownContent(node);
+        // Markdown body content. MarkdownBody.Of is the framework's single reader — shared with the
+        // export templates (ExportSource.MarkdownOf) precisely so this extractor is not hand-copied
+        // into every sample space again.
+        var rawContent = MarkdownBody.Of(node, host.Hub.JsonSerializerOptions);
         if (!string.IsNullOrEmpty(rawContent))
         {
             container = container.WithView(Controls.Markdown(rawContent));
@@ -122,22 +128,5 @@ public static class ArticleLayoutAreas
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
             return (UiControl?)MeshNodeThumbnailControl.FromNode(node, hubPath);
         });
-    }
-
-    /// <summary>
-    /// Extracts markdown content from a MeshNode.
-    /// </summary>
-    private static string GetMarkdownContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return string.Empty;
-
-        if (node.Content is MarkdownContent markdownContent)
-            return markdownContent.Content;
-
-        if (node.Content is string stringContent)
-            return stringContent;
-
-        return string.Empty;
     }
 }

--- a/samples/Graph/Data/Northwind/Customer/Source/CustomerNodeLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Customer/Source/CustomerNodeLayoutAreas.cs
@@ -4,7 +4,6 @@
 // </meshweaver>
 
 using System.Reactive.Linq;
-using System.Text.Json;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 
@@ -20,32 +19,16 @@ public static class CustomerNodeLayoutAreas
             .WithView("CustomerOverview", CustomerOverview)
             .WithView("ContactInfo", ContactInfo);
 
-    private static CustomerContent? ExtractCustomerContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return null;
-
-        if (node.Content is CustomerContent cc)
-            return cc;
-
-        if (node.Content is JsonElement json)
-        {
-            return new CustomerContent
-            {
-                CustomerId = json.TryGetProperty("customerId", out var cid) ? cid.GetString() ?? "" : "",
-                CompanyName = json.TryGetProperty("companyName", out var cn) ? cn.GetString() ?? "" : "",
-                ContactName = json.TryGetProperty("contactName", out var ctn) ? ctn.GetString() ?? "" : "",
-                ContactTitle = json.TryGetProperty("contactTitle", out var ct) ? ct.GetString() ?? "" : "",
-                City = json.TryGetProperty("city", out var city) ? city.GetString() ?? "" : "",
-                Region = json.TryGetProperty("region", out var region) ? region.GetString() ?? "" : "",
-                PostalCode = json.TryGetProperty("postalCode", out var pc) ? pc.GetString() ?? "" : "",
-                Country = json.TryGetProperty("country", out var country) ? country.GetString() ?? "" : "",
-                Phone = json.TryGetProperty("phone", out var phone) ? phone.GetString() ?? "" : "",
-                Fax = json.TryGetProperty("fax", out var fax) ? fax.GetString() ?? "" : ""
-            };
-        }
-        return null;
-    }
+    /// <summary>
+    /// The node's customer content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JSON branch:
+    /// the accessor covers the already-typed value AND the degraded JsonElement/JsonNode AND a
+    /// same-short-named <c>CustomerContent</c> from another build (every recompile of a dynamic
+    /// NodeType mints a new collectible assembly, so "the same" record has a different CLR identity
+    /// per build — the case the hand-rolled version had no round-trip to recover, leaving the view
+    /// blank after a recompile with nothing to grep).
+    /// </summary>
+    private static CustomerContent? ExtractCustomerContent(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<CustomerContent>(host.Hub.JsonSerializerOptions);
 
     /// <summary>Customer overview with company details.</summary>
     [Display(GroupName = "Overview", Order = 0)]
@@ -59,7 +42,7 @@ public static class CustomerNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var customer = ExtractCustomerContent(node);
+            var customer = ExtractCustomerContent(host, node);
 
             if (customer == null)
                 return (UiControl?)Controls.Markdown("*Customer data not available*");
@@ -127,7 +110,7 @@ public static class CustomerNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var customer = ExtractCustomerContent(node);
+            var customer = ExtractCustomerContent(host, node);
 
             if (customer == null)
                 return (UiControl?)Controls.Markdown("*Customer data not available*");

--- a/samples/Graph/Data/Northwind/Employee/Source/EmployeeNodeLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Employee/Source/EmployeeNodeLayoutAreas.cs
@@ -4,7 +4,6 @@
 // </meshweaver>
 
 using System.Reactive.Linq;
-using System.Text.Json;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 
@@ -20,33 +19,16 @@ public static class EmployeeNodeLayoutAreas
             .WithView("EmployeeOverview", EmployeeOverview)
             .WithView("Employment", Employment);
 
-    private static EmployeeContent? ExtractEmployeeContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return null;
-
-        if (node.Content is EmployeeContent ec)
-            return ec;
-
-        if (node.Content is JsonElement json)
-        {
-            return new EmployeeContent
-            {
-                EmployeeId = json.TryGetProperty("employeeId", out var eid) ? eid.GetInt32() : 0,
-                LastName = json.TryGetProperty("lastName", out var ln) ? ln.GetString() ?? "" : "",
-                FirstName = json.TryGetProperty("firstName", out var fn) ? fn.GetString() ?? "" : "",
-                Title = json.TryGetProperty("title", out var title) ? title.GetString() ?? "" : "",
-                TitleOfCourtesy = json.TryGetProperty("titleOfCourtesy", out var toc) ? toc.GetString() ?? "" : "",
-                BirthDate = json.TryGetProperty("birthDate", out var bd) ? bd.GetDateTime() : DateTime.MinValue,
-                HireDate = json.TryGetProperty("hireDate", out var hd) ? hd.GetDateTime() : DateTime.MinValue,
-                City = json.TryGetProperty("city", out var city) ? city.GetString() ?? "" : "",
-                Region = json.TryGetProperty("region", out var region) ? region.GetString() ?? "" : "",
-                Country = json.TryGetProperty("country", out var country) ? country.GetString() ?? "" : "",
-                ReportsTo = json.TryGetProperty("reportsTo", out var rt) ? rt.GetInt32() : 0
-            };
-        }
-        return null;
-    }
+    /// <summary>
+    /// The node's employee content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JSON branch:
+    /// the accessor covers the already-typed value AND the degraded JsonElement/JsonNode AND a
+    /// same-short-named <c>EmployeeContent</c> from another build (every recompile of a dynamic
+    /// NodeType mints a new collectible assembly, so "the same" record has a different CLR identity
+    /// per build — the case the hand-rolled version had no round-trip to recover, leaving the view
+    /// blank after a recompile with nothing to grep).
+    /// </summary>
+    private static EmployeeContent? ExtractEmployeeContent(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<EmployeeContent>(host.Hub.JsonSerializerOptions);
 
     /// <summary>Employee overview with personal details.</summary>
     [Display(GroupName = "Overview", Order = 0)]
@@ -60,7 +42,7 @@ public static class EmployeeNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var employee = ExtractEmployeeContent(node);
+            var employee = ExtractEmployeeContent(host, node);
 
             if (employee == null)
                 return (UiControl?)Controls.Markdown("*Employee data not available*");
@@ -115,7 +97,7 @@ public static class EmployeeNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var employee = ExtractEmployeeContent(node);
+            var employee = ExtractEmployeeContent(host, node);
 
             if (employee == null)
                 return (UiControl?)Controls.Markdown("*Employee data not available*");

--- a/samples/Graph/Data/Northwind/Product/Source/ProductNodeLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Product/Source/ProductNodeLayoutAreas.cs
@@ -4,7 +4,6 @@
 // </meshweaver>
 
 using System.Reactive.Linq;
-using System.Text.Json;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 
@@ -20,32 +19,16 @@ public static class ProductNodeLayoutAreas
             .WithView("ProductOverview", ProductOverview)
             .WithView("InventoryStatus", InventoryStatus);
 
-    private static ProductContent? ExtractProductContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return null;
-
-        if (node.Content is ProductContent pc)
-            return pc;
-
-        if (node.Content is JsonElement json)
-        {
-            return new ProductContent
-            {
-                ProductId = json.TryGetProperty("productId", out var pid) ? pid.GetInt32() : 0,
-                ProductName = json.TryGetProperty("productName", out var pn) ? pn.GetString() ?? "" : "",
-                SupplierId = json.TryGetProperty("supplierId", out var sid) ? sid.GetInt32() : 0,
-                CategoryId = json.TryGetProperty("categoryId", out var cid) ? cid.GetInt32() : 0,
-                QuantityPerUnit = json.TryGetProperty("quantityPerUnit", out var qpu) ? qpu.GetString() ?? "" : "",
-                UnitPrice = json.TryGetProperty("unitPrice", out var up) ? up.GetDouble() : 0,
-                UnitsInStock = json.TryGetProperty("unitsInStock", out var uis) ? uis.GetInt16() : (short)0,
-                UnitsOnOrder = json.TryGetProperty("unitsOnOrder", out var uoo) ? uoo.GetInt16() : (short)0,
-                ReorderLevel = json.TryGetProperty("reorderLevel", out var rl) ? rl.GetInt16() : (short)0,
-                Discontinued = json.TryGetProperty("discontinued", out var disc) && disc.GetBoolean()
-            };
-        }
-        return null;
-    }
+    /// <summary>
+    /// The node's product content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JSON branch:
+    /// the accessor covers the already-typed value AND the degraded JsonElement/JsonNode AND a
+    /// same-short-named <c>ProductContent</c> from another build (every recompile of a dynamic
+    /// NodeType mints a new collectible assembly, so "the same" record has a different CLR identity
+    /// per build — the case the hand-rolled version had no round-trip to recover, leaving the view
+    /// blank after a recompile with nothing to grep).
+    /// </summary>
+    private static ProductContent? ExtractProductContent(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<ProductContent>(host.Hub.JsonSerializerOptions);
 
     /// <summary>Product overview with details.</summary>
     [Display(GroupName = "Overview", Order = 0)]
@@ -59,7 +42,7 @@ public static class ProductNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var product = ExtractProductContent(node);
+            var product = ExtractProductContent(host, node);
 
             if (product == null)
                 return (UiControl?)Controls.Markdown("*Product data not available*");
@@ -116,7 +99,7 @@ public static class ProductNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var product = ExtractProductContent(node);
+            var product = ExtractProductContent(host, node);
 
             if (product == null)
                 return (UiControl?)Controls.Markdown("*Product data not available*");

--- a/samples/Graph/Data/Northwind/ReportsCatalog/Source/ReportsCatalogLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/ReportsCatalog/Source/ReportsCatalogLayoutAreas.cs
@@ -77,15 +77,20 @@ public static class ReportsCatalogLayoutAreas
         // Report cards
         foreach (var child in children)
         {
-            container = container.WithView(BuildReportCard(child));
+            container = container.WithView(BuildReportCard(host, child));
         }
 
         return container;
     }
 
-    private static UiControl BuildReportCard(MeshNode child)
+    private static UiControl BuildReportCard(LayoutAreaHost host, MeshNode child)
     {
-        var mc = child.Content as MarkdownContent;
+        // ContentAs, never `as`. This reads ANOTHER node's content across a hub boundary — the very
+        // case the accessor exists for: a report stored as bare JSON has no $type to resolve and
+        // arrives as a raw JsonElement, and a report re-typed by a recompiled dynamic NodeType is a
+        // same-short-named record from a different collectible assembly. `as` was silently null for
+        // both, and the card rendered with an empty abstract, no authors, no tags and no thumbnail.
+        var mc = child.ContentAs<MarkdownContent>(host.Hub.JsonSerializerOptions);
         var childTitle = System.Web.HttpUtility.HtmlEncode(child.Name ?? child.Id);
         var abstractText = System.Web.HttpUtility.HtmlEncode(mc?.Abstract ?? "");
         var path = child.Path;

--- a/samples/Graph/Data/Northwind/Supplier/Source/SupplierNodeLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/Supplier/Source/SupplierNodeLayoutAreas.cs
@@ -4,7 +4,6 @@
 // </meshweaver>
 
 using System.Reactive.Linq;
-using System.Text.Json;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 
@@ -20,30 +19,16 @@ public static class SupplierNodeLayoutAreas
             .WithView("SupplierOverview", SupplierOverview)
             .WithView("ContactInfo", ContactInfo);
 
-    private static SupplierContent? ExtractSupplierContent(MeshNode? node)
-    {
-        if (node?.Content == null)
-            return null;
-
-        if (node.Content is SupplierContent sc)
-            return sc;
-
-        if (node.Content is JsonElement json)
-        {
-            return new SupplierContent
-            {
-                SupplierId = json.TryGetProperty("supplierId", out var sid) ? sid.GetInt32() : 0,
-                CompanyName = json.TryGetProperty("companyName", out var cn) ? cn.GetString() ?? "" : "",
-                ContactName = json.TryGetProperty("contactName", out var ctn) ? ctn.GetString() ?? "" : "",
-                ContactTitle = json.TryGetProperty("contactTitle", out var ct) ? ct.GetString() ?? "" : "",
-                City = json.TryGetProperty("city", out var city) ? city.GetString() ?? "" : "",
-                Region = json.TryGetProperty("region", out var region) ? region.GetString() ?? "" : "",
-                Country = json.TryGetProperty("country", out var country) ? country.GetString() ?? "" : "",
-                Phone = json.TryGetProperty("phone", out var phone) ? phone.GetString() ?? "" : ""
-            };
-        }
-        return null;
-    }
+    /// <summary>
+    /// The node's supplier content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JSON branch:
+    /// the accessor covers the already-typed value AND the degraded JsonElement/JsonNode AND a
+    /// same-short-named <c>SupplierContent</c> from another build (every recompile of a dynamic
+    /// NodeType mints a new collectible assembly, so "the same" record has a different CLR identity
+    /// per build — the case the hand-rolled version had no round-trip to recover, leaving the view
+    /// blank after a recompile with nothing to grep).
+    /// </summary>
+    private static SupplierContent? ExtractSupplierContent(LayoutAreaHost host, MeshNode? node) =>
+        node.ContentAs<SupplierContent>(host.Hub.JsonSerializerOptions);
 
     /// <summary>Supplier overview with company details.</summary>
     [Display(GroupName = "Overview", Order = 0)]
@@ -57,7 +42,7 @@ public static class SupplierNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var supplier = ExtractSupplierContent(node);
+            var supplier = ExtractSupplierContent(host, node);
 
             if (supplier == null)
                 return (UiControl?)Controls.Markdown("*Supplier data not available*");
@@ -112,7 +97,7 @@ public static class SupplierNodeLayoutAreas
         return nodeStream.Select(nodes =>
         {
             var node = nodes.FirstOrDefault(n => n.Path == hubPath);
-            var supplier = ExtractSupplierContent(node);
+            var supplier = ExtractSupplierContent(host, node);
 
             if (supplier == null)
                 return (UiControl?)Controls.Markdown("*Supplier data not available*");

--- a/samples/Graph/Data/PythonDemo/PrimeReport/Source/PrimeReportLayoutAreas.cs
+++ b/samples/Graph/Data/PythonDemo/PrimeReport/Source/PrimeReportLayoutAreas.cs
@@ -6,7 +6,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Reactive.Linq;
-using System.Text.Json;
 using System.Threading;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
@@ -44,7 +43,7 @@ public static class PrimeReportLayoutAreas
 
         return nodeStream
             .Select(nodes => nodes?.FirstOrDefault(n => n.Path == hubPath))
-            .Select(node => Math.Clamp(ExtractReport(node)?.Count ?? 25, 1, 200))
+            .Select(node => Math.Clamp(ExtractReport(hub, node)?.Count ?? 25, 1, 200))
             .DistinctUntilChanged()
             .Select(count => ProcessPool(hub)
                 // InvokeBlocking = sync-blocking leaf on the pool's limited-concurrency
@@ -61,29 +60,17 @@ public static class PrimeReportLayoutAreas
         ?? IoPool.Unbounded;
 
     /// <summary>
-    /// Extracts the typed content from the MeshNode, handling both the typed record and
-    /// the raw JsonElement shape (content arrives as JSON before the type is bound).
+    /// The node's typed content. <c>ContentAs</c> — never <c>is</c> + a hand-rolled JsonElement
+    /// branch: the accessor covers the already-typed value AND the degraded JsonElement/JsonNode
+    /// (content arrives as JSON before the type is bound, and STAYS that way when it carries no
+    /// resolvable <c>$type</c>) AND a same-short-named <c>PrimeReport</c> from another build — every
+    /// recompile of this NodeType mints a new collectible assembly, so "the same" record has a
+    /// different CLR identity per build, which the hand-rolled version had no round-trip to recover.
+    /// It also reads with the HUB's options rather than a locally-invented
+    /// <c>JsonSerializerOptions</c>, and logs instead of swallowing in a bare <c>catch</c>.
     /// </summary>
-    private static PrimeReport? ExtractReport(MeshNode? node)
-    {
-        if (node?.Content is PrimeReport report)
-            return report;
-
-        if (node?.Content is JsonElement json)
-        {
-            try
-            {
-                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                return JsonSerializer.Deserialize<PrimeReport>(json.GetRawText(), options);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        return null;
-    }
+    private static PrimeReport? ExtractReport(IMessageHub hub, MeshNode? node) =>
+        node.ContentAs<PrimeReport>(hub.JsonSerializerOptions);
 
     /// <summary>
     /// The Python program: computes the first <paramref name="count"/> primes and formats

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-sample-space-views-stop-rendering-blank.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-sample-space-views-stop-rendering-blank.md
@@ -1,0 +1,37 @@
+---
+Name: Sample-space views stop rendering blank
+Category: Fix
+Description: Articles, report cards, task and product views in the sample spaces could come back empty — a title with no body, a card with no summary. They now read their content the tolerant way the platform already provides.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Sample-space views stop rendering blank
+
+Views across the ACME, Northwind, Cornerstone, FutuRe and Python demo spaces could render as an
+empty shell: an article with its title and nothing under it, a report card with no summary, no
+author line and no picture, a task or product page that just said the data was not available.
+
+The content was there the whole time. What went wrong was how each view asked for it.
+
+A stored item can arrive in one of several shapes. Usually it comes back as the exact kind of thing
+the view expects. But an item that was imported, or written through the API with a plain body, or
+saved before its kind existed, arrives as raw stored data with nothing to say what kind it is — and
+so does an item belonging to a package that the part of the platform doing the reading does not
+know about. There is a third case too: every time a package's code is rebuilt, its records get a
+fresh identity, so yesterday's record and today's are no longer recognisably the same thing.
+
+Each of these views checked for exactly one of those shapes and gave up on the rest. Giving up
+produced nothing at all — no error, no warning, no line in any log. The page simply rendered empty,
+which reads to the person looking at it as "there is nothing here" rather than "this could not be
+read".
+
+Every one of those reads now goes through the platform's tolerant accessor, which recognises all
+three shapes and reports what it could not convert instead of swallowing it.
+
+## Why so many places at once
+
+The article view was the same extractor copied word-for-word into three different sample spaces, so
+one defect shipped three times. That copy is gone: all three now call a single shared reader in the
+platform itself — the same one the PDF, Word and HTML exports use, so a fix reaches every reader at
+once and there is no longer a copy to drift.

--- a/src/MeshWeaver.Markdown.Export/Ast/ExportSource.cs
+++ b/src/MeshWeaver.Markdown.Export/Ast/ExportSource.cs
@@ -7,37 +7,17 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.Markdown.Export.Ast;
 
 /// <summary>
-/// Reads the markdown BODY out of an exported <see cref="MeshNode"/> — the one place every export
-/// template asks "what text does this node contribute to the document?".
+/// The export's view of a node's markdown body — <see cref="MarkdownBody.Of"/> plus the one
+/// diagnostic that only an export can state: "this chapter came out empty".
 ///
 /// <para>🚨 It lives here, in compiled framework code, because the three export templates
 /// (<c>ExportPdf.csx</c>, <c>ExportDocx.csx</c>, <c>ExportHtml.csx</c>) are <c>.csx</c> compiled at
 /// RUNTIME: no <c>dotnet build</c> ever type-checks them and no unit test could reach a private
-/// local function inside one. Three hand-copied extractors is how the defect below survived — and
-/// how a fix applied to one template would have drifted from the other two.</para>
-///
-/// <para><b>The defect (#1374).</b> Each copy read the body with a direct type test:</para>
-/// <code>
-/// if (node.Content is MarkdownContent mc) return mc.Content ?? "";   // ❌ trap-door
-/// </code>
-/// <para>That is correct only when the value already happens to be that CLR type. A node whose
-/// content was stored as plain JSON — an import, an MCP <c>create</c>/<c>patch</c> carrying a raw
-/// body, a document written before its content type existed — has no <c>$type</c> discriminator for
-/// the polymorphic converter to resolve, so it arrives (and STAYS, even on the node's own owning
-/// hub) a raw <see cref="JsonElement"/>. The test is simply false, the extractor returns <c>""</c>,
-/// and the export produces a cover page, a contents list and <b>no body</b> — no exception, no log
-/// line, nothing to grep, and it reads to the author as their own mistake rather than a platform
-/// bug. <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovers exactly that shape (and a
-/// same-short-named <c>MarkdownContent</c> from another dynamic-node build, by JSON round-trip).</para>
-///
-/// <para><b>Why this is a legitimate boundary read and not a routing mistake.</b> The rule's first
-/// question is whether the value should have been deserialized closer to where its type IS
-/// registered. Here it could not be: the shape that fails carries <b>no discriminator at all</b>, so
-/// no registry can type it — measured on the monolith, a <c>Markdown</c> node whose content was
-/// written as bare JSON is still a <see cref="JsonElement"/> when read from its OWN per-node hub,
-/// the very hub that declares <c>WithContentType&lt;MarkdownContent&gt;()</c>. Moving the read would
-/// change nothing. Reading stored JSON whose type cannot be resolved is the textbook case the
-/// accessor exists for.</para>
+/// local function inside one. Three hand-copied extractors is how the trap-door defect (#1374)
+/// survived — and how a fix applied to one template would have drifted from the other two. The
+/// reading itself moved one level down to <see cref="MarkdownBody"/> for the same reason: the
+/// sample Article views are runtime-compiled NodeType source carrying their OWN hand-copied copy of
+/// the same extractor (#1383), so there must be exactly one implementation for both to call.</para>
 /// </summary>
 public static class ExportSource
 {
@@ -61,24 +41,13 @@ public static class ExportSource
     /// </param>
     public static string MarkdownOf(MeshNode? node, JsonSerializerOptions options, ILogger? logger = null)
     {
-        if (node?.Content is null)
-            return "";
-
-        // The accessor FIRST: it covers the already-typed value, the degraded JsonElement/JsonNode,
-        // and a same-short-named MarkdownContent from another build. Deliberately without the
-        // logger — every non-markdown descendant of an IncludeChildren export lands here too, and
-        // As<T> logs an error for a typed-but-foreign value. The one genuinely diagnosable case is
-        // reported explicitly below instead, so the diagnosis survives without the storm.
-        if (node.ContentAs<MarkdownContent>(options)?.Content is { } markdown)
+        // The shared reader: it covers the already-typed value, the degraded JsonElement/JsonNode, a
+        // same-short-named MarkdownContent from another build, and a bare-string body. Deliberately
+        // WITHOUT the logger — every non-markdown descendant of an IncludeChildren export lands here
+        // too, and As<T> logs an error for a typed-but-foreign value. The one genuinely diagnosable
+        // case is reported explicitly below instead, so the diagnosis survives without the storm.
+        if (MarkdownBody.Of(node, options) is { } markdown)
             return markdown;
-
-        // A body stored as a bare string, either still typed or degraded to a JSON string.
-        if (node.Content is string s)
-            return s;
-        if (node.Content is JsonElement { ValueKind: JsonValueKind.String } je)
-            return je.GetString() ?? "";
-        if (node.Content is JsonValue jv && jv.TryGetValue<string>(out var raw))
-            return raw;
 
         // JSON-shaped content on a node that DECLARES itself a markdown document, yet no body came
         // out of it. That is the export silently losing its content, so say so rather than
@@ -88,7 +57,7 @@ public static class ExportSource
         // export walks every descendant, and a Todo or a Product whose typed content arrived as
         // JSON is not a fault, it is simply not a chapter. Only a node that was supposed to have a
         // body gets a line.
-        if (node.Content is JsonElement or JsonNode
+        if (node?.Content is JsonElement or JsonNode
             && string.Equals(node.NodeType, MarkdownNodeType.NodeType, StringComparison.Ordinal))
             logger?.LogWarning(
                 "Export: {Path} is a {NodeType} node whose content is JSON that yields no markdown "

--- a/src/MeshWeaver.Markdown/MarkdownBody.cs
+++ b/src/MeshWeaver.Markdown/MarkdownBody.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Markdown;
+
+/// <summary>
+/// Reads the markdown BODY out of a <see cref="MeshNode"/> — the one place anything on the mesh
+/// asks "what text does this node contribute?".
+///
+/// <para>🚨 It lives here, in compiled framework code, because every caller that needs it is
+/// invisible to <c>dotnet build</c>. The export templates are <c>.csx</c> compiled at RUNTIME
+/// (#1374/#1381), and the sample Article views are NodeType <c>Source/*.cs</c> stored in mesh nodes
+/// and compiled at RUNTIME too — no build and no test type-checks either. Hand-copying the
+/// extractor into each is exactly how the defect below survived: it was pasted
+/// character-for-character into three sample spaces (ACME, Northwind, Cornerstone) and nothing
+/// anywhere could flag the second and third copies (#1383).</para>
+///
+/// <para><b>The defect.</b> Each copy read the body with a direct type test:</para>
+/// <code>
+/// if (node.Content is MarkdownContent mc) return mc.Content;   // ❌ trap-door
+/// </code>
+/// <para>That is correct only when the value already happens to be that CLR type. A node whose
+/// content was stored as plain JSON — an import, an MCP <c>create</c>/<c>patch</c> carrying a raw
+/// body, a document written before its content type existed — has no <c>$type</c> discriminator for
+/// the polymorphic converter to resolve, so it arrives (and STAYS, even on the node's own owning
+/// hub) a raw <see cref="JsonElement"/>. The test is simply false, the reader returns nothing, and
+/// the article renders as a bare title with no body — no exception, no log line, nothing to grep.
+/// <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovers exactly that shape, and a
+/// same-short-named <see cref="MarkdownContent"/> from another dynamic-node build by JSON
+/// round-trip.</para>
+///
+/// <para><b>Why this is a legitimate boundary read and not a routing mistake.</b> The rule's first
+/// question is whether the value should have been deserialized closer to where its type IS
+/// registered. Here it cannot be: the shape that fails carries <b>no discriminator at all</b>, so no
+/// registry can type it — a <c>Markdown</c> node whose content was written as bare JSON is still a
+/// <see cref="JsonElement"/> when read from its OWN per-node hub, the very hub that declares
+/// <c>WithContentType&lt;MarkdownContent&gt;()</c>. Moving the read would change nothing.</para>
+/// </summary>
+public static class MarkdownBody
+{
+    /// <summary>
+    /// The node's markdown body, or <c>null</c> when it carries none that can be read.
+    ///
+    /// <para><c>null</c> rather than <c>""</c> so a caller can tell "this node is not
+    /// markdown-bodied" (the normal case when walking a subtree of typed content nodes) from "this
+    /// node has an empty body", and decide for itself whether the miss is worth a diagnostic —
+    /// which is what <c>ExportSource.MarkdownOf</c> does for the one shape that is.</para>
+    /// </summary>
+    /// <param name="node">The node to read. A null node, or one with no content, yields <c>null</c>.</param>
+    /// <param name="options">The reading hub's <c>JsonSerializerOptions</c> — the registry behind
+    /// them is what resolves a <c>$type</c>.</param>
+    /// <param name="logger">Optional. Pass one when the caller reads a SINGLE known node (a view of
+    /// its own node): an unreadable body is then diagnosed instead of silently blank. Leave it null
+    /// when walking many nodes of mixed types — <see cref="ObjectAsExtensions.As{T}"/> logs an error
+    /// per typed-but-foreign value, which at subtree size is a storm rather than a diagnosis.</param>
+    public static string? Of(MeshNode? node, JsonSerializerOptions options, ILogger? logger = null)
+    {
+        if (node?.Content is null)
+            return null;
+
+        // The accessor FIRST: it covers the already-typed value, the degraded JsonElement/JsonNode,
+        // and a same-short-named MarkdownContent from another build.
+        if (node.ContentAs<MarkdownContent>(options, logger)?.Content is { } markdown)
+            return markdown;
+
+        // A body stored as a bare string, either still typed or degraded to a JSON string.
+        if (node.Content is string s)
+            return s;
+        if (node.Content is JsonElement { ValueKind: JsonValueKind.String } je)
+            return je.GetString();
+        if (node.Content is JsonValue jv && jv.TryGetValue<string>(out var raw))
+            return raw;
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #1383.

Every `node.Content is X` / `as X` under `samples/**/Source/*.cs` now reads through `node.ContentAs<T>(hub.JsonSerializerOptions)`.

## The degradation is live, not theoretical

Booting the monolith on this tree logs it on every start, for **every content type behind these reads**:

```
Received '$type':'Todo' which is NOT registered in this (receiving) hub — it can only
be read as an untyped JsonElement (the value renders empty / reactive waits time out).
```

Same line for `Pricing`, `CustomerContent`, `EmployeeContent`, `ProductContent`, `SupplierContent`, `PrimeReport`, `BusinessUnit`, `LineOfBusiness`, `AmountType`, `ExchangeRate`, `TransactionMapping`, `Currency`, `Country`. So the `is X` branch is false in practice and the JSON branch is what actually ran — with no round-trip for the case it never covered.

## The two groups

**No fallback at all — blank today.** The three copies of `ArticleLayoutAreas.cs` (ACME, Northwind, Cornerstone) plus `ReportsCatalogLayoutAreas.cs`. The three Article copies were character-for-character identical apart from a display name, so one defect shipped three times and nothing anywhere could flag copies two and three.

**Hand-rolled `ContentAs`.** `is X`, then `is JsonElement` plus a manual deserialize: Todo, Pricing, PrimeReport, the four Northwind node views, and the FutuRe loader's seven converters. Correct for the JSON case, but with no round-trip to recover a **same-short-named record from another build** — which happens on every NodeType recompile, and which FutuRe's own comment described while working around it with a reflected `Currency` property:

> `BusinessUnit` gets compiled into `FutuRe_BusinessUnit`'s NodeAssemblyLoadContext while this loader lives in `FutuRe_LocalAnalysis`'s ALC, so `Content is BusinessUnit` returns false even though the runtime types match by full name.

That is precisely what `ContentAs<T>` recovers, so the JsonElement probe, the `is` test and the reflection fallback collapse into one call.

## One shared reader instead of three copies

Following #1381, the markdown-body extractor moved into compiled framework code as `MeshWeaver.Markdown.MarkdownBody.Of`. `ExportSource.MarkdownOf` now delegates to it (keeping its export-only "this chapter came out empty" warning), so the export templates and the sample Article views share **one** implementation — there is no longer a copy to drift.

## Also removed

Dead JSON helpers, a `Console.WriteLine` diagnostic, locally-invented `JsonSerializerOptions` that cannot resolve a `$type`, bare `catch { return null; }` swallows, and an unguarded `JsonSerializer.Serialize(object)` that routes through the polymorphic converter's `GetOrAddType` and adopts a foreign type into the hub's registry as a read side effect.

## Verification

In-mesh source has no CI gate, so a clean `-c Release -warnaserror` build proves nothing about most of it. What was actually run:

| Check | Result |
|---|---|
| `MeshWeaver.FutuRe.Test` — `<Compile>`-includes `FutuReDataLoader.cs`, so it IS statically type-checked; the suite also renders the group-analysis areas | `-c Release -warnaserror` clean · **59/59** |
| `MeshWeaver.Acme.Test` — renders the Todo Details/Thumbnail areas after a real Roslyn compile of the edited source | `-c Release -warnaserror` clean · **76/76** |
| `MeshWeaver.Markdown.Export.Test` — 11 `ExportSource` cases pin untyped-JSON, JsonObject, bare-string and cross-build recovery through `MarkdownBody.Of` | **110/110** |
| Offline compile of each edited NodeType's source set against the portal's own assemblies, with the compiler's injected usings | all edited files clean |
| `MeshWeaver.Markdown`, `MeshWeaver.Markdown.Export`, `MeshWeaver.Documentation.Test` | `-c Release -warnaserror` clean |

## Boundary reads, not routing mistakes

Checked per the rule rather than assumed. Each site is a genuine boundary: a cross-hub `IMeshService.Query<MeshNode>` result, an `ObserveChildren` list, or content carrying no resolvable `$type` (which no registry anywhere can type — the same finding #1374 measured on the monolith). The portal's own warning names the deeper cause — these dynamic NodeType content types are not registered in the *receiving* hub — but that is a framework/sample-config fix, separate from reading them tolerantly.

Out of scope, reported in the issue thread: `AnalyticsCatalog`, `ProjectLayoutAreas`, `InsuranceLayoutAreas` and the SocialMedia views read arbitrary JSON properties generically (`GetProp(node, "status")`) with no single content type to convert to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)