### PR TITLE
fix: seed AccessContext.Locale for anonymous sessions from Accept-Language

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/MeshUserProjection.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/MeshUserProjection.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Blazor.Infrastructure;
+
+/// <summary>
+/// The ONE projection of an authoritative mesh <c>User</c> node onto a seeded
+/// <see cref="AccessContext"/> — shared by every entry path that resolves a caller, so the SSR
+/// request path and the Blazor circuit path can never disagree about who a viewer is or what
+/// language and time zone they see the portal in.
+///
+/// <para>🚨 <b>Why shared rather than duplicated.</b> The two paths used to project differently:
+/// <c>CircuitAccessHandler</c> read <c>TimeZoneId</c> and <c>Locale</c> off the profile, while
+/// <c>UserContextMiddleware</c> took only <c>Id</c> and <c>Name</c> and left both null. That was
+/// invisible while nothing seeded a locale — every server-rendered string was English anyway. The
+/// moment a request-derived locale exists (<see cref="Locales.Negotiate"/>), the divergence becomes
+/// user-visible and WRONG: a signed-in user whose profile says English, browsing from a German
+/// browser, would get German chrome on the server-rendered shell and English inside the circuit.
+/// One projection, applied by both, makes "the stored preference wins" true by construction rather
+/// than by two call sites happening to agree.</para>
+///
+/// <para>Pure: a function of (seed, node, options) with no hub, circuit or HTTP state, which is why
+/// it can be pinned directly by tests.</para>
+/// </summary>
+public static class MeshUserProjection
+{
+    /// <summary>
+    /// Projects <paramref name="meshUser"/> onto <paramref name="seed"/>.
+    ///
+    /// <para>Identity (<c>ObjectId</c>, <c>Name</c>) always comes from the node — it is the
+    /// authoritative partition key, and a claim-derived guess must never outrank it. Preferences
+    /// (<c>TimeZoneId</c>, <c>Locale</c>) come from the node's profile WHEN SET, and otherwise leave
+    /// the seed untouched: an unset profile field means "this user never expressed a preference",
+    /// which must fall back to whatever the caller already knew (the request's
+    /// <c>Accept-Language</c>, say) rather than erase it to null.</para>
+    /// </summary>
+    /// <param name="seed">The context built from the authentication claims (and the request).</param>
+    /// <param name="meshUser">The authoritative mesh <c>User</c> node for that identity.</param>
+    /// <param name="options">Serializer options used to read the node's <c>User</c> content.</param>
+    public static AccessContext Apply(
+        AccessContext seed,
+        MeshNode meshUser,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(seed);
+        ArgumentNullException.ThrowIfNull(meshUser);
+        var profile = meshUser.ContentAs<User>(options);
+        var timeZoneId = profile?.TimeZoneId;
+        var locale = profile?.Locale;
+        return seed with
+        {
+            ObjectId = meshUser.Id,
+            Name = meshUser.Name ?? meshUser.Id,
+            TimeZoneId = string.IsNullOrWhiteSpace(timeZoneId) ? seed.TimeZoneId : timeZoneId,
+            Locale = string.IsNullOrWhiteSpace(locale) ? seed.Locale : locale
+        };
+    }
+}

--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -58,6 +58,15 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
         var hub = context.RequestServices.GetRequiredService<PortalApplication>().Hub;
         var userService = hub.ServiceProvider.GetRequiredService<AccessService>();
 
+        // 🚨 THE ONLY THING WE KNOW about an ANONYMOUS visitor's language. Everything downstream
+        // resolves text off AccessContext.Locale (never an ambient culture — a hub render hops the
+        // scheduler and an AsyncLocal culture does not survive it), and an anonymous visitor has no
+        // profile to read it from. Without this seed the field is null for EVERY first-time
+        // visitor, so "the viewer's language wins for chrome" is inert for exactly the audience a
+        // paywall / invite / public course page exists for. Null when the browser asked for nothing
+        // we ship — see Locales.Negotiate on why that stays distinguishable from "English".
+        var requestLocale = Locales.Negotiate(context.Request.Headers.AcceptLanguage.ToString());
+
         // Try OAuth first (browser sessions), then Bearer token (MCP / API clients).
         // The bearer-token bridge to Task happens once at the ASP.NET middleware boundary —
         // production surface is IObservable end-to-end (see ExtractFromBearerToken).
@@ -125,6 +134,12 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
             //      anonymous. The OnboardingMiddleware / dev login will
             //      provision the User node on a follow-up request and the
             //      cache picks it up.
+            // Seed the request's language BEFORE the profile lookup, so the profile can override it
+            // (MeshUserProjection keeps a set profile field and only falls back to the seed). A
+            // signed-in user's STORED preference must win over their browser's header — seeding is
+            // for the case where we know nothing, never an override.
+            userContext = userContext with { Locale = requestLocale };
+
             var identityIndexUnavailable = false;
             if (!string.IsNullOrEmpty(userContext.Email))
             {
@@ -132,11 +147,12 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                 identityIndexUnavailable = lookup.IsUnavailable;
                 if (lookup.Node is { } meshUser)
                 {
-                    userContext = userContext with
-                    {
-                        ObjectId = meshUser.Id,
-                        Name = meshUser.Name ?? meshUser.Id
-                    };
+                    // The SAME projection the circuit path applies (see MeshUserProjection): id and
+                    // name from the node, time zone and language from the profile when it has them.
+                    // This used to take only Id/Name here, which left every server-rendered string
+                    // English for a German user — harmless while nothing seeded a locale, and a
+                    // visible SSR-vs-circuit split the moment one does.
+                    userContext = MeshUserProjection.Apply(userContext, meshUser, hub.JsonSerializerOptions);
                 }
                 else if (identityIndexUnavailable)
                 {
@@ -172,7 +188,9 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                         : "no mesh User node carries this email");
                 // Never null — treat as Anonymous (least privilege) rather than
                 // null, which would fail-close the request at the never-null guard.
-                userService.SetContext(AnonymousContext);
+                // The language still rides along: refusing an identity is not a reason to serve
+                // the wrong language.
+                userService.SetContext(AnonymousContext with { Locale = requestLocale });
                 await next(context);
                 return;
             }
@@ -203,7 +221,12 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
             // Anonymous carries Permission.None by default; RLS still filters
             // reads to exactly what the Anonymous role is granted (public
             // pages), and any write is cleanly rejected — never fail-closed.
-            userService.SetContext(AnonymousContext);
+            //
+            // 🚨 …but it carries the REQUEST'S LANGUAGE. This is the paywall / invite / public
+            // course case: the visitor is anonymous BY DEFINITION, so the header is the only
+            // statement of language that exists, and dropping it here is what made the
+            // viewer's-language-wins decision inert for the audience it was written for.
+            userService.SetContext(AnonymousContext with { Locale = requestLocale });
         }
 
         await next(context);

--- a/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
@@ -106,6 +106,45 @@ An **unsupported** browser language deliberately writes *nothing*, leaving the p
 translation shipped later applies automatically instead of the user being pinned to a tag we would
 only ever render in English.
 
+### …and where an ANONYMOUS visitor's comes from
+
+Steps 1–3 all read a **profile**, and an anonymous visitor does not have one. Without a fourth
+source, `AccessContext.Locale` is null for every logged-out visitor and the whole feature is inert
+for exactly the audience it matters most to: the first-time viewer of a paywall, an invitation link
+or a public course page is anonymous *by definition*.
+
+So the request's `Accept-Language` header is negotiated against `Locales.Supported` and **seeded**
+onto the identity, on both entry paths:
+
+| Path | Where | Reads the header from |
+|---|---|---|
+| SSR / HTTP request | `UserContextMiddleware` | `HttpContext.Request.Headers.AcceptLanguage` |
+| Blazor circuit | `CircuitAccessHandler` **constructor** | `IHttpContextAccessor` — the live `/_blazor` request |
+
+`Locales.Negotiate` does the parsing: the full RFC 9110 list with `q=` weights, tried in descending
+weight, each matched by `Locales.TryMatch` so region variants fold onto the primary subtag exactly as
+everywhere else (`en-GB` → `en`). `q=0` is an explicit refusal and `*` is an absence of preference —
+both are skipped, so neither can pin a caller to a language it never asked for. Nothing matched
+returns **null**, not `en`, so "unsupported" stays distinguishable from "asked for English".
+
+Two properties this rests on, both load-bearing:
+
+- **It is a SEED, never an override.** A signed-in user's stored preference still wins:
+  `MeshUserProjection.Apply` — the single projection both entry paths use — keeps a profile's
+  language when the profile states one and only falls back to the seed when it does not. (Before
+  this, the two paths projected differently: the circuit read the profile's locale and time zone, the
+  middleware read only id and name. That divergence was invisible while nothing seeded a locale and
+  would have rendered German SSR chrome for an English-profile user the moment one existed.)
+- **It lands BEFORE the first render.** The header is read in the circuit handler's *constructor*,
+  because Blazor resolves the circuit's `CircuitHandler`s — and then runs `OnCircuitOpenedAsync` /
+  `OnConnectionUpAsync` — before it adds and renders any root component. That ordering is what makes
+  the seed effective at all: `LayoutAreaHost` captures the access context in its **constructor**, so
+  a locale arriving mid-circuit re-renders nothing.
+
+Note this is still an *explicit* resolution off `AccessContext.Locale` — the header is read once, at
+identity time, and never becomes a second ambient mechanism. `CultureInfo.CurrentUICulture` is not
+consulted anywhere (see "The one rule" above).
+
 ## Adding a language
 
 1. Add the tag to `Locales.Supported` and an endonym to `Locales.DisplayNames`.
