### PR TITLE
fix(#1424): the claim is a deterministic election — one builder, even across clusters

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-one-builder-even-across-clusters.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-one-builder-even-across-clusters.md
@@ -1,0 +1,21 @@
+---
+Name: One builder, even across clusters
+Category: Fix
+Description: A dedicated build process and a starting server no longer both run the build — the claim is now a deterministic election with a short convergence window, and a dedicated builder always outranks a serving pod.
+Icon: ShieldCheckmark
+Order: -20260813
+---
+
+# One builder, even across clusters
+
+The first production run of the dedicated build process surfaced a coordination gap: it and a
+starting server each believed they had won the build claim, and each ran the full build. Nothing
+corrupted — every build output is content-addressed, so both wrote the same artifacts — but the
+server paid the build's cost that the dedicated process exists to spare it.
+
+The claim decision is now a deterministic election. Registrations get a short convergence window
+so that candidates from different clusters see each other before anyone decides; then every
+decider computes the same winner from the same data, so even concurrent decisions agree.
+A dedicated build process always outranks a serving server — which is what makes servers stand
+down exactly when a dedicated builder is present, while remaining their own fallback when none
+is. Takeovers of a departed builder stay immediate, and per-part claims stay instant.

--- a/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
+++ b/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
@@ -70,7 +70,7 @@ public static class BuildCoordinationExtensions
     /// <returns>Cold observable emitting the node after the registration write.</returns>
     public static IObservable<MeshNode> RequestBuildClaim(
         this IMessageHub hub, string holder, string frameworkVersion,
-        string path = BuildNodeType.RootPath)
+        string path = BuildNodeType.RootPath, int priority = 0)
     {
         var identity = hub.ServiceProvider.GetService<IClusterMembership>()?.LocalIdentity;
         return hub.EnsureBuildNode(path)
@@ -87,7 +87,7 @@ public static class BuildCoordinationExtensions
                         RequestedClaims = (state.RequestedClaims
                             ?? ImmutableDictionary<string, BuildClaimRequest>.Empty)
                             .SetItem(holder, new BuildClaimRequest(
-                                frameworkVersion, DateTime.UtcNow, identity)),
+                                frameworkVersion, DateTime.UtcNow, identity, priority)),
                     }
                 };
             }));

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -53,6 +53,16 @@ public static class BuildNodeType
     public static readonly TimeSpan HeartbeatInterval = TimeSpan.FromMinutes(2);
 
     /// <summary>
+    /// How long a registration must have been visible before the arbiter may grant (#1424). One
+    /// arbiter runs per Orleans cluster that touches the node, over its own mirror of the same
+    /// durable row — the window is the time a concurrent registration from ANOTHER cluster needs
+    /// to propagate (a Postgres NOTIFY plus a mirror refresh, measured sub-second; 5 s covers a
+    /// slow feed) so that every arbiter elects from the same candidate set and computes the same
+    /// winner. Costs 5 s once per build against a bake measured in minutes.
+    /// </summary>
+    public static readonly TimeSpan GrantSettleWindow = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Registers the Build node type on the mesh builder by adding its MeshNode definition.
     /// </summary>
     /// <typeparam name="TBuilder">The mesh builder type.</typeparam>
@@ -124,7 +134,17 @@ public static class BuildNodeType
                     "|",
                     state!.RequestedClaims!.Keys.OrderBy(k => k, StringComparer.Ordinal)
                         .Append(state.ClaimedBy ?? string.Empty)))
-                .DistinctUntilChanged(),
+                .DistinctUntilChanged()
+                // A registration inside the settle window arbitrates to "not yet" (#1424), and no
+                // further emission is coming if nobody else registers — so every trigger also
+                // schedules ONE re-check just past the window. Redundant re-checks are free: an
+                // already-granted (or still-too-young) node comes back unchanged and writes
+                // nothing. SelectMany (not Switch): a second candidate's trigger must not cancel
+                // the first's pending re-check.
+                .SelectMany(key => Observable
+                    .Timer(GrantSettleWindow + TimeSpan.FromSeconds(1))
+                    .Select(_ => key)
+                    .StartWith(key)),
             _ => TryArbitrate(),
             hub.Address,
             logger,
@@ -168,8 +188,33 @@ public static class BuildNodeType
         if (HolderStillHoldsIt(state, now, membership))
             return node;
 
