### PR TITLE
fix(#890): own the Roslyn reference set per mesh — HELD pending the canary verdict

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
@@ -138,11 +138,12 @@ The build guard classifies permitted static fields into four buckets. Everything
 > `NoStaticCollectionsTest`, whatever the declared collection type, because the declared-type check
 > could not see an `IReadOnlyList<>`.
 >
-> The field itself is still there, listed as a `CACHE` debt with its issue number rather than
-> silently exempt — removing it gives every mesh its own reference set, which measurably costs ~15 MiB
-> per compiling mesh, and whether that buys anything is decided by #890's emit canary. **Landing the
-> detector does not require paying for the fix**, and an allowlist entry with a reason is what turns
-> "nobody noticed" into "we know, and here is the open question".
+> The field is now the mesh-scoped `CompilationReferenceSet`, so the reference set dies with the mesh
+> that built it. That cost ~15 MiB of resident PE metadata per compiling mesh (+98% peak RSS across
+> the full `Hosting.Monolith.Test` project) — a real price, paid because a process-wide Roslyn cache
+> is the shape this rule exists to forbid. It shipped **after** the detector, not with it: the guard
+> landed first carrying the field as a visible `CACHE` debt, which is the cheap half, and the memory
+> was paid only once the evidence justified it.
 
 ### MEMO — Pure memoization on process-global keys
 

--- a/src/MeshWeaver.Graph/Configuration/CompilationReferenceSet.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationReferenceSet.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The default Roslyn <see cref="MetadataReference"/> set every dynamic-NodeType compilation
+/// binds against — the trusted-platform-assembly list plus a few well-known additions — owned by
+/// the <b>mesh</b>, not by the process.
+///
+/// <para>🚨 Why this is a mesh-scoped instance and not a <c>static readonly</c> list. It used to
+/// be <c>MeshNodeCompilationService._references</c>, a <c>private static readonly
+/// IReadOnlyList&lt;MetadataReference&gt;</c>, and was twice written off in review as "a
+/// write-once constant lookup" — the sanctioned exemption in
+/// <see href="Doc/Architecture/NoStaticState.md">NoStaticState.md</see>. That reading is wrong,
+/// and the exemption does not apply: the <i>list</i> is write-once, but its <i>elements</i> are
+/// not constants. A <see cref="PortableExecutableReference"/> owns lazily materialized,
+/// <see cref="IDisposable"/> <c>Metadata</c> (a memory-mapped PE image) and Roslyn hangs its
+/// derived assembly/symbol tables — <c>AssemblyMetadata.CachedSymbols</c> — off that same
+/// instance. So the field was a mutable, process-wide cache wearing <c>static readonly</c>
+/// clothing: the exact shape the no-static-state rule exists to forbid, and the only state that
+/// every compilation in a test host demonstrably shared.</para>
+///
+/// <para>Registered as a singleton next to <c>MeshNodeCompilationService</c>, so its lifetime IS
+/// the mesh's: it becomes unreachable when the mesh's container does, and needs no
+/// <c>Clear()</c> for test isolation. Nothing else in the process holds these instances, so
+/// nothing outlives the mesh that built them.</para>
+///
+/// <para>🚨 It deliberately does NOT dispose the metadata at mesh teardown, and must not start.
+/// <c>Metadata</c> is <see cref="IDisposable"/>, but a compile can still be in flight (or a
+/// symbol graph still live) when a mesh is torn down — disposing underneath one is a
+/// use-after-free on the very object graph whose corruption this class exists to rule out.
+/// Dropping the reference and letting the mapping be released with the object is the only safe
+/// release, and it is enough for the isolation property.</para>
+///
+/// <para>💰 Cost, measured rather than assumed (macOS, .NET 10, Roslyn 5.6, the 470-reference set
+/// a <c>MeshWeaver.Hosting.Monolith.Test</c> process actually has). One set costs <b>~15 MiB of
+/// resident metadata</b> and ~73 ms to build; a process that builds one per mesh instead of one
+/// per process pays that per mesh that compiles. It is a HIGH-WATER cost, not a leak — the
+/// native metadata is reused once the sets are collected (five rounds of 50 sets plateau at
+/// ~1.1 GiB rather than growing) — but it is only reclaimed on finalization, which the GC has no
+/// pressure signal for. That is why construction is <b>lazy</b>: a mesh that never compiles a
+/// NodeType never materializes a reference set, which is most meshes in a test host.</para>
+/// </summary>
+public sealed class CompilationReferenceSet
+{
+    // Instance, not static. Lazy so that only a mesh that actually compiles pays the ~15 MiB /
+    // ~73 ms; ExecutionAndPublication so concurrent first compiles materialize exactly one set.
+    private readonly Lazy<ImmutableArray<MetadataReference>> references =
+        new(BuildDefaultReferences, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// This mesh's reference set. Materialized on first access and then a plain field read.
+    /// </summary>
+    public ImmutableArray<MetadataReference> References => references.Value;
+
+    /// <summary>
+    /// Builds one reference set — TPA assemblies plus a few well-known additions. Uses
+    /// <see cref="MetadataReference.CreateFromFile(string, MetadataReferenceProperties, DocumentationProvider)"/>
+    /// (mmap, lazy read) — Roslyn typically reads only a small fraction of each assembly's
+    /// metadata. An earlier attempt at
+    /// <see cref="MetadataReference.CreateFromStream(Stream, MetadataReferenceProperties, DocumentationProvider, string?)"/>
+    /// to avoid finalizer pressure ended up reading the whole DLL into managed memory eagerly —
+    /// net 10%+ slower in the autocomplete-test CPU profile, since most of those bytes were never
+    /// touched.
+    /// </summary>
+    internal static ImmutableArray<MetadataReference> BuildDefaultReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+
+        var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (trustedAssemblies != null)
+        {
+            foreach (var path in trustedAssemblies.Split(Path.PathSeparator))
+            {
+                if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                    continue;
+                try
+                {
+                    references.Add(MetadataReference.CreateFromFile(path));
+                }
+                catch
+                {
+                    // Skip assemblies that can't be loaded
+                }
+            }
+        }
+
+        // Three well-known additions in case TPA didn't include them. Dedup
+        // against TPA-derived set by Display path so we don't double-load.
+        var seen = new HashSet<string>(
+            references.Select(r => r.Display ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in new[]
+        {
+            typeof(object).Assembly,                                           // System.Runtime
+            typeof(System.ComponentModel.DataAnnotations.KeyAttribute).Assembly, // DataAnnotations
+            typeof(System.Text.Json.Serialization.JsonPropertyNameAttribute).Assembly, // System.Text.Json
+        })
+        {
+            if (!string.IsNullOrEmpty(assembly.Location)
+                && File.Exists(assembly.Location)
+                && seen.Add(assembly.Location))
+            {
+                try
+                {
+                    references.Add(MetadataReference.CreateFromFile(assembly.Location));
+                }
+                catch
+                {
+                    // Skip if it can't be loaded
+                }
+            }
+        }
+
+        return references.ToImmutable();
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -262,6 +262,15 @@ public static class GraphConfigurationExtensions
                 .AddNodeCopyDispatchHandler()
                 .WithServices(services =>
                 {
+                    // 📚 The Roslyn MetadataReference set every dynamic-NodeType compilation binds
+                    // against — mesh-scoped, so it dies with the mesh instead of living in a
+                    // `static readonly` field for the life of the process. It used to be exactly
+                    // that static field, misclassified as a "write-once constant lookup": the list
+                    // is write-once, but each PortableExecutableReference owns lazily materialized
+                    // IDisposable metadata plus Roslyn's symbol tables cached against it. Lazy, so
+                    // a mesh that never compiles never materializes one. See
+                    // CompilationReferenceSet for the rationale and the measured cost.
+                    services.AddSingleton<CompilationReferenceSet>();
                     // Register MeshNodeCompilationService as both concrete and interface
                     // for callers that need the concrete CompileAndGetConfigurations entry point.
                     services.AddSingleton<MeshNodeCompilationService>();

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -172,75 +172,23 @@ internal class MeshNodeCompilationService(
     // side menu can evaluate the *same* queries the compiler uses — the Sources /
     // Tests lists displayed in the UI are guaranteed to match the files compiled.
     //
-    // Default Roslyn references are process-wide: TPA list + a few well-known
-    // additions never change at runtime. Eager static-field init runs once at
-    // type load and the result is then a plain field read on every compile —
-    // no Lazy property dispatch, no synchronization, zero per-compile cost.
-    private static readonly IReadOnlyList<MetadataReference> _references = GetDefaultReferences();
+    // 🚨 The default Roslyn reference set belongs to the MESH, not the process. This was
+    // `private static readonly IReadOnlyList<MetadataReference> _references`, defended twice in
+    // review as "a write-once constant lookup" — but only the LIST is write-once. Each
+    // PortableExecutableReference owns lazily materialized, IDisposable metadata plus the Roslyn
+    // symbol tables cached against it, so the field was a mutable process-wide cache in
+    // static-readonly clothing, and it was the one piece of state every compilation in a test
+    // host shared. See CompilationReferenceSet for the full rationale, the measured cost, and
+    // why the set is never disposed. Resolved (not constructed) here: the set itself is lazy, so
+    // a mesh that never compiles never materializes one.
+    private readonly CompilationReferenceSet _referenceSet =
+        hub.ServiceProvider.GetRequiredService<CompilationReferenceSet>();
 
     /// <summary>
-    /// Builds the process-wide MetadataReference list — TPA assemblies plus a few
-    /// well-known additions. Uses <see cref="MetadataReference.CreateFromFile(string, MetadataReferenceProperties, DocumentationProvider)"/>
-    /// (mmap, lazy read) — Roslyn typically reads only a small fraction of each
-    /// assembly's metadata, so the upfront cost is tiny. An earlier attempt at
-    /// <see cref="MetadataReference.CreateFromStream(Stream, MetadataReferenceProperties, DocumentationProvider, string?)"/>
-    /// to avoid finalizer pressure ended up reading the whole DLL into managed
-    /// memory eagerly — net 10%+ slower in the autocomplete-test CPU profile,
-    /// since most of those bytes were never touched. The file-handle finalizer
-    /// pressure those references add is also tiny in practice (the static field
-    /// holds them for the process lifetime; finalizers only run at shutdown).
+    /// The reference set this compiler binds against — exposed so a test can assert it IS the
+    /// mesh's singleton (i.e. that no compile can reach a process-wide set again).
     /// </summary>
-    private static List<MetadataReference> GetDefaultReferences()
-    {
-        var references = new List<MetadataReference>();
-
-        var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
-        if (trustedAssemblies != null)
-        {
-            foreach (var path in trustedAssemblies.Split(Path.PathSeparator))
-            {
-                if (string.IsNullOrEmpty(path) || !File.Exists(path))
-                    continue;
-                try
-                {
-                    references.Add(MetadataReference.CreateFromFile(path));
-                }
-                catch
-                {
-                    // Skip assemblies that can't be loaded
-                }
-            }
-        }
-
-        // Three well-known additions in case TPA didn't include them. Dedup
-        // against TPA-derived set by Display path so we don't double-load.
-        var seen = new HashSet<string>(
-            references.Select(r => r.Display ?? string.Empty),
-            StringComparer.OrdinalIgnoreCase);
-        foreach (var assembly in new[]
-        {
-            typeof(object).Assembly,                                           // System.Runtime
-            typeof(System.ComponentModel.DataAnnotations.KeyAttribute).Assembly, // DataAnnotations
-            typeof(System.Text.Json.Serialization.JsonPropertyNameAttribute).Assembly, // System.Text.Json
-        })
-        {
-            if (!string.IsNullOrEmpty(assembly.Location)
-                && File.Exists(assembly.Location)
-                && seen.Add(assembly.Location))
-            {
-                try
-                {
-                    references.Add(MetadataReference.CreateFromFile(assembly.Location));
-                }
-                catch
-                {
-                    // Skip if it can't be loaded
-                }
-            }
-        }
-
-        return references;
-    }
+    internal CompilationReferenceSet ReferenceSet => _referenceSet;
 
     /// <summary>
     /// Regex matching @@path references in code files. The capture must LOOK LIKE A NODE PATH —
@@ -1682,10 +1630,10 @@ internal class MeshNodeCompilationService(
         IObservable<ImmutableArray<MetadataReference>> referencesObs =
             allNugetRefs.Count > 0
                 ? _ioPool.Run(ct => nugetResolver.ResolveAsync(allNugetRefs, targetFramework: null, ct))
-                    .Select(resolved => _references
+                    .Select(resolved => _referenceSet.References
                         .Concat(resolved.AssemblyPaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)))
                         .ToImmutableArray())
-                : Observable.Return(_references.ToImmutableArray());
+                : Observable.Return(_referenceSet.References);
 
         return referencesObs.Select(references =>
         {
@@ -1901,12 +1849,12 @@ internal class MeshNodeCompilationService(
         var nugetRefList = extractedRefs.ToList();
         StripBuiltInScopeGeneratorRef(nugetRefList, builtInPresent: BuiltInGeneratorPaths.Count > 0);
         var nugetRefs = nugetRefList.ToArray();
-        IEnumerable<MetadataReference> references = _references;
+        IEnumerable<MetadataReference> references = _referenceSet.References;
         IReadOnlyList<string> nugetAssemblyPaths = [];
         if (nugetRefs.Length > 0)
         {
             var resolved = await nugetResolver.ResolveAsync(nugetRefs, targetFramework: null, ct);
-            references = _references.Concat(
+            references = _referenceSet.References.Concat(
                 resolved.AssemblyPaths.Select(p => MetadataReference.CreateFromFile(p)));
             nugetAssemblyPaths = resolved.AssemblyPaths;
             cacheService.RegisterProbingDirectories(nodeName, resolved.ProbingDirectories);

--- a/test/MeshWeaver.Graph.Test/CompilationReferenceSetIsolationTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompilationReferenceSetIsolationTest.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The isolation contract of <see cref="CompilationReferenceSet"/> — issue #890.
+///
+/// <para>#890 is a process-wide poisoning: once one dynamic-NodeType compile fails inside
+/// Roslyn's PE metadata writer, EVERY later <c>Emit</c> in the process fails the same way — 17
+/// unrelated node paths over 6m41s in the instrumented occurrence, including a trivial
+/// nested-generic compilation built fresh against the same <c>MetadataReference</c> instances.
+/// The only state all of those compilations shared was
+/// <c>MeshNodeCompilationService._references</c>, a <c>private static readonly</c> list that had
+/// twice been classified as a "write-once constant lookup" and therefore exempt from the
+/// no-static-state rule. It is not: the LIST is write-once, but a
+/// <see cref="PortableExecutableReference"/> owns lazily materialized, <see cref="IDisposable"/>
+/// metadata and Roslyn caches derived assembly/symbol tables against that instance.</para>
+///
+/// <para>These tests pin the two properties that make the set mesh-owned rather than
+/// process-wide. They do NOT prove #890 is fixed — that needs a CI run — but they do prove the
+/// shared state it was attributed to is gone, and they fail if anyone reintroduces a
+/// process-wide memo behind the same API.</para>
+/// </summary>
+public class CompilationReferenceSetIsolationTest
+{
+    /// <summary>
+    /// Two meshes must not hand Roslyn the same <see cref="MetadataReference"/> objects. Roslyn's
+    /// symbol tables (<c>AssemblyMetadata.CachedSymbols</c>) hang off the reference instance, so
+    /// sharing one instance is what let one mesh's compile state reach another's.
+    /// </summary>
+    [Fact]
+    public void TwoSets_ShareNoMetadataReferenceInstance()
+    {
+        var a = new CompilationReferenceSet().References;
+        var b = new CompilationReferenceSet().References;
+
+        // An empty set would make the intersection assertion below vacuously true.
+        Assert.NotEmpty(a);
+        Assert.Equal(a.Length, b.Length);
+
+        var shared = a.Intersect(b, ReferenceEqualityComparer.Instance).ToList();
+        Assert.True(shared.Count == 0,
+            "each mesh must materialize its OWN references; a shared instance carries Roslyn's "
+            + "cached symbol tables across mesh boundaries, which is the process-wide state "
+            + $"issue #890's canary implicated. Shared instances: {shared.Count}");
+    }
+
+    /// <summary>
+    /// Nothing may root a reference set — or the <see cref="MetadataReference"/> instances inside
+    /// it — beyond the mesh that built it.
+    ///
+    /// <para>🚨 Both weak references are load-bearing, and the second is the one that catches the
+    /// realistic regression. A process-wide memo keyed by file path (the shape
+    /// <c>KernelScriptReferences.Materialized</c> deliberately has) would root the
+    /// <b>references</b> while leaving the <c>CompilationReferenceSet</c> wrapper perfectly
+    /// collectible — so a check on the wrapper alone would pass while the very state #890 is
+    /// about survived. The wrapper check catches the other shape: a registry of the sets
+    /// themselves.</para>
+    /// </summary>
+    [Fact]
+    public void NeitherTheSetNorItsReferencesAreRootedByStaticState()
+    {
+        var (weakSet, weakReference) = MaterializeAndForget();
+
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        Assert.False(weakSet.IsAlive,
+            "a CompilationReferenceSet must die with the mesh that built it — if it is still "
+            + "alive after a full collect, something process-wide is holding the set itself");
+
+        Assert.False(weakReference.IsAlive,
+            "the MetadataReference instances must die with it too. This is the assertion that "
+            + "fails if someone reintroduces a process-wide memo keyed by assembly path: the "
+            + "wrapper would still be collectible, but the references — which own the mmap'd "
+            + "metadata and Roslyn's symbol tables — would be shared across every mesh again, "
+            + "which is exactly the state issue #890 came down to");
+
+        // NoInlining so the locals cannot stay live in a register / on the frame under Release JIT.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static (WeakReference Set, WeakReference Reference) MaterializeAndForget()
+        {
+            var set = new CompilationReferenceSet();
+            var references = set.References;   // force materialization — an unmaterialized set proves nothing
+            Assert.NotEmpty(references);
+            return (new WeakReference(set), new WeakReference(references[0]));
+        }
+    }
+}

--- a/test/MeshWeaver.Graph.Test/CompilationReferenceSetWiringTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompilationReferenceSetWiringTest.cs
@@ -1,0 +1,35 @@
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The DI half of issue #890's fix: the Roslyn reference set every dynamic-NodeType compile
+/// binds against is resolved from the MESH's container — one per mesh, and the very instance the
+/// compiler holds. <see cref="CompilationReferenceSetIsolationTest"/> pins that two sets share
+/// no <c>MetadataReference</c> and that nothing static roots one; this pins that a real mesh
+/// actually routes its compiler to its own set rather than to a process-wide field.
+/// </summary>
+public class CompilationReferenceSetWiringTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public void Mesh_OwnsExactlyOneReferenceSet_AndTheCompilerBindsIt()
+    {
+        var fromMesh = Mesh.ServiceProvider.GetRequiredService<CompilationReferenceSet>();
+
+        // A transient would re-materialize ~15 MiB of PE metadata on every resolve.
+        Assert.Same(fromMesh, Mesh.ServiceProvider.GetRequiredService<CompilationReferenceSet>());
+
+        // The compiler must bind THIS mesh's references; binding anything else is the
+        // process-wide state issue #890's canary implicated.
+        Assert.Same(
+            fromMesh,
+            Mesh.ServiceProvider.GetRequiredService<MeshNodeCompilationService>().ReferenceSet);
+
+        // An empty set would make every NodeType compile fail to bind, so this also guards the
+        // lazy materialization actually producing the TPA list.
+        Assert.NotEmpty(fromMesh.References);
+    }
+}

--- a/test/MeshWeaver.PathResolution.Test/NoStaticCollectionsTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/NoStaticCollectionsTest.cs
@@ -175,39 +175,24 @@ public class NoStaticCollectionsTest
             ["MeshWeaver.Kernel.Hub.KernelScriptReferences.Materialized"] = "MEMO: assembly path -> shared PE reference",
             ["MeshWeaver.Kernel.Hub.KernelScriptReferences.SharedSnapshot"] = "MEMO: the snapshot over the same memo",
 
-            // 🚨 CACHE — the known violation this guard was written for, listed rather than fixed
-            // here ON PURPOSE. Removing it means giving every mesh its own reference set, which
-            // MEASURABLY costs ~15 MiB per compiling mesh (+98% peak RSS across the full
-            // Hosting.Monolith.Test project) — a certain cost against an uncertain benefit, since
-            // the Roslyn 5.6 source shows the symbol whose ContainingType goes null in #890 is a
-            // SOURCE symbol of the compilation being emitted, never a PE symbol arriving from a
-            // reference. That trade is decided by the emit canary's second leg, not by this guard.
-            // The entry stays until the canary reads canary=REFERENCES; #1438 removes both the
-            // field and this line. Listing it is the point: an allowlist entry is a visible debt,
-            // which is precisely what the field lacked when two reviews called it a constant.
-            ["MeshWeaver.Graph.Configuration.MeshNodeCompilationService._references"] =
-                "CACHE: process-wide Roslyn reference set — tracked by #890, migration held in #1438 pending the canary verdict",
         };
 
     /// <summary>
     /// The rule the #890 regression slipped through: <c>MeshNodeCompilationService._references</c>
-    /// is a <c>private static readonly IReadOnlyList&lt;MetadataReference&gt;</c>, which the
+    /// was a <c>private static readonly IReadOnlyList&lt;MetadataReference&gt;</c>, which the
     /// collection guard above cannot see (the declared type is an interface, not
     /// <c>List&lt;&gt;</c>) and which two reviews classified as a write-once constant lookup. The
-    /// list IS write-once; its ELEMENTS are not — a <c>PortableExecutableReference</c> owns lazily
+    /// list was write-once; its ELEMENTS were not — a <c>PortableExecutableReference</c> owns lazily
     /// memory-mapped, <see cref="IDisposable"/> metadata and Roslyn caches derived assembly/symbol
-    /// tables against that instance, so every dynamic-NodeType compile in a test host shares them.
+    /// tables against that instance, so every dynamic-NodeType compile in a test host shared them.
     /// This guard keys on the ELEMENT type, so no declared-type spelling — array,
     /// <c>ImmutableArray</c>, <c>IReadOnlyList</c>, <c>Lazy&lt;&gt;</c>, or a plain field — can
     /// hide it again.
     ///
-    /// <para>🚨 The guard ships BEFORE the field it was written for is removed, and that ordering
-    /// is deliberate. Removing the field costs a measured +98% peak RSS in the test host, and
-    /// whether that buys anything is decided by the emit canary, not by this test. So the field is
-    /// listed in <see cref="AllowedRoslynReferenceHolders"/> as a <c>CACHE</c> debt with its issue
-    /// number — visible and counted — rather than left invisible until someone re-derives the whole
-    /// argument. Landing the detector early is the cheap half; paying the memory is the half that
-    /// waits for evidence.</para>
+    /// <para>The field it was written for is gone as of this change — the reference set is now the
+    /// mesh-scoped <c>CompilationReferenceSet</c> — so <see cref="AllowedRoslynReferenceHolders"/>
+    /// carries no <c>CACHE</c> debt again. The only entries left are the kernel script path's
+    /// deliberate process-wide memo.</para>
     /// </summary>
     [Fact]
     public void No_static_fields_hold_Roslyn_metadata_references_outside_allowlist()


### PR DESCRIPTION
# 🚨 HELD — do not merge until the canary reports

**Merge only when #890's emit canary returns `canary=REFERENCES`. If it returns `canary=BELOW-ROSLYN`, close this unmerged** — no reference-set change can fix a CLR heap or JIT fault, and closing saves the memory cost entirely. At ~1.4% per run the verdict is roughly a day away.

Stacked on **#1445**, which carries the two halves of #890 that cost nothing and do not depend on this hypothesis: the **detector** (`NoStaticCollectionsTest` keying on the element type) and the **instrument** (the canary's second leg). This PR is the half that does depend on it.

## The change

`MeshNodeCompilationService._references` was a `private static readonly IReadOnlyList<MetadataReference>`, twice classified in review as a "write-once constant lookup". Only the **list** is write-once: a `PortableExecutableReference` owns lazily memory-mapped, `IDisposable` metadata and Roslyn caches derived assembly/symbol tables against that instance.

It becomes `CompilationReferenceSet` — a mesh-scoped singleton, **lazily** materialized so a mesh that never compiles never builds one. Deliberately **not** disposed at teardown: a compile can still be in flight when a mesh dies, and disposing metadata underneath one is a use-after-free on exactly the object graph this is chasing. Removing the field also empties the `CACHE` debt #1445 introduces.

Two tests pin what the change delivers: two sets share no `MetadataReference` instance, and **neither the set nor its references** survive a full collect. The second arm is the load-bearing one — a process-wide memo keyed by assembly path would leave the wrapper collectible while sharing the references again, so a check on the wrapper alone would pass while the very state #890 is about survived.

## Why it is held, not merged

Roslyn 5.6's own source (`dotnet/roslyn@c0573ed`) shows the NRE's guard admits a type only when `ContainingModule == moduleBeingBuilt.SourceModule` — so the symbol whose `ContainingType` reads null is a **source symbol of the compilation being emitted**, never a PE symbol arriving from a reference. The reference set is a **vector at best, not a demonstrated cause**.

Against that uncertain benefit, the cost is certain and measured — A/B, same base, same machine, same tests passing both sides:

| slice | baseline | this PR | delta |
|---|---|---|---|
| `CodeEditRecompileTest` (11) | 662 MiB | 1012 MiB | +53% peak RSS |
| `~Compile\|~NodeType` (133) | 1071 MiB | 1701 MiB | +59% peak RSS |
| **full project (667)** | **1157 MiB / 460.8 s** | **2292 MiB / 449.8 s** | **+98% peak RSS, wall clock unchanged** |

≈15 MiB and ~73 ms per set; a **high-water mark, not a leak** (repeated rounds plateau: 937 → 1042 → 1058 → 1083 → 1078 MiB). Still under the harness's 4 GiB `MEM_PRESSURE` / 6 GiB `MEM_CRITICAL_FAILFAST`, and CI splits the project in two. **No production cost** — a portal hosts one mesh, so one set per process exactly as today. macOS numbers; on Linux the metadata is kernel-reclaimable `RssFile`, so the CI magnitude is untested.

Paying a doubled memory ceiling *now* to pre-empt an answer that is one observation away is the wrong trade. The canary was built precisely so we would not have to reason for a week — its first leg killed the entire generated-source half of the search space in 95 minutes.

## One test failure still on the ledger

The with-change full run had `SilentReadNackTest.OwnerDisposedWithReadOutstanding_IsNacked_NotLeftHanging` fail (expected `DeliveryFailureException`, got `GetDataResponse`); the baseline run passed it, it passes in isolation, and it passed on Linux CI with the change. Its test was churned on main the same day (`46be4a096`/`82d62519c`/`3e49feb85`, one literally *"a read whose owner is recycled RECOVERS"*), and this diff compiles no NodeType. **But** one run each is not evidence of a pre-existing flake, and +1.1 GiB of peak RSS genuinely perturbs GC timing. Not claiming unrelated — claiming unproven.

## What's New

Skipped — pure-internal (architecture rule compliance). No user-visible effect: a portal hosts one mesh, so this is a no-op in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