@@ -134,5 +173,10 @@ only ever render in English.
 ## Tests
 
 - `LocalizationTest` (MeshWeaver.Messaging.Hub.Test) — catalog loads, fallback chain, plurals,
-  attribute lookup, and **every shipped language covers the full English key list with no orphans**.
+  attribute lookup, `Locales.Negotiate` over real `Accept-Language` shapes, and **every shipped
+  language covers the full English key list with no orphans**.
 - `LocalePreferenceTest` (MeshWeaver.Hosting.Monolith.Test) — the write-once decision.
+- `AnonymousCircuitLocaleSeedTest` (MeshWeaver.Hosting.Blazor.Test) — the anonymous seed, driven over
+  a **real SignalR WebSocket into Blazor's real `ComponentHub`**, because the only question that
+  matters is whether the circuit can still see the request that established it. A unit test of the
+  negotiation would stay green while the browser saw nothing.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
@@ -119,7 +119,19 @@ onto the identity, on both entry paths:
 | Path | Where | Reads the header from |
 |---|---|---|
 | SSR / HTTP request | `UserContextMiddleware` | `HttpContext.Request.Headers.AcceptLanguage` |
-| Blazor circuit | `CircuitAccessHandler` **constructor** | `IHttpContextAccessor` — the live `/_blazor` request |
+| Blazor circuit | `CircuitAccessHandler` **constructor** | `CircuitRequestLanguage`, published per hub invocation by the global `CircuitRequestLanguageFilter` |
+
+🚨 **The circuit reads it off the SignalR CONNECTION, not off `IHttpContextAccessor`.** The accessor
+works over WebSockets — the upgrade request stays in flight for the connection's life — and returns
+nothing under **long polling**, where every poll is a separate request that ASP.NET disposes (which
+nulls the accessor's holder for every flow that captured it). A browser behind a proxy that blocks
+WebSockets falls back to long polling, i.e. exactly a corporate network, so an accessor-only fix
+would reach most visitors and silently miss the rest. SignalR keeps an `IHttpContextFeature` on the
+connection and refreshes it per request, so `HubCallerContext.GetHttpContext()` answers for every
+transport; the filter reads it in the hub invocation that *creates* the circuit handlers. The
+accessor remains only as a fallback for a host that runs the Blazor hub without the filter.
+`AnonymousCircuitLocaleSeedTest` runs its cases over **both** transports — the long-polling rows are
+what caught this, and are what stop it regressing.
 
 `Locales.Negotiate` does the parsing: the full RFC 9110 list with `q=` weights, tried in descending
 weight, each matched by `Locales.TryMatch` so region variants fold onto the primary subtag exactly as

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-portal-speaks-your-language-before-you-sign-in.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-portal-speaks-your-language-before-you-sign-in.md
@@ -1,0 +1,26 @@
+---
+Name: The portal speaks your language before you sign in
+Category: Fix
+Description: Pages you can reach without an account now follow your browser's language instead of always appearing in English.
+Icon: Globe
+Order: -20260813
+---
+
+# The portal speaks your language before you sign in
+
+The portal renders its buttons, labels and messages in your language, and it worked out which
+language that is from your profile. That is fine once you are signed in — and useless before, because
+a visitor who has not signed in has no profile. Everyone arriving at a paywall, an invitation link or
+a public course page therefore got English, no matter what their browser asked for. It was precisely
+the audience the feature was built for that never saw it.
+
+Your browser states its preferred languages on every request, and the portal now reads that
+statement. An anonymous visitor whose browser asks for German gets German; one asking for British
+English gets English, even on a German-language course. Regional variants fold onto the language
+itself, so Swiss German, Austrian German and German all read the same. A language this portal does
+not ship falls back to English as before.
+
+Signing in changes nothing about your own choice: a language set in your profile still wins over
+whatever your browser says. What changed is the case where nobody had said anything yet — that now
+follows the browser rather than defaulting to English, and it does so on the very first render of
+the page rather than after a visible switch.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -42,6 +42,14 @@ public static class BlazorHostingExtensions
             .ConfigureServices(services => services
                 .AddContentService()
                 .AddFluentUIComponents()
+                // 🚨 Required by CircuitAccessHandler, which reads the establishing /_blazor
+                // request's Accept-Language to seed an ANONYMOUS visitor's language (they have no
+                // profile to read one from). Registered HERE rather than left to each host: the
+                // handler treats a missing accessor as "no request-derived language", so a host
+                // that forgot the call would silently serve English to every anonymous visitor —
+                // the exact defect this seeding exists to fix. AddHttpContextAccessor is
+                // TryAdd-based, so a host that already calls it is unaffected.
+                .AddHttpContextAccessor()
                 .AddSingleton<UserIdentityCache>()
                 .AddScoped<ICircuitContextAccessor, CircuitContextAccessor>()
                 .AddScoped<PortalApplication>()

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -16,6 +16,7 @@ using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.Extensions.Logging;
@@ -42,12 +43,19 @@ public static class BlazorHostingExtensions
             .ConfigureServices(services => services
                 .AddContentService()
                 .AddFluentUIComponents()
-                // 🚨 Required by CircuitAccessHandler, which reads the establishing /_blazor
-                // request's Accept-Language to seed an ANONYMOUS visitor's language (they have no
-                // profile to read one from). Registered HERE rather than left to each host: the
-                // handler treats a missing accessor as "no request-derived language", so a host
-                // that forgot the call would silently serve English to every anonymous visitor —
-                // the exact defect this seeding exists to fix. AddHttpContextAccessor is
+                // 🚨 The ANONYMOUS visitor's language. They have no profile, so the establishing
+                // /_blazor connection's Accept-Language is the only statement of language they make
+                // (see CircuitRequestLanguage). Registered HERE rather than left to each host: the
+                // handler treats a missing source as "no request-derived language", so a host that
+                // forgot the wiring would silently serve English to every anonymous visitor — the
+                // exact defect this seeding exists to fix.
+                .AddSingleton<CircuitRequestLanguage>()
+                .AddSingleton<CircuitRequestLanguageFilter>()
+                // GLOBAL SignalR filter: Blazor's ComponentHub is internal and cannot be named in a
+                // per-hub registration. Global filters apply to any hub that does not declare its
+                // own list, which ComponentHub does not. On every other hub this filter is a no-op.
+                .Configure<HubOptions>(o => o.AddFilter<CircuitRequestLanguageFilter>())
+                // The WebSocket-only fallback path — see CircuitAccessHandler's ctor.
                 // TryAdd-based, so a host that already calls it is unaffected.
                 .AddHttpContextAccessor()
                 .AddSingleton<UserIdentityCache>()

--- a/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
@@ -52,14 +52,13 @@ public class CircuitAccessHandler : CircuitHandler
     ///
     /// <para>🚨 Captured in the CONSTRUCTOR, deliberately, and this is the load-bearing detail of the
     /// whole seed. Blazor resolves the circuit's <c>CircuitHandler</c>s from inside a
-    /// <c>ComponentHub</c> hub method that it <b>awaits</b> — <c>StartCircuit</c> for a classic
-    /// Blazor Server payload, and the first <c>UpdateRootComponents</c> for a Blazor Web App, where
-    /// handler creation is deliberately deferred so a handler can see the restored application
-    /// state. Either way this constructor runs while the <c>/_blazor</c> request carrying the header
-    /// is unambiguously alive, on its own execution flow. The circuit lifecycle that follows
+    /// <c>ComponentHub</c> hub method — <c>StartCircuit</c> for a classic Blazor Server payload, and
+    /// the first <c>UpdateRootComponents</c> for a Blazor Web App, where handler creation is
+    /// deliberately deferred so a handler can see the restored application state. Either way this
+    /// constructor runs inside that hub invocation, which is exactly the flow
+    /// <see cref="CircuitRequestLanguageFilter"/> wraps. The circuit lifecycle that follows
     /// (<see cref="OnCircuitOpenedAsync"/>, then <see cref="OnConnectionUpAsync"/>) is dispatched
-    /// fire-and-forget from that same method, so reading the accessor THERE would be racing the
-    /// request's lifetime for no benefit.</para>
+    /// fire-and-forget from that same method, so there is no later point that is any safer.</para>
     ///
     /// <para><b>And the seed lands before the FIRST RENDER.</b> The framework runs
     /// <see cref="OnCircuitOpenedAsync"/> / <see cref="OnConnectionUpAsync"/> before it adds and
@@ -88,17 +87,23 @@ public class CircuitAccessHandler : CircuitHandler
     /// <param name="authStateProvider">Provides the authentication state used to resolve the circuit's user.</param>
     /// <param name="circuitContextAccessor">The circuit-scoped accessor that carries the circuit id and user context.</param>
     /// <param name="loggerFactory">Factory used to create the access-context logger.</param>
+    /// <param name="connectionLanguage">
+    /// The language of the <c>/_blazor</c> connection establishing this circuit, published by
+    /// <see cref="CircuitRequestLanguageFilter"/> — see <see cref="_requestLocale"/>. Optional so a
+    /// host that does not register it still builds circuits; such a host simply has no
+    /// request-derived language and renders English, exactly as before.
+    /// </param>
     /// <param name="httpContextAccessor">
-    /// Access to the <c>/_blazor</c> request that is establishing this circuit, used ONLY to read
-    /// <c>Accept-Language</c> (see <see cref="_requestLocale"/>). Optional so a host that does not
-    /// register it still builds circuits — such a host simply has no request-derived language and
-    /// falls back to English, exactly as before.
+    /// Fallback source for the same header, for a host that runs the Blazor hub without the filter.
+    /// Reliable only over WebSockets (see <see cref="CircuitRequestLanguage"/>), which is why it is
+    /// the fallback rather than the source.
     /// </param>
     public CircuitAccessHandler(
         IMessageHub hub,
         AuthenticationStateProvider authStateProvider,
         ICircuitContextAccessor circuitContextAccessor,
         ILoggerFactory loggerFactory,
+        CircuitRequestLanguage? connectionLanguage = null,
         IHttpContextAccessor? httpContextAccessor = null)
     {
         _hub = hub;
@@ -106,8 +111,9 @@ public class CircuitAccessHandler : CircuitHandler
         _circuitContextAccessor = circuitContextAccessor;
         _logger = loggerFactory.CreateLogger("MeshWeaver.AccessContext");
         _circuitLogger = loggerFactory.CreateLogger("MeshWeaver.Blazor.Circuit");
-        _requestLocale = Locales.Negotiate(
-            httpContextAccessor?.HttpContext?.Request.Headers.AcceptLanguage.ToString());
+        _requestLocale = connectionLanguage?.Current
+                         ?? Locales.Negotiate(
+                             httpContextAccessor?.HttpContext?.Request.Headers.AcceptLanguage.ToString());
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -46,23 +47,67 @@ public class CircuitAccessHandler : CircuitHandler
     private IDisposable? _identityRecovery;
 
     /// <summary>
+    /// The language this circuit's browser asked for, negotiated against <see cref="Locales.Supported"/>
+    /// — or <see langword="null"/> when it asked for nothing this deployment ships.
+    ///
+    /// <para>🚨 Captured in the CONSTRUCTOR, deliberately, and this is the load-bearing detail of the
+    /// whole seed. Blazor resolves the circuit's <c>CircuitHandler</c>s from inside a
+    /// <c>ComponentHub</c> hub method that it <b>awaits</b> — <c>StartCircuit</c> for a classic
+    /// Blazor Server payload, and the first <c>UpdateRootComponents</c> for a Blazor Web App, where
+    /// handler creation is deliberately deferred so a handler can see the restored application
+    /// state. Either way this constructor runs while the <c>/_blazor</c> request carrying the header
+    /// is unambiguously alive, on its own execution flow. The circuit lifecycle that follows
+    /// (<see cref="OnCircuitOpenedAsync"/>, then <see cref="OnConnectionUpAsync"/>) is dispatched
+    /// fire-and-forget from that same method, so reading the accessor THERE would be racing the
+    /// request's lifetime for no benefit.</para>
+    ///
+    /// <para><b>And the seed lands before the FIRST RENDER.</b> The framework runs
+    /// <see cref="OnCircuitOpenedAsync"/> / <see cref="OnConnectionUpAsync"/> before it adds and
+    /// renders any root component, so the language is on the circuit's identity by the time anything
+    /// draws. That ordering is not a nicety: <c>LayoutAreaHost</c> captures the access context in its
+    /// CONSTRUCTOR, so a locale arriving mid-circuit would re-render nothing and the fix would look
+    /// correct in a unit test while doing nothing in the browser. Pinned end-to-end over a real
+    /// SignalR connection by <c>AnonymousCircuitLocaleSeedTest</c>.</para>
+    ///
+    /// <para><b>Why the header at all.</b> An anonymous visitor has no profile, so
+    /// <c>AccessContext.Locale</c> is null for every one of them and every server-rendered string
+    /// falls back to English — which makes "the viewer's language wins for chrome" inert for exactly
+    /// the audience it was written for (a first-time visitor hitting a paywall is anonymous by
+    /// definition). The header is the only statement of language such a visitor makes. It is read
+    /// ONCE, here, and seeded onto the identity — it never becomes a second, ambient resolution
+    /// mechanism, and <c>CultureInfo.CurrentUICulture</c> is never consulted (a layout-area render
+    /// hops the hub scheduler, where an AsyncLocal culture would not survive and one user's UI would
+    /// pick up another user's language).</para>
+    /// </summary>
+    private readonly string? _requestLocale;
+
+    /// <summary>
     /// Initializes a new instance of the <c>CircuitAccessHandler</c> class.
     /// </summary>
     /// <param name="hub">The message hub used to resolve the <c>AccessService</c> and mesh services.</param>
     /// <param name="authStateProvider">Provides the authentication state used to resolve the circuit's user.</param>
     /// <param name="circuitContextAccessor">The circuit-scoped accessor that carries the circuit id and user context.</param>
     /// <param name="loggerFactory">Factory used to create the access-context logger.</param>
+    /// <param name="httpContextAccessor">
+    /// Access to the <c>/_blazor</c> request that is establishing this circuit, used ONLY to read
+    /// <c>Accept-Language</c> (see <see cref="_requestLocale"/>). Optional so a host that does not
+    /// register it still builds circuits — such a host simply has no request-derived language and
+    /// falls back to English, exactly as before.
+    /// </param>
     public CircuitAccessHandler(
         IMessageHub hub,
         AuthenticationStateProvider authStateProvider,
         ICircuitContextAccessor circuitContextAccessor,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IHttpContextAccessor? httpContextAccessor = null)
     {
         _hub = hub;
         _authStateProvider = authStateProvider;
         _circuitContextAccessor = circuitContextAccessor;
         _logger = loggerFactory.CreateLogger("MeshWeaver.AccessContext");
         _circuitLogger = loggerFactory.CreateLogger("MeshWeaver.Blazor.Circuit");
+        _requestLocale = Locales.Negotiate(
+            httpContextAccessor?.HttpContext?.Request.Headers.AcceptLanguage.ToString());
     }
 
     /// <summary>
@@ -248,7 +293,12 @@ public class CircuitAccessHandler : CircuitHandler
                     {
                         ObjectId = WellKnownUsers.Anonymous,
                         Name = "Guest",
-                        IsVirtual = true
+                        IsVirtual = true,
+                        // 🚨 THE PAYWALL CASE. This visitor has no profile and never will until they
+                        // sign up, so the request header is the only thing that can make the portal
+                        // speak their language. Null here (the previous behaviour) is what served
+                        // English chrome to every anonymous viewer, whatever their browser asked for.
+                        Locale = _requestLocale
                     },
                     // Nothing to re-ask: an unauthenticated circuit has no email, and the anonymous
                     // VUser is the ANSWER here, not a degraded stand-in for one.
@@ -271,7 +321,12 @@ public class CircuitAccessHandler : CircuitHandler
                        ?? string.Empty,
                 ObjectId = UsernameFromEmail(email),
                 Email = email,
-                Roles = user.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList()
+                Roles = user.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList(),
+                // The browser's request is a SEED, never an override: ApplyMeshUser below keeps a
+                // profile's language when the profile states one and only falls back to this. So a
+                // signed-in user's stored preference still wins, and a signed-in user who has never
+                // stated one finally gets their browser's language instead of unconditional English.
+                Locale = _requestLocale
             };
 
             // Authoritative resolution: the mesh User node's Id. The cache is a
@@ -318,9 +373,10 @@ public class CircuitAccessHandler : CircuitHandler
     }
 
     /// <summary>
-    /// Projects a resolved mesh <c>User</c> node onto a seeded context — the ONE place the
-    /// authoritative identity is read, shared by the circuit-open success path and by the
-    /// degraded-identity repair so the two can never drift apart.
+    /// Projects a resolved mesh <c>User</c> node onto a seeded context. A thin alias for
+    /// <see cref="MeshUserProjection.Apply"/> — the ONE place the authoritative identity is read,
+    /// shared by the circuit-open success path, by the degraded-identity repair, AND by the SSR
+    /// request path (<c>UserContextMiddleware</c>) so none of the three can drift apart.
     ///
     /// <para>Resolves the viewer's display time zone from their profile so it rides on the
     /// AccessContext to every render path — the Blazor circuit AND server-side hub layout areas —
@@ -346,20 +402,7 @@ public class CircuitAccessHandler : CircuitHandler
         AccessContext seed,
         MeshNode meshUser,
         System.Text.Json.JsonSerializerOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(seed);
-        ArgumentNullException.ThrowIfNull(meshUser);
-        var profile = meshUser.ContentAs<User>(options);
-        var timeZoneId = profile?.TimeZoneId;
-        var locale = profile?.Locale;
-        return seed with
-        {
-            ObjectId = meshUser.Id,
-            Name = meshUser.Name ?? meshUser.Id,
-            TimeZoneId = string.IsNullOrWhiteSpace(timeZoneId) ? seed.TimeZoneId : timeZoneId,
-            Locale = string.IsNullOrWhiteSpace(locale) ? seed.Locale : locale
-        };
-    }
+        => MeshUserProjection.Apply(seed, meshUser, options);
 
     /// <summary>
     /// The repair for a circuit that opened on a degraded identity: waits for the mesh user index

--- a/src/MeshWeaver.Hosting.Blazor/CircuitRequestLanguage.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitRequestLanguage.cs
@@ -1,0 +1,85 @@
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+
+namespace MeshWeaver.Hosting.Blazor;
+
+/// <summary>
+/// Carries the language of the <c>/_blazor</c> connection into the circuit that is being built on
+/// it, so <see cref="CircuitAccessHandler"/> can seed an ANONYMOUS visitor's
+/// <c>AccessContext.Locale</c> from <c>Accept-Language</c>.
+///
+/// <para>🚨 <b>Why this exists instead of just reading <c>IHttpContextAccessor</c>.</b> The accessor
+/// works over WebSockets — the upgrade request stays in flight for the connection's whole life, so
+/// its <c>HttpContext</c> is still there when Blazor constructs the circuit's handlers. Under LONG
+/// POLLING it does not: every poll is a separate request, and ASP.NET nulls the accessor's holder
+/// when a request completes, so the handler sees nothing and the visitor silently gets English. A
+/// browser behind a proxy that blocks WebSockets falls back to long polling, which is precisely a
+/// corporate-network shape — so "works on WebSockets" would have meant the fix reaches most
+/// visitors and silently misses the rest. Measured, not assumed: the long-polling rows of
+/// <c>AnonymousCircuitLocaleSeedTest</c> fail against the accessor-only version.</para>
+///
+/// <para>SignalR, unlike ASP.NET's request accessor, keeps an <c>IHttpContextFeature</c> on the
+/// CONNECTION and refreshes it per request, so <c>HubCallerContext.GetHttpContext()</c> answers for
+/// every transport. <see cref="CircuitRequestLanguageFilter"/> reads it in the hub-invocation flow
+/// that <i>creates</i> the circuit handlers, and publishes it here.</para>
+/// </summary>
+public sealed class CircuitRequestLanguage
+{
+    // AsyncLocal, and an INSTANCE field on a mesh-scoped singleton — the same shape AccessService
+    // uses for the per-circuit identity, and for the same reason: the value must be visible to the
+    // work this hub invocation dispatches and to nothing else. Never static: two circuits opening
+    // concurrently must not see each other's language.
+    private readonly AsyncLocal<string?> negotiated = new();
+
+    /// <summary>
+    /// The supported language tag this connection's browser asked for, or <see langword="null"/>
+    /// when it asked for nothing we ship — or when the reader is not on a hub-invocation flow at
+    /// all, in which case the caller falls back and, ultimately, renders English.
+    /// </summary>
+    public string? Current => negotiated.Value;
+
+    /// <summary>
+    /// Publishes the language for the remainder of the current hub invocation, including everything
+    /// it awaits or dispatches. Called only by <see cref="CircuitRequestLanguageFilter"/>.
+    /// </summary>
+    public void Set(string? locale) => negotiated.Value = locale;
+}
+
+/// <summary>
+/// Reads <c>Accept-Language</c> off the SignalR connection's HTTP context and publishes it on
+/// <see cref="CircuitRequestLanguage"/> for the duration of each hub invocation.
+///
+/// <para>Registered as a GLOBAL SignalR filter, because Blazor's <c>ComponentHub</c> is
+/// <c>internal</c> and cannot be named in a per-hub registration. On any other hub this is a
+/// two-field no-op.</para>
+///
+/// <para><b>Why a filter and not the handler itself.</b> Blazor builds the circuit's DI scope and
+/// constructs its <c>CircuitHandler</c>s inside a hub method — <c>StartCircuit</c> for a classic
+/// Blazor Server payload, the first <c>UpdateRootComponents</c> for a Blazor Web App. A filter wraps
+/// exactly that invocation, so the value set here flows into the construction (and into the
+/// circuit-opened lifecycle it dispatches) on every transport, without depending on how long the
+/// underlying HTTP request happens to live.</para>
+/// </summary>
+public sealed class CircuitRequestLanguageFilter(CircuitRequestLanguage language) : IHubFilter
+{
+    /// <inheritdoc />
+    public ValueTask<object?> InvokeMethodAsync(
+        HubInvocationContext invocationContext,
+        Func<HubInvocationContext, ValueTask<object?>> next)
+    {
+        Publish(invocationContext.Context);
+        return next(invocationContext);
+    }
+
+    /// <inheritdoc />
+    public Task OnConnectedAsync(HubLifetimeContext context, Func<HubLifetimeContext, Task> next)
+    {
+        Publish(context.Context);
+        return next(context);
+    }
+
+    private void Publish(HubCallerContext context) =>
+        language.Set(Locales.Negotiate(
+            context.GetHttpContext()?.Request.Headers.AcceptLanguage.ToString()));
+}

--- a/src/MeshWeaver.Hosting.Blazor/CircuitRequestLanguage.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitRequestLanguage.cs
@@ -79,7 +79,31 @@ public sealed class CircuitRequestLanguageFilter(CircuitRequestLanguage language
         return next(context);
     }
 
-    private void Publish(HubCallerContext context) =>
-        language.Set(Locales.Negotiate(
-            context.GetHttpContext()?.Request.Headers.AcceptLanguage.ToString()));
+    /// <summary>
+    /// Key under which the negotiated tag is memoised on the CONNECTION.
+    /// </summary>
+    private const string ItemsKey = "MeshWeaver.CircuitRequestLanguage";
+
+    /// <summary>
+    /// Publishes this connection's language, parsing the header at most ONCE per connection.
+    ///
+    /// <para>This filter is global, so it also sits on MeshWeaver's own SignalR hubs, where hub
+    /// invocations are mesh message traffic. Negotiating on every invocation would put a string
+    /// split and a sort on that path for a value that cannot change — a browser sends the same
+    /// <c>Accept-Language</c> on every request of a connection. Memoising on
+    /// <see cref="HubCallerContext.Items"/> keeps the cost to one parse per connection and makes
+    /// "a no-op on every other hub" true in cost as well as in effect. A benign race just
+    /// recomputes the same value.</para>
+    /// </summary>
+    private void Publish(HubCallerContext context)
+    {
+        if (!context.Items.TryGetValue(ItemsKey, out var negotiated))
+        {
+            negotiated = Locales.Negotiate(
+                context.GetHttpContext()?.Request.Headers.AcceptLanguage.ToString());
+            context.Items[ItemsKey] = negotiated;
+        }
+
+        language.Set(negotiated as string);
+    }
 }

