### PR TITLE
fix: DeleteNode's existence gate and its commit now ask the same providers (#1433)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-deleting-something-already-gone-no-longer-reports-an-error.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-deleting-something-already-gone-no-longer-reports-an-error.md
@@ -1,0 +1,29 @@
+---
+Name: Deleting something already gone no longer reports an error
+Category: Fix
+Description: When two clean-ups removed the same item at once, the one that arrived second failed with a message about storage, even though the item was correctly gone. It now reports success, and an item that genuinely cannot be deleted says so up front instead of part-way through.
+Icon: Delete
+Order: -20260813
+---
+
+# Deleting something already gone no longer reports an error
+
+Deleting an item happens in two steps: first we check it is there, then we remove it. Those two
+steps were not asking about quite the same places, and they were not asking at the same moment —
+so two things went wrong.
+
+If something else removed the item in between — a bulk clean-up running in parallel, a second
+server doing the same tidy-up — the removal step found nothing left and reported a failure that
+talked about storage providers. The item was gone, which is exactly what was asked for, but the
+operation was recorded as an error and the message pointed at something entirely unrelated. That
+now reports success: once the item is gone, the job is done, whoever finished it.
+
+The second problem was more serious. A few kinds of item are supplied by the product itself rather
+than stored in your workspace, and those genuinely cannot be deleted. The check step could see
+them, so a delete was allowed to start — and because a delete works from the innermost items
+outwards, everything beneath such an item was already removed by the time the refusal came. You
+were left with a partly emptied item you had been told could not be deleted at all. The refusal now
+happens before anything is removed, and it names what is supplying the item so it is clear why.
+
+Nothing new became deletable. The delete still only removes from the places it always could, and
+the case that now succeeds is precisely the one where there was nothing left to remove.

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -378,6 +378,12 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
         => inner.ListDescendantPaths(rootPath);
 
     /// <inheritdoc />
+    /// <remarks>Pure delegation — only the composite below knows its providers, and the
+    /// interface default (<c>null</c>) would silently drop the delete pre-flight (#1433).</remarks>
+    public IObservable<string?> FindDeleteBlockingProvider(string path)
+        => inner.FindDeleteBlockingProvider(path);
+
+    /// <inheritdoc />
     public IObservable<bool> Exists(string path) => inner.Exists(path);
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
@@ -22,7 +22,12 @@ namespace MeshWeaver.Hosting.Persistence;
 ///   <item><b>Delete</b> — fan out across <i>every</i> writable provider in
 ///     parallel; each self-checks containment (read-or-not) and deletes if
 ///     owned. Multiple owners (rare, but possible during cache races) each
-///     delete their copy. The user-facing emit is the deleted path.</item>
+///     delete their copy. The user-facing emit is the deleted path.
+///     🚨 Read spans MORE providers than Delete can reach, so "readable" and
+///     "deletable" are not the same predicate; <see cref="FindDeleteBlockingProvider"/>
+///     is how a caller asks the DELETE question before it starts removing
+///     things, and Delete classifies rather than blanket-refusing when nothing
+///     was removed (#1433).</item>
 ///   <item><b>Exists</b> — fan-out OR; any provider reporting true wins.</item>
 /// </list>
 ///
