### PR TITLE
Activity log: roll severity and message count into counters (1/3)

### DIFF
--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
@@ -219,7 +219,7 @@ internal static class ContentIndexingActivity
                 // (project_baddata_contentas_pattern.)
                 var log = node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger);
                 if (log is null) return node;
-                return node with { Content = log with { Messages = log.Messages.AddRange(messages) } };
+                return node with { Content = log.Append(messages) };
             }).Subscribe(_ => { }, ex => logger?.LogWarning(ex, "Indexing activity log append failed for {Path}", activityPath));
         }
     }
@@ -241,13 +241,13 @@ internal static class ContentIndexingActivity
                 // indexing-activity timeout). See project_baddata_contentas_pattern.
                 var log = node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger);
                 if (log is null) return node;
-                var messages = string.IsNullOrEmpty(finalMessage)
-                    ? log.Messages
-                    : log.Messages.Add(new LogMessage(finalMessage,
+                var withFinal = string.IsNullOrEmpty(finalMessage)
+                    ? log
+                    : log.Append(new LogMessage(finalMessage,
                         status == ActivityStatus.Failed ? LogLevel.Error : LogLevel.Information));
                 return node with
                 {
-                    Content = log with { Messages = messages, Status = status, End = DateTime.UtcNow, RequestedStatus = null }
+                    Content = withFinal with { Status = status, End = DateTime.UtcNow, RequestedStatus = null }
                 };
             }).Select(_ => Unit.Default);
         }

--- a/src/MeshWeaver.Data.Contract/ActivityLog.cs
+++ b/src/MeshWeaver.Data.Contract/ActivityLog.cs
@@ -25,6 +25,25 @@ public record ActivityLog(string Category)
     public string Id { get; init; } = Guid.NewGuid().AsString();
     /// <summary>The log messages accumulated by this activity, in order.</summary>
     public ImmutableList<LogMessage> Messages { get; init; } = ImmutableList<LogMessage>.Empty;
+
+    /// <summary>
+    /// How many messages this activity has appended in total — <see cref="Messages"/> plus anything
+    /// no longer held there. Maintained incrementally by <see cref="Append(IReadOnlyList{LogMessage})"/>.
+    /// <para>🚨 Read it through <see cref="TotalMessageCount"/>, never directly: a log persisted before
+    /// this field existed carries 0 while <see cref="Messages"/> is non-empty.</para>
+    /// </summary>
+    public int MessageCount { get; init; }
+
+    /// <summary>
+    /// The highest <see cref="LogLevel"/> ever appended to this activity — an incremental roll-up so the
+    /// terminal status is a <b>counter</b>, not a scan of the message list.
+    /// <para>🚨 <see cref="LogLevel.None"/> is never rolled up (it is numerically the largest level but
+    /// means "no logging", not "worse than Critical"). The default is <see cref="LogLevel.Trace"/>, which
+    /// is the identity element for the max — so a log persisted before this field existed rolls up to
+    /// exactly what a scan of its <see cref="Messages"/> yields.</para>
+    /// </summary>
+    public LogLevel MaxSeverity { get; init; } = LogLevel.Trace;
+
     /// <summary>The current status of the activity.</summary>
     public ActivityStatus Status { get; init; }
 
@@ -71,15 +90,51 @@ public record ActivityLog(string Category)
     public string? PrimaryNodePath => HubPath;
 
     /// <summary>
