### PR TITLE
fix(release): every packable project ships with readme + description — pack the whole solution clean

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,7 +1,7 @@
 name: Publish Container Images
 
 # Prod release path for the Memex deployment images. Fires on the SAME v*.*.* tag as
-# release-packages.yml (NuGet) so one tag ships the Aspire.Hosting.Memex package AND the
+# release-packages.yml (NuGet) so one tag ships the MeshWeaver.Aspire.Hosting.Memex package AND the
 # images the generated compose/Helm/ACA artifacts reference. Local testing uses the local
 # registry instead (see deploy/ + the repo's local-publish flow) — never this workflow.
 on:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Pack NuGet packages
       run: dotnet pack --configuration Release --no-build --output ./nupkgs /p:PackageVersion=${{ env.VERSION }}
 
-    - name: Create nuget.config
-      run: |
-
+    # --skip-duplicate makes a re-run idempotent: a push that died midway (transient 5xx,
+    # rate limit) can be re-fired and completes the remaining packages instead of failing
+    # on the first 409 for one already published.
     - name: publish to nuget.org
-      run: dotnet nuget push ./nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PAT }}
+      run: dotnet nuget push ./nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PAT }} --skip-duplicate

--- a/deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj
+++ b/deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj
@@ -11,7 +11,7 @@
 
   <!-- The Memex Aspire integration (builder.AddMemex). Project-referenced from the monorepo
        here; a true standalone customer solution swaps this for the published
-       <PackageReference Include="Aspire.Hosting.Memex" />. -->
+       <PackageReference Include="MeshWeaver.Aspire.Hosting.Memex" />. -->
   <ItemGroup>
     <ProjectReference Include="..\..\..\memex\aspire\Memex.Aspire.Hosting\Memex.Aspire.Hosting.csproj"
                       IsAspireProjectResource="false" />

--- a/deploy/aspire/Memex.Deploy.AppHost/Program.cs
+++ b/deploy/aspire/Memex.Deploy.AppHost/Program.cs
@@ -1,7 +1,7 @@
 // Dedicated, image-based deployment AppHost for the MeshWeaver Memex portal.
 //
 // Mirrors the conventions of the main memex/aspire/Memex.AppHost, but deploys the PUBLISHED
-// GHCR images via the Aspire.Hosting.Memex integration (builder.AddMemex → AddContainer) rather
+// GHCR images via the MeshWeaver.Aspire.Hosting.Memex integration (builder.AddMemex → AddContainer) rather
 // than building the portal from source. One model → many artifacts via the Aspire publishers:
 //
 //   aspire publish --apphost deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj \

--- a/memex/aspire/Memex.Aspire.Hosting/Memex.Aspire.Hosting.csproj
+++ b/memex/aspire/Memex.Aspire.Hosting/Memex.Aspire.Hosting.csproj
@@ -5,7 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>
-    <PackageId>Aspire.Hosting.Memex</PackageId>
+    <!-- 🚨 NOT `Aspire.Hosting.Memex`: nuget.org reserves the `Aspire.*` prefix for Microsoft
+         and its partners (every one of the 100+ published Aspire.* ids is prefix-verified), so a
+         push of a NEW id under it from this account is rejected — and since that nupkg sorts
+         first in the publish glob, it would fail the whole release-packages run. Vendor-prefixed
+         is the sanctioned shape for third-party Aspire integrations. -->
+    <PackageId>MeshWeaver.Aspire.Hosting.Memex</PackageId>
     <Description>Aspire hosting integration for the MeshWeaver Memex portal. builder.AddMemex() wires Postgres (pgvector) + a one-shot DB migration + the portal from published GHCR images; publish to Docker Compose, Kubernetes/Helm, or Azure Container Apps with the standard Aspire publishers.</Description>
     <Authors>Systemorph</Authors>
     <PackageTags>aspire;hosting;meshweaver;memex;mesh</PackageTags>

--- a/memex/aspire/Memex.Aspire.Hosting/README.md
+++ b/memex/aspire/Memex.Aspire.Hosting/README.md
@@ -1,4 +1,4 @@
-# Aspire.Hosting.Memex
+# MeshWeaver.Aspire.Hosting.Memex
 
 Aspire hosting integration for the MeshWeaver Memex portal. `builder.AddMemex(...)` composes
 a complete portal deployment from published container images — no portal source tree needed —

