### PR TITLE
Share the anonymous intermediate reduce instead of minting a hub per subscribe (#1324)

### DIFF
--- a/src/MeshWeaver.Data/ISynchronizationStream.cs
+++ b/src/MeshWeaver.Data/ISynchronizationStream.cs
@@ -55,6 +55,35 @@ public interface ISynchronizationStream : IDisposable
         Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>? config
     );
 
+    /// <summary>
+    /// 🚨 The SHARED, parent-owned reduce — for an INTERMEDIATE stream in a reduce chain, which
+    /// nobody owns and therefore nobody will ever dispose.
+    ///
+    /// <para><see cref="Reduce{TReduced}(WorkspaceReference{TReduced})"/> builds a NEW stream on
+    /// every call, and <c>WorkspaceStreams.CreateReducedStream</c> registers each one for disposal
+    /// on its PARENT. When the parent is a hub-lifetime stream (a data source's primary
+    /// <c>EntityStore</c>), a reduce on a hot path therefore mints a <c>sync/{id}</c> sub-hub — its
+    /// own Autofac scope, <c>TypeRegistry</c> and <c>JsonSerializerOptions</c>, about 140 KB — that
+    /// is reclaimed only when the whole hub dies. That is the #1345 defect (an unmemoized
+    /// <c>Workspace.GetStream</c>) one layer down, and it is what
+    /// <c>MeshDataSource</c>'s own-node factory was paying once per inbound
+    /// <c>SubscribeRequest</c> (Systemorph/MeshWeaver#1324).</para>
+    ///
+    /// <para><b>Use this ONLY for a stream the caller does not own</b> — a nameless intermediate
+    /// whose lifetime is deliberately the parent's. The result is SHARED with every other caller
+    /// asking for the same reference on this stream, so <b>the caller must never dispose it</b>;
+    /// it dies with the parent. A stream a caller owns and disposes (e.g. the Blazor
+    /// <c>LayoutAreaView</c>'s dialog / progress reduces, which it explicitly <c>Dispose()</c>s)
+    /// must keep using <see cref="Reduce{TReduced}(WorkspaceReference{TReduced})"/> — sharing one
+    /// of those would let one holder's teardown kill another holder's live stream, which is
+    /// exactly why this is an opt-in method and not a change to <c>Reduce</c>.</para>
+    /// </summary>
+    /// <typeparam name="TReduced">The reduced state type.</typeparam>
+    /// <param name="reference">Reference describing the reduced view.</param>
+    /// <returns>The shared reduced stream for <paramref name="reference"/>, or null if the
+    /// reference cannot be reduced.</returns>
+    ISynchronizationStream<TReduced>? ReduceShared<TReduced>(WorkspaceReference<TReduced> reference);
+
     /// <summary>The message hub associated with this stream.</summary>
     IMessageHub Hub { get; }
     /// <summary>The hub that hosts the underlying data source backing this stream.</summary>

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -97,6 +97,73 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     public ISynchronizationStream<TReduced>? Reduce<TReduced>(WorkspaceReference<TReduced> reference)
         => Reduce(reference, (Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>?)(x => x));
 