@@ -34,6 +39,9 @@ public sealed class PersistenceService : IStorageAdapter
 {
     private readonly IReadOnlyList<IPartitionStorageProvider> _allOrdered;
     private readonly IReadOnlyList<IPartitionStorageProvider> _writable;
+    // The complement of _writable, in read order. A path only THIS set serves is readable but
+    // structurally undeletable — see FindDeleteBlockingProvider / Delete (#1433).
+    private readonly IReadOnlyList<IPartitionStorageProvider> _readOnly;
     private readonly ILogger<PersistenceService>? _logger;
 
     /// <summary>
@@ -70,6 +78,7 @@ public sealed class PersistenceService : IStorageAdapter
             .ToList();
         _allOrdered = specific.Concat(wildcard).ToList();
         _writable = _allOrdered.Where(p => !p.IsReadOnly).ToList();
+        _readOnly = _allOrdered.Where(p => p.IsReadOnly).ToList();
 
         // Surface the union of every provider's Changes feed so consumers
         // that subscribe to IStorageAdapter.Changes see writes from any
@@ -209,9 +218,32 @@ public sealed class PersistenceService : IStorageAdapter
     /// <summary>
     /// Fan out across every writable adapter: each self-checks containment
     /// (Read returns non-null) and deletes if owned. Aggregates into the
-    /// deleted-path emit. Throws when nothing was actually deleted (every
-    /// adapter's Read returned null) — the user's semantics for
-    /// "delete-nonexistent must error".
+    /// deleted-path emit.
+    ///
+    /// <para>🚨 When nothing was deleted, the outcome is CLASSIFIED rather than blanket-refused
+    /// (#1433). The old shape threw one <c>InvalidOperationException</c> for two states that mean
+    /// opposite things — and, because <see cref="Read"/> consults EVERY provider while this
+    /// consults only the writable ones, it threw it for a delete whose requested end state
+    /// already held:</para>
+    /// <list type="bullet">
+    ///   <item><b>Nothing anywhere has the path</b> → it is gone; the delete's requested end state
+    ///     HOLDS, so this completes with the path. The caller's existence gate is what answers
+    ///     "did this node exist" (<c>HandleDeleteNodeRequest</c> stage 1 →
+    ///     <c>NodeNotFound</c>); by the time a commit runs, the row having vanished in between is
+    ///     a benign race — a parallel prune, another replica — not a failure. Every concurrent
+    ///     delete pruning the same subtree hit this: an ERROR-level "no writable storage provider
+    ///     has this node" that reads like a routing bug, for a path that is correctly gone. The
+    ///     recursive-delete drain pass already models it exactly this way, with
+    ///     <see cref="IStorageAdapter.DeleteIfExists"/>.</item>
+    ///   <item><b>A READ-ONLY provider serves it</b> → genuinely undeletable, and now SAID so:
+    ///     the refusal names the provider instead of claiming nothing has the node.</item>
+    /// </list>
+    ///
+    /// <para>🚨 What this does NOT do: widen what gets removed. The delete fan-out is still
+    /// <see cref="_writable"/> only, still gated on that provider's own containment read — a
+    /// read-only provider is never asked to delete, so shipped documentation and static nodes
+    /// cannot be tombstoned. The only case that newly SUCCEEDS is the one in which zero bytes are
+    /// removed, because there was nothing anywhere to remove.</para>
     /// </summary>
     public IObservable<string> Delete(string path)
         => _writable
@@ -223,8 +255,61 @@ public sealed class PersistenceService : IStorageAdapter
             .Aggregate(false, (any, deleted) => any || deleted)
             .SelectMany(any => any
                 ? Observable.Return(path)
-                : Observable.Throw<string>(new InvalidOperationException(
-                    $"Cannot delete '{path}': no writable storage provider has this node.")));
+                // No writable provider held it. Ask ONLY the read-only set here: the writable
+                // answer is the one we just computed, and re-probing it would let a concurrent
+                // RE-CREATE turn this into a false "deleted" for a node that now exists.
+                : FindServingReadOnlyProvider(path).SelectMany(blocking => blocking is null
+                    ? Observable.Return(path)
+                    : Observable.Throw<string>(new InvalidOperationException(
+                        $"Cannot delete '{path}': it is served by the READ-ONLY storage provider "
+                        + $"'{blocking}', which no delete can remove from. The node is readable but "
+                        + "not stored in any writable provider — remove it at its source, or "
+                        + "override it in a writable partition first."))));
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A WRITABLE holder wins: a path served by BOTH a read-only provider and a writable one (a
+    /// db-synced override of a shipped node) is deletable — the delete removes the writable copy —
+    /// so only "no writable provider has it, and a read-only one does" blocks.
+    /// </remarks>
+    public IObservable<string?> FindDeleteBlockingProvider(string path)
+        => _readOnly.Count == 0
+            // Nothing read-only is registered, so nothing can block. No probe at all — this runs
+            // on every user-initiated delete and must cost nothing on the common configuration.
+            ? Observable.Return<string?>(null)
+            : AnyWritableHas(path).SelectMany(writable => writable
+                ? Observable.Return<string?>(null)
+                : FindServingReadOnlyProvider(path));
+
+    /// <summary>
+    /// The first READ-ONLY provider (in the same order <see cref="Read"/> consults) whose adapter
+    /// holds <paramref name="path"/>, or <c>null</c>. A pure read — it never mutates anything.
+    /// </summary>
+    private IObservable<string?> FindServingReadOnlyProvider(string path)
+        => _readOnly.Count == 0
+            ? Observable.Return<string?>(null)
+            : _readOnly
+                .Select(p => p.Adapter.Read(path, JsonSerializerOptionsCache)
+                    .Select(node => node is null ? null : DescribeProvider(p)))
+                .Concat()
+                .Where(name => name is not null)
+                .DefaultIfEmpty(null)
+                .FirstAsync();
+
+    /// <summary>Fan-out OR: does any WRITABLE provider hold <paramref name="path"/>?</summary>
+    private IObservable<bool> AnyWritableHas(string path)
+        => _writable.Count == 0
+            ? Observable.Return(false)
+            : _writable
+                .Select(p => p.Adapter.Read(path, JsonSerializerOptionsCache)
+                    .Select(node => node is not null))
+                .Merge()
+                .Aggregate(false, (any, has) => any || has);
+
+    private static string DescribeProvider(IPartitionStorageProvider provider)
+        => provider.PartitionDefinition?.DataSource is { Length: > 0 } source
+            ? $"{provider.Name} ({source})"
+            : provider.Name;
 
     /// <summary>
     /// Shared JsonSerializerOptions instance for containment-check reads

--- a/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
@@ -110,6 +110,12 @@ internal sealed class SubtreeDeletionGuardStorageAdapter(
         => inner.ListDescendantPaths(rootPath);
 
     /// <inheritdoc />
+    /// <remarks>Pure delegation — only the composite below knows its providers, and the
+    /// interface default (<c>null</c>) would silently drop the delete pre-flight (#1433).</remarks>
+    public IObservable<string?> FindDeleteBlockingProvider(string path)
+        => inner.FindDeleteBlockingProvider(path);
+
+    /// <inheritdoc />
     public IObservable<bool> Exists(string path) => inner.Exists(path);
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/VersionWritingStorageAdapter.cs
@@ -71,6 +71,12 @@ internal class VersionWritingStorageAdapter(
     public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
         => inner.ListDescendantPaths(rootPath);
 
+    /// <inheritdoc />
+    /// <remarks>Pure delegation — only the composite below knows its providers, and the
+    /// interface default (<c>null</c>) would silently drop the delete pre-flight (#1433).</remarks>
+    public IObservable<string?> FindDeleteBlockingProvider(string path)
+        => inner.FindDeleteBlockingProvider(path);
+
     public IObservable<bool> Exists(string path) => inner.Exists(path);
 
     public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2262,7 +2262,52 @@ public static class MeshExtensions
                             return Observable.Empty<System.Reactive.Unit>();
                         }
 
-                        return RunDeletionValidatorsWithWarningsObs(hub, rootNode, capturedRequest, request.AccessContext)
+                        // 2b. 🚨 Is this node DELETABLE at all? Stage 1's existence gate reads
+                        //     across EVERY storage provider, read-only ones included, while the
+                        //     commit can only remove through the WRITABLE ones — so a node served
+                        //     solely by a read-only provider (static Agent/Harness/LanguageModel
+                        //     definitions, embedded documentation) passed the gate and then died
+                        //     in the commit with "no writable storage provider has this node":
+                        //     an ERROR that reads like a routing bug (#1433).
+                        //
+                        //     Asking here, BEFORE any storage side effect, is the part that
+                        //     matters. HierarchicalPathDeletion walks the subtree BOTTOM-UP, so
+                        //     the undeletable root is reached LAST — refusing at the commit means
+                        //     every writable descendant has already been removed and the operation
+                        //     still fails: a half-destroyed subtree. Refusing here removes nothing.
+                        //
+                        //     Root only. Descendants come from ListDescendantPaths, which
+                        //     enumerates WRITABLE providers exclusively (deliberately — a
+                        //     read-only provider can neither be deleted from nor leak survivors),
+                        //     so no read-only path can reach the plan; a cascade leaf carries
+                        //     CascadeRootPath and skips the probe. And the check is only ever a
+                        //     PRE-flight: PersistenceService.Delete still refuses at commit, so
+                        //     an adapter that cannot answer (the interface default, null) loses
+                        //     the early diagnosis, never the protection.
+                        return (capturedRequest.CascadeRootPath is null
+                                ? persistence.FindDeleteBlockingProvider(path)
+                                : Observable.Return<string?>(null))
+                            .TimeoutAtStage(opts.Timeout, () => DeleteStageTimeout(
+                                DeleteStage.ValidateRoot,
+                                $"the storage-provider probe for '{path}' did not answer within "
+                                + $"{opts.Timeout.TotalSeconds:0}s"))
+                            .SelectMany(blockingProvider =>
+                            {
+                                if (blockingProvider is not null)
+                                {
+                                    var msg = $"Cannot delete '{path}': it is served by the "
+                                        + $"read-only storage provider '{blockingProvider}'. "
+                                        + "Nothing was deleted.";
+                                    logger.LogWarning(
+                                        "[DeleteNode] read-only-provider path={Path} provider={Provider}",
+                                        path, blockingProvider);
+                                    PostFailed(msg, NodeDeletionRejectionReason.ValidationFailed,
+                                        [new LogMessage(msg, LogLevel.Error)],
+                                        ImmutableList.Create(path));
+                                    return Observable.Empty<System.Reactive.Unit>();
+                                }
+
+                                return RunDeletionValidatorsWithWarningsObs(hub, rootNode, capturedRequest, request.AccessContext)
                             .TimeoutAtStage(opts.Timeout, () => DeleteStageTimeout(
                                 DeleteStage.ValidateRoot,
                                 $"the INodeValidator chain for '{path}' did not complete within "
@@ -2526,6 +2571,7 @@ public static class MeshExtensions
                                             .Select(_ => System.Reactive.Unit.Default);
                                         });
                                     }));
+                            });
                             });
                     });
             })

