### PR TITLE
fix: a cold sync stream no longer starves when its owner recycles

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Reactive;
+using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using MeshWeaver.Json;
@@ -42,6 +43,13 @@ public static class JsonSynchronizationStream
     /// recycling pathologically and THAT is the bug.
     /// </summary>
     private const int MaxRecycleReArms = 3;
+
+    /// <summary>
+    /// How far up the hub tree the recycle re-arm looks for the local instance of a rejecting
+    /// owner (see <c>LocalInstanceOf</c>). Real trees are two or three deep — mesh → cache/client
+    /// → sync — so this is only a guard against a malformed parent chain.
+    /// </summary>
+    private const int MaxHostLookupDepth = 8;
 
     // Mirror of MeshWeaver.Mesh.Security.WellKnownUsers.System — Data sits below
     // Mesh.Contract in the project graph and cannot reference it. Same literal
@@ -568,26 +576,121 @@ public static class JsonSynchronizationStream
             //
             // So the rejection itself is the event. The owner told us, in the same breath, both
             // that it is going and that it is coming back ("the address may reactivate; retry to
-            // get the authoritative answer"), and by the time that verdict is produced the hub is
-            // already at RunLevel Dead — so the re-ask lands on a FRESH activation, which a
-            // SubscribeRequest creates on arrival.
+            // get the authoritative answer").
             //
-            // This is not the forbidden watchdog: nothing polls, nothing runs on a timer, and it
-            // fires only in response to an explicit typed rejection. It reuses Resubscribe, so it
-            // inherits the in-flight guard, ExpectResubscribeFull (the mirror must accept a
-            // re-snapshot stamped below its cached frame version) and the System impersonation.
-            // The re-ask asks for the CURRENT snapshot — it never re-asserts a cached frame, which
-            // is the #945 shape and the opposite of what this does. Bounded so that an owner stuck
-            // in a recycle LOOP degrades to the pre-existing "orphaned" behaviour instead of
-            // trading a stalled stream for a storm.
+            // 🚨 …but NOT YET, and that "yet" is the whole of issue #1360. This re-ask used to
+            // fire SYNCHRONOUSLY out of the NACK callback, justified by "by the time that verdict
+            // is produced the hub is already at RunLevel Dead — so the re-ask lands on a FRESH
+            // activation". It is not: MessageService NACKs from `RunLevel >= DisposeHostedHubs`,
+            // a phase in which the dying hub is STILL registered in its parent's
+            // HostedHubsCollection (it removes itself in the later ShutDown phase, from
+            // DisposeImpl's `disposables`). So routing resolved every re-ask to the SAME dying
+            // instance, which NACKed it identically and immediately: the whole bounded budget
+            // burned inside one teardown window — measured at FOUR rejections in 11 ms on
+            // MeshWeaver.Plugins run 31645120599 — and the stream was orphaned for good.
+            //
+            // A WARM handle hides that (its replayed snapshot satisfies readers, and the owner's
+            // next write re-converges it through the change-feed latch, ~2.0 s). A COLD handle has
+            // nothing to replay, so the orphaning is terminal: MeshNodeStreamHandle.UpdateRemote's
+            // initial-state wait runs out its full 30 s and aborts with "no initial state arrived
+            // for '…' within 30s" — the abort that failed #1360's install with 0 nodes written.
+            // Pinned by ColdHandleRecycleStarvationTest.
+            //
+            // The cure is to spend each attempt on a state that can actually answer: gate it on
+            // the rejecting instance's own DisposalCompleted. This is NOT a retry, a backoff or a
+            // watchdog — nothing polls, no timer runs, no bound moved, and the budget is the same
+            // MaxRecycleReArms. It is the same event-driven re-ask, fired once the event it was
+            // always waiting for has actually happened. PackageInstaller.RootTeardownSettled
+            // already holds itself to exactly this contract one layer up; the sync stream
+            // underneath it did not.
+            //
+            // It reuses Resubscribe, so it inherits the in-flight guard, ExpectResubscribeFull
+            // (the mirror must accept a re-snapshot stamped below its cached frame version) and
+            // the System impersonation. The re-ask asks for the CURRENT snapshot — it never
+            // re-asserts a cached frame, which is the #945 shape and the opposite of what this
+            // does. Bounded so that an owner stuck in a recycle LOOP degrades to the pre-existing
+            // "orphaned" behaviour instead of trading a stalled stream for a storm.
+            // Concat, not SelectMany: attempt N+1's wait starts only after attempt N's has ended,
+            // so two rejections arriving together can never sit on two teardowns at once and race
+            // into Resubscribe's in-flight guard. One at a time, without a lock.
             var recycleReArms = 0;
             var recycleReArm = rejectedByRecycle
                 .Where(_ => Interlocked.Increment(ref recycleReArms) <= MaxRecycleReArms)
