### PR TITLE
A teardown race permanently parks a NodeType (#1384)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -65,11 +65,49 @@
 
 name: MeshWeaver Build and Test
 
+# ──────────── EVERY PR, WHATEVER ITS BASE — including a STACKED one ────────────
+# 🚨 The `pull_request` trigger deliberately carries NO `branches:` filter. Do not
+# re-add one. It used to say `branches: [ "main" ]`, and the consequence (#1401) was
+# that a PR based on ANOTHER PR's branch — a stacked PR, which is the recommended way
+# to split a large change into reviewable pieces — never ran this suite at all.
+#
+# The failure mode is the dangerous half: an ABSENT check looks like nothing to wait
+# for. There is no "skipped", no pending, no marker of any kind — a stacked PR renders
+# as a short, all-green check list, visually IDENTICAL to one that ran the full suite
+# and passed. #1398 → #1399 → #1400 were split exactly as intended and two of the three
+# reached `MERGEABLE/CLEAN` with zero runs in their entire history.
+#
+# Three things make that state stickier than it looks, all confirmed on those PRs:
+#   * GitHub retargets a child PR to `main` only when the parent's branch is DELETED
+#     on merge. Branch deletion is off here, so a child keeps pointing at a merged
+#     branch indefinitely — "it gets tested later, just out of order" is not real.
+#     Left alone, a stacked PR was never tested at ANY point, including at merge.
+#   * `gh pr edit --base main` fires `pull_request.edited`, which is NOT in the default
+#     type set (opened/synchronize/reopened). The base changed, the checks stayed
+#     absent, and the PR still read CLEAN. Only close+reopen ever queued a run.
+#   * The `main pr protection` ruleset is scoped to `~DEFAULT_BRANCH`, so a PR whose
+#     base is not `main` is outside it: the `Consolidate test results` required check
+#     is not required there, and its absence therefore does not even block the merge.
+# So the pre-fix state had no signal at all: nothing ran, nothing was pending, nothing
+# was required. Running unconditionally is what turns that silence back into evidence.
+#
+# What a stacked run tests: GitHub builds `refs/pull/N/merge`, i.e. the branch merged
+# with ITS BASE. For a stacked PR that base is the parent's branch, so the run tests
+# the layer's own diff on top of the parent — real coverage of the code being reviewed.
+# That is the same "tested against a base that is not main's tip" posture the ruleset
+# already sanctions repo-wide (`strict_required_status_checks_policy: false`).
+#
+# Cost is small and bounded, because the green-tree reuse below is keyed on the TREE:
+# when the parent merges and main lands the identical tree, `precheck` finds the marker
+# the stacked run wrote and skips build+test. A stacked series pays for one full suite
+# per layer, not two.
+#
+# `push:` stays `main`-only on purpose — a full suite on every feature-branch push
+# would double every PR's cost for no extra evidence (the PR run already covers it).
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request:      # ← NO `branches:` filter. See the block above (#1401) before adding one.
   workflow_dispatch:
 
 # A force-push to a PR branch obsoletes the in-flight run — cancel it instead of

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -277,6 +277,29 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     // here: a live context roots its own assemblies natively, so the target only dies when the
     // whole context does.
     private WeakReference<Assembly>? _loadedAssembly;
+    // 🚨 TWO states, not one, and the difference is load-bearing.
+    //
+    //   _unloading — Dispose has STARTED. New scans are refused from here (Pin), but the
+    //                LoaderAllocator is still fully alive: Dispose drains the in-flight pins
+    //                BEFORE it calls Unload(), so anything already pinned is still loadable.
+    //   _disposed  — the drain is over and Unload() is imminent/underway. Now a load is
+    //                genuinely unsafe.
+    //
+    // Collapsing the two into `_disposed` is what made a pin worthless at the one moment it
+    // mattered. Pin() re-checks the flag after incrementing, so a pin that was HANDED OUT proves
+    // the context was live — and then Dispose could set the flag one instruction later and
+    // LoadNodeAssembly, which guards on the same flag, threw ObjectDisposedException into a
+    // scan that Dispose was at that very moment WAITING for. Nothing was wrong with the
+    // assembly; the teardown had simply been requested.
+    //
+    // That throw is not survivable downstream. CompileResultFromAssembly catches it, records
+    // CompilationStatus.Error, and the compile watcher PARKS the NodeType — "further activations
+    // serve the cached error without recompiling" — so a millisecond-wide teardown race
+    // permanently kills a type until someone rebuilds it by hand (StaleStampRootBindingTest,
+    // 6× on 08-10 and twice on 08-13 including on main). Same "one mis-read is not transient"
+    // shape as #1387, reached from the opposite side: there the bytes were incomplete, here the
+    // bytes were perfect and we refused to read them.
+    private volatile bool _unloading;
     private volatile bool _disposed;
     // In-flight SCANS of this context's loaded assembly (the GetTypes / MeshNodeProviderAttribute
     // reflection / Activator block in MeshNodeCompilationService). Dispose() drains these before
@@ -329,13 +352,13 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     /// </summary>
     public IDisposable Pin()
     {
-        if (_disposed)
+        if (_unloading || _disposed)
             throw new ObjectDisposedException(Name, "Cannot scan an assembly whose context is unloading");
         Interlocked.Increment(ref _pins);
-        // Re-check after the increment: Dispose sets _disposed then drains _pins, so a pin taken
+        // Re-check after the increment: Dispose sets _unloading then drains _pins, so a pin taken
         // concurrently with Dispose must not slip past the drain. If Dispose already started, back
         // out and throw — Dispose's drain will observe the decrement and proceed.
-        if (_disposed)
+        if (_unloading || _disposed)
         {
             Interlocked.Decrement(ref _pins);
             throw new ObjectDisposedException(Name, "Cannot scan an assembly whose context is unloading");
@@ -387,7 +410,10 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     {
         lock (_loadLock)
         {
-            if (_disposed)
+            // Both flags: once Dispose has passed its lease check it is committed to unloading
+            // (draining scans, then Unload), so a new lease could not keep the context alive.
+            // This is the pre-split behaviour — Dispose used to set _disposed at that same point.
+            if (_disposed || _unloading)
                 return NullLease.Instance;
             _leases++;
             return new LeaseScope(this);
@@ -398,7 +424,7 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     {
         bool unloadNow;
         lock (_loadLock)
-            unloadNow = --_leases == 0 && _unloadRequested && !_disposed;
+            unloadNow = --_leases == 0 && _unloadRequested && !_disposed && !_unloading;
 
         if (unloadNow)
             Dispose();
@@ -438,11 +464,33 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     }
 
     /// <summary>
+    /// True when a load must be refused. Deliberately NOT just <c>_disposed</c>, and deliberately
+    /// NOT just "teardown started" either:
+    ///
+    /// <list type="bullet">
+    ///   <item><c>_disposed</c> — the pin drain is over and <c>Unload()</c> is imminent/underway.
+    ///     Always refuse.</item>
+    ///   <item><c>_unloading</c> with NO pin outstanding — teardown has begun and nobody is holding
+    ///     the context open, so an <c>Unload()</c> can land between this load and the caller's
+    ///     <c>GetTypes()</c>. That is the "…format is invalid" corruption the pin exists to prevent,
+    ///     so an UNPINNED caller keeps the old, strict behaviour.</item>
+    ///   <item><c>_unloading</c> WITH a pin outstanding — allow it. Dispose drains pins BEFORE
+    ///     <c>Unload()</c>, so the LoaderAllocator is provably still alive and the assembly is
+    ///     perfectly loadable. This is the case that used to throw
+    ///     <c>ObjectDisposedException</c> into a scan the teardown was standing there waiting for,
+    ///     which <c>CompileResultFromAssembly</c> then recorded as a compile error and the watcher
+    ///     turned into a PARKED NodeType — permanent damage from a millisecond-wide race.</item>
+    /// </list>
+    /// </summary>
+    private bool IsClosedToLoads()
+        => _disposed || (_unloading && Volatile.Read(ref _pins) == 0);
+
+    /// <summary>
     /// Loads the node's assembly from disk.
     /// </summary>
     public Assembly? LoadNodeAssembly()
     {
-        if (_disposed)
+        if (IsClosedToLoads())
             throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
         // Fast path: already loaded
@@ -452,7 +500,7 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         lock (_loadLock)
         {
             // Double-check after acquiring lock
-            if (_disposed)
+            if (IsClosedToLoads())
                 throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
             if (LoadedAssembly is { } loaded)
@@ -581,7 +629,7 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     {
         lock (_loadLock)
         {
-            if (_disposed)
+            if (_disposed || _unloading)
                 return;
 
             // A hub is still executing this assembly (see Lease()). Unloading now would reclaim
@@ -596,13 +644,16 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
                 return;
             }
 
-            _disposed = true;
-            _loadedAssembly = null;
+            // 🚨 _unloading, NOT _disposed — and _loadedAssembly stays put. This closes Pin() to
+            // NEW scans while leaving the ones we are about to WAIT for able to finish their load.
+            // Flipping _disposed here instead made LoadNodeAssembly throw into a pinned scan and
+            // permanently park the NodeType; see the field comments.
+            _unloading = true;
 
             _logger?.LogDebug("Unloading AssemblyLoadContext {ContextName}", Name);
         }
 
-        // Drain in-flight assembly SCANS before tearing down the LoaderAllocator. _disposed is set
+        // Drain in-flight assembly SCANS before tearing down the LoaderAllocator. _unloading is set
         // above, so Pin() now rejects NEW scans; wait (time-bounded) for the ones already running to
         // release. Unloading mid-GetTypes/attribute-resolution corrupts the assembly the scanner is
         // holding (TypeLoadException '…format is invalid'), the race that flakes the concurrent
@@ -613,6 +664,13 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         var spin = new SpinWait();
         while (Volatile.Read(ref _pins) > 0 && Environment.TickCount64 < drainDeadline)
             spin.SpinOnce();
+
+        // The drain is over: from here a load really is unsafe, so close the door for good. Plain
+        // field writes, deliberately NOT under _loadLock — a scanner that overran the 5 s ceiling
+        // still holds that lock inside LoadNodeAssembly, and taking it here would block teardown
+        // behind the very scan the ceiling exists to stop waiting for.
+        _disposed = true;
+        _loadedAssembly = null;
 
         // Initiate unload outside the lock - the context will be collected when all references are released
         Unload();

--- a/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
+++ b/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
@@ -262,4 +262,64 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
         ctx.Dispose();
         Assert.Throws<ObjectDisposedException>(() => ctx.Pin());
     }
+
+    /// <summary>
+    /// 🚨 The other half of the pin contract, and the one that was missing: a pin must make the
+    /// assembly LOADABLE for as long as it is held, not merely delay <c>Unload()</c>.
+    ///
+    /// <para>Dispose() drains in-flight pins BEFORE it unloads, so while a pin is held the
+    /// LoaderAllocator is provably still alive and nothing about the assembly has changed. But
+    /// the "is this context dead?" flag that <c>LoadNodeAssembly</c> guards on was the SAME flag
+    /// Dispose raised on entry — so a scan that had legitimately pinned the context got
+    /// <c>ObjectDisposedException: Cannot load assembly from disposed context</c> thrown into it
+    /// by the very teardown that was standing there waiting for it to finish.</para>
+    ///
+    /// <para>That throw is not a hiccup. <c>CompileResultFromAssembly</c> catches it, writes
+    /// <c>CompilationStatus.Error</c>, and the compile watcher PARKS the NodeType — "further
+    /// activations serve the cached error without recompiling" — so a millisecond-wide teardown
+    /// race permanently kills the type. Observed as
+    /// <c>StaleStampRootBindingTest.StaleStampSelfTypedRoot_RootServesItsTypesArea</c> failing
+    /// with exactly that message on main (run 31683003325) and on an unrelated PR 40 minutes
+    /// later (run 31686258015), both 2026-08-13, plus 6× on 08-10.</para>
+    ///
+    /// <para>Deterministic, not timing-hopeful: the pin is taken FIRST and released only after the
+    /// load has been attempted, so the interleaving this asserts is the one that always happens.</para>
+    /// </summary>
+    [Fact]
+    public void PinnedScan_StillLoadsTheAssembly_WhileDisposeIsDraining()
+    {
+        const string nodeName = "pin_load_during_drain";
+        var dllPath = EmitTinyAssemblyToDisk(nodeName, "Widget");
+        var ctx = _service.GetOrCreateLoadContextForPath(nodeName, dllPath);
+
+        // A scan pins the context — exactly what CompileResultFromAssembly does via PinForScan.
+        using var pin = ctx.Pin();
+
+        // Teardown starts underneath it (a concurrent recompile/eviction/hub disposal) and parks
+        // in the drain, because our pin is outstanding.
+        var disposeReturned = new ManualResetEventSlim(false);
+        var disposer = new Thread(() => { ctx.Dispose(); disposeReturned.Set(); }) { IsBackground = true };
+        disposer.Start();
+        disposeReturned.Wait(300).Should().BeFalse(
+            "Dispose() must be draining — the pin is still held");
+
+        // THE ASSERTION: the pinned scan can still load. Before the fix this threw
+        // ObjectDisposedException and the caller recorded a permanent CompilationStatus.Error.
+        var assembly = ctx.LoadNodeAssembly();
+        assembly.Should().NotBeNull(
+            "a pin held across a concurrent Dispose must keep the assembly loadable: Dispose drains "
+            + "pins BEFORE Unload, so the LoaderAllocator is still alive and refusing the load only "
+            + "manufactures a compile 'failure' that parks the NodeType for good");
+        assembly!.GetTypes().Should().NotBeEmpty(
+            "the scan the pin exists to protect is GetTypes — it must complete against live metadata");
+
+        // Releasing the pin lets the deferred unload finish, exactly as before.
+        pin.Dispose();
+        disposeReturned.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
+            "releasing the pin must let Dispose() finish the unload");
+        disposer.Join();
+
+        // …and once the drain is over the context IS closed: a later load must not resurrect it.
+        Assert.Throws<ObjectDisposedException>(() => ctx.LoadNodeAssembly());
+    }
 }


### PR DESCRIPTION
Part of #1384 — one root, found by reading a red instead of re-running it.

> 🧪 **This PR is deliberately STACKED on #1402** (`fix/1401-stacked-pr-untested`), because it is the live proof of that fix. Before #1401, a PR with a non-`main` base ran **no** .NET suite at all and still read `CLEAN`. If `MeshWeaver Build and Test` appears on this PR, #1402 works. **Do not merge this before #1402.**

## The bug

A scan that had legitimately **pinned** a NodeType's `AssemblyLoadContext` could be handed an `ObjectDisposedException` by the very teardown that was standing there **waiting for that scan to finish** — and the NodeType was then parked permanently.

```
ObjectDisposedException: Cannot load assembly from disposed context
Object name: 'DynamicNode_ShopA_Front'
   at NodeAssemblyLoadContext.LoadNodeAssembly()          CompilationCacheService.cs:446
   at MeshNodeCompilationService.CompileResultFromAssembly(...)
NodeType 'ShopA/Front' PARKED after compile failure — further activations serve the
cached error without recompiling (failure contained, no retry storm).
```

`Pin()` and `LoadNodeAssembly()` guarded on the **same** `_disposed` flag, and `Dispose()` raised it on **entry**, before draining pins:

1. `Pin()` succeeds — it re-checks the flag after incrementing, so a pin that was *handed out* proves the context was live.
2. `Dispose()` sets `_disposed`, then **blocks in the pin drain, waiting for us**.
3. `LoadNodeAssembly()` reads `_disposed` and throws — against a LoaderAllocator that is provably still alive, because `Unload()` has not been called and *cannot* be until our pin releases.

The pin bought exactly the window it exists to buy, and the load refused to use it. Nothing was wrong with the assembly; teardown had merely been *requested*.

**Why a millisecond race becomes permanent damage.** `CompileResultFromAssembly` catches the throw, records `CompilationStatus.Error`, and the compile watcher parks the type with no retry — by design, to contain real compile failures. So one spurious `ObjectDisposedException` kills the NodeType until someone rebuilds it by hand. Same *"one mis-read is not transient"* shape as #1387, reached from the opposite side: there the bytes were incomplete; **here the bytes were perfect and we refused to read them.**

## The fix

Split the one flag into the two states it was conflating:

| state | meaning | effect |
|---|---|---|
| `_unloading` | `Dispose` has **started** | `Pin()` refuses **new** scans, so the drain can finish. The assembly is still loadable. |
| `_disposed` | the drain is **over**, `Unload()` imminent | loads refused. |

`LoadNodeAssembly` now consults `IsClosedToLoads()`, which deliberately keeps the **old, strict behaviour for an UNPINNED caller** (`_unloading && _pins == 0`): without a pin an `Unload()` really can land between the load and the caller's `GetTypes()`, and that is the "…format is invalid" corruption the pin exists to prevent. Only a **pinned** scan is let through. `Lease()` / `ReleaseLease()` consult both flags, so the deferred-unload path for live instance hubs is unchanged.

No retry, no sleep, no widened bound — the context is either still alive when the scan reads it, or it is not.

## Evidence this is live

`StaleStampRootBindingTest.StaleStampSelfTypedRoot_RootServesItsTypesArea`, which #1384's tail lists as **dead** ("6, all 08-10 — do not re-chase"), failed **twice on 08-13**:

| run | commit / branch | when |
|---|---|---|
| `31683003325` | `891aae06a`, **main** | 08:39Z |
| `31686258015` | #1402 (an unrelated CI-only diff) | 09:22Z |

The second one is what surfaced the stack — it reddened my own workflow-only PR 40 minutes after main. The 08:39 occurrence had a *different* signature (a >20 s hub-teardown wedge, `root ShopA never answered after its recycle`), so that test name currently covers **two** roots; this PR fixes the `ObjectDisposedException` one. Details and the rest of the sweep are in [my comment on #1384](https://github.com/Systemorph/MeshWeaver/issues/1384#issuecomment-5278651814).

## Verification — fail-before / pass-after

`PinnedScan_StillLoadsTheAssembly_WhileDisposeIsDraining` (new, in `AssemblyLoadContextLeakTest`) is **deterministic, not timing-hopeful**: the pin is taken first and released only after the load has been attempted, so the interleaving it asserts is the one that always happens.

```
before  FAIL — System.ObjectDisposedException : Cannot load assembly from disposed context
               (verbatim the CI failure)
after   pass
```

It also asserts the other half — once the drain is over, a later load still throws — so the fix cannot be "just delete the guard".

| | |
|---|---|
| `MeshWeaver.Graph.Test` | **1098/1098** |
| `MeshWeaver.PluginCatalog.Test` | **270/270** (carries the flaky test) |
| Release `-warnaserror` clean | `MeshWeaver.Graph` (`--no-incremental`), `Graph.Test`, `PluginCatalog.Test`, `FutuRe.Test` |

All runs `DOTNET_PROCESSOR_COUNT=4`, Release. `MeshWeaver.Hosting.Monolith.Test` + `FutuRe.Test` regression runs were in flight at push time; CI covers them.

No What's New entry: the user-visible symptom (a NodeType stuck on the compilation-error overlay) is real, but it is reached only through a teardown race that no released build has been observed to hit in production — this is a CI-integrity fix. Say the word and I will add a `Category: Fix` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