+        // 🚨 #1424 — CONVERGE BEFORE DECIDING, on the ROOT. There is one arbiter per Orleans
+        // cluster that touches this node (a bake Job's cluster and the serving cluster each
+        // activate their own hub over the same durable row), so the grant must be a DETERMINISTIC
+        // ELECTION over data both sides have seen — never "first arbiter to look wins", which is
+        // how the pilot got two winners and two full bakes. Holding the grant until the oldest
+        // registration has had a propagation window lets a concurrent registration from the other
+        // cluster land; the ordering below then computes the SAME winner on every arbiter, making
+        // concurrent grant writes idempotent. Under partition this degrades to the pilot's
+        // behaviour (a redundant bake into content-addressed stores), never a wedge and never
+        // corruption.
+        //
+        // FRESH ROOT ELECTIONS ONLY. The race this window closes is the simultaneous-boot one —
+        // several processes registering on an UNCLAIMED root within milliseconds of a rollout. A
+        // TAKEOVER is a different shape: the successor queue accumulated while the holder was
+        // alive and is long converged, and #1355's immediate-takeover property must not wait on a
+        // window. Chunks are excluded too: the root election decides THE builder, chunk claims
+        // arrive pre-arbitrated by it, and 37 chunks × 5 s of settle would put minutes of pure
+        // waiting into a bake measured at ~1m42s. When parallel builders make chunk contention
+        // real, chunk elections get the same treatment.
+        if (state.ClaimedBy is null
+            && string.Equals(node.Path, RootPath, StringComparison.OrdinalIgnoreCase)
+            && now - pending.Min(kv => kv.Value.RequestedAt) < GrantSettleWindow)
+            return node;
+
         var granted = pending
-            .OrderBy(kv => kv.Value.RequestedAt)
+            .OrderByDescending(kv => kv.Value.Priority)
+            .ThenBy(kv => kv.Value.RequestedAt)
             .ThenBy(kv => kv.Key, StringComparer.Ordinal)
             .First();
 

--- a/src/MeshWeaver.Graph/Configuration/BuildState.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildState.cs
@@ -36,8 +36,18 @@ public enum BuildStatus
 /// <see cref="BuildState.ClaimedByIdentity"/> when it grants, which is what lets a later takeover
 /// decision ask membership instead of a clock.
 /// </param>
+/// <param name="Priority">
+/// Election precedence — HIGHER wins before any timestamp is compared (#1424). A dedicated bake
+/// process registers at <see cref="BakePriority"/> so it beats every serving pod whenever both
+/// are candidates; serving pods register at the default 0 and thereby stand down exactly when a
+/// dedicated builder is present, while remaining the fallback when none is.
+/// </param>
 public sealed record BuildClaimRequest(
-    string FrameworkVersion, DateTime RequestedAt, string? ClusterIdentity = null);
+    string FrameworkVersion, DateTime RequestedAt, string? ClusterIdentity = null, int Priority = 0)
+{
+    /// <summary>The election precedence a dedicated bake process registers with.</summary>
+    public const int BakePriority = 1;
+}
 
 /// <summary>
 /// One completed build — the GO record for a framework fingerprint, kept as history on the root's

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -70,7 +70,18 @@ public static class BuildProtocolDriver
         var holder = $"{Environment.MachineName}/{Guid.NewGuid():N}";
         var fingerprint = report.FrameworkVersion;
 
-        return mesh.RequestBuildClaim(holder, fingerprint)
+        // A DEDICATED bake process outranks every serving pod in the claim election (#1424): when
+        // a bake Job is running, the pods lose deterministically, follow its GO, and never pay the
+        // bake's cost — and when none is, priority 0 candidates elect among themselves and the
+        // pods remain their own fallback. Same mode key the host's bake entrypoint switches on.
+        var priority = string.Equals(
+            mesh.ServiceProvider.GetService<Microsoft.Extensions.Configuration.IConfiguration>()
+                ?["Deployment:Mode"],
+            "Bake", StringComparison.OrdinalIgnoreCase)
+            ? BuildClaimRequest.BakePriority
+            : 0;
+
+        return mesh.RequestBuildClaim(holder, fingerprint, priority: priority)
             .SelectMany(_ => mesh.ObserveBuildClaim(holder)
                 .Take(1)
                 .Timeout(GrantWindow)

--- a/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
@@ -182,6 +182,110 @@ public class BuildCoordinationTest(ITestOutputHelper output) : MonolithMeshTestB
         result.RequestedClaims.Should().ContainKey("late");
     }
 
