### PR TITLE
test(#1405): make the stalled post-install read say WHERE it stalled — and fix the repro harness that could never measure a rate

### DIFF
--- a/.github/workflows/flake-repro.yml
+++ b/.github/workflows/flake-repro.yml
@@ -119,6 +119,13 @@ jobs:
         if: always()
         run: |
           set -uo pipefail
+          # 🚨 GitHub runs a `run:` block as `bash -e {0}`, and `set -uo pipefail` does NOT clear
+          # that. So the FIRST failing `dotnet test` killed the whole step on the spot: the
+          # `::error::REPRO on iteration N` annotation below had never once fired, the loop's own
+          # summary never printed, and `rate` mode could never reach a denominator — a reproduction
+          # and a harness crash were again indistinguishable, which is the exact failure mode the
+          # rest of this file is written to prevent. The loop checks every exit code itself.
+          set +e
           iters="$REPRO_ITERS"
           proj="$REPRO_PROJECT"
           filt="$REPRO_FILTER"
@@ -132,7 +139,7 @@ jobs:
             hunt|rate) ;;
             *) echo "::error::REPRO DID NOT RUN — unknown mode '$REPRO_MODE' (expected 'hunt' or 'rate')."; exit 1 ;;
           esac
-          echo "Looping '$filt' in $proj up to $iters× in '$REPRO_MODE' mode on a 2-vCPU runner (nproc=$(nproc))."
+          echo "Looping '$filt' in $proj up to $iters× in '$REPRO_MODE' mode (nproc=$(nproc) — the flake is load-dependent, so record this alongside the rate)."
           failures=0
           ran=0
           failed_iters=""

--- a/.github/workflows/flake-repro.yml
+++ b/.github/workflows/flake-repro.yml
@@ -25,9 +25,20 @@ on:
         type: string
         default: "FullyQualifiedName~CodeEditRecompileTest.PressingCompileButton_SetsRequestedReleaseAt_AndProducesNewRelease"
       iterations:
-        description: "Max loop iterations (stops on first failure)"
+        description: "Max loop iterations (stop-on-first-failure mode stops early; rate mode always runs all of them)"
         type: string
         default: "25"
+      mode:
+        # `hunt` answers "does it reproduce?" — stop at the first failure and keep the
+        # diagnostics from THAT iteration. `rate` answers "how often?" — run every
+        # iteration and report failures/iterations, which is the only mode in which a
+        # before/after comparison means anything. At a ~1-in-24 rate a clean 30-iteration
+        # hunt happens by luck ~28% of the time, so "one green loop" is not evidence that
+        # a fix worked; a rate over ≳100 iterations is.
+        description: "hunt = stop at first failure (diagnose) | rate = run all iterations and report failures/N (measure)"
+        type: choice
+        options: ["hunt", "rate"]
+        default: "hunt"
       loglevel:
         description: "Default log level for the looped runs (Debug/Trace to surface the watcher race)"
         type: string
@@ -52,6 +63,7 @@ jobs:
       REPRO_PROJECT: ${{ inputs.project || 'test/MeshWeaver.Hosting.Monolith.Test' }}
       REPRO_FILTER: ${{ inputs.filter || 'FullyQualifiedName~CodeEditRecompileTest.PressingCompileButton_SetsRequestedReleaseAt_AndProducesNewRelease' }}
       REPRO_ITERS: ${{ inputs.iterations || '80' }}
+      REPRO_MODE: ${{ inputs.mode || 'hunt' }}
       DOTNET_ENVIRONMENT: Development
       # 🚨 Logging cranked via ENV only — never a committed appsettings/Log* change
       # (those are production cost contract). Surfaces the watcher/messaging trace.
@@ -116,8 +128,14 @@ jobs:
             echo "::error::REPRO DID NOT RUN — project '$proj' not found. Nothing was reproduced; the job's failure is the harness, not the flake."
             exit 1
           fi
