### PR TITLE
feat(build): the protocol can drive the bake — claim, chunk activities, release reporting, GO-subscribed followers

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -71,6 +71,12 @@ data:
   PreWarm__DynamicTypes: "{{ .Values.config.memex_portal.PreWarm__DynamicTypes }}"
   PreWarm__GateReadiness: "{{ .Values.config.memex_portal.PreWarm__GateReadiness }}"
   PreWarm__AllowUnprovenBake: "{{ .Values.config.memex_portal.PreWarm__AllowUnprovenBake }}"
+  {{- /* PreWarm__BuildProtocol: coordinate the bake through the Build nodes (Admin/Build claim +
+         chunk activities + the per-fingerprint GO) instead of the file lease and the follower's
+         share poll — Doc/Architecture/BuildCoordination. Execution is the same sweep either way.
+         This key must exist HERE or it is silently dropped: the configmap lists keys explicitly
+         rather than iterating .Values.config, so an un-templated key never reaches the pod. */}}
+  PreWarm__BuildProtocol: "{{ .Values.config.memex_portal.PreWarm__BuildProtocol }}"
   # ---- Assembly-cache retention -------------------------------------------
   # The bake writes one WHOLE GENERATION of NodeType assemblies per image, because the store
   # keys every file by the MeshWeaver.Graph MVID and a CI build changes it on every publish.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-build-protocol-can-now-drive-the-bake.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-build-protocol-can-now-drive-the-bake.md