+    // ---- The cross-cluster election (#1424): priority, convergence window, determinism ----
+    //
+    // One arbiter runs per Orleans cluster that touches the node, each over its own mirror of the
+    // same durable row — so the grant must be a deterministic election over converged data, never
+    // "first arbiter to look wins" (the pilot's double bake).
+
+    /// <summary>
+    /// A dedicated bake process beats every serving pod, however much earlier the pod registered —
+    /// this is what makes the pods stand down exactly when a bake Job is present.
+    /// </summary>
+    [Fact]
+    public void Arbitrate_PriorityOutranksAnEarlierRegistration()
+    {
+        var t0 = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+        var node = BuildNode(new BuildState
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add("pod", new BuildClaimRequest("fp", t0))
+                .Add("bake-job", new BuildClaimRequest(
+                    "fp", t0.AddSeconds(3), Priority: BuildClaimRequest.BakePriority)),
+        });
+
+        var result = BuildNodeType.Arbitrate(node, Options, t0.AddSeconds(10))
+            .ContentAs<BuildState>(Options)!;
+
+        result.ClaimedBy.Should().Be("bake-job");
+        result.RequestedClaims.Should().ContainKey("pod");
+    }
+
+    /// <summary>
+    /// A fresh root election inside the settle window grants NOTHING — same reference back, no
+    /// write — because a concurrent registration from another cluster may still be propagating.
+    /// The re-check timer, not a new emission, is what revisits it.
+    /// </summary>
+    [Fact]
+    public void Arbitrate_FreshRootElection_WaitsOutTheSettleWindow()
+    {
+        var t0 = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+        var node = BuildNode(new BuildState
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add("pod", new BuildClaimRequest("fp", t0)),
+        });
+
+        BuildNodeType.Arbitrate(
+                node, Options, t0 + BuildNodeType.GrantSettleWindow - TimeSpan.FromSeconds(1))
+            .Should().BeSameAs(node);
+
+        BuildNodeType.Arbitrate(
+                node, Options, t0 + BuildNodeType.GrantSettleWindow + TimeSpan.FromSeconds(1))
+            .ContentAs<BuildState>(Options)!.ClaimedBy.Should().Be("pod");
+    }
+
+    /// <summary>
+    /// Chunk claims are NOT window-gated: the root election already decided the builder, and 37
+    /// chunks × 5 s of settle would put minutes of pure waiting into a ~2-minute bake.
+    /// </summary>
+    [Fact]
+    public void Arbitrate_ChunkClaims_GrantWithoutTheWindow()
+    {
+        var t0 = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+        var chunk = new MeshNode("Chess", "Admin/Build")
+        {
+            NodeType = BuildNodeType.NodeType,
+            Content = new BuildState
+            {
+                RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                    .Add("winner", new BuildClaimRequest("fp", t0)),
+            },
+        };
+
+        BuildNodeType.Arbitrate(chunk, Options, t0.AddSeconds(1))
+            .ContentAs<BuildState>(Options)!.ClaimedBy.Should().Be("winner");
+    }
+
+    /// <summary>
+    /// The property the whole fix rests on: two arbiters looking at the SAME converged data
+    /// compute the SAME winner, so their concurrent grant writes are idempotent instead of
+    /// last-write-wins. Asserted over both discriminators (priority and timestamp) at once.
+    /// </summary>
+    [Fact]
+    public void Arbitrate_IsDeterministic_AcrossArbiters()
+    {
+        var t0 = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+        var state = new BuildState
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add("pod-a", new BuildClaimRequest("fp", t0.AddMilliseconds(1)))
+                .Add("pod-b", new BuildClaimRequest("fp", t0.AddMilliseconds(2)))
+                .Add("bake-job", new BuildClaimRequest(
+                    "fp", t0.AddMilliseconds(3), Priority: BuildClaimRequest.BakePriority)),
+        };
+        var now = t0.AddSeconds(10);
+
+        var one = BuildNodeType.Arbitrate(BuildNode(state), Options, now)
+            .ContentAs<BuildState>(Options)!;
+        var two = BuildNodeType.Arbitrate(BuildNode(state), Options, now)
+            .ContentAs<BuildState>(Options)!;
+
+        one.ClaimedBy.Should().Be("bake-job");
+        two.ClaimedBy.Should().Be(one.ClaimedBy);
+        two.ClaimedAt.Should().Be(one.ClaimedAt);
+    }
+
     [Fact]
     public void Arbitrate_LeavesLiveClaimAlone()
     {


### PR DESCRIPTION
Fixes #1424 — the bake-mode pilot's finding: one arbiter per Orleans cluster over the same durable row, each granting its own candidate before the other's registration propagated → two winners, two full bakes.

## The election

- **Priority outranks time.** `BuildClaimRequest.Priority` — a dedicated bake process registers at `BakePriority` and beats every serving pod. This is what "disables any other bake": pods stand down deterministically whenever a Job is present, and remain their own fallback when none is — no config kill-switch, no hard dependency on the Job.
- **Fresh root elections converge before deciding.** `GrantSettleWindow` (5 s — a NOTIFY + mirror refresh measured sub-second) holds the grant until concurrent registrations from other clusters have landed; then priority → earliest → holder-ordinal computes the **same winner on every arbiter**, so concurrent grant writes are idempotent instead of last-write-wins. Under partition it degrades to the pilot's behaviour (redundant bake into content-addressed stores) — never a wedge, never corruption.
- **Deliberately not window-gated:** takeovers of a departed holder (#1355's immediate-takeover property — the successor queue is long converged) and chunk claims (pre-arbitrated by the root election; 37 × 5 s would put minutes of waiting into a ~2-minute bake).
- The arbiter schedules one re-check just past the window per trigger — a too-young election produces no further emission on its own.

## Verified

Four new pure election tests (priority-outranks-earlier, window-on-fresh-root-only, chunks-exempt, cross-arbiter determinism) alongside the existing protocol, membership-takeover and integration suites — 14/14 green under Release `-warnaserror`. Prod verification on the next roll: the Job's log should show the bake, the pod's log the GO-follow with `compiled=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)