### PR TITLE
feat(local): the memex-local install bakes at startup — same protocol, same silo, brew-upgradeable

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -77,6 +77,18 @@ data:
          This key must exist HERE or it is silently dropped: the configmap lists keys explicitly
          rather than iterating .Values.config, so an un-templated key never reaches the pod. */}}
   PreWarm__BuildProtocol: "{{ .Values.config.memex_portal.PreWarm__BuildProtocol }}"
+  {{- /* PreWarm__BatchBake: one linked batch build instead of per-type hub activations. Gated
+         pods batch by default in code; this key is the explicit override — and it was declared
+         in the AKS gate values for months while NOT templated here, i.e. silently dropped
+         (it only "worked" because the gate made batch the code default). Ungated hosts that
+         want the fast path (memex-local) need it to actually render. */}}
+  PreWarm__BatchBake: "{{ .Values.config.memex_portal.PreWarm__BatchBake }}"
+  {{- /* PreWarm__BetweenTypes: pacing between types on the activation path. Gated pods sweep at
+         full speed by default; ungated pods keep a serving-friendly trickle unless this says
+         otherwise ("00:00:00" = full speed — right for a single-replica local install where
+         nothing is serving during startup anyway). Empty renders harmlessly: the host skips
+         blank values without a warning. */}}
+  PreWarm__BetweenTypes: "{{ .Values.config.memex_portal.PreWarm__BetweenTypes }}"
   # ---- Assembly-cache retention -------------------------------------------
   # The bake writes one WHOLE GENERATION of NodeType assemblies per image, because the store
   # keys every file by the MeshWeaver.Graph MVID and a CI build changes it on every publish.

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -468,8 +468,13 @@ helm_deploy() {
     i=$((i + 1))
   done
 
+  # Layering: chart defaults < TRACKED local defaults (ship with the brew package, so existing
+  # installs pick up new behaviour like the startup bake on upgrade) < the user's overlay (their
+  # secrets + overrides — generated once, never regenerated, always wins).
+  local share_dir; share_dir="$(resolve_share)"
   helm upgrade --install "$RELEASE" "$chart" \
     -f "$chart/values.yaml" \
+    -f "$share_dir/values.local.defaults.yaml" \
     -f "$OVERLAY" \
     --set persistDataVolume=true \
     --set "config.memex_portal.Bootstrap__Secret=$LOCAL_BOOTSTRAP_SECRET" \

--- a/deploy/homebrew/share/values.local.defaults.yaml
+++ b/deploy/homebrew/share/values.local.defaults.yaml
@@ -1,0 +1,33 @@
+# =============================================================================
+# memex-local — TRACKED local defaults (upgrade with `brew upgrade memex-local`)
+# =============================================================================
+# This layer sits BETWEEN the neutral chart defaults and the user's overlay:
+#
+#   helm upgrade --install memex <chart> \
+#     -f <chart>/values.yaml \
+#     -f <share>/values.local.defaults.yaml   <-- this file (tracked, no secrets)
+#     -f ~/.memex-local/values.local.yaml     <-- the user's overlay (wins)
+#
+# WHY A SEPARATE FILE: the user overlay is generated ONCE (it carries their
+# Entra ids and generated secrets), so anything shipped inside its template
+# never reaches EXISTING installs. Defaults that should follow the product —
+# like the startup bake below — live here instead: a `brew upgrade` +
+# `memex-local up` delivers them to every install, and the user overlay can
+# still override any key the ordinary helm way (later file wins).
+# =============================================================================
+
+config:
+  memex_portal:
+    # ---- Startup bake — same process as prod, in this same silo --------------
+    # Compile every dynamic NodeType at startup through the build protocol
+    # (Doc/Architecture/BuildCoordination): the portal is the sole claim
+    # candidate locally, so it claims Admin/Build, bakes in one linked batch at
+    # full speed, publishes the per-fingerprint GO — and the first open of
+    # every type after a `memex-local update` stops paying a cold Roslyn
+    # compile. The readiness GATE stays off: a single-replica k3s has no
+    # previous pod to keep serving while it bakes, and arming the gate
+    # requires raising the startup-probe budget in the same change
+    # (deploy/helm/values.yaml).
+    PreWarm__DynamicTypes: "true"
+    PreWarm__BatchBake: "true"
+    PreWarm__BetweenTypes: "00:00:00"

--- a/deploy/homebrew/share/values.local.yaml
+++ b/deploy/homebrew/share/values.local.yaml
@@ -70,6 +70,13 @@ config:
     # Read as a Boolean — must be "true"/"false", never left empty (issue #352).
     OpenAICompatible__DiscoverModels: "false"
 
+    # NOTE: behaviour defaults that should FOLLOW the product (e.g. the startup
+    # bake) are NOT in this template — they live in the tracked layer
+    # share/values.local.defaults.yaml, which `memex-local up` passes before
+    # this overlay, so existing installs pick them up on `brew upgrade` without
+    # regenerating this file. Override any of them here the normal helm way
+    # (this file wins — it is passed last).
+
     # ---- Full logging (verbose) — see header note. Declared here for
     # visibility; ALSO applied by `memex-local up` via `kubectl set env`
     # because the chart's ConfigMap is a fixed allow-list. Set to Trace for

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-local-install-bakes-at-startup-too.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-the-local-install-bakes-at-startup-too.md
@@ -1,0 +1,25 @@
+---
+Name: The local install bakes at startup too
+Category: Feature
+Description: The Homebrew local install now compiles all dynamic content at startup through the same build protocol as production — the first open after an update stops paying a cold compile — and ships the setting in a defaults layer existing installs pick up on upgrade.
+Icon: Sparkle
+Order: -20260813
+---
+
+# The local install bakes at startup too
+
+Until now the local Homebrew install compiled dynamic content lazily: after every update, the
+first open of each page paid a cold compile. Production stopped working that way months ago — it
+bakes everything at startup — and now the local install runs the very same process, in the same
+portal process: it claims the build root, bakes everything in one linked batch at full speed, and
+publishes the completion signal, all observable on the build nodes exactly as in production.
+
+Getting the setting to EXISTING installs needed its own fix: the local configuration file is
+generated once (it holds your sign-in settings), so new defaults shipped inside its template never
+reached anyone who had already installed. Product-following defaults now live in a tracked layer
+that upgrades with the package — a `brew upgrade` plus `memex-local up` delivers them, and your
+own configuration file still overrides anything, the normal way.
+
+Two configuration keys that were silently dropped by the deployment chart — declared in values but
+never templated, so they never reached any pod — are now templated, which also makes the batch
+setting the production values have carried for months actually render.


### PR DESCRIPTION
Answers "does memex-local bake?" — it didn't (chart defaults: `PreWarm__DynamicTypes: false`, so every post-update first-open paid a cold Roslyn compile). Now it runs **the same protocol-coordinated bake as production, in the same portal process**: sole claim candidate locally → claims `Admin/Build` → one linked batch at full speed → publishes the GO — all observable on the build nodes exactly as in prod.

## The three pieces

1. **Chart: two silently-dropped keys templated.** `PreWarm__BatchBake` and `PreWarm__BetweenTypes` were declarable and never templated (the configmap lists keys explicitly) — the AKS gate values have carried `BatchBake: "true"` for months without it rendering; it only "worked" because the gate makes batch the code default. Ungated hosts need them to land. Blank renders are harmless (empty values are skipped without warnings).
2. **A tracked defaults layer** (`share/values.local.defaults.yaml`), passed by the CLI **between** the chart defaults and the user overlay. This is the distribution fix for existing installs: the overlay is generated once (it carries Entra ids + secrets), so anything shipped in its template never reaches anyone already installed. This layer upgrades with the brew package — `brew upgrade memex-local` + `memex-local up` delivers new product-following defaults, and the user overlay still overrides everything (helm later-file order).
3. **The layer's first content: the bake** — `DynamicTypes=true`, `BatchBake=true`, `BetweenTypes=00:00:00`. The readiness gate stays off locally: single-replica k3s has no previous pod to keep serving during the bake, and arming it requires the startup-probe raise the chart values warn about.

## Verified

`bash -n` on the CLI; `helm template` with the three-layer stack renders all three keys as set with the user overlay last. Live verification after merge: `brew upgrade` + `memex-local up` → portal log shows the `BuildProtocol` claim + GO, `@Admin/Build` populated on the local mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)