### PR TITLE
fix(build): the build claim is exclusive across clusters, not just within one

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -33,7 +33,9 @@ The protocol below removes all three **by construction** rather than by compensa
 
 ```
 Admin/Build                       ← the build ROOT (durable node, nodeType Build)
+Admin/Build/_Claim                ← the root's claim LOCK (durable; only atomic writes)
 Admin/Build/{chunkName}           ← one node per CHUNK (durable, nodeType Build)
+Admin/Build/{chunkName}/_Claim    ← the chunk's claim LOCK
 Admin/Build/{chunkName}/_Activity ← the chunk's execution activity (standard Activity)
 {nodeTypePath}/Release/{version}  ← unchanged: releases minted per compiled NodeType
 ```
@@ -57,31 +59,97 @@ files, no request/response types, no in-memory gates. Writers go through
 
 ## Who becomes the build master
 
-Nobody is elected. **Mastership is a claim written into the root node**, arbitrated the
-same way every concurrent write in this system is arbitrated: inside the `Update` lambda.
-
-```csharp
-stream.Update(node =>
-{
-    var b = node.ContentAs<BuildRoot>(hub.JsonSerializerOptions);
-    // The claim check and the claim write are one serialised step on the owning hub.
-    if (b is null || (b.ClaimedBy is not null && b.FrameworkVersion == myFingerprint))
-        return node;                    // someone else already owns this build — bail
-    return node with { Content = b with
-        { ClaimedBy = myIdentity, FrameworkVersion = myFingerprint, Status = BuildStatus.Planning } };
-});
-```
-
-The owning hub's action block serialises every writer, so the first candidate's lambda
-sees an unclaimed build and takes it; every later candidate's lambda re-reads the claimed
-state and returns the node unchanged. The claimant then observes its own claim on the
-stream before doing any work — a claim you cannot read back is a claim you do not hold.
-In-memory single-flight flags are permitted only as coalescers; **correctness comes from
-node state** (the [ActivityControlPlane](../ActivityControlPlane) rule).
+Nobody is elected. **Mastership is a claim written into the root node.** Candidates register
+under their own holder id in `RequestedClaims` (per-candidate keys — RFC 7396 merge-safe, so
+concurrent registrations compose instead of overwriting each other), and the node's own hub
+arbitrates. The claimant then observes its own claim on the stream before doing any work — a
+claim you cannot read back is a claim you do not hold. In-memory single-flight flags are
+permitted only as coalescers; **correctness comes from node state** (the
+[ActivityControlPlane](../ActivityControlPlane) rule).
 
 The same claim shape applies per chunk, which is what makes parallel builders safe later:
-each would-be builder claims `Admin/Build/{chunkName}`; the owning hub hands each chunk
-to exactly one.
+each would-be builder claims `Admin/Build/{chunkName}`; exactly one gets each chunk.
+
+### 🚨 The grant is taken on the DURABLE ROW — a hub lambda is only exclusive within ONE cluster
+
+The obvious implementation is to decide inside the owning hub's serialised `Update` lambda:
+the action block orders every writer, so the first candidate's lambda sees an unclaimed build
+and takes it, and every later lambda re-reads the claimed state and bails. That is correct —
+**and it is exclusive only within one Orleans cluster**, which is not the topology this
+protocol runs in.
+
+A second cluster over the same database activates its *own* hub for `Admin/Build`, runs its
+*own* arbiter against its *own* mirror, and grants its own candidate. Three things then line
+up to make the collision invisible (#1424):
+
+- both writes are minted at the same next `MeshNode.Version`, and the store's monotonic
+  condition **applies at equal versions** — re-persisting an unchanged node is a legitimate,
+  common shape — so both land, last-write-wins;
+- neither writer is told it lost: the "store refused" signal is `saved.Version >
+  written.Version`, and the versions are *equal*;
+- nothing propagates the other cluster's write back. Orleans membership and its memory
+  streams are per-cluster by construction, and there is no cross-process change feed running
+  (see the GO section below), so a mirror can be arbitrarily far behind and never learn.
+
+On 2026-08-13 that is exactly what happened on `memex-cloud`: the ephemeral bake Job and the
+rolling serving pod each claimed `Admin/Build` and each ran the full 268-type bake.
+
+#### The claim lives on a LOCK, not on the Build node
+
+Making the *grant* exclusive is necessary and not sufficient, and the second half is the less
+obvious one. Every cluster mirrors `Admin/Build` in its own workspace, and that mirror is
+flushed to storage as a **whole node** by the ordinary persistence sampler — a plain,
+unconditional write from a hub that may never have held the claim. `MeshNode.Version` is a
+per-node counter, not a cross-cluster logical clock, so both mirrors climb it independently and
+the later flush simply wins the row. A *losing* cluster therefore overwrites the winner's
+`ClaimedBy` with its own `null`, its arbiter sees a free build on the next pass, and the
+exclusivity a compare-and-set had just established is undone by a write that knows nothing about
+it. (This is observed behaviour, not a hypothesis: the cross-cluster test caught exactly it.)
+
+So the claim moved off the contended row onto a **lock node**, `Admin/Build/_Claim` (and
+`Admin/Build/{chunk}/_Claim`). The lock has no hub, no mirror and no sampler. Exactly two things
+ever write it, and neither is unconditional:
+
+| Operation | Primitive | Exclusivity |
+|---|---|---|
+| grant / takeover | `IStorageAdapter.WriteIfVersion(node, expectedVersion)` | compare-and-set on the version the arbiter read (`0` = "must not exist") |
+| heartbeat | `WriteIfVersion` | no-op unless this holder still owns the lock |
+| release | `IStorageAdapter.DeleteIfExists` | rowcount-gated, first delete wins |
+
+`BuildState.ClaimedBy` on the Build node stays as the **observable projection** — what the GUI
+and `ObserveBuildClaim` read. A flush clobbering it now costs a stale view in one cluster, never
+a second builder, because no decision is taken from it.
+
+#### The three steps, in this order
+
+`BuildNodeType.ArbitrateDurably`:
+
+1. **Read the lock.** Not the mirror — the mirror is per-cluster and cannot see a rival's grant.
+2. **Decide** with the unchanged `Arbitrate`, over the *lock's* holder state and *this cluster's*
+   pending registrations (from its mirror, because a candidate that registered milliseconds ago
+   has not reached storage yet — and a cluster can only ever grant one of its own candidates).
+3. **Commit with the compare-and-set** against the version step 1 read. At most one of N
+   concurrent arbiters is told `true`. Only then is the grant published on the Build node.
+
+Step 3 has to come before the mirror write, not after, because **the mirror commits ~200 ms
+before the persistence sampler reaches storage** and `ObserveBuildClaim` emits off the mirror.
+Adjudicating after the fact would find the loser already baking.
+
+Losing writes nothing and retries nothing: a refused compare-and-set means another cluster's
+grant is already durable, so this cluster does not grant, its candidate runs out its
+`GrantWindow` and follows the GO — the path the protocol already has for "held elsewhere".
+The arbiter is level-triggered, so the next legitimate trigger re-decides against fresh
+durable state. No timer, no election, no backoff loop.
+
+**It fails OPEN.** With no storage provider owning the path (or no persistence at all — a
+monolith, a test, a dev box) the grant is taken on the mirror exactly as before. Being wrong
+in that direction costs one duplicated bake: bounded and non-corrupting, because every
+downstream write is content-addressed (assembly store keyed by content, release versions
+minted from content hashes, GO keyed by fingerprint). Being wrong the other way — refusing to
+grant because exclusivity could not be proven — leaves the fingerprint with no GO at all,
+which holds every silo's readiness probe down and stalls the rollout. Same asymmetry the bake
+gate applies, and the opposite of `AssemblyCacheRetention`, where the wrong answer deletes
+bytes a running pod still needs.
 
 ### 🚨 When may the claim be taken away — cluster MEMBERSHIP decides, not a clock
 
@@ -107,6 +175,14 @@ runs probes, indirect probes and a membership table for precisely this. So the c
 `Unknown` is the only path that still consults a clock, and it covers exactly the hosts that have no
 cluster to ask — a monolith, a test, a dev box, the Orleans *client* host — plus a claim written
 before identities were stamped and an identity membership cannot resolve.
+
+🚨 **A holder in ANOTHER cluster is always `Unknown`**, because Orleans membership is per-cluster:
+the bake silo's ServiceId is not in the serving cluster's table and vice versa, and absence is
+`Unknown`, never `Gone`. So a cross-cluster takeover falls back to the `ClaimStaleAfter` clock —
+this is the one place the clock still governs a live fleet, and it is deliberate: the alternative
+is treating "I cannot see you" as "you are dead", which is precisely the eviction of a live builder
+the membership rule exists to prevent. What #1424 adds is that the takeover WRITE is itself a
+compare-and-set, so two clusters that time out on the same dead holder cannot both succeed it.
 
 🚨 **Absence from the membership snapshot is `Unknown`, never `Gone`.** Orleans keeps departed silos
 in the table as `Dead` until the defunct-cleanup window elapses, so a silo that really died IS in the
@@ -165,13 +241,28 @@ probe accordingly:
   written when *their* image baked, and a newer build's state transitions never revoke an
   older GO — the root's `Ready` is per-fingerprint history, not a global boolean.
 
-The broadcast rides the **durable store's change feed** (Postgres `LISTEN/NOTIFY` via
-`PostgreSqlChangeListener`), which is cross-process and therefore cross-ServiceId by
+The broadcast is *designed* to ride the **durable store's change feed** (Postgres `LISTEN/NOTIFY`
+via `PostgreSqlChangeListener`), which is cross-process and therefore cross-ServiceId by
 construction. It deliberately does *not* ride the Orleans stream relay — the bake cluster
 is not in the portal's cluster, and intra-cluster relays must not be a readiness
 dependency. The subscription itself is a remote-path watch and uses the
 `SubscribeWithReEstablish` fault taxonomy: transient faults re-establish; a poisoned or
 deleted root is terminal and loud, never a silent 1 Hz retry loop.
+
+🚨 **That feed is not running yet.** `PostgreSqlChangeListener` is registered but never started in
+either partitioned-PG overload — `AddPartitionedPostgreSqlPersistence` has the `AddHostedService`
+call commented out, and the Aspire overload the portal actually uses never had one. Within a
+cluster the GO still reaches every silo, because `GetMeshNodeStream` resolves to the ONE per-node
+hub that owns `Admin/Build` there; **across clusters nothing propagates it**, so a follower in the
+bake silo's peer cluster observes only what its own hub read at activation. Two consequences worth
+keeping straight:
+
+- the claim arbiter must not depend on notification — hence it READS the durable row on every pass
+  (see above) rather than waiting to be told;
+- `BuildProtocolDriver.FollowGo` subscribes to `ObserveBuildGo` with no bound, so a cross-cluster
+  follower can wait indefinitely for a GO it will never be shown. Starting the listener (or giving
+  the follower a bounded fall-back to its own sweep) is the outstanding work here; until then, treat
+  a *separate-cluster* bake host as "publishes the GO earlier", not as "spares its peers the bake".
 
 The probe semantics of `NodeTypeBakeGateState` are preserved unchanged — fail **closed**
 on a measured regression (the rollout stalls, the old image keeps serving), fail **open**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-two-servers-no-longer-run-the-same-build-twice.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-two-servers-no-longer-run-the-same-build-twice.md
