### PR TITLE
fix: adopting an already-durable external write is an observation, not a write (#1432)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-version-history-no-longer-collects-edits-nobody-made.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-version-history-no-longer-collects-edits-nobody-made.md
@@ -1,0 +1,26 @@
+---
+Name: Version history no longer collects edits nobody made
+Category: Fix
+Description: When a page was changed from somewhere else — another server, a sync, a repair job — the page picked the change up but also recorded it a second time under a brand-new version number, adding an entry to the history for an edit that never happened. Picking up someone else's change is now just that.
+Icon: History
+Order: -20260813
+---
+
+# Version history no longer collects edits nobody made
+
+A page can be changed from more than one place: another server in the same deployment, a
+repository sync, a background repair job. Whichever server is currently serving the page
+notices the change and takes it on, so everyone keeps seeing the same content. That part
+worked.
+
+What it also did was treat taking the change on as an edit of its own. It gave the content a
+fresh version number one above the one that had just been saved, and then saved that back —
+so the stored page ended up one version ahead of anything anybody had actually written, and
+the version history grew an entry whose contents were identical to the one before it. Every
+time two places converged on the same page, the history collected another such entry, and
+for a brief moment the page being served claimed a version that existed nowhere.
+
+Picking up a change someone else made is now treated as what it is — reading, not writing.
+The content is adopted exactly as it was saved, keeps the version it was saved under, and
+nothing is written back. Genuine edits are unaffected and still get their own version, and a
+change that arrives late is still ignored rather than being allowed to undo newer content.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -388,6 +388,12 @@ public static class MeshDataSourceExtensions
     /// each further cycle requires a NEW foreign write to the row. If the in-memory state already
     /// advanced past the stored version, the lambda no-ops (UpdateOwn completes with the
     /// unchanged node and skips the write).
+    /// <para>🚨 The MINT here is the point, which is what separates this from
+    /// <c>MeshNodeStreamHandle.AdoptPersisted</c> (the change-feed reconcile in
+    /// <c>SubscribeToOwnDeletion</c>). There, adopting an already-durable external write is a pure
+    /// OBSERVATION — minting above it manufactures a revision that exists nowhere and the sampler
+    /// persists it (#1432). Here a write was REFUSED, so this hub MUST climb strictly above the
+    /// durable row or its next save is refused too. Same word, opposite requirement.</para>
     /// </summary>
     private static void AdoptDurableTruth(IMessageHub hub, MeshNode stored, long refusedVersion, ILogger? logger)
     {
@@ -1377,25 +1383,32 @@ public static class MeshDataSourceExtensions
                     recentlyDeleted?.Clear(ownPath);
                     try
                     {
-                        // 🚨 FORWARD-ONLY refresh — never move the in-RAM node BACKWARD.
-                        // `notification.Entity` is the node as PERSISTED. The durable write + its
-                        // change notification are OFF-TURN, so under a write burst this notification
-                        // LAGS the in-RAM stream: by the time it arrives, the in-RAM commit may already
-                        // carry many newer writes. A blind `_ => newNode` overwrite re-applied that
-                        // STALE persisted snapshot over fresher in-RAM state and silently dropped every
-                        // field added since it was persisted — the concurrent cross-hub-write data-loss
-                        // bug (CrossHubPatchAtomicityTest: a burst of cross-mirror dict-adds settling
-                        // with entries permanently lost). The single-write echo-suppression above only
-                        // skips the EXACT latest version, not the older lagging echoes. The IN-RAM
-                        // commit is authoritative (the owner's monotonic Version is the one clock); a
-                        // persisted snapshot may only REPLACE it when it is STRICTLY NEWER (a genuine
-                        // out-of-band external write). A lagged own-write echo (version <= live) is a
-                        // no-op, so the in-RAM stream only ever moves forward.
+                        // 🚨 ADOPTION, NOT A WRITE — `notification.Entity` is the node as PERSISTED,
+                        // at the version storage already holds it under. AdoptPersisted lands it
+                        // VERBATIM: it does not mint (an `Update` here minted durable+1 — a phantom
+                        // revision that exists nowhere, which the persistence sampler then wrote back,
+                        // #1432) and it records the durable version so neither the sampler nor the
+                        // dispose-time flush echoes the observation to storage. Provenance is the
+                        // discriminator: only the durable change feed reaches this line, so nothing
+                        // here has to guess whether content is "already durable" — it is, by
+                        // construction. Every genuine change keeps going through Update and mints.
+                        //
+                        // 🚨 FORWARD-ONLY (AdoptPersisted's built-in guard) — never move the in-RAM
+                        // node BACKWARD. The durable write + its change notification are OFF-TURN, so
+                        // under a write burst this notification LAGS the in-RAM stream: by the time it
+                        // arrives, the in-RAM commit may already carry many newer writes. A blind
+                        // `_ => newNode` overwrite re-applied that STALE persisted snapshot over fresher
+                        // in-RAM state and silently dropped every field added since it was persisted —
+                        // the concurrent cross-hub-write data-loss bug (CrossHubPatchAtomicityTest: a
+                        // burst of cross-mirror dict-adds settling with entries permanently lost). The
+                        // single-write echo-suppression above only skips the EXACT latest version, not
+                        // the older lagging echoes. The IN-RAM commit is authoritative (the owner's
+                        // monotonic Version is the one clock); a persisted snapshot may only REPLACE it
+                        // when it is STRICTLY NEWER (a genuine out-of-band external write). A lagged
+                        // own-write echo (version <= live) is a no-op, so the in-RAM stream only ever
+                        // moves forward.
                         hub.GetWorkspace().GetMeshNodeStream()
-                            .Update(current =>
-                                current is not null && current.Version >= newNode.Version
-                                    ? current
-                                    : newNode)
+                            .AdoptPersisted(newNode)
                             .Subscribe(
                                 _ => { },
                                 ex => TryLogWarning(hub, ex,

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -698,7 +698,59 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             _workspace.Hub.ServiceProvider);
     }
 
-    private IObservable<MeshNode> UpdateOwn(Func<MeshNode, MeshNode> update)
+    /// <summary>
+    /// 🚨 ADOPT a state that is ALREADY DURABLE — an OBSERVATION, never a write.
+    ///
+    /// <para>Use this — and ONLY this — when <paramref name="persisted"/> is the node exactly as
+    /// STORAGE holds it, at exactly the <see cref="MeshNode.Version"/> storage holds it under: the
+    /// entity carried by a storage change notification for a write somebody else made (another
+    /// writer, a second silo, a migration, GitSync). It is the *provenance* of the node — off the
+    /// durable change feed — that makes this the right call, not anything about its content; a
+    /// genuine change never arrives that way, so there is no content heuristic to get wrong.</para>
+    ///
+    /// <para><b>Two things it does that <see cref="Update"/> must not.</b>
+    /// (1) It does NOT mint. <c>UpdateOwn</c>'s unconditional
+    /// <c>NextVersion(Math.Max(current.Version, updated.Version))</c> would leave the hub holding
+    /// <c>durable + 1</c> — a revision that exists nowhere, with content identical to the durable
+    /// row (#1432). (2) It records the durable version in <see cref="PostCommitFlushRegistry"/>,
+    /// so the per-node persistence sampler and the dispose-time flush both skip writing the
+    /// adopted state back — the SAME "one change, one durable write" gate #1249 built, and
+    /// sound for the same reason: two DISTINCT own-node states can never share a version.</para>
+    ///
+    /// <para><b>Forward-only</b>, so it stays the lagged-echo defence it replaces: a persisted
+    /// snapshot may replace in-RAM state only when it is STRICTLY NEWER. The durable write and
+    /// its change notification are off-turn, so under a write burst the notification LAGS the
+    /// in-RAM commit; re-applying that stale snapshot silently dropped every field added since
+    /// it was persisted (<c>CrossHubPatchAtomicityTest</c>). At or below the live version this
+    /// completes with the unchanged node and touches nothing.</para>
+    ///
+    /// <para>🚨 NOT <c>AdoptDurableTruth</c> (<c>MeshDataSource</c>), which is the opposite case:
+    /// there a write was REFUSED by the monotonic guard, so the owner must climb strictly ABOVE
+    /// the durable row for its next save to land — that one mints deliberately, through
+    /// <see cref="Update"/>.</para>
+    /// </summary>
+    /// <param name="persisted">The node exactly as persisted, carrying its durable version.</param>
+    /// <returns>A cold observable — the adoption runs on Subscribe — emitting the state the
+    /// node holds afterwards (the adopted node, or the unchanged live node when it is already
+    /// at or past the durable version).</returns>
+    public IObservable<MeshNode> AdoptPersisted(MeshNode persisted)
+    {
+        ArgumentNullException.ThrowIfNull(persisted);
+        if (!IsOwn)
+            throw new InvalidOperationException(
+                $"AdoptPersisted is an OWN-node operation, but this handle targets '{_path}' from "
+                + $"hub '{_workspace.Hub.Address}'. Only the owning hub observes its own node's "
+                + "storage change feed; a cross-hub caller has no durable-version authority.");
+        return new RequireSubscribeObservable<MeshNode>(
+            UpdateOwn(_ => persisted, adoptPersisted: true)
+                // Same clamp as Update — see the comment there.
+                .CarryAccessContext(_workspace.Hub.ServiceProvider, restoreNullCapture: true)
+                .Select(n => EnsureTypedContent(n, _jsonOptions, _contentTypeRegistry)),
+            $"MeshNodeStreamHandle.AdoptPersisted(path='{_path ?? "<own>"}')",
+            _workspace.Hub.ServiceProvider);
+    }
+
+    private IObservable<MeshNode> UpdateOwn(Func<MeshNode, MeshNode> update, bool adoptPersisted = false)
         => Observable.Create<MeshNode>(observer =>
         {
             var refStream = _workspace.GetStream(new MeshNodeReference())
@@ -836,10 +888,37 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // below the durable row forever. Ordinary lambdas (`current with {…}`)
                     // carry current.Version, so the extra term is a no-op for them; version
                     // restore writes Version = 0 and is likewise unaffected.
-                    updated = updated with
+                    if (adoptPersisted)
                     {
-                        Version = MeshNode.NextVersion(Math.Max(current.Version, updated.Version))
-                    };
+                        // 🚨 ADOPTION — an OBSERVATION of state that is ALREADY durable, so it
+                        // neither mints nor writes. See AdoptPersisted for the full contract.
+                        //
+                        // Forward-only, checked HERE against the authoritative in-turn `current`
+                        // (a caller-side check reads a snapshot that the action block may have
+                        // already moved past): a persisted snapshot may replace in-RAM state only
+                        // when it is STRICTLY NEWER. A lagged echo of our own write completes with
+                        // the unchanged node, so the in-RAM stream only ever moves forward.
+                        if (updated.Version <= current.Version)
+                        {
+                            EmitOnce(current);
+                            return null;
+                        }
+                        // The adopted version IS durable — record it on the same per-path
+                        // high-water HandleSaveMeshNode / FlushPendingOwnSave consult, so neither
+                        // the 200 ms persistence sampler nor the dispose-time flush writes this
+                        // observation back to storage (#1432; mechanism and soundness: #1249 /
+                        // PostCommitFlushRegistry). Recorded inside the commit turn, so an
+                        // adoption that did NOT apply never raises the mark.
+                        _workspace.Hub.ServiceProvider.GetService<PostCommitFlushRegistry>()
+                            ?.Record(updated.Path, updated.Version);
+                    }
+                    else
+                    {
+                        updated = updated with
+                        {
+                            Version = MeshNode.NextVersion(Math.Max(current.Version, updated.Version))
+                        };
+                    }
                     // Stamp BEFORE the commit — the echo subscription above only emits
                     // once it can see this write's Version on the target node.
                     System.Threading.Volatile.Write(ref stampedVersion, updated.Version);

--- a/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationDurableFirstSeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationDurableFirstSeedTest.cs
@@ -240,4 +240,67 @@ public class StaleActivationDurableFirstSeedTest(ITestOutputHelper output) : Mon
         after.Version.Should().Be(durableVersion, "the durable row must be untouched by the reactivation");
         after.Name.Should().Be("durable-advance");
     }
+
+    /// <summary>
+    /// #1432 — adopting an ALREADY-DURABLE external write is an OBSERVATION: it must mint nothing
+    /// and write nothing back. The hub here stays LIVE throughout — no recycle, no gate, no
+    /// reactivation — so nothing about this depends on the #1384 race; the race only ever decided
+    /// whether anyone noticed.
+    ///
+    /// <para><b>Fail-without:</b> the change-feed reconcile in <c>SubscribeToOwnDeletion</c> adopted
+    /// the persisted node through <c>Update</c>, whose <c>UpdateOwn</c> mints unconditionally
+    /// (<c>NextVersion(Math.Max(current.Version, updated.Version))</c>). Adopting durable v5000 left
+    /// the hub serving <b>v5001</b> — a revision that exists nowhere, content-identical to v5000 —
+    /// and because the mint is a fresh <c>with</c>-copy, <c>OwnNodeCache.PersistedSnapshot</c>'s
+    /// reference gate did not suppress it and the 200 ms persistence sampler wrote the phantom BACK
+    /// (an observation-time write-back, the #590 shape). <b>Pass-with:</b> <c>AdoptPersisted</c>
+    /// lands the durable node verbatim at v5000 and records that version on
+    /// <c>PostCommitFlushRegistry</c>, so <c>HandleSaveMeshNode</c> and the dispose flush both skip
+    /// it — served version, durable version and durable write count are all unchanged.</para>
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task LiveHub_AdoptingAnExternalDurableWrite_MintsNothing_AndWritesNothingBack()
+    {
+        var id = $"live-adopt-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+
+        // Durable state advances OUT OF BAND — a second writer / migration / GitSync / another
+        // silo. Straight through IStorageAdapter, whose Changes feed is what the live owner's
+        // reconcile subscribes to.
+        const long externalVersion = 5000L;
+        var durable = (await ReadDurable(path).Should().Within(30.Seconds()).Emit())!;
+        var writesBefore = Gated.WriteCount(path);
+        await Storage.Write(durable with
+        {
+            Name = "external-advance", Version = externalVersion
+        }, JsonOptions).Should().Within(30.Seconds()).Emit();
+
+        // The live hub adopts it — that part is required behaviour and must keep working.
+        var served = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .Should().Within(20.Seconds())
+            .Match(n => n.Name == "external-advance",
+                "the live owner must adopt an external durable write into its in-RAM node");
+
+        // Negative window: several persistence-sampler periods (200 ms) for a write-back to appear.
+        await Observable.Timer(TimeSpan.FromSeconds(2)).Should().Within(20.Seconds()).Emit();
+        var after = await ReadDurable(path).Should().Within(20.Seconds()).Emit();
+
+        served.Version.Should().Be(externalVersion,
+            "adopting an already-durable external write is an OBSERVATION — minting a revision "
+            + "above it makes the in-RAM node a phantom the sampler then writes back");
+        after!.Version.Should().Be(externalVersion,
+            $"observing someone else's durable write must not write anything back (row now reads "
+            + $"v{after.Version}/'{after.Name}')");
+        after.Name.Should().Be("external-advance");
+        Gated.WriteCount(path).Should().Be(writesBefore + 1,
+            "exactly ONE write reached storage in this window — the external one. A second is the "
+            + "owner echoing its own observation back.");
+    }
 }


### PR DESCRIPTION
Fixes #1432.

## The defect — deterministic, and nothing to do with recycles or races

A per-node hub reconciles its own node against the storage change feed so a write made by *someone else* (a second silo, a migration, a repair job, GitSync) is adopted into the in-RAM node. That reconcile ran through `Update`, whose `UpdateOwn` mints **unconditionally**:

```csharp
Version = MeshNode.NextVersion(Math.Max(current.Version, updated.Version));
```

So adopting a durable **v5000** left the hub holding **v5001** — a revision that exists nowhere, content-identical to v5000. The mint is a fresh `with`-copy, so `OwnNodeCache.PersistedSnapshot`'s reference-identity gate did not suppress it, and the 200 ms persistence sampler **wrote the phantom back**. Every cross-writer convergence persisted a content-identical revision into version history, and between the mint and the write-back the owner served a version *above* durable truth — an observation-time write-back, the #590 shape.

This surfaced only as `StaleActivationDurableFirstSeedTest`'s flake (#1384's largest live bucket) because the recycle window decided whether anyone *noticed*; it never caused it.

## How a durable adoption is discriminated from a genuine change

**By provenance, not by content.** Only the durable storage change feed reaches that line, so "this content is already durable at this version" is true *by construction* there and nowhere else. There is no content or version heuristic that a genuine change could trip: every genuine change still goes through `Update` and still mints. The discriminator is a distinct call, not a test applied inside the shared one.

New own-node primitive `MeshNodeStreamHandle.AdoptPersisted(node)`:

1. **Lands the persisted node verbatim, at its durable version** — no mint.
2. **Records that version on `PostCommitFlushRegistry`** — the same per-path durable high-water `HandleSaveMeshNode` and `FlushPendingOwnSave` already consult, so neither the sampler nor the dispose flush echoes the observation back. This reuses #1249's mechanism rather than inventing one, and it is sound for the same stated reason: two distinct own-node states can never share a version. It is also version-based rather than reference-based, so it survives an identity-breaking hop that `PersistedSnapshot` would not.
3. **Stays forward-only**, checked against the authoritative in-turn `current` rather than a caller-side snapshot.

### The known hazard: the lagged-echo defence is preserved

That `Update` lambda is `CrossHubPatchAtomicityTest`'s protection against a stale persisted snapshot overwriting fresher in-RAM state. `AdoptPersisted` keeps exactly that predicate — a persisted snapshot may replace in-RAM state **only when it is strictly newer**; at or below the live version it completes with the unchanged node and touches nothing. The only thing removed is the mint. Moving the check inside the write, against the in-turn `current`, makes it strictly *harder* to bypass than the caller-side lambda it replaces.

`AdoptDurableTruth` (`MeshDataSource`) keeps minting and is untouched — there a write was **refused** by the monotonic guard, so the owner must climb strictly *above* the durable row for its next save to land. Same word, opposite requirement; its doc now says so.

## Verification — fail-before / pass-after on the deterministic repro

`LiveHub_AdoptingAnExternalDurableWrite_MintsNothing_AndWritesNothingBack` (new, 2 s). The hub stays **live** throughout — no recycle, no gate, no reactivation.

```
before:  Expected value to be 5000 because adopting an already-durable external write is an
         OBSERVATION …, but found 5001.        (1 failed, 2 s)

after:   Passed! - Failed: 0, Passed: 3        (StaleActivationDurableFirstSeedTest, 5 s)
```

The test asserts all three symptoms: the served version, the durable version, and the durable **write count** (exactly one write in the window — the external one; a second is the owner echoing its own observation).

Regression arms:

- `MeshWeaver.Hosting.Monolith.Test` — **665 passed, 0 failed**, 3 pre-existing skips (7 m 34 s).
- `CrossHubPatchAtomicityTest.ConcurrentCrossHubPatches_DoNotDropAQueuedMessage` — the lagged-echo defence.

Release build clean with CI's flags (`-c Release -warnaserror`) for `MeshWeaver.Graph` (and `MeshWeaver.Mesh.Contract` beneath it) and `MeshWeaver.Hosting.Monolith.Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