@@ -1,0 +1,26 @@
+---
+Name: The build protocol can now drive the bake
+Category: Feature
+Description: Behind a flag, startup compilation is coordinated by the build nodes end to end — the claim decides who bakes, chunks record what each part produced, and waiting servers complete on the GO signal instead of polling the cache.
+Icon: Sparkle
+Order: -20260813
+---
+
+# The build protocol can now drive the bake
+
+The build coordination nodes introduced alongside this release no longer just describe the
+protocol — they can run it. With the flag enabled, startup compilation goes through them end to
+end:
+
+- the claim on the build root decides which process bakes — the lease file is not consulted at all;
+- one chunk node per content area opens with its own activity, and closes recording exactly which
+  release each of its types produced — the build's outputs become browsable mesh state instead of
+  log lines;
+- every other server subscribes to the build's GO signal and completes the moment it lands,
+  replacing the periodic re-polling of the shared cache — and a build that finished but never
+  published its GO heals itself on the next start.
+
+Execution itself is unchanged — the same dependency-ordered, store-probing sweep that runs today,
+so enabling the protocol changes who decides and how completion is announced, never what gets
+built. The flag stays off by default while the remaining pieces land: version-aware readiness fed
+from the GO history, and builds running in their own disposable process.

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Drives the pre-warm bake THROUGH the build protocol (<c>Doc/Architecture/BuildCoordination</c>)
+/// instead of the file lease: the claim on <c>Admin/Build</c> decides who bakes, chunk nodes under
+/// it record what each part of the build produced, and the per-fingerprint GO on the root is what
+/// every non-building silo waits for — a subscription, not a poll of the assembly share.
+///
+/// <para><b>Execution is unchanged in this slice.</b> The winner runs the same sequential,
+/// dependency-ordered sweep (<c>WarmPending</c>) it always ran — one global order, so cross-chunk
+/// source dependencies stay structurally correct. What changes is coordination: the claim replaces
+/// <see cref="NodeTypeBakeLease"/>, chunk nodes make the build observable (queries in, release
+/// paths out, one <c>_Activity</c> each), and losers complete on the GO emission instead of
+/// re-probing the share every 60 s. Chunk-scoped execution (per-chunk sweeps on a disposable
+/// separate-ServiceId bake silo) plugs into the same nodes next.</para>
+/// </summary>
+public static class BuildProtocolDriver
+{
+    /// <summary>Config key: route the bake through the build protocol. Default: off.</summary>
+    public const string EnabledConfigKey = "PreWarm:BuildProtocol";
+
+    /// <summary>
+    /// How long a candidate waits for the arbiter's grant before concluding another process is
+    /// building and switching to the GO subscription. The arbiter sits on the build node's own
+    /// hub, so an uncontended grant arrives in milliseconds — this bound only matters when the
+    /// claim is genuinely held elsewhere.
+    /// </summary>
+    public static readonly TimeSpan GrantWindow = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Claim → bake → GO; or, when the claim is held elsewhere, subscribe to the GO and report the
+    /// share's state when it arrives.
+    /// </summary>
+    /// <param name="mesh">The mesh hub.</param>
+    /// <param name="report">The store probe report (carries the framework fingerprint + pending set).</param>
+    /// <param name="definitions">Discovered NodeType definitions by path.</param>
+    /// <param name="store">The shared assembly store, for the follower's post-GO probe.</param>
+    /// <param name="bake">The actual sweep to run when this process wins the claim.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>The sweep's outcomes (winner), or the post-GO probe's outcomes (follower).</returns>
+    public static IObservable<PreWarmOutcome> Run(
+        IMessageHub mesh,
+        NodeTypeBakeReport report,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        Func<IObservable<PreWarmOutcome>> bake,
+        ILogger? logger)
+    {
+        // Unique per process RUN: two boots of the same pod must not look like one claimant, or
+        // the second boot would inherit (and heartbeat) a claim whose bake died with the first.
+        var holder = $"{Environment.MachineName}/{Guid.NewGuid():N}";
+        var fingerprint = report.FrameworkVersion;
+
+        return mesh.RequestBuildClaim(holder, fingerprint)
+            .SelectMany(_ => mesh.ObserveBuildClaim(holder)
+                .Take(1)
+                .Timeout(GrantWindow)
+                .SelectMany(__ => BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger))
+                .Catch((TimeoutException _) =>
+                    FollowGo(mesh, holder, fingerprint, definitions, store, logger)));
+    }
+
+    // ── the winner ──────────────────────────────────────────────────────────────────────────────
+
+    private static IObservable<PreWarmOutcome> BakeAsMaster(
+        IMessageHub mesh,
+        string holder,
+        string fingerprint,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        Func<IObservable<PreWarmOutcome>> bake,
+        ILogger? logger)
+    {
+        var chunks = PlanChunks(definitions.Keys);
+        logger?.LogInformation(
+            "BuildProtocol: claim granted to {Holder} for framework {Fingerprint} — {Chunks} chunk(s): {Names}",
+            holder, fingerprint, chunks.Count, string.Join(", ", chunks.Keys));
+
+        var outcomes = new List<PreWarmOutcome>();
+
+        // Heartbeat for the claim's lifetime: a bake measured in minutes must not read as a dead
+        // holder to the arbiter. Disposed with the sweep by the Using below.
+        IDisposable StartHeartbeat() => Observable.Interval(BuildNodeType.HeartbeatInterval)
+            .SelectMany(_ => mesh.BeatBuildClaim(holder))
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex, "BuildProtocol: heartbeat failed for {Holder}", holder));
+
+        return mesh
+            // Record the plan on the root, then materialize + claim + open an activity per chunk.
+            .UpdateBuildAsHolder(holder, s => s with
+            {
+                Status = BuildStatus.Building,
+                Chunks = chunks.Keys.OrderBy(k => k, StringComparer.Ordinal).ToImmutableList(),
+            })
+            .SelectMany(_ => chunks
+                .OrderBy(c => c.Key, StringComparer.Ordinal)
+                .Select(c => OpenChunk(mesh, holder, c.Key, c.Value, logger))
+                .Concat())
+            .ToList()
+            .SelectMany(openedChunks => Observable.Using(
+                StartHeartbeat,
+                _ => bake()
+                    .Do(outcomes.Add)
+                    .Concat(Observable.Defer(() =>
+                        CloseOut(mesh, holder, fingerprint, chunks, openedChunks.ToList(), outcomes, logger)
+                            .IgnoreElements()
+                            .Select(__ => default(PreWarmOutcome)!)))));
+    }
+
+    private static IObservable<OpenedChunk> OpenChunk(
+        IMessageHub mesh, string holder, string name, IReadOnlyList<string> members, ILogger? logger)
+    {
+        var chunkPath = $"{BuildNodeType.RootPath}/{name}";
+        var activityId = Guid.NewGuid().ToString("N");
+        var activityPath = $"{chunkPath}/_Activity/{activityId}";
+        var meshService = mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        return mesh.EnsureBuildNode(chunkPath, new BuildState
+            {
+                Queries = ImmutableList.Create(
+                    $"namespace:{name} scope:subtree nodeType:{MeshNode.NodeTypePath}"),
+            })
+            .SelectMany(_ => mesh.RequestBuildClaim(holder, name, chunkPath))
+            .SelectMany(_ => mesh.ObserveBuildClaim(holder, chunkPath)
+                .Take(1).Timeout(GrantWindow))
+            .SelectMany(_ => meshService.CreateNode(new MeshNode(activityId, $"{chunkPath}/_Activity")
+            {
+                NodeType = "Activity",
+                MainNode = chunkPath,
+                Content = new ActivityLog("ChunkBuild")
+                {
+                    Id = activityId,
+                    HubPath = chunkPath,
+                    Status = ActivityStatus.Running,
+                },
+            }))
+            .SelectMany(_ => mesh.UpdateBuildAsHolder(
+                holder,
+                s => s with { Status = BuildStatus.Building, ActivityPath = activityPath },
+                chunkPath))
+            .Select(_ => new OpenedChunk(name, chunkPath, activityPath, members))
+            .Catch((Exception ex) =>
+            {
+                // A chunk whose bookkeeping cannot open must not stop the BUILD — the sweep is
+                // what readiness depends on; the chunk node is its observability. Loud, then on.
+                logger?.LogWarning(ex,
+                    "BuildProtocol: could not open chunk {Chunk} — building without its bookkeeping",
+                    name);
+                return Observable.Empty<OpenedChunk>();
+            });
+    }
+
+    private static IObservable<System.Reactive.Unit> CloseOut(
+        IMessageHub mesh,
+        string holder,
+        string fingerprint,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> chunks,
+        IReadOnlyList<OpenedChunk> openedChunks,
+        IReadOnlyList<PreWarmOutcome> outcomes,
+        ILogger? logger)
+    {
+        var byType = outcomes
+            .GroupBy(o => o.TypePath, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
+
+        // The release paths each chunk's compiles minted live on the POST-bake definition stamps.
+        // Read them per node via the LIVE stream, never a query: the query index is eventually
+        // consistent and, right after the bake's own writes, provably lagged — the first version
+        // of this method re-enumerated and closed chunks with EMPTY written paths.
+        var workspace = mesh.GetWorkspace();
+        var successful = openedChunks
+            .SelectMany(c => c.Members)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(m => byType.TryGetValue(m, out var o) && o.ReachedUsableBuild)
+            .ToList();
+        return successful
+            .Select(m => workspace.GetMeshNodeStream(m)
+                .Where(n => n is not null)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .Select(n => (Type: m,
+                    Release: n!.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions)?.LatestReleasePath))
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex,
+                        "BuildProtocol: could not read the release stamp of {Type} — its chunk closes without it",
+                        m);
+                    return Observable.Return((Type: m, Release: (string?)null));
+                }))
+            .Concat()
+            .ToList()
+            .Select(stamps => stamps
+                .Where(s => !string.IsNullOrEmpty(s.Release))
+                .GroupBy(s => s.Type, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First().Release, StringComparer.OrdinalIgnoreCase))
+            .SelectMany(releases => openedChunks
+                .Select(chunk => CloseChunk(mesh, holder, chunk, byType, releases, logger))
+                .Concat()
+                .ToList()
+                .SelectMany(_ =>
+                {
+                    var gating = outcomes.Where(IsGatingFailure).Select(o => o.TypePath).ToList();
+                    if (gating.Count > 0)
+                    {
+                        logger?.LogWarning(
+                            "BuildProtocol: NOT publishing GO for {Fingerprint} — {Count} gating regression(s): {Types}",
+                            fingerprint, gating.Count, string.Join(", ", gating));
+                        return mesh.FailBuild(
+                            holder,
+                            $"{gating.Count} regression(s) on this image: {string.Join(", ", gating)}");
+                    }
+                    logger?.LogInformation(
+                        "BuildProtocol: publishing GO for framework {Fingerprint} ({Outcomes} outcome(s), {Chunks} chunk(s))",
+                        fingerprint, outcomes.Count, chunks.Count);
+                    return mesh.CompleteBuild(holder, new BuildGo(
+                        fingerprint,
+                        DateTime.UtcNow,
+                        Detail: $"{outcomes.Count(o => o.ReachedUsableBuild)}/{outcomes.Count} usable across {chunks.Count} chunk(s)"));
+                }))
+            .Select(_ => System.Reactive.Unit.Default);
+    }
+
+    private static IObservable<MeshNode> CloseChunk(
+        IMessageHub mesh,
+        string holder,
+        OpenedChunk chunk,
+        IReadOnlyDictionary<string, PreWarmOutcome> byType,
+        IReadOnlyDictionary<string, string?> releases,
+        ILogger? logger)
+    {
+        var memberOutcomes = chunk.Members
+            .Select(m => byType.TryGetValue(m, out var o) ? o : null)
+            .Where(o => o is not null)
+            .Select(o => o!)
+            .ToList();
+        var failed = memberOutcomes.Where(IsGatingFailure).ToList();
+        var written = chunk.Members
+            .Where(m => byType.TryGetValue(m, out var o) && o.ReachedUsableBuild)
+            .Select(m => releases.TryGetValue(m, out var r) ? r : null)
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Select(r => r!)
+            .ToImmutableList();
+
+        return mesh.UpdateBuildAsHolder(
+                holder,
+                s => s with
+                {
+                    Status = failed.Count > 0 ? BuildStatus.Failed : BuildStatus.Ready,
+                    Error = failed.Count > 0
+                        ? string.Join("; ", failed.Select(f => $"{f.TypePath}: {f.Detail}"))
+                        : null,
+                    WrittenPaths = written,
+                    ClaimedBy = null, ClaimedAt = null, HeartbeatAt = null,
+                },
+                chunk.Path)
+            .SelectMany(_ => FinishActivity(
+                mesh, chunk.ActivityPath,
+                failed.Count > 0 ? ActivityStatus.Failed : ActivityStatus.Succeeded))
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex, "BuildProtocol: could not close chunk {Chunk}", chunk.Name);
+                return Observable.Empty<MeshNode>();
+            });
+    }
+
+    private static IObservable<MeshNode> FinishActivity(
+        IMessageHub mesh, string activityPath, ActivityStatus status) =>
+        mesh.GetWorkspace().GetMeshNodeStream(activityPath).Update(node =>
+        {
+            var log = node?.ContentAs<ActivityLog>(mesh.JsonSerializerOptions);
+            if (node is null || log is null || log.Status.IsTerminal()) return node!;
+            return node with { Content = log.Finish(log.Version + 1, status) };
+        });
+
+    // ── the follower ────────────────────────────────────────────────────────────────────────────
+
+    private static IObservable<PreWarmOutcome> FollowGo(
+        IMessageHub mesh,
+        string holder,
+        string fingerprint,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        ILogger? logger)
+    {
+        logger?.LogInformation(
+            "BuildProtocol: claim held elsewhere — {Holder} subscribes to the GO for framework {Fingerprint}",
+            holder, fingerprint);
+
+        return mesh.ObserveBuildGo(fingerprint)
+            .Take(1)
+            .SelectMany(go =>
+            {
+                logger?.LogInformation(
+                    "BuildProtocol: GO received for framework {Fingerprint} (ready at {ReadyAt:O}) — probing the share",
+                    fingerprint, go.ReadyAt);
+                // The GO says the build finished; the share says what actually landed. Probing
+                // (rather than trusting) keeps the follower level-triggered on reality — the same
+                // property the sweep itself has. A type still pending after GO is reported as
+                // not-evaluated (non-gating): the follower has no verdict about it.
+                return NodeTypeBakeStatus.Probe(definitions, store, logger: logger)
+                    .SelectMany(fresh => fresh.Entries
+                        .Select(e => new PreWarmOutcome(
+                            e.TypePath,
+                            e.NeedsBake ? PreWarmStatus.TimedOut : PreWarmStatus.AlreadyBaked,
+                            e.NeedsBake
+                                ? "still pending on the share after the build published GO"
+                                : "on the share after GO")
+                        {
+                            WasHealthyBeforeBake = e.WasHealthy,
+                        }));
+            });
+    }
+
+    // ── shared ──────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Derive the chunk plan: one chunk per first path segment (the partition — which is exactly a
+    /// plugin's footprint for plugin content). Deterministic, order-independent, and derived rather
+    /// than invented, per the design doc.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, IReadOnlyList<string>> PlanChunks(
+        IEnumerable<string> typePaths) =>
+        typePaths
+            .Where(p => !string.IsNullOrEmpty(p))
+            .GroupBy(
+                p => { var i = p.IndexOf('/'); return i > 0 ? p[..i] : p; },
+                StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g.OrderBy(p => p, StringComparer.Ordinal).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Mirrors <c>NodeTypeBakeGateState.MarkOutcome</c>'s gating rules: only a measured failure of
+    /// a previously-healthy type blocks the GO. "I don't know" (timeouts, unevaluated upstreams)
+    /// and content verdicts (sources deleted) never do — the same leniency the readiness gate
+    /// applies, kept in one shape here so the GO and the gate cannot disagree about what a
+    /// regression is.
+    /// </summary>
+    internal static bool IsGatingFailure(PreWarmOutcome outcome) =>
+        !outcome.ReachedUsableBuild
+        && outcome.WasHealthyBeforeBake
+        && outcome.Status is not (PreWarmStatus.TimedOut
+            or PreWarmStatus.UpstreamUnevaluated
+            or PreWarmStatus.NoSources
+            or PreWarmStatus.UpstreamContentBroken);
+
+    private sealed record OpenedChunk(
+        string Name, string Path, string ActivityPath, IReadOnlyList<string> Members);
+}

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -255,7 +255,8 @@ public static class DynamicTypePreWarmer
         ILogger? logger = null,
         TimeSpan? perTypeBudget = null,
         TimeSpan? betweenTypes = null,
