### PR TITLE
fix: the build follower waits on facts it can read, not on a notification that cannot cross processes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -279,8 +279,8 @@ two **real** events:
 **Standing down is not bookkeeping.** `RequestBuildClaim`'s registration survives until a grant
 consumes it, so a follower that reached its answer some other way is later handed a build it will
 never run — holding the claim at `Planning`, never heartbeating, and never taken over, because its
-process is alive and [membership defends a live holder](#-when-may-the-claim-be-taken-away--cluster-membership-decides-not-a-clock)
-by design. The *next* image's fingerprint could then never be claimed and never get a GO, holding
+process is alive and the takeover rule below defends a live holder by design (a stopped heartbeat on
+a live process means busy, not dead). The *next* image's fingerprint could then never be claimed and never get a GO, holding
 every silo's readiness down. `WithdrawBuildClaim` removes the registration and gives back a claim
 that raced it; both halves are conditional, so they are safe against a concurrent grant.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -249,20 +249,49 @@ dependency. The subscription itself is a remote-path watch and uses the
 `SubscribeWithReEstablish` fault taxonomy: transient faults re-establish; a poisoned or
 deleted root is terminal and loud, never a silent 1 Hz retry loop.
 
-🚨 **That feed is not running yet.** `PostgreSqlChangeListener` is registered but never started in
+🚨 **That feed is not running.** `PostgreSqlChangeListener` is registered but never started in
 either partitioned-PG overload — `AddPartitionedPostgreSqlPersistence` has the `AddHostedService`
 call commented out, and the Aspire overload the portal actually uses never had one. Within a
 cluster the GO still reaches every silo, because `GetMeshNodeStream` resolves to the ONE per-node
 hub that owns `Admin/Build` there; **across clusters nothing propagates it**, so a follower in the
-bake silo's peer cluster observes only what its own hub read at activation. Two consequences worth
-keeping straight:
+bake silo's peer cluster observes only what its own hub read at activation.
 
-- the claim arbiter must not depend on notification — hence it READS the durable row on every pass
-  (see above) rather than waiting to be told;
-- `BuildProtocolDriver.FollowGo` subscribes to `ObserveBuildGo` with no bound, so a cross-cluster
-  follower can wait indefinitely for a GO it will never be shown. Starting the listener (or giving
-  the follower a bounded fall-back to its own sweep) is the outstanding work here; until then, treat
-  a *separate-cluster* bake host as "publishes the GO earlier", not as "spares its peers the bake".
+**Nothing in the protocol may therefore depend on being notified.** The arbiter never did — it
+READS the durable row on every pass (above). The follower used to, and that is #1440.
+
+### The follower has two doors, and it closes them behind it
+
+`BuildProtocolDriver.FollowGo` used to be a single `ObserveBuildGo(fingerprint).Take(1)`. That is a
+projection of *this cluster's mirror*, so a cross-cluster follower was waiting on an event that
+could not be delivered to it — and it had also stopped observing its own claim, so the one event
+that could still reach it in-process went unheard. It had no door at all. It now ends on either of
+two **real** events:
+
+1. **The GO becomes visible** — `ReadBuildGo` reads it off the durable build root (the same witness
+   the arbiter decides on) *and* `ObserveBuildGo` watches this cluster's mirror, whichever answers
+   first. The read is what lets a peer cluster's GO mean anything at all here.
+2. **The arbiter hands us the claim.** Registering as a candidate outlives the grant wait, and the
+   arbiter grants the moment the build falls free — whether the builder finished or died. On a grant
+   the follower **re-reads the durable witness**: a GO already there means the winner finished and
+   this process stands down without re-baking; no GO means the builder went away mid-build and this
+   process bakes. The grant is the level-trigger; the witness is the verdict.
+
+**Standing down is not bookkeeping.** `RequestBuildClaim`'s registration survives until a grant
+consumes it, so a follower that reached its answer some other way is later handed a build it will
+never run — holding the claim at `Planning`, never heartbeating, and never taken over, because its
+process is alive and [membership defends a live holder](#-when-may-the-claim-be-taken-away--cluster-membership-decides-not-a-clock)
+by design. The *next* image's fingerprint could then never be claimed and never get a GO, holding
+every silo's readiness down. `WithdrawBuildClaim` removes the registration and gives back a claim
+that raced it; both halves are conditional, so they are safe against a concurrent grant.
+
+There is deliberately **no timer and no bound bolted onto the wait**. A bound would end the wait by
+guessing, and a follower that guesses "the build finished" certifies a share it never probed — a
+silent wrong answer, strictly worse than a hang that announces itself. Both doors are level-triggered
+on durable state, exactly like the arbiter (and see #1366 for why the poll clock went).
+
+**Starting the listener is a separate decision.** It would make the GO propagate promptly across
+clusters instead of at the arbiter's next pass, but it changes behaviour for every partitioned-PG
+deployment and wants its own justification and measurement. The follower is correct without it.
 
 The probe semantics of `NodeTypeBakeGateState` are preserved unchanged — fail **closed**
 on a measured regression (the rollout stalls, the old image keeps serving), fail **open**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-follower-that-can-never-be-told.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-follower-that-can-never-be-told.md
@@ -1,0 +1,33 @@
+---
+Name: A rollout no longer waits on a message that cannot arrive
+Category: Fix
+Description: A portal that lets another process do the startup compile now works out for itself that the work finished — or takes it over when the other process stopped — instead of waiting for an announcement it could never receive.
+Icon: ArrowSync
+Order: -20260813
+---
+
+# A rollout no longer waits on a message that cannot arrive
+
+When several processes start on a new version, one of them does the compile and the rest wait for
+it to finish. Waiting was the problem: they waited to be *told*, and the announcement is delivered
+only inside the process group that made it. A compile running in a separate group — the dedicated
+build job, or a portal in another cluster sharing the same database — finished, announced, and the
+waiting processes were never reached. Nothing ended the wait.
+
+The same gap swallowed the other outcome too. A process that gives another one the job stays in the
+queue for it, so when the builder **stopped** — crashed, evicted mid-rollout — the job was handed
+straight to a process that had stopped listening. It held the job without doing it, and because it
+was alive and healthy nothing would ever take it away again. The next version could then never
+claim the build at all, and every portal on it stayed out of rotation waiting for a completion
+signal that no longer had an owner.
+
+Waiting has been replaced by looking. The completion signal is a durable record, so a follower now
+**reads** it — the same record the build's own arbitration already decides on — instead of hoping to
+be notified. And it keeps watching for the job: being handed the build is now a real event that ends
+the wait. On being handed it, the follower re-reads the record — finished means stand down without
+repeating a compile that already happened, not finished means the previous builder went away and
+this one takes over. A follower that reaches its answer any other way now gives the job back rather
+than sitting on it.
+
+No timer and no deadline were added. A deadline would end the wait by guessing, and a process that
+guesses "the compile finished" would report a version ready that it never checked.

--- a/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
+++ b/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph;
 
@@ -274,6 +275,13 @@ public static class BuildCoordinationExtensions
     /// assembly MVID), subscribes here, and holds its health probe not-ready until the emission.
     /// Old-image silos observe their own fingerprint's earlier GO and stay ready throughout a
     /// rollout.
+    ///
+    /// <para>🚨 This is a subscription to THIS cluster's MIRROR of the build root, so it only ever
+    /// emits for a GO this cluster has been told about. A builder in another process publishes to
+    /// the same durable row but no change feed crosses the process boundary (the PG <c>LISTEN</c>
+    /// session is not started in the partitioned wiring), so a mirror activated before that write
+    /// never learns. Anything that must not hang on the answer reads
+    /// <see cref="ReadBuildGo"/> — the durable witness — rather than waiting to be told (#1440).</para>
     /// </summary>
     /// <param name="hub">The calling hub.</param>
     /// <param name="frameworkVersion">The fingerprint to wait for.</param>
@@ -286,6 +294,99 @@ public static class BuildCoordinationExtensions
             .Where(go => go is not null)
             .Select(go => go!)
             .DistinctUntilChanged();
+
+    /// <summary>
+    /// READS the GO for <paramref name="frameworkVersion"/> off the DURABLE build root — the same
+    /// witness the claim arbiter decides on (<c>BuildNodeType.ArbitrateDurably</c>), and for the
+    /// same reason: it is the ONE record a process in another cluster shares with the builder, so
+    /// it answers where <see cref="ObserveBuildGo"/> can only wait (#1440).
+    ///
+    /// <para>Emits the GO record, or <c>null</c> for "this row carries no GO for that fingerprint".
+    /// <c>null</c> is also what a host with no durable store answers — there the mirror IS the
+    /// whole world and <see cref="ObserveBuildGo"/> is complete on its own — and what a FAILED read
+    /// answers, loudly: a store that cannot be read has told us nothing about the build, which is
+    /// not the same as telling us there is no GO, and the caller must keep its other doors open
+    /// rather than conclude anything. Emits exactly once and completes.</para>
+    /// </summary>
+    /// <param name="hub">The calling hub.</param>
+    /// <param name="frameworkVersion">The fingerprint whose GO is wanted.</param>
+    /// <param name="logger">Diagnostics — a failed witness read is reported here.</param>
+    /// <returns>Cold observable emitting the GO record or <c>null</c>, then completing.</returns>
+    public static IObservable<BuildGo?> ReadBuildGo(
+        this IMessageHub hub, string frameworkVersion, ILogger? logger = null)
+    {
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (storage is null)
+            return Observable.Return<BuildGo?>(null);
+
+        var options = hub.JsonSerializerOptions;
+        return storage.Read(BuildNodeType.RootPath, options)
+            .Take(1)
+            .Select(node => node?.ContentAs<BuildState>(options)?.Ready is { } ready
+                && ready.TryGetValue(frameworkVersion, out var go)
+                ? go
+                : null)
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "Build GO: could not read the durable witness at {Path} for {Fingerprint} — "
+                    + "treating it as 'no verdict', not as 'no GO'",
+                    BuildNodeType.RootPath, frameworkVersion);
+                return Observable.Return<BuildGo?>(null);
+            });
+    }
+
+    /// <summary>
+    /// STANDS DOWN as a claim candidate: removes <paramref name="holder"/>'s pending registration
+    /// and, if the arbiter granted it in the meantime, gives the claim straight back.
+    ///
+    /// <para>🚨 Registering is not free to abandon. <see cref="RequestBuildClaim"/>'s entry survives
+    /// until a grant consumes it, and the arbiter grants to whoever is queued the moment the build
+    /// falls free — so a candidate that stopped listening is handed a build nobody will ever run.
+    /// It then holds a claim with <see cref="BuildStatus.Planning"/>, never heartbeats, and — because
+    /// its process is alive and the cluster says so — is NEVER taken over
+    /// (<c>HolderStillHoldsIt</c> defends a live holder by design). The next image's fingerprint can
+    /// then never be claimed and never gets a GO, which holds every silo's readiness down. A
+    /// candidate that reaches its answer some other way must therefore say so here (#1440).</para>
+    ///
+    /// <para>Both halves are conditional and merge-safe: the registration is removed only if it is
+    /// still ours (its own key — RFC 7396 safe against concurrent candidates), the projection is
+    /// cleared only while we are the named holder and the build has not started, and
+    /// <see cref="ReleaseBuildClaim"/> drops the durable lock only if we own it.</para>
+    /// </summary>
+    /// <param name="hub">The calling hub.</param>
+    /// <param name="holder">The candidate standing down.</param>
+    /// <param name="path">Node path; defaults to the build root.</param>
+    /// <returns>Cold observable emitting the node after the write.</returns>
+    public static IObservable<MeshNode> WithdrawBuildClaim(
+        this IMessageHub hub, string holder, string path = BuildNodeType.RootPath)
+        => hub.GetWorkspace().GetMeshNodeStream(path).Update(curr =>
+            {
+                var state = curr?.ContentAs<BuildState>(hub.JsonSerializerOptions);
+                if (curr is null || state is null) return curr!;
+
+                var registered = state.RequestedClaims?.ContainsKey(holder) == true;
+                // Only a claim we were GRANTED but never started on is ours to hand back. A holder
+                // that is Building is mid-bake and must not clear its own claim from here.
+                var grantedNotStarted =
+                    state.ClaimedBy == holder && state.Status is BuildStatus.Planning;
+                if (!registered && !grantedNotStarted) return curr;
+
+                return curr with
+                {
+                    Content = state with
+                    {
+                        RequestedClaims = registered
+                            ? state.RequestedClaims!.Remove(holder)
+                            : state.RequestedClaims,
+                        ClaimedBy = grantedNotStarted ? null : state.ClaimedBy,
+                        ClaimedByIdentity = grantedNotStarted ? null : state.ClaimedByIdentity,
+                        ClaimedAt = grantedNotStarted ? null : state.ClaimedAt,
+                        HeartbeatAt = grantedNotStarted ? null : state.HeartbeatAt,
+                    }
+                };
+            })
+            .SelectMany(node => hub.ReleaseBuildClaim(holder, path).Select(_ => node));
 
     private static MeshNode NewBuildNode(string path, BuildState? initial)
     {

--- a/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
+++ b/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
@@ -301,12 +301,16 @@ public static class BuildCoordinationExtensions
     /// same reason: it is the ONE record a process in another cluster shares with the builder, so
     /// it answers where <see cref="ObserveBuildGo"/> can only wait (#1440).
     ///
-    /// <para>Emits the GO record, or <c>null</c> for "this row carries no GO for that fingerprint".
-    /// <c>null</c> is also what a host with no durable store answers — there the mirror IS the
-    /// whole world and <see cref="ObserveBuildGo"/> is complete on its own — and what a FAILED read
-    /// answers, loudly: a store that cannot be read has told us nothing about the build, which is
-    /// not the same as telling us there is no GO, and the caller must keep its other doors open
-    /// rather than conclude anything. Emits exactly once and completes.</para>
+    /// <para>Emits the GO record, or <c>null</c>. 🚨 <c>null</c> is deliberately NOT a claim that
+    /// there is no GO — it is "this call has no GO to give you", which covers three cases the
+    /// caller treats identically: the row carries no GO for that fingerprint; there is no durable
+    /// store at all (the mirror IS the whole world there, and <see cref="ObserveBuildGo"/> is
+    /// complete on its own); or the read FAILED, which is logged loudly. Collapsing them is safe
+    /// only because every caller's <c>null</c> branch is the conservative one — it bakes, into
+    /// content-addressed stores, which costs at worst one redundant build and can never corrupt.
+    /// Fail OPEN, the same asymmetry <c>BuildNodeType.ArbitrateDurably</c> applies, and the reason
+    /// no caller may read <c>null</c> as evidence that a build has not happened. Emits exactly once
+    /// and completes.</para>
     /// </summary>
     /// <param name="hub">The calling hub.</param>
     /// <param name="frameworkVersion">The fingerprint whose GO is wanted.</param>
@@ -330,7 +334,8 @@ public static class BuildCoordinationExtensions
             {
                 logger?.LogWarning(ex,
                     "Build GO: could not read the durable witness at {Path} for {Fingerprint} — "
-                    + "treating it as 'no verdict', not as 'no GO'",
+                    + "answering 'no GO to give you'. That is NOT evidence the build has not "
+                    + "happened; the caller's null branch is the conservative one (it bakes)",
                     BuildNodeType.RootPath, frameworkVersion);
                 return Observable.Return<BuildGo?>(null);
             });

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -85,9 +85,15 @@ public static class BuildProtocolDriver
             .SelectMany(_ => mesh.ObserveBuildClaim(holder)
                 .Take(1)
                 .Timeout(GrantWindow)
-                .SelectMany(__ => BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger))
-                .Catch((TimeoutException _) =>
-                    FollowGo(mesh, holder, fingerprint, definitions, store, logger)));
+                .Select(__ => true)
+                // The Catch bounds the GRANT WAIT and nothing else. It used to wrap the bake as
+                // well, so a TimeoutException raised anywhere inside the sweep demoted the winner
+                // to a follower — still holding its claim, now waiting for a GO only it could ever
+                // publish.
+                .Catch((TimeoutException _) => Observable.Return(false))
+                .SelectMany(granted => granted
+                    ? BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger)
+                    : FollowGo(mesh, holder, fingerprint, definitions, store, bake, logger)));
     }
 
     // ── the winner ──────────────────────────────────────────────────────────────────────────────
