### PR TITLE
Reclaim change-feed-evicted mirrors instead of parking them forever (#1324)

### DIFF
--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -130,11 +130,13 @@ public class Workspace : IWorkspace
         if (string.IsNullOrEmpty(path) || _remoteStreamCache.IsEmpty)
             return;
 
-        // Do NOT dispose the evicted stream — existing subscribers (e.g. live Blazor
-        // components) are still attached to it and need to keep receiving updates
-        // until they drop on their own. The eviction only prevents NEW callers from
-        // re-using the now-stale stream; the next GetRemoteStream creates a fresh one
-        // against the (re-)activated owner.
+        // Do NOT unconditionally dispose the evicted stream — an undeclared reader (e.g. a
+        // MeshDataSource reduce callback that handed the stream on) may still be attached and
+        // needs to keep receiving updates until it drops on its own. The eviction only prevents
+        // NEW callers from re-using the now-stale stream; the next GetRemoteStream creates a
+        // fresh one against the (re-)activated owner. A stream whose holders DECLARED
+        // themselves (see <see cref="LeaseRemoteStream"/>) and have all left is reclaimed
+        // immediately — it is out of the cache, so nothing can adopt it any more.
         foreach (var key in _remoteStreamCache.Keys)
         {
             // Owner-address match only — every identity's stream for that owner is evicted.
@@ -146,11 +148,121 @@ public class Workspace : IWorkspace
                 // disposed → TimerQueue-pinned forever). Only a materialised stream
                 // has a hub to dispose.
                 if (removed.IsValueCreated)
+                {
                     _evictedRemoteStreams[removed.Value] = 0;
+                    ReclaimIfUnheld(removed.Value);
+                }
                 _logger.LogDebug(
                     "Evicted remote stream cache for {Address} after change event.",
                     key.Owner);
             }
+        }
+    }
+
+    // 🚨 THE LIFETIME OF AN EVICTED STREAM — declared holders, NOT Rx subscriber counts.
+    //
+    // A change-feed eviction takes a stream OUT of _remoteStreamCache but cannot dispose it at
+    // the eviction site: it does not know whether anyone is still reading it. Parking it and
+    // hoping is what leaked — every write to a subscribed path minted a fresh client `sync/` hub
+    // (and, via its SubscribeRequest, a matching `sync/` hub on the owner) while every
+    // predecessor sat in _evictedRemoteStreams until the process died (Systemorph/MeshWeaver#1324:
+    // the parked set grew 1 → 23 monotonically over three NodeType recompiles and was never
+    // drained — its only reaper is the shared mesh-node cache's idle sweep, which needs zero
+    // subscribers AND ten minutes untouched, a condition a continuously-written path never meets).
+    //
+    // 🚨 Counting Rx subscribers CANNOT answer "is anyone still reading this": the reduce chain
+    // CreateExternalClient builds subscribes to the stream ITSELF (the outbound
+    // change-notification pipeline and the version-gate observer), so an evicted stream measures
+    // 2–3 subscribers and never reaches zero. That approach was implemented, measured and
+    // reverted — a mechanism that never triggers is worse than none.
+    //
+    // So holders DECLARE themselves. Everything that keeps a remote stream past the call that
+    // resolved it takes a LEASE (AcquireRemoteStreamUnchecked) and releases it when it is done — the
+    // shared mesh-node cache's hydration for as long as its entry lives, and each cross-hub write
+    // for the duration of its Observable.Create subscription. When the last declared holder
+    // leaves a stream that is already evicted, nothing can adopt it (it is out of the cache), so
+    // it is disposed at once: UnsubscribeRequest goes to the owner, both `sync/` hubs die.
+    //
+    // A stream NOBODY leased is never in this registry and keeps the old conservative parking —
+    // undeclared holders (the MeshDataSource / SyncedQueryDataSource reduce callbacks) are
+    // unaffected. Opting a call site in is one line and is what makes its streams reclaimable.
+    private readonly ConcurrentDictionary<ISynchronizationStream, int> _remoteStreamLeases =
+        new(StreamReferenceComparer.Instance);
+
+    /// <summary>
+    /// Resolves the remote stream for (<paramref name="owner"/>, <paramref name="reference"/>)
+    /// AND declares the caller as a holder of it. Dispose the returned lease when done — that is
+    /// what lets an evicted stream be reclaimed instead of parked forever (see the
+    /// <see cref="_remoteStreamLeases"/> note). The liveness re-check closes the window where the
+    /// stream was reclaimed between resolution and the lease: a dead instance is released and the
+    /// resolve retried, which builds a fresh one (the same retry contract as
+    /// <see cref="GetExternalClientSynchronizationStream{TReduced,TReference}"/>).
+    /// </summary>
+    internal (ISynchronizationStream<TReduced> Stream, IDisposable Lease)
+        AcquireRemoteStreamUnchecked<TReduced, TReference>(Address owner, TReference reference)
+        where TReference : WorkspaceReference
+    {
+        while (true)
+        {
+            var stream = GetRemoteStreamUnchecked<TReduced, TReference>(owner, reference);
+            var lease = LeaseRemoteStream(stream);
+            if (stream.Hub?.RunLevel <= MessageHubRunLevel.Started
+                && stream.Hub is not MessageHub { IsDisposing: true })
+                return (stream, lease);
+            lease.Dispose();
+        }
+    }
+
+    /// <summary>Declares a holder of <paramref name="stream"/>; disposing the returned
+    /// handle releases it (idempotent).</summary>
+    private IDisposable LeaseRemoteStream(ISynchronizationStream stream)
+    {
+        _remoteStreamLeases.AddOrUpdate(stream, 1, (_, count) => count + 1);
+        // Disposable.Create runs its action AT MOST ONCE (Interlocked-swapped internally), so a
+        // double-dispose of the lease handle cannot under-count the holders.
+        return System.Reactive.Disposables.Disposable.Create(() =>
+        {
+            while (true)
+            {
+                // 🚨 Read-then-TryUpdate, never AddOrUpdate: DetachRemoteStreams REMOVES the
+                // bookkeeping when it hands ownership out, and re-adding a zero entry here would
+                // pin a stream this workspace no longer owns.
+                if (!_remoteStreamLeases.TryGetValue(stream, out var current))
+                    return;
+                var remaining = current > 0 ? current - 1 : 0;
+                if (!_remoteStreamLeases.TryUpdate(stream, remaining, current))
+                    continue;
+                if (remaining == 0)
+                    ReclaimIfUnheld(stream);
+                return;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Disposes <paramref name="stream"/> iff it is BOTH evicted (parked — no caller can adopt
+    /// it) AND has no remaining declared holder. Called from the two edges that can make that
+    /// true: the eviction itself, and the release of the last lease.
+    /// </summary>
+    private void ReclaimIfUnheld(ISynchronizationStream stream)
+    {
+        if (!_remoteStreamLeases.TryGetValue(stream, out var leases) || leases != 0)
+            return;
+        if (!_evictedRemoteStreams.TryRemove(stream, out _))
+            return;
+        _remoteStreamLeases.TryRemove(stream, out _);
+        try
+        {
+            stream.Dispose();
+            _logger.LogDebug(
+                "Workspace {WorkspaceId} disposed superseded remote stream for {Owner} — "
+                + "no declared holder remains.", Id, stream.Owner);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Workspace {WorkspaceId} error disposing superseded remote stream for {Owner}",
+                Id, stream.Owner);
         }
     }
 
@@ -399,6 +511,12 @@ public class Workspace : IWorkspace
                 && _evictedRemoteStreams.TryRemove(parked, out _))
                 detached.Add(parked);
         }
+        // Ownership moves to the caller (it disposes, or hands them back via ParkRemoteStreams),
+        // so drop the lease bookkeeping: keeping a zero-count entry would pin a stream this
+        // workspace no longer owns. A re-parked stream simply re-enters the conservative
+        // "undeclared holders" bucket until a fresh lease is taken.
+        foreach (var stream in detached)
+            _remoteStreamLeases.TryRemove(stream, out _);
         return detached;
     }
 
@@ -440,7 +558,18 @@ public class Workspace : IWorkspace
                     () => (ISynchronizationStream)this.CreateExternalClient<TReduced, TReference>(address, reference),
                     LazyThreadSafetyMode.ExecutionAndPublication));
 
