### PR TITLE
perf: the fan-out ships a string SPLICE too — negotiated, because its consumers fail silently (#1284)

### DIFF
--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -228,6 +228,36 @@ public record SubscribeRequest(string StreamId, WorkspaceReference Reference)
     /// Used by AccessControlPipeline for permission checks.
     /// </summary>
     public string? Identity { get; init; }
+
+    /// <summary>
+    /// 🚨 THE ONE NEGOTIATED WIRE CAPABILITY of the owner→subscriber fan-out: this subscriber can
+    /// apply a <c>splice</c> operation — a changed string leaf carried as
+    /// <c>{ "$sd": [start, removed, "inserted"], "$sdb": [baseLength, "fingerprint"] }</c> instead
+    /// of the whole new string. Default <c>false</c>, and that default is load-bearing.
+    ///
+    /// <para><b>Why this is negotiated rather than simply emitted.</b> The write direction
+    /// (<c>PatchDataRequest</c>, #1414) could put its splice marker straight on the wire because the
+    /// only consumer is a C# owner, which fails LOUDLY on a shape it does not understand — the
+    /// merged node stops deserialising, the write is NACKed and never commits. The fan-out has no
+    /// such property. Its consumers include four hand-rolled appliers this repo's CI does not build
+    /// — <c>clients/grpc-web</c>, two in <c>clients/react</c>, and <c>clients/python</c> — and every
+    /// one of them fails SILENTLY: the JS appliers treat an unknown <c>op</c> as a no-op (the text
+    /// would simply stop updating mid-stream), and the Python one applies ANY unrecognised op as a
+    /// replace, writing <c>None</c> into the field. A browser also holds whatever bundle it loaded,
+    /// so "upgrade both ends together" is not available here the way it is between two pods.</para>
+    ///
+    /// <para>So the rule is the same one #1414 applied, reached from the other side: <b>never let a
+    /// consumer half-apply a frame</b>. A subscriber that does not say it understands splices gets
+    /// byte-identical bytes to what it gets today — no migration, no flag day, no shape it can
+    /// misread. The marker still rides INSIDE the patch, so a subscriber that claims the capability
+    /// and then cannot honour it still fails loudly (C#: <c>Unknown patch operation</c>).</para>
+    ///
+    /// <para>An unknown property is skipped by the messaging serializer
+    /// (<c>UnmappedMemberHandling.Skip</c>), so this is safe in both rolling-deploy directions: a
+    /// new subscriber against an old owner is simply not spliced to, and an old subscriber against a
+    /// new owner never sets it.</para>
+    /// </summary>
+    public bool AcceptsStringSplice { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -419,7 +419,15 @@ public static class JsonSynchronizationStream
                 () => (isRealUser ? accessService?.SwitchAccessContext(ambient) : accessService?.ImpersonateAsSystem())
                       ?? (IDisposable)System.Reactive.Disposables.Disposable.Empty,
                 _ => hub.Observe(
-                        new SubscribeRequest(reduced.StreamId, reference) { Identity = identityForSubscribe },
+                        new SubscribeRequest(reduced.StreamId, reference)
+                        {
+                            Identity = identityForSubscribe,
+                            // Declared by the assembly that also OWNS the applier
+                            // (ApplyPatchWithCorrectUnescaping below), so the claim can never be
+                            // wrong: whatever version of this code posts the subscribe is the version
+                            // that folds the frames.
+                            AcceptsStringSplice = true,
+                        },
                         o => impersonateAsHub ? o.WithTarget(owner).ImpersonateAsHub(hub.Address) : o.WithTarget(owner))
                     .Take(1))
             .Subscribe(
@@ -994,7 +1002,8 @@ public static class JsonSynchronizationStream
                 // (The client side already applies Fulls unconditionally — UpdateStream's
                 // monotonicity guard is PATCHES-ONLY; this mirrors that contract on the owner.)
                 .ToDataChanged<TReduced, DataChangedEvent>(
-                    c => c.ChangeType == ChangeType.Full || !reduced.ClientId.Equals(c.ChangedBy))
+                    c => c.ChangeType == ChangeType.Full || !reduced.ClientId.Equals(c.ChangedBy),
+                    request.AcceptsStringSplice)
                 .Synchronize()
                 .Where(x => x is not null)
                 .Select(x => x!)
@@ -1060,7 +1069,9 @@ public static class JsonSynchronizationStream
         return reduced;
     }
     private static IObservable<TChange?> ToDataChanged<TReduced, TChange>(
-        this ISynchronizationStream<TReduced> stream, Func<ChangeItem<TReduced>, bool> predicate) where TChange : JsonChange
+        this ISynchronizationStream<TReduced> stream,
+        Func<ChangeItem<TReduced>, bool> predicate,
+        bool acceptsStringSplice = false) where TChange : JsonChange
     {
         // Loss-detection chain (issue #1081): every emitted frame carries the Version of the frame
         // emitted immediately BEFORE it on this same forwarding subscription (-1 for the first).
@@ -1121,6 +1132,19 @@ public static class JsonSynchronizationStream
                         return null;
                     }
                     var patch = x.Updates.ToJsonPatch(stream.Host.JsonSerializerOptions, stream.Reference as WorkspaceReference);