+                .Select(reason => OwnerTeardownSettled().Select(_ => reason))
+                .Concat()
                 .Subscribe(
                     reason => Resubscribe(reason),
                     ex => logger.LogDebug(ex,
                         "Stream {StreamId}: recycle re-arm stream faulted", reduced.StreamId));
             reduced.RegisterForDisposal(recycleReArm);
+
+            // Completes once the teardown that just rejected us has finished, so the re-ask lands
+            // on a fresh activation instead of racing the same dying instance. Event-driven: it
+            // observes that hub instance's DisposalCompleted, a ReplaySubject(1), so a disposal
+            // that finishes between the probe and the subscribe still answers immediately. When
+            // there is nothing to wait for — no local instance (the owner lives on another silo,
+            // or its teardown already completed and it left the collection), or one that is not
+            // disposing — the re-ask proceeds at once, exactly as before.
+            //
+            // No .Timeout here, deliberately: this join must not out-run the answer it joins
+            // (#1317). MessageHub.Dispose arms a disposal watchdog that force-tears-down and
+            // signals DisposalCompleted as its last act, so the leg is already guaranteed
+            // terminal; the caller's own budget (UpdateRemote's initial-state wait) is the
+            // deadline that belongs to the caller.
+            IObservable<Unit> OwnerTeardownSettled()
+            {
+                var live = LocalInstanceOf(owner);
+                if (live is null || !live.IsDisposing)
+                    return Observable.Return(Unit.Default);
+                logger.LogDebug(
+                    "Stream {StreamId}: owner {Owner} is mid-teardown (RunLevel={RunLevel}) — "
+                    + "holding the re-ask until its disposal completes",
+                    reduced.StreamId, owner, live.RunLevel);
+                return live.DisposalCompleted
+                    .Take(1)
+                    .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+                    .DefaultIfEmpty(Unit.Default);
+            }
+
+            // The local hub instance serving `address`, or null when none does. A pure probe —
+            // HostedHubCreation.Never is a dictionary lookup that must never activate a hub as a
+            // side effect.
+            //
+            // 🚨 It walks UP, because the subscriber is almost never the owner's host: a per-node
+            // hub is hosted by the MESH hub, while `hub` here is whoever opened the stream — a
+            // `cache/{meshId}` or client hub, i.e. a SIBLING under that same mesh. And it cannot
+            // shortcut through DI: every hub registers ITSELF as `IMessageHub` in its own service
+            // collection (MessageHubConfiguration.ConfigureServices), so
+            // `hub.ServiceProvider.GetService<IMessageHub>()` hands back `hub`. The parent link is
+            // `Configuration.ParentHub`, which resolves `IMessageHub` from the PARENT provider.
+            // Depth-capped: the chain is finite by construction (a root hub has no parent), and
+            // the cap only ensures a malformed tree degrades to today's behaviour rather than
+            // spinning. Failures answer `null`, which likewise means "re-ask now", exactly as
+            // before this gate existed.
+            IMessageHub? LocalInstanceOf(Address address)
+            {
+                try
+                {
+                    var h = hub;
+                    for (var depth = 0; h is not null && depth < MaxHostLookupDepth; depth++)
+                    {
+                        if (h.GetHostedHub(address, HostedHubCreation.Never) is { } found)
+                            return found;
+                        h = h.Configuration.ParentHub;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // ParentHub re-resolves from ParentServiceProvider, which can already be
+                    // disposed when a whole tree is going down. Probing must never throw into
+                    // the NACK path.
+                    logger.LogDebug(ex,
+                        "Stream {StreamId}: could not probe the local instance of {Owner}",
+                        reduced.StreamId, address);
+                }
+
+                return null;
+            }
 
             // 🚨 THE LOST INITIAL — and why the first heartbeat comes EARLY.
             //

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-node-restarting-no-longer-strands-the-page-that-just-opened-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-node-restarting-no-longer-strands-the-page-that-just-opened-it.md
@@ -1,0 +1,19 @@
+---
+Name: A node restarting no longer strands the page that just opened it
+Category: Fix
+Description: Opening or saving something at the exact moment its node restarts no longer hangs for 30 seconds and then fails.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A node restarting no longer strands the page that just opened it
+
+Nodes restart routinely — after a republish, an idle deactivation, or a self-heal — and that
+normally passes unnoticed. But if you happened to open or save something in the split second a
+node was restarting, and nothing on your screen had loaded from it yet, the connection was quietly
+abandoned: the view sat empty, or the save spun for thirty seconds and then reported a timeout.
+Trying again worked, which is why this mostly looked like a random hiccup.
+
+The connection now waits for the restart to finish before asking again, so the work simply lands a
+moment later instead of failing. Installs are the most visible beneficiary — one could previously
+report zero items written when a node it was writing to restarted mid-run.

--- a/test/MeshWeaver.Hosting.Monolith.Test/ColdHandleRecycleStarvationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ColdHandleRecycleStarvationTest.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The COLD half of the recycle contract (issue #1360). <see cref="ResubscribeOnOwnerDisposeTest"/>
+/// pins the WARM case — a handle that already holds a snapshot re-converges after its owner
+/// recycles. This pins the half that used to have no recovery at all: a handle with <b>no initial
+/// state yet</b> when the recycle lands.
+///
+/// <para><b>The production trace</b> (issue #1360, MeshWeaver.Plugins run 31645120599 attempt 1).
+/// An install two seconds in:</para>
+/// <code>
+/// 22:03:44.045  ── Essentials: installing 36 file(s)…
+/// 22:03:46.382  warn: JsonSynchronizationStream Stream Q-…: resubscribe failed.
+///               DeliveryFailureException: Hub Essentials is shutting down
+///               (RunLevel=DisposeHostedHubs) … Rejecting now.     [ ×4 within 11 ms ]
+///               [ 28.043 s of TOTAL log silence — not one line ]
+/// 22:04:49.222  [FAIL] Essentials (0 node(s), 0 type(s))  install: TimeoutException
+/// </code>
+///
+/// <para><b>Why the budget is spent in 11 ms.</b> <c>JsonSynchronizationStream</c> answers a
+/// <see cref="ErrorType.ShuttingDown"/> NACK by re-asking at once, from the failure callback
+/// itself, bounded at <c>MaxRecycleReArms = 3</c>. Its source comment justifies the immediacy with
+/// "by the time that verdict is produced the hub is already at RunLevel Dead — so the re-ask lands
+/// on a FRESH activation". The trace says otherwise: the NACK names
+/// <c>RunLevel=DisposeHostedHubs</c>, a phase in which the dying hub is still registered in its
+/// parent's <c>HostedHubsCollection</c>. So routing resolves every re-ask to the SAME dying
+/// instance, which NACKs it identically and synchronously — the whole budget burns inside one
+/// teardown window, and the stream is orphaned for good.
+///
+/// <para>A WARM handle survives that: its replayed snapshot satisfies the reader, and the next
+/// owner write re-converges it through the change-feed latch (~2.0 s). A COLD handle has nothing
+/// to replay, so the orphaning is terminal — <c>UpdateRemote</c>'s initial-state wait runs out its
+/// full 30 s and aborts with <i>"no initial state arrived for '…' within 30s"</i>. That is exactly
+/// the abort #1360's install died on, and it is the only one of the two shapes that matches.</para>
+///
+/// <para><b>What this test asserts</b> is the contract, not the mechanism: a cold cross-hub write
+/// issued while the owner is mid-recycle must land once the recycle finishes. <c>PackageInstaller</c>
+/// already held itself to it (<c>RootTeardownSettled</c> gates its own re-ask on the dying
+/// instance's <see cref="IMessageHub.DisposalCompleted"/>); the sync stream underneath it now does
+/// the same, so each of its bounded re-asks is spent on a state that can answer. Against the
+/// unfixed stream this test fails at 30 s; against the fixed one it passes in ~3 s and emits no
+/// rejected re-ask at all.</para>
+/// </summary>
+public class ColdHandleRecycleStarvationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string NodeId = "cold-recycle-target";
+
+    private static readonly Address GateChildAddress = new("teardown-gate", NodeId);
+
+    /// <summary>
+    /// How long the owner sits at <see cref="MessageHubRunLevel.DisposeHostedHubs"/>.
+    ///
+    /// <para>NOT a sleep and not a test-side wait: it is the gate child's own
+    /// <c>QuiesceTimeout</c>, i.e. a hub budget the framework spends draining a pending response
+    /// callback. Modelling it is the point — a real per-node hub has <c>sync/*</c> children with
+    /// exactly such callbacks, which is why a production teardown occupies this phase at all
+    /// (the trace's own NACK reads <c>RunLevel=DisposeHostedHubs</c>). The measured re-arm burst
+    /// is 11 ms, so 1.5 s is ~136× the window it must outlast; lengthening it can only make the
+    /// starvation MORE certain, never turn a real failure green. Every wait in the test body is
+    /// on a condition.</para>
+    /// </summary>
+    private static readonly TimeSpan GateQuiesce = TimeSpan.FromMilliseconds(1500);
+
+    /// <summary>Accepted by the gate child and never answered — the pending response callback is
+    /// the ONLY thing the Quiescing phase counts, so it is what holds the phase open.</summary>
+    private record StallRequest : IRequest<StallAck>;
+
+    private record StallAck;
+
+    /// <summary>SubscribeRequests that reached the owner's handler, i.e. were NOT NACKed.</summary>
+    private int _subscribesServed;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder)
+            .ConfigureDefaultNodeHub(config =>
+            {
+                if (!config.Address.ToString()!.EndsWith(NodeId, StringComparison.Ordinal))
+                    return config;
+                return config
+                    // A hosted child that takes a realistic amount of time to quiesce. The
+                    // parent's DisposeHostedHubs phase joins hostedHubs.DisposalCompleted with NO
+                    // deadline of its own (#1317), so the owner sits in EXACTLY the RunLevel the
+                    // production NACK reported for as long as the child takes — no stalled action
+                    // block, no watchdog, no sleep. Created eagerly: WithHostedHub is lazy (first
+                    // delivery) and the child has to EXIST before the parent tears down.
+                    //
+                    // Same lever as SubscribeDuringRecycleTest (MeshWeaver.Layout.Test), which
+                    // parks an un-answered callback to hold a hub in its disposal window. The one
+                    // difference is WHERE: that test needs Quiescing, this one needs the LATER
+                    // DisposeHostedHubs, because that is where MessageService's shutdown gate
+                    // starts NACKing (`RunLevel >= DisposeHostedHubs`) and what the production
+                    // trace recorded. Parking the callback on a CHILD is what buys that phase.
+                    .WithInitialization(h =>
+                    {
+                        var child = h.GetHostedHub(
+                            GateChildAddress,
+                            c => c
+                                .WithTypes(typeof(StallRequest), typeof(StallAck))
+                                .WithQuiesceTimeout(GateQuiesce)
+                                // Longer than the gate window, so the callback is still pending
+                                // when the child starts quiescing.
+                                .WithRequestTimeout(TimeSpan.FromMinutes(2))
+                                .WithHandler<StallRequest>((_, d) => d.Processed()),
+                            HostedHubCreation.Always);
+                        child?.Observe<StallAck>(new StallRequest(), o => o.WithTarget(GateChildAddress))
+                            .Subscribe(_ => { }, _ => { });
+                    })
+                    // Passive counter: returns the delivery UNPROCESSED so the framework handler
+                    // still runs. Only subscribes that got PAST the shutdown gate are counted.
+                    .WithHandler<SubscribeRequest>((_, delivery) =>
+                    {
+                        Interlocked.Increment(ref _subscribesServed);
+                        return delivery;
+                    });
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddData();
+
+    [Fact(Timeout = 180_000)]
+    public async Task ColdCrossHubWrite_LandsAfterTheOwnersRecycleCompletes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/{NodeId}";
+
+        await NodeFactory
+            .CreateNode(new MeshNode(NodeId, TestPartition) { Name = "Original", NodeType = "Markdown" })
+            .Should().Within(30.Seconds()).Emit();
+
+        // Activate the owner hub WITHOUT touching GetMeshNodeStream: the per-path handle in
+        // IMeshNodeStreamCache is shared process-wide, so reading it here would warm the very
+        // handle the test needs cold. A bare fire-and-forget post activates the hub on arrival.
+        Mesh.Post(new HeartBeatEvent(), o => o.WithTarget(new Address(path)));
+        IMessageHub? owner = null;
+        await WaitUntil(
+            () => (owner = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never)) is not null,
+            "the owner hub must activate before it can be recycled");
+        Output.WriteLine($"owner activated: {owner!.Address} runLevel={owner.RunLevel}");
+
+        // Recycle the owner exactly as the framework does — a DisposeRequest, not a direct
+        // Dispose() — so the teardown is the production one.
+        Mesh.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
+        await WaitUntil(
+            () => owner.RunLevel >= MessageHubRunLevel.DisposeHostedHubs,
+            "the owner must reach DisposeHostedHubs, where it NACKs every SubscribeRequest");
+        Output.WriteLine($"owner parked at runLevel={owner.RunLevel} (gate child is quiescing)");
+
+        var servedBeforeWrite = Volatile.Read(ref _subscribesServed);
+
+        // THE COLD HANDLE. This client has never subscribed to the path, so its very first
+        // SubscribeRequest is the one that lands on the disposing owner and is NACKed.
+        var client = GetClient();
+        var write = client.GetWorkspace()
+            .GetMeshNodeStream(path)
+            .Update(node => node with { Name = "Updated" })
+            .FirstAsync()
+            .ToTask(ct);
+
+        // Nothing to release: the gate closes itself when the child finishes quiescing, and the
+        // owner's fresh activation becomes reachable. WITHOUT the fix the subscriber has by then
+        // already spent its whole re-arm budget against the dying instance and gone silent, so
+        // this dies at UpdateRemote's 30 s initial-state bound —
+        // "no initial state arrived for '…' within 30s", the abort #1360's install reported.
+        var updated = await write;
+        updated.Name.Should().Be("Updated",
+            "a cold cross-hub write must land once the owner's recycle completes");
+
+        Output.WriteLine(
+            $"subscribes served after the write = {Volatile.Read(ref _subscribesServed) - servedBeforeWrite}");
+        Volatile.Read(ref _subscribesServed).Should().BeGreaterThan(servedBeforeWrite,
+            "the subscriber must re-ask the FRESH activation — a re-ask that only ever hit the "
+            + "dying instance never reaches a handler at all");
+    }
+
+    /// <summary>
+    /// Polls a public state flag (a hub's <see cref="IMessageHub.RunLevel"/>) — the actual
+    /// condition, not a fixed settle. Same shape as <c>DisposalRaceNackTest.WaitUntil</c>.
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string because)
+    {
+        for (var i = 0; i < 600; i++)
+        {
+            if (condition())
+                return;
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"Timed out waiting: {because}");
+    }
+}


