### PR TITLE
fix: register EventSubscription so deferred invites actually fire (#1392)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-invitations-take-effect-the-moment-someone-signs-up.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-invitations-take-effect-the-moment-someone-signs-up.md
@@ -1,0 +1,30 @@
+---
+Name: Invitations take effect the moment someone signs up
+Category: Fix
+Description: An invitation to a space or a group could sit dormant until the portal was next restarted, so a newly signed-up colleague saw nothing. Deferred invitations now act the instant the account appears.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Invitations take effect the moment someone signs up
+
+When you invite someone who does not have an account yet, the platform stores the invitation and
+waits. The instant that person signs up, the stored invitation is supposed to act: it grants them
+the role you chose, adds them to the group you picked, and pins the space to their dashboard.
+
+That waiting step had stopped working. The invitation was written correctly and kept safely, but
+the background service that watches for the new account could no longer read its own list of
+outstanding invitations — so as far as it was concerned there were none, and nothing ever fired.
+Nothing failed and nothing was logged as an error; the invitation simply sat there.
+
+The effect depended on timing, which is why it looked so inconsistent. A restart of the portal did
+re-examine every outstanding invitation and catch up, so most invitations eventually landed and
+looked fine in hindsight. But anyone who signed up *between* restarts got no access at all until
+the next one — they arrived at a portal where the space they had been invited to was not there.
+Invitations that wait for something other than a sign-up — a scheduled time, or a piece of work
+finishing — were never caught up by a restart and so never ran at all.
+
+Both are fixed. Outstanding invitations are readable again, and they act immediately: sign-up,
+scheduled time, and completed-work triggers all fire while the portal is running. Nothing about who
+gets what has changed — the same role, on the same space or group, arrives when it should instead
+of hours later.

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -97,8 +97,16 @@ public sealed class EventSubscriptionRunner(
                 $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content"))
             .Subscribe(nodes =>
             {
+                // 🚨 ReadSubscription, NEVER `n.Content as EventSubscription` (issue #1392). This
+                // list IS the candidate set for every firing path — change feed, trigger-node
+                // watch, Timer, NodeStatus — so a soft-cast that yields null does not degrade the
+                // runner, it SILENCES it: an empty pending set means nothing can ever fire, with
+                // no error anywhere. That is exactly what ran in production, because the mesh hub
+                // resolving this query had no EventSubscription registration (now fixed in
+                // WithGraphTypes) and handed back untyped JsonElements. The sibling cold-start
+                // path below already read it tolerantly; the two must agree.
                 var list = (nodes ?? [])
-                    .Select(n => n.Content as EventSubscription)
+                    .Select(ReadSubscription)
                     .Where(s => s is { Status: EventSubscriptionStatus.Pending })
                     .Select(s => s!)
                     .ToList();
@@ -274,32 +282,16 @@ public sealed class EventSubscriptionRunner(
     }
 
     /// <summary>
-    /// Deserializes a node's content to <see cref="EventSubscription"/>, tolerating both a typed instance
-    /// (the workspace <c>GetQuery</c> path) and a raw <see cref="System.Text.Json.JsonElement"/> (the
-    /// storage <c>IMeshService.Query</c> path the cold-start seed reads from). Returns null otherwise.
+    /// Reads a node's content as an <see cref="EventSubscription"/> through the sanctioned
+    /// bad-data-tolerant accessor: a typed instance (the workspace <c>GetQuery</c> path) passes
+    /// through, a raw <c>JsonElement</c>/<c>JsonNode</c> (the storage <c>IMeshService.Query</c>
+    /// path the cold-start seed reads from, and the degraded GetQuery shape) is deserialized, and
+    /// anything unconvertible returns null — logged loud with the node path, never swallowed.
+    /// EVERY read of a subscription node goes through here; a bare <c>as</c> is the trap-door that
+    /// emptied the pending set in production (#1392).
     /// </summary>
-    private EventSubscription? ReadSubscription(MeshNode node) => node.Content switch
-    {
-        EventSubscription es => es,
-        System.Text.Json.JsonElement je => TryDeserializeSubscription(je),
-        _ => null,
-    };
-
-    private EventSubscription? TryDeserializeSubscription(System.Text.Json.JsonElement je)
-    {
-        try
-        {
-            // Deserialize straight from the JsonElement — no GetRawText() string round-trip / re-parse.
-            return System.Text.Json.JsonSerializer.Deserialize<EventSubscription>(je, hub.JsonSerializerOptions);
-        }
-        catch (System.Text.Json.JsonException ex)
-        {
-            // A malformed subscription node must not abort the whole cold-start seed — skip it, but SURFACE
-            // it (never a silent swallow) so a genuine data problem is visible.
-            logger?.LogWarning(ex, "Skipping malformed EventSubscription content in the cold-start reconcile");
-            return null;
-        }
-    }
+    private EventSubscription? ReadSubscription(MeshNode node)
+        => node.ContentAs<EventSubscription>(hub.JsonSerializerOptions, logger);
 
     private bool Matches(EventSubscription subscription, MeshNode node)
     {
@@ -459,7 +451,10 @@ public sealed class EventSubscriptionRunner(
             {
                 foreach (var node in nodes ?? [])
                 {
-                    if (node.Content is not ScheduledAction legacy)
+                    // Same rule as ReadSubscription: the tolerant accessor, never `is not X` — the
+                    // legacy node is read on a hub that never writes one, so a soft-cast would
+                    // silently migrate nothing and strand the in-flight invite it exists to save.
+                    if (node.ContentAs<ScheduledAction>(hub.JsonSerializerOptions, logger) is not { } legacy)
                         continue;
                     lock (gate)
                         if (!migratedLegacyIds.Add(legacy.Id))

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -478,6 +478,30 @@ public static class MeshNodeExtensions
         typeRegistry.WithType(typeof(Email), nameof(Email));
         typeRegistry.WithType(typeof(EmailDirection), nameof(EmailDirection));
         typeRegistry.WithType(typeof(EmailStatus), nameof(EmailStatus));
+        // EventSubscription — the content of the built-in "EventSubscription" NodeType and the
+        // durable record behind every deferred reaction (email-invite → grant on sign-up, a timed
+        // action, a delegated sub-thread reaching a resting state). It was the ONE content type
+        // whose reader is a BACKGROUND SERVICE rather than a view, which is why the omission read
+        // as silence instead of an empty render: EventSubscriptionRunner tracks its pending set
+        // through workspace.GetQuery on the mesh hub, and that hub — which never WRITES an
+        // EventSubscription on a cold boot — could not resolve the $type, so every node degraded
+        // to an untyped JsonElement and the pending set came back EMPTY. With no pending set the
+        // change-feed, trigger-node-watch, Timer and NodeStatus firing paths have no candidates at
+        // all, and an invited user who signs up gets nothing until the next restart's cold-start
+        // reconcile (Timer/NodeStatus subscriptions, which that reconcile does not cover, never
+        // fire). Observed on every prod boot from 2026-07 (issue #1392): a dozen Admin/
+        // EventSubscription grant nodes logging "stayed an untyped JsonElement".
+        typeRegistry.WithType(typeof(EventSubscription), nameof(EventSubscription));
+        typeRegistry.WithType(typeof(EventSubscriptionStatus), nameof(EventSubscriptionStatus));
+        typeRegistry.WithType(typeof(EventTriggerType), nameof(EventTriggerType));
+        typeRegistry.WithType(typeof(EventContinuationType), nameof(EventContinuationType));
+        // ScheduledAction — the LEGACY predecessor EventSubscription supersedes. Still a built-in
+        // NodeType, and EventSubscriptionRunner's startup migration reads it the same way, so it
+        // needs the same registration: unresolvable, the migration silently folds nothing and an
+        // in-flight legacy invite stays stranded forever.
+        typeRegistry.WithType(typeof(ScheduledAction), nameof(ScheduledAction));
+        typeRegistry.WithType(typeof(ScheduledActionStatus), nameof(ScheduledActionStatus));
+        typeRegistry.WithType(typeof(ScheduledActionKind), nameof(ScheduledActionKind));
         typeRegistry.WithType(typeof(ApiToken), nameof(ApiToken));
         typeRegistry.WithType(typeof(MeshDataSourceConfiguration), nameof(MeshDataSourceConfiguration));
         typeRegistry.WithType(typeof(PartitionDefinition), nameof(PartitionDefinition));

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionTypeRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionTypeRegistrationTest.cs
@@ -1,0 +1,157 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Domain;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins that <see cref="EventSubscription"/> — the content of the built-in <c>EventSubscription</c>
+/// NodeType — is resolvable on the hub that READS it, and that
+/// <see cref="EventSubscriptionRunner"/> keeps working when it is not.
+///
+/// <para><b>The production defect (issue #1392).</b> Every boot of the <c>memex</c> portal logged a
+/// dozen lines of <c>"MeshNodeStreamCache.GetQuery: Content for
+/// Admin/EventSubscription/grant_… stayed an untyped JsonElement after deserialization (TypeRegistry
+/// lacks the $type discriminator)"</c>. The stored JSON was perfectly well-formed and carried a
+/// correct <c>"$type":"EventSubscription"</c> — the reading hub simply had no registration for it,
+/// because <c>WithGraphTypes</c> listed every OTHER built-in content type and not this one.</para>
+///
+/// <para><b>Why it was not merely log noise.</b> The consumer is a background service, so the
+/// failure had no visible surface at all. <see cref="EventSubscriptionRunner"/> tracks its pending
+/// set through <c>workspace.GetQuery</c> and folded each node with
+/// <c>n.Content as EventSubscription</c> — a soft-cast that yields a silent null on the degraded
+/// shape. The pending set therefore came back <b>empty</b>, and that set is the candidate source for
+/// EVERY firing path: the change feed, the change-feed-independent trigger-node watch,
+/// <c>ScheduleTimer</c> and <c>WatchNodeStatus</c>. So a durable access grant existed in storage and
+/// did nothing. Only the cold-start reconcile survived (it read the node tolerantly), which is why
+/// most prod subscriptions eventually show <c>Fired</c> — after a restart. Between restarts an
+/// invited user who signed up got no access, and Timer / NodeStatus subscriptions — which the
+/// cold-start path does not cover at all — could never fire.</para>
+///
+/// <para>Two halves, both pinned below: the <b>registration</b> (the root cause — the type must
+/// resolve where the read happens) and the <b>tolerant read</b> (the runner must not go silent on a
+/// content shape it can still understand).</para>
+/// </summary>
+public class EventSubscriptionTypeRegistrationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "GrantSpace";
+    private const string InviteeEmail = "invitee@acme.com";
+    private const string InviteeId = "invitee";
+
+    /// <summary>
+    /// A verbatim copy of a real degraded payload from the production log (2026-08-13,
+    /// <c>Admin/EventSubscription/grant_rbuergi_systemorph_com_uwdeepfield</c>), with the identity
+    /// swapped for the test's. This is the exact JSON the storage layer hands the read path.
+    /// </summary>
+    private static string StoredJson(string id) =>
+        $$"""
+        {"$type":"EventSubscription","id":"{{id}}","role":"Editor","createdAt":"2026-07-11T09:36:45.1517307+00:00",
+         "createdBy":"rsalzmann","matchField":"email","matchValue":"{{InviteeEmail}}","targetPath":"{{Space}}",
+         "restingValues":[],"triggerNodeType":"User"}
+        """;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Grant Space", NodeType = "Space" });
+
+    /// <summary>
+    /// The root cause, at the seam that failed. A hub carrying exactly the mesh hub's graph
+    /// registration — and which has never itself WRITTEN an EventSubscription, so nothing was
+    /// auto-registered on it, the cold-boot condition — must resolve the stored payload to a typed
+    /// instance. <c>MeshNodeStreamCache.DeserializeContent</c> makes precisely this call
+    /// (<c>JsonSerializer.Deserialize&lt;object&gt;</c> through the reader's options) and warns
+    /// "stayed an untyped JsonElement" when it degrades.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void AHubThatOnlyReadsEventSubscriptions_ResolvesTheStoredDiscriminator()
+    {
+        var reader = Mesh.GetHostedHub(
+            new Address("client", Guid.NewGuid().ToString("N")[..12]),
+            c => c.AddData().WithGraphTypes());
+
+        reader.ServiceProvider.GetRequiredService<ITypeRegistry>()
+            .TryGetType(nameof(EventSubscription), out var definition).Should().BeTrue(
+                "EventSubscription is the content type of a built-in NodeType, so WithGraphTypes must "
+                + "register it like every other built-in content type — its absence is what degraded a "
+                + "dozen Admin/EventSubscription grant nodes on every production boot (#1392)");
+        definition!.Type.Should().Be(typeof(EventSubscription));
+
+        var content = JsonSerializer.Deserialize<object>(StoredJson("grant-read"), reader.JsonSerializerOptions);
+
+        content.Should().NotBeOfType<JsonElement>(
+            "a payload whose $type the reader cannot resolve DEGRADES to a raw JsonElement instead of "
+            + "throwing — the silent trap-door every downstream 'Content is X' then falls through");
+        var subscription = content.Should().BeOfType<EventSubscription>().Subject;
+        subscription.TargetPath.Should().Be(Space);
+        subscription.Role.Should().Be("Editor");
+        subscription.Status.Should().Be(EventSubscriptionStatus.Pending,
+            "an absent status field means Pending — the state the runner's pending-set filter selects on");
+    }
+
+    /// <summary>
+    /// The consumer half, end to end: a grant stored in the shape the read path can hand back must
+    /// actually GRANT. The subscription node is written with raw JSON content — never a typed CLR
+    /// instance — so nothing auto-registers the type along the write path and the runner reads
+    /// exactly what production storage holds. The runner is started BEFORE the triggering write, so
+    /// this exercises the LIVE paths (change feed + trigger-node watch) that draw their candidates
+    /// from the pending set, not the cold-start reconcile that masked the defect in production.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AGrantStoredAsRawJson_LandsTheAccessAssignment()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var runnerLogger = Mesh.ServiceProvider
+            .GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>();
+
+        const string subscriptionId = "grant-raw-json";
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(subscriptionId, EventSubscriptionNodeType.Namespace)
+            {
+                NodeType = EventSubscriptionNodeType.NodeType,
+                Name = "NodeChange → GrantSpaceAccess",
+                Content = JsonSerializer.Deserialize<JsonElement>(StoredJson(subscriptionId)),
+            }).Should().Emit();
+
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService, runnerLogger);
+        await runner.StartAsync(default);
+
+        // The invitee onboards — the trigger the subscription is waiting for.
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Invitee",
+                Content = new User { Email = InviteeEmail, FullName = "Invitee" },
+            }).Should().Emit();
+
+        // Wait for the subscription to reach a TERMINAL state FIRST — race-free, because that node
+        // already exists so the stream waits for its update, whereas opening a stream on a path that
+        // does not exist yet fails fast rather than waiting. A Failed status surfaces its error here.
+        // Before the fix this is where the test stops: the pending set folds the raw-JSON node to
+        // null, no firing path ever has a candidate, and the subscription stays Pending forever.
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscriptionId))
+            .Select(n => n.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        // The grant itself landed: {space}/_Access/{user}_Access carries the Editor role.
+        var granted = await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{InviteeId}_Access")
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+        Assert.NotNull(granted);
+    }
+}


### PR DESCRIPTION
Fixes #1392.

## The impact — grants really were inert

The issue asked to establish this before fixing, so: **yes, and worse than the log suggests.**

`EventSubscriptionRunner` is the ONE background service behind every deferred reaction. It tracks its pending set through `hub.GetWorkspace().GetQuery(...)` on the mesh hub and folded each node with:

```csharp
.Select(n => n.Content as EventSubscription)
.Where(s => s is { Status: EventSubscriptionStatus.Pending })
```

That `as` is the trap-door. On the degraded shape it yields a silent null, so **the pending set came back empty** — and `pending` is the candidate source for *every* firing path:

| Path | Fed from `pending`? | Effect while degraded |
|---|---|---|
| `OnChange` (change feed) | yes | never fires |
| `WatchTriggerNodeType` (change-feed-independent synced query) | yes | never even established |
| `ScheduleTimer` (Timer triggers) | yes | **never fires, ever** |
| `WatchNodeStatus` (NodeStatus / delegation backstop) | yes | **never fires, ever** |
| `startupSub` (cold-start reconcile) | **no** — reads via `ReadSubscription`, which tolerated `JsonElement` | the only thing still working |

So the practical impact is timing-shaped, which is why it looked fine in hindsight:

- A restart re-examines every outstanding subscription and catches up — hence most prod nodes read `Fired`.
- **Between restarts, a user who signs up gets nothing.** Their invite lands only at the next roll.
- **Timer and NodeStatus subscriptions have no cold-start path at all** (the reconcile covers only `NodeChange`/`Created`), so those never fired on this portal.
- The same trap-door in `MigrateLegacyScheduledActions` means legacy `Admin/ScheduledAction` nodes silently migrate nothing.

Prod evidence (Loki, `namespace=memex`, last 24 h — read-only, nothing mutated): 13 distinct `Admin/EventSubscription/grant_*` nodes degrade on **every** boot, across `UWDeepfield`, `ClientPartnerRe`, `rsalzmann/Games`, `rsalzmann/Games/Factory`. Two further lines confirm the diagnosis directly:

```
Unregistered type MeshWeaver.Mesh.EventSubscription (de)serialised on hub mesh/6-UsTH05JkWf3l906asShw
  with auto short-name $type='EventSubscription': the hub's TypeRegistry lacks it …
Received '$type':'EventSubscription' which is NOT registered in this (receiving) hub …
```

`Admin/EventSubscription/grant_robert_salzmann_gmail_com_uwdeepfield` (created 2026-07-14, role Editor on `UWDeepfield`) still carries **no `status` field** — i.e. `Pending` — a month later. Whether that particular invitee has signed up is not visible under RLS, so I am not claiming that one specific grant is provably stranded; what *is* established is that the mechanism which should fire it was dead between every pair of restarts.

## The fix, in the rule's priority order

**1. Register the type where the read happens** (the root cause). `EventSubscription` — the content of a built-in NodeType — joins `WithGraphTypes` alongside its three enums, exactly as `Email` did on 2026-08-12 for the same class of omission. The legacy `ScheduledAction` + enums go with it: the same runner reads it through the same seam, and unregistered its migration is a silent no-op that strands the in-flight invite the migration exists to save.

Deliberately **not** `.ContentAs<T>()`-first: that would have silenced the warning and left the registration gap, and the warning is currently the only thing making this visible.

**2. Make the two read paths agree** (the half that turned a warning into inert grants). The pending-set path now uses the same `ReadSubscription` its sibling cold-start path already used, and `ReadSubscription` goes through `node.ContentAs<EventSubscription>(hub.JsonSerializerOptions, logger)` — which also replaces a hand-rolled `JsonSerializer.Deserialize` + `catch (JsonException)`, and logs the node path when content is genuinely unconvertible instead of dropping it. Same treatment for the `ScheduledAction` read.

## Verification — fail-before, for the stated reason

Both tests were run against the pre-fix tree (`git diff > patch`, revert `src/`, rebuild, run, re-apply — no `git stash`). They fail, and the failures are exactly the mechanism, not an incidental error:

```
AHubThatOnlyReadsEventSubscriptions_ResolvesTheStoredDiscriminator
  Expected value to be true because EventSubscription is the content type of a built-in
  NodeType … but found False.

AGrantStoredAsRawJson_LandsTheAccessAssignment
  Content of 'Admin/EventSubscription/grant-raw-json' carries the polymorphic discriminator
  '$type': 'EventSubscription', which is not a registered content type for the built-in
  NodeType 'EventSubscription' …
```

Both pass after. The first pins the seam that failed — a hub carrying the mesh hub's graph registration, which has never itself *written* an EventSubscription (the cold-boot condition), must resolve a **verbatim copy of the real degraded prod payload** to a typed instance. The second is end-to-end: a grant written as raw JSON, the runner started *before* the trigger so only the live paths can satisfy it, and the `AccessAssignment` must land.

- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror --no-incremental` → 0 warnings, 0 errors
- `MeshWeaver.Graph.Test` → **1096 passed, 0 failed**
- `MeshWeaver.Documentation.Test` → 20 passed (What's New entry)

## Out of scope, noted

`WithGraphTypes` is still missing ~20 other built-in NodeType content types (`ActivityLog`, `Invitation`, `HomeConfig`, `NotificationRule`, `TeamsConversation`, …). None of their production consumers casts through a degrading read the way this runner did, so none is a live defect today — but the omission is systemic and deserves its own sweep rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)