+                    // 🚨 #1284, the fan-out half. A streaming cell rewrites its whole Text on every
+                    // Sample(100 ms) tick, so a whole-value `replace` costs O(ticks x final length)
+                    // PER SUBSCRIBER — the same quadratic the write path shed in #1414, once more for
+                    // every viewer and every cross-silo mirror. Encoding the changed span against the
+                    // text this subscription is KNOWN to hold (currentJson, the cache this method
+                    // keeps in lockstep with the subscriber) makes it O(chunk).
+                    //
+                    // Only for a subscriber that asked (SubscribeRequest.AcceptsStringSplice). Every
+                    // other one — every JS/Python client, every pod still on the previous image —
+                    // gets exactly the bytes it gets today, because the alternative is a consumer
+                    // that half-applies a frame in silence. See that property for the full argument.
+                    if (acceptsStringSplice)
+                        patch = PatchStringSplice.Compress(patch, currentJson.Value);
                     var patchJson = JsonSerializer.Serialize(patch, stream.Host.JsonSerializerOptions);
                     try
                     {
@@ -1284,6 +1308,9 @@ public static class JsonSynchronizationStream
                 case "remove":
                     ApplyRemove(currentNode!, segments);
                     break;
+                case "splice":
+                    ApplySplice(currentNode!, segments, value, pathString);
+                    break;
                 default:
                     // move/copy/test are never produced by ToJsonPatch, so this branch only ever
                     // sees a patch authored elsewhere. Defer them to MeshWeaver.Json's applier,
@@ -1380,6 +1407,52 @@ public static class JsonSynchronizationStream
                     $"Stale patch: replace at index {index} but array has {arr.Count} elements.");
             arr[index] = value;
         }
+    }
+
+    /// <summary>
+    /// Folds a <c>splice</c> (see <see cref="OperationType.Splice"/>) onto a string leaf — but ONLY
+    /// after the carried fingerprint proves the text already there is byte-identical to the text the
+    /// producer diffed against. That is the identical rule the write path follows (#1414): a splice
+    /// is never applied at an offset nothing vouched for, so the result is provably the same string
+    /// a whole-value <c>replace</c> would have written.
+    ///
+    /// <para>On a mismatch the correct reaction is neither to splice blind nor to drop the frame,
+    /// but to stop trusting the local snapshot: <see cref="StaleStreamStateException"/> is what
+    /// <c>SynchronizationStream.UpdateStream</c> already answers with a fresh authoritative Full from
+    /// the owner (storm-gated by <c>_resyncInFlight</c> — one resubscribe per gap, no timer, no
+    /// retry loop). In normal operation it cannot fire: the frame chain resyncs on a LOST frame
+    /// before any patch is applied, so producer and subscriber are in lockstep by construction. It
+    /// exists so that when they are not, the divergence is repaired rather than written into the
+    /// text.</para>
+    /// </summary>
+    private static void ApplySplice(JsonNode root, string[] segments, JsonNode? value, string pathString)
+    {
+        if (segments.Length == 0)
+            throw new InvalidOperationException("Cannot splice at root path");
+        if (!PatchStringSplice.TryDecodeOperation(value, out var delta, out var baseLength, out var fingerprint))
+            throw new InvalidOperationException(
+                $"Malformed splice operation at {pathString}: expected {{\"{PatchStringSplice.Marker}\":[start,removed,\"inserted\"],"
+                + $"\"{PatchStringSplice.BaseMarker}\":[length,\"fingerprint\"]}}");
+
+        var parent = EnsureParentPath(root, segments);
+        var key = segments[^1];
+        var live = parent switch
+        {
+            JsonObject obj => obj[key] as JsonValue,
+            JsonArray arr when int.TryParse(key, out var i) && i >= 0 && i < arr.Count => arr[i] as JsonValue,
+            _ => null,
+        };
+        var current = live is not null && live.TryGetValue<string>(out var s) ? s : null;
+        if (!PatchStringSplice.BaseMatches(current, baseLength, fingerprint))
+            throw new StaleStreamStateException(
+                $"Stale patch: splice at {pathString} was computed against a different base "
+                + $"(expected length {baseLength}, local length {current?.Length ?? -1}).");
+
+        var spliced = JsonValue.Create(delta.Apply(current));
+        if (parent is JsonObject target)
+            target[key] = spliced;
+        else if (parent is JsonArray array && int.TryParse(key, out var index))
+            array[index] = spliced;
     }
 
     private static void ApplyRemove(JsonNode root, string[] segments)

--- a/src/MeshWeaver.Data/Serialization/PatchStringSplice.cs
+++ b/src/MeshWeaver.Data/Serialization/PatchStringSplice.cs
@@ -1,6 +1,8 @@
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using MeshWeaver.Json;
 
 namespace MeshWeaver.Data.Serialization;
 