-        bool batchBake = false)
+        bool batchBake = false,
+        bool buildProtocol = false)
     {
         var budget = perTypeBudget ?? DefaultPerTypeBudget;
         var pacing = betweenTypes ?? BetweenTypes;
@@ -317,7 +318,7 @@ public static class DynamicTypePreWarmer
                         .Probe(definitions, store, logger: logger)
                         .SelectMany(report => BakeOrFollow(
                             mesh, workspace, accessService, definitions, nodes, store, report,
-                            budget, pacing, batchBake, logger));
+                            budget, pacing, batchBake, buildProtocol, logger));
                 })
                 // 🚨 NO Catch HERE, AND NO LOG-AND-SWALLOW — DELIBERATELY.
                 //
@@ -377,8 +378,22 @@ public static class DynamicTypePreWarmer
         TimeSpan budget,
         TimeSpan pacing,
         bool batchBake,
+        bool buildProtocol,
         ILogger? logger)
     {
+        // Build-protocol coordination (Doc/Architecture/BuildCoordination): the Admin/Build claim
+        // decides who bakes and the per-fingerprint GO is what everyone else waits on — no lease
+        // file, no follower poll. Deliberately BEFORE the IsComplete fast path: a complete share
+        // still (re)publishes its fingerprint's GO, so a baker that crashed between finishing the
+        // share and writing the GO heals on the next boot instead of stranding future GO waiters.
+        if (buildProtocol)
+            return BuildProtocolDriver.Run(
+                mesh, report, definitions, store,
+                () => WarmPending(
+                    mesh, workspace, accessService, definitions, nodes, report,
+                    budget, pacing, batchBake, logger),
+                logger);
+
         // Nothing outstanding — no lease needed, and nothing for a follower to wait for.
         if (report.IsComplete)
             return WarmPending(mesh, workspace, accessService, definitions, nodes, report, budget, pacing, batchBake, logger);
@@ -410,7 +425,8 @@ public static class DynamicTypePreWarmer
             .Timer(FollowPollInterval)
             .SelectMany(_ => NodeTypeBakeStatus.Probe(definitions, store, logger: logger))
             .SelectMany(fresh => BakeOrFollow(
-                mesh, workspace, accessService, definitions, nodes, store, fresh, budget, pacing, batchBake, logger));
+                mesh, workspace, accessService, definitions, nodes, store, fresh, budget, pacing,
+                batchBake, buildProtocol: false, logger));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -216,6 +216,23 @@ public sealed class DynamicTypePreWarmerHostedService(
                     batchBake ? "gated (batch)" : "serving (activation-driven)");
         }
 
