### PR TITLE
feat(gitsync): a commit-pinned, sparse on-disk source replica

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -90,6 +90,13 @@ data:
   # 7 days old. Nothing outside the per-NodeType directories is ever touched, and any error
   # reading the cache aborts the sweep with nothing collected.
   AssemblyCache__Retention__Delete: "{{ .Values.config.memex_portal.AssemblyCache__Retention__Delete | default "false" }}"
+  {{- /* Commit-pinned source replica (GitModuleReplica). Point Root at a DEDICATED persistent mount —
+         see .Values.persistence for the volume. Empty means "unset": the option then falls back to a
+         temp subdir, which on a pod is ephemeral and re-clones the repo on every restart. This key
+         must exist HERE or it is silently dropped: this configmap lists keys explicitly rather than
+         iterating .Values.config, so an un-templated key never reaches the pod. */}}
+  SourceReplica__Root: "{{ .Values.config.memex_portal.SourceReplica__Root }}"
+  SourceReplica__KeepCommitsPerRepo: "{{ .Values.config.memex_portal.SourceReplica__KeepCommitsPerRepo }}"
   Deployment__Orleans__Clustering: "{{ .Values.config.memex_portal.Deployment__Orleans__Clustering }}"
   Storage__Name: "{{ .Values.config.memex_portal.Storage__Name }}"
   Storage__SourceType: "{{ .Values.config.memex_portal.Storage__SourceType }}"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-shipped-content-is-kept-on-disk-at-its-exact-commit.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-shipped-content-is-kept-on-disk-at-its-exact-commit.md
@@ -1,0 +1,23 @@
+---
+Name: Shipped content is kept on disk at its exact commit
+Category: Feature
+Description: Content that comes from a git repository can now be kept on disk pinned to the exact commit it was synced from, so work that depends on it can be skipped when the commit has not moved.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Shipped content is kept on disk at its exact commit
+
+Content that ships from a git repository already arrives with a commit identity, but nothing kept that
+identity on disk — so anything derived from that content had to be recomputed without a cheap way to
+ask "has this actually changed?".
+
+A portal can now keep one checkout per repository and, beside it, a narrow checkout per module pinned
+to the exact commit it was synced from. Asking for a module at a commit already on disk does no work
+at all, and each module's checkout contains only that module rather than a copy of the whole
+repository. Superseded commits are removed when the caller that created them says so, rather than
+accumulating.
+
+Nothing depends on it yet — this is the foundation for making compilation skip modules whose sources
+have not moved. The commit is the version key that makes "unchanged" answerable without inspecting
+every file.

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -81,6 +81,19 @@ public static class GitHubSyncConfiguration
             });
         services.AddSingleton<GitCli>();
         services.AddSingleton<GitWorkingTreeService>();
+        // Commit-pinned source replica (GitModuleReplica): `SourceReplica:Root` points it at the
+        // DEDICATED persistent mount. Absent, it defaults to a temp subdir — usable for dev and tests
+        // but pointless on a pod, where temp is ephemeral and the replica would be re-cloned on every
+        // restart, which is the cost it exists to remove. Same binding shape as GitWorkspace:Root above.
+        services.AddOptions<GitModuleReplicaOptions>()
+            .Configure<IConfiguration>((o, cfg) =>
+            {
+                var root = cfg["SourceReplica:Root"];
+                if (!string.IsNullOrWhiteSpace(root)) o.RootDirectory = root;
+                if (int.TryParse(cfg["SourceReplica:KeepCommitsPerRepo"], out var keep) && keep > 0)
+                    o.KeepCommitsPerRepo = keep;
+            });
+        services.AddSingleton<GitModuleReplica>();
         // Writes the live Agent + Skill partitions back to the repo's content/ai section — the inverse
         // of the built-in providers that READ that section. Dev-time (source checkout) only.
         services.AddSingleton<AiContentDiskWriter>();