### PR DESCRIPTION
Fixes #1360.

## The defect

`JsonSynchronizationStream` answers an `ErrorType.ShuttingDown` NACK by re-asking **at once, from
the failure callback itself**, bounded at `MaxRecycleReArms = 3`. Its own source comment justifies
the immediacy:

> by the time that verdict is produced the hub is already at RunLevel Dead — so the re-ask lands on
> a FRESH activation

That is false. `MessageService` NACKs from **`RunLevel >= DisposeHostedHubs`**, a phase in which the
dying hub is *still registered* in its parent's `HostedHubsCollection` — it removes itself later, in
the ShutDown phase, from `DisposeImpl`'s `disposables`. So routing resolved every re-ask to the
**same dying instance**, which NACKed it identically and synchronously. The entire bounded budget
burned inside one teardown window — **four rejections in 11 ms** in the production trace on
MeshWeaver.Plugins run 31645120599 — and the stream was orphaned permanently.

A **warm** handle hides this: its replayed snapshot satisfies readers, and the owner's next write
re-converges it through the change-feed latch (~2.0 s). A **cold** handle has nothing to replay, so
the orphaning is terminal — `MeshNodeStreamHandle.UpdateRemote`'s initial-state wait runs its full
30 s and aborts with *"no initial state arrived for '…' within 30s"*. That is the abort that failed
#1360's install with **0 nodes written**, and the cold case is the only one of the two shapes that
matches the report.

