### PR TITLE
fix(#1419): a JSON object sent for a string tool parameter no longer kills the round

### DIFF
--- a/src/MeshWeaver.AI/ChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI/ChatClientAgentFactory.cs
@@ -4,6 +4,8 @@ using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.AI.Attributes;
 using MeshWeaver.AI.Plugins;
 using MeshWeaver.Data;
@@ -918,6 +920,14 @@ internal sealed class AccessContextAIFunction : DelegatingAIFunction
     private readonly AccessService _accessService;
     private readonly TimeSpan? _timeout;
 
+    /// <summary>
+    /// Names of the underlying method's parameters whose CLR type is <see cref="string"/> — the
+    /// ones <see cref="NormalizeJsonTextArguments"/> may hand raw JSON text. Computed once at wrap
+    /// time (the wrapper is built once per agent per tool). Empty when the function exposes no
+    /// underlying method (a lambda-built tool), which simply disables the normalization.
+    /// </summary>
+    private readonly HashSet<string> _jsonTextParameters;
+
     public AccessContextAIFunction(AIFunction inner, IAgentChat chat, AccessService accessService)
         : base(inner)
     {
@@ -927,6 +937,65 @@ internal sealed class AccessContextAIFunction : DelegatingAIFunction
             ? null
             : (inner.UnderlyingMethod?.GetCustomAttribute<ToolTimeoutAttribute>()?.Timeout
                 ?? DefaultTimeout);
+        _jsonTextParameters = inner.UnderlyingMethod?.GetParameters()
+                .Where(p => p.ParameterType == typeof(string) && p.Name is { Length: > 0 })
+                .Select(p => p.Name!)
+                .ToHashSet(StringComparer.Ordinal)
+            ?? [];
+    }
+
+    /// <summary>
+    /// 🚨 A JSON <b>object</b> or <b>array</b> the model sent for a <see cref="string"/>-typed tool
+    /// parameter is that parameter's value AS JSON TEXT — hand it over as text instead of letting the
+    /// binder die (issue #1419).
+    ///
+    /// <para><b>Why the model does this.</b> Our tool surface carries JSON documents in <c>string</c>
+    /// parameters and the model-facing <c>[Description]</c>s say so outright — <c>create</c>'s is
+    /// <i>"JSON MeshNode with required: id, name, nodeType, namespace. Example: {…}"</i> and
+    /// <c>patch</c>'s is <i>"JSON object with ONLY the fields to change"</i>. A model that sends the
+    /// object literal is following the instruction; it is the marshaller that has no rule for it.
+    /// <c>ReflectionAIFunction</c>'s per-parameter marshaller calls
+    /// <c>JsonSerializer.Deserialize(element, stringTypeInfo)</c>, <c>StringConverter</c> refuses a
+    /// <c>StartObject</c> token, and the resulting <c>JsonException</c> escapes
+    /// <see cref="InvokeCoreAsync"/> — so the tool body never runs and the whole agent round fails
+    /// (<c>[ThreadExec] ERROR</c>), rather than the model getting a result it can act on.</para>
+    ///
+    /// <para><b>Why raw text is the right value, not a pre-deserialized object.</b> The tool bodies
+    /// parse the JSON themselves, against the hub's <c>JsonSerializerOptions</c> — the options that
+    /// carry the TypeRegistry these payloads' <c>$type</c> discriminators resolve against (and
+    /// <c>MeshOperations.RepairJson</c> for truncated model output). Deserializing here would do it
+    /// with the wrong options in the wrong place; passing the text keeps the read where the types are
+    /// registered.</para>
+    ///
+    /// <para><b>Bound.</b> Only <see cref="JsonValueKind.Object"/> / <see cref="JsonValueKind.Array"/>
+    /// (and their <see cref="JsonNode"/> equivalents), and only for a parameter the method declares as
+    /// <c>string</c>. A JSON string already binds; a number, boolean or null sent for a <c>string</c>
+    /// parameter is a genuine model error with no defensible reinterpretation and still fails loudly.
+    /// Every other parameter type is untouched, so an object destined for a POCO parameter still binds
+    /// normally. Idempotent — a coerced value is a <c>string</c> and no longer matches.</para>
+    /// </summary>
+    private void NormalizeJsonTextArguments(AIFunctionArguments arguments)
+    {
+        if (_jsonTextParameters.Count == 0)
+            return;
+
+        // Materialize the keys first: we write back into the same dictionary while iterating.
+        foreach (var name in arguments.Keys.ToArray())
+        {
+            if (!_jsonTextParameters.Contains(name)
+                || !arguments.TryGetValue(name, out var value))
+                continue;
+
+            var text = value switch
+            {
+                JsonElement { ValueKind: JsonValueKind.Object or JsonValueKind.Array } e
+                    => e.GetRawText(),
+                JsonObject or JsonArray => ((JsonNode)value).ToJsonString(),
+                _ => null
+            };
+            if (text is not null)
+                arguments[name] = text;
+        }
     }
 
     protected override async ValueTask<object?> InvokeCoreAsync(
@@ -935,6 +1004,8 @@ internal sealed class AccessContextAIFunction : DelegatingAIFunction
         var userCtx = _chat.ExecutionContext?.UserAccessContext;
         if (userCtx != null)
             _accessService.SetContext(userCtx);
+
+        NormalizeJsonTextArguments(arguments);
 
         if (_timeout is null)
             return await base.InvokeCoreAsync(arguments, cancellationToken);

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-assistant-action-no-longer-fails-on-a-formatting-detail.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-an-assistant-action-no-longer-fails-on-a-formatting-detail.md
@@ -1,0 +1,28 @@
+---
+Name: An assistant action no longer fails on a formatting detail
+Category: Fix
+Description: When the assistant tried to create or change a page, the request could fail outright over how it had packaged the details — ending the reply with an error instead of doing the work.
+Icon: Sparkle
+Order: -20260813
+---
+
+# An assistant action no longer fails on a formatting detail
+
+Ask the assistant to write you a story, draft a page, or adjust something you already have, and it
+does that by calling one of the platform's own actions — create this, change that. Those actions
+take the details of what to write as a small structured document.
+
+Sometimes the assistant packaged that document one perfectly reasonable way and the platform
+insisted on the other. The two are the same information written down slightly differently, and the
+instructions the assistant is given actually show the very form that was being refused. But the
+mismatch was fatal rather than cosmetic: the action never ran, and the whole reply ended in an error
+rather than the assistant noticing and trying again. From your side, a request that should simply
+have worked came back broken, with nothing useful to act on.
+
+The platform now accepts both forms for these actions and reads the details out of either one. What
+happens next is unchanged — the same checks, the same permissions, the same result.
+
+The tolerance is deliberately narrow. It applies only where an action asks for a structured document
+in the first place, and only to the two ways of writing one down. Anything else the assistant might
+send that genuinely does not fit still fails plainly, so a real mistake stays visible instead of
+being quietly reinterpreted into something that was never asked for.

--- a/test/MeshWeaver.AI.Test/ToolArgumentJsonObjectTest.cs
+++ b/test/MeshWeaver.AI.Test/ToolArgumentJsonObjectTest.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Persistence;
+using MeshWeaver.Layout;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 A JSON OBJECT SENT FOR A <c>string</c> TOOL PARAMETER MUST NOT KILL THE AGENT ROUND (issue #1419).
+///
+/// <para>The mesh tool surface carries JSON documents in <c>string</c> parameters and the model-facing
+/// <c>[Description]</c>s say exactly that — <c>MeshPlugin.Create</c>'s is <i>"JSON MeshNode with
+/// required: id, name, nodeType, namespace. Example: {…}"</i>, <c>MeshPlugin.Patch</c>'s is <i>"JSON
+/// object with ONLY the fields to change"</i>, <c>Update</c>/<c>Delete</c> ask for a <i>JSON array</i>.
+/// A model that sends the object (or array) literal is doing what it was told; the binder is what has
+/// no rule for it. <c>ReflectionAIFunction</c>'s per-parameter marshaller runs
+/// <c>JsonSerializer.Deserialize(element, stringTypeInfo)</c>, <c>StringConverter</c> refuses the
+/// <c>StartObject</c> token, and the <c>JsonException</c> escapes
+/// <c>AccessContextAIFunction.InvokeCoreAsync</c> — the tool body never runs and the whole round fails
+/// (the production trace: <c>[ThreadExec] ERROR … Cannot get the value of a token type 'StartObject'
+/// as a string</c>, in a story-writing thread).</para>
+///
+/// <para>These drive REAL <c>AIFunction</c>s built by the real <c>AIFunctionFactory</c> and invoked
+/// through the real wrapper, with the argument supplied as a raw <see cref="JsonElement"/> — i.e. the
+/// shape the model's tool call actually arrives in. Nothing is mocked.</para>
+/// </summary>
+public class ToolArgumentJsonObjectTest
+{
+    // ── The reported shape, and its siblings ─────────────────────────────
+
+    /// <summary>The exact incident shape: an object where a <c>string</c> is declared.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonObject_ForAStringParameter_ArrivesAsItsRawJsonText()
+    {
+        var result = await Invoke(CreateNode, ("node", """{"id":"A","namespace":"MyOrg"}"""));
+
+        result.Should().Be("""created:{"id":"A","namespace":"MyOrg"}""",
+            "the parameter's value IS the JSON document — the tool body parses it itself, against "
+            + "the hub's JsonSerializerOptions where the $type discriminators are registered");
+    }
+
+    /// <summary>The sibling shape: <c>Update</c>/<c>Delete</c> declare <i>JSON array</i> in a string.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonArray_ForAStringParameter_ArrivesAsItsRawJsonText()
+    {
+        var result = await Invoke(CreateNode, ("node", """["A","B"]"""));
+
+        result.Should().Be("""created:["A","B"]""");
+    }
+
+    /// <summary>A nested object — the <c>patch</c> shape (<c>{"content":{…}}</c>) — round-trips whole.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task NestedJsonObject_KeepsItsFullStructure()
+    {
+        const string json = """{"content":{"logo":"<svg/>","tags":[1,2]},"name":"N"}""";
+
+        (await Invoke(CreateNode, ("node", json))).Should().Be($"created:{json}");
+    }
+
+    /// <summary>Only the <c>string</c> parameters are touched; the rest bind exactly as before.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task MixedArguments_OnlyTheStringParameterIsNormalized()
+    {
+        var result = await Invoke(PatchNode,
+            ("path", "\"@User/rbuergi/my-node\""),   // a JSON *string* — already binds, untouched
+            ("fields", """{"name":"New Name"}"""),   // an object for a string param — normalized
+            ("replaceAll", "true"));                 // a bool for a bool param — untouched
+
+        result.Should().Be("""patched:@User/rbuergi/my-node|{"name":"New Name"}|True""");
+    }
+
+    /// <summary>A model that sends an object where a POCO is declared still binds through the SDK.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonObject_ForANonStringParameter_StillBindsNormally()
+    {
+        var result = await Invoke(TypedTool, ("filter", """{"term":"laptop","take":3}"""));
+
+        result.Should().Be("typed:laptop/3",
+            "the normalization is scoped to parameters the method declares as string — an object "
+            + "destined for a POCO parameter must keep binding through the SDK's own marshaller");
+    }
+
+    // ── The bound: what must still fail loudly ───────────────────────────
+
+    /// <summary>
+    /// A NUMBER for a <c>string</c> parameter is a genuine model error with no defensible
+    /// reinterpretation — it must keep throwing. The fix is scoped to object/array, the two shapes the
+    /// tool descriptions actively ask for; silently stringifying scalars would mask prompt bugs.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonNumber_ForAStringParameter_StillThrows()
+    {
+        var act = () => Invoke(CreateNode, ("node", "123"));
+
+        await act.Should().ThrowAsync<JsonException>();
+    }
+
+    /// <summary>A plain JSON string is unaffected — it already bound, and must still bind verbatim.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonString_ForAStringParameter_IsUnchanged()
+    {
+        (await Invoke(CreateNode, ("node", "\"already text\""))).Should().Be("created:already text");
+    }
+
+    /// <summary>
+    /// The as-written DOM shape: some call paths hand the binder a <see cref="JsonNode"/> rather than
+    /// a <see cref="JsonElement"/>. Same value, same answer — the rule is about the JSON kind, not
+    /// about which DOM type happens to carry it.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task JsonNodeObject_IsNormalizedLikeAJsonElement()
+    {
+        var wrapper = Wrap(AIFunctionFactory.Create(CreateNode));
+
+        var result = await wrapper.InvokeAsync(
+            new AIFunctionArguments { ["node"] = JsonNode.Parse("""{"id":"A"}""") },
+            CancellationToken.None);
+
+        result?.ToString().Should().Be("""created:{"id":"A"}""");
+    }
+
+    /// <summary>Re-invoking with an already-normalized value is a no-op, not a double-encode.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task AlreadyNormalizedValue_IsIdempotent()
+    {
+        var wrapper = Wrap(AIFunctionFactory.Create(CreateNode));
+        var arguments = new AIFunctionArguments
+        {
+            ["node"] = JsonDocument.Parse("""{"id":"A"}""").RootElement
+        };
+
+        var first = await wrapper.InvokeAsync(arguments, CancellationToken.None);
+        var second = await wrapper.InvokeAsync(arguments, CancellationToken.None);
+
+        second?.ToString().Should().Be(first?.ToString(),
+            "a coerced value is a string and no longer matches the rule — re-marshalling the same "
+            + "arguments must not re-encode it into an escaped JSON literal");
+    }
+
+    // ── Harness ──────────────────────────────────────────────────────────
+
+    private static async Task<string?> Invoke(Delegate tool, params (string Name, string Json)[] arguments)
+    {
+        var wrapper = Wrap(AIFunctionFactory.Create(tool));
+        var args = new AIFunctionArguments();
+        foreach (var (name, json) in arguments)
+            args[name] = JsonDocument.Parse(json).RootElement;
+
+        var result = await wrapper.InvokeAsync(args, CancellationToken.None);
+        return result?.ToString();
+    }
+
+    private static AccessContextAIFunction Wrap(AIFunction inner) =>
+        // accessService is only touched when the chat carries a user context; the stub carries none.
+        new(inner, new TestAgentChat(), accessService: null!);
+
+    // ── Tool methods (the real shapes: a JSON document carried in a string) ──
+
+    [Description("Test tool mirroring MeshPlugin.Create — the node is a JSON document, as text.")]
+    private static string CreateNode(
+        [Description("JSON MeshNode. Example: {\"id\":\"my-page\",\"nodeType\":\"Markdown\"}")] string node)
+        => $"created:{node}";
+
+    [Description("Test tool mirroring MeshPlugin.Patch/EditContent — mixed parameter types.")]
+    private static string PatchNode(
+        [Description("Path to the node")] string path,
+        [Description("JSON object with ONLY the fields to change")] string fields,
+        [Description("Replace every occurrence")] bool replaceAll)
+        => $"patched:{path}|{fields}|{replaceAll}";
+
+    [Description("Test tool taking a structured parameter — must keep binding through the SDK.")]
+    private static string TypedTool(SearchFilter filter) => $"typed:{filter.Term}/{filter.Take}";
+
+    /// <summary>A structured tool parameter — deliberately NOT a string.</summary>
+    public sealed record SearchFilter(string Term, int Take);
+
+    /// <summary>
+    /// Minimal IAgentChat stub — AccessContextAIFunction only reads
+    /// <see cref="IAgentChat.ExecutionContext"/>; the rest get the interface's default no-ops.
+    /// </summary>
+    private sealed class TestAgentChat : IAgentChat
+    {
+        public void SetContext(AgentContext? applicationContext) { }
+        public void SetSelectedAgent(string? agentName) { }
+        public Task ResumeAsync(ChatConversation conversation) => Task.CompletedTask;
+        public Task<IReadOnlyList<AgentDisplayInfo>> GetOrderedAgentsAsync() =>
+            Task.FromResult<IReadOnlyList<AgentDisplayInfo>>([]);
+        public async IAsyncEnumerable<ChatMessage> GetResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        { await Task.CompletedTask; yield break; }
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        { await Task.CompletedTask; yield break; }
+        public void SetThreadId(string threadId) { }
+        public void DisplayLayoutArea(LayoutAreaControl layoutAreaControl) { }
+        public AgentContext? Context => null;
+    }
+}


### PR DESCRIPTION
Fixes #1419.

## The exact failing shape

`AccessContextAIFunction.InvokeCoreAsync` → `ReflectionAIFunction` → the per-parameter marshaller, when a tool parameter's CLR type is `string` and the model sends a JSON **object** (`StartObject`) or **array** (`StartArray`).

The mesh tool surface carries JSON documents in `string` parameters, and the model-facing `[Description]`s say so outright:

| Tool | Parameter | `[Description]` |
|---|---|---|
| `MeshPlugin.Create` | `string node` | *"JSON MeshNode with required: id, name, nodeType, namespace. **Example: {…}**"* |
| `MeshPlugin.Patch` | `string fields` | *"**JSON object** with ONLY the fields to change…"* |
| `MeshPlugin.Update` | `string nodes` | *"**JSON array** of complete MeshNode objects"* |
| `MeshPlugin.Delete` | `string paths` | *"**JSON array** of path strings"* |

A model that sends the object literal is following the instruction. The marshaller is what has no rule for it: it runs `JsonSerializer.Deserialize(element, stringTypeInfo)`, `StringConverter` refuses the token, and the `JsonException` escapes `InvokeCoreAsync`. **The tool body never runs and the whole agent round fails** — the reported `[ThreadExec] ERROR` in a story-writing thread. The user's message died on a formatting detail, and the model got nothing it could retry against.

### Which shapes fail, and which do not

Established by driving each one through the real binder before changing anything (all pinned as tests):

| Supplied for a `string` parameter | Before | After |
|---|---|---|
| object `{"id":"A"}` | ❌ `StartObject` | ✅ raw JSON text |
| array `["A","B"]` | ❌ `StartArray` | ✅ raw JSON text |
| nested object `{"content":{…}}` | ❌ | ✅ full structure preserved |
| `JsonNode` object (as-written DOM) | ❌ | ✅ |
| string `"already text"` | ✅ | ✅ unchanged |
| number `123` | ❌ | ❌ **still throws** (deliberate) |
| object for a **non-`string`** parameter | ✅ | ✅ unchanged |

## The fix

Normalize in `AccessContextAIFunction` — the single wrapper every agent tool call goes through: a `JsonElement`/`JsonNode` of kind `Object` or `Array` supplied for a parameter the underlying method declares as `string` is handed over as its **raw JSON text**.

**Raw text, not a pre-deserialized object, is the right value.** The tool bodies parse the JSON themselves against the hub's `JsonSerializerOptions` — the options carrying the TypeRegistry these payloads' `$type` discriminators resolve against, plus `MeshOperations.RepairJson` for truncated model output. Deserializing at the binder would do it with the wrong options in the wrong place; passing the text keeps the read where the types are registered.

## What bounds the fix

- **Object and Array only.** A number, boolean or null sent for a `string` parameter is a genuine model error with no defensible reinterpretation and still fails loudly — silently stringifying scalars would mask prompt bugs.
- **Only parameters the method declares as `string`**, resolved once from `UnderlyingMethod` at wrap time. An object destined for a POCO parameter still binds through the SDK's own marshaller.
- **Idempotent** — a coerced value is a `string` and no longer matches.
- **MCP is untouched.** That surface has its own seam (`McpArgumentValidation.CallToolFilter`) which *names* the mismatch to a client that can read the error and retry; its binder tests still assert the throw and still pass here. The in-portal LLM call has no such loop, which is why it needs the value rather than a message.
- No `[Description]` text was changed — those are model-facing and must not be edited casually.

Known gap, unchanged by this PR: `check_inbox` is injected per-round in `AgentChatClient` and bypasses the wrapper. It takes no parameters, so it cannot hit this.

## Verification

`test/MeshWeaver.AI.Test/ToolArgumentJsonObjectTest.cs` — 9 tests driving **real** `AIFunction`s built by the real `AIFunctionFactory` through the real `AccessContextAIFunction`, with arguments supplied as raw `JsonElement`s (the shape a model's tool call actually arrives in). Nothing mocked.

Fail-before reproduces the production exception verbatim:

```
System.Text.Json.JsonException : The JSON value could not be converted to System.String. Path: $ | LineNumber: 0 | BytePositionInLine: 1.
---- System.InvalidOperationException : Cannot get the value of a token type 'StartObject' as a string.
```

…on 6 of the 9, while the three bound tests (`JsonNumber_…StillThrows`, `JsonString_…IsUnchanged`, `JsonObject_ForANonStringParameter_StillBindsNormally`) pass either way — which is what shows the fix's scope is exactly the object/array-for-string case.

- `MeshWeaver.AI.Test` — **1166 passed, 0 failed**, 5 skipped (env-gated), incl. `McpArgumentValidationTest` and `ToolTimeoutAttributeTest`
- `MeshWeaver.Threading.Test` — 3/3 `AccessContextToolCallTest`
- `MeshWeaver.Documentation.Test` — What's New + link integrity green
- `dotnet build -c Release -warnaserror` clean on `MeshWeaver.AI.Test`, `MeshWeaver.Threading.Test`, `MeshWeaver.Documentation.Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