--- a/memex/aspire/Memex.Aspire.Hosting/README.md
+++ b/memex/aspire/Memex.Aspire.Hosting/README.md
@@ -1,0 +1,30 @@
+# Aspire.Hosting.Memex
+
+Aspire hosting integration for the MeshWeaver Memex portal. `builder.AddMemex(...)` composes
+a complete portal deployment from published container images — no portal source tree needed —
+and the standard Aspire publishers turn that one model into Docker Compose, Kubernetes/Helm,
+or Azure Container Apps artifacts.
+
+## Usage
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddMemex("memex", o => o
+    .WithBackend("Filesystem")
+    .WithOrleansClustering("AdoNet")
+    .WithImage(tag: "3.0.0-rc1"));
+
+builder.Build().Run();
+```
+
+## What it wires
+
+- PostgreSQL (pgvector) with a persistent volume
+- The one-shot database migration container, ordered before the portal
+- The portal container (`memex-portal` / `memex-portal-ai`) from the published image tag
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Connection.SignalR/MeshWeaver.Connection.SignalR.csproj
+++ b/src/MeshWeaver.Connection.SignalR/MeshWeaver.Connection.SignalR.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Client-side SignalR connection for MeshWeaver: connect an out-of-process .NET message hub to a running mesh over SignalR.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
   </ItemGroup>

--- a/src/MeshWeaver.Connection.SignalR/README.md
+++ b/src/MeshWeaver.Connection.SignalR/README.md
@@ -1,0 +1,16 @@
+# MeshWeaver.Connection.SignalR
+
+Client-side SignalR transport for MeshWeaver. Connects an out-of-process .NET message hub
+(a desktop app, a service, a test host) to a running mesh over the portal's SignalR endpoint,
+so it can exchange messages with in-mesh hubs as if it were local.
+
+## Features
+
+- `SignalRClientExtensions` — fluent configuration to attach a SignalR connection to a `MessageHubConfiguration`
+- Automatic serialization of mesh messages over the SignalR wire
+- Pairs with `MeshWeaver.Hosting.SignalR`, which hosts the server side of the same connection
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshWeaver.ContentCollections.Indexing.Graph.csproj
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshWeaver.ContentCollections.Indexing.Graph.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Mesh/portal integration for MeshWeaver content indexing: change-driven indexing activities, chunk autocomplete, and AI summarization.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- IChatClient / ChatMessage / ChatResponse for the ISummarizer impl. The concrete client
          is supplied by the host (it is not a globally-registered DI service in this codebase). -->

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/README.md
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.ContentCollections.Indexing.Graph
+
+Mesh/portal integration for the MeshWeaver content indexing pipeline. Watches content
+collections for changes, runs indexing as mesh activities, and surfaces the index in the
+portal (autocomplete, settings).
+
+## Features
+
+- `ContentIndexingObserver` / `ContentIndexingActivity` — change-driven re-indexing as activity-control-plane operations
+- `ContentChunkAutocompleteProvider` — chunk search results in `@` autocomplete
+- `ChatClientSummarizer` / `ChatClientImageDescriber` — AI-generated summaries and image descriptions for indexed content
+- `ContentIndexSettingsTab` — per-space index configuration in the portal settings
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>PostgreSQL/pgvector storage for MeshWeaver content indexing: chunked content vector store with embedding-provider integration.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Npgsql" />
     <PackageReference Include="Pgvector" />

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/README.md
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/README.md
@@ -1,0 +1,16 @@
+# MeshWeaver.ContentCollections.Indexing.PostgreSql
+
+PostgreSQL storage for the MeshWeaver content indexing pipeline. Stores content chunks and
+their embeddings in pgvector and serves chunk-level vector search.
+
+## Features
+
+- `PostgreSqlChunkedContentVectorStore` — pgvector-backed chunk store with cosine search
+- `PostgreSqlContentChunkSchema` — schema management for the chunk tables
+- `EmbeddingProviderChunkEmbedder` — bridges `IEmbeddingProvider` (see `MeshWeaver.Hosting.Embeddings`) into the indexing pipeline
+- `PostgreSqlContentIndexingExtensions` — one-call registration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.ContentCollections.Indexing/MeshWeaver.ContentCollections.Indexing.csproj
+++ b/src/MeshWeaver.ContentCollections.Indexing/MeshWeaver.ContentCollections.Indexing.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Content-to-vector indexing pipeline for MeshWeaver: chunking, document tracking, and chunk-search abstractions, storage- and embedding-agnostic.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="UglyToad.PdfPig" />
     <PackageReference Include="DocSharp.Markdown" />

--- a/src/MeshWeaver.ContentCollections.Indexing/README.md
+++ b/src/MeshWeaver.ContentCollections.Indexing/README.md
@@ -1,0 +1,20 @@
+# MeshWeaver.ContentCollections.Indexing
+
+Core content-to-vector indexing pipeline for MeshWeaver content collections. Splits content
+into chunks, tracks per-file `Document` records, and exposes chunk-level search abstractions.
+This package is storage- and embedding-agnostic — pair it with
+`MeshWeaver.ContentCollections.Indexing.PostgreSql` (pgvector store) and
+`MeshWeaver.ContentCollections.Indexing.Graph` (portal integration).
+
+## Features
+
+- `ContentIndexingService` — the chunk/embed/store pipeline over content collections
+- `ContentChunk` / `ChunkPosition` — chunk model with stable positions into the source file
+- `Document` / `DocumentInfo` — per-file index bookkeeping
+- `ContentChunkSearch` — search API over indexed chunks
+- `ContentIndexingOptions` — chunking and indexing configuration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Courses/MeshWeaver.Courses.csproj
+++ b/src/MeshWeaver.Courses/MeshWeaver.Courses.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Course authoring and delivery for MeshWeaver: course, module, and exercise node types with attempt tracking and validation.</Description>
     <ProjectGuid>{9f4c2d71-6b3e-4a8f-b2d5-1c7e9a0f4b62}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>

--- a/src/MeshWeaver.Courses/README.md
+++ b/src/MeshWeaver.Courses/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Courses
+
+Course authoring and delivery on the MeshWeaver mesh. Defines the node types and layout
+areas for structured learning content: courses containing modules containing exercises,
+with per-user attempt tracking and automatic validation.
+
+## Features
+
+- `Course` / `Exercise` / `ExerciseAttempt` node types with their layout areas
+- `CourseConfiguration` / `ModuleConfiguration` / `ExerciseConfiguration` — fluent course definition
+- `ExerciseValidationWatcher` — reactive validation of submitted attempts
+- `CourseNavigationProvider` — course structure in portal navigation
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-official-release-publishes-every-package.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-official-release-publishes-every-package.md
@@ -1,0 +1,26 @@
+---
+Name: An official release publishes every package again
+Category: Fix
+Description: Cutting an official release stopped halfway — newer components were missing the packaging metadata the publish step insists on, so nothing reached nuget.org. Every component now carries its documentation and ships.
+Icon: Sparkle
+Order: -20260813
+---
+
+# An official release publishes every package again
+
+Cutting an official release — the tagged kind that publishes the platform's packages to
+nuget.org — quietly stopped working somewhere between the last release and this one. The
+release run went red at the packaging step and not a single package was published.
+
+The cause was growth without ceremony: twenty-one components added since the previous release
+never received the short readme that nuget.org displays on a package's page, and the publish
+step — correctly — refuses to ship a package that promises a readme and does not contain one.
+One component had the opposite problem and packed its readme twice, and the project template
+package assembled its content in an order that only worked on a machine that had built it
+before, so on a clean release runner it packed empty.
+
+All of it is fixed at the source: every published component now carries a real readme and a
+description that will show up properly on nuget.org, the duplicate is gone, and the template
+package generates its content before — not after — the packaging step collects it. The whole
+publish sequence was replayed locally end-to-end, producing all seventy-six packages, before
+this change was allowed in.

--- a/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
+++ b/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Git synchronization for MeshWeaver content: sync mesh node trees with git repositories, including AI-content export and history.</Description>
     <ProjectGuid>{f3a7c2e1-9b4d-4e6a-8c1f-2d5e7a9b0c34}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/MeshWeaver.GitSync/README.md
+++ b/src/MeshWeaver.GitSync/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.GitSync
+
+Git synchronization for MeshWeaver content. Syncs mesh node trees with git repositories in
+both directions — pull repository content into the mesh, push mesh edits back as commits —
+configured per space via a `_GitSync` node.
+
+## Features
+
+- `GitCli` / `GitCredentials` — credentialed git operations against the configured remote
+- `ActivityRunner` — sync runs as activity-control-plane operations with progress and logs
+- `AiContentDiskWriter` / `ContentAssetMapper` — maps node content (markdown, code, assets) to repository file layout
+- `GitHistoryTab` and sync menu/areas in the portal
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Hosting.Embeddings/MeshWeaver.Hosting.Embeddings.csproj
+++ b/src/MeshWeaver.Hosting.Embeddings/MeshWeaver.Hosting.Embeddings.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Embedding provider abstraction for MeshWeaver with Azure AI Foundry and Ollama implementations, powering vector search and content indexing.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.AI.Inference" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/MeshWeaver.Hosting.Embeddings/README.md
+++ b/src/MeshWeaver.Hosting.Embeddings/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Hosting.Embeddings
+
+Embedding provider abstraction for MeshWeaver. Supplies the text-embedding capability used
+by mesh vector search and content indexing, with implementations for hosted and local models.
+
+## Features
+
+- `IEmbeddingProvider` — the single embedding abstraction the mesh consumes
+- `AzureFoundryEmbeddingProvider` — Azure AI Foundry embedding models
+- `OllamaEmbeddingProvider` — local models via Ollama
+- `NullEmbeddingProvider` — explicit no-embedding fallback (structured search only)
+- `EmbeddingExtensions` / `EmbeddingOptions` — registration and configuration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj
+++ b/src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>gRPC transport for the MeshWeaver mesh: connect external clients or services over gRPC/gRPC-web.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/MeshWeaver.Hosting.Grpc/README.md
+++ b/src/MeshWeaver.Hosting.Grpc/README.md
@@ -1,0 +1,16 @@
+# MeshWeaver.Hosting.Grpc
+
+gRPC transport for the MeshWeaver mesh. Hosts a gRPC service (`mesh.proto`) that lets
+external clients — non-.NET clients, browser apps via gRPC-web, or other services — exchange
+mesh messages and subscribe to streams.
+
+## Features
+
+- `MeshGrpcService` — the mesh message/stream surface as a gRPC service
+- `GrpcConnectionRegistry` — tracks connected clients and routes replies
+- `GrpcHostingExtensions` / `GrpcOptions` — hosting registration and configuration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Hosting.SignalR/MeshWeaver.Hosting.SignalR.csproj
+++ b/src/MeshWeaver.Hosting.SignalR/MeshWeaver.Hosting.SignalR.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Server-side SignalR hosting for MeshWeaver: the hub endpoint that browser and .NET clients connect to.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/MeshWeaver.Hosting.SignalR/README.md
+++ b/src/MeshWeaver.Hosting.SignalR/README.md
@@ -1,0 +1,16 @@
+# MeshWeaver.Hosting.SignalR
+
+Server-side SignalR hosting for MeshWeaver. Exposes the SignalR hub endpoint through which
+browser clients (including the Blazor portal's JS interop) and external .NET clients
+(`MeshWeaver.Connection.SignalR`) attach to the mesh.
+
+## Features
+
+- `SignalRConnectionHub` — the hub endpoint carrying mesh messages
+- `SignalRConnectionRegistry` — connection lifetime and routing
+- `SignalRHostingExtensions` — one-call registration on the host
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Hosting.Snowflake/MeshWeaver.Hosting.Snowflake.csproj
+++ b/src/MeshWeaver.Hosting.Snowflake/MeshWeaver.Hosting.Snowflake.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Snowflake storage backend for MeshWeaver: mesh persistence, change feed, cross-schema queries, and access projection on Snowflake.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Snowflake.Data" />
   </ItemGroup>

--- a/src/MeshWeaver.Hosting.Snowflake/README.md
+++ b/src/MeshWeaver.Hosting.Snowflake/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Hosting.Snowflake
+
+Snowflake storage backend for MeshWeaver. Persists mesh nodes in Snowflake, serves mesh
+queries across schemas, and surfaces changes through a polling change feed.
+
+## Features
+
+- `SnowflakeEventLogStore` — the mesh event/version log on Snowflake
+- `SnowflakeChangeFeedPoller` (+ hosted service) — change propagation into mesh streams
+- `SnowflakeCrossSchemaQueryProvider` — mesh queries spanning partition schemas
+- `SnowflakeAccessControl` / `SnowflakeAccessProjection` — access rules projected into queries
+- `SnowflakeCapabilities` / `SnowflakeConnectionSource` — backend capability declaration and connections
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Hosting.Sqlite/MeshWeaver.Hosting.Sqlite.csproj
+++ b/src/MeshWeaver.Hosting.Sqlite/MeshWeaver.Hosting.Sqlite.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>SQLite storage backend for MeshWeaver, including local vector search — lightweight single-file persistence for dev and edge scenarios.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <!-- Override the transitive SQLitePCLRaw.lib.e_sqlite3 2.1.11 (vuln GHSA-2m69-gcr7-jv3q / NU1903)

--- a/src/MeshWeaver.Hosting.Sqlite/README.md
+++ b/src/MeshWeaver.Hosting.Sqlite/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Hosting.Sqlite
+
+SQLite storage backend for MeshWeaver. Single-file, zero-infrastructure persistence for
+development, testing, and edge deployments — including local vector search.
+
+## Features
+
+- `SqliteStorageAdapter` / `SqlitePartitionStorageProvider` — mesh node persistence per partition
+- `SqliteEventLogStore` — the mesh event/version log
+- `SqliteVectorMeshQuery` — vector-backed free-text mesh search on SQLite
+- `ITextEmbedder` with `OllamaTextEmbedder` — local embeddings for the vector index
+- `SqliteExtensions` — one-call registration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.InstanceSync/MeshWeaver.InstanceSync.csproj
+++ b/src/MeshWeaver.InstanceSync/MeshWeaver.InstanceSync.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Cross-instance synchronization for MeshWeaver portals: OAuth-paired portals exchanging partition content.</Description>
     <ProjectGuid>{a2e5d7c9-4f1b-4a8e-9c3d-7b6a0e2f8d15}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/MeshWeaver.InstanceSync/README.md
+++ b/src/MeshWeaver.InstanceSync/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.InstanceSync
+
+Cross-instance synchronization for MeshWeaver portals. Pairs two portals via OAuth and keeps
+selected partitions in sync between them — the mechanism behind mirroring content across
+deployments.
+
+## Features
+
+- `InstanceOAuthService` — pairing and token exchange between portals
+- `InstanceSyncCoordinator` — drives sync runs over the configured partitions
+- `InstanceSyncPartitionSyncSourceProvider` — partition content as a sync source
+- `InstanceSyncLayoutArea` + menu integration — configure and monitor sync in the portal
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Maui.Abstractions/MeshWeaver.Maui.Abstractions.csproj
+++ b/src/MeshWeaver.Maui.Abstractions/MeshWeaver.Maui.Abstractions.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Shared abstractions for the MeshWeaver MAUI client: control manifests and projections consumed by both the server and the mobile app.</Description>
+  </PropertyGroup>
+
   <!--
     MAUI-FREE logic shared by the native MAUI view pack (MeshWeaver.Maui).
 

--- a/src/MeshWeaver.Maui.Abstractions/README.md
+++ b/src/MeshWeaver.Maui.Abstractions/README.md
@@ -1,0 +1,16 @@
+# MeshWeaver.Maui.Abstractions
+
+Shared abstractions between the MeshWeaver server and the MAUI mobile client. Declares the
+control manifest and projection contracts the server uses to shape layout-area content for
+native rendering — without taking any MAUI dependency itself.
+
+## Features
+
+- `MauiControlManifest` — the set of controls the mobile client can render
+- `MauiChatProjection` / `MauiItemTemplateProjection` — server-side projections of chat and list content
+- `MauiHref`, `MauiComboboxFilter`, `MauiOptionCoercion` — navigation and input shaping helpers
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.NuGet.AzureBlob/MeshWeaver.NuGet.AzureBlob.csproj
+++ b/src/MeshWeaver.NuGet.AzureBlob/MeshWeaver.NuGet.AzureBlob.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Azure Blob Storage package cache for MeshWeaver's in-process NuGet resolver.</Description>
     <RootNamespace>MeshWeaver.NuGet.AzureBlob</RootNamespace>
   </PropertyGroup>
 

--- a/src/MeshWeaver.NuGet.AzureBlob/README.md
+++ b/src/MeshWeaver.NuGet.AzureBlob/README.md
@@ -1,0 +1,14 @@
+# MeshWeaver.NuGet.AzureBlob
+
+Azure Blob Storage implementation of the MeshWeaver NuGet package cache. Lets a multi-silo
+deployment share one resolved-package cache instead of each pod downloading independently.
+
+## Features
+
+- `BlobNuGetPackageCache` — `INuGetPackageCache` over an Azure Blob container
+- `BlobNuGetPackageCacheExtensions` — registration on the host
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.NuGet/MeshWeaver.NuGet.csproj
+++ b/src/MeshWeaver.NuGet/MeshWeaver.NuGet.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>In-process NuGet package resolution for MeshWeaver: powers `#r \"nuget:...\"` in scripts and dynamically compiled node types.</Description>
     <RootNamespace>MeshWeaver.NuGet</RootNamespace>
   </PropertyGroup>
 

