### PR TITLE
fix(portal): resolve the circuit user so the AI menu's New thread entry works

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/Chat.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/Chat.razor
@@ -27,20 +27,9 @@ else
 
     private LayoutAreaControl? GetThreadComposerLayoutArea()
     {
-        // Durable circuit user first; skip a leaked system-security / hub principal on the
-        // AsyncLocal Context (which would point the composer at a non-existent
-        // system-security/_Thread/ThreadComposer). Mirrors ThreadSidePanelContent.ResolveUserHome.
-        string? userHome = null;
-        foreach (var candidate in new[] { AccessService.CircuitContext?.ObjectId, AccessService.Context?.ObjectId })
-        {
-            if (!string.IsNullOrEmpty(candidate)
-                && candidate != WellKnownUsers.System
-                && !AccessService.LooksLikeHubPrincipal(candidate))
-            {
-                userHome = candidate;
-                break;
-            }
-        }
+        // Durable circuit user first; a leaked system-security / hub principal on the AsyncLocal
+        // Context would point the composer at a non-existent system-security/_Thread/ThreadComposer.
+        var userHome = CircuitUser.ResolveUserId(AccessService);
         return string.IsNullOrEmpty(userHome)
             ? null
             : new LayoutAreaControl(ThreadComposerNodeType.PathFor(userHome), new LayoutAreaReference(string.Empty));

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -662,24 +662,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// <summary>
     /// The signed-in user's partition — the partition that owns
     /// <c>{user}/_Thread/ThreadComposer</c> and the namespace a submitted thread is created
-    /// under. Prefer <see cref="AccessService.CircuitContext"/> (the durable per-circuit
-    /// identity); <see cref="AccessService.Context"/> (AsyncLocal) is only a fallback and
-    /// is filtered for a leaked <c>system-security</c> / hub principal. Trusting
-    /// <c>Context</c> first pointed the composer at <c>system-security/_Thread/ThreadComposer</c>
-    /// and would have created threads under the wrong partition.
+    /// under. Trusting <c>Context</c> first pointed the composer at
+    /// <c>system-security/_Thread/ThreadComposer</c> and would have created threads under the
+    /// wrong partition — the resolution order lives in <see cref="CircuitUser.ResolveUserId"/>.
     /// </summary>
     private static string? ResolveUserHome(AccessService? accessSvc)
-    {
-        if (accessSvc is null) return null;
-        foreach (var candidate in new[] { accessSvc.CircuitContext?.ObjectId, accessSvc.Context?.ObjectId })
-        {
-            if (!string.IsNullOrEmpty(candidate)
-                && candidate != WellKnownUsers.System
-                && !AccessService.LooksLikeHubPrincipal(candidate))
-                return candidate;
-        }
-        return null;
-    }
+        => CircuitUser.ResolveUserId(accessSvc);
 
     // ResolveCircuitUser() / RunUnderCircuitUser<T>() / UpdateMeshNodeAsCircuitUser(...) are inherited
     // from BlazorView — the ONE place every circuit-scoped view re-establishes the durable circuit user

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor.cs
@@ -260,17 +260,7 @@ public partial class ThreadSidePanelContent : ComponentBase, IDisposable
     /// the composer at a non-existent <c>system-security/_Thread/ThreadComposer</c>, so the
     /// "+" new-chat rendered nothing — the "+ not working" bug.
     /// </summary>
-    private string? ResolveUserHome()
-    {
-        foreach (var candidate in new[] { AccessService.CircuitContext?.ObjectId, AccessService.Context?.ObjectId })
-        {
-            if (!string.IsNullOrEmpty(candidate)
-                && candidate != WellKnownUsers.System
-                && !AccessService.LooksLikeHubPrincipal(candidate))
-                return candidate;
-        }
-        return null;
-    }
+    private string? ResolveUserHome() => CircuitUser.ResolveUserId(AccessService);
 
     private string SidePanelTitle => selectedThreadName ?? "New Chat";
 

--- a/src/MeshWeaver.Blazor.Portal/CircuitUser.cs
+++ b/src/MeshWeaver.Blazor.Portal/CircuitUser.cs
@@ -1,0 +1,36 @@
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Blazor.Portal;
+
+/// <summary>
+/// The ONE place a portal-chrome component resolves "who is the signed-in user" at interaction time.
+///
+/// <para>🚨 Never read <see cref="AccessService.Context"/> alone in a Blazor event handler. That
+/// AsyncLocal is populated per HUB message delivery — a UI click is a circuit inbound activity, where
+/// <c>CircuitAccessHandler</c> stamps <see cref="AccessService.CircuitContext"/> instead, so
+/// <c>Context</c> reads null and a "resolve the user, then act" handler silently does nothing (the
+/// AI menu's dead "New thread" entry). The durable per-circuit identity is <c>CircuitContext</c>;
+/// <c>Context</c> is only a fallback for code reached from within a delivery, and is filtered for a
+/// leaked <c>system-security</c> / hub-shaped principal, which is never a real user.</para>
+/// </summary>
+internal static class CircuitUser
+{
+    /// <summary>
+    /// The signed-in user's id (their partition key), or null when no real user identity is
+    /// available (anonymous circuit, SSR/prerender, or a leaked system/hub principal).
+    /// </summary>
+    internal static string? ResolveUserId(AccessService? accessService)
+    {
+        if (accessService is null)
+            return null;
+        foreach (var candidate in new[] { accessService.CircuitContext?.ObjectId, accessService.Context?.ObjectId })
+        {
+            if (!string.IsNullOrEmpty(candidate)
+                && candidate != WellKnownUsers.System
+                && !AccessService.LooksLikeHubPrincipal(candidate))
+                return candidate;
+        }
+        return null;
+    }
+}

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -364,6 +364,9 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         // 'GlobalSettings'" DeliveryFailure → bounded resubscribe storm. Gate the navigation on the
         // canonical IsGlobalAdmin() predicate so a non-admin never issues that subscribe; route them
         // to their own account page instead.
+        // Resolve the user BEFORE subscribing: the callback runs on a hub scheduler, where both
+        // AccessContext AsyncLocals (Context AND CircuitContext) have been nulled.
+        var userId = CircuitUser.ResolveUserId(AccessService);
         Hub.IsGlobalAdmin()
             .Take(1)
             .Timeout(TimeSpan.FromSeconds(5))
@@ -375,7 +378,6 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
                     NavigationManager.NavigateTo($"/{GlobalSettingsLayoutArea.GlobalSettingsArea}");
                     return;
                 }