--- a/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IStorageAdapter.cs
@@ -136,6 +136,34 @@ public interface IStorageAdapter
         => System.Reactive.Linq.Observable.Select(Delete(path), _ => true);
 
     /// <summary>
+    /// 🚨 PRE-FLIGHT for <see cref="Delete"/> — names the READ-ONLY storage provider that makes
+    /// <paramref name="path"/> structurally undeletable, or <c>null</c> when a delete is
+    /// unobstructed. This is the question <see cref="Delete"/> itself answers at COMMIT time,
+    /// exposed so a caller can ask it BEFORE it starts removing anything (#1433).
+    ///
+    /// <para><b>Why it exists.</b> A composite adapter reads across every provider (read-only ones
+    /// included) but can only delete through the WRITABLE ones, so a path served solely by a
+    /// read-only provider passes an existence check and then cannot be committed. In a RECURSIVE
+    /// delete that is not a cosmetic mismatch: <c>HierarchicalPathDeletion</c> walks bottom-up, so
+    /// by the time the undeletable root is reached its writable descendants are already gone —
+    /// the subtree is destroyed and the operation still fails. Asking first is what keeps the
+    /// gate and the commit looking at the same thing.</para>
+    ///
+    /// <para>Non-null means REFUSE — it never means "delete it some other way". Nothing here
+    /// widens what a delete removes; a read-only provider is never asked to delete.</para>
+    ///
+    /// <para>The default is <c>null</c>: a single-store adapter has no read-only provider behind
+    /// it, so nothing can block a delete that its own <see cref="Delete"/> would not already
+    /// refuse. That default cannot open a hole — <see cref="Delete"/> remains the authority and
+    /// still refuses at commit; this only moves an inevitable refusal earlier. Decorators MUST
+    /// forward to their inner adapter (same rule as <see cref="ListDescendantPaths"/>).</para>
+    /// </summary>
+    /// <param name="path">The path a delete is being considered for.</param>
+    /// <returns>The blocking read-only provider's name, or <c>null</c> when nothing blocks.</returns>
+    IObservable<string?> FindDeleteBlockingProvider(string path)
+        => System.Reactive.Linq.Observable.Return<string?>(null);
+
+    /// <summary>
     /// Lists child paths under a parent path.
     /// Returns both node paths (records present at that level) and directory paths
     /// (intermediate folders that have nodes under them but no node at the folder level).