@@ -149,6 +151,100 @@ public static class PatchStringSplice
         live ??= string.Empty;
         return live.Length == length
                && string.Equals(Fingerprint(live), fingerprint, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same splice, in the shape the OWNER→SUBSCRIBER fan-out needs: one object carrying BOTH
+    /// markers, since an RFC 6902 operation has a single <c>value</c> slot and no sibling
+    /// <c>BaseValues</c> document to put the fingerprint in.
+    ///
+    /// <para>Shape: <c>{ "$sd": [start, removed, "inserted"], "$sdb": [baseLength, "fingerprint"] }</c>
+    /// — carried as the <c>value</c> of a <see cref="OperationType.Splice"/> operation. Same markers
+    /// as the write path on purpose: one shape, one meaning.</para>
+    /// </summary>
+    public static bool TryEncodeOperation(string? baseValue, string? newValue, out JsonObject? encoded)
+    {
+        encoded = null;
+        if (!TryEncode(baseValue, newValue, out var splice) || splice is null)
+            return false;
+        // The fingerprint is a fixed ~40 bytes, so the size check TryEncode already made still holds
+        // with room to spare for anything at or above MinSpliceLength (1 kB).
+        encoded = new JsonObject
+        {
+            [Marker] = splice[Marker]!.DeepClone(),
+            [BaseMarker] = EncodeBase(baseValue)[BaseMarker]!.DeepClone(),
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the combined shape written by <see cref="TryEncodeOperation"/>. Deliberately strict —
+    /// exactly the two markers, exactly their expected payloads — so an ordinary content object can
+    /// never be mistaken for one.
+    /// </summary>
+    public static bool TryDecodeOperation(
+        JsonNode? node, out StringDelta delta, out int baseLength, out string fingerprint)
+    {
+        delta = default;
+        baseLength = 0;
+        fingerprint = string.Empty;
+        if (node is not JsonObject obj || obj.Count != 2)
+            return false;
+        if (!obj.TryGetPropertyValue(Marker, out var spliceNode)
+            || !obj.TryGetPropertyValue(BaseMarker, out var baseNode))
+            return false;
+        return TryDecode(new JsonObject { [Marker] = spliceNode?.DeepClone() }, out delta)
+               && TryDecodeBase(
+                   new JsonObject { [BaseMarker] = baseNode?.DeepClone() }, out baseLength, out fingerprint);
+    }
+
+    /// <summary>
+    /// Rewrites every <c>replace</c> of a big string leaf in <paramref name="patch"/> as a
+    /// <see cref="OperationType.Splice"/>, using <paramref name="basis"/> — the producer's OWN cached
+    /// JSON for this subscription, which IS the document the subscriber currently holds — as the base.
+    /// Anything else in the patch is passed through untouched, and a leaf whose base is not a string,
+    /// is absent, or would not shrink is left as the plain <c>replace</c> it already was.
+    ///
+    /// <para>Diffing against the producer's applied cache rather than against the update's
+    /// <c>OldValue</c> is what makes the fingerprint check on the far side a formality rather than a
+    /// gamble: the two ends are kept in lockstep by the frame chain (<c>BasedOnVersion</c>), which
+    /// resyncs BEFORE applying whenever a frame was lost. So a mismatch means genuine divergence, and
+    /// the subscriber's only sound reaction — a fresh snapshot — is exactly what it already does for
+    /// a stale patch.</para>
+    ///
+    /// <para>🚨 Called ONLY for a subscriber that set <c>SubscribeRequest.AcceptsStringSplice</c>.
+    /// Every other subscriber gets <paramref name="patch"/> unmodified, byte for byte.</para>
+    /// </summary>
+    public static JsonPatch Compress(JsonPatch patch, JsonElement basis)
+    {
+        List<PatchOperation>? rewritten = null;
+        for (var i = 0; i < patch.Operations.Count; i++)
+        {
+            var op = patch.Operations[i];
+            var spliced = TryCompressOperation(op, basis);
+            if (spliced is null)
+            {
+                rewritten?.Add(op);
+                continue;
+            }
+            rewritten ??= [.. patch.Operations.Take(i)];
+            rewritten.Add(spliced);
+        }
+        return rewritten is null ? patch : new JsonPatch(rewritten);
+    }
+
+    private static PatchOperation? TryCompressOperation(PatchOperation op, JsonElement basis)
+    {
+        if (op.Op != OperationType.Replace
+            || op.Value is not JsonValue newNode
+            || !newNode.TryGetValue<string>(out var newValue)
+            || newValue.Length < MinSpliceLength)
+            return null;
+        if (op.Path.Evaluate(basis) is not { ValueKind: JsonValueKind.String } baseElement)
+            return null;
+        return TryEncodeOperation(baseElement.GetString(), newValue, out var encoded) && encoded is not null
+            ? PatchOperation.Splice(op.Path, encoded)
+            : null;
     }
 
     /// <summary>Stable content fingerprint of a string (truncated SHA-256 over its UTF-16 bytes).</summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -205,6 +205,21 @@ what changed:
 
 - **Owner → subscriber:** a **JSON patch** (RFC 6901 / merge-patch RFC 7396)
   for deltas (`ToJsonPatch`); a **Full** for the initial snapshot and roll-backs.
+- **Big strings, owner → subscriber → a `splice` operation, NEGOTIATED.** A `replace`
+  of a string leaf at or above `PatchStringSplice.MinSpliceLength` travels as
+  `{"op":"splice","path":…,"value":{"$sd":[start,removed,"inserted"],"$sdb":[baseLength,"fingerprint"]}}`
+  — the changed span plus a fingerprint of the text it was diffed against, so a streaming
+  cell costs `O(chunk)` per frame instead of `O(length)` per frame **per subscriber**
+  (measured: a 20 kB answer over 200 frames, 1.93 MB → 42 kB). The subscriber applies it
+  only when the fingerprint proves its text IS that base; otherwise it refuses and takes
+  the ordinary stale-patch route, `RequestFreshSnapshot()` (§6) — never a blind splice.
+  🚨 **Emitted only to a subscriber that set `SubscribeRequest.AcceptsStringSplice`.**
+  Unlike the write direction, this fan-out is consumed by hand-rolled appliers in
+  `clients/grpc-web`, `clients/react` and `clients/python` that this repo's CI does not
+  build, and each of them fails *silently* on a shape it does not know — the JS ones skip
+  an unknown `op`, the Python one applies it as a replace. So the capability is declared,
+  not assumed, and everyone who does not declare it receives byte-identical bytes to
+  before. (`PatchStringSplice.Compress`; test `FanOutStringSpliceTest`.)
 - **Subscriber → owner:** a `DataChangeRequest` carrying the **changed entities
   only** (per `(Collection, Id)`), not the whole store.
 - **Big strings → `EntityDeltaUpdate` (recursive string-delta):** a changed string

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-streaming-answers-cost-the-viewer-far-less.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-streaming-answers-cost-the-viewer-far-less.md
@@ -1,0 +1,30 @@
+---
+Name: Streaming answers cost far less to watch
+Category: Fix
+Description: While an agent types, the server no longer re-sends the whole answer-so-far to every viewer on every update — it sends the new words. A 20 kB reply went from 1.93 MB to 42 kB per viewer.
+Icon: Flash
+Order: -20260813
+---
+
+# Streaming answers cost far less to watch
+
+While an agent writes an answer, its text is pushed out about ten times a second so you see it
+appear. Each of those updates used to carry **the entire answer so far** — to every open view of
+it, and to every server in the cluster mirroring that node. The tenth update re-sent ten chunks,
+the hundredth re-sent a hundred, so the cost of one reply grew with the square of its length and
+multiplied by the number of people watching.
+
+An earlier change fixed the same problem on the way *in* — when an agent saves what it has written.
+This is the other direction, the one that reaches you. An update now carries just the newly added
+span, together with a fingerprint of the text it was computed against. Measured on a 20 kB answer
+delivered over 200 updates: **1.93 MB → 42 kB per viewer**, and the cost per character of the answer
+now *falls* as the answer grows instead of rising.
+
+The fingerprint is what makes it safe. A viewer applies the shortened update only when it can prove
+its copy is exactly the text the server started from; if anything has diverged it asks for a
+complete refresh instead of guessing. So the text you end up with is byte-for-byte the text the
+model wrote — never a partially-applied approximation of it.
+
+Older clients are unaffected on purpose. Each connection says whether it understands the shorter
+form, and one that does not keeps receiving exactly what it received before, so nothing changes
+underneath a browser tab that has been open across an upgrade.

--- a/src/MeshWeaver.Utils/Json/JsonPatch.cs
+++ b/src/MeshWeaver.Utils/Json/JsonPatch.cs
@@ -123,6 +123,11 @@ internal static class JsonPatchApplier
         OperationType.Move => Move(ref source, operation.From, operation.Path),
         OperationType.Copy => Copy(ref source, operation.From, operation.Path),
         OperationType.Test => Test(source, operation.Path, operation.Value),
+        // 🚨 Splice lands here DELIBERATELY. Folding one requires verifying the carried fingerprint
+        // against the live text first, which is the synchronization stream's job
+        // (JsonSynchronizationStream.ApplySplice) and needs the codec that lives with it. Applying it
+        // here without that check would be exactly the blind splice the whole design forbids, and
+        // skipping it would be the silent half-apply. Refusing says so.
         _ => $"Unsupported operation `{operation.Op}`."
     };
 

--- a/src/MeshWeaver.Utils/Json/PatchOperation.cs
+++ b/src/MeshWeaver.Utils/Json/PatchOperation.cs
@@ -21,7 +21,19 @@ public enum OperationType
     /// <summary><c>copy</c>.</summary>
     Copy,
     /// <summary><c>test</c>.</summary>
-    Test
+    Test,
+    /// <summary>
+    /// <c>splice</c> — MeshWeaver's ONE extension beyond RFC 6902. Replaces a string leaf by
+    /// carrying only the changed span plus a fingerprint of the text it was computed against, so a
+    /// field that grows one chunk at a time (a streaming agent response) costs <c>O(chunk)</c> per
+    /// frame instead of <c>O(length)</c> per frame per subscriber.
+    ///
+    /// <para>🚨 It is emitted ONLY to a subscriber that asked for it
+    /// (<c>SubscribeRequest.AcceptsStringSplice</c>) — see that property for why the fan-out must
+    /// negotiate where the write path could simply announce. Every consumer that has not opted in
+    /// keeps receiving a plain <see cref="Replace"/> with the whole value, byte for byte.</para>
+    /// </summary>
+    Splice
 }
 
 /// <summary>Reads/writes <see cref="OperationType"/> as its lowercase RFC 6902 verb.</summary>
@@ -40,6 +52,7 @@ public sealed class OperationTypeJsonConverter : JsonConverter<OperationType>
         "move" => OperationType.Move,
         "copy" => OperationType.Copy,
         "test" => OperationType.Test,
+        "splice" => OperationType.Splice,
         _ => OperationType.Unknown
     };
 