+    /// How many messages this activity has recorded, counting any no longer held in
+    /// <see cref="Messages"/>. Back-compatible with logs persisted before <see cref="MessageCount"/>
+    /// existed (those carry 0, so the in-list count wins).
+    /// </summary>
+    public int TotalMessageCount => Math.Max(MessageCount, Messages.Count);
+
+    /// <summary>
+    /// The ONE way to add messages to an activity log: appends them to <see cref="Messages"/> and rolls
+    /// <see cref="MessageCount"/> and <see cref="MaxSeverity"/> forward in the same step.
+    /// <para>🚨 Never write <c>Messages = Messages.Add(…)</c> directly — the roll-ups are what make the
+    /// terminal status independent of how many messages the list still holds.</para>
+    /// </summary>
+    /// <param name="messages">The messages to append, in order. An empty list is a no-op.</param>
+    /// <returns>The activity log with the messages appended and the roll-ups advanced.</returns>
+    public ActivityLog Append(IReadOnlyList<LogMessage> messages)
+    {
+        if (messages.Count == 0) return this;
+        var severity = MaxSeverity;
+        foreach (var m in messages)
+            if (m.LogLevel > severity && m.LogLevel != LogLevel.None)
+                severity = m.LogLevel;
+        return this with
+        {
+            Messages = Messages.AddRange(messages),
+            MessageCount = TotalMessageCount + messages.Count,
+            MaxSeverity = severity,
+        };
+    }
+
+    /// <summary>
+    /// Convenience overload of <see cref="Append(IReadOnlyList{LogMessage})"/> for a single message.
+    /// </summary>
+    /// <param name="message">The message to append.</param>
+    /// <returns>The activity log with the message appended and the roll-ups advanced.</returns>
+    public ActivityLog Append(LogMessage message) => Append([message]);
+
+    /// <summary>
     /// Returns a copy of this activity marked <see cref="ActivityStatus.Failed"/> with the
     /// given error appended as an error message and <see cref="End"/> set to now.
     /// </summary>
     /// <param name="error">The error message to record.</param>
     /// <returns>The failed activity log.</returns>
     public ActivityLog Fail(string error) =>
-        this with
+        Append(new LogMessage(error, LogLevel.Error)) with
         {
-            Messages = Messages.Add(new LogMessage(error, LogLevel.Error)),
             Status = ActivityStatus.Failed,
             End = DateTime.UtcNow,
         };
@@ -101,6 +156,15 @@ public record ActivityLog(string Category)
             Version = version
         };
 
+    /// <summary>
+    /// The status implied by what has been logged: the worse of the sub-activities' statuses and the
+    /// severity roll-up.
+    /// <para>🚨 Derived from <see cref="MaxSeverity"/> — a counter — <b>not</b> from a scan of
+    /// <see cref="Messages"/>, so it stays correct (and O(1)) when the list is a bounded window rather
+    /// than the whole transcript. The list is still folded in so a log written before
+    /// <see cref="MaxSeverity"/> existed, or one mutated outside <see cref="Append(IReadOnlyList{LogMessage})"/>,
+    /// yields exactly the pre-roll-up answer.</para>
+    /// </summary>
     private ActivityStatus GetFinalStatus()
     {
         var subActivityStatus = SubActivities
@@ -108,11 +172,25 @@ public record ActivityLog(string Category)
             .DefaultIfEmpty(ActivityStatus.Succeeded)
             .Max();
 
-        var maxLevel = Messages.Select(m => m.LogLevel).DefaultIfEmpty(LogLevel.Information).Max();
+        // The roll-up joins the fold as one more element. Its default (Trace) and the old
+        // empty-list default (Information) both land in the `_ => Succeeded` arm below, so seeding
+        // with the roll-up instead of Information cannot change the answer for a log that never
+        // recorded a Warning or worse.
+        // 🚨 LogLevel.None is excluded from BOTH sides of the fold. It is numerically above Critical
+        // but means "no logging", so a single None entry used to become the list's Max and drop the
+        // whole activity into the `_ => Succeeded` arm — swallowing a real Error logged beside it.
+        // Beyond being wrong, agreement here is what makes the message window safe: the status must
+        // come out the same whether a message is still in Messages or has been flushed into
+        // MaxSeverity, and only one of those two paths can see a None entry.
+        var maxLevel = Messages.Select(m => m.LogLevel)
+            .Append(MaxSeverity)
+            .Where(l => l != LogLevel.None)
+            .DefaultIfEmpty(LogLevel.Information)
+            .Max();
         var mapToStatus = maxLevel switch
         {
             LogLevel.Critical or LogLevel.Error => ActivityStatus.Failed,
-            LogLevel.Warning => ActivityStatus.Warning, 
+            LogLevel.Warning => ActivityStatus.Warning,
             _ => ActivityStatus.Succeeded
         };
 
@@ -122,10 +200,15 @@ public record ActivityLog(string Category)
     }
 
     /// <summary>
