### PR TITLE
feat(bake): bake mode — the portal image as an ephemeral, self-disposing build master

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/BakeModeCompletion.cs
+++ b/memex/aspire/Memex.Portal.Distributed/BakeModeCompletion.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// What makes a bake-mode process EPHEMERAL: subscribes to the pre-warm settlement and stops the
+/// host the moment the sweep settles — GO published, work done, process gone. Exiting is the
+/// point: every <c>sync/</c> hub and collectible ALC the compiles minted dies with the process,
+/// so the bake's memory cost (measured +1.9 GB managed for a full sweep) is reclaimed by
+/// construction instead of by leak-chasing.
+///
+/// <para><b>The exit code is the verdict</b> — a Job has no readiness probe to gate, so the
+/// contract the readiness gate provides on a serving pod is provided here by process exit:
+/// 0 = the sweep ran to completion (regressions, if any, are on the Build nodes and withheld the
+/// GO); 1 = the sweep FAULTED and verified nothing; 2 = nothing ran at all, which in a process
+/// whose only purpose is the bake is a configuration error and must never read as success.</para>
+/// </summary>
+public sealed class BakeModeCompletion(
+    PreWarmCompletion completion,
+    IHostApplicationLifetime lifetime,
+    ILogger<BakeModeCompletion> logger) : IHostedService, IDisposable
+{
+    private IDisposable? subscription;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "[BakeMode] ephemeral build master — waiting for the sweep to settle, then exiting");
+        subscription = completion.Settled
+            .Take(1)
+            .Subscribe(settlement =>
+            {
+                Environment.ExitCode = settlement switch
+                {
+                    PreWarmSettlement.Completed => 0,
+                    PreWarmSettlement.NotApplicable => 2,
+                    _ => 1,
+                };
+                logger.LogInformation(
+                    "[BakeMode] sweep settled as {Settlement} — stopping with exit code {ExitCode}",
+                    settlement, Environment.ExitCode);
+                lifetime.StopApplication();
+            });
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public void Dispose() => subscription?.Dispose();
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -160,6 +160,32 @@ builder.ConfigureMemexServices();
 var embeddingOptions = builder.Configuration.GetSection("Embedding").Get<EmbeddingOptions>() ?? new EmbeddingOptions();
 builder.Services.AddEmbeddings(embeddingOptions);
 
+// 🔥 BAKE MODE (Deployment:Mode=Bake): this SAME binary — and therefore the SAME image, the same
+// Graph MVID, the same framework fingerprint — runs as an ephemeral build master instead of a
+// serving portal. It joins NO live cluster (own ServiceId + localhost clustering below), runs the
+// protocol-coordinated sweep against the shared stores (Postgres, /data assembly cache, source
+// replica), publishes the per-fingerprint GO on Admin/Build, and EXITS (BakeModeCompletion).
+// Serving pods then find the share full and their GO already published.
+//
+// The retired 2025 bake image failed precisely because it was a DIFFERENT build with a foreign
+// fingerprint (#1347); same-image-different-mode is what makes its bakes valid by construction.
+// Exiting after GO also disposes every sync hub and collectible ALC the compiles minted — the
+// bake's memory cost (measured +1.9 GB managed for a full sweep) dies with the process.
+var bakeMode = string.Equals(
+    builder.Configuration["Deployment:Mode"], "Bake", StringComparison.OrdinalIgnoreCase);
+if (bakeMode)
+{
+    // The bake posture, forced regardless of the deployment's serving config: the sweep IS the
+    // job, batch direct-compile (nothing to be gentle to), and no readiness gate — a Job has no
+    // rotation to be held out of; its verdict is its EXIT CODE.
+    builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        [DynamicTypePreWarmerHostedService.EnabledConfigKey] = "true",
+        [DynamicTypePreWarmerHostedService.BatchBakeConfigKey] = "true",
+        [NodeTypeBakeGateExtensions.EnabledConfigKey] = "false",
+    });
+}
+
 // Configure Orleans clustering (co-hosted silo + web).
 //  - "AzureTables" (default): Aspire injects Azure Table clustering via config — no
 //    explicit provider here, exactly as before (no regression for ACA/Marketplace).