@@ -52,6 +65,7 @@ public sealed class OperationTypeJsonConverter : JsonConverter<OperationType>
         OperationType.Move => "move",
         OperationType.Copy => "copy",
         OperationType.Test => "test",
+        OperationType.Splice => "splice",
         _ => "unknown"
     };
 
@@ -113,6 +127,15 @@ public sealed class PatchOperation : IEquatable<PatchOperation>
     /// <summary>Creates a <c>test</c> operation.</summary>
     public static PatchOperation Test(JsonPointer path, JsonNode? value)
         => new(OperationType.Test, JsonPointer.Empty, path, value);
+
+    /// <summary>
+    /// Creates a <c>splice</c> operation — see <see cref="OperationType.Splice"/>. The
+    /// <paramref name="value"/> is the encoded splice + base fingerprint; the codec that builds and
+    /// reads it lives with the rest of the string-splice machinery in <c>MeshWeaver.Data</c>, so this
+    /// type stays a pure wire shape and knows nothing about the encoding.
+    /// </summary>
+    public static PatchOperation Splice(JsonPointer path, JsonNode? value)
+        => new(OperationType.Splice, JsonPointer.Empty, path, value);
 
     /// <inheritdoc />
     public bool Equals(PatchOperation? other) =>
@@ -207,6 +230,9 @@ public sealed class PatchOperationJsonConverter : JsonConverter<PatchOperation>
             case OperationType.Test:
                 if (!hasValue) throw new JsonException("`test` operation requires `value`");
                 return PatchOperation.Test(path.Value, value);
+            case OperationType.Splice:
+                if (!hasValue) throw new JsonException("`splice` operation requires `value`");
+                return PatchOperation.Splice(path.Value, value);
             default:
                 throw new JsonException($"Unknown JSON Patch operation `{op}`");
         }
@@ -233,6 +259,7 @@ public sealed class PatchOperationJsonConverter : JsonConverter<PatchOperation>
             case OperationType.Add:
             case OperationType.Replace:
             case OperationType.Test:
+            case OperationType.Splice:
                 writer.WritePropertyName("value"u8);
                 if (value.Value is null) writer.WriteNullValue();
                 else value.Value.WriteTo(writer, options);