@@ -312,41 +318,140 @@ public static class BuildProtocolDriver
 
     // ── the follower ────────────────────────────────────────────────────────────────────────────
 
-    private static IObservable<PreWarmOutcome> FollowGo(
+    /// <summary>
+    /// The path taken when the claim is held elsewhere. It ends on one of TWO real events, and the
+    /// point of #1440 is that it used to have neither reliably:
+    ///
+    /// <list type="number">
+    /// <item><b>The GO becomes visible.</b> Not "is announced" — <em>visible</em>. The old code
+    /// subscribed to <c>ObserveBuildGo</c> alone, which is a projection of THIS cluster's mirror of
+    /// <c>Admin/Build</c>. A builder in another process writes the same durable row, but no change
+    /// feed crosses the process boundary (<c>PostgreSqlChangeListener</c> is registered and never
+    /// started in either partitioned-PG overload), so a mirror that activated before that write is
+    /// never told and the wait was for an event that could not be delivered. So the GO is now also
+    /// READ off the durable witness — the same record, and for the same reason, the claim arbiter
+    /// decides on (<c>BuildNodeType.ArbitrateDurably</c>).</item>
+    /// <item><b>The arbiter hands US the claim.</b> Registering as a candidate is not free to
+    /// abandon: the registration outlives the grant wait, and the arbiter grants it the moment the
+    /// build falls free — whether the builder finished or died. The old follower had stopped
+    /// listening, so that grant went to a process that would never act on it, leaving the build
+    /// locked to a live holder the takeover rule then defends forever. Observing it instead turns
+    /// "the builder went away" into a real event that ends the wait, and turns the grant into the
+    /// level-trigger on which the durable witness is re-read.</item>
+    /// </list>
+    ///
+    /// <para>🚨 No timer, and no bound bolted onto the wait. A bound would end the wait by GUESSING,
+    /// and a follower that guesses "the build finished" certifies a share it never saw — a silent
+    /// wrong answer where the hang at least announced itself. Both doors above are level-triggered
+    /// on durable state, exactly like the arbiter (#1437, and #1366 for why the poll clock went).</para>
+    /// </summary>
+    internal static IObservable<PreWarmOutcome> FollowGo(
         IMessageHub mesh,
         string holder,
         string fingerprint,
         IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
         IAssemblyStore store,
+        Func<IObservable<PreWarmOutcome>> bake,
         ILogger? logger)
     {
         logger?.LogInformation(
-            "BuildProtocol: claim held elsewhere — {Holder} subscribes to the GO for framework {Fingerprint}",
+            "BuildProtocol: claim held elsewhere — {Holder} follows the build for framework "
+            + "{Fingerprint} (durable witness + this cluster's GO + its own claim candidacy)",
             holder, fingerprint);
 
-        return mesh.ObserveBuildGo(fingerprint)
+        // Door 1 — the GO is visible: on the durable row (the witness a peer cluster shares with
+        // the builder) or on this cluster's mirror, whichever answers first.
+        var go = mesh.ReadBuildGo(fingerprint, logger)
+            .Where(g => g is not null)
+            .Select(g => g!)
+            .Merge(mesh.ObserveBuildGo(fingerprint))
+            .Select(g => (Go: (BuildGo?)g, Granted: false));
+
+        // Door 2 — the build fell free and the arbiter granted it to us. Re-subscribing here also
+        // closes the race where the grant landed microseconds after the GrantWindow expired.
+        var granted = mesh.ObserveBuildClaim(holder)
             .Take(1)
+            .Select(_ => (Go: (BuildGo?)null, Granted: true));
+
+        return go.Merge(granted)
+            .Take(1)
+            .SelectMany(end => end.Granted
+                ? OnGranted(mesh, holder, fingerprint, definitions, store, bake, logger)
+                : ProbeAfterGo(mesh, holder, fingerprint, end.Go!, definitions, store, logger));
+    }
+
+    /// <summary>
+    /// The follower was handed the claim. That means the build fell free — but NOT which way: the
+    /// builder may have finished (published its GO and released) or gone away mid-bake. Only the
+    /// durable witness distinguishes them, and asking it here is what makes a peer cluster's GO
+    /// actually spare this process the bake instead of merely arriving too late to matter.
+    /// </summary>
+    private static IObservable<PreWarmOutcome> OnGranted(
+        IMessageHub mesh,
+        string holder,
+        string fingerprint,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        Func<IObservable<PreWarmOutcome>> bake,
+        ILogger? logger)
+        => mesh.ReadBuildGo(fingerprint, logger)
             .SelectMany(go =>
             {
+                if (go is not null)
+                {
+                    logger?.LogInformation(
+                        "BuildProtocol: {Holder} was granted the claim, but the durable witness "
+                        + "already carries the GO for framework {Fingerprint} (ready at {ReadyAt:O}) "
+                        + "— standing down instead of re-baking",
+                        holder, fingerprint, go.ReadyAt);
+                    return ProbeAfterGo(mesh, holder, fingerprint, go, definitions, store, logger);
+                }
+
                 logger?.LogInformation(
-                    "BuildProtocol: GO received for framework {Fingerprint} (ready at {ReadyAt:O}) — probing the share",
-                    fingerprint, go.ReadyAt);
-                // The GO says the build finished; the share says what actually landed. Probing
-                // (rather than trusting) keeps the follower level-triggered on reality — the same
-                // property the sweep itself has. A type still pending after GO is reported as
-                // not-evaluated (non-gating): the follower has no verdict about it.
-                return NodeTypeBakeStatus.Probe(definitions, store, logger: logger)
-                    .SelectMany(fresh => fresh.Entries
-                        .Select(e => new PreWarmOutcome(
-                            e.TypePath,
-                            e.NeedsBake ? PreWarmStatus.TimedOut : PreWarmStatus.AlreadyBaked,
-                            e.NeedsBake
-                                ? "still pending on the share after the build published GO"
-                                : "on the share after GO")
-                        {
-                            WasHealthyBeforeBake = e.WasHealthy,
-                        }));
+                    "BuildProtocol: {Holder} was granted the claim while following framework "
+                    + "{Fingerprint} — the previous builder released it without a GO, so this "
+                    + "process bakes",
+                    holder, fingerprint);
+                return BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger);
             });