--- a/src/MeshWeaver.NuGet/MeshWeaver.NuGet.csproj
+++ b/src/MeshWeaver.NuGet/MeshWeaver.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>In-process NuGet package resolution for MeshWeaver: powers `#r \"nuget:...\"` in scripts and dynamically compiled node types.</Description>
+    <Description>In-process NuGet package resolution for MeshWeaver: powers #r "nuget:..." in scripts and dynamically compiled node types.</Description>
     <RootNamespace>MeshWeaver.NuGet</RootNamespace>
   </PropertyGroup>
 

--- a/src/MeshWeaver.NuGet/README.md
+++ b/src/MeshWeaver.NuGet/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.NuGet
+
+In-process NuGet package resolution for MeshWeaver. Resolves `#r "nuget:..."` directives in
+scripts, notebooks, and dynamically compiled node types against configured feeds — at
+runtime, inside the portal process.
+
+## Features
+
+- `NuGetDirectiveParser` — extracts package references from source
+- `INuGetAssemblyResolver` / `NuGetAssemblyResolver` — resolves packages to metadata references for Roslyn compilation
+- `INuGetPackageCache` with `FileSystemNuGetPackageCache` — download-once package caching
+- `ResolvedPackageSet` — the resolved closure handed to the compiler
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Observability.Contract/MeshWeaver.Observability.Contract.csproj
+++ b/src/MeshWeaver.Observability.Contract/MeshWeaver.Observability.Contract.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Contracts for MeshWeaver observability: log parsing, severity model, structural incident identity, and burst aggregation.</Description>
     <ProjectGuid>{3b9e05c7-14da-4f62-9a88-cd2e7f610b93}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/MeshWeaver.Observability.Contract/README.md