-    /// Returns true if this activity's own messages contain at least one error.
+    /// Returns true if this activity has recorded at least one error (or critical) message.
+    /// Answered from the <see cref="MaxSeverity"/> roll-up so it does not depend on how much of the
+    /// transcript <see cref="Messages"/> still holds; the list is folded in for logs written before
+    /// the roll-up existed.
     /// </summary>
     /// <returns>True if an error message is present; otherwise false.</returns>
-    public bool HasErrors() => Messages.Any(m => m.LogLevel == LogLevel.Error);
+    public bool HasErrors() =>
+        MaxSeverity is LogLevel.Error or LogLevel.Critical
+        || Messages.Any(m => m.LogLevel == LogLevel.Error);
 
     /// <summary>
     /// This log plus, recursively, every <see cref="SubActivities"/> entry — flattened so a

--- a/src/MeshWeaver.Data/Activity.cs
+++ b/src/MeshWeaver.Data/Activity.cs
@@ -93,7 +93,7 @@ public class Activity : ILogger, IDisposable
     /// <param name="logLevel">Severity of the message.</param>
     /// <param name="scopes">Optional structured scopes attached to the message.</param>
     public void LogMessage(string message, LogLevel logLevel, IReadOnlyCollection<KeyValuePair<string, object>>? scopes = null)
-        => MutateLog(log => log with { Messages = log.Messages.Add(new LogMessage(message, logLevel) { Scopes = scopes }) });
+        => MutateLog(log => log.Append(new LogMessage(message, logLevel) { Scopes = scopes }));
 
     /// <summary>
     /// Reactive snapshot of the current <see cref="ActivityLog"/>, read on the activity hub's
@@ -126,7 +126,7 @@ public class Activity : ILogger, IDisposable
     /// <param name="exception">Optional exception associated with the entry.</param>
     /// <param name="formatter">Function that renders <paramref name="state"/> and <paramref name="exception"/> to text.</param>
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-        => MutateLog(log => log with { Messages = log.Messages.Add(new LogMessage(formatter.Invoke(state, exception), logLevel)) });
+        => MutateLog(log => log.Append(new LogMessage(formatter.Invoke(state, exception), logLevel)));
 
     /// <summary>Returns whether the given log level is enabled on the underlying logger.</summary>
     /// <param name="logLevel">Level to test.</param>

--- a/src/MeshWeaver.Data/WorkspaceOperations.cs
+++ b/src/MeshWeaver.Data/WorkspaceOperations.cs
@@ -186,7 +186,7 @@ public static class WorkspaceOperations
 
     /// <summary>Finishes a data-update log: status is rolled up from the message levels.</summary>
     private static ActivityLog Finish(IMessageHub hub, ImmutableList<LogMessage> messages) =>