-          echo "Looping '$filt' in $proj up to $iters× on a 2-vCPU runner (nproc=$(nproc))."
-          failed=0
+          case "$REPRO_MODE" in
+            hunt|rate) ;;
+            *) echo "::error::REPRO DID NOT RUN — unknown mode '$REPRO_MODE' (expected 'hunt' or 'rate')."; exit 1 ;;
+          esac
+          echo "Looping '$filt' in $proj up to $iters× in '$REPRO_MODE' mode on a 2-vCPU runner (nproc=$(nproc))."
+          failures=0
+          ran=0
+          failed_iters=""
           for i in $(seq 1 "$iters"); do
             echo "::group::iteration $i / $iters"
             # --no-build --no-restore: run the Release binaries built above, exactly
@@ -129,15 +147,34 @@ jobs:
               --blame-hang-timeout 120s --blame-hang-dump-type mini
             rc=$?
             echo "::endgroup::"
+            ran=$((ran + 1))
             if [ "$rc" -ne 0 ]; then
+              failures=$((failures + 1))
+              failed_iters="$failed_iters $i"
               echo "::error::REPRO on iteration $i (exit $rc) — diagnostics uploaded below."
-              failed=1
-              break
+              # hunt: stop here so the uploaded diagnostics belong to THIS iteration.
+              # rate: keep going — the whole point is the denominator.
+              if [ "$REPRO_MODE" = "hunt" ]; then break; fi
+            else
+              echo "iteration $i passed"
             fi
-            echo "iteration $i passed"
           done
-          if [ "$failed" = "0" ]; then
-            echo "No repro in $iters iterations (the flake did not surface this run)."
+          # The measured rate is the deliverable of a `rate` run, so put it where it cannot be
+          # missed: a comparison is only meaningful as failures/iterations, never as "it was green".
+          {
+            echo "### Flake repro — \`$REPRO_MODE\` mode"
+            echo ""
+            echo "- filter: \`$filt\`"
+            echo "- project: \`$proj\`"
+            echo "- **result: $failures failure(s) in $ran iteration(s) run** (of $iters requested)"
+            if [ -n "$failed_iters" ]; then echo "- failing iterations:$failed_iters"; fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "RESULT: $failures failure(s) in $ran iteration(s) run (requested $iters); failing iterations:${failed_iters:- none}"
+          if [ "$failures" = "0" ]; then
+            echo "No repro in $ran iterations (the flake did not surface this run)."
+            failed=0
+          else
+            failed=1
           fi
           # Exit non-zero on repro so the run is CLEARLY marked failed in the Actions
           # list (repro achieved = red). The diagnostics-collection + upload steps

--- a/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstanceOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstanceOrderingTest.cs
@@ -82,8 +82,11 @@ public class NodeRepoInstanceOrderingTest(ITestOutputHelper output) : MonolithMe
         (await Read("Pack")).NodeType.Should().Be("Space");
     }
 
-    private async Task<MeshNode> Read(string path) =>
-        await Mesh.GetWorkspace().GetMeshNodeStream(path)
-            .Where(n => n is not null).Select(n => n!)
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+    // Routed through StalledReadDiagnostics: this read is the one issue #1405 stalls on, and its
+    // reproduction carries NO distinguishing log line — thirty seconds of silence and a bare
+    // TimeoutException. The wrapper adds nothing to the happy path; on timeout it names the
+    // stalled stage. See StalledReadDiagnostics for the evidence and the fork it resolves.
+    private Task<MeshNode> Read(string path) =>
+        StalledReadDiagnostics.ReadOrExplain(
+            Mesh, path, TimeSpan.FromSeconds(30), Output.WriteLine);
 }

--- a/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
@@ -139,9 +139,11 @@ public class PluginDependencyOrderTest(ITestOutputHelper output) : MonolithMeshT
         foreach (var pkg in closure)
             (await Install(pkg)).Written.Should().BeGreaterThan(0, $"{pkg.Id} must land");
 