+++ b/src/MeshWeaver.Observability.Contract/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Observability.Contract
+
+Contracts and pure logic for MeshWeaver observability — shared by the ingest service and
+anything that reads or reports incidents.
+
+## Features
+
+- `LogLineParser` / `LogSeverity` — log line model and parsing
+- `ILogIncidentIdentity` with `StructuralLogIncidentIdentity` — fingerprinting that survives variable message parts
+- `BurstAggregator` — collapses error bursts into single incident updates
+- `LogIncidentReport` / `LogIncidentStatus` — the incident wire model
+- `LokiQuery` — query model for the Loki backend
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Observability/MeshWeaver.Observability.csproj
+++ b/src/MeshWeaver.Observability/MeshWeaver.Observability.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Log-incident control plane for MeshWeaver: watch logs, fingerprint recurring errors into incident nodes, and drive them to resolution.</Description>
     <ProjectGuid>{7f2c41ab-9d63-4e18-bb70-2a5c8e93d114}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/MeshWeaver.Observability/README.md
+++ b/src/MeshWeaver.Observability/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Observability
+
+Log-incident control plane for MeshWeaver deployments. Watches the deployment's logs,
+aggregates recurring errors by structural fingerprint, and files them as `LogIncident` nodes
+on the mesh — so production red logs become tracked, assignable work items.
+
+## Features
+
+- `LogIncidentIngestService` — log watching and incident ingestion (Loki-backed)
+- `LogIncidentNodeType` + `LogIncidentControlPlane` — incidents as mesh nodes with status transitions
+- `LogIncidentFiler` — files/updates incidents, deduplicating by structural identity
+- `LogWatchOptions` / `ObservabilityExtensions` — configuration and registration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
+++ b/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Description>Plugin catalog and installer for MeshWeaver: discover, verify, install, and update content packages from git-based registries.</Description>
+  </PropertyGroup>
+
   <!-- The mesh's "app store": browse installable folders in a git repo and install each
        folder's content into the mesh by picking a git commit + folder. Git-based, NO NuGet.
        References GitSync for the git CLI (GitCli) + NodeFileMapper, Graph for node types,