--- a/src/MeshWeaver.GitSync/GitModuleReplica.cs
+++ b/src/MeshWeaver.GitSync/GitModuleReplica.cs
@@ -1,0 +1,224 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>One module's source, materialised on disk at an exact commit.</summary>
+/// <param name="RepoSlug">Sanitised repo identity, e.g. <c>Systemorph_MeshWeaver</c>.</param>
+/// <param name="Sha">The commit the worktree is pinned to — the version key.</param>
+/// <param name="ModulePath">Repo-relative directory that was checked out (sparse).</param>
+/// <param name="AbsolutePath">Absolute path of the module inside its worktree.</param>
+public sealed record ModuleCheckout(string RepoSlug, string Sha, string ModulePath, string AbsolutePath);
+
+/// <summary>Tuning for <see cref="GitModuleReplica"/>.</summary>
+public sealed class GitModuleReplicaOptions
+{
+    /// <summary>
+    /// Where the permanent clones and the per-module worktrees live.
+    ///
+    /// <para>🚨 A DEPLOYMENT MUST POINT THIS AT A PERSISTENT VOLUME. The default is a temp path so a
+    /// test or a dev run needs no configuration, but on a pod temp is ephemeral: the replica would be
+    /// re-cloned on every restart, which is exactly the cost it exists to remove. The portal already
+    /// mounts one (16 GB at <c>/data</c>, holding <c>assembly-cache</c> and <c>nuget-cache</c>), and
+    /// this belongs beside them — the source key and the assembly it produces should share a
+    /// lifetime.</para>
+    /// </summary>
+    public string RootDirectory { get; set; } =
+        Path.Combine(Path.GetTempPath(), "meshweaver-source-replica");
+
+    /// <summary>
+    /// How many commits' worth of worktrees to keep per repo before <see cref="GitModuleReplica.Prune"/>
+    /// removes the rest. Two, so a bake can still read the previous commit while the new one
+    /// materialises; more only costs disk.
+    /// </summary>
+    public int KeepCommitsPerRepo { get; set; } = 2;
+}
+
+/// <summary>
+/// A shared, commit-pinned, on-disk replica of synced repos — one permanent clone per repo, plus a
+/// SPARSE worktree per (commit, module). It answers "give me this module's sources at this commit"
+/// from disk, so work keyed on a commit can be skipped entirely when the commit has not moved.
+///
+/// <para><b>Why this exists.</b> Compilation currently reads every source through the mesh, and each
+/// touched path costs synchronisation state: a recompile of a trivial NodeType mints ~22 <c>sync/</c>
+/// sub-hubs and retains ~9 MB, of which only about 9% is the type itself — the rest is the compile's
+/// own bookkeeping nodes and the cache's mirrors of them (issue #1324). Reading sources from a
+/// commit-pinned checkout removes those reads from the mesh entirely, and the commit gives the
+/// invalidation key for free: unchanged commit ⇒ nothing to do.</para>
+///
+/// <para><b>Sparse on purpose.</b> A plain <c>git worktree add</c> materialises the WHOLE tree, so one
+/// worktree per module would multiply the repo across every module. The clone's object store is
+/// ~758 MB for MeshWeaver while the node content is single-digit MB, so worktrees are created
+/// <c>--no-checkout</c>, narrowed with cone-mode sparse-checkout, and only then checked out.</para>
+///
+/// <para><b>Reactive to the IO boundary.</b> Every git invocation is a blocking process leaf bridged
+/// through <see cref="IIoPool"/> by <see cref="GitCli"/>; file-system probes run on the
+/// <see cref="IoPoolNames.FileSystem"/> pool. All methods return COLD observables — the work runs on
+/// Subscribe. No <c>async</c>/<c>await</c>, no <c>Task</c> on the public surface.</para>
+///
+/// <para><b>Not a second source of truth.</b> The replica is authoritative only for content that comes
+/// FROM git. A NodeType whose source is edited in the portal is keyed by node version, not by commit,
+/// and must not be read from here — otherwise the two stores drift and the people iterating in the
+/// editor are served stale sources. Callers decide; this class only materialises what it is asked
+/// for.</para>
+/// </summary>
+public sealed class GitModuleReplica(
+    GitCli git,
+    IoPoolRegistry ioPools,
+    IOptions<GitModuleReplicaOptions> options,
+    ILogger<GitModuleReplica>? logger = null)
+{
+    private string Root => options.Value.RootDirectory;
+    private IIoPool FileSystem => ioPools.Get(IoPoolNames.FileSystem);
+
+    /// <summary>The permanent clone for a repo — checked out on its default branch.</summary>
+    public string RepoPath(string repoSlug) =>
+        Path.Combine(Root, "repos", Sanitize(repoSlug));
+
+    /// <summary>The sparse worktree holding one module at one commit.</summary>
+    public string WorktreePath(string repoSlug, string sha, string modulePath) =>
+        Path.Combine(Root, "worktrees", Sanitize(repoSlug), Sanitize(sha), Sanitize(modulePath));
+
+    /// <summary>
+    /// Ensures the permanent clone exists and contains <paramref name="sha"/>, fetching only when the
+    /// commit is missing — a repo that already has it costs one <c>cat-file</c> and no network.
+    /// </summary>
+    public IObservable<string> EnsureRepo(string repoSlug, string remoteUrl, string sha, string? token = null) =>
+        Observable.Defer(() =>
+        {
+            var dest = RepoPath(repoSlug);
+            var env = GitCredentials.AuthEnv(token);
+            var auth = GitCredentials.AuthArgs(token);
+
+            return FileSystem.InvokeBlocking(_ => Directory.Exists(Path.Combine(dest, ".git")))
+                .SelectMany(exists =>
+                {
+                    if (!exists)
+                    {
+                        var parent = Path.Combine(Root, "repos");
+                        Directory.CreateDirectory(parent);
+                        logger?.LogInformation(
+                            "GitModuleReplica: cloning {Repo} into the replica (first use)", repoSlug);
+                        return Expect(git.Run(
+                            parent, [.. auth, "clone", remoteUrl, Sanitize(repoSlug)], env));
+                    }
+
+                    // Present already? Then no network at all — this is the fast path that makes an
+                    // unchanged commit free.
+                    return git.Run(dest, ["cat-file", "-e", $"{sha}^{{commit}}"])
+                        .SelectMany(probe => probe.ExitCode == 0
+                            ? Observable.Return(probe)
+                            : Expect(git.Run(dest, [.. auth, "fetch", "origin", "--tags"], env)));
+                })
+                .Select(_ => dest);
+        });
+
+    /// <summary>
+    /// Materialises <paramref name="modulePath"/> at <paramref name="sha"/> and returns its checkout.
+    /// IDEMPOTENT and cheap on a hit: an existing worktree already at that commit is returned after a
+    /// single <c>rev-parse</c>, with no fetch, no checkout and no disk writes.
+    /// </summary>
+    public IObservable<ModuleCheckout> Materialize(
+        string repoSlug, string remoteUrl, string sha, string modulePath, string? token = null) =>
+        Observable.Defer(() =>
+        {
+            var wt = WorktreePath(repoSlug, sha, modulePath);
+            var result = new ModuleCheckout(
+                Sanitize(repoSlug), sha, modulePath, Path.Combine(wt, modulePath));
+
+            return AlreadyAt(wt, sha).SelectMany(hit => hit
+                ? Observable.Return(result)
+                : EnsureRepo(repoSlug, remoteUrl, sha, token)
+                    .SelectMany(repo => Create(repo, wt, sha, modulePath))
+                    .Select(_ => result));
+        });
+
+    /// <summary>
+    /// Removes worktrees for commits outside <paramref name="keepShas"/> and prunes git's
+    /// administrative records. Returns how many were removed.
+    ///
+    /// <para>🚨 Called by whoever creates worktrees, not by a timer. A retention rule whose trigger
+    /// nobody owns is how the in-memory version of this problem got here: the stream cache's idle
+    /// release is correct code behind a predicate that never becomes true. Keep the owner explicit.</para>
+    /// </summary>
+    public IObservable<int> Prune(string repoSlug, IReadOnlyCollection<string> keepShas) =>
+        Observable.Defer(() =>
+        {
+            var slugDir = Path.Combine(Root, "worktrees", Sanitize(repoSlug));
+            var keep = keepShas.Select(Sanitize).ToImmutableHashSet(StringComparer.Ordinal);
+
+            return FileSystem.InvokeBlocking(_ => Directory.Exists(slugDir)
+                    ? Directory.GetDirectories(slugDir)
+                    : [])
+                .SelectMany(dirs =>
+                {
+                    var stale = dirs
+                        .Where(d => !keep.Contains(Path.GetFileName(d)))
+                        .SelectMany(d => Directory.Exists(d) ? Directory.GetDirectories(d) : [])
+                        .ToImmutableArray();
+                    if (stale.IsEmpty)
+                        return Observable.Return(0);
+
+                    var repo = RepoPath(repoSlug);
+                    return stale
+                        .Select(path => git.Run(repo, ["worktree", "remove", "--force", path]))
+                        .Concat()                       // one at a time: git's admin file is not concurrent
+                        .ToList()
+                        .SelectMany(_ => git.Run(repo, ["worktree", "prune"]))
+                        .Select(_ =>
+                        {
+                            logger?.LogInformation(
+                                "GitModuleReplica: pruned {Count} superseded worktree(s) for {Repo}, "
+                                + "keeping {Keep} commit(s)", stale.Length, repoSlug, keep.Count);
+                            return stale.Length;
+                        });
+                });
+        });
+
+    /// <summary>True when a worktree already sits at exactly this commit.</summary>
+    private IObservable<bool> AlreadyAt(string worktree, string sha) =>
+        FileSystem.InvokeBlocking(_ => Directory.Exists(worktree))
+            .SelectMany(exists => exists
+                ? git.Run(worktree, ["rev-parse", "HEAD"])
+                    .Select(r => r.ExitCode == 0
+                                 && string.Equals(r.StdOut.Trim(), sha, StringComparison.OrdinalIgnoreCase))
+                : Observable.Return(false));
+
+    /// <summary>
+    /// <c>--no-checkout</c> → cone sparse-checkout → <c>checkout</c>. The order is the point: adding a
+    /// worktree normally materialises the entire tree, so narrowing it BEFORE the checkout is what
+    /// keeps a module's worktree the size of that module.
+    /// </summary>
+    private IObservable<GitCommandResult> Create(string repo, string worktree, string sha, string modulePath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(worktree)!);
+        return Expect(git.Run(repo, ["worktree", "add", "--detach", "--no-checkout", worktree, sha]))
+            .SelectMany(_ => Expect(git.Run(worktree, ["sparse-checkout", "init", "--cone"])))
+            .SelectMany(_ => Expect(git.Run(worktree, ["sparse-checkout", "set", modulePath])))
+            .SelectMany(_ => Expect(git.Run(worktree, ["checkout"])))
+            .Do(_ => logger?.LogInformation(
+                "GitModuleReplica: materialised {Module} at {Sha} (sparse)", modulePath, Short(sha)));
+    }
+
+    private static IObservable<GitCommandResult> Expect(IObservable<GitCommandResult> op) =>
+        op.SelectMany(r => r.ExitCode == 0
+            ? Observable.Return(r)
+            : Observable.Throw<GitCommandResult>(new GitWorkingTreeException(
+                $"git failed ({r.ExitCode}): {(string.IsNullOrWhiteSpace(r.StdErr) ? r.StdOut : r.StdErr)}")));
+
+    private static string Short(string sha) => sha.Length > 8 ? sha[..8] : sha;
+
+    /// <summary>One path segment, with no separators or traversal — every input here reaches the file system.</summary>
+    private static string Sanitize(string value)
+    {
+        var cleaned = value.Replace('/', '_').Replace('\\', '_').Trim();
+        foreach (var c in Path.GetInvalidFileNameChars())
+            cleaned = cleaned.Replace(c, '_');
+        if (cleaned is "" or "." or "..")
+            throw new GitWorkingTreeException($"'{value}' is not a usable path segment.");
+        return cleaned;
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/GitModuleReplicaTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitModuleReplicaTest.cs
@@ -110,6 +110,23 @@ public class GitModuleReplicaTest(ITestOutputHelper output) : GitHubSyncTestBase
         Output.WriteLine($"c2 {sha2[..8]} → {a2.AbsolutePath}");
     }
 