--- a/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
+++ b/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Json;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// The OWNER→SUBSCRIBER half of the quadratic-streaming-write class (#1284). #1414 made the cross-hub
+/// WRITE ship a splice; the fan-out kept emitting an RFC 6902 <c>replace</c> carrying the whole new
+/// string — once per tick, and once more for every additional subscriber and cross-silo mirror.
+///
+/// <para>This suite pins the three things that make the fix safe to ship:</para>
+/// <list type="number">
+///   <item><b>Exactness.</b> Folding the splices of a whole streamed round reproduces, byte for byte,
+///     the text a whole-value patch would have produced — asserted over 200 frames, the chat shape.</item>
+///   <item><b>No blind splicing.</b> When the subscriber's text is not the text the producer diffed
+///     against, the frame is REFUSED with <see cref="StaleStreamStateException"/>, which
+///     <c>SynchronizationStream.UpdateStream</c> answers with a fresh authoritative snapshot. The
+///     same rule as the write path: a splice is never applied at an offset nothing vouched for.</item>
+///   <item><b>Negotiation.</b> A subscriber that did not ask for splices receives bytes IDENTICAL to
+///     what it receives today. That is not a nicety — four hand-rolled appliers this repo's CI does
+///     not build consume these frames, and every one of them fails silently on a shape it does not
+///     know (the JS ones skip an unknown op; the Python one applies it as a replace, writing null).</item>
+/// </list>
+/// </summary>
+public class FanOutStringSpliceTest(ITestOutputHelper output)
+{
+    private static readonly JsonSerializerOptions Wire = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// The chat shape: a response cell whose Text grows one chunk per sampled tick. 100 chars a
+    /// frame is roughly what 100 ms of token streaming carries, and the two sizes below are the ones
+    /// #1414 measured the WRITE half at — so the two halves of #1284 are directly comparable.
+    /// </summary>
+    private const int ChunkChars = 100;
+    private const int SmallAnswerChars = 5_000;
+    private const int LargeAnswerChars = 20_000;
+
+    private static string Chunk(int index) =>
+        $"Frame {index:D4}: the reinsurance treaty allocates losses across layers, and the cedent retains. "
+            .PadRight(ChunkChars)[..ChunkChars];
+
+    private static JsonNode Cell(string text) =>
+        new JsonObject { ["status"] = "Streaming", ["text"] = JsonValue.Create(text) };
+
+    private static JsonElement Element(JsonNode node) =>
+        JsonSerializer.Deserialize<JsonElement>(node.ToJsonString());
+
+    private static long Utf8(string s) => System.Text.Encoding.UTF8.GetByteCount(s);
+
+    // ---- 1. exactness, and the measurement -----------------------------------------------------
+
+    /// <summary>
+    /// 🚨 THE MEASUREMENT, and the correctness statement, in one run: the same 200-frame stream is
+    /// produced twice — once as today's whole-value patches, once spliced — and the folded result
+    /// must be byte-identical while the wire cost must stop scaling with the answer length.
+    ///
+    /// <para>Both columns run the REAL path end to end: the real differ
+    /// (<c>PatchExtensions.CreatePatch</c>), the real operation serializer, and the real consumer
+    /// (<c>DataChangedEvent.UpdateJsonElement</c> → <c>ApplyPatchWithCorrectUnescaping</c>). Only the
+    /// one negotiated step differs, which is the point — the two columns are otherwise the same code.</para>
+    /// </summary>
+    [Fact]
+    public void AStreamedRound_FoldsToTheIdenticalText_AtAFractionOfTheWireCost()
+    {
+        var smallBefore = FoldStream(SmallAnswerChars, splice: false);
+        var smallAfter = FoldStream(SmallAnswerChars, splice: true);
+        var largeBefore = FoldStream(LargeAnswerChars, splice: false);
+        var largeAfter = FoldStream(LargeAnswerChars, splice: true);
+
+        // Exactness first: a cheaper wire that loses a character is not cheaper, it is broken.
+        largeBefore.Text.Should().Be(Answer(LargeAnswerChars), "the baseline column must reproduce the stream");
+        largeAfter.Text.Should().Be(Answer(LargeAnswerChars),
+            "a spliced fan-out must fold to byte-for-byte the text the whole-value frames produce");
+        smallAfter.Text.Should().Be(Answer(SmallAnswerChars));
+
+        output.WriteLine(
+            $"fan-out wire bytes, PER SUBSCRIBER (whole-value -> spliced):"
+            + $"\n  {SmallAnswerChars:N0} chars / {SmallAnswerChars / ChunkChars} frames:"
+            + $" {smallBefore.Bytes:N0} B -> {smallAfter.Bytes:N0} B"
+            + $" ({(double)smallBefore.Bytes / smallAfter.Bytes:F1}x)"
+            + $"\n  {LargeAnswerChars:N0} chars / {LargeAnswerChars / ChunkChars} frames:"
+            + $" {largeBefore.Bytes:N0} B ({largeBefore.Bytes / 1024.0 / 1024.0:F2} MB)"
+            + $" -> {largeAfter.Bytes:N0} B ({largeAfter.Bytes / 1024.0:F1} kB)"
+            + $" ({(double)largeBefore.Bytes / largeAfter.Bytes:F1}x)");
+        output.WriteLine(
+            $"bytes per answer char: before {(double)smallBefore.Bytes / SmallAnswerChars:F1}"
+            + $" -> {(double)largeBefore.Bytes / LargeAnswerChars:F1} (GROWS 4x with the answer);"
+            + $" after {(double)smallAfter.Bytes / SmallAnswerChars:F1}"
+            + $" -> {(double)largeAfter.Bytes / LargeAnswerChars:F1} (falls — amortises)");
+
+        // 1. Absolute: the round must cost the answer a small constant number of times, not once
+        //    per frame per subscriber.
+        largeAfter.Bytes.Should().BeLessThan(largeBefore.Bytes / 10,
+            $"the fan-out must ship the answer about once, not once per frame "
+            + $"({largeBefore.Bytes:N0} B -> {largeAfter.Bytes:N0} B over {LargeAnswerChars / ChunkChars} frames)");
+
+        // 2. Relative — the SHAPE assertion, and the one that holds whatever the per-frame constant
+        //    happens to be: quadrupling the answer must not quadruple the cost PER CHARACTER. Before,
+        //    it does exactly that; after, the per-character cost falls as the constant amortises.
+        var beforeSmallPerChar = (double)smallBefore.Bytes / SmallAnswerChars;
+        var beforeLargePerChar = (double)largeBefore.Bytes / LargeAnswerChars;
+        var afterSmallPerChar = (double)smallAfter.Bytes / SmallAnswerChars;
+        var afterLargePerChar = (double)largeAfter.Bytes / LargeAnswerChars;
+
+        beforeLargePerChar.Should().BeGreaterThan(beforeSmallPerChar * 3,
+            "the baseline column must actually exhibit the quadratic shape this change removes — "
+            + "otherwise the comparison below proves nothing");
+        afterLargePerChar.Should().BeLessThan(afterSmallPerChar,
+            "wire cost per character of the answer must not grow with the length of the answer");
+    }
+
+    private static string Answer(int chars) =>
+        string.Concat(Enumerable.Range(1, chars / ChunkChars).Select(Chunk));
+
+    /// <summary>
+    /// Drives one column. Each frame diffs the previous cell against the next through the production
+    /// differ, optionally compresses against the SUBSCRIBER's current document (which is what the
+    /// producer's own cached JsonElement is), serialises it, and folds it on the far side.
+    /// </summary>
+    private static (long Bytes, string Text) FoldStream(int answerChars, bool splice)
+    {
+        var producerPrevious = Cell(string.Empty);
+        var subscriber = Element(Cell(string.Empty));
+        var bytes = 0L;
+        var soFar = string.Empty;
+
+        for (var i = 1; i <= answerChars / ChunkChars; i++)
+        {
+            soFar += Chunk(i);
+            var next = Cell(soFar);
+            var patch = producerPrevious.CreatePatch(next);
+            if (splice)
+                patch = PatchStringSplice.Compress(patch, subscriber);
+            var patchJson = JsonSerializer.Serialize(patch, Wire);
+            bytes += Utf8(patchJson);
+
+            var frame = new DataChangedEvent("stream", i, new RawJson(patchJson), ChangeType.Patch, null);
+            (subscriber, _) = frame.UpdateJsonElement(subscriber, Wire);
+            producerPrevious = next;
+        }
+
+        return (bytes, subscriber.GetProperty("text").GetString()!);
+    }
+
+    // ---- 2. never applied blind ----------------------------------------------------------------
+
+    [Fact]
+    public void WhenTheSubscribersTextIsNotTheProducersBase_TheFrameIsRefused_NeverSplicedBlind()
+    {
+        var producerBase = Cell(Big());
+        var next = Cell(Big() + " …and the newest chunk");
+        var patch = PatchStringSplice.Compress(producerBase.CreatePatch(next), Element(producerBase));
+        patch.Operations[0].Op.Should().Be(OperationType.Splice, "the frame under test must be a splice");
+
+        // The subscriber holds DIFFERENT text — the state a lost frame or a diverged mirror leaves.
+        var diverged = Element(Cell(Big() + " something else entirely"));
+        var frame = new DataChangedEvent(
+            "stream", 1, new RawJson(JsonSerializer.Serialize(patch, Wire)), ChangeType.Patch, null);
+
+        Action apply = () => frame.UpdateJsonElement(diverged, Wire);
+
+        apply.Should().Throw<StaleStreamStateException>(
+            "a splice may only be applied at offsets the fingerprint vouched for; when it cannot, the "
+            + "sound reaction is a fresh authoritative snapshot — which is exactly what "
+            + "SynchronizationStream.UpdateStream does with this exception — never a blind splice");
+    }
+
+    [Fact]
+    public void AMalformedSplice_IsRefusedLoudly_NeverWrittenIntoTheText()
+    {
+        var patch = new JsonPatch(PatchOperation.Splice(
+            JsonPointer.Parse("/text"), new JsonObject { ["$sd"] = "not an array" }));
+        var frame = new DataChangedEvent(
+            "stream", 1, new RawJson(JsonSerializer.Serialize(patch, Wire)), ChangeType.Patch, null);
+
+        Action apply = () => frame.UpdateJsonElement(Element(Cell(Big())), Wire);
+
+        apply.Should().Throw<InvalidOperationException>(
+            "an unreadable splice must surface, never be written into the string as a marker object");
+    }
+
+    // ---- 3. negotiation: everyone who did not ask sees today's bytes ----------------------------
+
+    [Fact]
+    public void WithoutCompression_TheBytesAreExactlyWhatTheyAreToday()
+    {
+        var previous = Cell(Big());
+        var next = Cell(Big() + " tail");
+        var patch = previous.CreatePatch(next);
+
+        JsonSerializer.Serialize(patch, Wire).Should()
+            .Be(JsonSerializer.Serialize(previous.CreatePatch(next), Wire));
+        patch.Operations.Should().AllSatisfy(op => op.Op.Should().NotBe(OperationType.Splice),
+            "an un-negotiated subscriber — every JS and Python client, and every pod on the previous "
+            + "image — must keep receiving the plain RFC 6902 shape its applier was written against");
+    }
+
+    [Fact]
+    public void ASubscribeRequestWithoutTheField_DoesNotAskForSplices()
+    {
+        // The rolling-deploy claim, both directions. An old subscriber's request has no such
+        // property; a new owner must read that as "whole values, please".
+        var old = JsonSerializer.Deserialize<SubscribeRequest>(
+            """{"streamId":"s","reference":null,"identity":"u"}""", Wire);
+
+        old!.AcceptsStringSplice.Should().BeFalse(
+            "absence must mean the conservative answer — the frame shape a client cannot misread");
+    }
+
+    [Fact]
+    public void ASmallString_AndANonStringLeaf_AreLeftAsPlainReplaces()
+    {
+        var previous = new JsonObject { ["text"] = "short", ["count"] = 1 };
+        var next = new JsonObject { ["text"] = "shorter still", ["count"] = 2 };
+
+        var patch = PatchStringSplice.Compress(previous.CreatePatch(next), Element(previous));
+
+        patch.Operations.Should().AllSatisfy(op => op.Op.Should().Be(OperationType.Replace),
+            "below MinSpliceLength the whole value is cheaper than a splice plus a fingerprint, and a "
+            + "non-string leaf has no splice to compute");
+    }
+
+    [Fact]
+    public void ALeafAbsentFromTheSubscribersDocument_StaysAWholeValueReplace()
+    {
+        // No base to fingerprint ⇒ nothing to splice against. Must degrade to the whole value
+        // rather than emit a splice whose offsets address text that is not there.
+        var previous = new JsonObject { ["text"] = Big() };
+        var next = new JsonObject { ["text"] = Big() + " tail" };
+
+        var patch = PatchStringSplice.Compress(previous.CreatePatch(next), Element(new JsonObject()));
+
+        patch.Operations[0].Op.Should().Be(OperationType.Replace);
+    }
+
+    // ---- 4. the wire shape ---------------------------------------------------------------------
+
+    [Fact]
+    public void TheSpliceWireShapeIsExact()
+    {
+        var previous = new JsonObject { ["text"] = Big() };
+        var next = new JsonObject { ["text"] = Big() + "TAIL" };
+        var patch = PatchStringSplice.Compress(previous.CreatePatch(next), Element(previous));
+
+        var json = JsonSerializer.Serialize(patch, Wire);
+
+        json.Should().StartWith("""[{"op":"splice","path":"/text","value":{"$sd":[""",
+            "op, then path, then value — the same property order every other operation uses");
+        json.Should().Contain("""TAIL""");
+        json.Should().Contain("\"$sdb\":[",
+            "the base fingerprint travels inside the operation, because an RFC 6902 operation has no "
+            + "sibling document to put it in");
+
+        // Round-trips through the operation converter — the receive side re-parses the patch, so a
+        // verb it cannot read would surface there rather than on the wire.
+        JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonPatch>(json, Wire), Wire).Should().Be(json);
+    }
+
+    [Fact]
+    public void TheGenericApplier_RefusesASpliceRatherThanIgnoringIt()
+    {
+        // The splice is folded by the synchronization stream, which verifies the base first. Anything
+        // else that meets one must say so — a silent skip is the failure mode this whole design is
+        // built to avoid.
+        var result = new JsonPatch(PatchOperation.Splice(JsonPointer.Parse("/text"), new JsonObject()))
+            .Apply(new JsonObject { ["text"] = "x" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("Splice");
+    }
+
+    private static string Big(string tail = "") =>
+        string.Concat(Enumerable.Repeat("The quick brown fox jumps over the lazy dog. ", 40)) + tail;
+}

--- a/test/MeshWeaver.Threading.Test/FanOutSpliceNegotiationTest.cs
+++ b/test/MeshWeaver.Threading.Test/FanOutSpliceNegotiationTest.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Threading.Test;
+
+/// <summary>
+/// The wiring half of #1284's fan-out change, asserted against the running mesh rather than inferred.
+///
+/// <para><see cref="MeshWeaver.Data.Test"/>'s <c>FanOutStringSpliceTest</c> pins what a splice DOES —
+/// how it is produced, folded, and refused. What it cannot say is whether the framework's own
+/// subscribers actually ask for one, and that is the single point on which the whole negotiation
+/// turns: a capability nobody declares is a feature that never runs, and the failure is silent in
+/// exactly the direction that looks fine (everyone keeps getting whole values, the measurement never
+/// moves, no test goes red).</para>
+///
+/// <para>So this asserts the declaration itself, on real <c>SubscribeRequest</c>s as the owning node
+/// hubs receive them. The recorder is the same passive shape
+/// <c>StreamingCellWriteByteCountTest</c> uses for <c>PatchDataRequest</c>: it reads the request and
+/// hands the delivery back UNPROCESSED, so the owner's real subscribe handler still runs.</para>
+/// </summary>
+public class FanOutSpliceNegotiationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly ConcurrentBag<SubscribeRequest> subscribes = [];
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureDefaultNodeHub(config => config.WithHandler<SubscribeRequest>((_, delivery) =>
+            {
+                subscribes.Add(delivery.Message);
+                return delivery;
+            }));
+
+    [Fact]
+    public async Task TheFrameworksOwnSubscribers_AskForSplices()
+    {
+        const string id = "splice-negotiation";
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Negotiation",
+            NodeType = "Markdown",
+            Content = "# Negotiation",
+        }).Should().Emit();
+
+        // A read through the ordinary surface — the same one the GUI, the routing layer and every
+        // cross-hub write resolve through — is what opens a subscription to the owning node hub.
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        var recorded = subscribes.ToList();
+        recorded.Should().NotBeEmpty(
+            "reading a node opens a SubscribeRequest against its owning hub — with none recorded this "
+            + "test would pass on no evidence");
+        Output.WriteLine(
+            $"SubscribeRequests seen: {recorded.Count}, "
+            + $"declaring AcceptsStringSplice: {recorded.Count(r => r.AcceptsStringSplice)}");
+
+        recorded.Should().AllSatisfy(r => r.AcceptsStringSplice.Should().BeTrue(
+            "every subscribe this framework posts is posted by the same assembly that folds the "
+            + "frames (JsonSynchronizationStream), so the claim is always safe to make — and if it "
+            + "were ever NOT made, the owner would keep shipping whole values and the fan-out fix "
+            + "would silently do nothing"));
+    }
+}


