### PR TITLE
review follow-up to #1434: a splice's array index is bounds-checked into the resync path

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1436,10 +1436,24 @@ public static class JsonSynchronizationStream
 
         var parent = EnsureParentPath(root, segments);
         var key = segments[^1];
+
+        // Bounds are checked HERE, with the same StaleStreamStateException ApplyReplace/ApplyRemove
+        // raise — not left to the indexer. A splice arrives off the wire, so an index past the end
+        // is a stale-snapshot symptom like any other, and it has to reach the resync path rather
+        // than escape as an ArgumentOutOfRangeException the caller does not catch.
+        var index = -1;
+        if (parent is JsonArray bounds)
+        {
+            if (!int.TryParse(key, out index) || index < 0 || index >= bounds.Count)
+                throw new StaleStreamStateException(
+                    $"Stale patch: splice at {pathString} addresses index {key} but the array has "
+                    + $"{bounds.Count} elements.");
+        }
+
         var live = parent switch
         {
             JsonObject obj => obj[key] as JsonValue,
-            JsonArray arr when int.TryParse(key, out var i) && i >= 0 && i < arr.Count => arr[i] as JsonValue,
+            JsonArray arr => arr[index] as JsonValue,
             _ => null,
         };
         var current = live is not null && live.TryGetValue<string>(out var s) ? s : null;
@@ -1451,7 +1465,7 @@ public static class JsonSynchronizationStream
         var spliced = JsonValue.Create(delta.Apply(current));
         if (parent is JsonObject target)
             target[key] = spliced;
-        else if (parent is JsonArray array && int.TryParse(key, out var index))
+        else if (parent is JsonArray array)
             array[index] = spliced;
     }
 

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1509,6 +1509,16 @@ public static class JsonSynchronizationStream
             }
             else if (current is JsonArray arr && int.TryParse(segment, out var index))
             {
+                // 🚨 Bounds belong HERE, not at the indexer. An INTERMEDIATE array segment that no
+                // longer addresses an element (`/lines/7/text` against a two-element array) is a
+                // stale-snapshot symptom exactly like a stale leaf index — but left to
+                // JsonArray's indexer it escapes as ArgumentOutOfRangeException, which
+                // SynchronizationStream.UpdateStream does NOT catch, so the divergence faults the
+                // stream instead of taking the RequestFreshSnapshot route it is entitled to.
+                // Shared by add / replace / splice, so all three recover the same way.
+                if (index < 0 || index >= arr.Count)
+                    throw new StaleStreamStateException(
+                        $"Stale patch: segment '{segment}' addresses an element of a {arr.Count}-element array.");
                 current = arr[index];
             }
             else
@@ -1532,6 +1542,11 @@ public static class JsonSynchronizationStream
             }
             else if (current is JsonArray arr && int.TryParse(segment, out var index))
             {
+                // Same rule as EnsureParentPath: a stale INTERMEDIATE index takes the resync
+                // route, never an ArgumentOutOfRangeException the caller cannot recover from.
+                if (index < 0 || index >= arr.Count)
+                    throw new StaleStreamStateException(
+                        $"Stale patch: segment '{segment}' addresses an element of a {arr.Count}-element array.");
                 current = arr[index];
             }
             else

--- a/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
+++ b/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
@@ -195,6 +195,33 @@ public class FanOutStringSpliceTest(ITestOutputHelper output)
             + "reach the resync path rather than escape as an ArgumentOutOfRangeException");
     }
 
+    [Theory]
+    [InlineData("splice")]
+    [InlineData("replace")]
+    [InlineData("add")]
+    public void AStaleINTERMEDIATEArrayIndex_TakesTheResyncPathForEveryOp(string op)
+    {
+        // The parent walk is shared by add / replace / splice, so a stale intermediate index
+        // (`/lines/7/text` against a two-element array) has to recover the same way for all three —
+        // otherwise the op that happens to be in flight decides whether the stream resyncs or faults.
+        var value = op == "splice"
+            ? (JsonNode)new JsonObject
+            {
+                [PatchStringSplice.Marker] = new JsonArray(0, 0, "x"),
+                [PatchStringSplice.BaseMarker] = new JsonArray(0, PatchStringSplice.Fingerprint(string.Empty)),
+            }
+            : JsonValue.Create("x")!;
+        var json = $$"""[{"op":"{{op}}","path":"/lines/7/text","value":{{value.ToJsonString()}}}]""";
+        var frame = new DataChangedEvent("stream", 1, new RawJson(json), ChangeType.Patch, null);
+        var live = Element(new JsonObject { ["lines"] = new JsonArray("a", "b") });
+
+        Action apply = () => frame.UpdateJsonElement(live, Wire);
+
+        apply.Should().Throw<StaleStreamStateException>(
+            "a stale intermediate index must reach RequestFreshSnapshot, not escape the applier as "
+            + "an ArgumentOutOfRangeException that faults the stream");
+    }
+
     [Fact]
     public void AMalformedSplice_IsRefusedLoudly_NeverWrittenIntoTheText()
     {

--- a/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
+++ b/test/MeshWeaver.Data.Test/FanOutStringSpliceTest.cs
@@ -172,6 +172,30 @@ public class FanOutStringSpliceTest(ITestOutputHelper output)
     }
 
     [Fact]
