### PR TITLE
fix(#1411): an instance mid-compile shows build progress on every area, not just Overview

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -255,11 +255,20 @@ to settle — but only **briefly** in silence. After a short grace
 delivery and settles onto the **compilation-in-progress overlay**
 (`WithCompilationInProgressOverlay`):
 
-- The instance's **Overview renders the type's live progress page**
+- **Every area of the instance renders the type's live progress page**
   (`NodeTypeLayoutAreas.CompileProgressView`): current status, the streaming compile
   activity log, and — when more types are queued (the framework-bump warm-up recompiles
   every dynamic type) — the whole sweep as an "N of M types compiled" progress bar with the
-  type currently compiling and the queued count. On `Ok` it redirects back to the instance.
+  type currently compiling and the queued count. On `Ok` it redirects back to the area the
+  caller asked for, so a deep link survives the wait.
+
+  The overlay registers `Overview` by name plus a **catch-all** guarded by
+  `LayoutDefinition.HasNamedRenderer` — the type's own areas (`KeyMetrics`, …) do not exist on
+  the overlay hub, and covering only `Overview` did not remove the silent park, it relocated it:
+  every other area answered `"**Area not found** — No renderer is registered for area
+  `KeyMetrics`"`, a terminal-looking verdict for a state that resolves itself in seconds
+  (issue #1411). The guard is what keeps the catch-all off areas the default node configuration
+  already owns — two renderers for one area are last-wins-*destructive*.
 - **Typed requests fail fast** with `ErrorType.CompilationInProgress` naming the NodeType
   (`UnhandledMessageNack`), instead of parking until the caller's own 60 s request timeout.
   Area clients handle that NACK by swapping to the type's `Progress` area

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-page-that-is-still-building-no-longer-says-it-does-not-exist.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-page-that-is-still-building-no-longer-says-it-does-not-exist.md
@@ -1,0 +1,38 @@
+---
+Name: A page that is still building no longer says it does not exist
+Category: Fix
+Description: While an item's code was being rebuilt, only its main view said so — open any other view of it and you were told that view did not exist. Every view now shows the same live build progress, and returns you to the view you asked for once the build finishes.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A page that is still building no longer says it does not exist
+
+Items in the portal get their views from code, and that code is compiled while the portal runs.
+Most of the time you never notice: a build takes a moment and the page opens. But after a platform
+update every item's code is rebuilt at once, and for a short while an item you open is genuinely
+waiting on its own build.
+
+The portal already had an answer for that. Open such an item and, instead of a page that hangs, you
+get a live progress view: what is building, how far along the whole queue is, and a link into the
+build log — and the moment the build finishes it takes you to the real page.
+
+The problem was that this answer only covered an item's **main** view. Open one of its other views
+— a specific chart, a table, a section you had bookmarked — and you got something much worse than a
+wait:
+
+> **Area not found** — No renderer is registered for area `KeyMetrics`.
+
+That reads like a verdict. Nothing is coming, you followed a dead link, the thing you bookmarked is
+gone. In fact nothing was wrong at all: the view's code was thirty seconds from being ready. The
+silence the progress view was built to remove had not been removed, only moved off the front page
+and onto every other one.
+
+Now every view of an item whose code is building shows that same live progress — and when the build
+lands it returns you to **the view you asked for**, not to the item's front page. A bookmark to a
+particular chart survives the wait instead of being answered with "that chart does not exist".
+
+The genuine case still answers honestly: ask for a view that really does not exist and you are
+still told so, plainly. The two situations were only ever distinguishable by reading the wording,
+which is why so much of the portal treated them the same — they now carry a machine-readable mark,
+so anything waiting on a view knows the difference between *not here* and *not yet*.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1816,17 +1816,58 @@ internal static class NodeTypeEnrichmentHelpers
             meshHub, nodeType, typeVersionAtOverlay: typeNode.Version, logger));
     }
 