-        var item = await Mesh.GetWorkspace().GetMeshNodeStream("Dependent/Item")
-            .Where(n => n is not null).Select(n => n!)
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        // Routed through StalledReadDiagnostics — this is issue #1405's read, and its reproduction
+        // carries NO distinguishing log line (thirty seconds of silence, then a bare
+        // TimeoutException). Happy path unchanged; on timeout the stalled stage is named.
+        var item = await StalledReadDiagnostics.ReadOrExplain(
+            Mesh, "Dependent/Item", TimeSpan.FromSeconds(30), Output.WriteLine);
         item.NodeType.Should().Be("Base/Widget",
             "the instance is typed by the NodeType its DEPENDENCY shipped — the whole point of "
             + "installing Base first");

--- a/test/MeshWeaver.PluginCatalog.Test/StalledReadDiagnostics.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StalledReadDiagnostics.cs
@@ -1,0 +1,133 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Timeout-only diagnostics for the post-install read
+/// (<c>GetMeshNodeStream(path).Where(n =&gt; n is not null).FirstAsync().Timeout(30s)</c>) that
+/// issue #1405 keeps stalling.
+///
+/// <para>🚨 <b>Why this exists.</b> A 150-iteration loop of the two affected tests on <c>main</c>
+/// reproduced the stall once, and the reproduction contained <b>no distinguishing log line at
+/// all</b>: the failing window held strictly LESS than every passing window — thirty seconds of
+/// pure silence between the install returning and the timeout. The two signals the issue's
+/// diagnosis rests on are not discriminators:</para>
+/// <list type="bullet">
+///   <item><c>HubDisposingException: Hub Pack/Sibling is shutting down</c> (and its
+///     <c>Dependent/Item</c> twin) fired in <b>51 of 51</b> runs — every pass included.</item>
+///   <item>The <c>Own-node refresh … failed on Pack/Widget/Nested</c> /
+///     <c>Cannot scan an assembly whose context is unloading</c> family appeared in <b>passing</b>
+///     windows and NOT in the failing one.</item>
+/// </list>
+///
+/// <para>So the next reproduction has to say something. These probes run ONLY after the read has
+/// already timed out — never during the race, so they cannot perturb it (the same contract as
+/// <c>WaitForLatestRelease</c>'s stuck-state diagnostic). They answer the one fork nobody can
+/// currently resolve from a red run:</para>
+/// <list type="number">
+///   <item><b>Is the row durable?</b> If the mesh query finds it, the install DID write it and the
+///     read path is what failed. If it does not, the stall is upstream of the read entirely and the
+///     recycle framing is about the wrong stage.</item>
+///   <item><b>Does a cache-BYPASSING read answer?</b> A fresh handle opens its own sync stream
+///     instead of joining the shared per-path <c>IMeshNodeStreamCache</c> entry. If the bypass read
+///     answers while the shared one never did, the orphaned thing is the CACHE ENTRY — it bound one
+///     stream at creation and never rebinds. If neither answers, the owner is silent to everybody
+///     and the cache is exonerated.</item>
+/// </list>
+///
+/// <para>Every probe is bounded and swallows its own failure into text: a diagnostic that can hang
+/// or throw would replace the failure it is explaining.</para>
+/// </summary>
+internal static class StalledReadDiagnostics
+{
+    /// <summary>Default per-probe bound. A diagnostic must never out-live the failure it explains.</summary>
+    public static readonly TimeSpan DefaultProbeBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Wraps a post-install read so a stall reports WHERE it stalled instead of a bare
+    /// <see cref="TimeoutException"/>.
+    /// </summary>
+    public static async Task<MeshNode> ReadOrExplain(
+        IMessageHub mesh, string path, TimeSpan timeout, Action<string> log)
+    {
+        try
+        {
+            return await mesh.GetWorkspace().GetMeshNodeStream(path)
+                .Where(n => n is not null).Select(n => n!)
+                .FirstAsync().Timeout(timeout).ToTask();
+        }
+        catch (TimeoutException ex)
+        {
+            var report = await Describe(mesh, path);
+            log(report);
+            throw new TimeoutException(
+                $"Post-install read of '{path}' produced no node within {timeout.TotalSeconds:0}s "
+                + $"(issue #1405). {report}", ex);
+        }
+    }
+
+    /// <summary>
+    /// The report itself, exposed so its contract — resolves the fork, never throws, never
+    /// out-runs its bound — is directly testable (<c>StalledReadDiagnosticsTest</c>).
+    /// </summary>
+    public static async Task<string> Describe(IMessageHub mesh, string path, TimeSpan? probeBudget = null)
+    {
+        var budget = probeBudget ?? DefaultProbeBudget;
+        var durable = await Probe(() => DurableRow(mesh, path), budget);
+        var bypass = await Probe(() => BypassCacheRead(mesh, path), budget);
+        return $"durable row: {durable}; cache-bypassing read: {bypass}. "
+               + "A durable row plus a working bypass read means the SHARED mesh-node cache entry "
+               + "for this path is orphaned (bound once at creation, never rebound); a durable row "
+               + "with both reads silent means the owner hub answers nobody; no durable row means "
+               + "the install, not the read, is the stalled stage.";
+    }
+
+    private static async Task<string> Probe(Func<IObservable<string>> probe, TimeSpan budget)
+    {
+        try
+        {
+            return await probe()
+                .Timeout(budget)
+                .Catch((Exception ex) => Observable.Return($"probe failed: {ex.GetType().Name}: {ex.Message}"))
+                .FirstAsync()
+                .ToTask();
+        }
+        catch (Exception ex)
+        {
+            // Belt and braces: this text must ALWAYS be producible.
+            return $"probe threw: {ex.GetType().Name}: {ex.Message}";
+        }
+    }
+
+    private static IObservable<string> DurableRow(IMessageHub mesh, string path) =>
+        mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}"))
+            .Take(1)
+            .Select(change =>
+            {
+                var node = change.Items.FirstOrDefault(n => n.Path == path);
+                return node is null
+                    ? "ABSENT (the query does not see it)"
+                    : $"present (Version={node.Version}, NodeType='{node.NodeType ?? "(none)"}', State={node.State})";
+            });
+
+    // A handle opened with bypassCache:true builds its OWN sync stream to the owner rather than
+    // joining the shared per-path cache entry — which is precisely the component suspected of
+    // being orphaned, so it must not be the thing doing the asking.
+    private static IObservable<string> BypassCacheRead(IMessageHub mesh, string path) =>
+        mesh.GetWorkspace().GetMeshNodeStreamBypassCache(path)
+            .Where(n => n is not null)
+            .Take(1)
+            .Select(n => $"answered (Version={n.Version}, NodeType='{n.NodeType ?? "(none)"}')");
+}