+    public void ASpliceAddressingAnIndexPastTheEndOfAnArray_TakesTheResyncPath()
+    {
+        // Bounds have to raise the SAME exception a stale replace/remove does. An
+        // ArgumentOutOfRangeException escaping the indexer would skip the caller's stale-snapshot
+        // recovery entirely (UpdateStream catches StaleStreamStateException, not that), turning a
+        // recoverable divergence into a faulted stream.
+        var value = new JsonObject
+        {
+            [PatchStringSplice.Marker] = new JsonArray(0, 0, "x"),
+            [PatchStringSplice.BaseMarker] = new JsonArray(0, PatchStringSplice.Fingerprint(string.Empty)),
+        };
+        var patch = new JsonPatch(PatchOperation.Splice(JsonPointer.Parse("/lines/7"), value));
+        var frame = new DataChangedEvent(
+            "stream", 1, new RawJson(JsonSerializer.Serialize(patch, Wire)), ChangeType.Patch, null);
+        var live = Element(new JsonObject { ["lines"] = new JsonArray("a", "b") });
+
+        Action apply = () => frame.UpdateJsonElement(live, Wire);
+
+        apply.Should().Throw<StaleStreamStateException>(
+            "an index past the end of the array is a stale-snapshot symptom like any other, and must "
+            + "reach the resync path rather than escape as an ArgumentOutOfRangeException");
+    }
+
+    [Fact]
     public void AMalformedSplice_IsRefusedLoudly_NeverWrittenIntoTheText()
     {
         var patch = new JsonPatch(PatchOperation.Splice(

--- a/test/MeshWeaver.Threading.Test/FanOutSpliceNegotiationTest.cs
+++ b/test/MeshWeaver.Threading.Test/FanOutSpliceNegotiationTest.cs
@@ -28,13 +28,20 @@ namespace MeshWeaver.Threading.Test;
 /// </summary>
 public class FanOutSpliceNegotiationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    private readonly ConcurrentBag<SubscribeRequest> subscribes = [];
+    /// <summary>
+    /// Recorded with the TARGET they were addressed to, so the assertion can name the one node
+    /// under test. Asserting over every subscribe the mesh happens to post during startup would
+    /// make this test fail for reasons that have nothing to do with the capability — and any
+    /// subscribe posted by something other than <c>JsonSynchronizationStream</c> is a different
+    /// question from the one asked here.
+    /// </summary>
+    private readonly ConcurrentBag<(string? Target, SubscribeRequest Request)> subscribes = [];
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             .ConfigureDefaultNodeHub(config => config.WithHandler<SubscribeRequest>((_, delivery) =>
             {
-                subscribes.Add(delivery.Message);
+                subscribes.Add((delivery.Target?.ToString(), delivery.Message));
                 return delivery;
             }));
 
@@ -56,12 +63,16 @@ public class FanOutSpliceNegotiationTest(ITestOutputHelper output) : MonolithMes
             .Where(n => n is not null)
             .FirstAsync().Timeout(30.Seconds()).ToTask();
 
-        var recorded = subscribes.ToList();
+        var recorded = subscribes
+            .Where(s => s.Target is not null
+                        && s.Target.EndsWith(path, StringComparison.OrdinalIgnoreCase))
+            .Select(s => s.Request)
+            .ToList();
         recorded.Should().NotBeEmpty(
             "reading a node opens a SubscribeRequest against its owning hub — with none recorded this "
             + "test would pass on no evidence");
         Output.WriteLine(
-            $"SubscribeRequests seen: {recorded.Count}, "
+            $"SubscribeRequests for {path}: {recorded.Count}, "
             + $"declaring AcceptsStringSplice: {recorded.Count(r => r.AcceptsStringSplice)}");
 
         recorded.Should().AllSatisfy(r => r.AcceptsStringSplice.Should().BeTrue(


### PR DESCRIPTION
Follow-up to #1434 (the fan-out string splice, #1284). Both findings came from the automatic review on that PR and arrived after it had already merged, so they land here.

## 1. A splice's array index is bounds-checked into the RESYNC path

`ApplySplice` assigned into a `JsonArray` on an index it had not validated.

In practice the fingerprint check refuses first — an out-of-range read yields a null `current`, which cannot match a non-empty base — but a splice declaring an **empty** base would have reached the indexer. And `ArgumentOutOfRangeException` is precisely the exception `SynchronizationStream.UpdateStream` does *not* catch: it catches `StaleStreamStateException` (→ `RequestFreshSnapshot`) and, failing that, `SyncFailed`s the delivery. So a recoverable divergence would have faulted the stream instead of asking the owner for a fresh snapshot.

Bounds are now checked explicitly, raising the same `StaleStreamStateException` that `ApplyReplace` and `ApplyRemove` raise, so every stale-shape symptom on this path lands in one recovery route. The splice is off the wire, so this is a hostile-input surface, not just a defensive nicety.

New test: `ASpliceAddressingAnIndexPastTheEndOfAnArray_TakesTheResyncPath`.

## 2. The negotiation test no longer asserts over unrelated subscribes

`FanOutSpliceNegotiationTest` recorded every `SubscribeRequest` any node hub saw and required *all* of them to declare the capability — so an unrelated subscribe posted during mesh startup could red it for a reason unconnected to what it tests. It now keeps the delivery target alongside the request and filters to the node under test.

The `NotEmpty` guard stays: without it, a filter that matches nothing would pass on no evidence, which is the failure mode this test exists to prevent in the first place.

## Verification

Local, `-c Release -warnaserror`, clean (`--no-incremental`) rebuild on top of current main:

| suite | result |
|---|---|
| `MeshWeaver.Data.Test` | 370 / 370 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
