### PR TITLE
chore: pre-bump PlatformVersion to 3.0.0-rc2 + lift SSH.NET past GHSA-q939-rpr3-3284

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,9 +62,11 @@
          a bare core it would pin to 3.0.0-preview1 the moment that image reached the registry and
          never roll forward again. Keep a pre-release label on the core until 3.0.0 ships clean.
 
-         It also has to RESOLVE: data-sync pulls content from the tag v$(PlatformVersion), and
-         v3.0.0 does not exist (only v3.0.0-preview1 and now v3.0.0-rc1). -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc1</PlatformVersion>
+         It also has to RESOLVE by the time anything pins content-sync to it: data-sync pulls
+         content from the tag v$(PlatformVersion). v3.0.0-rc1 shipped 2026-08-13; v3.0.0-rc2 is
+         the line NOW BUILDING and its tag is created only when rc2 is released — never tag it
+         early, the v*.*.* tag IS the trigger for the NuGet + image publish. -->
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc2</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -205,6 +205,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="System.Interactive" Version="7.0.1" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" /> <!-- High GHSA-q939-rpr3-3284; transitive via Testcontainers, direct-ref override in test/Directory.Build.props -->
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -26,6 +26,17 @@
          the central src policy here so the test tree tracks it uniformly. Vulnerability handling
          (bump/replace) is a deliberate dependency decision, not a per-build -warnaserror gate. -->
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;$(WarningsNotAsErrors)</WarningsNotAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Security override, not a dependency we use: Testcontainers (any published version, incl.
+         4.13.0) floats SSH.NET at [2025.1.0, ), and <= 2025.1.0 carries GHSA-q939-rpr3-3284 (High,
+         ScpClient arbitrary file write). A bare <PackageVersion> pin is INERT for a transitive-only
+         package, so this direct reference lifts the graph to the patched version. PrivateAssets=all
+         per the root props' override convention. Remove when Testcontainers' floor reaches
+         2026.0.0. -->
+    <PackageReference Include="SSH.NET" PrivateAssets="all" />
+  </ItemGroup>
+  <PropertyGroup>
     <!-- Required so the global <Using> items below (incl. MeshWeaver.Reactive.Assertions)
          are actually emitted. With ImplicitUsings disabled, <Using> is silently ignored,
          and Should()/Seconds() fail to resolve across every test file. -->


### PR DESCRIPTION
## What

- `PlatformVersion` `3.0.0-rc1` → **`3.0.0-rc2`**: rc1 shipped today; continuous builds move to `3.0.0-rc2-ci.N`, which sorts above the clean `3.0.0-rc1` (SemVer §11.4), so self-updates keep rolling forward. The props comment now states explicitly that the `v3.0.0-rc2` tag is created only at release time — a `v*.*.*` tag IS the publish trigger.
- **SSH.NET → 2026.0.0** (High [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284), ScpClient arbitrary file write). Transitive-only via Testcontainers (all published versions float `[2025.1.0,)`), so a bare central pin is inert — the fix is the root props' documented override shape: central pin + direct `PrivateAssets="all"` reference in `test/Directory.Build.props`. Remove when Testcontainers' floor reaches 2026.0.0.

No What's New entry: internal version/dependency housekeeping with no user-visible change.

## Verification

CI-style local build (`restore`, then `build -c Release --no-restore -warnaserror -p:CIRun=true`): 0 errors. `dotnet nuget why` shows SSH.NET resolving at 2026.0.0 in the test graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)