### PR TITLE
fix(#890): detect Roslyn MetadataReferences in static state + a canary leg that says which state is broken

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
@@ -123,6 +123,27 @@ The build guard classifies permitted static fields into four buckets. Everything
 
 `static readonly` collections initialized once and **never written at runtime**: media-type maps, reserved-word sets, built-in role tables, SQL-keyword lists, parser character sets. If nothing calls `Add`, `[]=`, `Remove`, or `Clear` on it after construction, it is a *constant*, not a cache — it is safe.
 
+> 🚨 **"Never written" is about the ELEMENTS, not just the collection.** A write-once list of objects
+> that carry their own mutable, lazily-materialized state is a process-wide cache, and CONST does not
+> cover it. This exemption was applied twice to
+> `MeshNodeCompilationService._references` — a `static readonly IReadOnlyList<MetadataReference>` —
+> on the grounds that the list is never mutated. It isn't; but each `PortableExecutableReference`
+> owns lazily memory-mapped, `IDisposable` metadata and Roslyn hangs its derived assembly/symbol
+> tables off that same instance, so the field is a mutable process-wide cache in `static readonly`
+> clothing. It survived two reviews and is the shared state
+> [#890](https://github.com/Systemorph/MeshWeaver/issues/890) came down to.
+>
+> Ask **"could two meshes observe each other through an element of this?"** — not "does anything call
+> `Add`". Roslyn `MetadataReference`s in particular are now rejected by their own guard in
+> `NoStaticCollectionsTest`, whatever the declared collection type, because the declared-type check
+> could not see an `IReadOnlyList<>`.
+>
+> The field itself is still there, listed as a `CACHE` debt with its issue number rather than
+> silently exempt — removing it gives every mesh its own reference set, which measurably costs ~15 MiB
+> per compiling mesh, and whether that buys anything is decided by #890's emit canary. **Landing the
+> detector does not require paying for the fix**, and an allowlist entry with a reason is what turns
+> "nobody noticed" into "we know, and here is the open question".
+
 ### MEMO — Pure memoization on process-global keys
 
 Process-global memoization keyed by a **process-global identity** (`Type`, `MethodInfo`, or deterministic content), where the cached value is a pure function of the key so cross-mesh sharing is always correct.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -2154,18 +2154,41 @@ internal class MeshNodeCompilationService(
         + "{ public T A; public U B; public V C; } } }";
 
     /// <summary>
-    /// Answers ONE question, at the moment a Roslyn <c>Emit</c> throws: is the fault specific to
-    /// THIS compilation's inputs, or is process-wide emit state broken?
+    /// Answers, at the moment a Roslyn <c>Emit</c> throws, which state is actually broken — in
+    /// TWO legs, because the first leg alone cannot tell "the shared reference set is poisoned"
+    /// from "the process is broken below Roslyn".
     ///
-    /// <para>It re-emits a trivial nested-generic compilation built against <b>the same
-    /// <see cref="MetadataReference"/> instances</b> as the compilation that just failed, to a
-    /// <see cref="MemoryStream"/>. Those references — and the Roslyn symbols cached on their
-    /// shared <c>AssemblyMetadata</c> — are the only state the two compilations have in common,
-    /// so the canary separates the two halves of the search space that issue #890 could not:
-    /// canary FAILS ⇒ the shared reference/symbol state is poisoned (a process-wide fault; the
-    /// next step is bisecting the reference set and reporting upstream). Canary SUCCEEDS ⇒ the
-    /// shared state is fine and the fault is a property of this node's own compilation inputs
-    /// (the next step is dumping its generated source).</para>
+    /// <para><b>Leg 1 — same references.</b> Re-emit a trivial nested-generic compilation built
+    /// against <b>the same <see cref="MetadataReference"/> instances</b> as the compilation that
+    /// just failed. Succeeds ⇒ shared state is healthy and the fault is a property of this node's
+    /// own compilation inputs (dump its generated source). This is the leg #1378 shipped, and on
+    /// 2026-08-13 it returned THREW — closing the "generated source" half of the search
+    /// space.</para>
+    ///
+    /// <para><b>Leg 2 — pristine references.</b> Run only when leg 1 fails: the SAME source
+    /// against a freshly created, minimal reference set that has never been handed to Roslyn
+    /// before and is shared with nothing. This is the discriminator, and it exists because
+    /// Roslyn's own source settles who can supply the null. The NRE's guard
+    /// (<c>NamedTypeSymbolAdapter.AsNestedTypeDefinitionImpl</c>) admits a type only when
+    /// <c>ContainingModule == moduleBeingBuilt.SourceModule</c> — so the symbol whose
+    /// <c>ContainingType</c> reads null is a <b>source</b> symbol of the compilation being
+    /// emitted, never a PE symbol arriving from a reference. Leg 1 therefore proves the fault is
+    /// process-wide without proving the reference set carries it.
+    /// <list type="bullet">
+    ///   <item><c>canary=REFERENCES</c> — pristine emits, shared does not: the poison travels
+    ///     with the reference instances (or the symbols Roslyn caches on their
+    ///     <c>AssemblyMetadata</c>), and scoping the set per-mesh is on the right axis.</item>
+    ///   <item><c>canary=BELOW-ROSLYN</c> — neither emits: brand-new references and freshly
+    ///     parsed source still cannot emit, so nothing about the reference set explains it. The
+    ///     broken state is under Roslyn (CLR heap / JIT / GC) and no reference-set change can fix
+    ///     it. Roslyn keeps no cross-emit state — the metadata writer's indices are per-emit, its
+    ///     object pools hold only scratch buffers, and <c>AssemblyMetadata.CachedSymbols</c> is a
+    ///     weak list of assembly symbols — so there is no Roslyn cache left to blame.</item>
+    ///   <item><c>canary=INCONCLUSIVE</c> — the pristine control could not be BUILT (no on-disk
+    ///     CoreLib to reference), so leg 2 never ran. Reported as its own verdict rather than
+    ///     folded into BELOW-ROSLYN: a probe that answers its scariest branch on its own
+    ///     inability would send triage after a CLR heap bug nothing observed.</item>
+    /// </list></para>
     ///
     /// <para>🚨 It cannot fail into the fault path it is diagnosing: every outcome — including
     /// the canary throwing — returns a STRING. A diagnostic that throws while diagnosing would
@@ -2177,32 +2200,89 @@ internal class MeshNodeCompilationService(
     /// <returns>A one-line verdict, safe to append to a log message.</returns>
     internal static string ProbeSharedEmitState(CSharpCompilation faulted)
     {
+        var shared = EmitCanary(() => faulted.References);
+        if (shared.StartsWith("OK", StringComparison.Ordinal))
+            return "canary=OK (a trivial nested-generic emit against the SAME reference set "
+                + "still succeeds ⇒ shared Roslyn/reference state is healthy; the fault is "
+                + "specific to THIS compilation's inputs — dump its generated source)";
+
+        // The shared-reference canary failed. Re-run the SAME source against a reference set that
+        // shares NOTHING with this process's other compilations — freshly created, minimal
+        // (System.Private.CoreLib is all the canary source needs), and never handed to Roslyn
+        // before.
+        //
+        // 🚨 BUILDING the pristine reference is a SEPARATE step from emitting against it, and its
+        // failure is a SEPARATE verdict. If CreateFromFile cannot produce it (an empty
+        // Assembly.Location on a single-file host, a missing file), the discriminator was never
+        // run — and folding that into BELOW-ROSLYN would make the probe answer its scariest
+        // branch on its own inability, sending triage after a CLR heap bug that nothing observed.
+        // A diagnostic that cannot report "I could not run" is the same defect as a gate that
+        // passes when its input is missing.
+        string? pristineUnavailable = null;
+        IReadOnlyList<MetadataReference> pristineRefs = [];
+        try
+        {
+            var coreLib = typeof(object).Assembly.Location;
+            if (string.IsNullOrEmpty(coreLib) || !File.Exists(coreLib))
+                pristineUnavailable = "no on-disk System.Private.CoreLib to reference";
+            else
+                pristineRefs = [MetadataReference.CreateFromFile(coreLib)];
+        }
+        catch (Exception buildError)
+        {
+            pristineUnavailable = $"{buildError.GetType().Name}: {buildError.Message}";
+        }
+
+        if (pristineUnavailable is not null)
+            return $"canary=INCONCLUSIVE shared:{shared} pristine:UNAVAILABLE({pristineUnavailable}) "
+                + "— the shared reference set cannot emit, but the pristine control could not be "
+                + "BUILT, so this says nothing about whether the reference set is the cause";
+
+        var pristine = EmitCanary(() => pristineRefs);
+
+        return pristine.StartsWith("OK", StringComparison.Ordinal)
+            ? $"canary=REFERENCES shared:{shared} pristine:{pristine} — the same source emits fine "
+                + "against BRAND-NEW references but fails against the shared set ⇒ the poison "
+                + "travels with the MetadataReference instances / the Roslyn symbols cached on "
+                + "them (reference-set scoping is the right axis)"
+            : $"canary=BELOW-ROSLYN shared:{shared} pristine:{pristine} — a trivial compilation "
+                + "with BRAND-NEW references and freshly parsed source cannot emit either ⇒ "
+                + "nothing about the reference set explains this; the broken state is below "
+                + "Roslyn (CLR heap / JIT / GC), so no reference-set change can fix it — "
+                + "capture a core dump and re-run with tiering disabled";
+    }
+
+    /// <summary>
+    /// One canary leg: emit <see cref="EmitCanarySource"/> against the references
+    /// <paramref name="references"/> produces, into memory, and reduce the outcome to a short
+    /// token. Never throws — see the "cannot fail into the fault path it is diagnosing" note on
+    /// <see cref="ProbeSharedEmitState"/>. The references arrive as a FACTORY so that building
+    /// them is inside this method's try as well: on a poisoned process even
+    /// <c>MetadataReference.CreateFromFile</c> is a candidate to fail.
+    /// </summary>
+    private static string EmitCanary(Func<IEnumerable<MetadataReference>> references)
+    {
         try
         {
             var canary = CSharpCompilation.Create(
                 "MeshWeaverEmitCanary",
                 syntaxTrees: [CSharpSyntaxTree.ParseText(EmitCanarySource)],
-                references: faulted.References,
+                references: references(),
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             using var canaryStream = new MemoryStream();
             var result = canary.Emit(canaryStream);
             if (result.Success)
-                return "canary=OK (a trivial nested-generic emit against the SAME reference set "
-                    + "still succeeds ⇒ shared Roslyn/reference state is healthy; the fault is "
-                    + "specific to THIS compilation's inputs — dump its generated source)";
+                return "OK";
 
             var ids = result.Diagnostics
                 .Where(d => d.Severity == DiagnosticSeverity.Error)
                 .Select(d => d.Id).Distinct().Take(5);
-            return $"canary=DIAGNOSTICS ({string.Join(",", ids)}) — the shared reference set no "
-                + "longer binds a trivial compilation ⇒ process-wide reference state is broken";
+            return $"DIAGNOSTICS({string.Join(",", ids)})";
         }
         catch (Exception probeError)
         {
-            return $"canary=THREW {probeError.GetType().Name}: {probeError.Message} — a trivial "
-                + "emit against the SAME reference set fails too ⇒ process-wide Roslyn/reference "
-                + "state is POISONED, not this compilation's inputs (bisect the reference set)";
+            return $"THREW {probeError.GetType().Name}: {probeError.Message}";
         }
     }
 

--- a/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
@@ -247,4 +247,61 @@ public class CompileFailureReportedOnceTest : IDisposable
             "a reference set that cannot bind a trivial compilation is exactly the "
             + "process-wide-breakage branch, and the canary must say so rather than throw");
     }
+
+    /// <summary>
+    /// 🚨 CALIBRATION for the canary's SECOND leg. Once leg 1 fails, the verdict turns on whether
+    /// the same source emits against a brand-new, minimal reference set. If that pristine set
+    /// could not bind <c>MwEmitCanary&lt;T&gt;</c> on a healthy process, leg 2 would ALWAYS fail
+    /// and every occurrence would be filed <c>canary=BELOW-ROSLYN</c> — a diagnostic that cannot
+    /// return the other answer, i.e. no diagnostic at all.
+    ///
+    /// <para>An empty reference set is the one case where "the references are broken" is true by
+    /// construction, so the verdict must come back <c>canary=REFERENCES</c>: leg 1 fails, leg 2
+    /// succeeds. That is exactly the discrimination #890 needs on its next occurrence.</para>
+    /// </summary>
+    [Fact]
+    public void The_emit_canary_distinguishes_a_broken_reference_set_from_a_broken_process()
+    {
+        var unusable = CSharpCompilation.Create(
+            "Demo_CanaryNoRefs",
+            syntaxTrees: [CSharpSyntaxTree.ParseText("public class X { }")],
+            references: [],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var verdict = MeshNodeCompilationService.ProbeSharedEmitState(unusable);
+
+        verdict.Should().StartWith("canary=REFERENCES",
+            "the pristine leg must be able to emit on a healthy process — otherwise the "
+            + "BELOW-ROSLYN branch is unfalsifiable and the canary answers the same thing "
+            + "whatever is wrong");
+        verdict.Should().Contain("pristine:OK");
+    }
+
+    /// <summary>
+    /// The verdict vocabulary must be able to say "I could not run the discriminator". Every
+    /// branch of <c>ProbeSharedEmitState</c> is reachable and each means something different —
+    /// in particular <c>BELOW-ROSLYN</c> ("the CLR is broken") must never be reachable by the
+    /// probe merely failing to BUILD its own control, which would send triage after a heap bug
+    /// nothing observed. This asserts the vocabulary is distinct and that the healthy-process
+    /// answer is never the inconclusive one.
+    /// </summary>
+    [Fact]
+    public void The_emit_canary_never_reports_below_roslyn_just_because_it_could_not_build_its_control()
+    {
+        var unusable = CSharpCompilation.Create(
+            "Demo_CanaryVocabulary",
+            syntaxTrees: [CSharpSyntaxTree.ParseText("public class X { }")],
+            references: [],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var verdict = MeshNodeCompilationService.ProbeSharedEmitState(unusable);
+
+        // On any host where this test can run at all, CoreLib is on disk, so the control builds
+        // and the verdict is a real discrimination — never INCONCLUSIVE, never BELOW-ROSLYN.
+        verdict.Should().NotStartWith("canary=INCONCLUSIVE",
+            "CoreLib is on disk in a test host, so the pristine control must have been built");
+        verdict.Should().NotStartWith("canary=BELOW-ROSLYN",
+            "nothing is wrong with this process — reaching the CLR-is-broken verdict here would "
+            + "mean the probe reports its scariest answer whenever its own control fails");
+    }
 }

--- a/test/MeshWeaver.PathResolution.Test/NoStaticCollectionsTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/NoStaticCollectionsTest.cs
@@ -145,6 +145,125 @@ public class NoStaticCollectionsTest
             string.Join("\n  ", unexpected));
     }
 
+    /// <summary>
+    /// Roslyn reference types that must NEVER sit in process-wide static state, however
+    /// "immutable" the collection holding them looks. A <c>PortableExecutableReference</c> owns
+    /// lazily materialized, <see cref="IDisposable"/> <c>Metadata</c> (a memory-mapped PE image)
+    /// and Roslyn caches derived assembly/symbol tables against that instance — so a
+    /// <c>static readonly</c> list of them is a mutable process-wide cache, not a constant
+    /// lookup.
+    /// </summary>
+    private static readonly string[] RoslynReferenceTypeNames =
+    {
+        "Microsoft.CodeAnalysis.MetadataReference",
+        "Microsoft.CodeAnalysis.PortableExecutableReference",
+        "Microsoft.CodeAnalysis.AssemblyMetadata",
+        "Microsoft.CodeAnalysis.ModuleMetadata",
+    };
+
+    /// <summary>
+    /// Sanctioned static holders of Roslyn references. Same classification vocabulary as
+    /// <see cref="Allowed"/>; every entry is a deliberate process-wide materialization.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> AllowedRoslynReferenceHolders =
+        new Dictionary<string, string>
+        {
+            // The kernel's script-reference memo. Deliberately process-wide: it exists BECAUSE
+            // re-materializing ~350 metadata blocks per script session leaked ~200 MiB/session.
+            // Already allowlisted above for the collection rule; listed again here so the
+            // Roslyn-reference exemption is explicit rather than incidental.
+            ["MeshWeaver.Kernel.Hub.KernelScriptReferences.Materialized"] = "MEMO: assembly path -> shared PE reference",
+            ["MeshWeaver.Kernel.Hub.KernelScriptReferences.SharedSnapshot"] = "MEMO: the snapshot over the same memo",
+
+            // 🚨 CACHE — the known violation this guard was written for, listed rather than fixed
+            // here ON PURPOSE. Removing it means giving every mesh its own reference set, which
+            // MEASURABLY costs ~15 MiB per compiling mesh (+98% peak RSS across the full
+            // Hosting.Monolith.Test project) — a certain cost against an uncertain benefit, since
+            // the Roslyn 5.6 source shows the symbol whose ContainingType goes null in #890 is a
+            // SOURCE symbol of the compilation being emitted, never a PE symbol arriving from a
+            // reference. That trade is decided by the emit canary's second leg, not by this guard.
+            // The entry stays until the canary reads canary=REFERENCES; #1438 removes both the
+            // field and this line. Listing it is the point: an allowlist entry is a visible debt,
+            // which is precisely what the field lacked when two reviews called it a constant.
+            ["MeshWeaver.Graph.Configuration.MeshNodeCompilationService._references"] =
+                "CACHE: process-wide Roslyn reference set — tracked by #890, migration held in #1438 pending the canary verdict",
+        };
+
+    /// <summary>
+    /// The rule the #890 regression slipped through: <c>MeshNodeCompilationService._references</c>
+    /// is a <c>private static readonly IReadOnlyList&lt;MetadataReference&gt;</c>, which the
+    /// collection guard above cannot see (the declared type is an interface, not
+    /// <c>List&lt;&gt;</c>) and which two reviews classified as a write-once constant lookup. The
+    /// list IS write-once; its ELEMENTS are not — a <c>PortableExecutableReference</c> owns lazily
+    /// memory-mapped, <see cref="IDisposable"/> metadata and Roslyn caches derived assembly/symbol
+    /// tables against that instance, so every dynamic-NodeType compile in a test host shares them.
+    /// This guard keys on the ELEMENT type, so no declared-type spelling — array,
+    /// <c>ImmutableArray</c>, <c>IReadOnlyList</c>, <c>Lazy&lt;&gt;</c>, or a plain field — can
+    /// hide it again.
+    ///
+    /// <para>🚨 The guard ships BEFORE the field it was written for is removed, and that ordering
+    /// is deliberate. Removing the field costs a measured +98% peak RSS in the test host, and
+    /// whether that buys anything is decided by the emit canary, not by this test. So the field is
+    /// listed in <see cref="AllowedRoslynReferenceHolders"/> as a <c>CACHE</c> debt with its issue
+    /// number — visible and counted — rather than left invisible until someone re-derives the whole
+    /// argument. Landing the detector early is the cheap half; paying the memory is the half that
+    /// waits for evidence.</para>
+    /// </summary>
+    [Fact]
+    public void No_static_fields_hold_Roslyn_metadata_references_outside_allowlist()
+    {
+        var offenders = new List<string>();
+
+        foreach (var asm in LoadMeshWeaverAssemblies())
+        {
+            foreach (var type in SafeGetTypes(asm))
+            {
+                if (type is null) continue;
+                if (type.Name.Contains('<') || type.IsDefined(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute), false))
+                    continue;
+
+                foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                {
+                    if (field.IsLiteral) continue; // const
+                    if (!MentionsRoslynReference(field.FieldType)) continue;
+                    offenders.Add($"{type.FullName}.{field.Name}");
+                }
+            }
+        }
+
+        var unexpected = offenders
+            .Where(o => !AllowedRoslynReferenceHolders.ContainsKey(o))
+            .OrderBy(o => o, StringComparer.Ordinal)
+            .ToList();
+
+        unexpected.Should().BeEmpty(
+            "a Roslyn MetadataReference owns lazily mmap'd IDisposable metadata plus the symbol "
+            + "tables Roslyn caches against it, so holding one in static state is process-wide "
+            + "mutable cache — NOT a constant lookup, whatever the collection type says "
+            + "(issue #890). Make it a mesh-scoped instance singleton, or add it to "
+            + "AllowedRoslynReferenceHolders with a reason. Found:\n  "
+            + string.Join("\n  ", unexpected));
+    }
+
+    /// <summary>
+    /// True when <paramref name="type"/> IS a Roslyn reference type or names one anywhere in its
+    /// generic arguments / array element type — so <c>MetadataReference[]</c>,
+    /// <c>ImmutableArray&lt;PortableExecutableReference&gt;</c>,
+    /// <c>Lazy&lt;ImmutableArray&lt;…&gt;&gt;</c> and
+    /// <c>ConcurrentDictionary&lt;string, PortableExecutableReference&gt;</c> all match.
+    /// </summary>
+    private static bool MentionsRoslynReference(Type type)
+    {
+        var name = type.FullName ?? type.Name;
+        if (RoslynReferenceTypeNames.Any(n => string.Equals(name, n, StringComparison.Ordinal)))
+            return true;
+
+        if (type.HasElementType && type.GetElementType() is { } element && MentionsRoslynReference(element))
+            return true;
+
+        return type.IsGenericType && type.GetGenericArguments().Any(MentionsRoslynReference);
+    }
+
     private static IEnumerable<Assembly> LoadMeshWeaverAssemblies()
     {
         var dir = AppContext.BaseDirectory;


### PR DESCRIPTION
Split out of #1438 so the **zero-cost halves of #890 land now** and the part with a measured memory cost waits for evidence. This PR carries the **detector** and the **instrument**; #1438 keeps the per-mesh reference set and stays open until the instrument reports.

## 1. The detector — a blind spot in `NoStaticCollectionsTest`

The guard matched only **concrete** collection types, so a `private static readonly IReadOnlyList<MetadataReference>` was invisible to it: the declared type is an interface, not `List<>`. That blind spot is *why* `MeshNodeCompilationService._references` was twice classified in review as a "write-once constant lookup".

The list **is** write-once. Its **elements** are not — a `PortableExecutableReference` owns lazily memory-mapped, `IDisposable` metadata, and Roslyn caches derived assembly/symbol tables against that instance. So the field is a mutable process-wide cache in `static readonly` clothing.

The new guard keys on the **element type**, so no declared-type spelling — array, `ImmutableArray`, `IReadOnlyList`, `Lazy<>`, or a plain field — can hide a Roslyn reference in static state again.

**Calibrated against the live field, not a synthetic probe:** deleting its allowlist line reds the test naming `MeshWeaver.Graph.Configuration.MeshNodeCompilationService._references`. (I also hit the incremental-build no-op doing this — a restored file with an older mtime built clean and ran the *previous* assembly. `--no-incremental` was the fix; noting it because it's the exact trap AGENTS.md documents.)

### The field stays, as a visible `CACHE` debt

Removing it means giving every mesh its own reference set, which measurably costs **+98% peak RSS** across the full `Hosting.Monolith.Test` project. Whether that buys anything is decided by the canary below, not by a detector. So the field is listed in `AllowedRoslynReferenceHolders` with its issue number rather than silently exempt.

**Landing the detector does not require paying for the fix**, and an allowlist entry with a reason is what turns "nobody noticed" into "we know, and here is the open question". #1438 removes both the field and the line.

## 2. The instrument — a second canary leg

Leg 1 (#1378) proved the fault is **process-wide**. It cannot prove the fault is in the **reference set** — and Roslyn 5.6's own source (`dotnet/roslyn@c0573ed`) argues against it. The NRE's guard admits a type only when `ContainingModule == moduleBeingBuilt.SourceModule`, so the symbol whose `ContainingType` reads null is a **source symbol of the compilation being emitted**, never a PE symbol arriving from a reference.

So when leg 1 fails, leg 2 re-runs the same source against a **brand-new minimal** reference set never handed to Roslyn before:

| verdict | meaning |
|---|---|
| `canary=REFERENCES` | pristine emits, shared does not ⇒ the poison travels with the reference instances — #1438 is on the right axis, merge it |
| `canary=BELOW-ROSLYN` | neither emits ⇒ the broken state is under Roslyn (CLR heap / JIT / GC); no reference change can fix it — close #1438 |
| `canary=INCONCLUSIVE` | the control could not be **built**, so leg 2 never ran |

`INCONCLUSIVE` is its own verdict deliberately. Folding it into `BELOW-ROSLYN` would make the probe answer its scariest branch — *"the CLR heap is broken, capture a core dump"* — on its own inability to construct itself. Same defect family as a gate that passes when its input is unprovisioned. (Caught by Copilot on #1438.) Tests pin that a healthy process reaches neither verdict, so the vocabulary stays discriminating rather than collapsing onto one answer.

## ⚠️ Sweep-vocabulary change

A detector grepping the literal **`canary=THREW` now misses.** The token survives inside `shared:THREW …`. **Grep `canary=` and read the leading verdict.** Flagged prominently on #890 too — this issue has already been bitten twice by silent detector regressions (the pre-instrumentation window, and annotation-only bucketing that hid 58 runs).

## What's New

Skipped — pure-internal (an architecture guard + CI diagnostics). No user-visible effect: the canary text only appears on an already-failing compile, and no production behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