### PR DESCRIPTION
Closes the **owner→subscriber** half of the quadratic-streaming class — #1284. The write half shipped in #1414; `JsonSynchronizationStream.CreateSingleObjectPatch` kept fanning out an RFC 6902 `replace` carrying the whole new string, once per `Sample(100 ms)` tick **and once more for every viewer and every cross-silo mirror**.

## Measured

Per subscriber, through the real path end to end — the production differ (`PatchExtensions.CreatePatch`), the real operation serializer, and the real consumer (`DataChangedEvent.UpdateJsonElement` → `ApplyPatchWithCorrectUnescaping`). The two columns are the same code with one negotiated step switched on.

| | 5,000 chars / 50 frames | 20,000 chars / 200 frames |
|---|---:|---:|
| **before** — wire bytes | 129,700 | **2,018,800** (1.93 MB) |
| **after** — wire bytes | 13,735 | **43,070** (42.1 kB) |
| **reduction** | 9.4× | **46.9×** |
| before — bytes per answer char | 25.9 | **100.9** (grows 4× with length) |
| after — bytes per answer char | 2.7 | **2.2** (falls — amortises) |

The shape assertion is the one that matters and it is asserted both ways: the baseline column must *exhibit* the quadratic (per-char cost grows >3× when the answer quadruples) — otherwise the comparison proves nothing — and the after column's per-char cost must *fall*.