-    private static Func<MessageHubConfiguration, MessageHubConfiguration>
+    /// <summary>
+    /// The overlay's layout: the compile-progress page on the instance's <c>Overview</c> AND on
+    /// every area the hub does not otherwise own.
+    ///
+    /// <para>🚨 The catch-all is the whole point. Registering only <c>Overview</c> did not remove
+    /// the silent park — it MOVED it: every other area of an overlaid instance fell to
+    /// <c>LayoutDefinition.BuildNotFoundControl</c> and told the user
+    /// <c>"No renderer is registered for area `KeyMetrics`"</c>, i.e. a terminal "this area does
+    /// not exist" for a state that resolves itself in seconds (#1411). Anyone deep-linking an
+    /// area during a framework-bump sweep got that answer.</para>
+    ///
+    /// <para>Two details of the sanctioned catch-all shape (<c>KernelContainer</c>) are
+    /// load-bearing here:</para>
+    /// <list type="bullet">
+    ///   <item><c>HasNamedRenderer</c> is evaluated against the definition that ALREADY carries
+    ///     the <c>Overview</c> view — every renderer matching an area first disposes and REMOVES
+    ///     that area's content, so two renderers for one area are last-wins-destructive (the
+    ///     2026-07-03 eternal-spinner RCA). The named areas the mesh default config registers
+    ///     (Data, Schema, Search, …) keep serving their generic views for the same reason.</item>
+    ///   <item><c>StartWith(null)</c> — <c>LayoutDefinition.Render</c> composes an area's
+    ///     renderers SEQUENTIALLY, so a catch-all that stays silent until the cross-hub type
+    ///     stream emits would dam the node menu behind it. A null renders as a pass-through.</item>
+    /// </list>
+    ///
+    /// <para>The redirect target is the area the caller ASKED for, not the instance root: once
+    /// the build settles, a deep link to <c>…/KeyMetrics</c> must land back on
+    /// <c>…/KeyMetrics</c>, not bounce the user to the overview of a page they never requested.</para>
+    /// </summary>
+    internal static Func<MessageHubConfiguration, MessageHubConfiguration>
         CreateCompilationInProgressConfiguration(string nodeType, string instancePath)
         => config => config.AddLayout(layout =>
-            layout.WithView(MeshNodeLayoutAreas.OverviewArea, (host, _) =>
+        {
+            var withOverview = layout.WithView(MeshNodeLayoutAreas.OverviewArea,
+                (host, _) => Progress(host, $"/{instancePath}"));
+            return withOverview.WithView(
+                ctx => !withOverview.HasNamedRenderer(ctx.Area),
+                (host, ctx) => Progress(host, RedirectTarget(ctx.Area))
+                    .StartWith((UiControl?)null));
+
+            string RedirectTarget(string? area) => string.IsNullOrEmpty(area)
+                ? $"/{instancePath}"
+                : $"/{instancePath}/{area}";
+
+            IObservable<UiControl?> Progress(LayoutAreaHost host, string redirectOnOk) =>
                 NodeTypeLayoutAreas.CompileProgressView(
                     host,
                     // Cross-hub: the instance overlay observes the TYPE's node through the
                     // shared IMeshNodeStreamCache handle — same stream the enrichment waited on.
                     host.Hub.GetMeshNodeStream(nodeType),
                     nodeTypePath: nodeType,
-                    redirectOnOk: $"/{instancePath}")));
+                    redirectOnOk: redirectOnOk);
+        });
 
     // Default guidance for a genuine Roslyn failure (Status=Error with captured
     // diagnostics). Other overlay callers (e.g. the framework-stale recompile

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -169,7 +169,8 @@ public static class NodeTypeLayoutAreas
                 var def = node?.ContentAs<NodeTypeDefinition>(host.Hub.JsonSerializerOptions);
                 if (node is null || def is null)
                     return (UiControl?)Controls.Markdown(
-                        $"*{host.Localize("ui.noNodeTypeDefinition")}*");
+                            $"*{host.Localize("ui.noNodeTypeDefinition")}*")
+                        .WithId(AreaFrameClassifier.CompileProgressId);
 
                 // Compile finished cleanly → redirect to the now-addressable page. The user
                 // only landed here because activation could not complete mid-compile; once
@@ -251,7 +252,12 @@ public static class NodeTypeLayoutAreas
                 if (def.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling)
                     stack = AppendSweepSummary(stack, host, sweepNodes);
 
-                return (UiControl?)stack;
+                // 🚨 Every frame this surface serves is tagged so a CONSUMER — not just a human
+                // reading the headline — can tell "the type is still building, keep waiting" from
+                // the framework's terminal "Area not found". Since the compilation-in-progress
+                // overlay serves this page on EVERY area of an instance, a waiter that latched it
+                // as the real content would fail on the assertion instead of waiting (#1411).
+                return (UiControl?)stack.WithId(AreaFrameClassifier.CompileProgressId);
             });
     }
 