--- a/src/MeshWeaver.PluginCatalog/README.md
+++ b/src/MeshWeaver.PluginCatalog/README.md
@@ -1,0 +1,18 @@
+# MeshWeaver.PluginCatalog
+
+The MeshWeaver plugin catalog and installer — the mesh's app store. Discovers content
+packages from git-based registries, verifies them, installs them into partitions, and keeps
+them updated.
+
+## Features
+
+- `GitPackageSource` / `GitHubPackageSource` — package sources over git repositories and registry endpoints
+- `InstanceCombo*` — assembly and verification of a deployment's installed-package set
+- `InstalledPackageRepairService` — reconciles installed content against the package
+- `InstanceAutoRegistrationService` — registers an install with its registry
+- `CatalogLayoutAreas` + coupon/admin settings — the store UI in the portal
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Reactive.Assertions/MeshWeaver.Reactive.Assertions.csproj
+++ b/src/MeshWeaver.Reactive.Assertions/MeshWeaver.Reactive.Assertions.csproj
@@ -14,8 +14,4 @@
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
 </Project>

--- a/src/MeshWeaver.Social/MeshWeaver.Social.csproj
+++ b/src/MeshWeaver.Social/MeshWeaver.Social.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>Social publishing for MeshWeaver: platform publisher abstraction with a LinkedIn implementation, approval-gated publishing, and analytics.</Description>
     <ProjectGuid>{d5c9f8a1-2b7e-4c9a-9f43-6d8f2a0e7b41}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/MeshWeaver.Social/README.md