+            // The counterpart of the eviction line below, and the one #1324 needed: a client
+            // `sync/` hub (plus its owner-side twin) is born here, so "who keeps minting mirrors
+            // for this path, under which identity" is answerable from a Debug-level run instead of
+            // a heap dump. Logged only on a genuine MISS — a cache hit is free and silent.
+            var freshlyCreated = !lazy.IsValueCreated;
+
             var stream = lazy.Value;
+
+            if (freshlyCreated)
+                _logger.LogDebug(
+                    "Workspace {WorkspaceId} opened remote stream {StreamId} for {Owner} as {Identity}.",
+                    Id, stream.StreamId, key.Item1, key.Item3);
 
             // Check if cached stream is still alive. Hub.RunLevel alone is not
             // sufficient because hub shutdown is async: right after stream.Dispose()
@@ -674,6 +803,8 @@ public class Workspace : IWorkspace
                 _logger.LogDebug(ex, "Workspace {WorkspaceId} error disposing evicted remote stream", Id);
             }
         }
+        // Nothing left to reclaim — drop the holder bookkeeping so it stops referencing streams.
+        _remoteStreamLeases.Clear();
 
         // Local reduced streams are OWNED by their parent (CreateReducedStream registers each on
         // the data-source stream that produced it), so DataContext.Dispose below tears them down.

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -151,6 +151,35 @@ NodeType activation, MCP get/search, synced-query grain warming — leaked a
 permanently-connected upstream stream (~1,650 live streams / 37 heartbeats-per-second
 measured on a long-lived portal).
 