@@ -1,0 +1,31 @@
+---
+Name: Two servers no longer run the same build twice
+Category: Fix
+Description: A build claim is now exclusive across every server sharing a database, not just within one cluster — so a rollout compiles the platform's dynamic content once instead of once per server.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Two servers no longer run the same build twice
+
+When a new version of the platform is deployed, every piece of dynamic content in it has to be
+recompiled before any server may serve. One server is supposed to claim that work and the rest wait
+for its result.
+
+The claim held only within a single server cluster. Two servers that share a database but belong to
+different clusters each kept their own view of the build, each concluded that nobody had claimed it,
+and each wrote its claim — and neither was told it had lost the race, because the two writes were
+indistinguishable to the database. On the last deployment that meant the whole content set, 268
+items, was compiled twice: once by the dedicated build server that exists precisely to spare the
+live server that cost, and once by the live server anyway.
+
+Claims are now settled in the database itself, by a write that can only succeed for one claimant.
+The server that loses is told so, skips the build, and waits for the winner's result — the behaviour
+that was always intended when a build is already running elsewhere. The claim also moved onto a
+record of its own, so that a server which never held it can no longer overwrite the holder's claim
+when it saves its own copy of the build state.
+
+Nothing about the build's output changes: it was never at risk, because compiled artefacts are
+stored under a key derived from their content, so two servers producing the same build produced the
+same bytes. What is saved is the duplicated work — and, on the live server during a rollout, the
+memory it took.

--- a/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
+++ b/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
@@ -22,6 +23,13 @@ namespace MeshWeaver.Graph;
 /// (<see cref="ObserveBuildClaim"/>). Holder-side writes go through
 /// <see cref="UpdateBuildAsHolder"/>, which no-ops unless the caller still holds the claim —
 /// a builder that lost its claim to staleness cannot corrupt its successor's state.</para>
+///
+/// <para>🚨 <b>Who holds the build is decided on the claim LOCK</b>
+/// (<see cref="BuildNodeType.ClaimPath"/>), not on the Build node — a mirror is per-cluster and is
+/// flushed wholesale, so a field on it cannot be exclusive across clusters (#1424). The lock is
+/// touched by exactly three operations, all conditional: the arbiter's compare-and-set grant,
+/// <see cref="BeatBuildClaim"/>'s stamp refresh, and <see cref="ReleaseBuildClaim"/>. Everything
+/// else on this surface is ordinary node state.</para>
 /// </summary>
 public static class BuildCoordinationExtensions
 {
@@ -129,14 +137,79 @@ public static class BuildCoordinationExtensions
             return curr with { Content = change(state) };
         });
 
-    /// <summary>Refreshes the holder's liveness stamp. Call on <see cref="BuildNodeType.HeartbeatInterval"/>.</summary>
+    /// <summary>
+    /// Refreshes the holder's liveness stamp. Call on <see cref="BuildNodeType.HeartbeatInterval"/>.
+    ///
+    /// <para>Two writes, one meaning: the visible stamp on the Build node, and — the load-bearing
+    /// one — the stamp on the claim LOCK, which is what every cluster's arbiter ages when membership
+    /// has no opinion about the holder (across clusters it never has). The lock write is a
+    /// compare-and-set that no-ops unless this holder still owns the lock, so a superseded builder's
+    /// heartbeat cannot keep a claim it no longer has alive.</para>
+    /// </summary>
     /// <param name="hub">The calling hub.</param>
     /// <param name="holder">The claim holder.</param>
     /// <param name="path">Node path; defaults to the build root.</param>
     /// <returns>Cold observable emitting the node after the write.</returns>
     public static IObservable<MeshNode> BeatBuildClaim(
         this IMessageHub hub, string holder, string path = BuildNodeType.RootPath)
-        => hub.UpdateBuildAsHolder(holder, s => s with { HeartbeatAt = DateTime.UtcNow }, path);
+        => hub.UpdateBuildAsHolder(holder, s => s with { HeartbeatAt = DateTime.UtcNow }, path)
+            .SelectMany(node => OnOwnLock(
+                    hub, holder, path,
+                    (storage, held, state, options) => storage.WriteIfVersion(
+                        held with
+                        {
+                            Content = state with { HeartbeatAt = DateTime.UtcNow },
+                            Version = MeshNode.NextVersion(held.Version),
+                        },
+                        held.Version,
+                        options))
+                .Select(_ => node));
+
+    /// <summary>
+    /// Releases the claim LOCK — the step that lets any cluster's arbiter grant the next candidate.
+    /// A no-op unless <paramref name="holder"/> still owns the lock, so a superseded builder's
+    /// completion cannot release its successor's claim.
+    ///
+    /// <para><see cref="CompleteBuild"/> and <see cref="FailBuild"/> chain this automatically;
+    /// call it directly only where a claim is released WITHOUT going through them — the chunk
+    /// close-out in <c>BuildProtocolDriver</c>, which clears the claim fields itself.</para>
+    /// </summary>
+    /// <param name="hub">The calling hub.</param>
+    /// <param name="holder">The claim holder releasing the build.</param>
+    /// <param name="path">The Build node (root or chunk) whose claim is released.</param>
+    /// <returns>Cold observable completing when the lock is gone (or was never ours).</returns>
+    public static IObservable<System.Reactive.Unit> ReleaseBuildClaim(
+        this IMessageHub hub, string holder, string path)
+        => OnOwnLock(
+            hub, holder, path,
+            (storage, held, _, _) => storage.DeleteIfExists(held.Path).Select(_ => (bool?)true));
+
+    /// <summary>
+    /// Reads the claim lock for <paramref name="path"/> and runs <paramref name="act"/> only while
+    /// <paramref name="holder"/> still owns it. The read-then-act window is safe because every
+    /// action is itself conditional (a compare-and-set on the version read, or a rowcount-gated
+    /// delete) — the lock's whole point is that no write to it is unconditional.
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> OnOwnLock(
+        IMessageHub hub,
+        string holder,
+        string path,
+        Func<IStorageAdapter, MeshNode, BuildState, JsonSerializerOptions, IObservable<bool?>> act)
+    {
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (storage is null)
+            return Observable.Return(System.Reactive.Unit.Default);
+        var options = hub.JsonSerializerOptions;
+        return storage.Read(BuildNodeType.ClaimPath(path), options)
+            .Take(1)
+            .SelectMany(held =>
+            {
+                var state = held?.ContentAs<BuildState>(options);
+                return held is null || state?.ClaimedBy != holder
+                    ? Observable.Return(System.Reactive.Unit.Default)
+                    : act(storage, held, state, options).Select(_ => System.Reactive.Unit.Default);
+            });
+    }
 
     /// <summary>
     /// Completes the build: records the GO for <paramref name="go"/>'s fingerprint on the
@@ -151,18 +224,21 @@ public static class BuildCoordinationExtensions
     public static IObservable<MeshNode> CompleteBuild(
         this IMessageHub hub, string holder, BuildGo go, string path = BuildNodeType.RootPath)
         => hub.UpdateBuildAsHolder(
-            holder,
-            s => s with
-            {
-                Status = BuildStatus.Ready,
-                Ready = (s.Ready ?? ImmutableDictionary<string, BuildGo>.Empty)
-                    .SetItem(go.FrameworkVersion, go),
-                ClaimedBy = null,
-                ClaimedByIdentity = null,
-                ClaimedAt = null,
-                HeartbeatAt = null,
-            },
-            path);
+                holder,
+                s => s with
+                {
+                    Status = BuildStatus.Ready,
+                    Ready = (s.Ready ?? ImmutableDictionary<string, BuildGo>.Empty)
+                        .SetItem(go.FrameworkVersion, go),
+                    ClaimedBy = null,
+                    ClaimedByIdentity = null,
+                    ClaimedAt = null,
+                    HeartbeatAt = null,
+                },
+                path)
+            // …and drop the LOCK, which is what actually frees the build for the next candidate in
+            // ANY cluster. Clearing ClaimedBy on the node alone would only free it here.
+            .SelectMany(node => hub.ReleaseBuildClaim(holder, path).Select(_ => node));
 
     /// <summary>
     /// Fails the build: records the error and releases the claim. The fingerprint gets NO GO —
@@ -177,17 +253,20 @@ public static class BuildCoordinationExtensions
     public static IObservable<MeshNode> FailBuild(
         this IMessageHub hub, string holder, string error, string path = BuildNodeType.RootPath)
         => hub.UpdateBuildAsHolder(
-            holder,
-            s => s with
-            {
-                Status = BuildStatus.Failed,
-                Error = error,
-                ClaimedBy = null,
-                ClaimedByIdentity = null,
-                ClaimedAt = null,
-                HeartbeatAt = null,
-            },
-            path);
+                holder,
+                s => s with
+                {
+                    Status = BuildStatus.Failed,
+                    Error = error,
+                    ClaimedBy = null,
+                    ClaimedByIdentity = null,
+                    ClaimedAt = null,
+                    HeartbeatAt = null,
+                },
+                path)
+            // A failed build releases the claim exactly like a completed one — the fingerprint gets
+            // no GO, but the build must not stay locked to a holder that has stopped.
+            .SelectMany(node => hub.ReleaseBuildClaim(holder, path).Select(_ => node));
 
     /// <summary>
     /// THE readiness primitive: emits the GO record once the build root's history covers

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
@@ -21,8 +22,23 @@ namespace MeshWeaver.Graph.Configuration;
 /// <see cref="BuildClaimRequest"/> under their own holder id in
 /// <see cref="BuildState.RequestedClaims"/> (per-candidate keys — RFC 7396 merge-safe), and the
 /// node's OWN hub arbitrates: <see cref="InstallClaimArbiter"/> grants the earliest pending
-/// request inside a serialised <c>Update</c> lambda, and steals a claim whose holder has gone.
-/// Correctness comes from node state, never from an in-memory gate.</para>
+/// request and steals a claim whose holder has gone. Correctness comes from node state, never
+/// from an in-memory gate.</para>
+///
+/// <para><b>🚨 The grant is taken on a durable LOCK, not on the hub's mirror (#1424).</b> A hub's
+/// serialised <c>Update</c> lambda makes the decision exclusive within ONE Orleans cluster, and that
+/// is all it can ever make it: a second cluster over the same database activates its OWN hub for
+/// <see cref="RootPath"/>, runs its OWN arbiter against its OWN mirror, and grants its own candidate.
+/// Both writes are minted at the same next version, the store's monotonic condition applies at equal
+/// versions, and neither writer is told it lost — so on 2026-08-13 the ephemeral bake Job and the
+/// rolling serving pod each claimed <c>Admin/Build</c> and each ran the full 268-type bake. Worse, the
+/// grant is observed off the RAM mirror, which commits ~200 ms BEFORE the persistence sampler reaches
+/// storage, so no amount of adjudication after the fact can stop the second builder starting.
+/// <see cref="ArbitrateDurably"/> therefore inverts the order: read the claim LOCK
+/// (<see cref="ClaimPath"/> — the ONE witness both clusters can see, since the Orleans membership
+/// table cannot be, being per-cluster by construction, and no change feed crosses processes), decide
+/// against it, and publish the grant on the Build node only after an atomic
+/// <see cref="IStorageAdapter.WriteIfVersion"/> has said this cluster won.</para>
 ///
 /// <para><b>Takeover is decided by cluster MEMBERSHIP, not by a clock</b> (#1355). A staleness
 /// budget is a stand-in for "is the holder still alive?", and where a cluster exists it already
@@ -37,6 +53,39 @@ public static class BuildNodeType
 
     /// <summary>The build root — the node whose <see cref="BuildState.Ready"/> map is the GO signal.</summary>
     public const string RootPath = "Admin/Build";