+
+    /// <summary>
+    /// The GO says the build finished; the share says what actually landed. Probing (rather than
+    /// trusting) keeps the follower level-triggered on reality — the same property the sweep itself
+    /// has. A type still pending after GO is reported as not-evaluated (non-gating): the follower
+    /// has no verdict about it.
+    ///
+    /// <para>Standing down FIRST is not bookkeeping. A candidate that reached its answer without a
+    /// grant still has a live registration, and the arbiter will hand it the next free build — a
+    /// build this process has already finished with and will never run. See
+    /// <c>WithdrawBuildClaim</c> for why that wedges the following image's rollout.</para>
+    /// </summary>
+    private static IObservable<PreWarmOutcome> ProbeAfterGo(
+        IMessageHub mesh,
+        string holder,
+        string fingerprint,
+        BuildGo go,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        ILogger? logger)
+    {
+        logger?.LogInformation(
+            "BuildProtocol: GO visible for framework {Fingerprint} (ready at {ReadyAt:O}) — "
+            + "{Holder} stands down and probes the share",
+            fingerprint, go.ReadyAt, holder);
+
+        return mesh.WithdrawBuildClaim(holder)
+            .SelectMany(_ => NodeTypeBakeStatus.Probe(definitions, store, logger: logger))
+            .SelectMany(fresh => fresh.Entries
+                .Select(e => new PreWarmOutcome(
+                    e.TypePath,
+                    e.NeedsBake ? PreWarmStatus.TimedOut : PreWarmStatus.AlreadyBaked,
+                    e.NeedsBake
+                        ? "still pending on the share after the build published GO"
+                        : "on the share after GO")
+                {
+                    WasHealthyBeforeBake = e.WasHealthy,
+                }));
     }
 
     // ── shared ──────────────────────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
