### PR TITLE
An artifact that is not the assembly we compiled must never be published (#1412)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-nodetype-parks-on-damaged-assembly.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-nodetype-parks-on-damaged-assembly.md
@@ -1,0 +1,24 @@
+---
+Name: A damaged compiled assembly no longer parks a node type
+Category: Fix
+Description: A freshly compiled node type is published only once the file on disk is proven to be the assembly that was compiled, so a lost or partial write is recompiled instead of permanently disabling the type.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A damaged compiled assembly no longer parks a node type
+
+When a node type is compiled, the resulting assembly is written to the compilation cache and then
+loaded to discover the layout areas and content types it provides. Until now the only check before
+that file became visible to readers was that it existed and was not empty — so a file that was
+short, or the right size but missing a chunk in the middle, was published and loaded anyway.
+
+That failure was permanent rather than temporary. Loading a damaged assembly is recorded as a
+compilation error, and a node type that has already failed once is never rebuilt on its own, so a
+single bad write left the type showing a compilation error until someone rebuilt it by hand. A node
+type stuck in that state also holds up the portal becoming ready.
+
+The compiler now records a fingerprint of the assembly it produced and refuses to publish the file
+unless the bytes on disk match it, recompiling instead. If the artifact still cannot be written
+correctly after three attempts the compile fails with a message naming exactly what was wrong,
+rather than silently disabling the type.

--- a/src/MeshWeaver.Graph/Configuration/EmittedArtifact.cs
+++ b/src/MeshWeaver.Graph/Configuration/EmittedArtifact.cs
@@ -1,0 +1,107 @@
+using System.Security.Cryptography;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// What an emit produced, and the fingerprint that lets the publisher prove the file on disk still
+/// IS that. Returned by <c>MeshNodeCompilationService.EmitCompilationToDirectory</c> and checked by
+/// <c>MeshNodeCompilationService.EmitToDiskWithRetry</c> before the staged directory is renamed into
+/// the discovery namespace.
+///
+/// <para>🚨 Why a fingerprint and not a size. The acceptance test used to be
+/// <c>File.Exists(dll) &amp;&amp; new FileInfo(dll).Length &gt; 0</c> — "non-empty", not "the bytes we
+/// emitted". A compiled NodeType assembly is published under a name readers discover by, and the
+/// discovered path goes straight to <c>AssemblyLoadContext.LoadFromAssemblyPath</c>, so anything
+/// that gate lets through is executed as an assembly. Two shapes get through it, and both are
+/// TERMINAL rather than transient:</para>
+/// <list type="bullet">
+///   <item><description>A <b>short</b> image throws <see cref="BadImageFormatException"/> at LOAD,
+///   so <c>LoadNodeAssembly</c> hands back null and the compile records
+///   <c>CompilationStatus.Error</c>.</description></item>
+///   <item><description>A <b>full-length</b> image with an unwritten region inside it LOADS — header
+///   and assembly identity are intact — and throws <c>ReflectionTypeLoadException</c> on the first
+///   <c>Assembly.GetTypes()</c>: <i>"Could not load type 'X' from assembly 'DynamicNode_…' because
+///   the format is invalid"</i>. That is MeshWeaver#1412's signature verbatim, and a length check
+///   cannot see it.</description></item>
+/// </list>
+///
+/// <para>Either way <c>CompileResultFromAssembly</c> writes <c>CompilationStatus.Error</c> and the
+/// first-build kickoff is gated on <c>Status == null</c>, so it never recompiles: <b>the bytes may
+/// heal, the verdict does not</b>, and the NodeType is parked until someone deletes the artifact by
+/// hand. A parked NodeType refuses portal readiness.</para>
+///
+/// <para><b>Why exact-match instead of "does it parse".</b> Validating the staged file as an
+/// assembly (PE header + metadata tables) was tried and measured: over a census of damaged images it
+/// still admitted <b>19</b> that the real loader refuses — corrupt signature blobs, corrupt type
+/// references, names that read as strings but are rejected as identities. Metadata validation is a
+/// leaky approximation of "usable". Comparing against the digest of what the emit actually produced
+/// is not an approximation: it admits the emitted image and nothing else.</para>
+///
+/// <para>This is a publication CONTRACT, not a retry around a load. Nothing re-reads a bad artifact
+/// hoping for a better answer; a bad artifact simply never becomes discoverable, and the compile
+/// re-runs the emit it already re-ran for a lost write — bounded, stateless, and never applied to a
+/// genuine compile error.</para>
+/// </summary>
+/// <param name="DllPath">Path the emit wrote the assembly to (inside the staging directory).</param>
+/// <param name="Sha256">SHA-256 of the emitted image, taken from the bytes in memory.</param>
+/// <param name="Length">Length in bytes of the emitted image.</param>
+internal readonly record struct EmittedArtifact(string DllPath, byte[] Sha256, long Length)
+{
+    /// <summary>Fingerprints an in-memory image.</summary>
+    /// <param name="dllPath">Path the image was written to.</param>
+    /// <param name="image">The emitted bytes.</param>
+    /// <returns>The artifact descriptor to hand to the publisher.</returns>
+    public static EmittedArtifact For(string dllPath, ReadOnlySpan<byte> image)
+    {
+        var hash = new byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(image, hash);
+        return new EmittedArtifact(dllPath, hash, image.Length);
+    }
+
+    /// <summary>
+    /// True when the file at <see cref="DllPath"/> holds exactly the emitted image.
+    /// </summary>
+    /// <param name="reason">On false, what was wrong — carried into the log and, after the last
+    /// attempt, into the terminal <c>CompilationException</c> so the operator is not left with a
+    /// generic "could not be persisted" pointing at a read-only cache directory.</param>
+    /// <returns>Whether the staged file may be published.</returns>
+    public bool MatchesFileOnDisk(out string reason)
+    {
+        try
+        {
+            var info = new FileInfo(DllPath);
+            if (!info.Exists)
+            {
+                reason = "the artifact is not on disk";
+                return false;
+            }
+            if (info.Length != Length)
+            {
+                reason = $"the artifact is {info.Length} bytes on disk but {Length} were emitted";
+                return false;
+            }
+
+            // Read rather than memory-map: a mapped file that a concurrent writer truncates faults
+            // as SIGBUS — a process kill, not an exception — and a verification step must never be
+            // able to do that.
+            using var stream = new FileStream(
+                DllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize: 64 * 1024);
+            var onDisk = SHA256.HashData(stream);
+            if (!onDisk.AsSpan().SequenceEqual(Sha256))
+            {
+                reason = $"the artifact on disk differs from the emitted image ({Length} bytes, "
+                         + $"digest {Convert.ToHexString(onDisk.AsSpan(0, 6))} != "
+                         + $"{Convert.ToHexString(Sha256.AsSpan(0, 6))})";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            reason = $"the artifact could not be read back — {ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -2056,8 +2056,17 @@ internal class MeshNodeCompilationService(
 
     /// <summary>
     /// Runs the real Roslyn emit for <paramref name="nodeName"/> into <paramref name="releaseDir"/>
-    /// (dll + pdb + XML doc) and returns the DLL path it wrote. A failed emit throws a
-    /// <see cref="CompilationException"/> carrying the formatted diagnostics.
+    /// (dll + pdb + XML doc) and returns the DLL path it wrote TOGETHER WITH the digest of the image
+    /// it produced. A failed emit throws a <see cref="CompilationException"/> carrying the formatted
+    /// diagnostics.
+    ///
+    /// <para>🚨 It emits into memory and writes the bytes out, rather than streaming Roslyn straight
+    /// at the file, for one reason: the publisher has to be able to prove the file on disk IS the
+    /// image that was emitted. Streaming leaves nothing to compare against, which is how the old
+    /// <c>Length &gt; 0</c> gate came to publish an artifact whose metadata had an unwritten region
+    /// in it and PARK the NodeType for good (#1412). Peak memory is unchanged in practice — Roslyn
+    /// already serialises the whole PE into an in-memory <c>BlobBuilder</c> before it writes a single
+    /// byte. See <see cref="EmittedArtifact"/>.</para>
     ///
     /// <para>🚨 It does NOT log. A compile failure is reported EXACTLY ONCE, by the compile
     /// pipeline's single <c>.Catch&lt;…, CompilationException&gt;</c> funnel in
@@ -2071,32 +2080,44 @@ internal class MeshNodeCompilationService(
     /// "your C# does not compile" read like an emit/IO defect. Extracted and <c>internal</c> so
     /// the log-once contract is unit-testable against a real broken compilation.</para>
     /// </summary>
-    internal static string EmitCompilationToDirectory(
+    internal static EmittedArtifact EmitCompilationToDirectory(
         CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir, CancellationToken ct)
     {
         var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
         var pdbPath = Path.Combine(releaseDir, $"{nodeName}.pdb");
         var xmlDocPath = Path.Combine(releaseDir, $"DynamicNode_{nodeName}.xml");
 
-        using (var dllStream = File.Create(dllPath))
-        using (var pdbStream = File.Create(pdbPath))
-        using (var xmlDocStream = File.Create(xmlDocPath))
-        {
-            var emitOptions = new EmitOptions(
-                debugInformationFormat: DebugInformationFormat.PortablePdb,
-                pdbFilePath: pdbPath);
+        using var dllImage = new MemoryStream();
+        using var pdbImage = new MemoryStream();
+        using var xmlDoc = new MemoryStream();
 
-            var emitResult = compilation.Emit(
-                dllStream, pdbStream, xmlDocumentationStream: xmlDocStream,
-                options: emitOptions, cancellationToken: ct);
+        var emitOptions = new EmitOptions(
+            debugInformationFormat: DebugInformationFormat.PortablePdb,
+            pdbFilePath: pdbPath);
 
-            if (!emitResult.Success)
-                // Deterministic compile error — propagates straight out of the retry loop,
-                // unlogged, to the pipeline's single reporting funnel.
-                throw new CompilationException(nodePath, FormatCompileFailure(nodePath, emitResult.Diagnostics));
-        }
-        // Streams flushed + closed here, before EmitToDiskWithRetry verifies the file.
-        return dllPath;
+        var emitResult = compilation.Emit(
+            dllImage, pdbImage, xmlDocumentationStream: xmlDoc,
+            options: emitOptions, cancellationToken: ct);
+
+        if (!emitResult.Success)
+            // Deterministic compile error — propagates straight out of the retry loop,
+            // unlogged, to the pipeline's single reporting funnel.
+            throw new CompilationException(nodePath, FormatCompileFailure(nodePath, emitResult.Diagnostics));
+
+        // The DLL last: it is the discovery key of the release directory, so a reader that ever sees
+        // the staging dir mid-write still finds the symbols and docs already beside it. (Publication
+        // itself is the atomic Directory.Move in EmitToDiskWithRetry; this is belt and braces.)
+        File.WriteAllBytes(pdbPath, Bytes(pdbImage));
+        File.WriteAllBytes(xmlDocPath, Bytes(xmlDoc));
+        var image = Bytes(dllImage);
+        File.WriteAllBytes(dllPath, image);
+
+        return EmittedArtifact.For(dllPath, image);
+
+        // Expandable MemoryStreams created with the parameterless ctor expose their buffer, so the
+        // common path hands out a span over it instead of copying a multi-megabyte image.
+        static ReadOnlySpan<byte> Bytes(MemoryStream s)
+            => s.TryGetBuffer(out var seg) ? seg.AsSpan() : s.ToArray();
     }
 
     /// <summary>
@@ -2119,21 +2140,26 @@ internal class MeshNodeCompilationService(
 
     /// <summary>
     /// Emits to a fresh per-attempt subdirectory under <paramref name="cacheDirectory"/> and
-    /// confirms the assembly actually persisted, re-emitting up to <paramref name="maxAttempts"/>
-    /// times when the DLL is missing or empty afterward. <paramref name="emitToReleaseDir"/> runs
-    /// the real Roslyn emit into the supplied directory and returns the DLL path it wrote; it may
-    /// throw <see cref="CompilationException"/> for a genuine compile error, which propagates
-    /// immediately (NEVER retried — only a lost/empty artifact triggers a re-emit). Extracted and
-    /// <c>internal</c> so the lost-write self-heal is unit-testable without a real flaky filesystem.
+    /// confirms the assembly on disk IS the image that was emitted, re-emitting up to
+    /// <paramref name="maxAttempts"/> times when it is not. <paramref name="emitToReleaseDir"/> runs
+    /// the real Roslyn emit into the supplied directory and returns the DLL path together with the
+    /// digest of the image it produced (<see cref="EmittedArtifact"/>); it may throw
+    /// <see cref="CompilationException"/> for a genuine compile error, which propagates immediately
+    /// (NEVER retried — only a lost or mismatched artifact triggers a re-emit). Extracted and
+    /// <c>internal</c> so the publication contract is unit-testable without a real flaky filesystem.
     /// </summary>
     internal static string EmitToDiskWithRetry(
         string cacheDirectory,
         string nodeName,
         int maxAttempts,
         ILogger logger,
-        Func<string, string> emitToReleaseDir)
+        Func<string, EmittedArtifact> emitToReleaseDir)
     {
         string? lastDllPath = null;
+        // Why the LAST attempt failed to publish, carried into the terminal exception: "could not
+        // be persisted" alone sent operators looking for a read-only cache directory when the real
+        // answer was an artifact that is present and unreadable.
+        var lastReason = "the artifact never appeared";
 
         static void TryDeleteDir(string dir)
         {
@@ -2165,10 +2191,10 @@ internal class MeshNodeCompilationService(
             // The real emit (a genuine compile error throws straight through — never retried). Discard
             // the half-written staging dir first so a failed emit leaves no partial artifact behind (the
             // old code leaked a glob-discoverable `{nodeName}_{ticks}` dir here — the same hazard).
-            string stagedDllPath;
+            EmittedArtifact staged;
             try
             {
-                stagedDllPath = emitToReleaseDir(stagingDir);
+                staged = emitToReleaseDir(stagingDir);
             }
             catch
             {
@@ -2176,24 +2202,39 @@ internal class MeshNodeCompilationService(
                 throw;
             }
 
-            // Confirm the bytes are genuinely on disk, then atomically publish. EVERY fault here is a
-            // RETRYABLE publish failure — an ephemeral-cache eviction racing the size read, or a
-            // transient rename IO error — so discard staging and re-emit rather than aborting the compile.
+            // Confirm the staged file IS the image the emit produced, then atomically publish. EVERY
+            // fault here is a RETRYABLE publish failure — an ephemeral-cache eviction racing the
+            // read, a lost or partial write, or a transient rename IO error — so discard staging and
+            // re-emit rather than aborting the compile.
+            //
+            // 🚨 The predicate is "these are the bytes we emitted", NOT "this file is non-empty".
+            // `Length > 0` accepts a 1-byte file, a truncated PE, and — the case that survived
+            // #1387 — a full-length image with an unwritten region inside its metadata. None of
+            // those is rejected by the loader in any way the pipeline survives: the first two make
+            // LoadNodeAssembly return null, the third loads fine and throws
+            // ReflectionTypeLoadException "…because the format is invalid" on the first GetTypes().
+            // CompileResultFromAssembly records either as CompilationStatus.Error, and the
+            // first-build kickoff is gated on Status == null, so it NEVER retries — the bytes may
+            // heal, the verdict does not, and the NodeType is parked for good (#1412). Proving the
+            // artifact before it enters the discovery namespace is the publication contract, the
+            // same one AtomicFileWrite gives the assembly store; it is emphatically NOT a retry
+            // around a load. See EmittedArtifact for why a digest and not a metadata walk.
             try
             {
-                if (File.Exists(stagedDllPath) && new FileInfo(stagedDllPath).Length > 0)
+                if (staged.MatchesFileOnDisk(out lastReason))
                 {
                     Directory.Move(stagingDir, releaseDir);
                     return lastDllPath;
                 }
 
                 logger.LogWarning(
-                    "Emit for {NodeName} reported success but the assembly was missing or empty at " +
-                    "{DllPath} after flush (attempt {Attempt}/{Max}); re-emitting.",
-                    nodeName, stagedDllPath, attempt, maxAttempts);
+                    "Emit for {NodeName} reported success but the staged assembly at {DllPath} is " +
+                    "not the image that was emitted — {Reason} (attempt {Attempt}/{Max}); re-emitting.",
+                    nodeName, staged.DllPath, lastReason, attempt, maxAttempts);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
+                lastReason = $"publishing failed — {ex.GetType().Name}: {ex.Message}";
                 logger.LogWarning(ex,
                     "Publishing the emitted assembly for {NodeName} failed (attempt {Attempt}/{Max}); re-emitting.",
                     nodeName, attempt, maxAttempts);
@@ -2204,9 +2245,10 @@ internal class MeshNodeCompilationService(
         }
 
         throw new CompilationException(nodeName,
-            $"Compilation succeeded but the emitted assembly for '{nodeName}' could not be persisted to " +
-            $"'{cacheDirectory}' after {maxAttempts} attempts (last target '{lastDllPath}'). The compilation " +
-            "host's cache directory may be read-only or evicting files.");
+            $"Compilation succeeded but the emitted assembly for '{nodeName}' could not be published to " +
+            $"'{cacheDirectory}' after {maxAttempts} attempts (last target '{lastDllPath}'; last failure: " +
+            $"{lastReason}). The compilation host's cache directory may be read-only, evicting files, or " +
+            "losing writes.");
     }
 
     /// <summary>
@@ -2233,205 +2275,6 @@ internal class MeshNodeCompilationService(
         var assemblyBytes = dllStream.ToArray();
         var pdbBytes = pdbStream.ToArray();
         cacheService.LoadAssemblyFromBytes(nodeName, assemblyBytes, pdbBytes);
-    }
-
-    /// <summary>
-    /// Compiles a node type to a specific release folder.
-    /// This method is thread-safe and multi-process safe when used with CompilationLock.
-    /// The caller is responsible for acquiring the lock before calling this method.
-    /// </summary>
-    /// <param name="release">The NodeTypeRelease containing all compilation inputs.</param>
-    /// <param name="node">The MeshNode being compiled.</param>
-    /// <param name="releaseFolder">Target folder for the compiled assembly.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Compilation result with assembly location and configurations.</returns>
-    internal async Task<NodeCompilationResult?> CompileToReleaseAsync(
-        NodeTypeRelease release,
-        MeshNode node,
-        string releaseFolder,
-        CancellationToken ct = default)
-    {
-        var sanitizedPath = release.GetSanitizedPath();
-
-        logger.LogInformation("Compiling {NodePath} to release folder {ReleaseFolder}", node.Path, releaseFolder);
-
-        // Ensure release folder exists
-        Directory.CreateDirectory(releaseFolder);
-
-        var dllPath = Path.Combine(releaseFolder, $"{sanitizedPath}.dll");
-        var pdbPath = Path.Combine(releaseFolder, $"{sanitizedPath}.pdb");
-        var sourcePath = Path.Combine(releaseFolder, $"{sanitizedPath}.cs");
-        var xmlDocPath = Path.Combine(releaseFolder, $"{sanitizedPath}.xml");
-
-        ct.ThrowIfCancellationRequested();
-
-        // Generate source code
-        var codeConfig = string.IsNullOrEmpty(release.Code) ? null : new CodeConfiguration { Code = release.Code };
-        var rawSource = _attributeGenerator.GenerateAttributeSource(node, codeConfig, release.HubConfiguration, release.ContentCollections);
-
-        // Strip #r "nuget:..." directives — Roslyn compilation (unlike scripting) does not process them.
-        var (source, extractedRefs) = NuGetDirectiveParser.Extract(rawSource);
-        // 🚨 Same legacy-#r strip as AssembleCompilationInputs: a node Source still carrying
-        // `#r "nuget:MeshWeaver.BusinessRules.Generator"` must NOT reach the NuGet resolver —
-        // the generator ships built-in, and the mesh-local feed it used to resolve from is gone
-        // (#395), so resolving hard-fails ("The local source '…/dist/packages' doesn't exist").
-        // This RELEASE-folder compile path previously lacked the strip: the PensionFund sample
-        // (legacy #r intact) compiled green on CI only because the workflow's pack step happened
-        // to recreate the feed — the strip in the OTHER compile path never covered this one.
-        var nugetRefList = extractedRefs.ToList();
-        StripBuiltInScopeGeneratorRef(nugetRefList, builtInPresent: BuiltInGeneratorPaths.Count > 0);
-        var nugetRefs = nugetRefList.ToArray();
-        IEnumerable<MetadataReference> references = _references;
-        IReadOnlyList<string> probingDirs = [];
-        IReadOnlyList<string> nugetAssemblyPaths = [];
-        if (nugetRefs.Length > 0)
-        {
-            var resolved = await nugetResolver.ResolveAsync(nugetRefs, targetFramework: null, ct);
-            references = _references.Concat(
-                resolved.AssemblyPaths.Select(p => MetadataReference.CreateFromFile(p)));
-            probingDirs = resolved.ProbingDirectories;
-            nugetAssemblyPaths = resolved.AssemblyPaths;
-        }
-
-        // Write source file for debugging
-        if (_cacheOptions.EnableSourceDebugging)
-        {
-            await File.WriteAllTextAsync(sourcePath, source, ct);
-            logger.LogDebug("Wrote source file: {SourcePath}", sourcePath);
-        }
-
-        // Parse with source path embedded for PDB source linking
-        var sourceText = Microsoft.CodeAnalysis.Text.SourceText.From(source, System.Text.Encoding.UTF8);
-        var parseOptions = new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose);
-        var syntaxTree = CSharpSyntaxTree.ParseText(
-            sourceText,
-            parseOptions,
-            path: _cacheOptions.EnableSourceDebugging ? sourcePath : "",
-            cancellationToken: ct);
-
-        var assemblyName = sanitizedPath;
-
-        var compilation = RunSourceGenerators(CSharpCompilation.Create(
-            assemblyName,
-            syntaxTrees: [syntaxTree],
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithOptimizationLevel(OptimizationLevel.Debug)
-                .WithPlatform(Platform.AnyCpu)), nugetAssemblyPaths, logger, ct);
-
-        // Emit to release folder
-        await using var dllStream = File.Create(dllPath);
-        await using var pdbStream = File.Create(pdbPath);
-        await using var xmlDocStream = File.Create(xmlDocPath);
-
-        var emitOptions = new EmitOptions(
-            debugInformationFormat: DebugInformationFormat.PortablePdb,
-            pdbFilePath: pdbPath);
-
-        var emitResult = compilation.Emit(dllStream, pdbStream, xmlDocumentationStream: xmlDocStream, options: emitOptions, cancellationToken: ct);
-
-        if (!emitResult.Success)
-        {
-            // Clean up partial files on failure
-            await dllStream.DisposeAsync();
-            await pdbStream.DisposeAsync();
-            await xmlDocStream.DisposeAsync();
-
-            try { Directory.Delete(releaseFolder, recursive: true); } catch { /* ignore */ }
-
-            var errorMessage = FormatCompileFailure(node.Path, emitResult.Diagnostics);
-            logger.LogError("{ErrorMessage}", errorMessage);
-            throw new CompilationException(node.Path, errorMessage);
-        }
-
-        // Close streams before writing metadata
-        await dllStream.DisposeAsync();
-        await pdbStream.DisposeAsync();
-        await xmlDocStream.DisposeAsync();
-
-        // Write the NodeTypeRelease as release.json (contains all metadata)
-        var metadataPath = Path.Combine(releaseFolder, "release.json");
-        var metadataJson = JsonSerializer.Serialize(release, new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(metadataPath, metadataJson, ct);
-
-        // Persist NuGet probing directories alongside the release so the load context
-        // can probe for transitive dependencies at load time.
-        if (probingDirs.Count > 0)
-        {
-            var probingPath = Path.Combine(releaseFolder, "probing.json");
-            var probingJson = JsonSerializer.Serialize(probingDirs);
-            await File.WriteAllTextAsync(probingPath, probingJson, ct);
-        }
-
-        logger.LogInformation("Successfully compiled {NodePath} to {DllPath}", node.Path, dllPath);
-
-        // Load and extract configurations
-        return await LoadAndExtractConfigurationsFromReleaseAsync(release, releaseFolder, ct);
-    }
-
-    /// <summary>
-    /// Loads an assembly from a release folder and extracts NodeTypeConfigurations.
-    /// </summary>
-    internal async Task<NodeCompilationResult?> LoadAndExtractConfigurationsFromReleaseAsync(
-        NodeTypeRelease release,
-        string releaseFolder,
-        CancellationToken _)
-    {
-        var sanitizedPath = release.GetSanitizedPath();
-        var dllPath = Path.Combine(releaseFolder, $"{sanitizedPath}.dll");
-
-        try
-        {
-            // PIN across load + the GetTypes/MeshNodeProviderAttribute scan below — same
-            // unload-during-scan race as CompileResultFromAssembly (TypeLoadException 'format is
-            // invalid'). Released when the method returns; Dispose() drains pins before Unload().
-            // Resolve+pin is ONE operation for the reason spelled out there: an eviction landing
-            // between the two steps otherwise yields an empty configuration list that reads as
-            // authoritative (#1151).
-            using var pinned = cacheService.PinForScanOfRelease(release, releaseFolder);
-            var context = pinned.Context;
-            var assembly = context.LoadNodeAssembly();
-            if (assembly == null)
-            {
-                logger.LogWarning("Failed to load assembly from {DllPath}", dllPath);
-                return new NodeCompilationResult(dllPath, []);
-            }
-
-            var configurations = new List<NodeTypeConfiguration>();
-            foreach (var type in assembly.GetTypes())
-            {
-                if (typeof(MeshNodeProviderAttribute).IsAssignableFrom(type) && !type.IsAbstract)
-                {
-                    var attribute = (MeshNodeProviderAttribute?)Activator.CreateInstance(type);
-                    if (attribute != null)
-                    {
-                        foreach (var meshNode in attribute.Nodes)
-                        {
-                            var hubConfig = meshNode.HubConfiguration;
-                            if (hubConfig != null)
-                            {
-                                configurations.Add(new NodeTypeConfiguration
-                                {
-                                    NodeType = meshNode.Path,
-                                    DataType = typeof(object),
-                                    HubConfiguration = hubConfig,
-                                    DisplayName = meshNode.Name,
-                                    Icon = meshNode.Icon,
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-
-            logger.LogDebug("Extracted {Count} NodeTypeConfigurations from {DllPath}", configurations.Count, dllPath);
-            return new NodeCompilationResult(dllPath, configurations);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to extract NodeTypeConfigurations from {DllPath}", dllPath);
-            return new NodeCompilationResult(dllPath, []);
-        }
     }
 }
 

--- a/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
@@ -195,12 +195,12 @@ public class CompileFailureReportedOnceTest : IDisposable
             releaseDir =>
             {
                 emits++;
-                var path = MeshNodeCompilationService.EmitCompilationToDirectory(
+                var emitted = MeshNodeCompilationService.EmitCompilationToDirectory(
                     ValidCompilation(nodeName), nodeName, "Acme/LostWrite", releaseDir,
                     CancellationToken.None);
                 if (emits == 1)
-                    File.Delete(path); // the ephemeral-/tmp eviction
-                return path;
+                    File.Delete(emitted.DllPath); // the ephemeral-/tmp eviction
+                return emitted;
             });
 
         emits.Should().Be(2);

--- a/test/MeshWeaver.Graph.Test/EmitToDiskWithRetryTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmitToDiskWithRetryTest.cs
@@ -1,20 +1,36 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
 using MeshWeaver.Graph.Configuration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// Unit tests for the disk-emit self-heal
-/// (<see cref="MeshNodeCompilationService.EmitToDiskWithRetry"/>).
+/// The publication contract of <see cref="MeshNodeCompilationService.EmitToDiskWithRetry"/>:
+/// <b>an artifact becomes discoverable only when the file on disk IS the image the emit produced</b>,
+/// and a lost write is re-emitted rather than poisoning the NodeType.
 ///
-/// Reproduces the prod <c>AgenticPension/Datenpunkt</c> failure (2026-06-22): a Roslyn emit
-/// reports success but the assembly is missing on disk afterward (the ephemeral container
-/// <c>/tmp</c> cache evicted the just-written file). That used to poison the NodeType with a
-/// permanent "Compilation succeeded but DLL not found" error that no recompile could clear.
-/// The fix re-emits the lost artifact; an unrecoverable loss surfaces a clear, loud failure.
+/// <para>The lost-write half reproduces the prod <c>AgenticPension/Datenpunkt</c> failure
+/// (2026-06-22): a Roslyn emit reports success but the assembly is missing on disk afterward (the
+/// ephemeral container <c>/tmp</c> cache evicted the just-written file), which used to poison the
+/// NodeType with a permanent "Compilation succeeded but DLL not found".</para>
+///
+/// <para>The integrity half is MeshWeaver#1412. The acceptance test used to be
+/// <c>File.Exists(dll) &amp;&amp; new FileInfo(dll).Length &gt; 0</c> — "non-empty", not "the bytes we
+/// emitted" — so a truncated PE, or a full-length image with an unwritten region inside its
+/// metadata, was published under the name readers discover by and handed straight to
+/// <c>AssemblyLoadContext.LoadFromAssemblyPath</c>. Neither is survivable downstream:
+/// <c>CompileResultFromAssembly</c> records the load/scan fault as <c>CompilationStatus.Error</c>
+/// and the first-build kickoff is gated on <c>Status == null</c>, so it never retries — the bytes
+/// may heal, the verdict does not, and the NodeType is PARKED.</para>
 /// </summary>
 public class EmitToDiskWithRetryTest : IDisposable
 {
@@ -25,16 +41,65 @@ public class EmitToDiskWithRetryTest : IDisposable
 
     public void Dispose()
     {
+        GC.SuppressFinalize(this);
         try { Directory.Delete(_cacheDir, recursive: true); }
         catch { /* best-effort cleanup */ }
     }
 
-    /// <summary>Writes a non-empty placeholder assembly into the release dir, like a real emit.</summary>
-    private static string WriteAssembly(string releaseDir, string nodeName)
+    /// <summary>
+    /// A REAL compiled assembly, shaped like a dynamic NodeType's output (a record plus a type that
+    /// consumes it). Placeholder bytes cannot be used any more, and that is the point: the publisher
+    /// now proves the artifact is the emitted image, so a test that stages <c>MZ\0\0</c> and claims
+    /// it emitted an assembly would be asserting the very contract this fixes.
+    /// </summary>
+    internal static byte[] RealAssemblyBytes(string assemblyName = "DynamicNode_TestWidget")
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            """
+            public record Widget { public string Title { get; init; } = string.Empty; }
+            public class WidgetProvider
+            {
+                public string Describe(Widget w) => w.Title;
+                public int Count { get; set; }
+            }
+            """);
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName, [tree], references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        Assert.True(result.Success,
+            "the fixture assembly must compile: "
+            + string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return ms.ToArray();
+    }
+
+    /// <summary>Stages <paramref name="image"/> as an honest emit would: write it, report its digest.</summary>
+    private static EmittedArtifact Stage(string releaseDir, string nodeName, byte[] image)
     {
         var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
-        File.WriteAllBytes(dllPath, new byte[] { 0x4D, 0x5A, 0x90, 0x00 }); // MZ header-ish, non-empty
-        return dllPath;
+        File.WriteAllBytes(dllPath, image);
+        return EmittedArtifact.For(dllPath, image);
+    }
+
+    /// <summary>
+    /// Stages a DAMAGED file while reporting the digest of the image the emit produced — the shape of
+    /// every real defect here: Roslyn emitted a good image, the bytes that reached disk are not it.
+    /// </summary>
+    private static EmittedArtifact StageDamaged(
+        string releaseDir, string nodeName, byte[] emitted, byte[] onDisk)
+    {
+        var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
+        File.WriteAllBytes(dllPath, onDisk);
+        return EmittedArtifact.For(dllPath, emitted);
     }
 
     [Fact]
@@ -45,11 +110,11 @@ public class EmitToDiskWithRetryTest : IDisposable
 
         var result = MeshNodeCompilationService.EmitToDiskWithRetry(
             _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
-            releaseDir => { attempts++; return WriteAssembly(releaseDir, nodeName); });
+            releaseDir => { attempts++; return Stage(releaseDir, nodeName, RealAssemblyBytes()); });
 
         attempts.Should().Be(1, "a persisted artifact needs no re-emit");
         File.Exists(result).Should().BeTrue();
-        new FileInfo(result).Length.Should().BeGreaterThan(0);
+        LoaderVerdict(result).Should().BeNull("the published artifact must load and enumerate");
     }
 
     [Fact]
@@ -65,10 +130,10 @@ public class EmitToDiskWithRetryTest : IDisposable
             releaseDir =>
             {
                 attempts++;
-                var dllPath = WriteAssembly(releaseDir, nodeName);
+                var staged = Stage(releaseDir, nodeName, RealAssemblyBytes());
                 if (attempts == 1)
-                    File.Delete(dllPath); // simulate the ephemeral-/tmp eviction
-                return dllPath;
+                    File.Delete(staged.DllPath); // simulate the ephemeral-/tmp eviction
+                return staged;
             });
 
         attempts.Should().Be(2, "the lost first artifact must trigger exactly one re-emit");
@@ -82,22 +147,80 @@ public class EmitToDiskWithRetryTest : IDisposable
         // A zero-byte DLL (truncated write) is as broken as a missing one — it must re-emit.
         const string nodeName = "Demo_Truncated";
         var attempts = 0;
+        var whole = RealAssemblyBytes();
 
         var result = MeshNodeCompilationService.EmitToDiskWithRetry(
             _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
             releaseDir =>
             {
                 attempts++;
-                var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
-                if (attempts == 1)
-                    File.WriteAllBytes(dllPath, Array.Empty<byte>()); // empty == broken
-                else
-                    File.WriteAllBytes(dllPath, new byte[] { 1, 2, 3, 4 });
-                return dllPath;
+                return attempts == 1
+                    ? StageDamaged(releaseDir, nodeName, whole, [])
+                    : Stage(releaseDir, nodeName, whole);
             });
 
         attempts.Should().Be(2);
-        new FileInfo(result).Length.Should().BeGreaterThan(0);
+        new FileInfo(result).Length.Should().Be(whole.Length);
+    }
+
+    /// <summary>
+    /// 🚨 #1412. A SHORT-but-non-empty artifact passed the old <c>Length &gt; 0</c> gate and was
+    /// published. It is not a survivable state: the loader throws <c>BadImageFormatException</c>,
+    /// <c>LoadNodeAssembly</c> returns null, and the compile settles at a terminal
+    /// <c>CompilationStatus.Error</c> that the kickoff never retries.
+    /// </summary>
+    [Fact]
+    public void Re_emits_when_the_staged_artifact_is_truncated()
+    {
+        const string nodeName = "Demo_TruncatedPe";
+        var attempts = 0;
+        var whole = RealAssemblyBytes();
+
+        var result = MeshNodeCompilationService.EmitToDiskWithRetry(
+            _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
+            releaseDir =>
+            {
+                attempts++;
+                return attempts == 1
+                    ? StageDamaged(releaseDir, nodeName, whole, whole[..(whole.Length / 2)])
+                    : Stage(releaseDir, nodeName, whole);
+            });
+
+        attempts.Should().Be(2, "a truncated image is not a publishable artifact — it must re-emit");
+        new FileInfo(result).Length.Should().Be(whole.Length);
+        LoaderVerdict(result).Should().BeNull("the published artifact must load and enumerate");
+    }
+
+    /// <summary>
+    /// 🚨 #1412's actual signature. A full-LENGTH image with an unwritten region inside its metadata
+    /// LOADS — the header and assembly identity are intact — and throws
+    /// <c>ReflectionTypeLoadException … "because the format is invalid"</c> on the first
+    /// <c>GetTypes()</c>, which is what parks the NodeType. A length check cannot see it; comparing
+    /// against the emitted image can.
+    /// </summary>
+    [Fact]
+    public void Re_emits_when_the_staged_artifact_is_full_length_but_corrupt_inside()
+    {
+        const string nodeName = "Demo_MetadataHole";
+        var attempts = 0;
+        var whole = RealAssemblyBytes();
+        var holed = WithMetadataHole(whole);
+        holed.Length.Should().Be(whole.Length, "the corruption must be invisible to a length check");
+        LoaderVerdict(WriteTemp(holed)).Should().NotBeNull(
+            "the fixture must be damage the real loader actually refuses");
+
+        var result = MeshNodeCompilationService.EmitToDiskWithRetry(
+            _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
+            releaseDir =>
+            {
+                attempts++;
+                return attempts == 1
+                    ? StageDamaged(releaseDir, nodeName, whole, holed)
+                    : Stage(releaseDir, nodeName, whole);
+            });
+
+        attempts.Should().Be(2, "an image that is not what we emitted must re-emit, not publish");
+        LoaderVerdict(result).Should().BeNull("the published artifact must load and enumerate");
     }
 
     [Fact]
@@ -113,16 +236,46 @@ public class EmitToDiskWithRetryTest : IDisposable
                 releaseDir =>
                 {
                     attempts++;
-                    var dllPath = WriteAssembly(releaseDir, nodeName);
-                    File.Delete(dllPath); // every attempt loses the artifact
-                    return dllPath;
+                    var staged = Stage(releaseDir, nodeName, RealAssemblyBytes());
+                    File.Delete(staged.DllPath); // every attempt loses the artifact
+                    return staged;
                 });
         });
 
-        ex.Message.Should().Contain("could not be persisted");
+        ex.Message.Should().Contain("could not be published");
         ex.Message.Should().Contain(nodeName);
         ex.NodePath.Should().Be(nodeName);
         attempts.Should().Be(3, "it must exhaust all attempts before failing loudly");
+    }
+
+    /// <summary>
+    /// A persistently damaged artifact must fail LOUDLY and say what was wrong — not park the
+    /// NodeType behind a generic "could not be persisted" that sends the operator looking for a
+    /// read-only cache directory.
+    /// </summary>
+    [Fact]
+    public void Throws_naming_the_damage_when_every_attempt_is_corrupt()
+    {
+        const string nodeName = "Demo_AlwaysCorrupt";
+        var attempts = 0;
+        var whole = RealAssemblyBytes();
+        var holed = WithMetadataHole(whole);
+
+        var ex = Assert.Throws<CompilationException>(() =>
+            MeshNodeCompilationService.EmitToDiskWithRetry(
+                _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
+                releaseDir =>
+                {
+                    attempts++;
+                    return StageDamaged(releaseDir, nodeName, whole, holed);
+                }));
+
+        attempts.Should().Be(3);
+        ex.Message.Should().Contain("last failure:",
+            "the terminal error must carry WHY the last publish was refused");
+        ex.Message.Should().Contain("differs from the emitted image");
+        Directory.GetDirectories(_cacheDir, $"{nodeName}_*").Should()
+            .BeEmpty("a damaged artifact must never reach the discovery namespace");
     }
 
     [Fact]
@@ -160,7 +313,7 @@ public class EmitToDiskWithRetryTest : IDisposable
 
         var result = MeshNodeCompilationService.EmitToDiskWithRetry(
             _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
-            releaseDir => WriteAssembly(releaseDir, nodeName));
+            releaseDir => Stage(releaseDir, nodeName, RealAssemblyBytes()));
 
         File.Exists(result).Should().BeTrue();
         Path.GetDirectoryName(result)!.Should().NotContain(".staging-");
@@ -192,5 +345,137 @@ public class EmitToDiskWithRetryTest : IDisposable
             .BeEmpty("a failed compile must leave no discoverable artifact");
         Directory.GetDirectories(_cacheDir, ".staging-*").Should()
             .BeEmpty("the failed staging dir is cleaned up");
+    }
+
+    private string WriteTemp(byte[] bytes)
+    {
+        var p = Path.Combine(_cacheDir, $"probe-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(p, bytes);
+        return p;
+    }
+
+    /// <summary>Zeroes bytes in the middle of the image's CLI metadata, keeping the length.</summary>
+    internal static byte[] WithMetadataHole(byte[] image, double position = 0.5, int holeBytes = 64)
+    {
+        int mdOffset, mdSize;
+        using (var pe = new PEReader(new MemoryStream(image)))
+        {
+            mdOffset = pe.PEHeaders.MetadataStartOffset;
+            mdSize = pe.PEHeaders.MetadataSize;
+        }
+        var copy = (byte[])image.Clone();
+        var start = Math.Min(mdOffset + (int)(mdSize * position), image.Length - holeBytes);
+        Array.Clear(copy, start, holeBytes);
+        return copy;
+    }
+
+    /// <summary>
+    /// What the REAL reader does with this file: load it into a collectible context and enumerate
+    /// its types, exactly as <c>CompileResultFromAssembly</c> does. Returns null when that succeeds,
+    /// otherwise the failure text — so a test can assert on the loader's verdict rather than on a
+    /// guess about which corruptions matter.
+    /// </summary>
+    internal static string? LoaderVerdict(string dllPath)
+    {
+        var alc = new AssemblyLoadContext($"verdict-{Guid.NewGuid():N}", isCollectible: true);
+        try
+        {
+            var assembly = alc.LoadFromAssemblyPath(dllPath);
+            var types = assembly.GetTypes();
+            return types.Length == 0 ? "the assembly exposed no types" : null;
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return string.Join("; ", ex.LoaderExceptions
+                .Where(e => e is not null).Select(e => e!.Message).Distinct());
+        }
+        catch (Exception ex)
+        {
+            return $"{ex.GetType().Name}: {ex.Message}";
+        }
+        finally
+        {
+            alc.Unload();
+        }
+    }
+}
+
+/// <summary>
+/// 🚨 The census behind MeshWeaver#1412, in the shape #1387 used for the assembly store: over a
+/// population of damaged images, measure how many the OLD acceptance test (<c>Length &gt; 0</c>)
+/// would have published and how many of those the REAL loader then cannot use. Every one of the
+/// latter is a permanently parked NodeType, because <c>CompileResultFromAssembly</c> records the
+/// fault as <c>CompilationStatus.Error</c> and the first-build kickoff never retries.
+///
+/// <para>The gate is asserted against the loader's own verdict, never against a guess about which
+/// byte ranges matter — a metadata-walking approximation was tried first and measurably leaked (19
+/// of these samples load-fail yet parse cleanly), which is why the shipped gate compares the
+/// artifact with the image that was emitted instead.</para>
+/// </summary>
+public class PublishedAssemblyIsCompleteTest
+{
+    [Fact(Timeout = 120_000)]
+    public void No_damaged_artifact_may_pass_the_publication_gate()
+    {
+        var whole = EmitToDiskWithRetryTest.RealAssemblyBytes();
+        int mdOffset, mdSize;
+        using (var pe = new PEReader(new MemoryStream(whole)))
+        {
+            mdOffset = pe.PEHeaders.MetadataStartOffset;
+            mdSize = pe.PEHeaders.MetadataSize;
+        }
+
+        var samples = new List<(string Name, byte[] Bytes)> { ("empty", []) };
+        foreach (var keep in new[] { 0.05, 0.25, 0.5, 0.75, 0.95, 0.99 })
+            samples.Add(($"truncated to {keep:P0}", whole[..(int)(whole.Length * keep)]));
+        // Full-LENGTH damage: a 64-byte unwritten region swept across the metadata. This is the
+        // shape that loads and then throws "…because the format is invalid" at GetTypes().
+        for (var off = mdOffset; off < mdOffset + mdSize - 64; off += 64)
+        {
+            var copy = (byte[])whole.Clone();
+            Array.Clear(copy, off, 64);
+            samples.Add(($"metadata hole at +{off - mdOffset}", copy));
+        }
+
+        var dir = Path.Combine(Path.GetTempPath(), $"mesh-image-census-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var loaderRefused = 0;
+            var oldGateWouldPublish = 0;
+            var escapes = new List<string>();
+
+            foreach (var (name, bytes) in samples)
+            {
+                var path = Path.Combine(dir, $"s{Guid.NewGuid():N}.dll");
+                File.WriteAllBytes(path, bytes);
+
+                // The gate as it stood before #1412: present and non-empty.
+                if (File.Exists(path) && new FileInfo(path).Length > 0)
+                    oldGateWouldPublish++;
+                if (EmitToDiskWithRetryTest.LoaderVerdict(path) is not null)
+                    loaderRefused++;
+
+                // The gate as it stands now: this file is the image the emit produced.
+                if (EmittedArtifact.For(path, whole).MatchesFileOnDisk(out _))
+                    escapes.Add($"{name} ({bytes.Length} bytes)");
+            }
+
+            // The population has to be real, or the assertion below is vacuous.
+            loaderRefused.Should().BeGreaterThan(10,
+                $"the census must actually damage images ({samples.Count} samples)");
+            oldGateWouldPublish.Should().BeGreaterThan(0,
+                "if `Length > 0` had rejected every damaged image there would have been nothing to fix");
+
+            escapes.Should().BeEmpty(
+                "a damaged artifact must never be published "
+                + $"({samples.Count} samples, {loaderRefused} the real loader refuses, "
+                + $"{oldGateWouldPublish} the old `Length > 0` gate would have published):"
+                + Environment.NewLine + string.Join(Environment.NewLine, escapes));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
     }
 }


### PR DESCRIPTION
Closes #1412.

## The second root

#1387 made both `IAssemblyStore` implementations publish atomically, and the `format is invalid`
signature recurred **on #1387's own merge commit** — from the compilation-cache path, whose publish
is already atomic (`.staging-…` → `Directory.Move`). #1412 asked what the second root is.

It is not the rename. **It is what the rename is gated on.** `EmitToDiskWithRetry` accepted

```csharp
if (File.Exists(stagedDllPath) && new FileInfo(stagedDllPath).Length > 0)
    Directory.Move(stagingDir, releaseDir);
```

"Non-empty" is not "the bytes we emitted", and the gap is terminal rather than transient:

* a **short** image throws `BadImageFormatException` at LOAD → `LoadNodeAssembly` returns null;
* a **full-length** image with an unwritten region inside its metadata **loads cleanly** — header and
  assembly identity intact — and throws `ReflectionTypeLoadException … "because the format is
  invalid"` on the first `GetTypes()`.

Either way `CompileResultFromAssembly` writes `CompilationStatus.Error`, and the first-build kickoff
is gated on `Status == null`, so it never recompiles. **The bytes may heal, the verdict does not**,
and the NodeType is parked until someone deletes the artifact by hand — and a parked NodeType
refuses portal readiness.

## The change

The emit keeps the image it produced and hands its digest to the publisher; the publisher renames
staging into the discovery namespace only if the file on disk matches. This is a publication
CONTRACT, not a retry around a load — nothing re-reads a bad artifact hoping for a better answer. A
bad artifact simply never becomes discoverable, and the compile re-runs the emit it already re-ran
for a lost write (bounded, stateless, never applied to a genuine compile error). The terminal
failure now names what was wrong instead of pointing at a read-only cache directory.

Also deletes `CompileToReleaseAsync` + `LoadAndExtractConfigurationsFromReleaseAsync` — #1412's
**latent third site**. No callers in `src/` or `test/`, yet it did `Directory.CreateDirectory` +
`File.Create` + `Emit` straight onto `{cacheDir}/{nodeName}_{releaseKey}`, a name the live
`{nodeName}_*` glob matches (ordered by directory write-time, so a folder being written right now
sorts newest) with `IsReleaseValid` satisfied by a 0-byte DLL. Inert because dead — but a
working-looking template sitting next to the corrected path, which is how #1359 → #1387 kept finding
new copies.

## Measured, not reasoned

Three things were established by measurement rather than argued:

| observation | result |
|---|---|
| A plain **truncation** | faults with `BadImageFormatException` at **LOAD**, not at `GetTypes()` — so it is not what the CI signature shows |
| `AssemblyLoadContext.Unload()` | does **NOT** break `GetTypes()` on an already-loaded assembly (43/43 types still enumerated after `Unload`) |
| A 64-byte **unwritten region inside the metadata** of a full-length image | loads, then throws `TypeLoadException … because the format is invalid` — the CI signature verbatim |

The first version of this fix *validated* the staged file as an assembly (PE header + metadata
tables + type-def walk). It leaked: over a census of damaged images it still admitted **19** that the
real loader refuses — corrupt signature blobs, corrupt type references, names that read as strings
but are rejected as identities. Metadata validation is a leaky approximation of "usable"; comparing
against the emitted image is not an approximation. `PublishedAssemblyIsCompleteTest` keeps that
census as a regression, asserting against the **real loader's** verdict rather than a guess about
which byte ranges matter.

## Verification

* **Fail-before/pass-after**: with the old `Length > 0` gate restored, the three deterministic
  publication tests fail (the corrupt artifact is published); with the fix they pass.
* `MeshWeaver.Graph.Test` **1102/1102**, `MeshWeaver.PluginCatalog.Test` **270/270**.
* `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph` and `MeshWeaver.Graph.Test`.

## What this does NOT claim

I could not reproduce the CI failure on this host: `CodePackageInstallTest` ran **40/40** green
single-test, and the whole `MeshWeaver.PluginCatalog.Test` project **6 × 270/270** at
`DOTNET_PROCESSOR_COUNT=2`, with zero occurrences of the signature. So this closes the weak link
#1412 names and makes the failure mode unreachable *through this publisher*; it is not proof that
the CI occurrence originated there. If the signature recurs after this lands, the gate's warning and
terminal message now name the artifact and the mismatch, which moves the hunt downstream (mapping /
shared volume) instead of leaving it at "the format is invalid".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
