### PR TITLE
Regression from #1343: an install publishes TWICE, and I recycled on both

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1567,12 +1567,17 @@ internal static class NodeTypeEnrichmentHelpers
         IMessageHub instanceHub,
         string nodeType,
         string boundAssemblyPath,
-        ILogger? logger)
+        ILogger? logger,
+        IScheduler? scheduler = null)
         => typeStream
             .Where(t => t?.Content is NodeTypeDefinition d
                 && NodeTypeCompilationHelpers.HasUsableBuild(t, d)
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && !string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal))
+            // 🚨 Wait for the type to stop publishing — see AssemblySettleWindow. An install
+            // publishes twice (type, then its Source/) while instances are being read, and
+            // recycling on each one disposes hubs mid-read.
+            .Throttle(AssemblySettleWindow, scheduler ?? Scheduler.Default)
             .Take(1)
             .Subscribe(
                 t =>
@@ -1731,6 +1736,22 @@ internal static class NodeTypeEnrichmentHelpers
     /// instance cannot spin, short enough that a deploy heals itself well inside a support call.
     /// </summary>
     private static readonly TimeSpan SelfHealGrace = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// How long a NodeType must stop publishing before <see cref="ArmStaleAssemblySelfHeal"/> acts.
+    ///
+    /// <para>🚨 An INSTALL publishes more than once: the type node lands, compiles, and then its
+    /// <c>Source/</c> lands and it compiles AGAIN, seconds apart — while its instances are being
+    /// activated and read. Recycling on each publication put a <c>DisposeRequest</c> through hubs
+    /// mid-read and broke <c>NodeRepoInstanceOrderingTest</c> 6 runs in 8 (measured; 8/8 green with
+    /// the watcher disabled). Waiting for quiet collapses a burst into ONE recycle, after the burst
+    /// — which is also what the watcher meant all along: "a NEW build superseded mine", not "the
+    /// type is still settling".</para>
+    ///
+    /// <para>A real deploy publishes once and goes quiet, so it heals one window later — the deploy
+    /// case this whole watcher exists for is unaffected in substance.</para>
+    /// </summary>
+    private static readonly TimeSpan AssemblySettleWindow = TimeSpan.FromSeconds(10);
 
     /// <param name="activityPath">
     /// The NodeType's <see cref="NodeTypeDefinition.LastCompilationActivityPath"/>, when

--- a/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Subjects;
+using Microsoft.Reactive.Testing;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -96,6 +97,10 @@ public class StaleAssemblySelfHealWatcherTest
             }
         };
 
+    /// <summary>Let the settle window elapse — the watcher only acts once the type goes quiet.</summary>
+    private static void Settle(TestScheduler scheduler) =>
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(30).Ticks);
+
     private static void AssertNoDispose(IMessageHub hub) =>
         hub.DidNotReceive().Post(
             Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
@@ -109,8 +114,9 @@ public class StaleAssemblySelfHealWatcherTest
     {
         var hub = BuildInstanceHub(out var capturedOptions);
         var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
-            typeStream, hub, NodeTypePath, BoundAssembly, logger: null);
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
 
         // The replayed at-bind state: the very assembly this instance is running. Firing here
         // would recycle every instance on every emission of its own current state.
@@ -124,12 +130,18 @@ public class StaleAssemblySelfHealWatcherTest
         // 🚨 THE signal: a DIFFERENT assembly is published. This is the emission that was ignored
         // before the fix, leaving the instance executing the old DLL indefinitely.
         typeStream.OnNext(TypeNode(version: 12, assemblyPath: "TestData_StaleAssemblyType/v12-abc-222222222222.dll"));
+        // …but NOT instantly: the type may still be publishing (an install compiles the type, then
+        // recompiles when its Source/ lands). Recycling here disposes hubs mid-install.
+        AssertNoDispose(hub);
+
+        Settle(scheduler);
         AssertDisposedExactlyOnce(hub);
         AssertTargetsItself(capturedOptions);
 
         // Take(1): further publications do not re-post. The instance is already tearing down, and
         // re-enrichment will bind the newest assembly.
         typeStream.OnNext(TypeNode(version: 13, assemblyPath: "TestData_StaleAssemblyType/v13-abc-333333333333.dll"));
+        Settle(scheduler);
         AssertDisposedExactlyOnce(hub);
     }
 
@@ -143,11 +155,13 @@ public class StaleAssemblySelfHealWatcherTest
     {
         var hub = BuildInstanceHub(out _);
         var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
-            typeStream, hub, NodeTypePath, BoundAssembly, logger: null);
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
 
         for (var version = 11; version <= 20; version++)
             typeStream.OnNext(TypeNode(version, assemblyPath: BoundAssembly));
+        Settle(scheduler);
 
         AssertNoDispose(hub);
     }