@@ -152,6 +155,136 @@ public class BuildCoordinationTest(ITestOutputHelper output) : MonolithMeshTestB
             .Where(l => l is not null && l.Status.IsTerminal())
             .FirstAsync().Timeout(WaitBudget).ToTask();
         activity!.Status.Should().Be(ActivityStatus.Succeeded);
+    }
+
+    // ---- The follower (#1440): a wait that ends on a real event, never on a notification ----
+    //
+    // Both tests below drive the PUBLIC entry point BuildProtocolDriver.Run, so they compile
+    // unchanged against the pre-fix implementation — and both hang there until their [Fact] timeout.
+    // What they pin is that a follower has TWO doors out, and that it closes them behind it:
+    //
+    //   • the GO becomes VISIBLE — read off the durable witness, not merely awaited on this
+    //     cluster's mirror, which a builder in another process can never reach; and
+    //   • the arbiter hands US the claim, because the builder went away.
+    //
+    // The 15 s each test spends before its trigger is BuildProtocolDriver.GrantWindow — a declared
+    // bound of the protocol that the candidate must run out before it becomes a follower at all,
+    // not a guess at how long some propagation takes. Trigger earlier and the arbiter grants the
+    // candidate during its grant wait, which exercises the master path instead.
+
+    private static readonly IReadOnlyDictionary<string, NodeTypeDefinition?> NoDynamicTypes =
+        new Dictionary<string, NodeTypeDefinition?>();
+
+    private static IObservable<Unit> AfterTheGrantWindow() =>
+        Observable.Timer(BuildProtocolDriver.GrantWindow + TimeSpan.FromSeconds(2))
+            .Select(_ => Unit.Default);
+
+    private IObservable<BuildState> Root() =>
+        Mesh.GetWorkspace().GetMeshNodeStream(BuildNodeType.RootPath)
+            .Select(n => n?.ContentAs<BuildState>(Mesh.JsonSerializerOptions))
+            .Where(s => s is not null)
+            .Select(s => s!);
+
+    /// <summary>
+    /// The builder goes away WITHOUT ever publishing a GO. Nothing will ever emit the event the
+    /// follower was waiting for — the only process that could publish it has stopped — and the
+    /// protocol has already handed the build to the follower, which is the event it should have
+    /// been watching. Before the fix the follower had unsubscribed from its own claim, so the grant
+    /// went to a process that would never act on it and this test runs out its timeout.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Follower_TakesOverTheBake_WhenTheBuildFallsFreeWithoutAGo()
+    {
+        var hub = Mesh;
+        const string fingerprint = "fp-falls-free";
+
+        // A rival wins the build and starts baking.
+        await hub.RequestBuildClaim("rival", fingerprint).FirstAsync().ToTask();
+        await hub.ObserveBuildClaim("rival").FirstAsync().Timeout(WaitBudget).ToTask();
+
+        var baked = 0;
+        var run = BuildProtocolDriver.Run(
+                hub,
+                NodeTypeBakeReport.Empty(fingerprint),
+                NoDynamicTypes,
+                NullAssemblyStore.Instance,
+                () => Observable.Defer(() =>
+                {
+                    Interlocked.Increment(ref baked);
+                    return Observable.Return(
+                        new PreWarmOutcome("Test/FallsFree", PreWarmStatus.Compiled, "baked by the follower"));
+                }),
+                logger: null)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(45))
+            .ToTask();
+
+        // Past the grant window our candidate is a follower. Now the builder dies: the claim is
+        // dropped and no GO is ever published for this fingerprint.
+        await AfterTheGrantWindow().FirstAsync().ToTask();
+        await hub.FailBuild("rival", "builder process gone").FirstAsync().ToTask();
+
+        var outcomes = await run;
+
+        baked.Should().Be(1, "the follower was handed the build and must run it");
+        outcomes.Should().ContainSingle().Which.TypePath.Should().Be("Test/FallsFree");
+
+        // …and it finished the job properly: the GO it published is what every other silo is waiting on.
+        var final = await Root().Where(s => s.Ready?.ContainsKey(fingerprint) == true)
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        final.ClaimedBy.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The builder finishes normally. The follower must complete on the GO — and STAND DOWN, which
+    /// is the half that used to be missing: its registration outlived the wait, so the arbiter
+    /// handed it the freed build, it never acted on it, and the claim stuck to a live holder the
+    /// takeover rule defends by design. The next image's fingerprint could then never be claimed.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Follower_StandsDown_SoTheNextBuildCanStillBeClaimed()
+    {
+        var hub = Mesh;
+        const string fingerprint = "fp-stand-down";
+
+        await hub.RequestBuildClaim("rival", fingerprint).FirstAsync().ToTask();
+        await hub.ObserveBuildClaim("rival").FirstAsync().Timeout(WaitBudget).ToTask();
+
+        var baked = 0;
+        var run = BuildProtocolDriver.Run(
+                hub,
+                NodeTypeBakeReport.Empty(fingerprint),
+                NoDynamicTypes,
+                NullAssemblyStore.Instance,
+                () => Observable.Defer(() =>
+                {
+                    Interlocked.Increment(ref baked);
+                    return Observable.Empty<PreWarmOutcome>();
+                }),
+                logger: null)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(45))
+            .ToTask();
+
+        await AfterTheGrantWindow().FirstAsync().ToTask();
+        await hub.CompleteBuild("rival", new BuildGo(fingerprint, DateTime.UtcNow))
+            .FirstAsync().ToTask();
+
+        await run;
+        baked.Should().Be(0, "the build was done — the follower had nothing to bake");
+
+        // The build must be free for the NEXT candidate: no holder, and nobody queued who has
+        // already walked away. A single pending registration here is the wedge.
+        var settled = await Root()
+            .Where(s => s.ClaimedBy is null && s.RequestedClaims is null or { Count: 0 })
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        settled.Ready.Should().ContainKey(fingerprint);
+
+        // …and it really is claimable: a fresh candidate is granted rather than queued forever.
+        await hub.RequestBuildClaim("next-image", "fp-next").FirstAsync().ToTask();
+        var grantedNext = await hub.ObserveBuildClaim("next-image")
+            .FirstAsync().Timeout(WaitBudget).ToTask();
+        grantedNext.FrameworkVersion.Should().Be("fp-next");
     }
 
     // ---- Arbitrate as a pure decision procedure: the staleness rules without wall-clock ----