+        // Build-protocol mode (Doc/Architecture/BuildCoordination): coordination through the
+        // Admin/Build claim + chunk nodes + the per-fingerprint GO instead of the file lease and
+        // the follower's share poll. DEFAULT OFF while the protocol slices land — execution is the
+        // same sweep either way, so this flips only WHO decides and HOW completion is broadcast.
+        var buildProtocol = false;
+        var protocolRaw = services.GetService<IConfiguration>()?[BuildProtocolDriver.EnabledConfigKey];
+        if (!string.IsNullOrWhiteSpace(protocolRaw))
+        {
+            if (bool.TryParse(protocolRaw, out var parsedProtocol))
+                buildProtocol = parsedProtocol;
+            else
+                logger.LogWarning(
+                    "DynamicTypePreWarmer: ignoring invalid {Key}='{Value}' — build-protocol "
+                    + "coordination stays off",
+                    BuildProtocolDriver.EnabledConfigKey, protocolRaw);
+        }
+
         // 🚨 SEQUENCE THE SWEEP BEHIND THE STATIC REPO IMPORT — it is content this bake must see.
         //
         // The import is kicked fire-and-forget from its own StartAsync (it has to be: subscribing on
@@ -248,7 +265,7 @@ public sealed class DynamicTypePreWarmerHostedService(
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         _warmSubscription = (importSettled?.Settled ?? Observable.Return(Unit.Default))
             .SelectMany(_ => DynamicTypePreWarmer
-                .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes, batchBake))
+                .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes, batchBake, buildProtocol))
             .Subscribe(
                 outcome =>
                 {

--- a/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh;
 using Xunit;
 
@@ -22,6 +23,12 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 public class BuildCoordinationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     private static readonly TimeSpan WaitBudget = TimeSpan.FromSeconds(15);
+
+    // The protocol-bake test drives a full cold Roslyn kickoff compile plus a protocol sweep —
+    // the same budget reasoning as NodeTypeReleaseTest's override: align the base class's dispose
+    // watchdog with the longest [Fact] timeout in the class so it cannot kill the test before its
+    // own declared budget.
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(240);
 
     [Fact(Timeout = 60_000)]
     public async Task ClaimQueue_Go_And_HolderGuard()
@@ -78,6 +85,73 @@ public class BuildCoordinationTest(ITestOutputHelper output) : MonolithMeshTestB
         final.Ready.Should().ContainKey("fp-b");
         final.ClaimedBy.Should().BeNull();
         final.Status.Should().Be(BuildStatus.Ready);
+    }
+
+    /// <summary>
+    /// The executor path end-to-end: a protocol-driven sweep claims the root, opens a chunk per
+    /// partition with its own <c>_Activity</c>, records the release paths the build produced, and
+    /// publishes the GO — including when the share already holds every build (that re-publish IS
+    /// the crashed-before-GO healing path).
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task ProtocolDrivenBake_PublishesGo_AndChunkReportsReleases()
+    {
+        var workspace = Mesh.GetWorkspace();
+        const string partition = "TestBuildProto";
+        const string typeId = "Sample";
+        var typePath = $"{partition}/{typeId}";
+
+        await NodeFactory.CreateNode(new MeshNode(typeId, partition)
+        {
+            Name = "Sample Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Sample for the protocol bake test.",
+                Configuration = "config => config.AddDefaultLayoutAreas()"
+            }
+        }).Should().Emit();
+
+        // The kickoff compile (per-NodeType hub watcher) settles first — cold Roslyn on a 2-core
+        // CI runner can take 60-90s.
+        _ = await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestReleasePath));
+
+        var outcomes = await DynamicTypePreWarmer
+            .WarmDynamicTypes(Mesh, buildProtocol: true)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(120))
+            .ToTask();
+        (outcomes.Count > 0).Should().Be(true);
+
+        var root = await workspace.GetMeshNodeStream(BuildNodeType.RootPath)
+            .Select(n => n?.ContentAs<BuildState>(Mesh.JsonSerializerOptions))
+            .Where(s => s?.Ready is { Count: > 0 })
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        root!.Status.Should().Be(BuildStatus.Ready);
+        root.ClaimedBy.Should().BeNull();
+
+        var chunk = await workspace.GetMeshNodeStream($"{BuildNodeType.RootPath}/{partition}")
+            .Select(n => n?.ContentAs<BuildState>(Mesh.JsonSerializerOptions))
+            .Where(s => s is { Status: BuildStatus.Ready })
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        // The sweep may have re-baked the type (a host without an assembly store re-compiles by
+        // design), so the chunk's written path can be a NEWER release than the kickoff one — what
+        // is contractual is that the paths it reports are release nodes of this chunk's types.
+        chunk!.WrittenPaths.Should().NotBeNull();
+        (chunk.WrittenPaths!.Count > 0).Should().Be(true);
+        chunk.WrittenPaths.All(p => p.StartsWith($"{typePath}/Release/", StringComparison.Ordinal))
+            .Should().Be(true);
+        chunk.ActivityPath.Should().NotBeNull();
+
+        var activity = await workspace.GetMeshNodeStream(chunk.ActivityPath!)
+            .Select(n => n?.ContentAs<ActivityLog>(Mesh.JsonSerializerOptions))
+            .Where(l => l is not null && l.Status.IsTerminal())
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        activity!.Status.Should().Be(ActivityStatus.Succeeded);
     }
 
     // ---- Arbitrate as a pure decision procedure: the staleness rules without wall-clock ----