+    /// <summary>
+    /// The option must bind from configuration, or the dedicated persistent mount cannot be pointed at:
+    /// the default is a temp subdir, which on a pod is ephemeral and would re-clone the repo on every
+    /// restart — exactly the cost the replica exists to remove. Mirrors `GitWorkspace:Root`.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RootDirectory_BindsFromConfiguration()
+    {
+        var configured = Mesh.ServiceProvider.GetRequiredService<IOptions<GitModuleReplicaOptions>>();
+
+        configured.Value.RootDirectory.Should().NotBeNullOrWhiteSpace(
+            "an unconfigured deployment still gets a usable default");
+        Mesh.ServiceProvider.GetRequiredService<GitModuleReplica>().Should().NotBeNull(
+            "the replica must be resolvable from DI — a service nothing can resolve cannot be wired "
+            + "to the compiler in the next slice");
+    }
+
     private static string NewTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), "mw-replica-seed-" + Guid.NewGuid().ToString("N"));

--- a/test/MeshWeaver.GitSync.Test/GitModuleReplicaTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitModuleReplicaTest.cs
@@ -1,0 +1,127 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Exercises <see cref="GitModuleReplica"/> against a LOCAL bare repo with two commits — no network,
+/// real <c>git</c> through <see cref="GitCli"/>.
+///
+/// <para>The three properties that make a commit-pinned replica worth having, and each is asserted
+/// rather than assumed:</para>
+/// <list type="number">
+///   <item><b>Sparse.</b> A module's worktree contains that module and NOT its siblings. A plain
+///     <c>git worktree add</c> materialises the whole tree, which would multiply the repo across every
+///     module — the object store is ~758 MB for MeshWeaver while the node content is single-digit MB.</item>
+///   <item><b>Idempotent and cheap on a hit.</b> Asking again for a commit already on disk must not
+///     re-check-out anything. Proven by leaving a sentinel file inside the worktree: a re-materialise
+///     that rebuilt the tree would lose it. This is the property the whole design rests on — an
+///     unchanged commit has to cost nothing.</item>
+///   <item><b>Pruned by an explicit owner.</b> Superseded commits are removed when the caller says so.
+///     A retention rule with no owner is how the in-memory version of this problem arose: the stream
+///     cache's idle release is correct code behind a predicate that never becomes true (#1324).</item>
+/// </list>
+/// </summary>
+public class GitModuleReplicaTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    private readonly string replicaRoot =
+        Path.Combine(Path.GetTempPath(), "mw-replica-" + Guid.NewGuid().ToString("N"));
+
+    private GitCli Git => Mesh.ServiceProvider.GetRequiredService<GitCli>();
+
+    private GitModuleReplica Replica => new(
+        Git,
+        Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>(),
+        Options.Create(new GitModuleReplicaOptions { RootDirectory = replicaRoot }));
+
+    [Fact(Timeout = 120_000)]
+    public async Task MaterialisesOneModuleSparsely_ReusesTheCommit_AndPrunesTheRest()
+    {
+        var temp = NewTempDir();
+        var bare = Path.Combine(temp, "remote.git");
+        var seed = Path.Combine(temp, "seed");
+
+        await RunGit(temp, "init", "--bare", "-b", "main", bare);
+        await RunGit(temp, "-c", "init.defaultBranch=main", "init", seed);
+
+        // Two sibling modules — the second one is what must NOT appear in the first one's worktree.
+        Directory.CreateDirectory(Path.Combine(seed, "moduleA"));
+        Directory.CreateDirectory(Path.Combine(seed, "moduleB"));
+        await File.WriteAllTextAsync(Path.Combine(seed, "moduleA", "a.cs"), "// A v1\n");
+        await File.WriteAllTextAsync(Path.Combine(seed, "moduleB", "b.cs"), "// B v1\n");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Test", "commit", "-m", "c1");
+        var sha1 = (await RunGit(seed, "rev-parse", "HEAD")).Trim();
+
+        await File.WriteAllTextAsync(Path.Combine(seed, "moduleA", "a.cs"), "// A v2\n");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Test", "commit", "-m", "c2");
+        var sha2 = (await RunGit(seed, "rev-parse", "HEAD")).Trim();
+
+        await RunGit(seed, "remote", "add", "origin", bare);
+        await RunGit(seed, "push", "origin", "main");
+
+        // 1. SPARSE — moduleA at c1, and moduleB must be absent from that worktree.
+        var a1 = await Replica.Materialize("demo/repo", bare, sha1, "moduleA")
+            .Timeout(90.Seconds()).ToTask();
+
+        File.Exists(Path.Combine(a1.AbsolutePath, "a.cs")).Should().BeTrue(
+            "the requested module must be materialised");
+        (await File.ReadAllTextAsync(Path.Combine(a1.AbsolutePath, "a.cs"))).Should().Contain("A v1",
+            "the worktree is pinned to the commit that was asked for, not to the branch head");
+
+        var worktreeRoot = Replica.WorktreePath("demo/repo", sha1, "moduleA");
+        Directory.Exists(Path.Combine(worktreeRoot, "moduleB")).Should().BeFalse(
+            "a sibling module must NOT be checked out — without cone sparse-checkout every module's "
+            + "worktree would materialise the entire repository");
+
+        // 2. IDEMPOTENT — a sentinel proves the second call did not rebuild the tree.
+        var sentinel = Path.Combine(worktreeRoot, "sentinel.txt");
+        await File.WriteAllTextAsync(sentinel, "still here");
+
+        var a1Again = await Replica.Materialize("demo/repo", bare, sha1, "moduleA")
+            .Timeout(90.Seconds()).ToTask();
+
+        a1Again.AbsolutePath.Should().Be(a1.AbsolutePath);
+        File.Exists(sentinel).Should().BeTrue(
+            "re-materialising a commit already on disk must be a no-op — if it re-checked-out, an "
+            + "unchanged commit would cost work, which is exactly what this replica exists to avoid");
+
+        // 3. A DIFFERENT COMMIT gets its own worktree, with that commit's content.
+        var a2 = await Replica.Materialize("demo/repo", bare, sha2, "moduleA")
+            .Timeout(90.Seconds()).ToTask();
+
+        a2.AbsolutePath.Should().NotBe(a1.AbsolutePath);
+        (await File.ReadAllTextAsync(Path.Combine(a2.AbsolutePath, "a.cs"))).Should().Contain("A v2");
+
+        // 4. PRUNE keeps only what it is told to keep.
+        var removed = await Replica.Prune("demo/repo", [sha2]).Timeout(90.Seconds()).ToTask();
+
+        removed.Should().Be(1, "exactly the superseded commit's worktree is removed");
+        Directory.Exists(a1.AbsolutePath).Should().BeFalse("the pruned worktree is gone from disk");
+        Directory.Exists(a2.AbsolutePath).Should().BeTrue("the kept commit survives");
+
+        Output.WriteLine($"replica root: {replicaRoot}");
+        Output.WriteLine($"c1 {sha1[..8]} → {a1.AbsolutePath}");
+        Output.WriteLine($"c2 {sha2[..8]} → {a2.AbsolutePath}");
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-replica-seed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Runs git and returns stdout — the SHA-reading calls need the output, not just success.</summary>
+    private async Task<string> RunGit(string dir, params string[] args)
+    {
+        var r = await Git.Run(dir, args).Timeout(30.Seconds()).ToTask();
+        Assert.True(r.Ok, $"git {string.Join(' ', args)} failed (exit {r.ExitCode}): {r.Message}");
+        return r.StdOut;
+    }
+}