## The change

A changed **string** leaf at or above `PatchStringSplice.MinSpliceLength` travels as a new operation verb:

```json
{"op":"splice","path":"/content/text",
 "value":{"$sd":[start,removed,"inserted"],"$sdb":[baseLength,"fingerprint"]}}
```

Same `$sd` / `$sdb` markers as the write path — one shape, one meaning — combined into the single `value` slot an RFC 6902 operation has.

**The base is the producer's own cached `JsonElement` for that subscription**, not the update's `OldValue`. That cache *is* the document the subscriber holds: the two are kept in lockstep by the frame chain, which resyncs on a lost frame *before* applying anything. So the fingerprint check on the far side is a proof obligation rather than a gamble, and the compression is a pure post-pass over the finished patch — `CreatePatch` and every existing operation's bytes are untouched.

**No blind splicing.** The subscriber applies the splice only when the fingerprint proves its text is byte-identical to the base. On a mismatch it throws `StaleStreamStateException`, which `SynchronizationStream.UpdateStream` already answers with a fresh authoritative Full from the owner (storm-gated by `_resyncInFlight` — one resubscribe per gap, no timer, no retry loop). That is #1414's rule with a strictly better recovery: a resync instead of a NACK.

## Why this one is NEGOTIATED, where the write path was not