--- a/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/BuildCoordinationTest.cs
@@ -173,7 +173,7 @@ public class BuildCoordinationTest(ITestOutputHelper output) : MonolithMeshTestB
     // candidate during its grant wait, which exercises the master path instead.
 
     private static readonly IReadOnlyDictionary<string, NodeTypeDefinition?> NoDynamicTypes =
-        new Dictionary<string, NodeTypeDefinition?>();
+        ImmutableDictionary<string, NodeTypeDefinition?>.Empty;
 
     private static IObservable<Unit> AfterTheGrantWindow() =>
         Observable.Timer(BuildProtocolDriver.GrantWindow + TimeSpan.FromSeconds(2))


### PR DESCRIPTION
Fixes #1440.

## What the wait was waiting on, and why it could not arrive

`BuildProtocolDriver.FollowGo` was a single `mesh.ObserveBuildGo(fingerprint).Take(1)`. That is a
projection of **this cluster's mirror** of `Admin/Build`. A builder in another process writes the
same durable row, but **no change feed crosses the process boundary** — `PostgreSqlChangeListener`
is registered and never started in either partitioned-PG overload (`AddPartitionedPostgreSqlPersistence`
has the `AddHostedService` commented out; the Aspire overload never had one). A mirror activated
before that write is never told, so the follower was waiting for an event that could not be
delivered to it.