-                var userId = AccessService?.Context?.ObjectId;
                 NavigationManager.NavigateTo(string.IsNullOrEmpty(userId) ? "/" : $"/User/{userId}");
             }));
     }
@@ -388,9 +390,13 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     /// </summary>
     private void NavigateToThreads()
     {
-        var userId = AccessService?.Context?.ObjectId;
+        var userId = CircuitUser.ResolveUserId(AccessService);
         if (string.IsNullOrEmpty(userId))
+        {
+            Logger.LogWarning(
+                "NavigateToThreads: no circuit user resolved (CircuitContext and Context both empty) — not navigating.");
             return;
+        }
         NavigationManager.NavigateTo($"/User/{userId}/Activity");
     }
 
@@ -453,9 +459,17 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     /// </summary>
     private void OpenNewThreadInMain()
     {
-        var userId = AccessService?.Context?.ObjectId;
+        // 🚨 CircuitUser.ResolveUserId, never AccessService.Context alone: a menu click is a circuit
+        // inbound activity, where CircuitAccessHandler stamps CircuitContext — Context is only set
+        // during a hub message delivery, so reading it here is always null and the click silently
+        // did nothing (the dead "New thread" menu entry).
+        var userId = CircuitUser.ResolveUserId(AccessService);
         if (string.IsNullOrEmpty(userId))
+        {
+            Logger.LogWarning(
+                "OpenNewThreadInMain: no circuit user resolved (CircuitContext and Context both empty) — not navigating.");
             return;
+        }
 
         // Drop any side-panel conversation first, so the composer exists exactly once, in main.
         SidePanelState.SetContentPath(null);

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-new-thread-menu-works.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-new-thread-menu-works.md
@@ -1,0 +1,17 @@
+---
+Name: The ➕ New thread menu entry works again
+Category: Fix
+Description: Clicking ➕ New thread in the AI menu now opens the composer in the main view and collapses the side panel — it previously did nothing.
+Icon: Chat
+Order: -20260813
+---
+
+# What's New — 13 August 2026
+
+## The ➕ New thread menu entry works again
+
+Clicking **➕ New thread** in the AI (✨) menu did nothing — no navigation, no composer, no error. The click handler resolved the signed-in user from an identity slot that is only populated while the server is processing a mesh message, not while it is handling a browser click, so it always concluded "no user" and silently gave up.
+
+The handler now resolves the user from the circuit's durable identity — the same source every chat surface uses. Clicking **➕ New thread** opens a fresh conversation composer in the main view and collapses the side panel, so the new conversation exists exactly once, in front of you.
+
+The same repair applies to the two neighbouring header actions that resolved the user the same broken way: the settings button's route to your account page, and the threads shortcut to your activity dashboard.

--- a/test/Memex.Portal.Shared.Test/CircuitUserResolutionTest.cs
+++ b/test/Memex.Portal.Shared.Test/CircuitUserResolutionTest.cs
@@ -1,0 +1,77 @@
+using MeshWeaver.Blazor.Portal;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the click-time identity contract behind the AI menu's "New thread" entry (and every other
+/// portal-chrome action that resolves "who is the signed-in user" in a Blazor event handler).
+/// <para>
+/// Why this exists: the entry was reported dead — clicking it did nothing. The handler resolved the
+/// user from <c>AccessService.Context</c> alone, but that AsyncLocal is populated per HUB message
+/// delivery; a UI click is a circuit inbound activity, where <c>CircuitAccessHandler</c> stamps
+/// <c>CircuitContext</c> instead. So <c>Context</c> read null and the handler early-returned without
+/// a trace. These tests pin the resolution ORDER (CircuitContext first) and the principal filtering,
+/// so the regression cannot ship silently again.
+/// </para>
+/// </summary>
+public class CircuitUserResolutionTest
+{
+    private static AccessContext User(string id) => new() { ObjectId = id, Name = id };
+
+    [Fact]
+    public void Resolves_From_CircuitContext_When_Context_Is_Null()
+    {
+        // The click-time shape: CircuitAccessHandler stamped the circuit user; no delivery is active.
+        var access = new AccessService();
+        access.SetCircuitContext(User("alice"));
+
+        Assert.Equal("alice", CircuitUser.ResolveUserId(access));
+    }
+
+    [Fact]
+    public void CircuitContext_Wins_Over_Context()
+    {
+        // Context can carry a leaked identity from an unrelated delivery; the durable circuit
+        // identity is authoritative.
+        var access = new AccessService();
+        access.SetCircuitContext(User("alice"));
+        access.SetContext(User("bob"));
+
+        Assert.Equal("alice", CircuitUser.ResolveUserId(access));
+    }
+
+    [Fact]
+    public void Falls_Back_To_Context_When_No_CircuitContext()
+    {
+        // Code reached from within a hub delivery (no circuit activity) still resolves.
+        var access = new AccessService();
+        access.SetContext(User("bob"));
+
+        Assert.Equal("bob", CircuitUser.ResolveUserId(access));
+    }
+
+    [Fact]
+    public void Skips_System_And_Hub_Principals()
+    {
+        // A leaked system-security / hub-shaped principal is never a real user — fall through to
+        // the next candidate rather than acting as the platform.
+        var access = new AccessService();
+        access.SetCircuitContext(User(WellKnownUsers.System));
+        access.SetContext(User("carol"));
+
+        Assert.Equal("carol", CircuitUser.ResolveUserId(access));
+
+        access.SetCircuitContext(User("portal/some-circuit-id"));
+        Assert.Equal("carol", CircuitUser.ResolveUserId(access));
+    }
+
+    [Fact]
+    public void Null_When_No_Identity_At_All()
+    {
+        Assert.Null(CircuitUser.ResolveUserId(new AccessService()));
+        Assert.Null(CircuitUser.ResolveUserId(null));
+    }
+}


### PR DESCRIPTION
## Problem

Clicking **➕ New thread** in the top-bar AI (✨) menu did nothing — no navigation, no composer, no error, nothing in the logs.

## Root cause

`PortalLayoutBase.OpenNewThreadInMain` resolved the signed-in user from `AccessService.Context` alone. That AsyncLocal is populated **per hub message delivery**; a menu click is a **circuit inbound activity**, where `CircuitAccessHandler` stamps `CircuitContext` instead. So `Context` always read null, the guard early-returned, and the click died silently. `NavigateToThreads` and `NavigateToSettings`' non-admin fallback carried the same defect.

## Fix

- New `CircuitUser.ResolveUserId(AccessService?)` — the ONE canonical resolver: `CircuitContext` first (the durable circuit identity), `Context` as fallback, leaked `system-security` / hub-shaped principals filtered.
- `OpenNewThreadInMain` and `NavigateToThreads` use it, and log a warning instead of silently no-op'ing when no identity resolves.
- `NavigateToSettings` resolves the user **before** its `IsGlobalAdmin` Subscribe — the callback runs on a hub scheduler where both AsyncLocals are nulled.
- The three pre-existing copies of the same chain (`ThreadChatView.ResolveUserHome`, `ThreadSidePanelContent.ResolveUserHome`, `Chat.razor`) now delegate to the shared helper, so the resolution order can't drift again.

Clicking the entry now opens the composer in the main view (`/User/{me}/Chat`) and collapses the side panel, as `OpenNewThreadInMain` always intended — that logic was correct and unreachable.

## Tests

- New `CircuitUserResolutionTest` pins the resolution order (CircuitContext wins, Context fallback), the system/hub-principal filtering, and the null case.
- `Memex.Portal.Shared.Test`: 310 passed / 0 failed locally (Release).
- Touched projects build clean with CI flags (`-c Release -warnaserror`).

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)