--- a/test/MeshWeaver.PluginCatalog.Test/StalledReadDiagnosticsTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StalledReadDiagnosticsTest.cs
@@ -1,0 +1,76 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the contract of <see cref="StalledReadDiagnostics"/> itself. It runs on the failure path of
+/// issue #1405's post-install read, which means it runs at the exact moment the mesh is already
+/// misbehaving — so a diagnostic that throws, or that waits longer than the failure it explains,
+/// would REPLACE the evidence instead of producing it. That is not a hypothetical: the whole reason
+/// this helper exists is that the one reproduction we have contains no distinguishing log line at
+/// all, so the report is the only thing the next red run will carry.
+/// </summary>
+public class StalledReadDiagnosticsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
+
+    /// <summary>
+    /// The worst input the helper can get: a path with nothing behind it — no durable row, no owner
+    /// to answer, so BOTH probes fail. It must still return prose, inside its bound, naming the
+    /// fork.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task OnAPathWithNothingBehindIt_ItStillReportsInsideItsBudget()
+    {
+        var budget = TimeSpan.FromSeconds(3);
+        var started = DateTimeOffset.UtcNow;
+
+        var report = await StalledReadDiagnostics.Describe(Mesh, "NoSuchSpace/NoSuchNode", budget);
+
+        Output.WriteLine(report);
+        var elapsed = DateTimeOffset.UtcNow - started;
+
+        report.Should().Contain("durable row: ABSENT",
+            "resolving whether the row is durable is the fork the report exists to answer — an "
+            + "absent row means the INSTALL, not the read, is the stalled stage");
+        report.Should().Contain("cache-bypassing read:",
+            "the second probe must always be reported, including when it is the one that failed");
+        elapsed.Should().BeLessThan(TimeSpan.FromSeconds(30),
+            "two probes at a {0}s budget must not out-live the read they explain", budget.TotalSeconds);
+    }
+
+    /// <summary>
+    /// The happy path stays exactly the read it wraps: a node that IS there comes back, and nothing
+    /// about the diagnostic is on that path.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task AReadThatSucceeds_IsUntouched()
+    {
+        const string path = "DiagProbe/Node";
+        await Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .CreateNode(MeshNode.FromPath(path) with
+            {
+                Name = "Node",
+                State = MeshNodeState.Active,
+                Content = "content"
+            })
+            .Should().Emit();
+
+        var node = await StalledReadDiagnostics.ReadOrExplain(
+            Mesh, path, TimeSpan.FromSeconds(30), Output.WriteLine);
+
+        node.Path.Should().Be(path);
+    }
+}