--- a/src/MeshWeaver.Messaging.Contract/Localization/Locales.cs
+++ b/src/MeshWeaver.Messaging.Contract/Localization/Locales.cs
@@ -46,6 +46,83 @@ public static class Locales
     public static string Resolve(string? requested) => TryMatch(requested) ?? Default;
 
     /// <summary>
+    /// Resolves a whole HTTP <c>Accept-Language</c> header to a SUPPORTED language, or <c>null</c>
+    /// when the visitor asked for nothing this deployment ships.
+    ///
+    /// <para>This is the ONLY thing we know about an ANONYMOUS visitor's language. A first-time
+    /// visitor — the audience a paywall, an invite or a public course page exists for — has no
+    /// profile, so <see cref="AccessContext.Locale"/> would otherwise be null and every one of them
+    /// would be served English regardless of who they are. The header is seeded onto the identity
+    /// (see <c>UserContextMiddleware</c> and <c>CircuitAccessHandler</c>) so it rides the SAME
+    /// explicit path a signed-in user's stored preference does, rather than becoming a second,
+    /// ambient resolution mechanism.</para>
+    ///
+    /// <para>Full header shape per RFC 9110: a comma-separated list of tags, each optionally
+    /// weighted (<c>de-CH, de;q=0.9, en;q=0.8</c>). Entries are tried in descending weight — ties
+    /// keep the order the browser sent, which is already the browser's own preference order — and
+    /// each is matched by <see cref="TryMatch"/>, so region variants fold onto their primary subtag
+    /// exactly as everywhere else (<c>en-GB</c> → <c>en</c>, <c>de-CH</c> → <c>de</c>). Entries with
+    /// <c>q=0</c> are explicit REFUSALS and are skipped; the <c>*</c> wildcard means "no preference"
+    /// and is skipped too, so it can never outrank a real tag or pin a visitor to a language they
+    /// never asked for.</para>
+    ///
+    /// <para>🚨 Returns <c>null</c>, not <see cref="Default"/>, when nothing matches — for the same
+    /// reason <see cref="TryMatch"/> does. "This visitor asked for something we do not ship" must
+    /// stay distinguishable from "this visitor asked for English", so a later, better answer (a
+    /// profile that loads a moment afterwards) is not shadowed by a guess.</para>
+    /// </summary>
+    /// <param name="acceptLanguageHeader">The raw header value; null, empty or malformed is fine.</param>
+    /// <returns>A tag from <see cref="Supported"/>, or <c>null</c>.</returns>
+    public static string? Negotiate(string? acceptLanguageHeader)
+    {
+        if (string.IsNullOrWhiteSpace(acceptLanguageHeader))
+            return null;
+
+        // Weight-ordered, ties broken by the order the browser sent — the header's own order is
+        // already a preference statement, so the index tiebreak is spelled out rather than left to
+        // LINQ's (documented, but easy to overlook) stable sort.
+        var best = acceptLanguageHeader
+            .Split(',')
+            .Select((entry, order) => (Entry: entry.Split(';'), Order: order))
+            .Select(e => (Tag: e.Entry[0].Trim(), Quality: QualityOf(e.Entry), e.Order))
+            // "*" is "anything is acceptable" — an absence of preference, not a request for the
+            // first language we happen to list. Treating it as a match would pin every browser that
+            // sends "*" (curl, many bots) to a language chosen by our ordering. q<=0 is the
+            // header's way of saying "explicitly NOT this language".
+            .Where(e => e.Tag.Length > 0 && e.Tag != "*" && e.Quality > 0d)
+            .OrderByDescending(e => e.Quality)
+            .ThenBy(e => e.Order)
+            .Select(e => TryMatch(e.Tag))
+            .FirstOrDefault(matched => matched is not null);
+
+        return best;
+    }
+
+    /// <summary>
+    /// The <c>q=</c> weight of one already-split <c>Accept-Language</c> entry; 1.0 when absent.
+    /// A MALFORMED weight keeps the default rather than dropping the entry — the browser still
+    /// named a language, and discarding the preference over a bad number is the wrong trade.
+    /// </summary>
+    private static double QualityOf(string[] entryParts)
+    {
+        for (var p = 1; p < entryParts.Length; p++)
+        {
+            var parameter = entryParts[p].Trim();
+            if (!parameter.StartsWith("q=", StringComparison.OrdinalIgnoreCase))
+                continue;
+            return double.TryParse(
+                parameter.AsSpan(2),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var parsed)
+                ? parsed
+                : 1.0d;
+        }
+
+        return 1.0d;
+    }
+
+    /// <summary>
     /// Returns the supported tag matching <paramref name="requested"/>, or <c>null</c> when this
     /// deployment ships no translation for it. Use <see cref="Resolve"/> when you need a usable
     /// tag; use this when "unsupported" must stay distinguishable from "English" — the write-once

