### PR TITLE
fix(#1422): a compiled source no longer prunes its own release history

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-release-history-stops-being-erased-on-every-import.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-release-history-stops-being-erased-on-every-import.md
@@ -1,0 +1,35 @@
+---
+Name: Release history stops being erased on every import
+Category: Fix
+Description: Built-in areas of the platform kept only their newest release record — every earlier one was deleted the next time the content was refreshed. The whole history is kept now.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Release history stops being erased on every import
+
+Every time a live-compiled area of the platform builds successfully, it writes down a small record
+of that build: when it happened, what went into it, and the notes its author wrote. Those records
+are the release history you see on the area's page.
+
+For the parts of the platform that ship with the product — the documentation, and the built-in
+catalogs — that history was being wiped. Only the newest record ever survived; the moment the
+shipped content was refreshed, everything older vanished. Areas outside those built-in sections kept
+their full history, so the difference was easy to miss unless you happened to look at both.
+
+The cause was a disagreement about what "missing" means. Refreshing shipped content works by
+comparing what is in the product against what is in the platform, and removing anything the product
+no longer carries — that is what keeps a deleted page from lingering forever. A release record can
+never be in the product, though: it does not exist until the platform compiles the area, minutes or
+days after the product was built. So every record looked like something that had been deleted, and
+was duly removed.
+
+A related version of this was fixed earlier for content synchronised from a repository, but the fix
+had to be opted into and the built-in content never did — so it kept deleting its own history, and
+the failed cleanup attempts showed up as errors nobody could place.
+
+The platform now treats a release record as something *it* produced rather than something the
+product supplied, so its absence from the product is no longer read as a deletion. This can only
+result in fewer things being removed, never more: ordinary content that genuinely disappeared from
+the product is still cleaned up exactly as before, and a page whose name merely resembles a release
+is untouched.

--- a/src/MeshWeaver.Graph/Configuration/ReleaseNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ReleaseNodeType.cs
@@ -27,6 +27,17 @@ public static class ReleaseNodeType
     public const string NodeType = "Release";
 
     /// <summary>
+    /// The path SEGMENT release records are minted under — <c>{nodeTypePath}/Release/{version}</c>.
+    /// One declaration shared by the writer (<c>MeshDataSourceExtensions.TryCreateReleaseNode</c>)
+    /// and by every reader that has to recognise a mesh-minted release from its path alone: the
+    /// static-repo import's prune guard (a release is absent from EVERY source by construction, so
+    /// its absence is never evidence of a deletion — issues #1326 / #1422) and the sync-ignore
+    /// default. It happens to equal <see cref="NodeType"/>; it is declared separately because they
+    /// are different facts, and code that means "the path segment" must not read as a type name.
+    /// </summary>
+    public const string ReleaseSegment = "Release";
+
+    /// <summary>
     /// Registers the Release node type on the mesh builder by adding its MeshNode definition.
     /// </summary>
     /// <typeparam name="TBuilder">The mesh builder type.</typeparam>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -722,7 +722,7 @@ public static class MeshDataSourceExtensions
                 .Replace('+', '-').Replace('/', '_').TrimEnd('=')[..8];
             var version = $"{DateTime.UtcNow:yyyyMMddHHmmss}-{hash}";
 
-            var releaseNamespace = $"{nodeTypePath}/Release";
+            var releaseNamespace = $"{nodeTypePath}/{ReleaseNodeType.ReleaseSegment}";
             var releasePath = $"{releaseNamespace}/{version}";
 
             // Partition the compiler's combined {path → version} snapshot into

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -341,6 +341,13 @@ public static class StaticRepoImporter
     /// per-partition policy; the per-node <see cref="SyncBehavior"/> guard above applies in every mode
     /// (a claimed node is never a candidate).
     ///
+    /// <para>🚨 <see cref="IsMeshMintedRelease"/> is the guard for what the MESH generated rather than
+    /// the source: a compile-minted <c>{nodeTypePath}/Release/{version}</c> record cannot exist in any
+    /// repo or embedded assembly, so its absence can never be evidence of a deletion. It is checked
+    /// here — unconditionally, for every source and every mode — because #1326 fixed only the GitSync
+    /// half via <paramref name="isExcludedFromMirror"/> (default <c>false</c>) and left every COMPILED
+    /// source deleting its own release history on each import (issue #1422).</para>
+    ///
     /// <para>🚨 <paramref name="isExcludedFromMirror"/> is the FIFTH guard and the one that stops the
     /// prune from eating what the source never carries BY DESIGN
     /// (<see cref="IStaticRepoSource.IsExcludedFromMirror"/>). "Absent from the source" is only
@@ -372,6 +379,7 @@ public static class StaticRepoImporter
                         && !source.Contains(t.Path)
                         && t.SyncBehavior == SyncBehavior.Include
                         && !IsGovernance(t)
+                        && !IsMeshMintedRelease(t)
                         && isExcludedFromMirror?.Invoke(t.Path) != true
                         && !excluded.Any(root => IsAtOrUnder(t.Path, root))
                         // Additive: only prune what the source PREVIOUSLY owned — a user-added node
@@ -1527,6 +1535,39 @@ public static class StaticRepoImporter
     /// </summary>
     private static bool IsGovernance(MeshNode node) =>
         node.Segments.Skip(1).Any(seg => seg.StartsWith('_'));
+
+    /// <summary>
+    /// 🚨 A MESH-MINTED release record at <c>{nodeTypePath}/Release/{version}</c> — written by the
+    /// compile pipeline (<c>MeshDataSourceExtensions.TryCreateReleaseNode</c>) every time a NodeType
+    /// compiles. Never pruned, in any mode, by any source.
+    ///
+    /// <para><b>Why this is not covered by the existing guards (issue #1422 — the same data loss as
+    /// #1326, on a different set of partitions).</b> The prune's rule is "absent from the source ⇒
+    /// mirror it away". A release record is absent from EVERY source by construction: it does not
+    /// exist until the mesh compiles the type, so no repo and no embedded assembly can ever carry it.
+    /// <see cref="IsGovernance"/> spares <c>_</c>-prefixed segments only, which <c>Release</c> is not.
+    /// #1326 put the protection behind <see cref="IStaticRepoSource.IsExcludedFromMirror"/> — but that
+    /// hook DEFAULTS TO <c>false</c> and only <c>InMemoryStaticRepoSource</c> (GitSync) implements it,
+    /// so every COMPILED source was left unguarded: <c>DocumentationStaticRepoSource</c> overrides
+    /// neither the hook nor <see cref="IStaticRepoSource.SyncMode"/>, so the <c>Doc</c> partition ran
+    /// the default <see cref="PartitionSyncMode.FullReplace"/> and deleted its release records on every
+    /// import (issue #1422: four <c>Doc/…/Release/…</c> deletes minted 20 minutes earlier by the same
+    /// run). The tell in production: source-owned partitions held exactly ONE release per NodeType
+    /// while ordinary partitions accumulated dozens.</para>
+    ///
+    /// <para>The rule belongs HERE, at the one prune decision, rather than in each source's opt-in:
+    /// "the mesh generated it, so its absence from the source is meaningless" is a property of the
+    /// NODE, not of who is importing. It matches <c>SyncIgnore.Default</c>, which already declares
+    /// <c>Release/</c> as the platform-wide never-syncs rule — the two now agree for every source
+    /// instead of only for GitSync.</para>
+    ///
+    /// <para>Matched as a whole path SEGMENT after the partition root and case-insensitively (mesh
+    /// paths do not distinguish case — the #1326 <c>release/</c> vs <c>Release/</c> lesson), so a
+    /// partition or node whose name merely starts with "Release" is unaffected.</para>
+    /// </summary>
+    private static bool IsMeshMintedRelease(MeshNode node) =>
+        node.Segments.Skip(1).Any(seg =>
+            string.Equals(seg, ReleaseNodeType.ReleaseSegment, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Computes prerendered HTML for markdown nodes via the shared <see cref="MarkdownContent.Parse"/>

--- a/test/MeshWeaver.Graph.Test/StaticRepoImporterSyncModeTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaticRepoImporterSyncModeTest.cs
@@ -112,6 +112,81 @@ public class StaticRepoImporterSyncModeTest
         }
     }
 
+    /// <summary>
+    /// 🚨 A COMPILED source must not delete its own release history (issue #1422 — the #1326 data loss
+    /// on a different set of partitions).
+    ///
+    /// <para>A release record at <c>{nodeTypePath}/Release/{version}</c> is minted by the mesh when a
+    /// NodeType compiles, so it is absent from EVERY source by construction — no repo and no embedded
+    /// assembly can carry a node that does not exist until the compiler runs. #1326 protected them via
+    /// <c>IStaticRepoSource.IsExcludedFromMirror</c>, but that hook defaults to <c>false</c> and only
+    /// GitSync's <c>InMemoryStaticRepoSource</c> implements it. <c>DocumentationStaticRepoSource</c>
+    /// overrides neither it nor <c>SyncMode</c>, so the <c>Doc</c> partition ran the default
+    /// <c>FullReplace</c> and pruned its releases on every import — the four
+    /// <c>Doc/…/Release/…</c> deletes in #1422, minted 20 minutes earlier by the same run.</para>
+    ///
+    /// <para>This drives the decision with <c>isExcludedFromMirror: null</c> — a source that does NOT
+    /// implement the hook, i.e. every compiled source — so it fails before the fix and passes after.</para>
+    /// </summary>
+    [Fact]
+    public void MeshMintedReleaseRecord_IsNeverPruned_EvenWhenTheSourceHasNoMirrorExclusions()
+    {
+        // Both were "previously owned" so only the guards can protect them — and the compile
+        // pipeline writes releases under a NodeType, i.e. two levels below the partition root.
+        var release = new MeshNode("20260813115710-4VyYozA9", $"{Partition}/SocialMedia/Post/Release")
+        { State = MeshNodeState.Active, NodeType = "Release" };
+        // Casing must not decide whether data is destroyed — mesh paths do not distinguish it
+        // (the #1326 `release/` vs `Release/` lesson).
+        var lowerCased = new MeshNode("20260813115711-UtXMgXv0", $"{Partition}/SocialMedia/Profile/release")
+        { State = MeshNodeState.Active, NodeType = "Release" };
+
+        foreach (var mode in new[]
+                 {
+                     PartitionSyncMode.FullReplace, PartitionSyncMode.Additive, PartitionSyncMode.UpsertOnly
+                 })
+        {
+            var pruned = StaticRepoImporter.ComputePrunableNodes(
+                    new[] { release, lowerCased },
+                    CurrentSourcePaths,
+                    previouslyOwnedPaths:
+                    ["AI/SocialMedia/Post/Release/20260813115710-4VyYozA9",
+                     "AI/SocialMedia/Profile/release/20260813115711-UtXMgXv0"],
+                    excludedRoots: [],
+                    mode,
+                    // The compiled-source case: no mirror-exclusion hook at all.
+                    isExcludedFromMirror: null)
+                .Select(n => n.Path)
+                .ToArray();
+
+            pruned.Should().BeEmpty(
+                $"a mesh-minted release is absent from every source BY CONSTRUCTION, so its absence is "
+                + $"not evidence of a deletion — pruning it destroys compile history the source can "
+                + $"never restore ({mode})");
+        }
+    }
+
+    [Fact]
+    public void APartitionOrNodeMerelyNamedLikeARelease_IsStillPruned()
+    {
+        // The guard matches a whole path SEGMENT after the partition root. A node whose name merely
+        // starts with "Release", and a segment named "Releases", are ordinary content — the fix must
+        // not quietly make them un-prunable (that would be the guard eating real mirror behaviour).
+        var namedLike = new MeshNode("ReleaseNotes", Partition) { State = MeshNodeState.Active };
+        var plural = new MeshNode("page", $"{Partition}/Releases") { State = MeshNodeState.Active };
+
+        var pruned = StaticRepoImporter.ComputePrunableNodes(
+                new[] { namedLike, plural },
+                CurrentSourcePaths,
+                previouslyOwnedPaths: ["AI/ReleaseNotes", "AI/Releases/page"],
+                excludedRoots: [],
+                PartitionSyncMode.FullReplace)
+            .Select(n => n.Path)
+            .ToArray();
+
+        pruned.Should().BeEquivalentTo(
+            new[] { "AI/ReleaseNotes", "AI/Releases/page" }, JsonSerializerOptions.Default);
+    }
+
     [Fact]
     public void NodeUnderExcludedRoot_IsNeverPruned()
     {


### PR DESCRIPTION
Fixes #1422.

## The exact failing path

`StaticRepoImporter.ComputePrunableNodes` — the ONE prune decision the static-repo import runs after upserting a source's nodes.

The prune rule is *"absent from the source ⇒ mirror it away"*. A compile-minted release record at `{nodeTypePath}/Release/{version}` is absent from **every** source **by construction**: it does not exist until the mesh compiles the type, so no repo and no embedded assembly can ever carry it. None of the existing guards covered that:

- `IsGovernance` spares `_`-prefixed segments only — `Release` is not one.
- #1326 put the protection behind `IStaticRepoSource.IsExcludedFromMirror`, but that hook **defaults to `false`** and only GitSync's `InMemoryStaticRepoSource` implements it.

So every **compiled** source kept deleting its own release history. `DocumentationStaticRepoSource` overrides neither the hook nor `SyncMode`, so the `Doc` partition ran the default `FullReplace` and pruned its releases on each import — the four `Doc/…/Release/…` deletes in the report were minted 20 minutes earlier by the same run.

**Corroborated against the live mesh**, not inferred: source-owned partitions hold exactly **one** release per NodeType (`Doc/DataMesh/SocialMedia/Post/Release/*` → 1 result), while an ordinary partition accumulates dozens (`AgenticOffice/*/Release/*` → 40+ over three days). Only something that prunes explains that difference, and only source-owned partitions have one.

### About the reported exception

`InvalidOperationException: no writable storage provider has this node` is the *symptom*, not the defect. The prune fires its deletes in parallel (`.Merge(BatchSize)`), so a path can pass `DeleteNode`'s not-found gate (`PersistenceService.Read`, which fans out over **all** providers) and then fail at the commit (`PersistenceService.Delete`, which fans out over **writable** providers only) — hence `partial-deleted=0` on all four at the same second. It stops once the prune no longer targets these nodes.

Two things I deliberately did **not** change, and why:
- **`Release` is not missing from the satellite mapping.** `PartitionDefinition.ResolveTable(path)` (read) and `ResolveTable(path, nodeType)` (write) both resolve a `Release` path to `mesh_nodes` — no `_`-segment match, no `NodeTypeTableMappings` entry, `SegmentForNodeType("Release")` is null. Read and write are symmetric; a release is an ordinary `mesh_nodes` row, correctly.
- **The `PersistenceService` read/delete provider-set asymmetry stands.** Widening `Delete` to fan out over read-only providers would let `EmbeddedResourceStorageAdapter.Delete` tombstone shipped documentation — a cleanup that starts working and takes too much. It is a real diagnostic wart (an unexpected `InvalidOperationException` where a clear refusal belongs) but it is a separate change with its own blast radius.

## What bounds the fix

**It can only ever delete less, never more.** The change adds one conjunct to the prune predicate:

```csharp
&& !IsMeshMintedRelease(t)
```

There is no path by which a delete that did not happen before starts happening. The segment match is anchored after the partition root and case-insensitive (the #1326 `release/` vs `Release/` lesson), so a node merely *named* like a release is untouched — `APartitionOrNodeMerelyNamedLikeARelease_IsStillPruned` pins that `AI/ReleaseNotes` and `AI/Releases/page` are still pruned.

Release records already accumulate unbounded in every non-source-owned partition, so this makes `Doc` match existing platform behaviour rather than introducing new growth. A real retention policy is a separate feature.

## Verification

Fail-before/pass-after, no mocking — `ComputePrunableNodes` is pure and public, so the decision itself is driven directly.

`MeshMintedReleaseRecord_IsNeverPruned_EvenWhenTheSourceHasNoMirrorExclusions` passes `isExcludedFromMirror: null` (the compiled-source case) across all three sync modes. **Without the guard** it fails with `found 2 item(s)` under `FullReplace` — exactly the production deletion — while every other test in the file still passes.

- `MeshWeaver.Graph.Test` — 15/15 `StaticRepoImporter*`
- `MeshWeaver.GitSync.Test` — 22/22 including `ForcePrunePreservesIgnoredNodesTest` (the #1326 regression guard)
- `MeshWeaver.Documentation.Test` — What's New + link integrity green
- `dotnet build -c Release -warnaserror` clean on `MeshWeaver.Graph.Test`, `MeshWeaver.GitSync.Test`, `MeshWeaver.Documentation.Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)