+
+    /// <summary>Last segment of a claim LOCK node — see <see cref="ClaimPath"/>.</summary>
+    internal const string ClaimSegment = "_Claim";
+
+    /// <summary>
+    /// The claim LOCK for a Build node: a tiny satellite carrying ONLY the current holder, written
+    /// exclusively through <see cref="IStorageAdapter.WriteIfVersion"/> and
+    /// <see cref="IStorageAdapter.DeleteIfExists"/>.
+    ///
+    /// <para>🚨 <b>Why the claim cannot live on the Build node's own row (#1424).</b> Every cluster
+    /// keeps its own mirror of <c>Admin/Build</c>, and that mirror is flushed to storage as a WHOLE
+    /// NODE by the ordinary persistence sampler — a plain, unconditional write from a hub that may
+    /// never have held the claim. `MeshNode.Version` is a per-node counter, not a cross-cluster
+    /// logical clock, so both mirrors climb it independently and the later flush simply wins the
+    /// whole row. A losing cluster therefore overwrites the winner's <c>ClaimedBy</c> with its own
+    /// <c>null</c>, the arbiter sees a free build on its next pass, and the exclusivity a
+    /// compare-and-set had just established is undone by a write that knows nothing about it. This
+    /// was observed directly: making the GRANT exclusive was not enough while the granted field
+    /// still lived on a row two mirrors flush wholesale.</para>
+    ///
+    /// <para>The lock has no hub, no mirror and no sampler — nothing writes it except the two atomic
+    /// storage primitives — so "who holds the build" has exactly one writer path and one witness.
+    /// <see cref="BuildState.ClaimedBy"/> on the Build node remains the OBSERVABLE projection the
+    /// GUI and <c>ObserveBuildClaim</c> read; a clobber there costs a stale view, never a second
+    /// builder.</para>
+    /// </summary>
+    /// <param name="buildPath">The Build node (root or chunk) whose claim is wanted.</param>
+    /// <returns>The lock node's path.</returns>
+    public static string ClaimPath(string buildPath) => $"{buildPath}/{ClaimSegment}";
+
+    /// <summary>Whether <paramref name="path"/> IS a claim lock rather than a Build node.</summary>
+    internal static bool IsClaimPath(string? path) =>
+        path is not null && path.EndsWith('/' + ClaimSegment, StringComparison.Ordinal);
 
     /// <summary>
     /// How long a claim survives without a heartbeat before the arbiter hands it to the next
@@ -88,14 +137,13 @@ public static class BuildNodeType
     };
 
     /// <summary>
-    /// The claim arbiter — runs on each Build node's OWN hub, where <c>Update</c> lambdas are
-    /// serialised by the action block, so the grant check and the grant write are one atomic step.
+    /// The claim arbiter — runs on each Build node's OWN hub.
     ///
     /// <para>Two triggers, one decision procedure: every own-stream emission (a candidate
     /// registered, a holder released) and a slow periodic tick (a dead holder emits nothing — the
-    /// stale steal can only come from a timer). Both funnel into <see cref="Arbitrate"/>, which
-    /// re-reads state inside the lambda and returns the node UNCHANGED when there is nothing to
-    /// do, so redundant triggers write nothing.</para>
+    /// stale steal can only come from a timer). Both funnel into <see cref="ArbitrateDurably"/>,
+    /// which re-reads the durable row and does nothing when there is nothing to do, so redundant
+    /// triggers write nothing.</para>
     /// </summary>
     /// <param name="hub">The Build node's own hub.</param>
     /// <returns>The subscription to dispose with the hub.</returns>
@@ -104,13 +152,22 @@ public static class BuildNodeType
         var logger = hub.ServiceProvider.GetService<ILogger<MeshNode>>();
         var workspace = hub.GetWorkspace();
 
+        // A claim LOCK is not a build. It shares the Build node type so it needs no registration of
+        // its own, but it must never arbitrate — it has no candidates and no claim of its own, and
+        // an arbiter there would go looking for `…/_Claim/_Claim`.
+        if (IsClaimPath(hub.Address.Path))
+            return System.Reactive.Disposables.Disposable.Empty;
+
         // Absent on a monolith, a test, a dev box and the Orleans CLIENT host — all of which is
         // "no cluster", which Arbitrate reads as Unknown and answers with the heartbeat clock.
         var membership = hub.ServiceProvider.GetService<IClusterMembership>();
 
+        // The cross-cluster witness. Absent only on a host with no persistence at all, which is
+        // single-process by construction — there the mirror IS the whole world (see ArbitrateDurably).
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+
         void TryArbitrate() =>