--- a/test/MeshWeaver.NodeOperations.Test/DeleteProviderAgreementTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/DeleteProviderAgreementTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.NodeOperations.Test;
+
+/// <summary>
+/// #1433 — pins that <see cref="PersistenceService"/>'s existence CHECK and its delete ACTION
+/// answer the same question about the same providers.
+///
+/// <para><b>The asymmetry.</b> <c>Read</c> consults EVERY provider ("read-only providers and
+/// writable providers participate equally", per the class doc) while <c>Delete</c> can only remove
+/// through the writable ones — and it used to throw ONE message,
+/// <i>"no writable storage provider has this node"</i>, for two states that mean opposite things:
+/// a path that is genuinely gone, and a path a read-only provider is serving. The first is a
+/// benign race (a parallel prune removed the row between the caller's gate and this commit) whose
+/// requested END STATE already holds; reporting it as an ERROR-level unexpected
+/// <c>InvalidOperationException</c> sent triage looking at storage routing. The second is a real
+/// refusal that never said what was actually wrong.</para>
+///
+/// <para><b>The bound these tests exist to hold.</b> Classifying must not widen what a delete
+/// removes. Delete still fans out over WRITABLE providers only, still gated on that provider's own
+/// containment read, so a read-only provider is never asked to delete — see
+/// <see cref="OnlyAReadOnlyProviderHasIt_Refuses_NamesTheProvider_AndLeavesItServed"/>, which
+/// asserts the node is still there after the refusal. The only case that newly SUCCEEDS is the one
+/// in which nothing was removed because there was nothing anywhere to remove.</para>
+/// </summary>
+public class DeleteProviderAgreementTest
+{
+    private static readonly JsonSerializerOptions Json = new();
+
+    /// <summary>A read-only provider over a fixed node set — the shape of the static
+    /// Agent/Harness/LanguageModel definitions and of embedded documentation.</summary>
+    private sealed class ReadOnlyProvider(string name, params MeshNode[] nodes) : IPartitionStorageProvider
+    {
+        public string Name => name;
+        public bool IsReadOnly => true;
+        public IStorageAdapter Adapter { get; } = new StaticNodeStorageAdapter(nodes);
+        public PartitionDefinition? PartitionDefinition { get; } = new()
+        {
+            Namespace = name, DataSource = "static", Versioned = false
+        };
+        public ImmutableHashSet<string> Contexts => [];
+    }
+
+    private static (PersistenceService Service, InMemoryPartitionStorageProvider Writable)
+        Build(params IPartitionStorageProvider[] readOnly)
+    {
+        var writable = new InMemoryPartitionStorageProvider(new InMemoryStorageAdapter(null));
+        var providers = new List<IPartitionStorageProvider>(readOnly) { writable };
+        return (new PersistenceService(providers), writable);
+    }
+
+    /// <summary>
+    /// The positive direction: what the check says EXISTS in a writable provider, the action
+    /// removes. Guards against a classification that starts refusing real deletes.
+    /// </summary>
+    [Fact]
+    public async Task WritableProviderHasIt_DeletesIt()
+    {
+        var (service, writable) = Build();
+        var node = new MeshNode("Doomed", "AgreementSpace") { Name = "Doomed", NodeType = "Markdown" };
+        await service.Write(node, Json).Should().Within(10.Seconds()).Emit();
+
+        (await service.FindDeleteBlockingProvider(node.Path).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("a writable provider holds it, so nothing blocks the delete");
+
+        (await service.Delete(node.Path).Should().Within(10.Seconds()).Emit())
+            .Should().Be(node.Path);
+
+        (await writable.Adapter.Read(node.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("the row must actually be gone");
+    }
+
+    /// <summary>
+    /// The benign race: by commit time nothing anywhere has the path, so the delete's requested
+    /// end state HOLDS and it completes. <b>Fail-without:</b> this threw
+    /// <c>InvalidOperationException("… no writable storage provider has this node.")</c>, which the
+    /// delete handler logged as <c>[DeleteNode] unexpected … partial-deleted=0</c> — the #1422
+    /// failures, all landing in the same second under a parallel prune.
+    /// <para>Whether a delete of a node that never existed is an ERROR is answered by the CALLER's
+    /// existence gate (<c>HandleDeleteNodeRequest</c> stage 1 → <c>NodeNotFound</c>), not here —
+    /// past that gate, "the row is no longer there" is the outcome that was asked for.</para>
+    /// </summary>
+    [Fact]
+    public async Task NothingAnywhereHasIt_Completes_AndRemovesNothingElse()
+    {
+        var (service, writable) = Build();
+        // A bystander in the same store: whatever the absent-path delete does, it must not touch it.
+        var bystander = new MeshNode("Bystander", "AgreementSpace")
+        {
+            Name = "Bystander", NodeType = "Markdown"
+        };
+        await service.Write(bystander, Json).Should().Within(10.Seconds()).Emit();
+
+        var absent = "AgreementSpace/never-existed";
+        (await service.FindDeleteBlockingProvider(absent).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("nothing serves it, so nothing blocks a delete of it");
+
+        (await service.Delete(absent).Should().Within(10.Seconds()).Emit())
+            .Should().Be(absent,
+                "the requested end state — the path is gone — already holds, so the commit has "
+                + "nothing to refuse. A parallel prune winning the race is not a routing fault");
+
+        (await writable.Adapter.Read(bystander.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().NotBeNull("a delete that removed nothing must have removed NOTHING");
+    }
+
+    /// <summary>
+    /// The real refusal — and the bound. A path only a READ-ONLY provider serves is readable and
+    /// structurally undeletable: the refusal must name the provider (it used to claim, falsely,
+    /// that no provider had the node), and — the part that matters — the node must still be there
+    /// afterwards. Widening the delete fan-out to every provider would let this tombstone shipped
+    /// documentation and static definitions; that is the change this test forbids.
+    /// </summary>
+    [Fact]
+    public async Task OnlyAReadOnlyProviderHasIt_Refuses_NamesTheProvider_AndLeavesItServed()
+    {
+        var shipped = new MeshNode("Shipped", "ReadOnlyNs") { Name = "Shipped", NodeType = "Markdown" };
+        var readOnly = new ReadOnlyProvider("ReadOnlyNs", shipped);
+        var (service, writable) = Build(readOnly);
+
+        (await service.Read(shipped.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().NotBeNull("the read side sees it — that is the whole asymmetry");
+
+        (await service.FindDeleteBlockingProvider(shipped.Path).Should().Within(10.Seconds()).Emit())
+            .Should().Contain("ReadOnlyNs",
+                "the pre-flight must name the provider that blocks, so the delete handler can "
+                + "refuse BEFORE the bottom-up subtree walk removes any writable descendant");
+
+        Func<Task> act = async () => await service.Delete(shipped.Path).FirstAsync().ToTask();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*READ-ONLY*ReadOnlyNs*",
+                "the refusal must say WHY and WHICH provider serves it — not claim, falsely, that "
+                + "no provider has the node");
+
+        (await readOnly.Adapter.Read(shipped.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().NotBeNull("a refused delete must leave the read-only provider's node intact");
+        (await writable.Adapter.Read(shipped.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("and must not have written a tombstone into a writable provider");
+    }
+
+    /// <summary>
+    /// A path served by BOTH a read-only provider and a writable one — a db-synced override of a
+    /// shipped node — stays deletable: the delete removes the writable copy. The block predicate
+    /// is "no writable provider has it AND a read-only one does", never "a read-only one does".
+    /// </summary>
+    [Fact]
+    public async Task ReadOnlyAndWritableBothHaveIt_DoesNotBlock_AndDeletesTheWritableCopy()
+    {
+        var shipped = new MeshNode("Overridden", "ReadOnlyNs")
+        {
+            Name = "Overridden", NodeType = "Markdown"
+        };
+        var readOnly = new ReadOnlyProvider("ReadOnlyNs", shipped);
+        var (service, writable) = Build(readOnly);
+
+        // The override lives in the writable store under the same path.
+        await writable.Adapter.Write(shipped with { Name = "Override" }, Json)
+            .Should().Within(10.Seconds()).Emit();
+
+        (await service.FindDeleteBlockingProvider(shipped.Path).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("a writable copy exists, so the delete has something it CAN remove");
+
+        (await service.Delete(shipped.Path).Should().Within(10.Seconds()).Emit())
+            .Should().Be(shipped.Path);
+
+        (await writable.Adapter.Read(shipped.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().BeNull("the writable override is what a delete removes");
+        (await readOnly.Adapter.Read(shipped.Path, Json).Should().Within(10.Seconds()).Emit())
+            .Should().NotBeNull("the shipped node underneath is untouched — it was never asked to delete");
+    }
+}


### PR DESCRIPTION
Fixes #1433.

## The asymmetry

`PersistenceService` reads across **every** provider (read-only ones "participate equally", per its own class doc) but can only delete through the **writable** ones — and it threw **one** message for two states that mean opposite things:

```
Cannot delete '…': no writable storage provider has this node.
```

### 1. The benign race — a correct outcome reported as an error

The caller's gate reads a snapshot; the commit runs later. Anything deleting in parallel (`StaticRepoImporter`'s `.Merge(BatchSize)` prune, another replica) can remove the row in between. The delete's requested **end state** — the path is gone — then holds, and it was reported as an ERROR-level unexpected `InvalidOperationException`, logged `[DeleteNode] unexpected path=… partial-deleted=0`, pointing triage at storage routing. The recursive-delete drain pass already models this correctly with the idempotent `DeleteIfExists`; the first pass did not.

Now: **nothing anywhere has the path ⇒ complete.** Whether the node existed *at all* is answered by the caller's gate (`HandleDeleteNodeRequest` stage 1 → `NodeNotFound`), which is unchanged — `Delete_NonExistentNode_Throws` and `Missing_Node_Fails_NotFound` still pass.

### 2. A read-only provider serving it — this one destroyed data

Static `Agent`/`Harness`/`LanguageModel` definitions and embedded documentation are readable and structurally undeletable, so such a root passed the gate and died at the commit. `HierarchicalPathDeletion` walks **bottom-up**, so by then every writable descendant was already gone: a half-emptied subtree *and* a failure.

The refusal now happens **before any commit**, through a new pre-flight `IStorageAdapter.FindDeleteBlockingProvider(path)`, and it names the provider instead of claiming nothing has the node.

## 🚨 What bounds the delete

Deletion is destructive, so the safety argument is explicit:

- **The fan-out is unchanged.** `Delete` still iterates `_writable` only, still gated on each provider's own containment read. A read-only provider is never asked to delete — shipped docs and static nodes cannot be tombstoned. This is why widening `Delete` to `_allOrdered` (the "obvious fix" the issue warns about) was not done.
- **`FindDeleteBlockingProvider` non-null means REFUSE.** It never routes a delete somewhere new. It is a pure `Read`.
- **The only newly-succeeding case removes zero bytes** — because there was nothing anywhere to remove.
- **Both changes reduce or preserve what is deleted**, never increase it: an undeletable root now removes *nothing* instead of its whole writable subtree.
- **The interface default is `null`**, so an adapter that cannot answer forfeits the early diagnosis but never the protection — `PersistenceService.Delete` still refuses at commit. The three decorators wrapping the composite (`SubtreeDeletionGuard`, `MonotonicWriteGuard`, `VersionWriting`) forward it.
- A path served by **both** a read-only and a writable provider (a db-synced override) stays deletable — the predicate is "no writable has it **and** a read-only does".

## Verification — fail-before / pass-after

`DeleteProviderAgreementTest` (new, 4 tests, 47 ms), constructing `PersistenceService` directly as `PersistenceClaimPriorityTest` already does — no mocking of core interfaces:

| | before | after |
|---|---|---|
| `NothingAnywhereHasIt_Completes_AndRemovesNothingElse` | ❌ errored: *no writable storage provider has this node* | ✅ completes; bystander node untouched |
| `OnlyAReadOnlyProviderHasIt_Refuses_NamesTheProvider_AndLeavesItServed` | ❌ message claimed no provider had it | ✅ names the provider; node still served; no tombstone written |
| `WritableProviderHasIt_DeletesIt` | ✅ | ✅ |
| `ReadOnlyAndWritableBothHaveIt_DoesNotBlock_AndDeletesTheWritableCopy` | ✅ | ✅ |

Both directions of "the gate and the commit agree":

- **exists ⇒ deletable** — `WritableProviderHasIt_DeletesIt`; and the read-only case no longer passes the gate at all.
- **absent ⇒ not silently half-deleted** — `MeshWeaver.NodeOperations.Test` **93/93** (incl. `Delete_NonExistentNode_Throws`) and `MeshWeaver.Hosting.Monolith.Test --filter Delete` **34/34** (incl. `Missing_Node_Fails_NotFound`, `RecursiveDeletePermissionTest`, `RecursiveDeleteAuthoritativeTest`, `DeleteTimeoutStageDiagnosticsTest`).

Release build clean with CI's flags (`-c Release -warnaserror`) for `MeshWeaver.Hosting`, `MeshWeaver.NodeOperations.Test`, `MeshWeaver.Hosting.Monolith.Test`.

No data repair is implied by this change — it alters the classification and timing of a refusal, not any stored state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