#1414 could put its marker straight on the wire, and deliberately did: the only consumer is a C# owner, which fails **loudly** on a shape it does not understand — the merged node stops deserialising, the write is NACKed and never commits. Loud beats silent.

The fan-out has no such property. Its consumers are **four hand-rolled appliers this repo's CI does not build**, and every one of them fails *silently*:

| consumer | on an unknown `op` |
|---|---|
| `clients/grpc-web/src/jsonPatch.ts:92` | `default: break` — no-op; the text simply stops updating mid-stream |
| `clients/react/src/live/grpcSource.ts:322` | `default: break` — same |
| `clients/react/src/area/pointer.ts:86` | no `default` clause at all — same |
| `clients/python/meshweaver/mesh.py:70` | applied **as a replace**, writing `op.get("value")` → `None` into the field |
| C# `SynchronizationStream` | throws `Unknown patch operation` — the only loud one |

And a browser holds whatever bundle it loaded, so "upgrade both ends together" is not available here the way it is between two pods.

So `SubscribeRequest` gains **`AcceptsStringSplice`** (default `false`). The owner splices only for a subscriber that declared it; everyone else receives **byte-identical bytes to today** — no migration, no flag day, no shape they can misread. The marker still rides *inside* the patch, so a consumer that claims the capability and cannot honour it still fails loudly.

**How an old JS client is handled, concretely: it is not spliced to.** `clients/grpc-web`, `clients/react` and `clients/python` do not set the flag, so their frames are unchanged and `JsonPatchWireFormatTest` — the pinned gate standing between a refactor and a silent client break — is untouched and green (366/366). They can opt in later by implementing the verb and setting the flag; nothing about this change obliges them to.

Rolling deploys are safe in both directions: the messaging serializer runs `UnmappedMemberHandling.Skip`, so a new subscriber against an old owner is simply not spliced to, and an old subscriber against a new owner never sets the field.

## Not in scope

- **`clients/*` splice support.** Deliberately separate: it is TS/Python this repo's CI does not build, and the negotiation exists precisely so it can land on its own schedule. The measured win is already where the megabytes are — the Blazor GUI, the mesh-node cache and every cross-silo mirror are all C#.
- **#1351's ~2× transport constant**, for the same reason #1414 left it: a transport concern, and no longer material for chat now the payload is ~47× smaller.

## Verification

Local, `-c Release -warnaserror` on every touched project:

| suite | result |
|---|---|
| `MeshWeaver.Data.Test` | 368 / 368 (incl. new `FanOutStringSpliceTest`, 9) |
| `MeshWeaver.Json.Test` | 366 / 366 — the pinned client wire-format gate |
| `FanOutSpliceNegotiationTest` | passes — the framework's own subscribes really do declare the capability, asserted on live `SubscribeRequest`s as the owning node hubs receive them |

That last one exists because the failure mode of a negotiation is silent in the direction that looks fine: if nobody declared the capability, everyone would keep getting whole values, the measurement would never move, and no test would go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