-        new ActivityLog(ActivityCategory.DataUpdate) { Messages = messages }
+        new ActivityLog(ActivityCategory.DataUpdate).Append(messages)
             .Finish((int)hub.Version, null);
 
     // Maps an instance to its routing tuple. An EntityDeltaUpdate (a minimal-bytes

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-activity-status-from-counters.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-activity-status-from-counters.md
@@ -1,0 +1,15 @@
+---
+Name: Activity status no longer misses errors
+Category: Fix
+Description: An activity's final status is now rolled up from counters as it runs, so an error can no longer be swallowed by a silenced log entry.
+Icon: CheckmarkCircle
+Order: -20260813
+---
+
+# What's New — 13 August 2026
+
+## Activity status no longer misses errors
+
+An activity's final status — Succeeded, Warning, Failed — was worked out at the end by scanning its whole message list for the worst severity. That let a single entry logged at the "None" level, which means *no logging* rather than *worse than critical*, come out as the highest severity in the list and drop the entire activity into Succeeded, hiding real errors logged beside it.
+
+Severity is now rolled up as each message is recorded, so the outcome is decided by a counter rather than by a scan, and a silenced entry can no longer outrank a genuine error. "Has errors" now also reports critical-level messages, matching the error list that has always included them.

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -256,7 +256,7 @@ public static class ActivityRunner
                 // content can arrive as a degraded JsonElement — `is ActivityLog` would silently
                 // no-op and the progress line would never land (same read as the cancel watch).
                 if (node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger) is not { } log) return node;
-                return node with { Content = log with { Messages = log.Messages.Add(new LogMessage(message, level)) } };
+                return node with { Content = log.Append(new LogMessage(message, level)) };
             }).Subscribe(_ => { }, ex => logger?.LogWarning(ex, "Activity log append failed for {Path}", activityPath));
         }
     }
@@ -277,9 +277,9 @@ public static class ActivityRunner
                 // content can arrive as a degraded JsonElement — `is ActivityLog` would silently
                 // no-op and the activity would hang Running forever (same read as the cancel watch).
                 if (node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger) is not { } log) return node;