@@ -163,10 +177,12 @@ public class StaleAssemblySelfHealWatcherTest
     {
         var hub = BuildInstanceHub(out var capturedOptions);
         var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
-            typeStream, hub, NodeTypePath, BoundAssembly, logger: null);
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
 
         typeStream.OnNext(TypeNode(version: 10, assemblyPath: "TestData_StaleAssemblyType/v10-abc-999999999999.dll"));
+        Settle(scheduler);
 
         AssertDisposedExactlyOnce(hub);
         AssertTargetsItself(capturedOptions);
@@ -178,8 +194,9 @@ public class StaleAssemblySelfHealWatcherTest
     {
         var hub = BuildInstanceHub(out _);
         var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
-            typeStream, hub, NodeTypePath, BoundAssembly, logger: null);
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
 
         typeStream.OnNext(TypeNode(version: 11, assemblyPath: null));
         typeStream.OnNext(new MeshNode("StaleAssemblyType", "TestData")
@@ -188,7 +205,44 @@ public class StaleAssemblySelfHealWatcherTest
             Version = 12,
             Content = "not a definition"
         });
+        Settle(scheduler);
         AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION (#1343, caught by NodeRepoInstanceOrderingTest failing 6 runs in 8 while
+    /// the same commit with this watcher disabled passed 8/8).
+    ///
+    /// <para>An INSTALL publishes more than once — the type node lands and compiles, then its
+    /// <c>Source/</c> lands and it compiles AGAIN, seconds apart — all while its instances are
+    /// being activated and READ. Recycling on each publication put a <c>DisposeRequest</c> through
+    /// those hubs mid-read ("Hub Pack/Widget/Nested is shutting down") and the post-install read
+    /// timed out.</para>
+    ///
+    /// <para>A burst must therefore cost exactly ONE recycle, and only once the type goes quiet.</para>
+    /// </summary>
+    [Fact]
+    public void APublicationBurst_CostsExactlyOneRecycle_AndOnlyAfterItGoesQuiet()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
+
+        // The install shape: several builds in quick succession, instances live throughout.
+        for (var version = 11; version <= 15; version++)
+        {
+            typeStream.OnNext(TypeNode(version,
+                assemblyPath: $"TestData_StaleAssemblyType/v{version}-abc-{version}00000000.dll"));
+            // A short hop — far inside the settle window. Nothing may be disposed yet.
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+            AssertNoDispose(hub);
+        }
+
+        // Quiet at last: exactly one recycle, onto the NEWEST build.
+        Settle(scheduler);
+        AssertDisposedExactlyOnce(hub);
     }
 
     /// <summary>Disposal (the hub's RegisterForDisposal hook) stops the watcher.</summary>
@@ -197,11 +251,13 @@ public class StaleAssemblySelfHealWatcherTest
     {
         var hub = BuildInstanceHub(out _);
         var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
         var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
-            typeStream, hub, NodeTypePath, BoundAssembly, logger: null);
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
 
         watcher.Dispose();
         typeStream.OnNext(TypeNode(version: 12, assemblyPath: "TestData_StaleAssemblyType/v12-abc-222222222222.dll"));
+        Settle(scheduler);
 
         AssertNoDispose(hub);
     }


### PR DESCRIPTION
**I shipped this.** #1343's watcher recycles an instance whenever its type publishes a new assembly — and an **install publishes more than once**: the type node lands and compiles, then its `Source/` lands and it compiles *again*, seconds apart, while its instances are being activated and **read**. Each publication put a `DisposeRequest` through those hubs mid-read.

## The measurement

Same machine, same commit, one predicate different:

| | result |
|---|---|
| the watcher as merged in #1343 | 2 pass / **6 fail** |
| watcher disabled (control) | **8 pass** / 0 fail |
| **with this fix** | **8 pass** / 0 fail |

The test is `NodeRepoInstanceOrderingTest.TypedInstances_UnderAndBesideTheirInPackageType_InstallOnFreshMesh`, and the CI failure names the mechanism outright:

```
Hub Pack/Widget/Nested is shutting down — cannot create '/MeshNode'.
The address may reactivate (recycle / restart); retry to get the authoritative answer.
```

`main`'s CI passing twice with #1343 in it was luck, not evidence — I had taken it as evidence, which is how this got a second chance to bite.

## The fix

Wait for the type to go **quiet** (`AssemblySettleWindow`, 10 s) before acting, so a publication burst collapses into **one** recycle, after the burst. That is also what the watcher meant all along — *"a new build superseded mine"*, not *"the type is still settling"*. A real deploy publishes once and goes quiet, so the case #1343 exists for still heals, one window later.

Pinned by `APublicationBurst_CostsExactlyOneRecycle_AndOnlyAfterItGoesQuiet`, which walks the install shape (five builds a second apart) and asserts **nothing** is disposed until quiet — it fails without the throttle. The existing five cases keep their contracts, now advanced through the window on a `TestScheduler`.

## How it was tested

- The install test: **8/8** green (from 2/8)
- `MeshWeaver.Graph.Test` **1105/1105** green
- Clean under `-c Release -p:CIRun=true -warnaserror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)