+    // 🚨 Intermediate reduced streams are CACHED, for the same reason Workspace.GetStream caches
+    // local reduced streams (#1345) and _remoteStreamCache caches mirrors: a reduce is neither free
+    // nor garbage-collectable.
+    //
+    // CreateReducedStream constructs a SynchronizationStream — hence a hosted `sync/{id}` sub-hub
+    // with its own Autofac scope, TypeRegistry and JsonSerializerOptions (~140 KB) — and registers
+    // it for disposal ON THIS STREAM. So when THIS stream is hub-lifetime (a data source's primary
+    // EntityStore), every uncached reduce is a hub that survives until the hub dies. MeshDataSource's
+    // own-node factory paid exactly that once per inbound SubscribeRequest, which is the residual
+    // measured in Systemorph/MeshWeaver#1324 after #1415 closed the eviction-parking retainer.
+    //
+    // Keyed by reference only: a shared reduce carries no caller-specific configuration by
+    // construction (that is what makes it shareable — see ISynchronizationStream.ReduceShared).
+    private readonly ConcurrentDictionary<WorkspaceReference, Lazy<ISynchronizationStream>> sharedReduceCache = new();
+
+    /// <inheritdoc />
+    public ISynchronizationStream<TReduced>? ReduceShared<TReduced>(WorkspaceReference<TReduced> reference)
+    {
+        // 🚨 A DISPOSED PARENT IS NEVER SERVED FROM CACHE — sharing must not outlive the thing being
+        // shared FROM. The cached child's own sub-hub is a sibling under `Host`, not a child of this
+        // stream's hub, so it stays alive when this stream is disposed: a liveness check on the child
+        // alone happily hands back a mirror of a dead source. Reads then bind to a stream that will
+        // never emit and never complete, so a reader gets neither an answer nor the NACK that
+        // `DataExtensions.HandleGetDataRequest`'s disposal arm owes it — it hangs for its whole
+        // budget (SilentReadNackTest, both arms). Falling through to the plain reduce keeps the
+        // behaviour a disposed parent has always had.
+        if (isDisposed)
+            return Reduce(reference, x => x);
+
+        while (true)
+        {
+            var lazy = sharedReduceCache.GetOrAdd(reference,
+                _ => new Lazy<ISynchronizationStream>(
+                    () => Reduce(reference, x => x)
+                          ?? throw new InvalidOperationException(
+                              $"Cannot reduce stream {StreamId} to {reference}"),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+
+            ISynchronizationStream reduced;
+            try
+            {
+                reduced = lazy.Value;
+            }
+            catch
+            {
+                // A Lazy in ExecutionAndPublication mode CACHES the exception, so one transient
+                // failure (e.g. HubDisposingException from a hub winding down) would otherwise
+                // poison this reference for the parent's whole life. Drop the faulted entry — only
+                // if it is still ours — and let the caller see the original fault.
+                Remove(reference, lazy);
+                throw;
+            }
+
+            // Same liveness contract as Workspace.GetStream: a cached child whose sub-hub is gone
+            // is replaced rather than handed out dead.
+            if (reduced.Hub?.RunLevel <= MessageHubRunLevel.Started
+                && reduced.Hub is not MessageHub { IsDisposing: true })
+                return (ISynchronizationStream<TReduced>)reduced;
+
+            Remove(reference, lazy);
+        }
+
+        void Remove(WorkspaceReference key, Lazy<ISynchronizationStream> entry) =>
+            ((ICollection<KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>>)sharedReduceCache)
+                .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(key, entry));
+    }
+
 
     /// <summary>
     /// Derives a reduced stream of <typeparamref name="TReduced"/> for the given reference, applying the
@@ -1521,6 +1588,10 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
         // the 1-item replay buffer is equally reachable via `current` for the stream's
         // remaining lifetime.
         Store.OnCompleted();
+        // The shared children were registered for disposal on THIS stream (CreateReducedStream),
+        // so the hub teardown below is what disposes them; dropping the index here just stops this
+        // corpse from referencing them.
+        sharedReduceCache.Clear();
         if (Hub is not null && Hub.RunLevel <= MessageHubRunLevel.Started)
             Hub.Dispose();
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/WorkspaceReferences.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WorkspaceReferences.md
@@ -231,6 +231,53 @@ EntityStore                      (root store — all collections)
 
 Each level can register a `PatchFunction` for write-back. Write-back travels the chain in reverse: typed changes are serialized to JSON, dispatched to the owner hub via `PatchDataChangeRequest` or `DataChangeRequest`, and applied using the registered `PatchFunction`.
 
+### 🚨 An intermediate reduce is `ReduceShared`, never `Reduce`
+
+**Every level of that chain is a hub.** `WorkspaceStreams.CreateReducedStream` constructs a
+`SynchronizationStream`, which constructs a hosted `sync/{id}` sub-hub with its own Autofac lifetime
+scope, `TypeRegistry` and `JsonSerializerOptions` — about 140 KB — and then registers the child for
+disposal **on its parent**. So a reduce is neither free nor garbage-collectable: when the parent is a
+data source's primary `EntityStore` stream, whose lifetime is the hub's, every call to `Reduce` mints
+a hub that is reclaimed only when the whole hub dies.
+
+That matters for the **middle** of a chain, because a middle stream has no owner. A stream factory
+that reduces `primary → InstanceCollection → MeshNode` hands the *last* stream to its caller, who
+disposes it on unsubscribe — but the `InstanceCollection` stream in the middle is nameless, nobody
+disposes it, and building a fresh one per call leaks one hub per call. Uncached, that factory runs
+once per inbound `SubscribeRequest`.
+
+```csharp
+// ❌ leaks a sync/ hub per call — the intermediate is parented on a hub-lifetime stream
+var collectionStream = primary?.Reduce<InstanceCollection>(new CollectionReference(nameof(MeshNode)));
+
+// ✅ memoized on the parent; one intermediate per (parent, reference), for the parent's life
+var collectionStream = primary?.ReduceShared<InstanceCollection>(new CollectionReference(nameof(MeshNode)));
+return collectionStream?.Reduce((WorkspaceReference<MeshNode>)ownPathReference, configuration);
+```
+
+**The rule is ownership, not depth:**
+
+| the stream is… | use | why |
+|---|---|---|
+| an intermediate nobody owns or disposes | `ReduceShared` | one instance per `(parent, reference)`, dies with the parent |
+| the stream you hand to a caller who will `Dispose()` it | `Reduce` | sharing would let one holder's teardown kill another's live stream |
+| caller-specific (a `configuration` with a client id / subscriber) | `Reduce` | it is not shareable by construction |
+
+`ReduceShared` is deliberately opt-in rather than a change to `Reduce`: the Blazor `LayoutAreaView`
+explicitly disposes the dialog and progress streams it reduces off its area stream, so making every
+reduce shared would break the second view on the same area. The same split — memoize when there is no
+caller-specific configuration — is what `Workspace.GetStream` does one layer up.
+
+> 🚨 **A cached child does NOT die with its parent, so caching one must check the PARENT's liveness,
+> not just the child's.** `CreateReducedStream` builds the child's `sync/{id}` sub-hub under
+> `stream.Host` — the data source's hub — so it is the parent's *sibling*, not its descendant, and it
+> stays alive after the parent is disposed. A cache that only asks "is the child still alive?"
+> therefore keeps serving a mirror of a dead source: reads bind to a stream that will never emit and
+> never complete, and the reader gets neither an answer nor the NACK
+> `DataExtensions.HandleGetDataRequest`'s disposal arm owes it — it hangs for its whole budget.
+> `ReduceShared` bypasses the cache entirely once the parent is disposed, falling through to a plain
+> `Reduce` so the behaviour is exactly what it always was. `SilentReadNackTest` pins this.
+
 ---
 
 ## Bidirectional Sync

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-rebuilding-in-portal-code-costs-half-of-what-it-did.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-rebuilding-in-portal-code-costs-half-of-what-it-did.md
@@ -1,0 +1,38 @@
+---
+Name: Rebuilding in-portal code costs half of what it did
+Category: Fix
+Description: Every time something subscribed to a page, the portal built a private copy of an internal lookup it could have shared — and never gave it back. Those copies are now shared, halving what a rebuild of in-portal code leaves behind.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Rebuilding in-portal code costs half of what it did
+
+The portal reads a page through a chain of narrowing views: the whole store, then one collection
+inside it, then the single item you asked for. Each link in that chain is real machinery — it keeps
+itself in step with the one above it, and it costs memory for as long as it exists.
+
+Only the last link belongs to whoever asked. The middle one is anonymous: it exists solely so the
+last link has something to narrow, and nobody ever holds it, names it, or closes it. It is owned by
+the link above, which for the store at the root of a page lives as long as the page is being served.
+
+The portal was building a fresh middle link every time anything subscribed — a view opening, a
+background watcher attaching, a save routed through. The last link was cleaned up properly when the
+subscriber went away. The anonymous middle one was not, because nothing had ever been made
+responsible for it. So every subscription left one behind, permanently.
+
+That was quiet on a page read a handful of times, and loud on anything the portal writes to
+constantly. Rebuilding a piece of in-portal code writes to its status record dozens of times, and
+the status record was where these accumulated fastest — it accounted for the single largest share of
+what a rebuild never gave back.
+
+Anonymous middle links are now shared. Asking for the same one twice returns the same instance, and
+it lives and dies with the link above it. Links that a caller genuinely owns — the ones a view
+closes when you navigate away — are untouched and still private, because sharing those would let one
+view's cleanup break another's.
+
+Measured on a rebuild loop: what a rebuild leaves behind dropped from about thirteen pieces of
+internal machinery to six, and from seven megabytes to four. Two of the three places that were
+growing now grow by nothing at all. The remaining share belongs to the per-rebuild record itself,
+which is a different mechanism, and the measurement that found this is tightened again so it cannot
+quietly get worse.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -195,8 +195,24 @@ public static class MeshDataSourceExtensions
                                 var ownDataSource = workspace.DataContext
                                     .GetDataSourceForType(typeof(MeshNode));
                                 var primary = ownDataSource?.GetStreamForPartition(null);
+                                // 🚨 ReduceShared, NOT Reduce — this InstanceCollection stream is a
+                                // NAMELESS INTERMEDIATE that no caller owns. A plain Reduce builds a
+                                // new one per call and registers it for disposal on `primary`, the
+                                // data source's hub-lifetime stream — so every call permanently
+                                // added a `sync/{id}` sub-hub (its own Autofac scope, TypeRegistry
+                                // and JsonSerializerOptions, ~140 KB). This factory runs uncached on
+                                // every call that passes a `configuration`, i.e. once per inbound
+                                // SubscribeRequest, so an unsubscribe reaped the subscription's own
+                                // stream and left this intermediate behind forever: the residual
+                                // measured in Systemorph/MeshWeaver#1324 after #1415 closed the
+                                // eviction-parking retainer. Same defect as #1345 (an unmemoized
+                                // Workspace.GetStream) one layer down at stream.Reduce.
+                                //
+                                // Sharing is safe here precisely because the intermediate is
+                                // ownerless: nobody disposes it, and it carries no caller-specific
+                                // configuration. The caller-specific half stays a fresh Reduce below.
                                 var collectionStream = primary
-                                    ?.Reduce<InstanceCollection>(new CollectionReference(nameof(MeshNode)));
+                                    ?.ReduceShared<InstanceCollection>(new CollectionReference(nameof(MeshNode)));
                                 var ownPathReference = string.IsNullOrEmpty(meshRef.Path)
                                     ? new MeshNodeReference(workspace.Hub.Address.Path)
                                     : meshRef;

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRecompileAlcLeakTest.cs
@@ -67,13 +67,14 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
     /// <c>TypeRegistry</c> and <c>JsonSerializerOptions</c> — about 140 KB — so the two numbers move
     /// together, but only this one says WHERE.</para>
     ///
-    /// <para>Measured on this repro: <b>12 hubs and ~6–7 MB per recompile</b> (12.0 / 12.3 / 12.0
-    /// over three Release runs), down from 22 and ~8 MB. Attributed by walking the hosted-hub tree
-    /// (see <see cref="HubsByParent"/>, printed below): the three per-compile
-    /// <c>_Activity/compile-&lt;ts&gt;</c> node hubs ~+17 over three recompiles (plus the 2 node hubs
-    /// themselves), <c>_Activity/compile-state</c> +12, the NodeType's own hub +3, the shared
-    /// <c>cache/</c> hub +3–4. Almost all of them are <c>sync/{id}</c> sub-hubs — one per
-    /// <c>SynchronizationStream</c>.</para>
+    /// <para>Measured on this repro: <b>6.2 hubs and 3–5 MB per recompile</b> (5.3 / 7.0 / 6.3 over
+    /// three Release runs), down from 12.7 and 7 MB, and from 22 / ~8 MB before that. Attributed by
+    /// walking the hosted-hub tree (see <see cref="HubsByParent"/>, printed below), the residual is
+    /// now ALMOST ENTIRELY the per-compile activity nodes: the <c>_Activity/compile-&lt;ts&gt;</c>
+    /// node hubs +3–5 <c>sync/</c> apiece plus the 2–3 node hubs themselves, and the shared
+    /// <c>cache/</c> hub +3. <c>_Activity/compile-state</c> and the NodeType's own hub, which used
+    /// to contribute +13 and +3, now contribute <b>nothing</b>. Almost all retained hubs are
+    /// <c>sync/{id}</c> sub-hubs — one per <c>SynchronizationStream</c>.</para>
     ///
     /// <para><b>What the 22 → 12 change closed (#1324):</b> <c>Workspace.EvictForPath</c> fires on
     /// EVERY mesh change event — including the echo of the writer's own write — and used to PARK the
@@ -91,30 +92,45 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
     /// — the 6 survivors are the one live hydration mirror per path, which is the correct steady
     /// state.</para>
     ///
-    /// <para><b>What still retains, and why the bound is 15 rather than single digits</b> — two
-    /// mechanisms, neither of them the parking one:</para>
-    /// <list type="number">
-    ///   <item>The per-compile <c>_Activity/compile-&lt;ts&gt;</c> NODE HUBS (~6 apiece) are created
-    ///     per compile and never reclaimed — a node-lifecycle question, not a stream one. This is now
-    ///     the LARGEST share of the residual.</item>
-    ///   <item>Owner-side intermediate reduced streams. <c>MeshDataSource</c>'s own-node
-    ///     <c>AddWorkspaceReferenceStream&lt;MeshNode&gt;</c> factory builds
-    ///     <c>primary.Reduce&lt;InstanceCollection&gt;(CollectionReference("MeshNode"))</c> and then
-    ///     reduces THAT to the node — and <c>WorkspaceStreams.CreateReducedStream</c> registers each
-    ///     child for disposal ON ITS PARENT, which here is the data source's primary stream (hub
-    ///     lifetime). The factory runs uncached on every call that passes a <c>configuration</c> —
-    ///     i.e. once per inbound <c>SubscribeRequest</c> — so an unsubscribe reaps the subscription's
-    ///     own hub but leaves the intermediates behind. Same defect shape as #1345 (which memoized
-    ///     <c>Workspace.GetStream</c>), one layer down at <c>stream.Reduce</c>. Correlating the
-    ///     surviving hubs against the client stream ids says this is what <c>compile-state</c>'s +12
-    ///     now is: 27 of the 34 surviving <c>sync/</c> hubs match NO client mirror.</item>
-    /// </list>
+    /// <para><b>What the 12.7 → 6.2 change closed (#1324): the owner-side INTERMEDIATE reduce.</b>
+    /// <c>MeshDataSource</c>'s own-node <c>AddWorkspaceReferenceStream&lt;MeshNode&gt;</c> factory
+    /// builds <c>primary.Reduce&lt;InstanceCollection&gt;(CollectionReference("MeshNode"))</c> and
+    /// then reduces THAT to the node — and <c>WorkspaceStreams.CreateReducedStream</c> registers each
+    /// child for disposal ON ITS PARENT, which here is the data source's primary stream (hub
+    /// lifetime). The factory runs uncached on every call that passes a <c>configuration</c> — i.e.
+    /// once per inbound <c>SubscribeRequest</c> — so an unsubscribe reaped the subscription's own hub
+    /// and left the nameless intermediate behind forever. Same defect shape as #1345 (which memoized
+    /// <c>Workspace.GetStream</c>), one layer down at <c>stream.Reduce</c>. The cure is
+    /// <c>ISynchronizationStream.ReduceShared</c>: an OPT-IN memoized reduce for an intermediate
+    /// nobody owns. Opt-in, not a change to <c>Reduce</c>, because a reduced stream a caller DOES own
+    /// and disposes (the Blazor <c>LayoutAreaView</c>'s dialog / progress reduces) must not be shared
+    /// — one holder's teardown would kill another's. Measured: <c>compile-state</c> +13 → <b>0</b>
+    /// and the NodeType's own hub +3 → <b>0</b>.</para>
+    ///
+    /// <para><b>What still retains, and why the bound is 9 rather than ~2</b> — one mechanism, and it
+    /// is a NODE-LIFECYCLE question rather than a stream one. Every compile creates
+    /// <c>{typePath}/_Activity/compile-&lt;ts&gt;</c> (<c>NodeTypeCompilationHelpers.RunCompile</c>),
+    /// whose hub is activated by the first activity-log write's <c>SubscribeRequest</c> and which now
+    /// accounts for essentially the whole residual (+3–5 <c>sync/</c> apiece, plus the node hub).
+    /// Nothing in the compile path releases it at terminal status: <c>Complete(...)</c> is the last
+    /// touch, and there is no hook that drops the mirror, prunes the node, or disposes the hub.</para>
+    ///
+    /// <para>🚨 The two reclamation mechanisms that EXIST are both time-based and therefore invisible
+    /// to this test, which measures seconds: the shared mesh-node cache's idle sweep needs zero
+    /// subscribers AND ten minutes untouched (<c>MeshNodeStreamCacheOptions.ReadStreamIdleExpiration</c>),
+    /// and <c>KernelContainer.DisposeOnTimeout</c> disposes an idle node hub after fifteen — but its
+    /// timer is reset by EVERY message, and a surviving mirror heart-beats the owner every 45 s
+    /// (<c>SyncStreamOptions.HeartbeatInterval</c>), which also holds the Orleans grain up via
+    /// <c>TryDelayDeactivation</c>. So whether the residual is a permanent leak or a ~25-minute
+    /// bounded retention turns entirely on whether the activity's mirror is actually released once
+    /// the compile ends — that is the question for the next pass, and it needs a longer-horizon
+    /// measurement than this one. Do NOT "fix" it by shortening a timer.</para>
     ///
     /// <para>So this bound is a RATCHET at the measured value, not an aspiration: it fails the moment
-    /// the residual gets worse, and it is to be tightened again by whoever fixes either mechanism
-    /// above.</para>
+    /// the residual gets worse, and it is to be tightened again by whoever closes the activity-hub
+    /// mechanism above.</para>
     /// </summary>
-    private const int MaxHubsPerRecompile = 15;
+    private const int MaxHubsPerRecompile = 9;
 
     /// <summary>
     /// Live collectible contexts for this NodeType. The name is
@@ -258,15 +274,14 @@ public class NodeTypeRecompileAlcLeakTest(ITestOutputHelper output) : MonolithMe
         // Caching local reduced streams the way remote ones were always cached took it to ~9 MB
         // and 22 hubs, and took the mesh's steady-state hub count from 187 to 48.
         //
-        // 12 MB, not single digits, is deliberate. The eviction-parking retainer is fixed (#1324 —
-        // see MaxHubsPerRecompile), which took this from ~8 to ~6–7 MB per recompile; what is left
-        // belongs to the two mechanisms named there (per-compile activity NODE hubs, and the
-        // owner-side intermediate reduced streams registered on a hub-lifetime parent). Tighten this
-        // bound with whichever of those is fixed next — a bound nothing can currently pass is a red
-        // test, not a guard. Bytes also move with unrelated allocation, which is exactly why the hub
-        // delta below is the primary assertion.
+        // 8 MB, not single digits, is deliberate. Both stream-side retainers are now fixed (#1324 —
+        // see MaxHubsPerRecompile): the eviction parking took this from ~8 to ~6–7 MB, and sharing
+        // the owner-side intermediate reduce took it to 3–5 MB. What is left belongs to the
+        // per-compile activity NODE hubs named there. Tighten this bound when that is fixed — a
+        // bound nothing can currently pass is a red test, not a guard. Bytes also move with
+        // unrelated allocation, which is exactly why the hub delta below is the primary assertion.
         var perRecompile = managedGrowth / Recompiles;
-        perRecompile.Should().BeLessThan(12 * 1024 * 1024,
+        perRecompile.Should().BeLessThan(8 * 1024 * 1024,
             $"a recompile of a trivial type must return its memory; {perRecompile / (1024 * 1024)} MB "
             + $"retained per recompile ({managedGrowth / (1024 * 1024)} MB over {Recompiles}) means "
             + "compile state survives the context that owned it");


### PR DESCRIPTION
Part of #1324 — closes retainer #2, the one #1415 named as "a NEW finding that replaces this issue's guess about `compile-state`". **Does not close the issue**: the per-compile activity node hubs remain, and what is now known about them is recorded in the test.

## The retainer

`MeshDataSource`'s own-node `AddWorkspaceReferenceStream<MeshNode>` factory builds

```csharp
var collectionStream = primary?.Reduce<InstanceCollection>(new CollectionReference(nameof(MeshNode)));
return collectionStream?.Reduce((WorkspaceReference<MeshNode>)ownPathReference, configuration);
```

`WorkspaceStreams.CreateReducedStream` registers every child for disposal **on its parent**. Here the parent is `primary`, the data source's `EntityStore` stream, whose lifetime is the hub's — so each call permanently added a hosted `sync/{id}` sub-hub with its own Autofac scope, `TypeRegistry` and `JsonSerializerOptions` (~140 KB). The factory runs uncached on every call that passes a `configuration`, i.e. **once per inbound `SubscribeRequest`**, so an unsubscribe reaped the subscription's own stream and left the nameless intermediate behind forever.

That is exactly #1345's defect — an unmemoized `Workspace.GetStream` — one layer down at `stream.Reduce`.

## The fix, and why it is opt-in

`ISynchronizationStream.ReduceShared` — a memoized reduce, keyed by reference, cached on the parent, with the same liveness re-check and faulted-`Lazy` eviction as `Workspace.GetStream`.

**Opt-in rather than a change to `Reduce`, and that is load-bearing.** The rule is ownership, not depth:

| the stream is… | use | why |
|---|---|---|
| an intermediate nobody owns or disposes | `ReduceShared` | one per `(parent, reference)`, dies with the parent |
| handed to a caller who will `Dispose()` it | `Reduce` | sharing would let one holder's teardown kill another's live stream |
| caller-specific (`configuration` with a client id / subscriber) | `Reduce` | not shareable by construction |

Making every no-config `Reduce` shared was the obvious move and it is **wrong**: the Blazor `LayoutAreaView` explicitly `Dispose()`s the dialog and progress streams it reduces off its area stream (`LayoutAreaView.razor.cs:148-149`, `:174-175`), and its area stream already comes from the memoized `Workspace.GetStream` — so two views on the same layout area would share those reduces and the first to navigate away would kill the second's binding. Recording it here so nobody re-derives it.

### The trap this hit, found by the suite and worth keeping

**A cached child does not die with its parent.** `CreateReducedStream` builds the child's `sync/{id}` sub-hub under `stream.Host` — the data source's hub — so it is the parent's **sibling**, not its descendant, and it stays alive after the parent is disposed. The first cut checked only the child's liveness (copying `Workspace.GetStream`), so once a parent stream was disposed the cache happily kept serving a mirror of a dead source: reads bound to a stream that would never emit and never complete, and the reader got neither an answer nor the NACK `DataExtensions.HandleGetDataRequest`'s disposal arm owes it. It hung for its whole budget.

`SilentReadNackTest` caught it — deterministically, both arms, in isolation — because disposing the owner's data-source stream is exactly how that test manufactures an unanswerable read. `ReduceShared` now bypasses the cache entirely when the parent is disposed, falling through to a plain `Reduce` so the disposed-parent path behaves exactly as it always did. Documented in `WorkspaceReferences.md` next to the ownership table.

## Measured — `NodeTypeRecompileAlcLeakTest`, Release, three recompiles of `config => config`

| | before | after |
|---|---|---|
| **hubs / recompile** | **12.7** | **6.1** (5.3 / 7.0 / 6.3 / 6.0 / 6.0 over five runs) |
| managed / recompile | 7 MB | 3–5 MB |
| `_Activity/compile-state` >> `sync/*` | +13 | **0** |
| the NodeType's own hub >> `sync/*` | +3 | **0** |
| `cache/<mesh>` >> `sync/*` | +4 | +3 |
| `_Activity/compile-<ts>` >> `sync/*` | +6 / +6 / +5 | +3…5 apiece |

`compile-state` — the largest single bucket after #1415 — goes to **zero**, which confirms #1415's attribution quantitatively: it really was intermediates, not subscriptions.

Cumulatively on this repro: **20 MB / 63 hubs → 3–5 MB / 6.2 hubs** per recompile across #1345, #1415 and this.

Ratchet tightened: **15 → 9** hubs and **12 → 8** MB per recompile (measured max 7.0 hubs / 5 MB).

## What still retains — recorded in the test, not guessed

The residual is now essentially all the per-compile `_Activity/compile-<ts>` node hubs. This is a **node-lifecycle** question, and the useful new fact is that *two reclamation mechanisms already exist and both are time-based*, so this test — which measures seconds — cannot see either:

- the shared mesh-node cache's idle sweep (zero subscribers **and** 10 min untouched, `MeshNodeStreamCacheOptions.ReadStreamIdleExpiration`), and
- `KernelContainer.DisposeOnTimeout`, which disposes an idle node hub after 15 min — but its timer is reset by **every** message, and a surviving mirror heart-beats the owner every 45 s (`SyncStreamOptions.HeartbeatInterval`), which also holds the Orleans grain up via `TryDelayDeactivation`.

So whether the residual is a permanent leak or a ~25-minute bounded retention turns on whether the activity's mirror is released once the compile ends — nothing in the compile path does that today (`Complete(...)` is the last touch). That needs a longer-horizon measurement, and the test says so, including **do not "fix" it by shortening a timer**.

## Verification

- `dotnet build -c Release -warnaserror` clean (0 errors) for `MeshWeaver.Data`, `MeshWeaver.Graph`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Documentation.Test`; full `--no-incremental` rebuild of the Monolith test graph also clean.
- `NodeTypeRecompileAlcLeakTest` 2/2, five measurement runs.
- `MeshWeaver.Data.Test` 344/344 · `MeshWeaver.Documentation.Test` 20/20 · `MeshWeaver.Serialization.Test` 14/14 · `MeshWeaver.Messaging.Hub.Test` 218/218.
- `MeshWeaver.Hosting.Monolith.Test` full suite green (646/649, 3 skipped) — the same suite on unmodified `origin/main` was run as the control, which is what established the two `SilentReadNackTest` failures above as mine rather than pre-existing.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