-                var messages = string.IsNullOrEmpty(finalMessage)
-                    ? log.Messages
-                    : log.Messages.Add(new LogMessage(finalMessage,
+                var withFinal = string.IsNullOrEmpty(finalMessage)
+                    ? log
+                    : log.Append(new LogMessage(finalMessage,
                         status == ActivityStatus.Failed ? LogLevel.Error : LogLevel.Information));
                 // Honour what the command reported via ctx.Log: ActivityLog.Finish computes
                 // MAX(status, roll-up from Messages) — an Error line a command appended flips
@@ -289,7 +289,7 @@ public static class ActivityRunner
                 // throwing would end "Succeeded" with errors in its own log.
                 // The hub's current version stamps the finished log — the same
                 // `(int)hub.Version` every other Finish caller records.
-                var finished = (log with { Messages = messages }).Finish((int)workspace.Hub.Version, status);
+                var finished = withFinal.Finish((int)workspace.Hub.Version, status);
                 return node with
                 {
                     Content = finished with { RequestedStatus = null }

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -574,13 +574,13 @@ internal class MeshNodeCompilationService(
     }
 
     private static ActivityLog AppendInfo(ActivityLog log, string message)
-        => log with { Messages = log.Messages.Add(new LogMessage(message, LogLevel.Information)) };
+        => log.Append(new LogMessage(message, LogLevel.Information));
 
     private static ActivityLog AppendWarning(ActivityLog log, string message)
-        => log with { Messages = log.Messages.Add(new LogMessage(message, LogLevel.Warning)) };
+        => log.Append(new LogMessage(message, LogLevel.Warning));
 
     private static ActivityLog AppendError(ActivityLog log, string message)
-        => log with { Messages = log.Messages.Add(new LogMessage(message, LogLevel.Error)) };
+        => log.Append(new LogMessage(message, LogLevel.Error));
 
     /// <summary>
     /// Source-set discovery via the workspace SyncedQuery registry — one

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
@@ -144,13 +144,7 @@ internal static class NodeTypeCompilationActivity
                 hub.GetWorkspace().GetMeshNodeStream(activityPath!)
                     .Update(current =>
                         current?.Content is ActivityLog log
-                            ? current with
-                            {
-                                Content = log with
-                                {
-                                    Messages = log.Messages.AddRange(messages)
-                                }
-                            }
+                            ? current with { Content = log.Append(messages) }
                             : current!)
                     .Subscribe(
                         _ => { },
@@ -188,11 +182,10 @@ internal static class NodeTypeCompilationActivity
                         current?.Content is ActivityLog log
                             ? current with
                             {
-                                Content = log with
+                                Content = log.Append(messages) with
                                 {
                                     Status = status,
                                     End = DateTime.UtcNow,
-                                    Messages = log.Messages.AddRange(messages)
                                 }
                             }
                             : current!)
@@ -250,14 +243,13 @@ internal static class NodeTypeCompilationActivity
                         current?.Content is ActivityLog log
                             ? current with
                             {
-                                Content = log with
+                                Content = (error is { Length: > 0 }
+                                    ? log.Append(new LogMessage(error,
+                                        Microsoft.Extensions.Logging.LogLevel.Error))
+                                    : log) with
                                 {
                                     Status = status,
                                     End = DateTime.UtcNow,
-                                    Messages = error is { Length: > 0 }
-                                        ? log.Messages.Add(new LogMessage(error,
-                                            Microsoft.Extensions.Logging.LogLevel.Error))
-                                        : log.Messages
                                 }
                             }
                             : current!)

--- a/src/MeshWeaver.Graph/RunningActivitiesStripe.cs
+++ b/src/MeshWeaver.Graph/RunningActivitiesStripe.cs
@@ -103,7 +103,9 @@ public static class RunningActivitiesStripe
 
     private static UiControl BuildRow(MeshNode activity, ActivityLog log, string? locale = null)
     {
-        var label = $"{System.Net.WebUtility.HtmlEncode(log.Category)} · {log.Messages.Count} msg";
+        // TotalMessageCount, not Messages.Count: Messages is a bounded WINDOW — the caption must
+        // report how many lines the activity has produced, not how many it still holds.
+        var label = $"{System.Net.WebUtility.HtmlEncode(log.Category)} · {log.TotalMessageCount} msg";
         var elapsed = log.End is null
             ? FormatElapsed(DateTime.UtcNow - log.Start)
             : FormatElapsed(log.End.Value - log.Start);
@@ -162,8 +164,12 @@ public static class RunningActivitiesStripe
                 // ContentAs (deserialize), not `as ActivityLog`: on JsonElement frames `as` → null →
                 // both counts collapse to 0 → the comparer reports "equal" while message counts actually
                 // diverge (or vice-versa), so the stripe both misses real updates AND churns spuriously.
-                var lx = x[i].ContentAs<ActivityLog>(options)?.Messages.Count ?? 0;
-                var ly = y[i].ContentAs<ActivityLog>(options)?.Messages.Count ?? 0;
+                // 🚨 TotalMessageCount, NOT Messages.Count. Messages is a bounded window that stops
+                // growing once an activity passes the window size — keying the DistinctUntilChanged on
+                // it would silently FREEZE the stripe for exactly the long-running activities it exists
+                // to show. The monotonic total is the progress signal.
+                var lx = x[i].ContentAs<ActivityLog>(options)?.TotalMessageCount ?? 0;
+                var ly = y[i].ContentAs<ActivityLog>(options)?.TotalMessageCount ?? 0;
                 if (lx != ly) return false;
             }
             return true;

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -281,8 +281,7 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
                 Status = resolution.OverwrittenMembers.IsEmpty
                     ? ActivityStatus.Succeeded
                     : ActivityStatus.Warning,
-                Messages = messages
-            }
+            }.Append(messages)
         };
 
         inner.Write(activity, options).Subscribe(

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2444,9 +2444,8 @@ public static class MeshExtensions
                                             .Do(deletedPaths =>
                                             {
                                                 var messages = collectedMessages.ToImmutable();
-                                                var okLog = baseActivity with
+                                                var okLog = baseActivity.Append(messages) with
                                                 {
-                                                    Messages = messages,
                                                     AffectedPaths = deletedPaths.ToImmutableList(),
                                                     End = DateTime.UtcNow,
                                                     Status = messages.Any(m => m.LogLevel >= LogLevel.Warning)
@@ -3844,10 +3843,9 @@ public static class MeshExtensions
 
         void PostOk(MeshNode result, bool isCreate, string logLine)
         {
-            var okLog = baseActivity with
+            var okLog = baseActivity.Append(
+                new LogMessage(logLine, Microsoft.Extensions.Logging.LogLevel.Information)) with
             {
-                Messages = baseActivity.Messages.Add(
-                    new LogMessage(logLine, Microsoft.Extensions.Logging.LogLevel.Information)),
                 End = DateTime.UtcNow,
                 Status = ActivityStatus.Succeeded,
             };
@@ -3860,10 +3858,9 @@ public static class MeshExtensions
 
         void PostFail(string error, NodeUpsertRejectionReason reason)
         {
-            var failLog = baseActivity with
+            var failLog = baseActivity.Append(
+                new LogMessage(error, Microsoft.Extensions.Logging.LogLevel.Error)) with
             {
-                Messages = baseActivity.Messages.Add(
-                    new LogMessage(error, Microsoft.Extensions.Logging.LogLevel.Error)),
                 End = DateTime.UtcNow,
                 Status = ActivityStatus.Failed,
             };

--- a/test/MeshWeaver.Data.Test/ActivityLogRollupTest.cs
+++ b/test/MeshWeaver.Data.Test/ActivityLogRollupTest.cs
@@ -1,0 +1,151 @@
+using System.Collections.Immutable;
+using MeshWeaver.Data;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the <see cref="ActivityLog"/> roll-ups — <see cref="ActivityLog.MessageCount"/> and
+/// <see cref="ActivityLog.MaxSeverity"/> — that make an activity's terminal status and error
+/// predicate a function of COUNTERS rather than a scan of <see cref="ActivityLog.Messages"/>.
+///
+/// <para>Why this matters: <c>Messages</c> is on its way to becoming a bounded window (older lines
+/// flushed to satellites), so anything derived from "the whole list" silently changes meaning the
+/// moment an activity outgrows it. <c>Finish()</c> was exactly that — its status came from
+/// <c>Messages.Max(LogLevel)</c>, so a long failing activity whose error line had scrolled out of the
+/// window would have finished <c>Succeeded</c>.</para>
+///
+/// <para>The second half of the file is the BACK-COMPATIBILITY half: a log written before the
+/// roll-ups existed carries <c>MessageCount = 0</c> and <c>MaxSeverity = Trace</c>, and must still
+/// produce byte-identical answers. Pure-function tests — deterministic, no hub.</para>
+/// </summary>
+public class ActivityLogRollupTest
+{
+    private static LogMessage Msg(LogLevel level) => new($"{level}", level);
+
+    [Fact]
+    public void Append_AdvancesCountAndSeverity()
+    {
+        var log = new ActivityLog("Test")
+            .Append(Msg(LogLevel.Information))
+            .Append([Msg(LogLevel.Debug), Msg(LogLevel.Warning)]);
+
+        Assert.Equal(3, log.MessageCount);
+        Assert.Equal(3, log.TotalMessageCount);
+        Assert.Equal(LogLevel.Warning, log.MaxSeverity);
+        Assert.Equal(3, log.Messages.Count);
+    }
+
+    [Fact]
+    public void Append_Empty_IsANoOp()
+    {
+        var log = new ActivityLog("Test").Append(Msg(LogLevel.Information));
+        Assert.Same(log, log.Append(ImmutableList<LogMessage>.Empty));
+    }
+
+    /// <summary>
+    /// <see cref="LogLevel.None"/> is numerically ABOVE Critical but means "no logging" — rolling it
+    /// up would turn a silenced line into the worst thing that ever happened to the activity.
+    /// </summary>
+    [Fact]
+    public void Append_NeverRollsUpNone()
+    {
+        var log = new ActivityLog("Test").Append([Msg(LogLevel.Warning), Msg(LogLevel.None)]);
+
+        Assert.Equal(LogLevel.Warning, log.MaxSeverity);
+        Assert.Equal(ActivityStatus.Warning, log.Finish(1, null).Status);
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION GUARD for the window migration. The severity that decides the terminal status
+    /// must survive the messages leaving <c>Messages</c>. Dropping the list here stands in for the
+    /// window having scrolled past the error line.
+    /// </summary>
+    [Theory]
+    [InlineData(LogLevel.Information, ActivityStatus.Succeeded)]
+    [InlineData(LogLevel.Warning, ActivityStatus.Warning)]
+    [InlineData(LogLevel.Error, ActivityStatus.Failed)]
+    [InlineData(LogLevel.Critical, ActivityStatus.Failed)]
+    public void FinalStatus_SurvivesTheMessagesLeavingTheWindow(LogLevel level, ActivityStatus expected)
+    {
+        var full = new ActivityLog("Test").Append(Msg(level));
+        var windowed = full with { Messages = ImmutableList<LogMessage>.Empty };
+
+        Assert.Equal(expected, full.Finish(1, null).Status);
+        Assert.Equal(expected, windowed.Finish(1, null).Status);
+        Assert.Equal(level >= LogLevel.Error, windowed.HasErrors());
+    }
+
+    /// <summary>A sub-activity's status still rolls up, and still wins when it is the more severe one.</summary>
+    [Fact]
+    public void FinalStatus_TakesTheWorseOfSubActivitiesAndSeverity()
+    {
+        var failedChild = new ActivityLog("Child") { Status = ActivityStatus.Failed };
+        var parent = new ActivityLog("Parent")
+        {
+            SubActivities = [failedChild]
+        }.Append(Msg(LogLevel.Information));
+
+        Assert.Equal(ActivityStatus.Failed, parent.Finish(1, null).Status);
+    }
+
+    /// <summary><c>Fail()</c> routes through <c>Append</c>, so it advances both roll-ups.</summary>
+    [Fact]
+    public void Fail_AdvancesTheRollups()
+    {
+        var log = new ActivityLog("Test").Fail("boom");
+
+        Assert.Equal(1, log.MessageCount);
+        Assert.Equal(LogLevel.Error, log.MaxSeverity);
+        Assert.Equal(ActivityStatus.Failed, log.Status);
+        Assert.True(log.HasErrors());
+    }
+
+    // ---- back-compatibility with logs persisted before the roll-ups existed ----
+
+    /// <summary>
+    /// A pre-roll-up log has <c>MessageCount = 0</c> while <c>Messages</c> is non-empty. Every derived
+    /// answer must come out exactly as the old list-scanning code produced it.
+    /// </summary>
+    [Theory]
+    [InlineData(LogLevel.Trace, ActivityStatus.Succeeded, false)]
+    [InlineData(LogLevel.Information, ActivityStatus.Succeeded, false)]
+    [InlineData(LogLevel.Warning, ActivityStatus.Warning, false)]
+    [InlineData(LogLevel.Error, ActivityStatus.Failed, true)]
+    public void LegacyLog_WithoutRollups_AnswersFromTheListExactlyAsBefore(
+        LogLevel level, ActivityStatus expectedStatus, bool expectedHasErrors)
+    {
+        // Exactly the shape JSON written before MessageCount/MaxSeverity existed deserializes into.
+        var legacy = new ActivityLog("Test") { Messages = [Msg(level)] };
+
+        Assert.Equal(0, legacy.MessageCount);
+        Assert.Equal(LogLevel.Trace, legacy.MaxSeverity);
+        Assert.Equal(1, legacy.TotalMessageCount);
+        Assert.Equal(expectedStatus, legacy.Finish(1, null).Status);
+        Assert.Equal(expectedHasErrors, legacy.HasErrors());
+    }
+
+    /// <summary>An activity that logged nothing at all is Succeeded — the old <c>DefaultIfEmpty(Information)</c>.</summary>
+    [Fact]
+    public void EmptyLog_IsSucceeded()
+    {
+        var empty = new ActivityLog("Test");
+
+        Assert.Equal(0, empty.TotalMessageCount);
+        Assert.Equal(ActivityStatus.Succeeded, empty.Finish(1, null).Status);
+        Assert.False(empty.HasErrors());
+    }
+
+    /// <summary>An explicit override still wins when it is the more severe outcome.</summary>
+    [Fact]
+    public void Finish_OverrideWinsWhenMoreSevere()
+    {
+        var log = new ActivityLog("Test").Append(Msg(LogLevel.Information));
+
+        Assert.Equal(ActivityStatus.Cancelled, log.Finish(1, ActivityStatus.Cancelled).Status);
+        // …and never DOWNgrades a failure the log already recorded.
+        Assert.Equal(ActivityStatus.Failed,
+            log.Append(Msg(LogLevel.Error)).Finish(1, ActivityStatus.Succeeded).Status);
+    }
+}


### PR DESCRIPTION
**Merge order: 1 of 3.** Stacked ahead of #1399 and #1400 — merge this one first.

Part of the activity satellite migration (#1284 / #1351). This PR is the prerequisite refactor; the actual window + segments land in 2/3.

## The problem

An activity's terminal status was a function of its message **list**: `Finish()` computed it from `Messages.Max(LogLevel)` and `HasErrors()` scanned the list. Both are O(list), and — the reason this blocks the migration — both silently change meaning the moment `Messages` stops holding the whole transcript.

## What this does

Two incremental roll-ups on `ActivityLog`:

| field | meaning |
|---|---|
| `MessageCount` | total messages ever appended (read via `TotalMessageCount`, which falls back to `Messages.Count` for logs persisted before the field existed) |
| `MaxSeverity` | highest `LogLevel` ever appended (default `Trace` — the identity element of the max, so a legacy log rolls up to exactly what a scan of its `Messages` yields) |

`ActivityLog.Append(...)` becomes the one way to add messages and advances both in the same step. Every append site in `src/` is migrated to it, including the fresh-log initialisers that assigned `Messages` wholesale. `GetFinalStatus()` / `HasErrors()` fold the counter together with the list, so they answer identically before and after the list is trimmed.

## Two behaviour corrections fall out

Both are required for the counter and the list to agree — that agreement is what makes the window safe in 2/3:

- **`LogLevel.None` is excluded from the status fold.** It is numerically above `Critical` but means "no logging", so one `None` entry became the list's `Max` and dropped the whole activity into the `Succeeded` arm, swallowing a real `Error` logged beside it. Caught by a new test, not by inspection.
- **`HasErrors()` now also reports `Critical`**, matching `Errors()`, which has always included it.

## `RunningActivitiesStripe` (the landmine this defuses early)

The stripe keys its `DistinctUntilChanged` on the message count. Moved to `TotalMessageCount`: keying on the in-list count would **freeze the stripe** for exactly the long-running activities it exists to show, once that list becomes a window in 2/3.

## Verification

- `ActivityLogRollupTest` (new, pure, 15 cases) — the roll-ups, the `None` rule, the sub-activity fold, and a back-compatibility half asserting a pre-roll-up log (`MessageCount = 0`, `MaxSeverity = Trace`) produces byte-identical answers.
- `MeshWeaver.Data.Test` 344/344 · `MeshWeaver.Graph.Test` 1095/1095 · `MeshWeaver.GitSync.Test` 161/161 · `MeshWeaver.AI.Test` activity filter 34/34.
- Solution build clean under `-c Release -p:CIRun=true -warnaserror` (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