-            workspace.GetMeshNodeStream()
-                .Update(node => Arbitrate(node, hub.JsonSerializerOptions, DateTime.UtcNow, membership))
+            ArbitrateDurably(hub, storage, membership, logger)
                 .Subscribe(
                     _ => { },
                     ex => logger?.LogWarning(
@@ -130,6 +187,26 @@ public static class BuildNodeType
             logger,
             "build claim arbiter");
 
+        // 🚨 The LOCK changing is its own trigger, and a required one now that the decision is taken
+        // there. The mirror emission above fires the instant a holder RELEASES its claim, but the
+        // release clears the node's projection first and drops the lock a moment later — so a pass
+        // triggered by the mirror reads a lock that still names the outgoing holder, correctly
+        // declines to grant, and then has nothing left to wake it until the slow tick. The store
+        // publishes Changes from inside its own write/delete, so this edge fires exactly when the
+        // lock actually moved: level-triggered on a real state change, never a poll or a retry. It
+        // cannot loop — a pass with nothing to grant writes nothing, so it publishes nothing.
+        var claimPath = ClaimPath(hub.Address.Path);
+        var onDurableChange = storage is null
+            ? System.Reactive.Disposables.Disposable.Empty
+            : storage.Changes
+                .Where(change =>
+                    string.Equals(change.Path, claimPath, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(change.Path, hub.Address.Path, StringComparison.OrdinalIgnoreCase))
+                .Subscribe(
+                    _ => TryArbitrate(),
+                    ex => logger?.LogWarning(
+                        ex, "Build claim arbiter lost the durable change feed on {Address}", hub.Address));
+
         // A holder that died emits nothing — its departure can only be observed by a timer, whether
         // the evidence is a membership verdict or an aged heartbeat. The tick is cheap by
         // construction: Arbitrate returns the node unchanged unless a pending claim exists AND the
@@ -137,12 +214,208 @@ public static class BuildNodeType
         var staleTick = Observable.Interval(HeartbeatInterval)
             .Subscribe(_ => TryArbitrate());
 
-        return new System.Reactive.Disposables.CompositeDisposable(onEmission, staleTick);
+        return new System.Reactive.Disposables.CompositeDisposable(
+            onEmission, onDurableChange, staleTick);
     }
 
     /// <summary>
-    /// The single decision procedure, executed inside the owning hub's serialised
-    /// <c>Update</c> lambda. Grants the earliest pending claim when the node is unclaimed or the
+    /// One arbitration pass, taken on the DURABLE row so it is exclusive across Orleans clusters
+    /// and not merely within one (#1424). Three steps, and the ORDER is the fix:
+    ///
+    /// <list type="number">
+    /// <item>Read the durable row. It is the only witness a second cluster also sees — Orleans
+    /// membership is per-cluster by construction, and no change feed crosses the process boundary
+    /// (the PG <c>LISTEN</c> session is not started in the partitioned wiring), so a mirror can be
+    /// arbitrarily far behind another cluster's grant and will never be told.</item>
+    /// <item>Decide with <see cref="Arbitrate"/> over the DURABLE holder state and the union of
+    /// durable + mirror registrations. Registrations come from the mirror as well because a
+    /// candidate that registered milliseconds ago has not reached storage yet, and per-candidate
+    /// keys make the union safe (that is exactly why <see cref="BuildState.RequestedClaims"/> is a
+    /// map). Holder state comes ONLY from durable — that is the contested field.</item>
+    /// <item>Commit with <see cref="IStorageAdapter.WriteIfVersion"/> against the version we read,
+    /// and write the grant into this hub's mirror only if the store says we won. The mirror write
+    /// is what <c>ObserveBuildClaim</c> emits on, and it commits ~200 ms before the persistence
+    /// sampler reaches storage — so the durable decision has to come FIRST or the loser has already
+    /// started baking by the time it could be told.</item>
+    /// </list>
+    ///
+    /// <para><b>Losing writes nothing and retries nothing.</b> A refused compare-and-set means
+    /// another cluster's grant is already durable; this cluster simply does not grant, its candidate
+    /// runs out its <c>GrantWindow</c> and follows the GO — the path the protocol already has for
+    /// "the claim is held elsewhere". No timer, no election, no backoff loop: the arbiter is
+    /// level-triggered and the next legitimate trigger re-decides against fresh durable state.</para>
+    ///
+    /// <para>🚨 <b>Fail OPEN, deliberately.</b> When no adapter owns the path (<c>null</c> from the
+    /// try-then-claim chain) or there is no persistence at all, the grant is taken on the mirror
+    /// exactly as before. Being wrong in this direction costs ONE duplicated bake — bounded and
+    /// non-corrupting, because every downstream write is content-addressed (the assembly store is
+    /// keyed by content, release versions are minted from content hashes, the GO is keyed by
+    /// fingerprint). Being wrong in the other direction — refusing to grant because exclusivity
+    /// could not be proven — would leave the fingerprint with no GO at all, which holds every
+    /// silo's readiness probe down and stalls the rollout. That asymmetry is the same one the bake
+    /// gate applies (fail closed on a measured regression, fail open when nothing is measuring) and
+    /// the opposite of <c>AssemblyCacheRetention</c>, where the wrong answer deletes bytes a running
+    /// pod needs.</para>
+    /// </summary>
+    /// <param name="hub">The Build node's own hub.</param>
+    /// <param name="storage">The durable store, or <c>null</c> on a host without persistence.</param>
+    /// <param name="membership">Cluster membership, or <c>null</c> where this host is in no cluster.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>Cold observable completing when the pass is done.</returns>
+    internal static IObservable<Unit> ArbitrateDurably(
+        IMessageHub hub,
+        IStorageAdapter? storage,
+        IClusterMembership? membership,
+        ILogger? logger)
+    {
+        var workspace = hub.GetWorkspace();
+        var options = hub.JsonSerializerOptions;
+
+        if (storage is null)
+            return GrantOnMirror(workspace, options, membership, DateTime.UtcNow);
+
+        var claimPath = ClaimPath(hub.Address.Path);
+        return workspace.GetMeshNodeStream()
+            .Where(n => n is not null)
+            .Take(1)
+            .SelectMany(mirror => storage.Read(claimPath, options)
+                .Take(1)
+                .SelectMany(held => CommitGrant(
+                    workspace, storage, options, membership, logger, mirror, claimPath, held)));
+    }
+
+    /// <summary>
+    /// The pre-#1424 behaviour, kept for hosts with no durable store — a single process, where the
+    /// hub's own serialised <c>Update</c> IS the whole arbitration, and for the fail-open path.
+    /// </summary>
+    private static IObservable<Unit> GrantOnMirror(
+        IWorkspace workspace, System.Text.Json.JsonSerializerOptions options,
+        IClusterMembership? membership, DateTime now)
+        => workspace.GetMeshNodeStream()
+            .Update(node => Arbitrate(node, options, now, membership))
+            .Select(_ => Unit.Default);
+
+    private static IObservable<Unit> CommitGrant(
+        IWorkspace workspace,
+        IStorageAdapter storage,
+        System.Text.Json.JsonSerializerOptions options,
+        IClusterMembership? membership,
+        ILogger? logger,
+        MeshNode mirror,
+        string claimPath,
+        MeshNode? held)
+    {
+        // Candidates come from THIS hub's mirror: a registration written milliseconds ago has not
+        // reached storage yet, and each cluster can only ever grant one of its own candidates
+        // anyway. Nothing pending ⇒ nothing to decide, and no read of anything else.
+        var pending = mirror.ContentAs<BuildState>(options)?.RequestedClaims;
+        if (pending is not { Count: > 0 })
+            return Observable.Return(Unit.Default);
+
+        // Holder state comes from the LOCK — never from the mirror and never from the Build node's
+        // own durable row (see ClaimPath for why that row cannot hold it).
+        var decisionInput = (held ?? NewClaimNode(claimPath)) with
+        {
+            Content = (held?.ContentAs<BuildState>(options) ?? new BuildState()) with
+            {
+                RequestedClaims = pending,
+            }
+        };
+
+        var decided = Arbitrate(decisionInput, options, DateTime.UtcNow, membership);
+        if (ReferenceEquals(decided, decisionInput))
+            return Observable.Return(Unit.Default);   // nothing to grant — the quiet path, no write
+
+        var granted = decided.ContentAs<BuildState>(options)!;
+        var expectedVersion = held?.Version ?? 0;
+        var toWrite = decided with
+        {
+            // The lock carries the CLAIM and nothing else; registrations stay on the Build node,
+            // which is where candidates write them.
+            Content = granted with { RequestedClaims = null },
+            Version = MeshNode.NextVersion(expectedVersion),
+            LastModified = DateTimeOffset.UtcNow,
+        };
+
+        return storage.WriteIfVersion(toWrite, expectedVersion, options)
+            .Take(1)
+            .SelectMany(applied =>
+            {
+                if (applied is false)
+                {
+                    // Another cluster's arbiter got there first. Say so — a silently-not-granted
+                    // claim is indistinguishable from an arbiter that never ran.
+                    logger?.LogInformation(
+                        "Build claim {ClaimPath}: NOT granting {Holder} — the lock moved past "
+                        + "Version={Expected} while this pass ran, which means another cluster's "
+                        + "arbiter granted first. This candidate follows the GO instead of building.",
+                        claimPath, granted.ClaimedBy, expectedVersion);
+                    return Observable.Return(Unit.Default);
+                }
+
+                if (applied is null)
+                    logger?.LogDebug(
+                        "Build claim {ClaimPath}: no storage provider owns this path, so the grant to "
+                        + "{Holder} is taken on the mirror alone (single-store host).",
+                        claimPath, granted.ClaimedBy);
+
+                // Won the lock (or fail-open). Publish the grant on the Build node so
+                // ObserveBuildClaim emits — the field set only, never a wholesale replace: a
+                // registration written milliseconds ago may not have reached storage, and replacing
+                // the mirror would drop it and strand its candidate.
+                return workspace.GetMeshNodeStream()
+                    .Update(current => ApplyGrant(current, granted, options))
+                    .Select(_ => Unit.Default);
+            });
+    }
+
+    /// <summary>
+    /// A fresh, unheld claim lock — the node the compare-and-set INSERTS when nobody holds the
+    /// build (<c>expectedVersion 0</c>).
+    /// </summary>
+    private static MeshNode NewClaimNode(string claimPath)
+    {
+        var split = claimPath.LastIndexOf('/');
+        return new MeshNode(claimPath[(split + 1)..], claimPath[..split])
+        {
+            NodeType = NodeType,
+            Name = "Build claim",
+            Content = new BuildState(),
+        };
+    }
+
+    /// <summary>
+    /// Applies a grant this cluster WON durably onto its own mirror — the claim field set only, so
+    /// nothing the mirror holds and storage has not seen yet is lost.
+    /// </summary>
+    private static MeshNode ApplyGrant(
+        MeshNode node, BuildState granted, System.Text.Json.JsonSerializerOptions options)
+    {
+        if (node is null) return node!;
+        var state = node.ContentAs<BuildState>(options) ?? new BuildState();
+        if (state.ClaimedBy == granted.ClaimedBy && state.Status == granted.Status)
+            return node;   // already reflects this grant — a redundant pass writes nothing
+        return node with
+        {
+            Content = state with
+            {
+                ClaimedBy = granted.ClaimedBy,
+                ClaimedByIdentity = granted.ClaimedByIdentity,
+                ClaimedAt = granted.ClaimedAt,
+                HeartbeatAt = granted.HeartbeatAt,
+                FrameworkVersion = granted.FrameworkVersion,
+                Status = granted.Status,
+                Error = null,
+                RequestedClaims = granted.ClaimedBy is { } holder
+                    ? state.RequestedClaims?.Remove(holder)
+                    : state.RequestedClaims,
+            }
+        };
+    }
+
+    /// <summary>
+    /// The single decision procedure, pure over its inputs. Grants the earliest pending claim when
+    /// the node is unclaimed or the
     /// current holder is gone; otherwise returns the node unchanged. Pure over its inputs — the
     /// instant and the membership verdict are both parameters — so every takeover rule is testable
     /// without a cluster and without waiting on wall-clock.

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -223,17 +223,17 @@ public static class BuildNodeType
     /// and not merely within one (#1424). Three steps, and the ORDER is the fix:
     ///
     /// <list type="number">
-    /// <item>Read the durable row. It is the only witness a second cluster also sees — Orleans
-    /// membership is per-cluster by construction, and no change feed crosses the process boundary
-    /// (the PG <c>LISTEN</c> session is not started in the partitioned wiring), so a mirror can be
-    /// arbitrarily far behind another cluster's grant and will never be told.</item>
-    /// <item>Decide with <see cref="Arbitrate"/> over the DURABLE holder state and the union of
-    /// durable + mirror registrations. Registrations come from the mirror as well because a
-    /// candidate that registered milliseconds ago has not reached storage yet, and per-candidate
-    /// keys make the union safe (that is exactly why <see cref="BuildState.RequestedClaims"/> is a
-    /// map). Holder state comes ONLY from durable — that is the contested field.</item>
-    /// <item>Commit with <see cref="IStorageAdapter.WriteIfVersion"/> against the version we read,
-    /// and write the grant into this hub's mirror only if the store says we won. The mirror write
+    /// <item>Read the claim LOCK (<see cref="ClaimPath"/>). It is the only witness a second cluster
+    /// also sees — Orleans membership is per-cluster by construction, and no change feed crosses the
+    /// process boundary (the PG <c>LISTEN</c> session is not started in the partitioned wiring), so
+    /// a mirror can be arbitrarily far behind another cluster's grant and will never be told.</item>
+    /// <item>Decide with <see cref="Arbitrate"/> over the LOCK's holder state and THIS cluster's
+    /// pending registrations. Registrations come from the mirror because a candidate that registered
+    /// milliseconds ago has not reached storage yet — and a cluster can only ever grant one of its
+    /// own candidates anyway. Holder state comes only from the lock: that is the contested field,
+    /// and the one place it cannot be overwritten by a whole-node flush.</item>
+    /// <item>Commit with <see cref="IStorageAdapter.WriteIfVersion"/> against the version step 1
+    /// read, and publish the grant on the Build node only if the store says we won. That publication
     /// is what <c>ObserveBuildClaim</c> emits on, and it commits ~200 ms before the persistence
     /// sampler reaches storage — so the durable decision has to come FIRST or the loser has already
     /// started baking by the time it could be told.</item>
@@ -278,10 +278,22 @@ public static class BuildNodeType
         return workspace.GetMeshNodeStream()
             .Where(n => n is not null)
             .Take(1)
-            .SelectMany(mirror => storage.Read(claimPath, options)
-                .Take(1)
-                .SelectMany(held => CommitGrant(
-                    workspace, storage, options, membership, logger, mirror, claimPath, held)));
+            .SelectMany(mirror =>
+            {
+                // Candidates come from THIS hub's mirror: a registration written milliseconds ago
+                // has not reached storage yet, and a cluster can only ever grant one of its own
+                // candidates anyway. Checked BEFORE the lock is read, so the periodic tick on a
+                // quiet build node costs nothing at all — no storage round-trip, no write.
+                var pending = mirror.ContentAs<BuildState>(options)?.RequestedClaims;
+                if (pending is not { Count: > 0 })
+                    return Observable.Return(Unit.Default);
+
+                return storage.Read(claimPath, options)
+                    .Take(1)
+                    .SelectMany(held => CommitGrant(
+                        workspace, storage, options, membership, logger,
+                        pending, claimPath, held));
+            });
     }
 
     /// <summary>
@@ -301,17 +313,10 @@ public static class BuildNodeType
         System.Text.Json.JsonSerializerOptions options,
         IClusterMembership? membership,
         ILogger? logger,