--- a/src/MeshWeaver.Layout/AreaFrameClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaFrameClassifier.cs
@@ -1,0 +1,80 @@
+namespace MeshWeaver.Layout;
+
+/// <summary>
+/// Static, dependency-free classification of the PLACEHOLDER FRAMES a layout area can serve.
+/// The twin of <see cref="AreaErrorClassifier"/>: that one classifies the exceptions an area
+/// subscription surfaces, this one classifies the controls it RENDERS when the area's real
+/// content is not (yet) available.
+///
+/// <para>Why frames need classifying at all: the two placeholders look alike to a human and
+/// mean opposite things to a consumer. <b>Area not found</b> is a VERDICT — nothing on this hub
+/// will ever render this area, so a waiter should give up and say so. The <b>compile-progress</b>
+/// page is a PROMISE — the instance's NodeType is still building, and the real content arrives
+/// (via a <see cref="RedirectControl"/> the moment the build settles) without anyone doing
+/// anything. A consumer that cannot tell them apart either gives up on a page that was merely
+/// compiling, or waits forever on an area that genuinely does not exist.</para>
+///
+/// <para>The distinction is carried by <see cref="UiControl.Id"/> — a stable, well-known token,
+/// never the prose. The prose is localized, reworded, and read by humans; the id round-trips
+/// through the sync stream as a plain JSON string, so a client that only ever sees serialized
+/// frames (the plugin-gate probe) can match the same constant the typed predicates below use.</para>
+/// </summary>
+public static class AreaFrameClassifier
+{
+    /// <summary>
+    /// <see cref="UiControl.Id"/> of the framework's "Area not found" placeholder
+    /// (<c>LayoutDefinition.BuildNotFoundControl</c>) — no renderer on this hub produced the
+    /// requested area. TERMINAL.
+    /// </summary>
+    public const string AreaNotFoundId = "area-not-found";
+
+    /// <summary>
+    /// <see cref="UiControl.Id"/> of every frame the compile-progress surface serves
+    /// (<c>NodeTypeLayoutAreas.CompileProgressView</c>) — the instance's NodeType has not
+    /// finished building, so this area is not being served YET. TRANSIENT.
+    /// </summary>
+    public const string CompileProgressId = "compile-progress";
+
+    // The pre-id signal, kept as a fallback so a frame that lost its id on the way here (an
+    // older peer, a control rebuilt from partial JSON) is still recognised. Never localize:
+    // BuildNotFoundControl is deliberately English — it is a framework diagnostic, not UI copy.
+    private const string AreaNotFoundMarkdownMarker = "**Area not found**";
+
+    /// <summary>
+    /// True for the framework's "Area not found" placeholder: NO renderer is registered for the
+    /// requested area on the hub that answered. Distinct from <see cref="IsCompileProgress"/> —
+    /// see the type remarks for why conflating them is the bug this class exists to prevent.
+    /// </summary>
+    /// <param name="control">The rendered control, or <c>null</c>.</param>
+    public static bool IsAreaNotFound(UiControl? control)
+        => HasFrameId(control, AreaNotFoundId)
+           || (control is MarkdownControl markdown
+               && (markdown.Markdown?.ToString() ?? string.Empty)
+                   .Contains(AreaNotFoundMarkdownMarker, StringComparison.Ordinal));
+
+    /// <summary>
+    /// True for a frame served by the compile-progress surface — the live status page an
+    /// instance serves on EVERY area while its NodeType is still building.
+    /// </summary>
+    /// <param name="control">The rendered control, or <c>null</c>.</param>
+    public static bool IsCompileProgress(UiControl? control)
+        => HasFrameId(control, CompileProgressId);
+
+    /// <summary>
+    /// True for a frame that is not the area's content and will be REPLACED without anyone
+    /// acting: the compile-progress page, and the <see cref="RedirectControl"/> it emits once
+    /// the build settles. The single predicate a waiter needs — "keep waiting, this is not the
+    /// answer". A genuinely missing area (<see cref="IsAreaNotFound"/>) is deliberately NOT
+    /// transient: nothing is going to replace it.
+    /// </summary>
+    /// <param name="control">The rendered control, or <c>null</c>.</param>
+    public static bool IsTransientFrame(UiControl? control)
+        => IsCompileProgress(control) || control is RedirectControl;
+
+    // UiControl.Id is `object?`, so a frame that came back over the sync stream carries it as
+    // whatever the deserializer produced for a JSON string (a JsonElement, not a string). Compare
+    // the rendered text, never the CLR type — the typed check silently answered "no" for every
+    // client-side frame, which is the only place these predicates matter.
+    private static bool HasFrameId(UiControl? control, string id)
+        => control?.Id is { } actual && string.Equals(actual.ToString(), id, StringComparison.Ordinal);
+}

--- a/src/MeshWeaver.Layout/Composition/LayoutDefinition.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutDefinition.cs
@@ -227,6 +227,12 @@ public record LayoutDefinition(IMessageHub Hub)
     /// <summary>
     /// The visible "Area not found" placeholder control — shown instead of an eternal spinner when no
     /// renderer produced content for the requested area. Lists the hub's named areas to aid diagnosis.
+    ///
+    /// <para>🚨 Carries <see cref="AreaFrameClassifier.AreaNotFoundId"/> as its
+    /// <see cref="UiControl.Id"/> so a consumer can tell this VERDICT ("nothing will ever render
+    /// here") apart from the compile-progress PROMISE an instance serves while its NodeType is
+    /// still building — the two are indistinguishable to anything that only reads the prose.
+    /// Keep the id stable; the markdown is free to change.</para>
     /// </summary>
     private MarkdownControl BuildNotFoundControl(LayoutAreaHost host, object area)
     {
@@ -235,7 +241,10 @@ public record LayoutDefinition(IMessageHub Hub)
             ? "_no named areas registered on this hub_"
             : "Available named areas: " + string.Join(", ", availableAreas.Select(a => $"`{a}`"));
         return new MarkdownControl(
-            $"**Area not found**\n\nNo renderer is registered for area `{area}` on hub `{host.Hub.Address}`.\n\n{availableLine}");
+            $"**Area not found**\n\nNo renderer is registered for area `{area}` on hub `{host.Hub.Address}`.\n\n{availableLine}")
+        {
+            Id = AreaFrameClassifier.AreaNotFoundId
+        };
     }
 
     private EntityStoreAndUpdates NotFound(LayoutAreaHost host, RenderingContext context, EntityStore store)

--- a/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
+++ b/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
@@ -1272,23 +1272,24 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             address, reference);
 