@@ -176,8 +202,17 @@ builder.UseOrleansMeshServer(address, silo =>
     {
         silo.Configure<ClusterOptions>(opts =>
         {
-            opts.ClusterId = MemexDistributedConstants.ClusterId;
-            opts.ServiceId = MemexDistributedConstants.ServiceId;
+            // Bake mode gets its OWN service identity: bake grains instantiate in the bake
+            // cluster because it is the only cluster they exist in, and no discovery round-trip
+            // can land on (or starve against) a serving pod's activations — the #1218 class is
+            // unrepresentable rather than mitigated. Membership state is keyed by these ids, so
+            // the live cluster's tables are never touched.
+            opts.ClusterId = bakeMode
+                ? $"{MemexDistributedConstants.ClusterId}-bake"
+                : MemexDistributedConstants.ClusterId;
+            opts.ServiceId = bakeMode
+                ? $"{MemexDistributedConstants.ServiceId}-bake"
+                : MemexDistributedConstants.ServiceId;
         });
         // Membership-probe tolerance. EVERY portal crash on memex-cloud over 2026-07-15..22 was the
         // same self-inflicted death: a silo starved by load (boot import/compile storm, GC pauses
@@ -194,7 +229,14 @@ builder.UseOrleansMeshServer(address, silo =>
             opts.NumMissedProbesLimit = 5;
             opts.EnableIndirectProbes = true;
         });
-        if (string.Equals(orleansClustering, "Localhost", StringComparison.OrdinalIgnoreCase))
+        if (bakeMode)
+        {
+            // A bake silo is a cluster of ONE by design — it must never join (or even see) the
+            // serving membership, whatever provider the deployment configured. Localhost
+            // clustering is that isolation: no membership store, no gossip, no probes.
+            silo.UseLocalhostClustering();
+        }
+        else if (string.Equals(orleansClustering, "Localhost", StringComparison.OrdinalIgnoreCase))
         {
             silo.UseLocalhostClustering();
         }
@@ -302,6 +344,21 @@ builder.Services.AddHealthChecks()
 // assembly cache — types already baked for this framework are skipped, so a second replica
 // (or a restart) inherits the first pod's work instead of repeating it.
 builder.Services.AddDynamicTypePreWarming();
+
+if (bakeMode)
+{
+    // The sweep settling is this process's whole purpose — settle ⇒ exit, exit code = verdict.
+    builder.Services.AddHostedService<Memex.Portal.Distributed.BakeModeCompletion>();
+    // A bake Job must never act as a fleet manager: the self-updater patches the DEPLOYMENT'S
+    // image on its startup poll, and a short-lived Job doing that mid-roll is exactly the kind of
+    // surprise a build process must not spring. Remove the hosted service rather than flag it —
+    // there is no configuration in which a bake Job should self-update anything.
+    foreach (var descriptor in builder.Services
+                 .Where(d => d.ServiceType == typeof(IHostedService)
+                     && d.ImplementationType == typeof(Memex.Portal.Shared.SelfUpdate.SelfUpdateHostedService))
+                 .ToList())
+        builder.Services.Remove(descriptor);
+}
 
 // 🚦 "Fail before prod, not in prod." Opt-in (PreWarm:GateReadiness) gate that holds /health
 // RED until this pod's NodeTypes are built against ITS image. Combined with the deployment's

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-builds-can-run-in-their-own-disposable-process.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-builds-can-run-in-their-own-disposable-process.md
@@ -1,0 +1,25 @@
+---
+Name: Builds can run in their own disposable process
+Category: Feature
+Description: The portal binary gains a bake mode — an ephemeral build master with its own cluster identity that compiles everything, publishes the GO, and exits, so serving pods start against a full cache and build memory is reclaimed by process exit.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Builds can run in their own disposable process
+
+The same portal binary — and therefore the same image and the same framework fingerprint — can now
+run as a dedicated build process instead of a serving portal. In bake mode it joins no serving
+cluster (it gets its own cluster identity, so build work and live traffic cannot contend or starve
+each other), runs the coordinated build against the shared stores, publishes the GO signal, and
+exits.
+
+Exiting is the point: everything a full build allocates — measured at roughly two gigabytes for a
+complete sweep — is reclaimed the moment the process ends, instead of living on inside a serving
+pod. And because a build's outcome must never be ambiguous, the process's exit code is its
+verdict: success, a faulted sweep that verified nothing, or a misconfiguration that ran no build
+at all.
+
+Serving pods keep their own build capability as a fallback — the claim on the build root
+arbitrates cleanly between a dedicated build process and a pod baking for itself, so running the
+build ahead of a rollout is an acceleration, never a requirement.


### PR DESCRIPTION
Fifth slice (#1390 replica → #1404 protocol → #1406 executor → #1413 default-on → this). `Deployment:Mode=Bake` runs **this same binary — same image, same Graph MVID, same framework fingerprint** — as a build master instead of a serving portal.

## What bake mode does

- **A cluster of ONE, by construction.** Own `{ClusterId,ServiceId}-bake` identity + localhost clustering regardless of the deployment's provider: it never joins, probes, or starves against the serving membership. Build grains instantiate in the bake cluster because it is the only cluster they exist in — the #1218 starved-discovery class is unrepresentable rather than mitigated.
- **Forced bake posture**: sweep on, batch direct-compile, readiness gate OFF — a Job has no rotation to be held out of. **The exit code is the verdict** (`BakeModeCompletion`): 0 = sweep settled (regressions, if any, are on the Build nodes and withheld the GO), 1 = sweep faulted and verified nothing, 2 = nothing ran — a misconfiguration that must never read as success.
- **Exit reclaims everything.** Every `sync/` hub and collectible ALC the compiles minted dies with the process — the +1.9 GB managed a full sweep measured today is bounded by process lifetime instead of leak-chasing.
- **The self-updater's hosted service is removed in bake mode** — a short-lived Job must never patch the fleet's deployment image mid-roll.

## Why this works where the 2025 bake image failed

The retired `memex-bake` image (#1347) computed a FOREIGN framework fingerprint — it was a different build. The fingerprint is Graph.dll's MVID, so only byte-identical binaries produce bakes the portal can use: same-image-different-mode is correct by construction.

## Coordination is already arbitrated

Serving pods keep their own bake as fallback. The `Admin/Build` claim (default-on since #1413) arbitrates Job-vs-pod cleanly: whoever claims first builds, everyone else completes on the GO. Running the Job ahead of a rollout is an acceleration, never a requirement — there is no flag-day and no new failure mode when the Job is absent.

## Not in this PR

The Kubernetes Job wiring (derived from the live deployment spec, `Deployment__Mode=Bake` env, `restartPolicy: Never`) lands in the private deployments repo next, with the memex-cloud pilot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)