## The fix

Gate each re-arm on the rejecting instance's own `DisposalCompleted`, so the attempt is spent on a
state that can actually answer. `PackageInstaller.RootTeardownSettled` already holds itself to
exactly this contract one layer up; the sync stream underneath it did not.

**This is not a retry, a backoff or a watchdog.** Nothing polls, no timer runs, **no bound moved**,
and the budget is the same `MaxRecycleReArms = 3`. It is the same event-driven re-ask, fired once
the event it was always waiting for has actually happened. It strictly *reduces* traffic: the
measured run goes from three rejected re-asks to **zero**.

Details worth noting in review:

- `DisposalCompleted` is a `ReplaySubject(1)`, so a disposal finishing between the probe and the
  subscribe still answers immediately — no new race.
- **No `.Timeout` on the new wait, deliberately** (#1317 — a join must not out-run the answer it
  joins). `MessageHub.Dispose` arms a disposal watchdog that force-tears-down and signals
  `DisposalCompleted` as its last act, so the leg is already guaranteed terminal. The caller's own
  budget stays the deadline that belongs to the caller.
- When there is nothing to wait for — no local instance (owner on another silo, or its teardown
  already finished and it left the collection) or one that is not disposing — the re-ask proceeds
  at once, exactly as before.
- `Concat`, not `SelectMany`, so two rejections can never sit on two teardowns at once and race into
  `Resubscribe`'s in-flight guard.