### PR DESCRIPTION
First slice of the git-keyed compilation design. **Nothing consumes it yet**, so it cannot regress a compile — this lands the load-bearing half (git mechanics, sparseness, idempotence, lifecycle) with its properties asserted.

## What it does

One permanent clone per synced repo, plus a **sparse worktree per (commit, module)**. So "give me this module's sources at this commit" is answerable from disk, and an unchanged commit costs nothing.

## Why it matters beyond speed

Compilation reads every source **through the mesh**, and each touched path costs synchronisation state: a recompile of a trivial NodeType mints **~22 `sync/` sub-hubs and retains ~9 MB**, of which only ~9% is the type itself — the rest is the compile's own bookkeeping nodes and the cache's mirrors of them (#1324).

Reading sources from a commit-pinned checkout takes those reads out of the mesh, and the commit **is** the invalidation key. Unchanged commit ⇒ no work ⇒ the leak's driver shrinks before the retention itself is fixed. It also dissolves the mount-relative `@@`-include class fixed in #1251, because on disk those are ordinary relative paths.

## Built on what exists

`GitCli` (blocking process leaves bridged through `IIoPool`), `GitCredentials`' `GW_TOKEN` credential helper (the secret never reaches argv), and the `GitWorkingTreeService` patterns. Reactive end-to-end, cold observables, no `async`/`await` on the surface, no static state.

## Three properties, each asserted

Against a **local bare repo with real git and no network** (`GitModuleReplicaTest`, **802 ms**):

- **Sparse** — a module's worktree holds that module and **not** its siblings. Created `--no-checkout`, narrowed with cone sparse-checkout, then checked out; the order is the point. The object store is ~758 MB for MeshWeaver while node content is single-digit MB, so full-tree worktrees per module would not fit the volume.
- **Idempotent** — re-asking for a commit already on disk is a no-op, proven by a **sentinel file** inside the worktree that a re-checkout would have destroyed. The whole design rests on this being free.
- **Pruned by an explicit owner** — superseded commits go when the caller says so. Deliberate: a retention rule with no owner is how the in-memory version of this problem arose, where the stream cache's idle release is correct code behind a predicate that never becomes true.

## Deployment note

⚠️ `RootDirectory` must point at the **persistent volume**. The portal mounts 16 GB at `/data` (11 GB free, already holding `assembly-cache` and `nuget-cache`) and this belongs beside them — the source key and the assembly it produces should share a lifetime. On temp it would re-clone every restart, which is exactly the cost it exists to remove. One values line, and it is inert until then.

## Not in this PR

- Wiring the compiler to read from the replica (the next slice, with before/after numbers for bake time, hubs minted, and mesh reads).
- Chunked compilation into shared Roslyn workspaces.
- Distributed orchestration across peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)