-        // 🚨 `**Area not found**` is a TRANSIENT frame, never a terminal verdict — do not
-        // latch it. A global `WithRenderer(_ => true, RenderMenus)` runs on every hub, so
-        // `applicable.Count` is always >= 1 and LayoutDefinition emits its not-found
-        // placeholder SYNCHRONOUSLY for an area whose real renderer has not registered yet
-        // (the instance hub re-registers its layout after a cold compile / activation).
-        // `x is not null` accepts that placeholder, so on a loaded CI runner the first frame
-        // won this race and the test read the placeholder as the answer — which is how
+        // 🚨 Neither `**Area not found**` nor the compile-progress page is this area's content —
+        // do not latch either (see IsNotYetTheArea for why each one shows up). A global
+        // `WithRenderer(_ => true, RenderMenus)` runs on every hub, so `applicable.Count` is
+        // always >= 1 and LayoutDefinition emits its not-found placeholder SYNCHRONOUSLY for an
+        // area whose real renderer has not registered yet (the instance hub re-registers its
+        // layout after a cold compile / activation). `x is not null` accepts that placeholder,
+        // so on a loaded CI runner the first frame won this race and the test read the
+        // placeholder as the answer — which is how
         // EuropeRe_AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution went red on CI
-        // while passing on every local run. Wait for the REAL condition (a frame that is not
-        // the placeholder) instead of the first non-null one; the existing timeout still
-        // bounds a renderer that genuinely never appears.
+        // while passing on every local run. Wait for the REAL condition instead of the first
+        // non-null one; the existing timeout still bounds a renderer that genuinely never appears.
         // Same lesson already recorded in tools/MeshWeaver.PluginTester/AreaProbe.cs.
         var control = await stream
             .GetControlStream(reference.Area!)
             .Should().Within(Math.Max(timeoutSeconds, ActivationBudgetSeconds).Seconds())
-            .Match(x => x is not null && !IsAreaNotFound(x),
-                $"{areaName} should render at {addressPath} (not the 'Area not found' placeholder)");
+            .Match(x => x is not null && !IsNotYetTheArea(x),
+                $"{areaName} should render at {addressPath} (not the 'Area not found' placeholder "
+                + "and not the mid-compile progress page)");
 
         if (unwrap)
         {
@@ -1307,7 +1308,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
                 control = await stream
                     .GetControlStream(childKey)
                     .Should().Within(timeoutSeconds.Seconds())
-                    .Match(x => x is not null && !IsAreaNotFound(x)
+                    .Match(x => x is not null && !IsNotYetTheArea(x)
                                 && (!waitForData || HasNonTrivialData(x)));
                 Output.WriteLine($"  Ã¢â€ â€™ {control?.GetType().Name}");
             }
@@ -1317,26 +1318,41 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             control = await stream
                 .GetControlStream(reference.Area!)
                 .Should().Within(timeoutSeconds.Seconds())
-                .Match(x => x is not null && HasNonTrivialData(x));
+                .Match(x => x is not null && !IsNotYetTheArea(x) && HasNonTrivialData(x));
         }
 
         return control;
     }
 
     /// <summary>
-    /// True for the framework's <c>**Area not found**</c> placeholder
-    /// (<c>LayoutDefinition.BuildNotFoundControl</c>).
+    /// True for a frame that is NOT this area's content and will be replaced on its own — the
+    /// only correct answer to which is "keep waiting".
     ///
-    /// <para>🚨 This frame is TRANSIENT, not a verdict. Every hub carries a global
+    /// <para>🚨 Two distinct frames land here, for two distinct reasons.</para>
+    ///
+    /// <para><b>The <c>**Area not found**</c> placeholder</b>
+    /// (<c>LayoutDefinition.BuildNotFoundControl</c>). Every hub carries a global
     /// <c>WithRenderer(_ => true, RenderMenus)</c>, so the composed stream always has an
     /// applicable renderer and LayoutDefinition emits the placeholder immediately for an area
     /// whose real renderer has not registered yet. Any wait of the shape
-    /// <c>Match(x => x is not null)</c> can therefore latch it on a loaded runner — the whole
-    /// reason this helper exists. Treat it as "keep waiting", never as the rendered control.</para>
+    /// <c>Match(x => x is not null)</c> can therefore latch it on a loaded runner — the original
+    /// reason this helper exists.</para>
+    ///
+    /// <para><b>The compile-progress page</b> (<c>NodeTypeLayoutAreas.CompileProgressView</c>),
+    /// and the <c>RedirectControl</c> it emits once the build settles. Since #1411 the
+    /// compilation-in-progress overlay serves that page on EVERY area of an instance whose
+    /// NodeType is mid-compile, not just <c>Overview</c> — which is exactly the state this test
+    /// hits on a cold CI runner. It is not the placeholder, so a wait that only skipped
+    /// <c>**Area not found**</c> would latch the progress page and fail on
+    /// <c>Should().Contain("Total Premium")</c>: faster than the timeout it replaced, and
+    /// reading like a data defect rather than "the build hadn't finished".</para>
+    ///
+    /// <para>Both are matched by <c>AreaFrameClassifier</c> on the frame's well-known
+    /// <c>Id</c>, never on its prose.</para>
     /// </summary>