+### The idle sweep is not the only reaper — an evicted upstream dies with its last holder
+
+The idle sweep answers *"this path went quiet"*. It cannot answer *"this write is finished
+with its mirror"*, and that is the case a busy path is always in: `Workspace.EvictForPath`
+retires a path's upstream on **every** change event — including the echo of the writer's own
+write — so the next writer diffs against the owner's authoritative state rather than a stale
+snapshot. That eviction is load-bearing; parking the retired stream until the idle sweep
+happened to notice was not, and a continuously-written path never meets the sweep's
+"zero subscribers **and** ten minutes untouched" condition
+([#1324](https://github.com/Systemorph/MeshWeaver/issues/1324)).
+
+Reference counting the stream's Rx subscribers cannot decide it either: the reduce chain
+`JsonSynchronizationStream.CreateExternalClient` builds subscribes to the stream **itself**, so
+a retired mirror sits at 2–3 subscribers forever and a "dispose at zero" rule never fires.
+
+So holders **declare** themselves. Anything keeping a remote stream past the call that resolved
+it takes a lease from `Workspace.AcquireRemoteStreamUnchecked` and disposes it when done:
+
+| holder | lease lifetime |
+|---|---|
+| this cache's per-entry hydration (`CreateEntry` → `handle.Subscribe`) | the entry's whole life — it *is* the path's one live mirror |
+| a cross-hub write (`MeshNodeStreamHandle.UpdateRemote` / `WriteViaSyncStream`) | the write's `Observable.Create` subscription |
+| a reduce callback that hands the stream on (`MeshDataSource`, `SyncedQueryDataSourceExtensions`) | **none** — undeclared, so it keeps the conservative parking |
+
+An **evicted** stream with no remaining declared holder is disposed at once — `UnsubscribeRequest`
+reaches the owner, and both the client and owner `sync/` hubs die. A stream nobody leased is never
+touched by this and is still reclaimed by the idle release above or at workspace disposal. Steady
+state on a hot path is therefore ONE live mirror, not one per write.
+
 ## The storm breaker — absent nodes can't melt the silo
 
 A read whose owner answers *NotFound* is cached as a **negative entry** with exponential backoff (2 s doubling up to 5 min). While the window is open, re-subscribing to that path replays the cached failure instead of re-opening an upstream subscription — so a loop that keeps re-reading an absent node cannot hammer the routing layer. The entry simply **expires** (the next natural read re-probes once; a successful read clears it immediately) — there is no timer that re-subscribes on its own.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
@@ -195,6 +195,20 @@ This is exactly what the `MeshNodeReference(path)` reducer registered by `AddSyn
 - When the cached stream's hub leaves `MessageHubRunLevel.Started` (disposed or failed), the next `GetRemoteStream` call replaces it with a fresh instance.
 - When an explicit `IMeshChangeFeed` event reports a path change (ownership churn — see `Workspace.EvictForPath`), open subscribers stay attached to their existing stream while new callers bind to a fresh one tied to the re-activated owner.
 
+**An evicted stream is closed as soon as its last declared holder lets go.** Eviction removes the
+stream from the cache but cannot dispose it at the eviction site — it does not know whether anyone
+is still reading. Rx subscriber counts cannot answer that either: the reduce chain
+`CreateExternalClient` builds subscribes to the stream itself, so an evicted stream sits at 2–3
+subscribers forever. So holders **declare** themselves: anything that keeps a remote stream past the
+call that resolved it takes one through `Workspace.AcquireRemoteStreamUnchecked` and disposes the
+returned lease when it is done — the shared mesh-node cache's hydration for its entry's whole life,
+each cross-hub write for the duration of its `Observable.Create` subscription. When the last lease on
+an already-evicted stream goes, it is disposed at once: `UnsubscribeRequest` reaches the owner and
+both `sync/` hubs die. A stream **nobody** leased keeps the conservative parking (it may still have
+undeclared readers) and is reclaimed by the mesh-node cache's idle release or at workspace disposal.
+Without the leases every write to a subscribed path left a client `sync/` hub and its owner-side twin
+behind for the process lifetime — [#1324](https://github.com/Systemorph/MeshWeaver/issues/1324).
+
 The full integrity story is a plain dictionary, single-threaded access, and shared-by-default semantics — made safe entirely by the actor model.
 
 The `RemoteStreamCacheTest` (`test/MeshWeaver.Query.Test`) pins this contract: two `GetRemoteStream(...)` calls for the same key are reference-equal, and a disposed stream is evicted before the next caller receives it.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-writing-to-a-page-no-longer-leaves-a-connection-behind.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-writing-to-a-page-no-longer-leaves-a-connection-behind.md
@@ -1,0 +1,38 @@
+---
+Name: Writing to a page no longer leaves a connection behind
+Category: Fix
+Description: Every save to a busy item used to abandon the internal connection it wrote through and open a fresh one, so the portal accumulated connections for as long as it ran. Abandoned connections are now closed the moment nobody is using them.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Writing to a page no longer leaves a connection behind
+
+When one part of the portal reads or writes something owned by another part, it opens a private
+live connection to it — a mirror that stays in step while it is needed. Mirrors are shared, so a
+page being read by ten things costs one mirror, not ten.
+
+There is one moment when a mirror has to be replaced rather than reused: the item changed, and the
+next writer must diff against what the owner actually holds, not against a snapshot from before.
+The portal handled that by retiring the mirror so the next caller would build a fresh one. Retiring
+it was correct. What was missing was closing it.
+
+Nothing could close it safely, because nothing knew whether anyone was still reading. Counting
+readers does not answer the question — a mirror's own internal plumbing subscribes to it, so the
+count never reaches zero even when every real reader has gone. So a retired mirror was simply
+parked, and parked mirrors were only ever cleaned up when the item went untouched for ten minutes
+— which an item being written to continuously never does.
+
+The result: every save to a busy item retired one mirror and opened another, on both ends of the
+connection, and neither of the retired pair ever went away. A single rebuild of in-portal code left
+about twenty of these behind; a morning of them left thousands.
+
+Holders now say so. Anything that keeps a mirror past the moment it asked for one — a live view
+being read, a save in flight — declares itself, and a retired mirror is closed the instant its last
+declared holder lets go. Measured over a rebuild loop: of twenty-four mirrors opened and
+twenty-three retired, eighteen are now closed immediately and the survivors are exactly the ones
+still being read. A rebuild costs roughly half the internal machinery it did this morning, and the
+saving applies to every ordinary save, not only to rebuilds.
+
+Two smaller sources of the same kind of growth remain, both with different causes, and the
+measurement that found this one is tightened again so neither can hide.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -133,12 +133,22 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         || string.Equals(_path, _workspace.Hub.Address.Path, StringComparison.Ordinal)
         || string.Equals(_path, _workspace.Hub.Address.ToString(), StringComparison.Ordinal);
 
-    private ISynchronizationStream<MeshNode> GetStream()
+    /// <summary>
+    /// Resolves this handle's stream AND — for a REMOTE path — declares this caller as a holder
+    /// of it (see <c>Workspace.AcquireRemoteStreamUnchecked</c>). Dispose the returned lease
+    /// together with whatever subscription/operation used the stream: that declaration is what
+    /// lets a change-feed-evicted stream be reclaimed the moment its last holder leaves, instead
+    /// of being parked for the process lifetime (#1324 — every cross-hub write to a subscribed
+    /// path otherwise left a client `sync/` hub and its owner-side twin behind). Own-hub streams
+    /// are local reductions owned by the data source; they take no lease.
+    /// </summary>
+    private (ISynchronizationStream<MeshNode> Stream, IDisposable Lease) AcquireStream()
     {
         if (IsOwn)
-            return _workspace.GetStream(new MeshNodeReference())
-                ?? throw new InvalidOperationException(
-                    "MeshNode stream is not available â€” the workspace has no MeshNodeReference reducer.");
+            return (_workspace.GetStream(new MeshNodeReference())
+                    ?? throw new InvalidOperationException(
+                        "MeshNode stream is not available â€” the workspace has no MeshNodeReference reducer."),
+                Disposable.Empty);
         // 🚨 Open the remote MeshNode subscription under the system identity.
         // Reading MeshNode content is infrastructure (routing, path resolution,
         // permission probing, NodeType activation, satellite enumeration). The
@@ -158,7 +168,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // discouraged-usage warning. This cache/bypass handle is the sanctioned hot
             // path, so it opens the raw single-node remote reduce via the internal
             // unchecked overload — no warning noise.
-            return ((Workspace)_workspace).GetRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
+            return ((Workspace)_workspace).AcquireRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
                 new Address(_path!), new MeshNodeReference());
         }
     }
@@ -226,10 +236,26 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     .Where(n => n is not null)
                     .Subscribe(typedObserver);
 
-            return GetStream()
-                .Where(change => change.Value != null)
-                .Select(change => change.Value!)
-                .Subscribe(typedObserver);
+            // 🚨 The lease lives exactly as long as this subscription. The shared mesh-node
+            // cache's hydration comes through here, so its entry IS the declared holder of the
+            // path's upstream for the entry's whole life — which is what makes every OTHER
+            // (write-scoped) stream for the same path reclaimable on eviction.
+            var (stream, lease) = AcquireStream();
+            try
+            {
+                var subscription = stream
+                    .Where(change => change.Value != null)
+                    .Select(change => change.Value!)
+                    .Subscribe(typedObserver);
+                return new CompositeDisposable(subscription, lease);
+            }
+            catch
+            {
+                // A lease the caller never receives can never be released, and an
+                // unreleased lease pins the mirror against reclamation forever.
+                lease.Dispose();
+                throw;
+            }
         }
         catch (Exception ex)
         {
@@ -873,10 +899,24 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
 
             // 🚨 Sanctioned escape hatch (cache/bypass write path) — route through the
             // internal unchecked overload; the public GetRemoteStream<MeshNode> warns.
-            var remoteStream = ((Workspace)_workspace).GetRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
-                new Address(_path!), new MeshNodeReference());
+            // The LEASE (disposed with this subscription) is what tells the workspace this
+            // write still needs the stream, so an eviction landing mid-write parks it rather
+            // than reclaiming it — and reclaims it the instant the write is done (#1324).
+            //
+            // 🚨 Unlike UpdateRemote — which only READS the initial snapshot off the stream and
+            // then writes with hub.Post — this path writes THROUGH the stream, and EmitOnce
+            // completes the caller inside the stream's own UpdateStreamRequest turn (just before
+            // SetCurrent). So the lease ends a hair before the turn does. Leasing is still
+            // strictly the safer choice: leaving this path undeclared would let an eviction
+            // reclaim the very mirror the overwrite is writing through. Closing the last
+            // microseconds needs an `applied` hook on the value-based SetFull/Update overloads
+            // (SynchronizationStream already runs one post-apply, same turn, for the
+            // ChangeItem-based overload) — worth doing when that API is next touched.
+            var (remoteStream, streamLease) = ((Workspace)_workspace)
+                .AcquireRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
+                    new Address(_path!), new MeshNodeReference());
 
-            var composite = new CompositeDisposable();
+            var composite = new CompositeDisposable(streamLease);
             var emitted = 0;
             void EmitOnce(MeshNode value)
             {
@@ -998,10 +1038,14 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
 
             // 🚨 Sanctioned escape hatch (cache/bypass write path) — route through the
             // internal unchecked overload; the public GetRemoteStream<MeshNode> warns.
-            var remoteStream = ((Workspace)_workspace).GetRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
-                new Address(_path!), new MeshNodeReference());
+            // Leased for the life of this subscription — see WriteViaSyncStream's note and
+            // Workspace._remoteStreamLeases (#1324): without the declaration the workspace
+            // cannot tell a write-scoped mirror from one a live reader still needs.
+            var (remoteStream, streamLease) = ((Workspace)_workspace)
+                .AcquireRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
+                    new Address(_path!), new MeshNodeReference());
 
-            var composite = new CompositeDisposable();
+            var composite = new CompositeDisposable(streamLease);
 
             // Wait for the per-node hub's initial SubscribeResponse before
             // running the user lambda — the lambda needs a non-null current

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
@@ -67,28 +67,54 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
     /// <c>TypeRegistry</c> and <c>JsonSerializerOptions</c> — about 140 KB — so the two numbers move
     /// together, but only this one says WHERE.</para>
     ///
-    /// <para>Measured on this repro at the time of writing: <b>22 hubs and ~8.7 MB per recompile</b>,
-    /// attributed by walking the hosted-hub tree (see <see cref="HubsByParent"/>, printed below):
-    /// <c>_Activity/compile-state</c> +22 over three recompiles, the shared <c>cache/</c> hub +17, the
-    /// three per-compile <c>_Activity/compile-&lt;ts&gt;</c> node hubs +16, the NodeType's own hub +6.
-    /// Almost all of them are <c>sync/{id}</c> sub-hubs — one per <c>SynchronizationStream</c>.</para>
+    /// <para>Measured on this repro: <b>12 hubs and ~6–7 MB per recompile</b> (12.0 / 12.3 / 12.0
+    /// over three Release runs), down from 22 and ~8 MB. Attributed by walking the hosted-hub tree
+    /// (see <see cref="HubsByParent"/>, printed below): the three per-compile
+    /// <c>_Activity/compile-&lt;ts&gt;</c> node hubs ~+17 over three recompiles (plus the 2 node hubs
+    /// themselves), <c>_Activity/compile-state</c> +12, the NodeType's own hub +3, the shared
+    /// <c>cache/</c> hub +3–4. Almost all of them are <c>sync/{id}</c> sub-hubs — one per
+    /// <c>SynchronizationStream</c>.</para>
     ///
-    /// <para>The remaining retainer is <c>Workspace.EvictForPath</c>: it fires on EVERY mesh change
-    /// event, including the echo of the writer's own write, evicts the mirror that write used and
-    /// PARKS it in <c>_evictedRemoteStreams</c> without disposing. Instrumented over this loop the
-    /// parked set goes 1 → 23 monotonically and is never drained: its only reaper is the shared
-    /// mesh-node cache's idle sweep, which needs zero subscribers AND ten minutes untouched — a
-    /// condition a continuously-written path never meets. The eviction itself is load-bearing (with it
-    /// disabled the next write diffs against a stale snapshot and the owner's MergeGuard refuses it,
-    /// so the compile never settles), and a plain "dispose when the subscriber count hits zero"
-    /// does not fire either: an evicted stream measures 2–3 subscribers because the reduce chain
-    /// built by <c>CreateExternalClient</c> subscribes to itself. Reclaiming it needs the shared cache
-    /// — which knows which mirror is live — to re-bind on eviction. Issue #1324.</para>
+    /// <para><b>What the 22 → 12 change closed (#1324):</b> <c>Workspace.EvictForPath</c> fires on
+    /// EVERY mesh change event — including the echo of the writer's own write — and used to PARK the
+    /// mirror that write had used in <c>_evictedRemoteStreams</c> without disposing it, so a
+    /// continuously-written path minted a fresh client <c>sync/</c> hub (and its owner-side twin) per
+    /// write and never gave one back; instrumented over this loop the parked set grew 1 → 23
+    /// monotonically. The eviction itself is load-bearing (disabled, the next write diffs against a
+    /// stale snapshot and the owner's MergeGuard refuses it, so the compile never settles) and a
+    /// "dispose when the Rx subscriber count hits zero" rule does not fire at all (the reduce chain
+    /// <c>CreateExternalClient</c> builds subscribes to the stream itself, so an evicted stream sits
+    /// at 2–3 subscribers forever). The cure is a DECLARED holder: everything that keeps a remote
+    /// stream past the call that resolved it takes a lease
+    /// (<c>Workspace.AcquireRemoteStreamUnchecked</c>) and an evicted stream is disposed the instant
+    /// its last lease goes. Measured over this loop: 24 mirrors opened, 23 evicted, <b>18 reclaimed</b>
+    /// — the 6 survivors are the one live hydration mirror per path, which is the correct steady
+    /// state.</para>
+    ///
+    /// <para><b>What still retains, and why the bound is 15 rather than single digits</b> — two
+    /// mechanisms, neither of them the parking one:</para>
+    /// <list type="number">
+    ///   <item>The per-compile <c>_Activity/compile-&lt;ts&gt;</c> NODE HUBS (~6 apiece) are created
+    ///     per compile and never reclaimed — a node-lifecycle question, not a stream one. This is now
+    ///     the LARGEST share of the residual.</item>
+    ///   <item>Owner-side intermediate reduced streams. <c>MeshDataSource</c>'s own-node
+    ///     <c>AddWorkspaceReferenceStream&lt;MeshNode&gt;</c> factory builds
+    ///     <c>primary.Reduce&lt;InstanceCollection&gt;(CollectionReference("MeshNode"))</c> and then
+    ///     reduces THAT to the node — and <c>WorkspaceStreams.CreateReducedStream</c> registers each
+    ///     child for disposal ON ITS PARENT, which here is the data source's primary stream (hub
+    ///     lifetime). The factory runs uncached on every call that passes a <c>configuration</c> —
+    ///     i.e. once per inbound <c>SubscribeRequest</c> — so an unsubscribe reaps the subscription's
+    ///     own hub but leaves the intermediates behind. Same defect shape as #1345 (which memoized
+    ///     <c>Workspace.GetStream</c>), one layer down at <c>stream.Reduce</c>. Correlating the
+    ///     surviving hubs against the client stream ids says this is what <c>compile-state</c>'s +12
+    ///     now is: 27 of the 34 surviving <c>sync/</c> hubs match NO client mirror.</item>
+    /// </list>
     ///
     /// <para>So this bound is a RATCHET at the measured value, not an aspiration: it fails the moment
-    /// the residual gets worse, and it must be tightened by whoever fixes the eviction ownership.</para>
+    /// the residual gets worse, and it is to be tightened again by whoever fixes either mechanism
+    /// above.</para>
     /// </summary>
-    private const int MaxHubsPerRecompile = 26;
+    private const int MaxHubsPerRecompile = 15;
 
     /// <summary>
     /// Live collectible contexts for this NodeType. The name is
@@ -232,14 +258,15 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
         // Caching local reduced streams the way remote ones were always cached took it to ~9 MB
         // and 22 hubs, and took the mesh's steady-state hub count from 187 to 48.
         //
-        // 16 MB, not single digits, is deliberate: the REMAINING ~9 MB is a second, named retainer —
-        // `Workspace.EvictForPath` parks the evicted remote stream in `_evictedRemoteStreams`
-        // WITHOUT disposing it, so every change event on a subscribed path mints a fresh
-        // client/owner `sync/` pair (6 + 8 hubs per compile here). Tighten this bound to single
-        // digits in the change that fixes THAT — a bound nothing can currently pass is a red test,
-        // not a guard.
+        // 12 MB, not single digits, is deliberate. The eviction-parking retainer is fixed (#1324 —
+        // see MaxHubsPerRecompile), which took this from ~8 to ~6–7 MB per recompile; what is left
+        // belongs to the two mechanisms named there (per-compile activity NODE hubs, and the
+        // owner-side intermediate reduced streams registered on a hub-lifetime parent). Tighten this
+        // bound with whichever of those is fixed next — a bound nothing can currently pass is a red
+        // test, not a guard. Bytes also move with unrelated allocation, which is exactly why the hub
+        // delta below is the primary assertion.
         var perRecompile = managedGrowth / Recompiles;
-        perRecompile.Should().BeLessThan(16 * 1024 * 1024,
+        perRecompile.Should().BeLessThan(12 * 1024 * 1024,
             $"a recompile of a trivial type must return its memory; {perRecompile / (1024 * 1024)} MB "
             + $"retained per recompile ({managedGrowth / (1024 * 1024)} MB over {Recompiles}) means "
             + "compile state survives the context that owned it");


### PR DESCRIPTION
Part of #1324 — closes retainer #1 (the `EvictForPath` parking). **Does not close the issue**: two other mechanisms remain and are named below and in the test's comment.

## The retainer, and why the two obvious cures were already dead

`Workspace.EvictForPath` fires on **every** mesh change event — including the echo of the writer's own write — takes the mirror out of `_remoteStreamCache` and **parks it in `_evictedRemoteStreams` without disposing it**. So a continuously-written path mints a fresh client `sync/` hub (and, via its `SubscribeRequest`, a matching `sync/` hub on the owner) per write and never gives one back. Instrumented over the recompile repro the parked set grew **1 → 23 monotonically**; its only reaper is the shared mesh-node cache's idle sweep, which needs zero subscribers **and** ten minutes untouched — a condition a continuously-written path never meets.

Both easy answers were measured and rejected in earlier passes on this issue, and both are now recorded in the test comment so nobody re-derives them:

1. **The eviction cannot be skipped.** Disabled, the next write diffs against a stale snapshot and the owner's `MergeGuard` refuses it (`refused stale/reordered cross-hub write to 'compilationStatus'`); the compile never settles. The eviction is load-bearing; the *parking* is the defect.
2. **"Dispose when the Rx subscriber count hits zero" never fires.** The reduce chain `JsonSynchronizationStream.CreateExternalClient` builds subscribes to the stream **itself** (the outbound change-notification pipeline, the version-gate observer), so an evicted stream sits at 2–3 subscribers forever.

## The fix: holders declare themselves

Subscriber counts cannot separate consumers from the stream's own plumbing — so consumers say so explicitly. `Workspace.AcquireRemoteStreamUnchecked` resolves the stream **and** returns a lease; an evicted stream with no remaining declared holder is disposed at once, which posts `UnsubscribeRequest` to the owner and kills **both** `sync/` hubs.

| holder | lease lifetime |
|---|---|
| the shared mesh-node cache's per-entry hydration (`MeshNodeStreamHandle.Subscribe`) | the entry's whole life — it *is* the path's one live mirror |
| a cross-hub write (`UpdateRemote`, `WriteViaSyncStream`) | its `Observable.Create` subscription |
| reduce callbacks that hand the stream on (`MeshDataSource`, `SyncedQueryDataSourceExtensions`) | **none** — undeclared, so they keep today's conservative parking |

A stream nobody leased is never in the registry, so this cannot pull a mirror out from under an undeclared reader. `DetachRemoteStreams` drops the bookkeeping when it hands ownership out; the acquire re-checks liveness so a stream reclaimed between resolve and lease is released and re-resolved fresh.

`EvictForPath` also gained the Debug counterpart of its eviction line — "opened remote stream {StreamId} for {Owner} as {Identity}" on a genuine cache miss — which is what made this measurable without a heap dump, and what the attribution below is built from.

## Measured — `NodeTypeRecompileAlcLeakTest`, Release, three recompiles of `config => config`

| | before | after |
|---|---|---|
| **hubs / recompile** | **22.0** | **12.0 / 12.3 / 12.0** (three runs) |
| managed / recompile | ~8 MB | ~6–7 MB |
| `cache/<mesh>` | +18 | **+3** |
| `_Activity/compile-state` | +23 | **+12** |
| the NodeType's own hub | +6 | **+3** |
| `_Activity/compile-<ts>` (3 new node hubs) | +16 | +16 (unchanged — see below) |

Directly on the mechanism, from the Debug trace over one run: **24 mirrors opened, 23 evicted, 18 reclaimed.** The 6 survivors are exactly the one live hydration mirror per path — the correct steady state.

Ratchet tightened: **26 → 15** hubs and **16 → 12** MB per recompile.

## What still retains (for the follow-up, not this PR)

1. **The per-compile `_Activity/compile-<ts>` NODE hubs** (~6 sync hubs apiece) — created per compile, never reclaimed. Now the largest single share of the residual. A node-lifecycle question, not a stream one.
2. **Owner-side intermediate reduced streams — a NEW finding that replaces this issue's guess about `compile-state`.** `MeshDataSource`'s own-node `AddWorkspaceReferenceStream<MeshNode>` factory builds `primary.Reduce<InstanceCollection>(CollectionReference("MeshNode"))` and then reduces *that* to the node, and `WorkspaceStreams.CreateReducedStream` registers each child for disposal **on its PARENT** — here the data source's primary stream, i.e. hub lifetime. The factory runs uncached on every call that passes a `configuration`, which is once per inbound `SubscribeRequest`, so an unsubscribe reaps the subscription's own hub and leaves the intermediates behind. Exactly #1345's defect shape, one layer down at `stream.Reduce`. Correlating the surviving hubs against the client stream ids says this is what `compile-state`'s +12 now is: **27 of the 34 surviving `sync/` hubs match no client mirror at all.**

## Verification

- `dotnet restore` + `dotnet build --no-restore -c Release -p:CIRun=true -warnaserror` (CI's exact flags) — **0 errors**.
- `MeshWeaver.Hosting.Monolith.Test` 653/653 · `MeshWeaver.Query.Test` 390/390 (incl. `RemoteStreamCacheTest`) · `MeshWeaver.Data.Test` 344/344 · `MeshWeaver.Security.Test` 407/407 (incl. `RemoteStreamCacheIdentityTest`) · `MeshWeaver.Documentation.Test` 20/20.

What's New entry included (`Category: Fix` — this is the OOM curve users see).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