- The local-instance probe walks **up** the parent chain. A per-node hub is hosted by the *mesh*
  hub while the subscriber is a `cache/{meshId}` or client hub — a sibling — and it cannot shortcut
  through DI, because every hub registers *itself* as `IMessageHub` in its own service collection.
  Probing is `HostedHubCreation.Never` (a dictionary lookup that never activates a hub), depth-capped,
  and any failure answers `null` = "re-ask now", i.e. the pre-existing behaviour.

## Repro — written first, and it fails on the unfixed code

`test/MeshWeaver.Hosting.Monolith.Test/ColdHandleRecycleStarvationTest.cs` is the COLD counterpart to
the existing warm-case `ResubscribeOnOwnerDisposeTest`.

It holds the owner at `RunLevel=DisposeHostedHubs` — the exact production RunLevel — by giving it a
hosted child with one un-answered response callback, so the child's Quiescing cannot drain and the
parent's deadline-free `hostedHubs.DisposalCompleted` join waits it out. That is the same lever
`SubscribeDuringRecycleTest` uses, one phase later. **No sleeps and no racing:** the test waits on
the observed `RunLevel`, issues the cold write, and the window then closes on the hub's own budget.

| | unfixed | fixed |
|---|---|---|
| result | **FAIL** at 30 s — `no initial state arrived for '…' within 30s` | **PASS** in ~3 s |
| rejected re-asks | 3 | 0 |

⚠️ Per #1360's own retraction ("one green standalone run was luck"), this was verified inside the
**full project run**, not standalone, with `DOTNET_PROCESSOR_COUNT=4`.

## Not done, on purpose

The `IsRootRecycling` arm was **not** added to `PackageInstaller`'s `RootRetypeReconciled` /
`RootRetypePersisted`. That was the original hypothesis in #1360 and it was falsified there; the
failing stage is the write path, and applying it to the retype stages would not have touched this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
