### PR TITLE
CI: run the .NET suite on every PR, not only those based on main

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -65,11 +65,49 @@
 
 name: MeshWeaver Build and Test
 
+# ──────────── EVERY PR, WHATEVER ITS BASE — including a STACKED one ────────────
+# 🚨 The `pull_request` trigger deliberately carries NO `branches:` filter. Do not
+# re-add one. It used to say `branches: [ "main" ]`, and the consequence (#1401) was
+# that a PR based on ANOTHER PR's branch — a stacked PR, which is the recommended way
+# to split a large change into reviewable pieces — never ran this suite at all.
+#
+# The failure mode is the dangerous half: an ABSENT check looks like nothing to wait
+# for. There is no "skipped", no pending, no marker of any kind — a stacked PR renders
+# as a short, all-green check list, visually IDENTICAL to one that ran the full suite
+# and passed. #1398 → #1399 → #1400 were split exactly as intended and two of the three
+# reached `MERGEABLE/CLEAN` with zero runs in their entire history.
+#
+# Three things make that state stickier than it looks, all confirmed on those PRs:
+#   * GitHub retargets a child PR to `main` only when the parent's branch is DELETED
+#     on merge. Branch deletion is off here, so a child keeps pointing at a merged
+#     branch indefinitely — "it gets tested later, just out of order" is not real.
+#     Left alone, a stacked PR was never tested at ANY point, including at merge.
+#   * `gh pr edit --base main` fires `pull_request.edited`, which is NOT in the default
+#     type set (opened/synchronize/reopened). The base changed, the checks stayed
+#     absent, and the PR still read CLEAN. Only close+reopen ever queued a run.
+#   * The `main pr protection` ruleset is scoped to `~DEFAULT_BRANCH`, so a PR whose
+#     base is not `main` is outside it: the `Consolidate test results` required check
+#     is not required there, and its absence therefore does not even block the merge.
+# So the pre-fix state had no signal at all: nothing ran, nothing was pending, nothing
+# was required. Running unconditionally is what turns that silence back into evidence.
+#
+# What a stacked run tests: GitHub builds `refs/pull/N/merge`, i.e. the branch merged
+# with ITS BASE. For a stacked PR that base is the parent's branch, so the run tests
+# the layer's own diff on top of the parent — real coverage of the code being reviewed.
+# That is the same "tested against a base that is not main's tip" posture the ruleset
+# already sanctions repo-wide (`strict_required_status_checks_policy: false`).
+#
+# Cost is small and bounded, because the green-tree reuse below is keyed on the TREE:
+# when the parent merges and main lands the identical tree, `precheck` finds the marker
+# the stacked run wrote and skips build+test. A stacked series pays for one full suite
+# per layer, not two.
+#
+# `push:` stays `main`-only on purpose — a full suite on every feature-branch push
+# would double every PR's cost for no extra evidence (the PR run already covers it).
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request:      # ← NO `branches:` filter. See the block above (#1401) before adding one.
   workflow_dispatch:
 
 # A force-push to a PR branch obsoletes the in-flight run — cancel it instead of


### PR DESCRIPTION
Closes #1401.

## The change

One line: `dotnet-test.yml`'s `pull_request` trigger loses its `branches: [ "main" ]` filter, so **every PR runs `MeshWeaver Build and Test` whatever its base**. The rest of the diff is the comment block explaining why, so nobody re-adds the filter.

This is option 1 from the issue (run the suite on stacked PRs), not option 2 (emit a blocking "not tested" status). Option 2 would be a check that, after this change, can never fire — and the repo's own rule is that a check which cannot fail is worse than no check. There is no `if:`-shaped skip anywhere in the diff: a skipped job renders with the same tick as a passed one, which would reproduce the defect one level up.

## Why the pre-fix state read as CLEAN

Four things stacked up, and all four were confirmed on #1398 → #1399 → #1400:

| | |
|---|---|
| **No run at all** | The trigger filtered on base = `main`, so a PR based on another PR's branch never matched. |
| **No retarget** | GitHub retargets a child PR to `main` only when the parent's branch is **deleted** on merge. Branch deletion is off here, so children keep pointing at merged branches indefinitely — "it gets tested later, just out of order" is not real. Left alone a stacked PR is tested at **no** point, including at merge. |
| **No trigger on a hand retarget** | `gh pr edit --base main` fires `pull_request.edited`, which is not in the default type set (`opened`, `synchronize`, `reopened`). The base changed, the checks stayed absent. Only close + reopen ever queued a run. |
| **No required check either** | The `main pr protection` ruleset is scoped to `~DEFAULT_BRANCH` (`conditions.ref_name.include: ["~DEFAULT_BRANCH"]`), so a PR whose base is not `main` sits outside it. `Consolidate test results` is not required there, so its *absence* does not block the merge. |

So there was no red, nothing pending, nothing skipped, and nothing required — an untested PR was byte-for-byte indistinguishable from a passing one. Two of the three PRs in that split reached `MERGEABLE/CLEAN` with **zero** runs in their entire history.

`dotnet-test.yml` was the only workflow with the filter — `clients.yml` already triggers on all bases, which is why the stacked PRs showed a green `Clients` suite and simply *no* .NET suite.

## What a stacked run actually tests

GitHub builds `refs/pull/N/merge` = the branch merged with **its base**. For a stacked PR that base is the parent's branch, so the run tests the layer's own diff on top of the parent — real coverage of the code under review. That is the same "tested against a base that is not main's tip" posture the ruleset already sanctions repo-wide (`strict_required_status_checks_policy: false`).

## CI cost

Bounded, because the green-tree reuse is keyed on the **tree**, not the commit. When the parent merges and main lands the identical tree, `precheck` finds the marker the stacked run already wrote and skips build + test. A stacked series pays one full suite per layer, not two.

`push:` stays `main`-only on purpose — a full suite on every feature-branch push would double every PR's cost for no extra evidence.

## Left deliberately undone (needs a repo-settings decision, not a PR)

The ruleset's `~DEFAULT_BRANCH` scope means a stacked PR still has **no required status check**: the suite now runs and is visible, but a red one does not mechanically block the merge. Widening `conditions.ref_name.include` to `~ALL` would close that, and it is repo configuration rather than anything in this tree — flagging it rather than changing it silently.

## Verification

`.github/workflows/dotnet-test.yml` parses (`yaml.safe_load` → `on: {'push': {'branches': ['main']}, 'pull_request': None, 'workflow_dispatch': None}`, all seven jobs intact), and no job in the file keys off `github.base_ref` / `head_branch` / `refs/heads/main`, so nothing downstream assumed a `main` base.

**This PR is itself the test**: it is based on `main`, so it proves only the unstacked path. The stacked path is proven by the follow-up PR for #1384, which I will stack on this branch — if the suite attaches there, the fix works.

No What's New entry: CI-only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