### PR DESCRIPTION
Third slice of the git-keyed compilation design (protocol core: #1404; source replica: #1390). Behind **`PreWarm:BuildProtocol` (default OFF)** — enabling it changes who decides and how completion is announced, never what gets built.

## What runs through the protocol now

- **The claim replaces the lease.** `BuildProtocolDriver` registers on `Admin/Build`; the arbiter grants; a heartbeat covers the bake's lifetime. In protocol mode the `.bake-lease` file is not consulted at all.
- **Chunks report what they produced.** One chunk node per first path segment opens with its own `_Activity`, and closes recording the release paths its types minted (`{nodeTypePath}/Release/{version}`) — the build's outputs become browsable mesh state. Stamps are read per node off the LIVE stream, never the query index: the first version re-enumerated and closed chunks with empty written paths, because the index is eventually consistent and provably lagged right after the bake's own writes (the CQRS rule, met in the wild).
- **Followers subscribe to the GO.** A process that loses the claim completes on `ObserveBuildGo` instead of re-polling the share every 60 s, then probes the store once for its outcomes — level-triggered on reality, like the sweep itself.
- **GO and gate cannot disagree.** `IsGatingFailure` mirrors `NodeTypeBakeGateState.MarkOutcome`'s leniency (timeouts and content verdicts never block; only a measured failure of a previously-healthy type does). A complete share still (re)publishes its fingerprint's GO — healing a baker that crashed between finishing the share and announcing it.
- **Execution is unchanged**: the same dependency-ordered, store-probing `WarmPending` sweep, batch or activation path, one global topological order (cross-chunk source dependencies stay structurally correct).

## Asserted

End-to-end on the monolith mesh (`ProtocolDrivenBake_PublishesGo_AndChunkReportsReleases`): a protocol-driven sweep claims the root, opens the chunk with its activity, closes it `Ready` with `WrittenPaths` pointing at the chunk's release nodes and the activity `Succeeded`, and publishes the GO with the claim released. Plus the six protocol-core tests from #1404, all green on the merged tree.

## Not in this PR

- Feeding the readiness probe from the GO history (the gate still completes off sweep completion — which for followers already requires the GO).
- Flipping the default and deleting `NodeTypeBakeLease`.
- The ephemeral bake silo (portal image, bake entrypoint, own Orleans ServiceId, k8s Job) — the executor above is the piece it will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)