It had also **stopped observing its own claim**, which closed the second door. `RequestBuildClaim`'s
registration outlives the grant wait and the arbiter grants it the moment the build falls free — so
the follower was handed builds it never ran. It then held the claim at `Planning`, never
heartbeating, and was **never taken over**, because its process is alive and `HolderStillHoldsIt`
defends a live holder by design (a stopped heartbeat on a live process means busy, not dead).

Both terminal states were therefore un-endable:

| the builder… | what the follower needed | what it had |
|---|---|---|
| **died** mid-bake | to take the build over | nothing — the only process that could publish that GO had stopped |
| **finished** | to stand down cleanly | its stranded registration locked the *next* image out of the build entirely |

## The fix

The follower ends on either of two **real** events, both level-triggered on durable state — the same
property #1437 gave the arbiter, and for the same reason:

1. **The GO becomes VISIBLE.** `ReadBuildGo` reads it off the durable build root — the one witness a
   peer cluster shares with the builder — merged with this cluster's mirror.
2. **The arbiter hands us the claim.** On a grant the durable witness is **re-read**: a GO already
   there means the winner finished and this process stands down without re-baking; no GO means the
   builder went away mid-bake and this process bakes.

`WithdrawBuildClaim` gives back the candidacy (and a claim that raced it) when the follower reaches
its answer some other way. `Run`'s `Catch` now bounds the **grant wait only** — it used to wrap the
bake, so a `TimeoutException` anywhere in the sweep demoted the winner to a follower still holding
its own claim.