### PR DESCRIPTION
Refs #1405. **This does not fix #1405** — deliberately; see *Why no fix* below. It makes the flake measurable and the next reproduction diagnosable, and it falsifies the mechanism the issue's diagnosis rests on.

## 1. #1405 is still live on current `main`, post-#1408

Dispatched `flake-repro.yml` against `main @ c7368b136` (which contains #1408), looping both affected tests. **Reproduced at iteration 51** — same signature as the issue: `Read(path)` times out after 30 s, `HubDisposingException … MeshNodeStreamHandle.UpdateOwn` in the window.

A second dispatch, the first ever to run the full requested count (see §4), gives the denominator — [run 31698412767](https://github.com/Systemorph/MeshWeaver/actions/runs/31698412767):

```
RESULT: 2 failure(s) in 150 iteration(s) run (requested 150); failing iterations: 104 123
```

iteration 104 = `PluginDependencyOrderTest`, iteration 123 = `NodeRepoInstanceOrderingTest` — **one failure each, so this is one defect surfacing through two independently-written reads.**

**Baseline: 3 failures in 201 iterations ≈ 1.5%**, on runners reporting `nproc=4`. The issue's earlier 1-in-24 was measured at `nproc=2`; the flake is load-dependent, so the core count now gets printed next to the number. At 1.5% a clean 30-iteration loop happens by luck **~64%** of the time and a clean 150 about **10%** — so a fix wants `mode: rate` at ≳300 iterations compared against this 3/201, never "it went green".

## 2. The reported mechanism is not the discriminator

Segmenting the run's trace by test window (51 `NodeRepoInstanceOrderingTest` runs, one failing) and diffing the failing window against every passing one:

| signal | failing run | passing runs |
|---|---|---|
| `HubDisposingException: Hub Pack/Sibling is shutting down — cannot create '/MeshNode'` @ `MeshNodeStreamHandle.UpdateOwn` | present | **present in all 50** |
| its `Dependent/Item` twin (`PluginDependencyOrderTest`) | present | **present in all 50** |
| `Own-node refresh … failed on Pack/Widget/Nested` + `ObjectDisposedException: Cannot scan an assembly whose context is unloading` (the #1408 shape) | **absent** | present in 6 |
| anything else unique to the failing window | **nothing** | — |

51 of 51, every pass included. The exception the issue is titled after is **ambient**, not causal — which also explains the observation in the comments that this family "keeps surfacing under whichever test happens to touch the root next".

What actually distinguishes the failing run is **thirty seconds of complete silence** between the install returning and the timeout. There is nothing to root-cause from.

One thing the stack frame does narrow: the caller line is `NodeRepoInstanceOrderingTest.cs:81`, i.e. `Read("Pack/Sibling")` — **the very hub whose teardown fires in every run**, not the nested instance. The same holds for the original report, where `Dependent/Item` is likewise the path whose teardown fires in every `PluginDependencyOrderTest` run. Consistent with "the subscribe lands inside the owner's teardown window and the recovery leg does not fire" — but silent on *which* leg.

## 3. So make the next reproduction speak — `StalledReadDiagnostics`

Both tests' post-install read now runs through a wrapper that, **only after the read has already timed out**, probes two things and prints the fork. It cannot run during the race, so it cannot perturb it — the same contract `WaitForLatestRelease`'s stuck-state diagnostic holds, and the reason this is not the "crank the logging" approach the workflow header warns is a heisenbug here.

1. **Is the row durable?** Absent ⇒ the **install**, not the read, is the stalled stage, and the recycle framing is aimed at the wrong thing.
2. **Does a cache-BYPASSING read answer?** A `GetMeshNodeStreamBypassCache` handle opens its own sync stream instead of joining the shared per-path `IMeshNodeStreamCache` entry — the component most suspected of being orphaned, so it must not be the one doing the asking. Answers ⇒ the **cache entry** is orphaned (it binds one stream at creation and is never rebound for a healthy entry). Silent ⇒ the **owner** answers nobody and the cache is exonerated.

Both probes are bounded and swallow their own failures into text. `StalledReadDiagnosticsTest` pins that contract on the worst input — a path with nothing behind it, where both probes fail — because a diagnostic that hangs or throws replaces the evidence it exists to produce.

### Why timeout-only, and not just louder logging

That was a design guess when I wrote it. It now has evidence. Same 150-iteration loop, same commit, same runner class, changing **only** `loglevel` from `Warning` to `Information` ([run 31699902507](https://github.com/Systemorph/MeshWeaver/actions/runs/31699902507)):

```
RESULT: 0 failure(s) in 150 iteration(s) run (requested 150); failing iterations: none
```

versus `2 failure(s) in 150` at `Warning`. I chose `Information` precisely because the workflow header warns that **Debug** masks this class of race, and `JsonSynchronizationStream.Resubscribe` logs its attempt at `Information` — which looked like a free way to separate the three recovery legs. It is not. A clean 150 at p≈1.5% happens by luck ~10% of the time so this alone is suggestive rather than conclusive, but it lines up with the header's two prior data points (caught at iterations 19 and 4 at `Warning`; missed across 40 + 80 iterations at `Debug`).

So: the legs cannot be separated by turning logging up, and **a fix must not be gated on a run at `Information` or above** — it will come back green regardless. Gate on `loglevel=Warning`, `mode=rate`, ≳300 iterations, against the 3/201 baseline.

## 4. Two harness defects — the repro loop could never measure anything

Both were silent, and both matter to anyone else trying to gate a fix on this workflow:

- **`flake-repro.yml`'s loop never survived its first failure.** GitHub runs a `run:` block as `bash -e`, and the script's `set -uo pipefail` does not clear that — so the first failing `dotnet test` killed the step outright. Consequence: the `::error::REPRO on iteration N` annotation the loop has carried since it was written **has never fired once** (the iteration numbers people have been reading come from the `##[group]` marker), and no mode that needs to keep counting was possible. `set +e`; the loop already checks every exit code itself.
- **There was no way to express a rate.** `mode: rate` runs every iteration and reports failures/iterations to the job summary. `hunt` stays the default and stays byte-identical. This matters because at ~1-in-24 a clean 30-iteration loop happens by luck ~28% of the time, so "one green loop" is not evidence a fix worked — the trap the issue thread already flags.

## Why no fix

The root cause is not established. The one hole I found by reading (**not** by observing) is that `JsonSynchronizationStream`'s initial `SubscribeRequest` treats only `ErrorType.ShuttingDown` as recoverable: an owner that **accepts** the request and then dies before answering produces no event at all — there is deliberately no per-attempt timeout, and the change-feed latch cannot fire because a recycle is not a write. That is *consistent* with the observed silence and is *not evidence for it*.

That file's comments record five separate outages caused by changes to this exact path. Shipping a guess there to move a 2% flake is the wrong trade. The next step is a reproduction that carries the fork above — which this PR provides.

## Verification

`MeshWeaver.PluginCatalog.Test` 272/272 local, Release + `-warnaserror`, 0 warnings. No production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