-    private static bool IsAreaNotFound(UiControl? control)
-        => control is MarkdownControl md
-           && (md.Markdown?.ToString() ?? "").Contains("**Area not found**", StringComparison.Ordinal);
+    private static bool IsNotYetTheArea(UiControl? control)
+        => AreaFrameClassifier.IsAreaNotFound(control)
+           || AreaFrameClassifier.IsTransientFrame(control);
 
     /// <summary>
     /// Checks if a control has meaningful data (not all zeros).

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileProgressOverlayAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileProgressOverlayAreaTest.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Issue #1411 — <b>the compilation-in-progress overlay covered only <c>Overview</c></b>.
+///
+/// <para>While an instance's NodeType is building, its hub is activated against the overlay
+/// configuration produced by
+/// <see cref="NodeTypeEnrichmentHelpers.CreateCompilationInProgressConfiguration"/>. That
+/// registered ONE named renderer, so every other area fell through to
+/// <c>LayoutDefinition.BuildNotFoundControl</c> and answered
+/// <c>"**Area not found** — No renderer is registered for area `KeyMetrics`"</c>. The silent park
+/// the overlay set out to remove was not removed, it was RELOCATED: a user who deep-links any
+/// non-Overview area during a framework-bump sweep is told the area does not exist, when the truth
+/// is that its code is still building.</para>
+///
+/// <para>Both directions are asserted here, because a catch-all that swallowed the genuine miss
+/// would be a worse bug than the one it fixes:</para>
+/// <list type="number">
+///   <item>an area of an OVERLAID instance that nothing else registers renders the compile-progress
+///     page, not the placeholder;</item>
+///   <item>an area that genuinely has no renderer, on a hub with no overlay, still renders the
+///     placeholder;</item>
+///   <item>and the two are told apart by a CONSUMER — <see cref="AreaFrameClassifier"/> on the
+///     frame's well-known id — not by a human reading the prose. That is the coupling the issue
+///     calls out: converting a terminal-looking frame into a transient one breaks every waiter
+///     that treated "not the placeholder" as "the content arrived", so the distinction has to be
+///     mechanically available in the same change.</item>
+/// </list>
+///
+/// <para>The overlay is applied here as a STATIC node configuration rather than by stalling a real
+/// Roslyn compile: the mesh composes it with <c>DefaultNodeHubConfiguration</c> exactly as
+/// <c>MeshNodeHubFactory</c> does for the real activation path, so the layout under test is the
+/// production one — without a timing-dependent compile to keep in flight.</para>
+/// </summary>
+public class CompileProgressOverlayAreaTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The NodeType the overlaid instance is waiting on — held at <c>Compiling</c>.</summary>
+    private const string PendingTypePath = "overlay/PendingType";
+
+    /// <summary>The instance whose hub carries the compilation-in-progress overlay.</summary>
+    private const string OverlaidPath = "overlay/Overlaid";
+
+    /// <summary>A plain node hub — no overlay — used for the "genuinely missing" direction.</summary>
+    private const string PlainPath = "overlay/Plain";
+
+    /// <summary>An area no configuration on either hub registers.</summary>
+    private const string TypeOwnedArea = "KeyMetrics";
+
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(90);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(180);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddMeshNodes(MeshNode.FromPath(OverlaidPath) with
+            {
+                Name = "Overlaid",
+                State = MeshNodeState.Active,
+                // The production overlay, verbatim. The mesh composes DefaultNodeHubConfiguration
+                // underneath it (MeshNodeHubFactory), which is what puts the standard named areas
+                // — and therefore the HasNamedRenderer guard the catch-all depends on — in play.
+                HubConfiguration = NodeTypeEnrichmentHelpers
+                    .CreateCompilationInProgressConfiguration(PendingTypePath, OverlaidPath)
+            })
+            .AddMeshNodes(MeshNode.FromPath(PlainPath) with
+            {
+                Name = "Plain",
+                State = MeshNodeState.Active,
+                HubConfiguration = config => config
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>
+    /// The defect: an area of an instance whose type is mid-compile answered "this area does not
+    /// exist". It must answer "this area's code is still building" — the same live progress page
+    /// the instance's Overview already served.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AreaOfAnInstanceMidCompile_RendersProgress_NotAreaNotFound()
+    {
+        await CreateCompilingType();
+
+        var control = await Render(OverlaidPath, TypeOwnedArea);
+
+        AreaFrameClassifier.IsAreaNotFound(control).Should().BeFalse(
+            "an area whose renderer has not been registered YET, because the instance's NodeType is "
+            + "still compiling, must not be reported as an area that does not exist");
+        AreaFrameClassifier.IsCompileProgress(control).Should().BeTrue(
+            "every area of an overlaid instance serves the same live compile-progress page its "
+            + "Overview serves — the catch-all is what makes the overlay cover the whole hub");
+        AreaFrameClassifier.IsTransientFrame(control).Should().BeTrue(
+            "the frame must announce itself as one that will be replaced without anyone acting");
+    }
+
+    /// <summary>
+    /// The regression guard for what already worked: Overview keeps its own named renderer, and
+    /// the catch-all must not have replaced it (two renderers for one area are
+    /// last-wins-DESTRUCTIVE — the 2026-07-03 eternal-spinner RCA).
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task OverviewOfAnInstanceMidCompile_StillRendersProgress()
+    {
+        await CreateCompilingType();
+
+        var control = await Render(OverlaidPath, MeshNodeLayoutAreas.OverviewArea);
+
+        AreaFrameClassifier.IsCompileProgress(control).Should().BeTrue(
+            "the named Overview renderer must survive the catch-all's registration");
+    }
+
+    /// <summary>
+    /// The other direction, and the reason the catch-all is guarded by <c>HasNamedRenderer</c>
+    /// rather than being a bare <c>_ =&gt; true</c>: a hub WITHOUT the overlay must still tell the
+    /// truth about an area nothing renders. A fix that made every missing area look like a
+    /// compiling one would trade a false "does not exist" for a wait that never ends.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AreaThatGenuinelyHasNoRenderer_StillReportsAreaNotFound()
+    {
+        var control = await Render(PlainPath, TypeOwnedArea);
+
+        AreaFrameClassifier.IsAreaNotFound(control).Should().BeTrue(
+            "no overlay is in play here, so the area really has no renderer and must say so");
+        AreaFrameClassifier.IsCompileProgress(control).Should().BeFalse(
+            "nothing is compiling — presenting a permanent miss as a build in progress would turn "
+            + "a clear verdict into a wait that never ends");
+        AreaFrameClassifier.IsTransientFrame(control).Should().BeFalse(
+            "a missing area is a verdict, not a promise");
+    }
+
+    /// <summary>
+    /// The coupling the issue names: the two frames must be distinguishable BY A CONSUMER. Both
+    /// are rendered here and each classifier is asserted against BOTH frames, so a marker that
+    /// silently stopped being emitted (or started matching everything) fails here rather than
+    /// months later in whichever waiter latched the wrong one.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task CompilingAndMissing_AreMechanicallyDistinguishable()
+    {
+        await CreateCompilingType();
+
+        var compiling = await Render(OverlaidPath, TypeOwnedArea);
+        var missing = await Render(PlainPath, TypeOwnedArea);
+
+        AreaFrameClassifier.IsCompileProgress(compiling).Should().BeTrue();
+        AreaFrameClassifier.IsCompileProgress(missing).Should().BeFalse();
+        AreaFrameClassifier.IsAreaNotFound(missing).Should().BeTrue();
+        AreaFrameClassifier.IsAreaNotFound(compiling).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The NodeType the overlaid instance waits on, parked at <see cref="CompilationStatus.Compiling"/>:
+    /// no sources, no configuration and no <c>RequestedReleaseAt</c>, so nothing kicks a compile and
+    /// the state is stable for the length of the test.
+    /// </summary>
+    private async Task CreateCompilingType()
+    {
+        // Each [Fact] gets its own mesh (ShareMeshAcrossTests is off), so this is always a create.
+        await MeshService.CreateNode(MeshNode.FromPath(PendingTypePath) with
+        {
+            Name = "PendingType",
+            NodeType = "NodeType",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { CompilationStatus = CompilationStatus.Compiling }
+        }).Should().Emit();
+    }
+
+    /// <summary>
+    /// Renders one area through the layout client — the exact path the GUI drives — and waits for
+    /// the first frame that carries a control for it.
+    /// </summary>
+    private async Task<UiControl?> Render(string addressPath, string area)
+    {
+        var client = GetClient();
+        var reference = new LayoutAreaReference(area);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(addressPath), reference);
+        try
+        {
+            var control = await stream
+                .GetControlStream(reference.Area!)
+                .Should().Within(60.Seconds())
+                .Match(c => c is not null,
+                    $"{area} on {addressPath} must produce SOME frame — a hub that produces none is "
+                    + "the eternal spinner both placeholders exist to prevent");
+            Output.WriteLine($"{addressPath}/{area} → {control?.GetType().Name} (Id={control?.Id})");
+            return control;
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Layout.Test/AreaFrameClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaFrameClassifierTest.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the boundary between the two placeholder frames a layout area can serve. They look alike
+/// to a human and mean opposite things to a consumer: "Area not found" is a VERDICT (nothing will
+/// ever render here — give up and say so), the compile-progress page is a PROMISE (the instance's
+/// NodeType is still building — keep waiting). Collapsing them either way is a real defect:
+/// treating the promise as a verdict is issue #1411; treating the verdict as a promise turns a
+/// clear answer into a wait that never ends.
+/// </summary>
+public class AreaFrameClassifierTest
+{
+    private static MarkdownControl NotFoundFrame() =>
+        new("**Area not found**\n\nNo renderer is registered for area `KeyMetrics` on hub `A/B`.")
+        {
+            Id = AreaFrameClassifier.AreaNotFoundId
+        };
+
+    private static StackControl CompileProgressFrame() =>
+        Controls.Stack.WithId(AreaFrameClassifier.CompileProgressId);
+
+    [Fact]
+    public void NotFoundFrame_IsNotFound_AndNotTransient()
+    {
+        var frame = NotFoundFrame();
+        AreaFrameClassifier.IsAreaNotFound(frame).Should().BeTrue();
+        AreaFrameClassifier.IsCompileProgress(frame).Should().BeFalse();
+        AreaFrameClassifier.IsTransientFrame(frame).Should().BeFalse(
+            "a missing area is a verdict — nothing is going to replace it");
+    }
+
+    [Fact]
+    public void CompileProgressFrame_IsTransient_AndNotNotFound()
+    {
+        var frame = CompileProgressFrame();
+        AreaFrameClassifier.IsCompileProgress(frame).Should().BeTrue();
+        AreaFrameClassifier.IsTransientFrame(frame).Should().BeTrue();
+        AreaFrameClassifier.IsAreaNotFound(frame).Should().BeFalse(
+            "a page that is still building must never be reported as a page that does not exist");
+    }
+
+    /// <summary>
+    /// The redirect the compile-progress surface emits the instant the build settles is just as
+    /// much "not the content" as the progress page itself — a waiter that accepted it would latch
+    /// a navigation instruction as the area's control.
+    /// </summary>
+    [Fact]
+    public void Redirect_IsTransient()
+    {
+        AreaFrameClassifier.IsTransientFrame(Controls.Redirect("/Some/Where")).Should().BeTrue();
+        AreaFrameClassifier.IsAreaNotFound(Controls.Redirect("/Some/Where")).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 The trap that makes the marker worth a test. <see cref="UiControl.Id"/> is
+    /// <c>object?</c>, so a frame that came back over the sync stream carries a
+    /// <see cref="JsonElement"/> there, not a <see cref="string"/> — and the client side is the
+    /// ONLY place these predicates are consulted. A CLR type test would answer "no" for every
+    /// real frame while passing every unit test built from freshly-constructed controls.
+    /// </summary>
+    [Fact]
+    public void FrameIdSurvivesTheWire_WhereIdIsAJsonElementNotAString()
+    {
+        var wireId = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(AreaFrameClassifier.CompileProgressId));
+        wireId.Should().NotBeOfType<string>();
+
+        var frame = Controls.Stack.WithId(wireId);
+        AreaFrameClassifier.IsCompileProgress(frame).Should().BeTrue();
+        AreaFrameClassifier.IsTransientFrame(frame).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The markdown fallback: a not-found frame whose id did not survive (an older peer, a control
+    /// rebuilt from partial JSON) is still recognised, so the fix cannot regress a consumer that
+    /// used to match the banner.
+    /// </summary>
+    [Fact]
+    public void NotFoundFrameWithoutItsId_IsStillRecognised()
+        => AreaFrameClassifier.IsAreaNotFound(
+                new MarkdownControl("**Area not found**\n\nNo renderer is registered for area `X`."))
+            .Should().BeTrue();
+
+    [Fact]
+    public void OrdinaryContent_IsNeither()
+    {
+        var content = Controls.Markdown("### Total Premium\n\n1,234");
+        AreaFrameClassifier.IsAreaNotFound(content).Should().BeFalse();
+        AreaFrameClassifier.IsCompileProgress(content).Should().BeFalse();
+        AreaFrameClassifier.IsTransientFrame(content).Should().BeFalse();
+
+        AreaFrameClassifier.IsAreaNotFound(null).Should().BeFalse();
+        AreaFrameClassifier.IsCompileProgress(null).Should().BeFalse();
+        AreaFrameClassifier.IsTransientFrame(null).Should().BeFalse();
+    }
+}

--- a/tools/MeshWeaver.PluginTester/AreaProbe.cs
+++ b/tools/MeshWeaver.PluginTester/AreaProbe.cs
@@ -28,6 +28,15 @@ public static class AreaProbe
     private const string RenderFailedMarker = "This area failed to render";
     private const string RenderEmergencyMarker = "cannot be rendered";
 
+    // 🚨 The gate probes a node whose type may still be COMPILING — an install is the most likely
+    // moment for that. Such an instance serves the compile-progress page on every area
+    // (NodeTypeEnrichmentHelpers.CreateCompilationInProgressConfiguration), so a frame carrying
+    // this marker is TRANSIENT in exactly the way "Area not found" is: keep waiting, the real
+    // Tests area arrives when the build settles. Matched on the frame's well-known Id — which
+    // AreaFrameClassifier exposes as a plain string precisely so a JSON-only consumer like this
+    // one can use the same constant the typed predicates use — never on the localized prose.
+    private static readonly string CompileProgressMarker = AreaFrameClassifier.CompileProgressId;
+
     private static readonly Regex PassSummary = new(
         @"(\d+)\s*/\s*(\d+)\s+passed", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
@@ -58,6 +67,11 @@ public static class AreaProbe
                     {
                         lastTransient = FirstLines(notFound);
                         return null;   // keep waiting — registration may still be catching up
+                    }
+                    if (IsCompiling(strings))
+                    {
+                        lastTransient = "the node's NodeType is still compiling";
+                        return null;   // keep waiting — the build settles into the real area
                     }
                     var error = strings.FirstOrDefault(s =>
                         s.Contains(RenderFailedMarker, StringComparison.Ordinal)
@@ -148,6 +162,12 @@ public static class AreaProbe
             return null;
         }
 
+        if (IsCompiling(strings))
+        {
+            onTransient("the node's NodeType is still compiling");
+            return null;
+        }
+
         var renderError = strings.FirstOrDefault(s =>
             s.Contains(RenderFailedMarker, StringComparison.Ordinal)
             || s.Contains(RenderEmergencyMarker, StringComparison.Ordinal));
@@ -216,6 +236,11 @@ public static class AreaProbe
 
     // Every string VALUE in the frame, unescaped — the classification scans real text, not
     // wire-escaped JSON.
+    // The frame carries the compile-progress marker as a control Id, i.e. as a whole JSON string
+    // value — hence the exact comparison rather than a substring sniff.
+    private static bool IsCompiling(IReadOnlyList<string> strings)
+        => strings.Any(s => string.Equals(s, CompileProgressMarker, StringComparison.Ordinal));
+
     private static IReadOnlyList<string> CollectStrings(JsonElement element)
     {
         var strings = new List<string>();


### PR DESCRIPTION
Fixes #1411.

## The defect

`CreateCompilationInProgressConfiguration` registered ONE named renderer — `Overview`. Every other area of an overlaid instance fell through to `LayoutDefinition.BuildNotFoundControl`:

```
**Area not found**

No renderer is registered for area `KeyMetrics` on hub `FutuRe/EuropeRe/Analysis`.
```

The silent park the overlay set out to remove was not removed — it was **relocated**. Deep-link any non-`Overview` area during a framework-bump sweep and you are told the area does not exist, when in fact its code is seconds from ready.

## The fix

A catch-all alongside `Overview`, guarded by `LayoutDefinition.HasNamedRenderer` — the sanctioned shape from `KernelContainer.cs:87`:

- the predicate is evaluated against the definition that **already** carries the `Overview` view, so the two renderers cannot fight (two renderers for one area are last-wins-*destructive* — the 2026-07-03 eternal-spinner RCA);
- the areas the mesh **default** node configuration owns (Data, Schema, Search, …) keep their generic views, for the same reason;
- `StartWith(null)` because `LayoutDefinition.Render` composes an area's renderers sequentially — a catch-all that stays silent until the cross-hub type stream emits would dam the node menu behind it;
- on `Ok` the redirect targets **the area the caller asked for**, not the instance root, so a deep link survives the wait.

## The coupling trap, handled in the same commit

Converting a **terminal-looking** frame into a **transient** one breaks every waiter that treated "not the placeholder" as "the content arrived": it would latch the progress page and fail on the content assertion — faster than the timeout it replaced, and reading like a data defect. So the difference is made available **to a consumer**, not just to a human reading the text:

| | frame | id | meaning |
|---|---|---|---|
| verdict | `**Area not found**` | `area-not-found` | nothing will ever render here |
| promise | compile-progress page (+ its `RedirectControl`) | `compile-progress` | still building; it will replace itself |

`AreaFrameClassifier` (new, beside `AreaErrorClassifier` — that one classifies the *exceptions* an area subscription surfaces, this one the *frames* it renders) exposes `IsAreaNotFound` / `IsCompileProgress` / `IsTransientFrame`.

Two details worth reviewing:

- It compares `UiControl.Id`'s **rendered text**, not its CLR type. `Id` is `object?`, so a frame that came back over the sync stream carries a `JsonElement` there — a typed `is string` check answers "no" for every real client-side frame while passing every unit test built from freshly-constructed controls. Pinned by `FrameIdSurvivesTheWire_WhereIdIsAJsonElementNotAString`.
- The markdown banner is untouched and still matched as a fallback, so no existing consumer regresses.

Consumers updated in the same change:

- `FutuReAnalysisTest.GetControl` — `IsAreaNotFound` became `IsNotYetTheArea`, covering both frames, at all three wait sites.
- `tools/MeshWeaver.PluginTester/AreaProbe` — the gate probes freshly installed nodes, the likeliest moment for a type to still be compiling. It reads frames as raw JSON, which is exactly why the marker is exposed as a plain string constant: an exact match on the id value, never a prose sniff.

## Verification — both directions, rendered

`CompileProgressOverlayAreaTest` (new) renders through the layout client on a real mesh, with the production overlay function composed under `DefaultNodeHubConfiguration` the way `MeshNodeHubFactory` composes it.

**Fail-before**: with the catch-all reverted (everything else in place), 2 of 4 fail —

```
Failed AreaOfAnInstanceMidCompile_RendersProgress_NotAreaNotFound [181 ms]
  Expected value to be false because an area whose renderer has not been registered YET,
  because the instance's NodeType is still compiling, must not be reported as an area
  that does not exist, but found True.
Failed! - Failed: 2, Passed: 2
```

— verbatim the reported defect. **Pass-after**: 4/4. The two that pass either way are the guards: `Overview` must keep its named renderer, and an area that genuinely has no renderer must still report missing.

Local, Release + `-warnaserror`, 0 warnings:

| suite | result |
|---|---|
| MeshWeaver.FutuRe.Test | 59/59 |
| MeshWeaver.Layout.Test | 414/414 |
| MeshWeaver.PluginTester.Test | 37/37 |
| Monolith (new + NodeTypeRebind + UserHomeLegacyPathResolution) | 12/12 |

## Not in scope

`CreateCompilationErrorConfiguration` (the compile-**error** overlay) has the identical single-named-area shape. Left alone deliberately: several tests use its "Area not found" as the oracle for "this instance is on the fallback configuration", so changing it is a separate change set with its own blast radius.

## i18n

No new user-visible strings — the catch-all reuses the existing, already-localized progress page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)