**No timer, and no bound bolted onto the wait.** A bound would end it by guessing, and a follower
that guesses "the build finished" certifies a share it never probed — a silent wrong answer where
the hang at least announced itself. (#1366 removed a staleness clock for exactly this reason.)

## Deliberately NOT in scope

**Starting the PG change listener.** It would make the GO propagate promptly across clusters rather
than at the arbiter's next pass, but it changes behaviour for every partitioned-PG deployment and
wants its own justification and measurement — the issue says so explicitly. The follower is correct
without it.

## Verification — fail before, pass after

Both tests drive the **public** `BuildProtocolDriver.Run`, so they compile unchanged against the
previous implementation. Reverting only the two `src/` files and re-running:

```
Follower_TakesOverTheBake_WhenTheBuildFallsFreeWithoutAGo   FAIL  System.TimeoutException  [45 s]
Follower_StandsDown_SoTheNextBuildCanStillBeClaimed         FAIL  System.TimeoutException  [32 s]
```

With the fix, the whole class and then the whole project:

```
BuildCoordinationTest          Passed: 16, Failed: 0            (37 s)
MeshWeaver.Hosting.Monolith.Test   Passed: 667, Failed: 0, Skipped: 3   (8 m 15 s)
```

`dotnet build -c Release -warnaserror --no-incremental` clean on `MeshWeaver.Hosting`,
`MeshWeaver.Graph` and `MeshWeaver.Documentation`; `DocumentationLinkIntegrityTest` green.

## Noted in passing, not fixed here

`BuildNodeType.ArbitrateDurably` builds its decision input from the **claim lock** node
(`Admin/Build/_Claim`), and `Arbitrate`'s `GrantSettleWindow` guard tests `node.Path == RootPath` —
which is never true on that path. So #1424's convergence window is inert whenever a storage adapter
exists. Out of scope here; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)