+++ b/src/MeshWeaver.Social/README.md
@@ -1,0 +1,17 @@
+# MeshWeaver.Social
+
+Social publishing on the MeshWeaver mesh. Turns mesh content into platform posts through an
+approval-gated pipeline, with LinkedIn as the first platform integration.
+
+## Features
+
+- `IPlatformPublisher` / `IPublishQueue` — the platform-agnostic publishing pipeline
+- `ApprovalToPublishHandler` — publishing gated on mesh `Approval` nodes
+- `LinkedInPublisher` / `LinkedInPublishService` / `LinkedInPostsApi` — publish, list, and manage LinkedIn posts
+- `LinkedInAnalytics` + `PastPostIngestJob` — per-post analytics and history import
+- `PlatformCredential` — per-user platform credentials as mesh data
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
+++ b/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Speech-to-text for MeshWeaver: transcriber abstraction with a Whisper container implementation for voice input in the portal.</Description>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>

--- a/src/MeshWeaver.Speech/README.md
+++ b/src/MeshWeaver.Speech/README.md
@@ -1,0 +1,15 @@
+# MeshWeaver.Speech
+
+Speech-to-text for MeshWeaver. Provides the transcription capability behind voice input in
+the portal (dictating into the chat composer), with a self-hosted Whisper implementation.
+
+## Features
+
+- `ISpeechTranscriber` — the transcription abstraction
+- `WhisperContainerTranscriber` — transcription against a Whisper container endpoint
+- `SpeechConfiguration` / `SpeechServiceExtensions` — configuration and registration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/tools/MeshWeaver.MemexTemplate.Pack/MeshWeaver.MemexTemplate.Pack.csproj
+++ b/tools/MeshWeaver.MemexTemplate.Pack/MeshWeaver.MemexTemplate.Pack.csproj
@@ -19,19 +19,34 @@
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..'))</RepoRoot>
     <TemplateRoot>$(RepoRoot)\dist\templates\</TemplateRoot>
     <GeneratorScript>$(MSBuildThisFileDirectory)..\generate-memex-template.cs</GeneratorScript>