--- a/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 THE ANONYMOUS VISITOR'S LANGUAGE, proven on a REAL Blazor circuit.
+///
+/// <para><b>What was broken.</b> Every localized string resolves explicitly off
+/// <see cref="AccessContext.Locale"/> — deliberately, because a layout-area render hops the hub
+/// scheduler and an ambient <c>CultureInfo.CurrentUICulture</c> would not survive it (one user's UI
+/// would pick up another user's language). That field is populated from the signed-in user's
+/// profile. An ANONYMOUS visitor has no profile, so it was <see langword="null"/> for every one of
+/// them and the portal answered in English regardless of what their browser asked for. The audience
+/// that decision was written for — a first-time visitor hitting a paywall, an invite, a public
+/// course page — is anonymous BY DEFINITION, so the feature was inert for exactly them.</para>
+///
+/// <para><b>Why this test drives a real circuit instead of asserting a pure function.</b> The
+/// portal's pages render through the Blazor CIRCUIT, not the SSR pass
+/// (<c>Routes.razor</c> returns early until <c>BrowserDimensionWatcher</c> resolves the viewport, so
+/// the server-rendered shell contains no page content at all). The only question that matters is
+/// therefore whether the circuit can still see the <c>Accept-Language</c> header of the
+/// <c>/_blazor</c> request that established it — and no unit test can answer that. A test of
+/// <c>Locales.Negotiate</c> alone would stay green while the browser saw nothing, which is the exact
+/// failure mode this suite exists to rule out. So: a real <c>WebApplication</c>, the real Blazor
+/// <c>ComponentHub</c>, a real SignalR WebSocket carrying a real header, the real
+/// <see cref="CircuitAccessHandler"/>, and the real per-circuit
+/// <see cref="ICircuitContextAccessor"/> that the portal hub stamps on every post.</para>
+///
+/// <para><b>The ordering claim it also pins.</b> Blazor resolves the circuit's
+/// <c>CircuitHandler</c>s — hence runs this handler's constructor, which is where the header is read
+/// — and then runs <c>OnCircuitOpenedAsync</c> / <c>OnConnectionUpAsync</c> BEFORE it adds and
+/// renders any root component. The probe below observes the identity in
+/// <c>OnConnectionUpAsync</c>, i.e. at the last moment before the first render, so a seed that
+/// arrived one render too late would fail here rather than look correct.</para>
+/// </summary>
+public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Where the probe handler publishes the identity the real handler resolved.</summary>
+    private sealed class CircuitIdentitySink
+    {
+        private readonly ReplaySubject<AccessContext?> resolved = new(1);
+        public void Publish(AccessContext? context) => resolved.OnNext(context);
+
+        /// <summary>The first identity any circuit resolved, or a timeout if none ever opened.</summary>
+        public Task<AccessContext?> FirstAsync(CancellationToken ct) =>
+            resolved.FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask(ct);
+    }
+
+    /// <summary>
+    /// Reads what <see cref="CircuitAccessHandler"/> wrote onto the circuit-scoped accessor. Ordered
+    /// AFTER it (<see cref="CircuitHandler.Order"/> 0), and observing in
+    /// <c>OnConnectionUpAsync</c> — the last framework hook before the first component renders.
+    /// </summary>
+    private sealed class CircuitIdentityProbe(ICircuitContextAccessor accessor, CircuitIdentitySink sink)
+        : CircuitHandler
+    {
+        public override int Order => 1000;
+
+        public override Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
+        {
+            sink.Publish(accessor.UserContext);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Lets the SignalR test client speak plain JSON to Blazor's <c>ComponentHub</c>.
+    ///
+    /// <para>Blazor restricts that hub to its own <c>blazorpack</c> protocol, whose implementation is
+    /// <c>internal</c> — so a test client cannot speak it. Widening the SERVER's accepted protocol
+    /// list is the only seam, and it changes nothing about the code under test: the hub, the circuit
+    /// factory, the circuit handlers and the HTTP request are all the production ones; only the wire
+    /// encoding of two string arguments differs.</para>
+    /// </summary>
+    private sealed class AllowJsonProtocol<THub> : IPostConfigureOptions<HubOptions<THub>>
+        where THub : Hub
+    {
+        public void PostConfigure(string? name, HubOptions<THub> options)
+            => options.SupportedProtocols = ["json", "blazorpack"];
+    }
+
+    /// <summary>
+    /// A <c>RootComponentOperationBatch</c> with no operations — the shape <c>blazor.web.js</c> sends,
+    /// minus the data-protected component markers a test cannot forge. Zero operations is enough:
+    /// the framework creates the circuit handlers and runs the circuit-opened / connection-up
+    /// lifecycle on the FIRST <c>UpdateRootComponents</c> call, before it looks at the operations.
+    /// </summary>
+    private const string EmptyRootComponentBatch = """{"batchId":1,"operations":[]}""";
+
+    private readonly CircuitIdentitySink sink = new();
+    private WebApplication? portal;
+
+    /// <summary>
+    /// The portal's Blazor wiring, reduced to the pieces the circuit identity actually needs — the
+    /// same registrations <c>AddBlazor()</c> makes, plus the probe. Everything that decides the
+    /// answer (the handler, the accessor, the HTTP-context accessor, the Blazor hub) is the real
+    /// production type.
+    /// </summary>
+    private WebApplication BuildPortal()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(sink);
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+        builder.Services.TryAddScoped<AuthenticationStateProvider, ServerAuthenticationStateProvider>();
+        builder.Services.AddScoped<ICircuitContextAccessor, CircuitContextAccessor>();
+        builder.Services.AddScoped<CircuitAccessHandler>();
+        builder.Services.AddScoped<CircuitHandler>(sp => sp.GetRequiredService<CircuitAccessHandler>());
+        builder.Services.AddScoped<CircuitHandler, CircuitIdentityProbe>();
+
+        // See AllowJsonProtocol — ComponentHub is internal, so the option has to be reached by name.
+        var componentHub = typeof(CircuitHandler).Assembly
+            .GetType("Microsoft.AspNetCore.Components.Server.ComponentHub")
+            ?? throw new InvalidOperationException(
+                "Blazor's ComponentHub type was not found — the SignalR entry point this test drives "
+                + "has moved, and the test must be re-pointed rather than skipped.");
+        builder.Services.AddSingleton(
+            typeof(IPostConfigureOptions<>).MakeGenericType(
+                typeof(HubOptions<>).MakeGenericType(componentHub)),
+            typeof(AllowJsonProtocol<>).MakeGenericType(componentHub));
+
+        var app = builder.Build();
+        app.UseAntiforgery();
+        app.MapRazorComponents<RouterProbeApp>().AddInteractiveServerRenderMode();
+        return app;
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        portal = BuildPortal();
+        await portal.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (portal is not null)
+            await portal.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Opens a real Blazor circuit over a real SignalR WebSocket whose handshake carries
+    /// <paramref name="acceptLanguage"/>, and returns the identity the circuit resolved.
+    ///
+    /// <para>The two hub calls mirror what <c>blazor.web.js</c> does: <c>StartCircuit</c> with an
+    /// EMPTY component list (a Blazor Web App sends no initial components — they arrive via
+    /// <c>UpdateRootComponents</c>), then <c>UpdateRootComponents</c>, which is where the framework
+    /// deliberately defers creating the circuit handlers to. That deferral is the reason the header
+    /// is still readable: this whole exchange runs inside the live <c>/_blazor</c> request.</para>
+    /// </summary>
+    private async Task<AccessContext?> OpenCircuitAsync(string? acceptLanguage)
+    {
+        var server = portal!.GetTestServer();
+        var connection = new HubConnectionBuilder()
+            .WithUrl(new Uri(server.BaseAddress, "_blazor"), o =>
+            {
+                o.Transports = HttpTransportType.WebSockets;
+                // No negotiate round-trip: the WebSocket handshake IS the request whose header the
+                // circuit must be able to see, so there is exactly one request and no ambiguity
+                // about which one supplied the language.
+                o.SkipNegotiation = true;
+                o.HttpMessageHandlerFactory = _ => server.CreateHandler();
+                o.WebSocketFactory = async (context, ct) =>
+                {
+                    var wsClient = server.CreateWebSocketClient();
+                    wsClient.ConfigureRequest = request =>
+                    {
+                        if (acceptLanguage is not null)
+                            request.Headers["Accept-Language"] = acceptLanguage;
+                    };
+                    return await wsClient.ConnectAsync(context.Uri, ct);
+                };
+            })
+            .Build();
+
+        // Blazor reports a rejected hub call by pushing "JS.Error" and aborting the connection, which
+        // otherwise surfaces to the caller as a bare TaskCanceledException. Surface the real reason.
+        var hubError = string.Empty;
+        connection.On<string>("JS.Error", message => hubError = message);
+        connection.Closed += ex =>
+        {
+            if (ex is not null)
+                hubError = string.IsNullOrEmpty(hubError) ? ex.ToString() : $"{hubError}; {ex}";
+            return Task.CompletedTask;
+        };
+
+        await using (connection)
+        {
+            await connection.StartAsync(TestContext.Current.CancellationToken);
+            try
+            {
+                await connection.InvokeAsync<string?>(
+                    "StartCircuit", "http://localhost/", "http://localhost/", "[]", "",
+                    TestContext.Current.CancellationToken);
+                await connection.InvokeAsync(
+                    "UpdateRootComponents", EmptyRootComponentBatch, "",
+                    TestContext.Current.CancellationToken);
+                return await sink.FirstAsync(TestContext.Current.CancellationToken);
+            }
+            catch (Exception ex) when (!string.IsNullOrEmpty(hubError))
+            {
+                throw new InvalidOperationException(
+                    $"Blazor refused to open the circuit: {hubError}", ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE PAYWALL CASE, and the reason this change exists. An anonymous visitor whose browser
+    /// asks for British English gets an ENGLISH identity — on a portal whose content may well be
+    /// German. Before the fix <c>Locale</c> was null here and every such visitor was served the
+    /// default language no matter what they asked for.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnonymousCircuit_WithEnglishBrowser_ResolvesEnglish()
+    {
+        var identity = await OpenCircuitAsync("en-GB");
+
+        identity.Should().NotBeNull("an open circuit always resolves an identity, anonymous at minimum");
+        identity!.ObjectId.Should().Be(WellKnownUsers.Anonymous);
+        identity.Locale.Should().Be("en",
+            "en-GB folds onto the primary subtag, exactly as a signed-in profile's tag would");
+    }
+
+    /// <summary>
+    /// The mirror, which is what stops "always English" from passing: the same anonymous circuit
+    /// with a German browser must resolve GERMAN. A fix that hard-coded the default would satisfy
+    /// the test above and fail here.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnonymousCircuit_WithGermanBrowser_ResolvesGerman()
+    {
+        var identity = await OpenCircuitAsync("de-CH,de;q=0.9,en;q=0.8");
+
+        identity!.Locale.Should().Be("de",
+            "the viewer's language wins for chrome — a Swiss-German browser gets German");
+    }
+
+    /// <summary>
+    /// A language this deployment does not ship must degrade CLEANLY — no throw, no half-set
+    /// identity — and stay <see langword="null"/> rather than being pinned to a guess, so a later
+    /// and better answer (a profile that loads after sign-in) is not shadowed. Rendering then falls
+    /// back to English through <c>Locales.Resolve</c>, which is the correct outcome.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnonymousCircuit_WithAnUnsupportedLanguage_FallsBackCleanly()
+    {
+        var identity = await OpenCircuitAsync("fr-FR,fr;q=0.9");
+
+        identity.Should().NotBeNull("an unsupported language must not break circuit identity resolution");
+        identity!.Locale.Should().BeNull(
+            "unsupported must stay distinguishable from an explicit request for English");
+    }
+
+    /// <summary>A client that sends no header at all is the no-preference case — unchanged behaviour.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnonymousCircuit_WithNoHeader_ResolvesNoLanguage()
+    {
+        var identity = await OpenCircuitAsync(acceptLanguage: null);
+
+        identity.Should().NotBeNull();
+        identity!.Locale.Should().BeNull();
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  PRECEDENCE — a SEED, never an override. Pure, because it is a pure rule, and because both
+    //  entry paths (the circuit and the SSR request) reach it through the same function.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions =
+        new(System.Text.Json.JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// 🚨 The constraint that keeps the seed honest. A signed-in user who chose English in their
+    /// profile must KEEP English on a German browser. Seeding is for the case where we know nothing;
+    /// the moment the profile states a language, the header stops mattering.
+    /// </summary>
+    [Fact]
+    public void AStoredPreference_BeatsTheBrowsersHeader()
+    {
+        // What the entry paths build: claims identity + the request's negotiated language.
+        var seed = new AccessContext { ObjectId = "rbuergi", Locale = "de" };
+        var profile = new MeshWeaver.Mesh.MeshNode("rbuergi")
+        {
+            Name = "Roland",
+            Content = new User { Email = "rbuergi@systemorph.com", Locale = "en" }
+        };
+
+        MeshUserProjection.Apply(seed, profile, JsonOptions).Locale.Should().Be("en");
+    }
+
+    /// <summary>
+    /// The other half: a signed-in user who has never stated a preference finally gets their
+    /// browser's language instead of unconditional English. An unset profile field means "no
+    /// preference", which must fall back to the seed rather than erase it.
+    /// </summary>
+    [Fact]
+    public void NoStoredPreference_FallsBackToTheBrowsersHeader()
+    {
+        var seed = new AccessContext { ObjectId = "rbuergi", Locale = "de" };
+        var profile = new MeshWeaver.Mesh.MeshNode("rbuergi")
+        {
+            Name = "Roland",
+            Content = new User { Email = "rbuergi@systemorph.com" }
+        };
+
+        MeshUserProjection.Apply(seed, profile, JsonOptions).Locale.Should().Be("de");
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
@@ -115,8 +115,8 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
     /// <summary>
     /// The portal's Blazor wiring, reduced to the pieces the circuit identity actually needs — the
     /// same registrations <c>AddBlazor()</c> makes, plus the probe. Everything that decides the
-    /// answer (the handler, the accessor, the HTTP-context accessor, the Blazor hub) is the real
-    /// production type.
+    /// answer (the circuit handler, the circuit-context accessor, the connection-language filter,
+    /// the Blazor hub itself) is the real production type.
     /// </summary>
     private WebApplication BuildPortal()
     {

--- a/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/AnonymousCircuitLocaleSeedTest.cs
@@ -126,6 +126,13 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
         builder.Services.AddSingleton<IMessageHub>(Mesh);
         builder.Services.AddSingleton(sink);
         builder.Services.AddHttpContextAccessor();
+        // Exactly what AddBlazor() registers for the language seed — the connection-scoped source
+        // plus the global SignalR filter that publishes it. Registering it here rather than calling
+        // AddBlazor() keeps the harness minimal, but it must stay in step with AddBlazor: if these
+        // two drift, the long-polling rows below are what notices.
+        builder.Services.AddSingleton<CircuitRequestLanguage>();
+        builder.Services.AddSingleton<CircuitRequestLanguageFilter>();
+        builder.Services.Configure<HubOptions>(o => o.AddFilter<CircuitRequestLanguageFilter>());
         builder.Services.AddRazorComponents().AddInteractiveServerComponents();
         builder.Services.TryAddScoped<AuthenticationStateProvider, ServerAuthenticationStateProvider>();
         builder.Services.AddScoped<ICircuitContextAccessor, CircuitContextAccessor>();
@@ -167,7 +174,7 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
     }
 
     /// <summary>
-    /// Opens a real Blazor circuit over a real SignalR WebSocket whose handshake carries
+    /// Opens a real Blazor circuit over a real SignalR connection whose request carries
     /// <paramref name="acceptLanguage"/>, and returns the identity the circuit resolved.
     ///
     /// <para>The two hub calls mirror what <c>blazor.web.js</c> does: <c>StartCircuit</c> with an
@@ -175,18 +182,27 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
     /// <c>UpdateRootComponents</c>), then <c>UpdateRootComponents</c>, which is where the framework
     /// deliberately defers creating the circuit handlers to. That deferral is the reason the header
     /// is still readable: this whole exchange runs inside the live <c>/_blazor</c> request.</para>
+    ///
+    /// <para><paramref name="transport"/> is a real dimension, not thoroughness for its own sake: a
+    /// browser behind a proxy that blocks WebSockets falls back to long polling, where each poll is
+    /// a SEPARATE request. If the seed only survived one transport, the feature would work for most
+    /// visitors and silently not for the rest — and "most" is not something a test should leave
+    /// unstated.</para>
     /// </summary>
-    private async Task<AccessContext?> OpenCircuitAsync(string? acceptLanguage)
+    private async Task<AccessContext?> OpenCircuitAsync(
+        string? acceptLanguage, HttpTransportType transport = HttpTransportType.WebSockets)
     {
         var server = portal!.GetTestServer();
         var connection = new HubConnectionBuilder()
             .WithUrl(new Uri(server.BaseAddress, "_blazor"), o =>
             {
-                o.Transports = HttpTransportType.WebSockets;
-                // No negotiate round-trip: the WebSocket handshake IS the request whose header the
-                // circuit must be able to see, so there is exactly one request and no ambiguity
-                // about which one supplied the language.
-                o.SkipNegotiation = true;
+                o.Transports = transport;
+                // WebSockets: skip the negotiate round-trip so the handshake IS the one request that
+                // could have supplied the language — no ambiguity about where it came from. Long
+                // polling has to negotiate, so the header goes on every request the client makes.
+                o.SkipNegotiation = transport == HttpTransportType.WebSockets;
+                if (acceptLanguage is not null)
+                    o.Headers["Accept-Language"] = acceptLanguage;
                 o.HttpMessageHandlerFactory = _ => server.CreateHandler();
                 o.WebSocketFactory = async (context, ct) =>
                 {
@@ -239,10 +255,12 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
     /// German. Before the fix <c>Locale</c> was null here and every such visitor was served the
     /// default language no matter what they asked for.
     /// </summary>
-    [Fact(Timeout = 60000)]
-    public async Task AnonymousCircuit_WithEnglishBrowser_ResolvesEnglish()
+    [Theory(Timeout = 60000)]
+    [InlineData(HttpTransportType.WebSockets)]
+    [InlineData(HttpTransportType.LongPolling)]
+    public async Task AnonymousCircuit_WithEnglishBrowser_ResolvesEnglish(HttpTransportType transport)
     {
-        var identity = await OpenCircuitAsync("en-GB");
+        var identity = await OpenCircuitAsync("en-GB", transport);
 
         identity.Should().NotBeNull("an open circuit always resolves an identity, anonymous at minimum");
         identity!.ObjectId.Should().Be(WellKnownUsers.Anonymous);
@@ -255,10 +273,12 @@ public class AnonymousCircuitLocaleSeedTest(ITestOutputHelper output) : Monolith
     /// with a German browser must resolve GERMAN. A fix that hard-coded the default would satisfy
     /// the test above and fail here.
     /// </summary>
-    [Fact(Timeout = 60000)]
-    public async Task AnonymousCircuit_WithGermanBrowser_ResolvesGerman()
+    [Theory(Timeout = 60000)]
+    [InlineData(HttpTransportType.WebSockets)]
+    [InlineData(HttpTransportType.LongPolling)]
+    public async Task AnonymousCircuit_WithGermanBrowser_ResolvesGerman(HttpTransportType transport)
     {
-        var identity = await OpenCircuitAsync("de-CH,de;q=0.9,en;q=0.8");
+        var identity = await OpenCircuitAsync("de-CH,de;q=0.9,en;q=0.8", transport);
 
         identity!.Locale.Should().Be("de",
             "the viewer's language wins for chrome — a Swiss-German browser gets German");

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
@@ -9,6 +9,11 @@
          degraded-identity repair entirely on a virtual clock; the window it exercises (the mesh
          user index unable to answer) cannot be held open against a live mesh. -->
     <PackageReference Include="Microsoft.Reactive.Testing" />
+    <!-- AnonymousCircuitLocaleSeedTest drives the REAL Blazor ComponentHub over a REAL SignalR
+         WebSocket connection, because the thing under test is precisely whether the circuit can
+         still see the request that established it. Nothing short of a real connection can answer
+         that — a unit test of the negotiation would pass while the browser saw nothing. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />

--- a/test/MeshWeaver.Messaging.Hub.Test/LocalizationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/LocalizationTest.cs
@@ -115,6 +115,71 @@ public class LocalizationTest
         Locales.TryMatch("de-CH").Should().Be("de");
     }
 
+    // ---- Accept-Language: the ONLY language statement an anonymous visitor makes ----------
+
+    /// <summary>
+    /// <see cref="Locales.Negotiate"/> is what makes "the viewer's language wins for chrome" mean
+    /// anything for an ANONYMOUS visitor — the audience a paywall, an invite or a public course page
+    /// exists for, who has no profile to read a preference from. It must fold region variants onto
+    /// the primary subtag EXACTLY as <see cref="Locales.TryMatch"/> does (the product and the plugins
+    /// both match on the primary subtag; agreeing by construction is the whole point of putting the
+    /// rule here), and it must honour the header's weights rather than its textual order.
+    /// </summary>
+    [Theory]
+    // The paywall case: a British visitor on a German course page gets ENGLISH chrome.
+    [InlineData("en-GB", "en")]
+    [InlineData("en-US,en;q=0.9", "en")]
+    // The mirror.
+    [InlineData("de", "de")]
+    [InlineData("de-CH", "de")]
+    [InlineData("de-CH,de;q=0.9,en;q=0.8", "de")]
+    // Weight beats textual order — "en" is listed first but explicitly less preferred.
+    [InlineData("en;q=0.8,de;q=0.9", "de")]
+    // Languages we don't ship are skipped, not treated as a match that blocks the next candidate.
+    [InlineData("fr-FR,fr;q=0.9,de;q=0.8", "de")]
+    [InlineData("zh-CN,ja;q=0.9,en-GB;q=0.7", "en")]
+    // A malformed weight must not discard a preference the browser genuinely stated.
+    [InlineData("de;q=nonsense", "de")]
+    [InlineData("de;q=", "de")]
+    // Whitespace and casing are header noise, not meaning.
+    [InlineData("  DE-ch ;q=0.9 ", "de")]
+    public void Negotiate_PicksTheHighestWeightedSupportedLanguage(string header, string expected)
+        => Locales.Negotiate(header).Should().Be(expected);
+
+    /// <summary>
+    /// The null cases, kept apart because they are the ones that must NOT become "en": an
+    /// unresolvable header has to stay distinguishable from an explicit request for English, so a
+    /// better answer arriving later (a profile that loads a moment afterwards) is not shadowed by a
+    /// guess. Same contract as <see cref="Locales.TryMatch"/>.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Nothing we ship.
+    [InlineData("fr-FR,fr;q=0.9")]
+    [InlineData("zz-ZZ")]
+    // "*" is an ABSENCE of preference (curl, many bots). Matching it would pin every such caller to
+    // whichever language happens to head Locales.Supported.
+    [InlineData("*")]
+    [InlineData("*;q=0.5")]
+    // q=0 is an explicit REFUSAL of that language, not a weak preference for it.
+    [InlineData("de;q=0")]
+    [InlineData("de;q=0,en;q=0")]
+    // Garbage must degrade to "we know nothing", never to a throw.
+    [InlineData(",,,")]
+    [InlineData(";q=0.9")]
+    public void Negotiate_ReturnsNullWhenTheBrowserAskedForNothingWeShip(string? header)
+        => Locales.Negotiate(header).Should().BeNull();
+
+    /// <summary>
+    /// A refusal must not suppress the next acceptable candidate — <c>q=0</c> removes one language
+    /// from consideration, it does not end the negotiation.
+    /// </summary>
+    [Fact]
+    public void Negotiate_SkipsARefusedLanguageAndKeepsLooking()
+        => Locales.Negotiate("de;q=0,en;q=0.5").Should().Be("en");
+
     [Fact]
     public void MissingKey_FallsBackToEnglishThenToTheKeyItself()
     {


### PR DESCRIPTION
## The problem

"The viewer's language wins for chrome" is implemented in the plugins (Store #458, Edu/CourseInvite #463) and resolves off `AccessContext.Locale`. That field is populated from the signed-in user's **profile** — and an anonymous visitor has no profile. So it was `null` for every one of them, and the portal answered in English whatever their browser asked for.

The decision was therefore **inert for exactly the audience it was written for**: a first-time visitor hitting a paywall, an invite or a public course page is anonymous *by definition*.

`Accept-Language` was read nowhere in the framework — no middleware, no `RequestLocalization`, no culture cookie, no `?lang=`.

## The fix

Seed `AccessContext.Locale` from the request's `Accept-Language`, negotiated against `Locales.Supported`, on **both** entry paths.

| Path | Where | Reads the header from |
|---|---|---|
| SSR / HTTP request | `UserContextMiddleware` | `HttpContext.Request.Headers.AcceptLanguage` |
| Blazor circuit | `CircuitAccessHandler` **constructor** | `CircuitRequestLanguage`, published per hub invocation by the global `CircuitRequestLanguageFilter` |

`Locales.Negotiate` parses the full RFC 9110 header (comma list, `q=` weights, descending, ties in header order) and matches each tag through **`Locales.TryMatch`** — so region variants fold onto the **primary subtag** exactly as everywhere else (`en-GB` → `en`, `de-CH` → `de`), and the harness and the product agree by construction rather than coincidence. `q=0` (an explicit refusal) and `*` (an absence of preference) are skipped. Nothing matched returns **`null`, not `"en"`**, so "unsupported" stays distinguishable from "asked for English".

### Why the circuit reads the SignalR connection, not `IHttpContextAccessor`

The first cut used `IHttpContextAccessor`. Extending the test to cover **both** SignalR transports showed that it works over WebSockets — the upgrade request stays in flight for the connection's life — and returns **nothing under long polling**, where every poll is a separate request that ASP.NET disposes, nulling the accessor's holder for every flow that captured it. A browser behind a proxy that blocks WebSockets falls back to long polling, i.e. exactly a corporate network, so shipping that would have meant the fix reaches most anonymous visitors and silently misses the rest.

SignalR keeps an `IHttpContextFeature` on the **connection** and refreshes it per request, so `HubCallerContext.GetHttpContext()` answers for every transport. `CircuitRequestLanguageFilter` reads it in the hub invocation that *creates* the circuit handlers and publishes it on `CircuitRequestLanguage` — an `AsyncLocal` held as an instance field on a mesh-scoped singleton (the same shape `AccessService` uses for per-circuit identity; never `static`, so two circuits opening concurrently cannot see each other's language), memoised per connection so the parse happens once rather than per message. `IHttpContextAccessor` remains only as a fallback for a host that runs the Blazor hub without the filter.

The filter is registered **globally** because Blazor's `ComponentHub` is `internal` and cannot be named in a per-hub registration; `ComponentHub` declares no filters of its own, so the global list applies. On any other hub it is a memoised no-op (the repo has no other hub filters).

### Does the seed land before the first render? **Yes.**

This is the question the change lives or dies on, because `LayoutAreaHost` captures the access context in its **constructor** and `CircuitContext` is a plain non-observable `AsyncLocal` — a locale arriving mid-circuit re-renders nothing.

- The header is read in the handler's **constructor**. Blazor resolves the circuit's `CircuitHandler`s from inside a `ComponentHub` hub method — `StartCircuit` for a classic Blazor Server payload, and the first `UpdateRootComponents` for a **Blazor Web App** (which this portal is), where handler creation is *deliberately* deferred so a handler can see the restored application state. That invocation is exactly what the filter wraps.
- The framework then runs `OnCircuitOpenedAsync` → `OnConnectionUpAsync` → **only then** `AddComponentAsync` (the first render). So the language is on the circuit identity before anything draws.
- The circuit is also the path that matters: the portal's SSR pass renders no page content at all (`Routes.razor` returns early until `BrowserDimensionWatcher` resolves the viewport), so a middleware-only fix would have been inert for the paywall.

### A stored preference still wins

Both paths now share **one** projection, `MeshUserProjection.Apply`: identity from the node, preferences from the profile *when set*, falling back to the seed when not. The two paths used to project differently — the circuit read locale + time zone, the middleware only id + name. That was invisible while nothing seeded a locale, and would have rendered **German SSR chrome for an English-profile user** the moment one existed. `CircuitAccessHandler.ApplyMeshUser` is now a thin alias, so its existing tests still pin the same rule.

`CultureInfo.CurrentUICulture` is **not** consulted anywhere. The header is read once, at identity time, and never becomes a second ambient resolution mechanism.

## Verification

**`AnonymousCircuitLocaleSeedTest`** (`MeshWeaver.Hosting.Blazor.Test`) drives a **real SignalR connection into Blazor's real `ComponentHub`** on a real `WebApplication` over a real monolith mesh — real `CircuitAccessHandler`, real per-circuit `ICircuitContextAccessor`, real filter. A probe `CircuitHandler` ordered after it reads the resolved identity in `OnConnectionUpAsync`, i.e. at the last moment before the first render. No mocks.

Nothing short of a real connection can answer the question this change turns on; a unit test of the negotiation alone would stay green while the browser saw nothing — and it is precisely the real-connection test that caught the long-polling gap.

- `Accept-Language: en-GB` → `Locale == "en"` — **the paywall case: English chrome on a `de-CH` course.** Run over **WebSockets and long polling**.
- `Accept-Language: de-CH,de;q=0.9,en;q=0.8` → `"de"` — the mirror, which is what stops "always English" from passing. Both transports.
- `Accept-Language: fr-FR,fr;q=0.9` → `null`, no throw — unsupported falls back cleanly.
- No header → `null` — unchanged.
- Plus two pure precedence tests: a stored `en` beats a German browser; an unset profile falls back to the browser.

**Fail-before confirmed, twice.** (1) With `Locale = null` restored in the anonymous branch, the en-GB and de-CH cases fail with `Expected value to be "en" … but found <null>`; the two null-expectation cases stay green (handler byte-restored afterwards, verified by `diff`). (2) Against the accessor-only version, the two **long-polling** rows fail with the same `found <null>` — which is what drove the connection-scoped redesign.

`Locales.Negotiate` is additionally pinned in `LocalizationTest` over real header shapes (weights beating textual order, `q=0`, `*`, malformed weights, whitespace/casing, unsupported).

### Runs

- `MeshWeaver.Hosting.Blazor.Test` — **402/402** ✅ (8 in the new class, across both transports)
- `MeshWeaver.Messaging.Hub.Test` — **56/56** ✅
- `MeshWeaver.Hosting.Monolith.Test` `~LocalePreference` — **17/17** ✅
- `MeshWeaver.Documentation.Test` `~DocumentationLinkIntegrity` — **1/1** ✅
- Release + `-warnaserror`: `MeshWeaver.Messaging.Contract`, `MeshWeaver.Blazor`, `MeshWeaver.Hosting.Blazor`, `Memex.Portal.Monolith` (`-p:CIRun=true`), `MeshWeaver.Hosting.Monolith.Test`, both touched test projects — all `0 Error(s)`.

No new localization **keys** were added, so the `clients/react/src/i18n/` mirror is untouched by design.

## Noted, not fixed — for the education repo

The education harness has a latent version of this bug and should be picked up there (**not** touched by this PR):

- `80-primer.spec.ts:32` loops `CONTENT_COURSES` (which **does** include `AgenticPrimerDe`) and asserts the English `STORE.priceLine` / `STORE.enrollRedirect` at lines 126-131, while `StoreTexts.German.PricePaid` is `"**{0}** — voller Zugang zu allen Inhalten."`. Those pass today only because a `/Subscribe/` heading regex carries them — i.e. the assertion that would catch a language regression is not actually asserting language.
- `STORE.enrollRedirect = 'Taking you to enroll'` exists nowhere in the vendored plugin source — a stale literal.

Both become live once anonymous visitors genuinely render in their own language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