-        MeshNode mirror,
+        ImmutableDictionary<string, BuildClaimRequest> pending,
         string claimPath,
         MeshNode? held)
     {
-        // Candidates come from THIS hub's mirror: a registration written milliseconds ago has not
-        // reached storage yet, and each cluster can only ever grant one of its own candidates
-        // anyway. Nothing pending ⇒ nothing to decide, and no read of anything else.
-        var pending = mirror.ContentAs<BuildState>(options)?.RequestedClaims;
-        if (pending is not { Count: > 0 })
-            return Observable.Return(Unit.Default);
-
         // Holder state comes from the LOCK — never from the mirror and never from the Build node's
         // own durable row (see ClaimPath for why that row cannot hold it).
         var decisionInput = (held ?? NewClaimNode(claimPath)) with

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
@@ -220,6 +220,15 @@ internal sealed class PostgreSqlPathRoutingAdapter : IStorageAdapter
         // (invalid partition segments). Still NEVER creates a schema.
         => RouteWrite<MeshNode?>(node.Path, a => a.Write(node, options), null);
 
+    /// <summary>
+    /// Routes the atomic compare-and-set to the owning schema's adapter, declining with <c>null</c>
+    /// for a path PG does not route — the same try-then-claim signal <see cref="Write"/> gives.
+    /// Explicit, because the interface default would read-compare-write through <c>this</c> and
+    /// silently strip the per-schema rowcount gate that makes the primitive exclusive.
+    /// </summary>
+    public IObservable<bool?> WriteIfVersion(MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => RouteWrite<bool?>(node.Path, a => a.WriteIfVersion(node, expectedVersion, options), null);
+
     public IObservable<string> Delete(string path)
         => AdapterForRead(path) is { } a
             ? a.Delete(path)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -749,25 +749,45 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         //   null  → the ordinary monotonic guard: apply unless the row is already NEWER.
         //   0     → insert-only: exclusive create, the row must not exist.
         //   v     → compare-and-set: apply only while the row still carries exactly v.
-        string conflict;
-        if (expectedVersion == 0)
+        // 🚨 expectedVersion > 0 is a PLAIN UPDATE, never an upsert. "The row still carries exactly
+        // v" is false when there is no row at all, and an INSERT ... ON CONFLICT would have
+        // RESURRECTED a deleted row and reported success — which for the build claim means a
+        // heartbeat racing a release re-creates the lock its holder just dropped and blocks the next
+        // candidate for the whole staleness budget. The in-memory adapter refuses the same case;
+        // the two backends must not disagree about what compare-and-set means.
+        if (expectedVersion is > 0)
         {
-            conflict = "ON CONFLICT (namespace, id) DO NOTHING";
-        }
-        else
-        {
-            string predicate;
-            if (expectedVersion is { } expected)
-            {
-                parameters.Add(expected);
-                predicate = $"WHERE target.version = ${parameters.Count}";
-            }
-            else
-            {
-                predicate = "WHERE target.version <= EXCLUDED.version";
-            }
-            conflict =
+            parameters.Add(expectedVersion.Value);
+            // Mirrors the ON CONFLICT SET list exactly — created_by / created_date stay untouched
+            // (insert-only there, absent here), so authorship survives a compare-and-set too.
+            var casSync = writeSync ? ",\n                sync_behavior = $16" : "";
+            var casAuthor = writeSync ? ",\n                last_modified_by = $18" : "";
+            var casExclude = writeSync ? ",\n                exclude_from_context = $20" : "";
+            return (
                 $"""
+                UPDATE {table} SET
+                    name = $3,
+                    description = $4,
+                    node_type = $5,
+                    category = $6,
+                    icon = $7,
+                    display_order = $8,
+                    last_modified = $9,
+                    version = $10,
+                    state = $11,
+                    content = $12::jsonb,
+                    desired_id = $13,
+                    embedding = $14,
+                    main_node = $15{casSync}{casAuthor}{casExclude}
+                WHERE namespace = $1 AND id = $2 AND version = ${parameters.Count}
+                """,
+                parameters);
+        }
+
+        var conflict = expectedVersion == 0
+            // Insert-only: an exclusive create, and the row must not already exist.
+            ? "ON CONFLICT (namespace, id) DO NOTHING"
+            : $"""
                 ON CONFLICT (namespace, id) DO UPDATE SET
                     name = EXCLUDED.name,
                     description = EXCLUDED.description,
@@ -782,9 +802,8 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                     desired_id = EXCLUDED.desired_id,
                     embedding = EXCLUDED.embedding,
                     main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}{excludeUpdate}
-                {predicate}
+                WHERE target.version <= EXCLUDED.version
                 """;
-        }
 
         var sql =
             $"""

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -621,14 +621,37 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// (see <see cref="BuildUpsertAsync"/>), so a row count of zero is not an error — it is the store
     /// refusing a write whose <see cref="MeshNode.Version"/> is below the durable row's (#971).
     /// </summary>
-    private async Task<bool> WriteAsyncCore(MeshNode node, JsonSerializerOptions options, CancellationToken ct)
+    private async Task<bool> WriteAsyncCore(
+        MeshNode node, JsonSerializerOptions options, CancellationToken ct, long? expectedVersion = null)
     {
-        var (sql, parameters) = await BuildUpsertAsync(node, options).ConfigureAwait(false);
+        var (sql, parameters) = await BuildUpsertAsync(node, options, expectedVersion).ConfigureAwait(false);
         await using var cmd = _dataSource.CreateCommand(sql);
         foreach (var value in parameters)
             cmd.Parameters.AddWithValue(value);
         return await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false) > 0;
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The atomic cross-replica compare-and-set: ONE statement whose row count is the verdict.
+    /// Row-level locking serialises concurrent upserts on the same key, so of N callers that each
+    /// read the row at <c>expectedVersion</c> exactly one sees a row count of 1 — that is the whole
+    /// exclusivity guarantee, and it holds across processes, silos and Orleans clusters because it
+    /// is the database, not any in-process gate, that decides. <c>expectedVersion == 0</c> compiles
+    /// to <c>ON CONFLICT … DO NOTHING</c> ("insert only if absent"); anything else adds
+    /// <c>WHERE target.version = @expected</c>. The change feed fires only for the winner.
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => _ioPool.Invoke<bool?>(async ct =>
+        {
+            var applied = await WriteAsyncCore(node, options, ct, expectedVersion).ConfigureAwait(false);
+            if (!applied)
+                return false;
+            _changes.OnNext(DataChangeNotification.Updated(
+                string.IsNullOrEmpty(node.Path) ? node.Id : node.Path, node));
+            return true;
+        });
 
     /// <summary>
     /// The upsert for ONE node: its SQL text and its positional parameters, in order.
@@ -637,8 +660,19 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// in particular the ON CONFLICT set, which deliberately omits created_by/created_date
     /// so an update preserves the original author.
     /// </summary>
+    /// <param name="node">The node to upsert.</param>
+    /// <param name="options">Serializer options for the content payload.</param>
+    /// <param name="expectedVersion">
+    /// <c>null</c> — the ordinary monotonic condition (<c>target.version &lt;= EXCLUDED.version</c>),
+    /// which APPLIES at equal versions because re-persisting an unchanged node is legitimate.
+    /// Non-null switches the statement to compare-and-set for
+    /// <see cref="WriteIfVersion"/>: <c>0</c> means "only if no row exists"
+    /// (<c>ON CONFLICT … DO NOTHING</c>), anything else means "only while the row still carries
+    /// exactly this version". The equality is what makes the write EXCLUSIVE rather than merely
+    /// non-regressing — see the contract note on <see cref="IStorageAdapter.WriteIfVersion"/>.
+    /// </param>
     private async Task<(string Sql, IReadOnlyList<object> Parameters)> BuildUpsertAsync(
-        MeshNode node, JsonSerializerOptions options)
+        MeshNode node, JsonSerializerOptions options, long? expectedVersion = null)
     {
         var ns = node.Namespace ?? "";
 
@@ -679,29 +713,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         // still apply — re-persisting an unchanged node is a legitimate, common shape. The alias is
         // required: inside ON CONFLICT DO UPDATE the target row is referenced by its range-table name,
         // and `{table}` is schema-qualified.
-        var sql =
-            $"""
-            INSERT INTO {table} AS target (namespace, id, name, description, node_type, category, icon, display_order,
-                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol}{excludeInsertCol})
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal}{excludeInsertVal})
-            ON CONFLICT (namespace, id) DO UPDATE SET
-                name = EXCLUDED.name,
-                description = EXCLUDED.description,
-                node_type = EXCLUDED.node_type,
-                category = EXCLUDED.category,
-                icon = EXCLUDED.icon,
-                display_order = EXCLUDED.display_order,
-                last_modified = EXCLUDED.last_modified,
-                version = EXCLUDED.version,
-                state = EXCLUDED.state,
-                content = EXCLUDED.content,
-                desired_id = EXCLUDED.desired_id,
-                embedding = EXCLUDED.embedding,
-                main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}{excludeUpdate}
-            WHERE target.version <= EXCLUDED.version
-            """;
-
-        var parameters = new List<object>(20)
+        var parameters = new List<object>(21)
         {
             ns,
             node.Id,
@@ -731,6 +743,56 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 ? efc.ToArray()
                 : (object)DBNull.Value);
         }
+
+        // The conflict action. Built AFTER the parameter list so the compare-and-set predicate can
+        // bind the next free positional slot ($16 or $21, depending on writeSync).
+        //   null  → the ordinary monotonic guard: apply unless the row is already NEWER.
+        //   0     → insert-only: exclusive create, the row must not exist.
+        //   v     → compare-and-set: apply only while the row still carries exactly v.
+        string conflict;
+        if (expectedVersion == 0)
+        {
+            conflict = "ON CONFLICT (namespace, id) DO NOTHING";
+        }
+        else
+        {
+            string predicate;
+            if (expectedVersion is { } expected)
+            {
+                parameters.Add(expected);
+                predicate = $"WHERE target.version = ${parameters.Count}";
+            }
+            else
+            {
+                predicate = "WHERE target.version <= EXCLUDED.version";
+            }
+            conflict =
+                $"""
+                ON CONFLICT (namespace, id) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    description = EXCLUDED.description,
+                    node_type = EXCLUDED.node_type,
+                    category = EXCLUDED.category,
+                    icon = EXCLUDED.icon,
+                    display_order = EXCLUDED.display_order,
+                    last_modified = EXCLUDED.last_modified,
+                    version = EXCLUDED.version,
+                    state = EXCLUDED.state,
+                    content = EXCLUDED.content,
+                    desired_id = EXCLUDED.desired_id,
+                    embedding = EXCLUDED.embedding,
+                    main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}{excludeUpdate}
+                {predicate}
+                """;
+        }
+
+        var sql =
+            $"""
+            INSERT INTO {table} AS target (namespace, id, name, description, node_type, category, icon, display_order,
+                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol}{excludeInsertCol})
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal}{excludeInsertVal})
+            {conflict}
+            """;
 
         return (sql, parameters);
     }

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePathRoutingAdapter.cs
@@ -256,6 +256,20 @@ internal sealed class SnowflakePathRoutingAdapter : IStorageAdapter
         // route (invalid partition segments). Still NEVER creates a schema.
         => RouteWrite<MeshNode?>(node.Path, a => a.Write(node, options), null);
 
+    /// <summary>
+    /// Routes the atomic compare-and-set to the owning schema's adapter, declining with <c>null</c>
+    /// for a path Snowflake does not route — the same try-then-claim signal <see cref="Write"/>
+    /// gives. Explicit so the routing survives; the per-schema adapter decides whether it can honour
+    /// the condition atomically or falls back to the interface's read-compare-write.
+    /// </summary>
+    public IObservable<bool?> WriteIfVersion(MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => RouteWrite<bool?>(
+            node.Path,
+            // Through the interface: SnowflakeStorageAdapter takes the DEFAULT implementation, which
+            // is only reachable as an IStorageAdapter member.
+            a => ((IStorageAdapter)a).WriteIfVersion(node, expectedVersion, options),
+            null);
+
     /// <inheritdoc/>
     public IObservable<string> Delete(string path)
         => AdapterForRead(path) is { } a

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -276,6 +276,10 @@ public static class BuildProtocolDriver
                     ClaimedBy = null, ClaimedAt = null, HeartbeatAt = null,
                 },
                 chunk.Path)
+            // This close-out clears the claim fields itself instead of going through
+            // CompleteBuild/FailBuild, so it has to drop the chunk's LOCK explicitly — clearing
+            // ClaimedBy on the node alone would free the chunk in this cluster only.
+            .SelectMany(node => mesh.ReleaseBuildClaim(holder, chunk.Path).Select(_ => node))
             .SelectMany(_ => FinishActivity(
                 mesh, chunk.ActivityPath,
                 failed.Count > 0 ? ActivityStatus.Failed : ActivityStatus.Succeeded))

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -611,16 +611,21 @@ internal static class NodeTypeBatchBake
         return storage
             .Read(typeNode.Path, options)
             .Take(1)
-            .Select(fresh => fresh ?? typeNode)
-            .Select(fresh =>
+            // The durable version the stamp is computed FROM — 0 when there is no row at all, which
+            // the compare-and-set below reads as "insert only if absent". Carried explicitly rather
+            // than derived from stampedNode.Version - 1, which would silently rot if the mint
+            // changed.
+            .Select(stored => (Expected: stored?.Version ?? 0, Fresh: stored ?? typeNode))
+            .Select(read =>
             {
+                var fresh = read.Fresh;
                 var def = fresh.ContentAs<NodeTypeDefinition>(options, logger);
                 if (def is null)
                 {
                     logger?.LogWarning(
                         "BatchBake: {TypePath} content could not be read as NodeTypeDefinition — "
                         + "stamp skipped", typeNode.Path);
-                    return null;
+                    return (Expected: read.Expected, Stamped: (MeshNode?)null);
                 }
                 var stamped = ok
                     // currentNodeVersion = typeNode.Version — the version the compiler's
@@ -630,51 +635,53 @@ internal static class NodeTypeBatchBake
                         def, result!, typeNode.Version, activityPath: null, releasePath)
                     : NodeTypeCompilationHelpers.ApplyCompileFailure(
                         def, result, error, activityPath: null);
-                return fresh with
+                return (Expected: read.Expected, Stamped: (MeshNode?)(fresh with
                 {
                     Content = stamped,
                     Version = MeshNode.NextVersion(fresh.Version)
-                };
+                }));
             })
-            .SelectMany(stampedNode => stampedNode is null
+            .SelectMany(stamp => stamp.Stamped is not { } stampedNode
                 ? Observable.Return(Unit.Default)
                 : storage
-                    .WriteAndPublishUpdated(stampedNode, options, changeFeed)
-                    // 🚨 A REFUSED stamp must not be silent. The monotonic write guard answers a
-                    // backward write by emitting the STORED (winning) node — Version strictly
-                    // above the one we wrote — which here means a LIVE owner hub moved this
-                    // record between our read and our write. The bytes are on the share but the
-                    // record does not name them, so the type simply stays pending and the next
-                    // level-triggered probe re-bakes and re-stamps it. Saying so is the
-                    // difference between a self-healing skip and a stamp that vanished.
+                    // 🚨 COMPARE-AND-SET, not a plain write (#1424). The other writer here is the
+                    // type's OWN per-node hub — not a baker at all: it stamps compile state from the
+                    // activation-driven path, the sources watcher and the release watcher, and it is
+                    // legitimately live while a batch bake runs. So the read-modify-write above stays
+                    // racy by construction, and the single-baker claim does NOT close it (the claim
+                    // excludes second bakers; this writer is not one).
                     //
-                    // 🚨 THE SINGLE-BAKER CLAIM DOES NOT CLOSE THIS, AND IS NOT MEANT TO (#1355).
-                    // It removes one of the two writers that can race here — a SECOND BAKER, which
-                    // the build protocol's claim arbiter excludes, handing a claim on only when
-                    // cluster membership says the holder is gone rather than when a clock expires
-                    // (BuildNodeType.Arbitrate). The
-                    // other writer is the type's OWN per-node hub, which is not a baker at all: it
-                    // stamps compile state from the activation-driven path, the sources watcher and
-                    // the release watcher, and it is legitimately live while a batch bake runs. So
-                    // the read-modify-write at NextVersion stays racy by construction, and the guard
-                    // above stays the thing that makes it safe.
+                    // What the plain write got WRONG is what happened when it lost. Both writers read
+                    // the row at v and both mint v+1, and the store's monotonic condition applies at
+                    // EQUAL versions — re-persisting an unchanged node is a legitimate shape — so both
+                    // writes landed, last-write-wins, and the refusal branch below could never fire
+                    // (saved.Version was equal, never strictly greater). One stamp was silently
+                    // destroyed and the log that was supposed to say so stayed quiet. Conditioning on
+                    // the version we READ makes the loser deterministic and LOUD.
                     //
-                    // It is DEFENDED rather than fixed because the loser's outcome is already the
-                    // correct one: the bytes are durable and content-addressed, the record is left
-                    // pending, and the level-triggered probe re-bakes the type on the next pass
-                    // (NodeTypeBakeStatus.Probe asks the STORE, not the record). Turning it into a
-                    // compare-and-re-apply here would buy one saved recompile at the cost of a
-                    // second write path into the same record from a driver that does not own it —
-                    // which is the shape that produced the racing writers in the first place.
-                    .Do(saved =>
+                    // The loser's outcome is unchanged and still correct: the bytes are durable and
+                    // content-addressed, the record is left pending, and the level-triggered probe
+                    // re-bakes the type on the next pass (NodeTypeBakeStatus.Probe asks the STORE, not
+                    // the record). Deliberately NO compare-and-re-apply loop: that would be a second
+                    // write path into a record this driver does not own, which is the shape that
+                    // produced the racing writers in the first place.
+                    .WriteIfVersion(stampedNode, stamp.Expected, options)
+                    .Do(applied =>
                     {
-                        if (saved is not null && saved.Version > stampedNode.Version)
+                        if (applied is false)
+                        {
                             logger?.LogWarning(
                                 "BatchBake: compile-state stamp for {TypePath} at Version={Written} "
-                                + "was REFUSED — the durable row is already at Version={Stored} (a "
-                                + "live owner hub is writing this record). The assembly is on the "
-                                + "share; the next probe re-bakes the type and re-stamps it.",
-                                typeNode.Path, stampedNode.Version, saved.Version);
+                                + "was REFUSED — the durable row moved past Version={Expected} while "
+                                + "the compile ran (a live owner hub is writing this record). The "
+                                + "assembly is on the share; the next probe re-bakes and re-stamps it.",
+                                typeNode.Path, stampedNode.Version, stamp.Expected);
+                            return;
+                        }
+                        // Post-commit announce, exactly as WriteAndPublishUpdated did — the
+                        // mesh-change feed is what invalidates the resolution / stream caches.
+                        if (applied is true)
+                            changeFeed?.Publish(MeshChangeEvent.Updated(stampedNode));
                     })
                     .Select(_ => Unit.Default))
             .Catch<Unit, Exception>(ex =>

--- a/src/MeshWeaver.Hosting/Persistence/CachingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/CachingStorageAdapter.cs
@@ -238,6 +238,28 @@ public class CachingStorageAdapter : IStorageAdapter
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Forwarded to a fresh inner adapter so the version comparison is taken against the FILE, never
+    /// against this decorator's snapshot — a stale cached read would let a compare-and-set "succeed"
+    /// against a row that has already moved, which is the one outcome the primitive exists to
+    /// prevent. Atomicity is still only as good as the file-system backend's (single-writer dev
+    /// host); a multi-replica deployment uses Postgres, which is genuinely atomic.
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+    {
+        // Cast to the interface: WriteIfVersion is a DEFAULT interface member on the file-system
+        // adapter (it does not override it), so it is only reachable through IStorageAdapter.
+        IStorageAdapter innerAdapter =
+            new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry);
+        return innerAdapter.WriteIfVersion(node, expectedVersion, options)
+            .Do(applied =>
+            {
+                if (applied is true) RefreshCacheForPath(node.Path);
+            });
+    }
+
+    /// <inheritdoc />
     public IObservable<string> Delete(string path)
     {
         var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry);

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -133,6 +133,56 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         });
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Atomic via <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/> (expected version 0 —
+    /// "no row") and <see cref="ConcurrentDictionary{TKey,TValue}.TryUpdate"/> against the exact
+    /// snapshot we compared (any other version). Both are single interlocked operations, so N
+    /// concurrent callers holding the same <c>expectedVersion</c> produce exactly ONE <c>true</c> —
+    /// the in-memory twin of the Postgres row-count gate, and the property #1424 needs. The change
+    /// notification fires only for the winner.
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            // Same delegate strip as Write — a store of record must never hold an in-process
+            // HubConfiguration (see the note there).
+            if (node.HubConfiguration is not null)
+                node = node with { HubConfiguration = null };
+            var path = Norm(node.Path);
+            if (string.IsNullOrEmpty(path))
+                return Observable.Return<bool?>(null);
+
+            if (expectedVersion == 0)
+            {
+                if (!_nodes.TryAdd(path, node))
+                {
+                    _logger?.LogDebug(
+                        "[InMemoryAdapter#{Id:X}] WriteIfVersion {Path} REFUSED — a row already exists",
+                        GetHashCode(), path);
+                    return Observable.Return<bool?>(false);
+                }
+                _changes.OnNext(DataChangeNotification.Updated(path, node));
+                return Observable.Return<bool?>(true);
+            }
+
+            if (!_nodes.TryGetValue(path, out var existing) || existing.Version != expectedVersion)
+            {
+                _logger?.LogDebug(
+                    "[InMemoryAdapter#{Id:X}] WriteIfVersion {Path} REFUSED — expected v{Expected}, stored v{Stored}",
+                    GetHashCode(), path, expectedVersion, existing?.Version);
+                return Observable.Return<bool?>(false);
+            }
+            // TryUpdate compares against the instance we just read; a concurrent winner replaced it,
+            // so the CAS fails and this caller learns it lost instead of clobbering the winner.
+            if (!_nodes.TryUpdate(path, node, existing))
+                return Observable.Return<bool?>(false);
+
+            _changes.OnNext(DataChangeNotification.Updated(path, node));
+            return Observable.Return<bool?>(true);
+        });
+
+    /// <inheritdoc />
     public override IObservable<string> Delete(string path)
         => Observable.Defer(() =>
         {

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -330,6 +330,24 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Explicit forward, and NO guard of its own: a compare-and-set is conditioned on the exact
+    /// durable version the caller read, so by construction it cannot move the row backward — the
+    /// store itself refuses when the row has advanced. Applying the high-water FILTER here would be
+    /// strictly harmful, because the caller of a CAS wants the store's verdict, not a merge. The
+    /// mark is still claimed on an APPLIED write so the ordinary <see cref="Write"/> path stays
+    /// sound afterwards (the "claim before the row is mutated" rule cannot apply — the row's fate is
+    /// decided inside the store — so we record what the store confirmed instead).
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => inner.WriteIfVersion(node, expectedVersion, options)
+            .Do(applied =>
+            {
+                if (applied is true) Observe(node);
+            });
+
+    /// <inheritdoc />
     public IObservable<string> Delete(string path)
         => inner.Delete(path).Do(_ => Forget(path));
 

--- a/src/MeshWeaver.Hosting/Persistence/PathFilteringStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PathFilteringStorageAdapter.cs
@@ -25,6 +25,17 @@ public sealed class PathFilteringStorageAdapter(IStorageAdapter inner, Func<stri
             : Observable.Return<MeshNode?>(null);
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Out of scope declines with <c>null</c> — "not mine" — exactly as <see cref="Write"/> does, so
+    /// the try-then-claim chain moves on instead of reading a refusal as this provider's verdict.
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => matches(node.Path)
+            ? inner.WriteIfVersion(node, expectedVersion, options)
+            : Observable.Return<bool?>(null);
+
+    /// <inheritdoc />
     public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
         => matches(path)
             ? inner.Read(path, options)

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
@@ -207,6 +207,29 @@ public sealed class PersistenceService : IStorageAdapter
                 });
 
     /// <summary>
+    /// Sequential try-then-claim for the compare-and-set write, mirroring
+    /// <see cref="TryWriteFrom"/>: provider <c>i + 1</c> is asked only after provider <c>i</c>
+    /// declined with <c>null</c> ("not my path"). A <c>true</c>/<c>false</c> from a provider is its
+    /// VERDICT on the row and ends the walk — a refusal must never be retried against another
+    /// store, which would be two chances at a claim that is meant to be exclusive.
+    /// Nobody owns the path ⇒ <c>null</c>, which callers read as "no durable arbiter here".
+    /// </summary>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => TryWriteIfVersionFrom(node, expectedVersion, options, 0);
+
+    private IObservable<bool?> TryWriteIfVersionFrom(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options, int index)
+        => index >= _writable.Count
+            ? Observable.Return<bool?>(null)
+            : Observable.Defer(() => _writable[index].Adapter.WriteIfVersion(node, expectedVersion, options))
+                .Take(1)
+                .DefaultIfEmpty()
+                .SelectMany(applied => applied is null
+                    ? TryWriteIfVersionFrom(node, expectedVersion, options, index + 1)
+                    : Observable.Return(applied));
+
+    /// <summary>
     /// Fan out across every writable adapter: each self-checks containment
     /// (Read returns non-null) and deletes if owned. Aggregates into the
     /// deleted-path emit. Throws when nothing was actually deleted (every

--- a/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
@@ -88,6 +88,31 @@ internal sealed class SubtreeDeletionGuardStorageAdapter(
             });
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Guarded exactly like <see cref="Write"/> — a compare-and-set into a subtree being deleted is
+    /// still a write — and otherwise forwarded, because the interface default would fall back to a
+    /// non-atomic read-compare-write and silently strip the backend's atomicity at the OUTERMOST
+    /// decorator, which is this one.
+    /// </remarks>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => registry is null
+            ? inner.WriteIfVersion(node, expectedVersion, options)
+            : Observable.Defer(() =>
+            {
+                if (registry.IsUnderActiveDeletion(node.Path, out var root))
+                {
+                    logger?.LogWarning(
+                        "[SubtreeDeletionGuard] REFUSED compare-and-set write to {Path}: the subtree "
+                        + "'{Root}' is being deleted.",
+                        node.Path, root);
+                    return Observable.Throw<bool?>(new InvalidOperationException(
+                        $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
+                }
+                return inner.WriteIfVersion(node, expectedVersion, options);
+            });
+
+    /// <inheritdoc />
     public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
         => inner.Read(path, options);
 

--- a/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
@@ -55,6 +55,28 @@ internal class VersionWritingStorageAdapter(
             .LastAsync()
             .Select(_ => (MeshNode?)saved);
 
+    /// <summary>
+    /// Explicit forward — the interface default would read-compare-write through <c>this</c> and
+    /// strip the backend's atomic compare-and-set. An APPLIED write gets its version-history
+    /// snapshot exactly like <see cref="Write"/>; a refused one deliberately gets none (nothing
+    /// changed durably, so there is no revision to record).
+    /// </summary>
+    public IObservable<bool?> WriteIfVersion(
+        MeshNode node, long expectedVersion, JsonSerializerOptions options)
+    {
+        var write = inner.WriteIfVersion(node, expectedVersion, options);
+        if (versionQuery is null)
+            return write;
+
+        return write.SelectMany(applied => applied is true
+            ? versionQuery.WriteVersion(node, options)
+                .Catch<MeshNode, Exception>(_ => Observable.Empty<MeshNode>())
+                .DefaultIfEmpty(node)
+                .LastAsync()
+                .Select(_ => applied)
+            : Observable.Return(applied));
+    }
+
     public IObservable<string> Delete(string path) => inner.Delete(path);
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
@@ -119,6 +119,52 @@ public interface IStorageAdapter
                     n => n!)),
             written => (IReadOnlyList<MeshNode>)written);
 
+    /// <summary>
+    /// COMPARE-AND-SET — the atomic "first writer wins" primitive, and the WRITE-side twin of
+    /// <see cref="DeleteIfExists"/>. Applies <paramref name="node"/> only while the durable row
+    /// still carries <paramref name="expectedVersion"/> (or no row exists at all, when it is
+    /// <c>0</c>), and reports which of the two happened:
+    ///
+    /// <list type="bullet">
+    /// <item><c>true</c> — APPLIED. The durable row now holds <paramref name="node"/>.</item>
+    /// <item><c>false</c> — REFUSED. Somebody else moved the row (or it is absent when a version
+    /// was expected). The caller's intent did NOT land and it must not act as though it did.</item>
+    /// <item><c>null</c> — this adapter does not own the path, so the try-then-claim chain in
+    /// <c>PersistenceService</c> moves on to the next writable provider. Same "not mine" signal
+    /// <see cref="Write"/> gives by emitting <c>null</c>.</item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>Why the ordinary <see cref="Write"/> cannot serve here (#1424).</b> The regular
+    /// upsert is version-conditional but NOT exclusive: it applies at EQUAL versions, because
+    /// re-persisting an unchanged node is a legitimate, common shape. Two writers that each read the
+    /// row at version <c>v</c> and each mint <c>v+1</c> therefore BOTH commit, last-write-wins, and
+    /// neither is told it lost — the store returns the node it was handed, so the
+    /// <c>saved.Version &gt; written.Version</c> refusal signal never fires. That is exactly how two
+    /// Orleans clusters sharing one Postgres database each granted themselves the build claim and each
+    /// ran the full bake. Exclusivity needs an equality condition on a version the caller READ, which
+    /// is what this method is: at most one of N concurrent callers holding the same
+    /// <paramref name="expectedVersion"/> can be told <c>true</c>.</para>
+    ///
+    /// <para>Backends that can express the condition MUST override — Postgres via
+    /// <c>ON CONFLICT … DO UPDATE … WHERE target.version = @expected</c> (and
+    /// <c>DO NOTHING</c> for <paramref name="expectedVersion"/> <c>0</c>) plus the row count,
+    /// in-memory via <c>TryAdd</c>/<c>TryUpdate</c>. The default below is a NON-ATOMIC
+    /// read-compare-write, correct only for single-writer backends (a FileSystem dev host) —
+    /// the same contract, and the same caveat, as <see cref="DeleteIfExists"/>.</para>
+    ///
+    /// <para>🚨 Decorators MUST forward to their inner adapter, or the atomicity is silently lost at
+    /// the outermost decorator that falls back to the default — the same forwarding rule as
+    /// <see cref="Changes"/>, <see cref="DeleteIfExists"/>, <see cref="ResolvePath"/> and
+    /// <see cref="ListDescendantPaths"/>.</para>
+    /// </summary>
+    IObservable<bool?> WriteIfVersion(MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => System.Reactive.Linq.Observable.SelectMany(
+            System.Reactive.Linq.Observable.Take(Read(node.Path, options), 1),
+            stored => (stored?.Version ?? 0) != expectedVersion
+                ? System.Reactive.Linq.Observable.Return<bool?>(false)
+                : System.Reactive.Linq.Observable.Select(
+                    Write(node, options), written => written is null ? (bool?)null : true));
+
     /// <summary>Deletes a node from storage and emits the deleted path.</summary>
     IObservable<string> Delete(string path);
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/CrossClusterBuildClaimTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CrossClusterBuildClaimTest.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ServiceProvider;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The build claim across ORLEANS CLUSTERS (#1424) — the case the intra-cluster tests in
+/// <see cref="BuildCoordinationTest"/> structurally cannot cover.
+///
+/// <para><b>What "another cluster" is here.</b> Two independent meshes, each with its own hub tree,
+/// its own workspace mirrors, its own arbiter and its own <see cref="InMemoryStorageAdapter"/>
+/// instance — over ONE shared backing dictionary. That is exactly the production shape the incident
+/// happened in: the ephemeral bake silo (own <c>-bake</c> ServiceId, localhost clustering) and the
+/// rolling serving pod are separate Orleans clusters against the same Postgres database. The
+/// adapters are deliberately SEPARATE instances so the in-process change feeds do not cross — a
+/// faithful model, because nothing propagates a write between processes today (Orleans membership
+/// and its memory streams are per-cluster by construction, and the PG <c>LISTEN</c> session is not
+/// started in the partitioned wiring). The durable row is the only witness both sides share.</para>
+///
+/// <para><b>The defect this pins.</b> Both arbiters read their own mirror, both see an unclaimed
+/// build, both mint the same next version, and the store's monotonic condition APPLIES at equal
+/// versions — so both writes landed, neither writer was told it lost, and both candidates observed
+/// their own grant off their own RAM mirror and ran the full bake. Before the fix this test sees TWO
+/// grants; after it, exactly one, because the grant is now taken with an atomic
+/// <see cref="IStorageAdapter.WriteIfVersion"/> against the durable version the arbiter read, and
+/// the mirror is written only by the cluster the store said won.</para>
+/// </summary>
+public class CrossClusterBuildClaimTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Long enough for a loser to give up looking for a grant it will never get.</summary>
+    private static readonly TimeSpan GrantBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>ONE durable store. Two adapter instances over it = two processes over one database.</summary>
+    private readonly ConcurrentDictionary<string, MeshNode> _rows = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, List<object>> _partitionObjects =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(120);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        // Registered BEFORE AddInMemoryPersistence's TryAddSingleton, so this shared-store adapter is
+        // the one the decorator chain wraps.
+        => base.ConfigureMesh(builder.ConfigureServices(UseSharedStore));
+
+    private IServiceCollection UseSharedStore(IServiceCollection services)
+    {
+        services.AddSingleton<IStorageAdapter>(sp => new InMemoryStorageAdapter(
+            _rows, _partitionObjects, sp.GetService<ILogger<InMemoryStorageAdapter>>()));
+        return services;
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task TwoClustersClaimingConcurrently_ExactlyOneBuilderProceeds()
+    {
+        // Cluster A is the test-base mesh. Materialize the build root and wait until it is DURABLE —
+        // the arbiters decide against the row, so the row has to be there before either claims.
+        var clusterA = Mesh;
+        await clusterA.EnsureBuildNode().FirstAsync().ToTask();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .Where(_ => _rows.ContainsKey(BuildNodeType.RootPath))
+            .FirstAsync()
+            .Timeout(GrantBudget)
+            .ToTask();
+
+        using var clusterB = BuildSecondCluster();
+
+        const string fingerprint = "fp-cross-cluster";
+        const string holderA = "cluster-a/builder";
+        const string holderB = "cluster-b/builder";
+
+        // Both candidates register at the same moment. Which cluster wins is not determined — that
+        // exactly ONE does is the contract.
+        await Task.WhenAll(
+            clusterA.RequestBuildClaim(holderA, fingerprint).FirstAsync().ToTask(),
+            clusterB.Hub.RequestBuildClaim(holderB, fingerprint).FirstAsync().ToTask());
+
+        // Each cluster watches for ITS OWN grant. The winner emits; the loser runs out the budget and
+        // yields null. Running both to completion is the point — a test that stopped at the first
+        // emission could not tell one grant from two.
+        var grants = await Observable
+            .Merge(
+                WatchOwnGrant(clusterA, holderA, "A"),
+                WatchOwnGrant(clusterB.Hub, holderB, "B"))
+            .ToList()
+            .ToTask();
+
+        var winners = grants.Where(g => g is not null).Select(g => g!).ToList();
+        winners.Should().HaveCount(1,
+            "the claim must be exclusive ACROSS clusters, not merely within one — two grants is the "
+            + "#1424 shape, in which the bake Job and the serving pod each ran the full bake");
+
+        // …and the LOCK must agree with the cluster that thinks it won: a grant nobody else can see
+        // is the same defect wearing a different hat. Asserted on the lock, never on the Build
+        // node's ClaimedBy — that field is a per-cluster projection which a losing cluster's whole-
+        // node flush may overwrite, which is precisely why the claim does not live there.
+        _rows.TryGetValue(BuildNodeType.ClaimPath(BuildNodeType.RootPath), out var held)
+            .Should().Be(true, "winning the claim must leave a durable lock behind");
+        var lockState = held!.ContentAs<BuildState>(clusterA.JsonSerializerOptions);
+        lockState.Should().NotBeNull();
+        lockState!.ClaimedBy.Should().Be(winners[0] == "A" ? holderA : holderB);
+        lockState.FrameworkVersion.Should().Be(fingerprint);
+    }
+
+    /// <summary>
+    /// Emits the holder tag once this cluster grants <paramref name="holder"/>, or <c>null</c> when
+    /// the budget elapses without a grant — the loser's expected outcome, and the shape that lets
+    /// both watchers be merged and COUNTED.
+    /// </summary>
+    private static IObservable<string?> WatchOwnGrant(IMessageHub hub, string holder, string tag)
+        => hub.ObserveBuildClaim(holder)
+            .Take(1)
+            .Select(_ => (string?)tag)
+            .Timeout(GrantBudget)
+            .Catch((TimeoutException _) => Observable.Return<string?>(null));
+
+    /// <summary>
+    /// A second, fully independent monolith mesh over the SAME backing store — the stand-in for the
+    /// bake silo's separate Orleans cluster. Its recipe mirrors
+    /// <c>MonolithMeshTestBase.ConfigureMeshBase</c>; only the persistence adapter is shared.
+    /// </summary>
+    private SecondCluster BuildSecondCluster()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging(l => l.ClearProviders());
+        services.AddOptions();
+
+        var builder = new MeshBuilder(c => c.Invoke(services), AddressExtensions.CreateMeshAddress())
+            .ConfigureServices(UseSharedStore)
+            .UseMonolithMesh()
+            .AddInMemoryPersistence()
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType()
+            .AddMeshNodes(TestUsers.DevLoginAdminAccess())
+            .AddMeshNodes(TestUsers.PublicAdminAccess())
+            .ConfigureHub(c => c.WithRequestTimeout(TimeSpan.FromSeconds(60)));
+
+        services.AddSingleton(builder.BuildHub);
+        var serviceProvider = services.CreateMeshWeaverServiceProvider();
+        var hub = serviceProvider.GetRequiredService<IMessageHub>();
+        TestUsers.DevLogin(hub);
+        return new SecondCluster(serviceProvider, hub);
+    }
+
+    private sealed record SecondCluster(IServiceProvider ServiceProvider, IMessageHub Hub) : IDisposable
+    {
+        public void Dispose()
+        {
+            Hub.Dispose();
+            (ServiceProvider as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/CompareAndSetWriteTests.cs
+++ b/test/MeshWeaver.Hosting.Test/CompareAndSetWriteTests.cs
@@ -1,0 +1,129 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins <see cref="IStorageAdapter.WriteIfVersion"/> — the atomic compare-and-set that makes a
+/// claim exclusive across processes and Orleans clusters (#1424), and the write-side twin of
+/// <see cref="IStorageAdapter.DeleteIfExists"/>.
+///
+/// <para>Every case resolves the adapter from DI, so these pin that the primitive SURVIVES the
+/// production decorator chain (SubtreeDeletionGuard → MonotonicWriteGuard → VersionWriting → leaf).
+/// That matters more than it looks: the interface default is a non-atomic read-compare-write, so a
+/// decorator that forgets to forward silently downgrades every caller to the behaviour the
+/// primitive exists to replace — and nothing else would notice.</para>
+/// </summary>
+public class CompareAndSetWriteTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    private static IStorageAdapter BuildStore()
+    {
+        var services = new ServiceCollection();
+        services.AddInMemoryPersistence(new InMemoryStorageAdapter());
+        return services.BuildServiceProvider().GetRequiredService<IStorageAdapter>();
+    }
+
+    private static MeshNode Node(long version, string? name = null) =>
+        new("claim", "Test") { NodeType = "Build", Name = name, Version = version };
+
+    /// <summary>
+    /// The exclusivity property itself: N writers that all read "no row" and all try to create it,
+    /// and exactly ONE is told it won. This is the whole fix in one assertion — the ordinary write
+    /// path would have accepted all of them (its condition applies at equal versions) and told none
+    /// of them they lost.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentCreates_ExactlyOneWins()
+    {
+        var store = BuildStore();
+
+        var outcomes = await Task.WhenAll(Enumerable.Range(0, 8).Select(i =>
+            Task.Run(() => store
+                .WriteIfVersion(Node(version: 1, name: $"claimant-{i}"), expectedVersion: 0, JsonOptions)
+                .FirstAsync()
+                .ToTask())));
+
+        outcomes.Count(o => o is true).Should().Be(1,
+            "an insert-only compare-and-set is how a claim becomes exclusive; two winners is #1424");
+        outcomes.Count(o => o is false).Should().Be(7, "every loser must be TOLD it lost");
+
+        var stored = await store.Read("Test/claim", JsonOptions).FirstAsync().ToTask();
+        stored!.Name.Should().StartWith("claimant-");
+    }
+
+    /// <summary>
+    /// The same property one step on: N writers that all read the row at v and all try to succeed
+    /// it. This is the takeover case — several clusters timing out on the same dead holder — and it
+    /// must not produce two successors.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentSuccessions_ExactlyOneWins()
+    {
+        var store = BuildStore();
+        (await store.WriteIfVersion(Node(1, "holder"), 0, JsonOptions).FirstAsync().ToTask())
+            .Should().Be(true);
+
+        var outcomes = await Task.WhenAll(Enumerable.Range(0, 8).Select(i =>
+            Task.Run(() => store
+                .WriteIfVersion(Node(version: 2, name: $"successor-{i}"), expectedVersion: 1, JsonOptions)
+                .FirstAsync()
+                .ToTask())));
+
+        outcomes.Count(o => o is true).Should().Be(1);
+        var stored = await store.Read("Test/claim", JsonOptions).FirstAsync().ToTask();
+        stored!.Name.Should().StartWith("successor-");
+        stored.Version.Should().Be(2);
+    }
+
+    /// <summary>A version that does not match is refused, and the stored row is left alone.</summary>
+    [Fact]
+    public async Task WrongExpectedVersion_IsRefused_AndLeavesTheRow()
+    {
+        var store = BuildStore();
+        await store.WriteIfVersion(Node(1, "holder"), 0, JsonOptions).FirstAsync().ToTask();
+
+        (await store.WriteIfVersion(Node(9, "impostor"), expectedVersion: 7, JsonOptions)
+            .FirstAsync().ToTask())
+            .Should().Be(false);
+
+        var stored = await store.Read("Test/claim", JsonOptions).FirstAsync().ToTask();
+        stored!.Name.Should().Be("holder");
+        stored.Version.Should().Be(1);
+    }
+
+    /// <summary>
+    /// 🚨 A compare-and-set expecting a version must NOT resurrect a deleted row. "The row still
+    /// carries exactly v" is false when there is no row at all, and an upsert here would report
+    /// success — which for the build claim means a heartbeat racing a release re-creates the lock
+    /// its holder just dropped, blocking the next candidate for the whole staleness budget. Postgres
+    /// therefore issues a plain UPDATE for this case rather than INSERT … ON CONFLICT; this pins the
+    /// semantic the two backends must agree on.
+    /// </summary>
+    [Fact]
+    public async Task ExpectingAVersion_DoesNotResurrectADeletedRow()
+    {
+        var store = BuildStore();
+        await store.WriteIfVersion(Node(1, "holder"), 0, JsonOptions).FirstAsync().ToTask();
+        (await store.DeleteIfExists("Test/claim").FirstAsync().ToTask()).Should().Be(true);
+
+        (await store.WriteIfVersion(Node(2, "zombie"), expectedVersion: 1, JsonOptions)
+            .FirstAsync().ToTask())
+            .Should().Be(false, "an absent row does not carry the expected version");
+
+        (await store.Read("Test/claim", JsonOptions).FirstAsync().ToTask())
+            .Should().BeNull("the refused write must not have re-created the row");
+    }
+}


### PR DESCRIPTION
Closes #1424.

## What was wrong

The claim arbiter's exclusivity came from the owning per-node hub serialising its `Update` lambdas — which holds **per cluster**. A second Orleans cluster over the same database activates its *own* hub for `Admin/Build`, arbitrates against its *own* mirror, and grants its own candidate. Three things then made the collision invisible:

- both grants were minted at the same next `MeshNode.Version`, and the store's monotonic condition **applies at equal versions** (re-persisting an unchanged node is a legitimate shape), so both landed last-write-wins;
- neither writer was told it lost — the refusal signal is `saved.Version > written.Version`, and the versions were *equal*;
- nothing propagates a rival's write. Orleans membership and its memory streams are per-cluster by construction, and `PostgreSqlChangeListener` is registered but never started in either partitioned-PG wiring.

On top of that, the grant is observed off the RAM mirror, which commits **~200 ms before** the persistence sampler reaches storage — so adjudicating after the write lands can never stop the second builder starting.

## The fix

**1. `IStorageAdapter.WriteIfVersion` — an atomic compare-and-set.** The write-side twin of `DeleteIfExists`: applies only while the durable row still carries the version the caller read (`0` = "must not exist"), so at most one of N concurrent callers is told `true`. Postgres implements it as one statement whose row count is the verdict (`ON CONFLICT … DO UPDATE … WHERE target.version = @expected`, or `DO NOTHING`); in-memory via `TryAdd`/`TryUpdate`. Every decorator forwards explicitly — the interface default is a non-atomic read-compare-write, correct only for single-writer backends, exactly the contract `DeleteIfExists` already documents.

**2. The claim moved onto a lock node, `Admin/Build/_Claim`.** Making the *grant* exclusive turned out to be necessary and not sufficient, and the test caught it: every cluster mirrors `Admin/Build` and flushes it **wholesale** through the persistence sampler, and `MeshNode.Version` is a per-node counter rather than a cross-cluster logical clock — so a *losing* cluster's flush overwrote the winner's `ClaimedBy` with its own `null`, and the next arbitration pass found a free build. The lock has no hub, no mirror and no sampler; it is written only by the compare-and-set grant, a compare-and-set heartbeat, and a rowcount-gated `DeleteIfExists` on release. `BuildState.ClaimedBy` stays as the observable projection `ObserveBuildClaim` reads — a clobber there now costs a stale view, never a second builder.

A refused claim **writes nothing and retries nothing**: the arbiter is level-triggered and re-decides on the next real change. The lock's own change feed is now one of its triggers, which is what hands a released claim on without waiting for the slow tick.

**Fails OPEN.** With no adapter owning the path (or no persistence at all — monolith, test, dev box) the grant is taken on the mirror exactly as before. Being wrong that way costs one duplicated bake — bounded and non-corrupting, because every downstream write is content-addressed. Being wrong the other way leaves the fingerprint with no GO at all, which holds every silo's readiness probe down and stalls the rollout. Same asymmetry the bake gate applies; the opposite of `AssemblyCacheRetention`, where the wrong answer deletes bytes a running pod needs.

## Also, since we were in this code

`NodeTypeBatchBake.WriteStamp` now uses the same primitive. Its racing writer is the type's **own per-node hub** — not a baker, so the claim does not and cannot exclude it, and the existing comment was right that election cannot close this. But the comment's conclusion ("the guard above stays the thing that makes it safe") was wrong at *equal* versions: both sides read `v` and minted `v+1`, the store applied both, one stamp was silently destroyed, and the "REFUSED" warning never fired because it tests for a strictly greater version. Conditioning on the version we read makes the loser deterministic and loud. Its outcome is unchanged and still correct (bytes durable and content-addressed, record pending, level-triggered probe re-bakes). Deliberately **no** compare-and-re-apply loop — that would be a second write path into a record this driver does not own.

## Verified

- **`CrossClusterBuildClaimTest`** — two independent meshes (own hubs, own mirrors, own adapter instances, so no change feed crosses) over **one shared backing store**, both claiming concurrently. **Fails before with `found 2`; passes after with exactly 1**, and the durable lock names the winner. Run with `DOTNET_PROCESSOR_COUNT=4`.
- `BuildCoordinationTest` (incl. the full protocol-driven bake), prewarm/bake/write-integrity filter: **80/80**.
- `MeshWeaver.Hosting.Test` **163/163**, `MeshWeaver.Graph.Test` **1104/1104**, `MeshWeaver.Documentation.Test` **20/20**.
- `-c Release -warnaserror` clean on every touched project plus `Memex.Portal.Distributed`.

## Follow-up found while here (not fixed)

`BuildCoordination.md` claimed the GO broadcast rides the PG `LISTEN/NOTIFY` feed "cross-process and therefore cross-ServiceId by construction". That listener is **never started** in either partitioned-PG overload, so across clusters nothing propagates the GO, and `BuildProtocolDriver.FollowGo` subscribes with no bound. The doc now says so. This does not affect the fix (the arbiter reads the lock rather than waiting to be told), but it means a *separate-cluster* bake host should still be treated as "publishes the GO earlier", not "spares its peers the bake". Starting the listener, or giving the follower a bounded fall-back to its own sweep, is the outstanding work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)