+
+    <!-- 🚨 The template payload is GENERATED (dist/templates does not exist on a clean checkout),
+         so it must enter the package through the TargetsForTfmSpecificContentInPackage extension
+         point, whose target runs — and evaluates its ItemGroup — during pack, AFTER generation.
+         A static <Content> item with a BeforeTargets="Pack" generator is evaluated at project
+         load, when the glob matches NOTHING: pack then fails NU5017 ("no dependencies nor
+         content") on every clean machine, which is exactly how the v3.0.0-rc1 release run went
+         red. (BeforeTargets="Pack" is also too late: GenerateNuspec is a DEPENDENCY of Pack, so
+         it collects package files before any BeforeTargets="Pack" hook fires.) -->
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GenerateMemexTemplate</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="GenerateMemexTemplate" BeforeTargets="Pack">
+  <Target Name="GenerateMemexTemplate">
     <Message Text="Regenerating Memex template (v$(Version)) from memex/ source..." Importance="high" />
     <Exec Command="dotnet run &quot;$(GeneratorScript)&quot; -- &quot;$(Version)&quot; &quot;$(RepoRoot)&quot;"
           WorkingDirectory="$(RepoRoot)" />
+    <ItemGroup>
+      <_MemexTemplateFile Include="$(TemplateRoot)**\*"
+                          Exclude="$(TemplateRoot)**\bin\**;$(TemplateRoot)**\obj\**" />
+      <TfmSpecificPackageFile Include="@(_MemexTemplateFile)"
+                              PackagePath="content\%(_MemexTemplateFile.RecursiveDir)%(_MemexTemplateFile.Filename)%(_MemexTemplateFile.Extension)" />
+    </ItemGroup>
+    <Error Condition="'@(_MemexTemplateFile)' == ''"
+           Text="Template generation produced no files under $(TemplateRoot) — the package would be empty." />
   </Target>
 
   <ItemGroup>
     <None Remove="README.md" />
-    <Content Include="$(TemplateRoot)**\*"
-             Exclude="$(TemplateRoot)**\bin\**;$(TemplateRoot)**\obj\**"
-             PackagePath="content" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why

Tagging `v3.0.0-rc1` fired the official release pipeline for the first time since April — and `release-packages.yml` failed at `dotnet pack`, publishing **nothing**. CI never packs, so four months of new projects accumulated packaging debt that only a release run could surface.

## What failed (or would have failed next)

| Error | Scope | Cause |
|---|---|---|
| NU5019 | 21 projects (20 `src/` + `Memex.Aspire.Hosting`) | No `README.md`, while root `Directory.Build.props` unconditionally declares `PackageReadmeFile=README.md` |
| NU5118 | `MeshWeaver.Reactive.Assertions` | csproj packs `README.md` itself on top of the root props item → duplicate |
| NU5017 | `MeshWeaver.MemexTemplate` | Template payload is generated at pack time, but the static `<Content>` glob evaluates at project load (empty on a clean machine); `BeforeTargets="Pack"` fires after `GenerateNuspec` already collected files |
| 403 (latent) | `Aspire.Hosting.Memex` | nuget.org reserves the `Aspire.*` prefix for Microsoft + partners; this NEW id sorts first in the publish glob, so its rejection would have failed the whole push |

## Fix

- Real `README.md` + `<Description>` for each of the 21 packages — these render on nuget.org, so they're written as package documentation, not stubs.
- Removed the duplicate README item from `Reactive.Assertions`.
- `MemexTemplate.Pack` now generates + collects its content inside a `TargetsForTfmSpecificContentInPackage` target (the supported extension point that runs during pack, after generation), and fails loudly if generation produces no files instead of packing empty.
- Package id renamed `Aspire.Hosting.Memex` → **`MeshWeaver.Aspire.Hosting.Memex`** (project/assembly names unchanged), with the reasoning recorded in the csproj.

## Verification

Replayed the workflow's exact steps locally (`restore` → `build -c Release /p:Version=3.0.0-rc1` → `pack --no-build /p:PackageVersion=3.0.0-rc1`): **76 packages, 0 errors**; template package contains 308 content files; single README in Reactive.Assertions; `-warnaserror -p:CIRun=true` build green.

After merge, `v3.0.0-rc1` will be re-pointed at the merge commit and the release workflows re-fired (nothing was published by the failed run, so the version is not burned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)