### PR TITLE
feat(graph): the code cell IS the editor for a viewer who may edit — no Edit button

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -2,6 +2,8 @@
 @using MeshWeaver.Layout.Client
 @using MeshWeaver.Data
 @using MeshWeaver.Blazor.Components.Monaco
+@using MeshWeaver.Mesh
+@using MeshWeaver.Mesh.Services
 @using MeshWeaver.Mesh.Services.LanguageServer
 @using System.Text.Json
 @using System.Reactive.Disposables
@@ -57,6 +59,16 @@
     // Store the data pointer for two-way binding
     private JsonPointerReference? ValuePointer;
 
+    // AUTO-SAVE (opt-in via CodeEditorControl.AutoSaveAddress): the debounced editor text is
+    // persisted into the named Code node's CodeConfiguration.Code through the process-wide
+    // IMeshNodeStreamCache — the same circuit-side seam the markdown editor's auto-save uses
+    // (MarkdownEditorView), so the write carries THIS circuit's identity and every reader on
+    // the path observes the patch in order through the shared upstream handle.
+    private AutoSaveHandler? autoSaveHandler;
+    private IMeshNodeStreamCache? _cache;
+    private string? autoSavePath;
+    private static readonly TimeSpan AutoSaveThrottleInterval = TimeSpan.FromMilliseconds(500);
+
     // ViewModel / Stream / Area / DataContext now come from BlazorView, which is also what binds
     // Id / Class / Style. Re-declaring them as local [Parameter]s is exactly what kept this view
     // outside the contract the registry types it into (#1333) — BindData never ran for it, so the
@@ -106,6 +118,21 @@
         BoundHeight = ResolveValue<string>(ViewModel.Height) ?? "300px";
         BoundReadonly = ResolveValue<bool?>(ViewModel.Readonly) ?? false;
         BoundPlaceholder = ResolveValue<string>(ViewModel.Placeholder) ?? "";
+
+        // AUTO-SAVE opt-in: persist the (debounced) editor text into the Code node the control
+        // names. Created per bind and registered as a binding, so the base disposes it on
+        // re-bind and teardown — exactly the markdown editor's auto-save lifecycle.
+        autoSaveHandler = null;
+        autoSavePath = ViewModel.AutoSaveAddress;
+        if (!string.IsNullOrEmpty(autoSavePath))
+        {
+            _cache ??= Services.GetService(typeof(IMeshNodeStreamCache)) as IMeshNodeStreamCache;
+            if (_cache != null)
+            {
+                autoSaveHandler = new AutoSaveHandler(AutoSaveThrottleInterval, AutoSaveCode);
+                AddBinding(autoSaveHandler);
+            }
+        }
 
         // LSP opt-in: when the control specifies LanguageServer, resolve IMeshLanguageService
         // from DI and build a closure that feeds the editor's current text into CheckSpeculative
@@ -234,7 +261,36 @@
             Stream.UpdatePointer(value, GetEffectiveDataContext(), ValuePointer);
         }
 
+        // Feed the auto-save debounce (no-op unless the control opted in via AutoSaveAddress).
+        autoSaveHandler?.OnValueChanged(value);
+
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The auto-save writer — invoked by <see cref="AutoSaveHandler"/> after the debounce window.
+    /// Preserves every other <see cref="CodeConfiguration"/> field: only <c>Code</c> is replaced.
+    /// A node whose content cannot be read as <see cref="CodeConfiguration"/> is deliberately left
+    /// UNTOUCHED (returning it unchanged makes the merge patch empty) — auto-save must never
+    /// clobber content it does not understand.
+    /// </summary>
+    private void AutoSaveCode(string value)
+    {
+        var path = autoSavePath;
+        if (_cache == null || string.IsNullOrEmpty(path))
+            return;
+        // Fire-and-forget like the markdown editor's AutoSaveContentAsync: the cache owns the
+        // write's lifetime; only a failure surfaces.
+        _cache.Update(path!,
+                current =>
+                {
+                    var config = current.ContentAs<CodeConfiguration>(Hub.JsonSerializerOptions);
+                    return config is null || config.Code == value
+                        ? current
+                        : current with { Content = config with { Code = value } };
+                },
+                Hub.JsonSerializerOptions)
+            .Subscribe(_ => { }, ex => SurfaceError(ex, "Code auto-save"));
     }
 
     public async ValueTask<string> GetValueAsync()

--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -121,12 +121,22 @@
 
         // AUTO-SAVE opt-in: persist the (debounced) editor text into the Code node the control
         // names. Created per bind and registered as a binding, so the base disposes it on
-        // re-bind and teardown — exactly the markdown editor's auto-save lifecycle.
+        // re-bind and teardown — exactly the markdown editor's auto-save lifecycle, including the
+        // LOUD resolution failure: a silently-absent cache would read as "auto-save just doesn't
+        // work" with nothing to diagnose by.
         autoSaveHandler = null;
         autoSavePath = ViewModel.AutoSaveAddress;
         if (!string.IsNullOrEmpty(autoSavePath))
         {
-            _cache ??= Services.GetService(typeof(IMeshNodeStreamCache)) as IMeshNodeStreamCache;
+            try
+            {
+                _cache ??= Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex,
+                    "Failed to resolve IMeshNodeStreamCache for auto-save at {Address}", autoSavePath);
+            }
             if (_cache != null)
             {
                 autoSaveHandler = new AutoSaveHandler(AutoSaveThrottleInterval, AutoSaveCode);

--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -24,9 +24,11 @@ namespace MeshWeaver.Graph;
 
 /// <summary>
 /// Layout views for Code nodes.
-/// - Content (default): Read-only code display as markdown code block
+/// - Content (default): the notebook cell. For a viewer holding Update the code segment IS an
+///   inline Monaco editor (edit mode is the mode — no Edit button, auto-saved, Run persists the
+///   buffer first); for everyone else it is the read-only markdown code block.
 /// - Overview: Splitter with sibling code list and embedded content view
-/// - Edit: Monaco editor with language support
+/// - Edit: Monaco editor with language support (kept for deep links and metadata edits)
 /// </summary>
 public static class CodeLayoutAreas
 {
@@ -60,6 +62,14 @@ public static class CodeLayoutAreas
     public const string CopyDialogCancelArea = "CopyDialogCancel";
     /// <summary>Area id of the Confirm button inside the copy-to-home dialog.</summary>
     public const string CopyDialogConfirmArea = "CopyDialogConfirm";
+
+    /// <summary>
+    /// Data id of the EDIT-MODE cell's code buffer — what the inline editor binds. Seeded ONCE
+    /// per rendered area from the node's stored code (see <see cref="Content"/>) and written by
+    /// the editor from then on; Run snapshots it so the kernel always executes what the viewer
+    /// sees.
+    /// </summary>
+    public const string CellBufferDataId = "cellCode";
 
     private const string CodeDataId = "code";
     private const string SiblingNodesDataId = "siblingCodeNodes";
@@ -147,11 +157,46 @@ public static class CodeLayoutAreas
             .DistinctUntilChanged(log => (log?.Status, log?.RequestedStatus))
             .StartWith((ActivityLog?)null);
 
-        return nodeStream.CombineLatest(lastActivityStream, permissionStream,
-            (node, lastActivity, permissions) => (UiControl?)BuildContent(host, node, lastActivity, permissions));
+        // The edit-mode buffer: seeded ONCE from the first emission and never re-seeded — from
+        // then on the EDITOR is the writer (its auto-save persists through the node stream
+        // cache), and a save echo re-seeding the buffer would clobber whatever the viewer typed
+        // since. The editor height is fixed from the same seed so the editor CONTROL stays
+        // identical across re-renders: the client diff then never re-mounts Monaco (a re-mount
+        // mid-typing loses cursor and scroll).
+        var editorSetup = nodeStream
+            .Where(n => n is not null)
+            .Select(n => n.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions)?.Code ?? "")
+            .Take(1)
+            .Select(code =>
+            {
+                host.UpdateData(CellBufferDataId, code);
+                return CellEditorHeight(code);
+            })
+            // Render is never held hostage to the seed: a defensive null-first emission (or a
+            // ghost node) still paints the page with the floor height; the real seed follows.
+            .StartWith(CellEditorHeight(null));
+
+        return nodeStream.CombineLatest(lastActivityStream, permissionStream, editorSetup,
+            (node, lastActivity, permissions, editorHeight) =>
+                (UiControl?)BuildContent(host, node, lastActivity, permissions, editorHeight));
     }
 
-    private static UiControl BuildContent(LayoutAreaHost host, MeshNode? node, ActivityLog? lastActivity, Permission permissions)
+    /// <summary>
+    /// The inline editor's height for a cell seeded with <paramref name="code"/>: Monaco's 19px
+    /// per line plus the frame chrome, clamped to [96, 480] px. Computed once from the SEED —
+    /// a height that followed the text would change the editor control on every save and
+    /// re-mount Monaco under the viewer's cursor. Pure.
+    /// </summary>
+    public static string CellEditorHeight(string? code)
+    {
+        var lines = string.IsNullOrEmpty(code) ? 1 : code!.Split('\n').Length;
+        var px = Math.Clamp(lines * 19 + 20, 96, 480);
+        return $"{px}px";
+    }
+
+    private static UiControl BuildContent(
+        LayoutAreaHost host, MeshNode? node, ActivityLog? lastActivity, Permission permissions,
+        string editorHeight)
     {
         var hubAddress = host.Hub.Address;
         var codeConfig = node.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions);
@@ -160,6 +205,7 @@ public static class CodeLayoutAreas
         var title = node?.Name ?? node?.Id ?? "Code";
         var isExecutable = codeConfig?.IsExecutable == true;
         var language = codeConfig?.Language ?? "csharp";
+        var canEdit = permissions.HasFlag(Permission.Update);
 
         // Page header: title only. Run/Cancel/Edit live in the cell toolbar
         // below — ONE source of truth for the notebook controls, no second Run
@@ -176,8 +222,14 @@ public static class CodeLayoutAreas
             .WithStyle("border: 1px solid var(--neutral-stroke-rest); border-radius: 6px; " +
                        "overflow: hidden; background: var(--neutral-layer-1);");
 
-        // Code segment (markdown fence rendering, unchanged).
-        if (!string.IsNullOrEmpty(codeConfig?.Code))
+        // Code segment. A viewer who may edit gets the EDITOR — edit mode IS the mode, there is
+        // no separate page behind a button. Everyone else keeps the read-only fence rendering.
+        if (canEdit)
+        {
+            cell = cell.WithView(BuildCellEditor(hubAddress.ToString(), language, editorHeight),
+                CellCodeArea);
+        }
+        else if (!string.IsNullOrEmpty(codeConfig?.Code))
         {
             cell = cell.WithView(Controls.Markdown($"```{language}\n{codeConfig.Code}\n```")
                     .WithStyle("width: 100%; overflow: auto; padding: 0 12px;"),
@@ -221,8 +273,7 @@ public static class CodeLayoutAreas
         // Toolbar LAST — the composer bar at the bottom of the cell frame,
         // below the output segment.
         cell = cell.WithView(
-            BuildCellToolbar(hubAddress, codeConfig, isExecutable, language, lastActivity,
-                canEdit: permissions.HasFlag(Permission.Update)),
+            BuildCellToolbar(hubAddress, codeConfig, isExecutable, language, lastActivity, canEdit),
             CellToolbarArea);
 
         stack = stack.WithView(cell, CellArea);
@@ -239,12 +290,14 @@ public static class CodeLayoutAreas
     /// The cell's toolbar — the composer bar on the BOTTOM edge of the cell:
     /// ▶ Run (accent), ⏹ Cancel (only while the last run is actually running and
     /// no cancel is already in flight — the shared
-    /// <see cref="ActivityLayoutAreas.IsCancelButtonVisible"/> predicate), ✎ Edit,
+    /// <see cref="ActivityLayoutAreas.IsCancelButtonVisible"/> predicate),
     /// then subtle right-aligned metadata (language badge, last-run provenance).
-    /// <para>Edit is rights-gated: with <see cref="Permission.Update"/> on the node
-    /// it navigates straight to the Edit area; without it, it opens the
-    /// copy-to-home dialog (<see cref="OpenCopyToHomeDialog"/>) offering to copy
-    /// the node into the viewer's own home space via the standard copy machinery.</para>
+    /// <para>A viewer WITH <see cref="Permission.Update"/> gets NO Edit button — their cell's
+    /// code segment already IS the editor (see <see cref="BuildCellEditor"/>), and their Run
+    /// persists the buffer before executing (<see cref="RunFromBuffer"/>). A read-only viewer
+    /// keeps the Edit button, which opens the copy-to-home dialog
+    /// (<see cref="OpenCopyToHomeDialog"/>) offering to copy the node into their own home space
+    /// via the standard copy machinery.</para>
     /// </summary>
     internal static UiControl BuildCellToolbar(
         Address hubAddress,
@@ -275,14 +328,20 @@ public static class CodeLayoutAreas
             // button client-side hid it even from admins when the live
             // permission stream had a transient empty emission, which is exactly
             // the state we once spent a session debugging.
+            // For an EDITOR the click persists the cell buffer FIRST: the kernel executes the
+            // STORED code, the editor's auto-save is debounced, and running anything other than
+            // what the viewer sees is the classic stale-cell trap.
             toolbar = toolbar.WithView(Controls.Button(LocalizationCatalog.Get("common.run", locale))
                     .WithIconStart(RunGlyph(isStale))
                     .WithAppearance(Appearance.Accent)
                     .WithClickAction(ctx =>
                     {
-                        ctx.Host.Hub.Post(
-                            new ExecuteScriptRequest(),
-                            o => o.WithTarget(hubAddress));
+                        if (canEdit)
+                            RunFromBuffer(ctx.Host, hubAddress);
+                        else
+                            ctx.Host.Hub.Post(
+                                new ExecuteScriptRequest(),
+                                o => o.WithTarget(hubAddress));
                         return Task.CompletedTask;
                     }),
                 RunButtonArea);
@@ -314,21 +373,13 @@ public static class CodeLayoutAreas
             }
         }
 
-        if (canEdit)
+        if (!canEdit)
         {
-            // Direct edit navigation — ONLY for viewers holding Update on the node.
-            toolbar = toolbar.WithView(Controls.Button("")
-                    .WithIconStart(FluentIcons.Edit())
-                    .WithAppearance(Appearance.Accent)
-                    .WithNavigateToHref(new LayoutAreaReference(EditArea).ToHref(hubAddress)),
-                EditButtonArea);
-        }
-        else
-        {
-            // Read-only viewer: Edit still shows, but opens the copy-to-home
-            // dialog instead of navigating (no NavigateToHref — the click action
-            // drives the DialogControl area). Identity resolution + the actual
+            // Read-only viewer: Edit opens the copy-to-home dialog (no NavigateToHref — the
+            // click action drives the DialogControl area). Identity resolution + the actual
             // copy happen at CLICK time under the clicker's AccessContext.
+            // An EDITOR gets no Edit button at all: their cell IS the editor (see
+            // BuildContent) — there is no second mode to navigate to.
             var sourcePath = hubAddress.ToString();
             toolbar = toolbar.WithView(Controls.Button(LocalizationCatalog.Get("common.edit", locale))
                     .WithIconStart(FluentIcons.Edit())
@@ -389,6 +440,89 @@ public static class CodeLayoutAreas
         var (glyph, label) = ActivityLayoutAreas.StatusGlyph(lastActivity.Status, locale);
         return Controls.Body($"{glyph} {label}")
             .WithStyle($"font-weight: 600; color: {ActivityLayoutAreas.StatusColor(lastActivity.Status)};");
+    }
+
+    /// <summary>
+    /// The EDIT-MODE code segment: an inline Monaco bound to the cell buffer (seeded once in
+    /// <see cref="Content"/>), with Roslyn language services for C# and AUTO-SAVE back into this
+    /// node — the circuit-side <c>IMeshNodeStreamCache</c> seam (<c>CodeEditorView</c>), so the
+    /// debounced write carries the viewer's own identity. Every property is deterministic for a
+    /// given node + seed, so re-renders (each auto-save echoes a node emission) produce an
+    /// IDENTICAL control and the client diff leaves the live editor — and the cursor — alone.
+    /// </summary>
+    internal static UiControl BuildCellEditor(string sourcePath, string language, string editorHeight)
+    {
+        var editor = new CodeEditorControl()
+            .WithLanguage(language)
+            .WithHeight(editorHeight)
+            .WithLineNumbers(true)
+            .WithMinimap(false)
+            .WithWordWrap(true)
+            .WithAutoSave(sourcePath);
+        if (language == "csharp")
+            editor = editor.WithLanguageServer(OwnerPathOf(sourcePath), sourcePath);
+        return editor with
+        {
+            DataContext = LayoutAreaReference.GetDataPointer(CellBufferDataId),
+            Value = new JsonPointerReference(""),
+        };
+    }
+
+    /// <summary>
+    /// The compilation OWNER of a source path — the NodeType above <c>/Source/</c> when there is
+    /// one (siblings in scope), else the parent (a standalone script cell — e.g. a course
+    /// lesson's <c>{lesson}/Source/{cell}</c> — answers from the kernel's script environment).
+    /// Shared by the inline cell editor and the Edit area. Pure.
+    /// </summary>
+    internal static string OwnerPathOf(string sourcePath)
+    {
+        var sourceMarkerIdx = sourcePath.IndexOf("/Source/", StringComparison.Ordinal);
+        var lastSlashIdx = sourcePath.LastIndexOf('/');
+        return sourceMarkerIdx > 0
+            ? sourcePath.Substring(0, sourceMarkerIdx)
+            : lastSlashIdx > 0 ? sourcePath.Substring(0, lastSlashIdx) : sourcePath;
+    }
+
+    /// <summary>
+    /// Run for an EDITOR: persist the cell buffer FIRST, then execute. The kernel runs the
+    /// STORED code and the editor's auto-save is debounced, so the freshest keystrokes may not
+    /// have landed yet — executing without this save runs code the viewer is no longer looking
+    /// at. The save mirrors the Edit area's (snapshot both, write only when they differ, post
+    /// under the clicker's context); an unchanged buffer executes immediately.
+    /// </summary>
+    private static void RunFromBuffer(LayoutAreaHost host, Address hubAddress)
+    {
+        void Execute() => host.Hub.Post(new ExecuteScriptRequest(), o => o.WithTarget(hubAddress));
+        void Fail(string detail) => host.UpdateArea(DialogControl.DialogArea, Controls.Dialog(
+                Controls.Markdown($"**Save before run failed:**\n\n{detail}"), "Save Failed")
+            .WithSize("M").WithClosable(true));
+
+        host.Stream.GetDataStream<string>(CellBufferDataId).Take(1)
+            .CombineLatest(host.Workspace.GetMeshNodeStream().Take(1), (buffer, node) => (buffer, node))
+            .Take(1)
+            .Subscribe(t =>
+            {
+                var config = t.node.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions);
+                if (config is null || (config.Code ?? "") == (t.buffer ?? ""))
+                {
+                    Execute();
+                    return;
+                }
+                var delivery = host.Hub.Post(
+                    new DataChangeRequest { ChangedBy = host.Stream.ClientId }
+                        .WithUpdates(config with { Code = t.buffer }),
+                    o => o.WithTarget(hubAddress))!;
+                host.Hub.Observe(delivery).Subscribe(
+                    response =>
+                    {
+                        if (response.Message is DataChangeResponse { Log.Status: ActivityStatus.Succeeded })
+                            Execute();
+                        else
+                            Fail((response.Message as DataChangeResponse)?.Log.ToString()
+                                 ?? response.Message?.GetType().Name ?? "no response");
+                    },
+                    ex => Fail(ex.Message));
+            });
     }
 
     /// <summary>
@@ -712,14 +846,9 @@ public static class CodeLayoutAreas
         // Either way the editor completes exactly what that cell can actually compile, so
         // there is no longer a reason to leave standalone scripts without language services.
         var sourcePath = host.Hub.Address.ToString();
-        var sourceMarkerIdx = sourcePath.IndexOf("/Source/", StringComparison.Ordinal);
-        var lastSlashIdx = sourcePath.LastIndexOf('/');
-        var ownerPath = sourceMarkerIdx > 0
-            ? sourcePath.Substring(0, sourceMarkerIdx)
-            : lastSlashIdx > 0 ? sourcePath.Substring(0, lastSlashIdx) : sourcePath;
         CodeEditorLanguageServerConfig? lspConfig = language == "csharp"
             ? new CodeEditorLanguageServerConfig(
-                NodeTypePath: ownerPath,
+                NodeTypePath: OwnerPathOf(sourcePath),
                 SourcePath: sourcePath)
             : null;
 

--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -226,7 +226,9 @@ public static class CodeLayoutAreas
         // no separate page behind a button. Everyone else keeps the read-only fence rendering.
         if (canEdit)
         {
-            cell = cell.WithView(BuildCellEditor(hubAddress.ToString(), language, editorHeight),
+            // Address.Path, never ToString(): a hosted address stringifies as "path~host", and the
+            // editor uses this as the auto-save target and the LSP source path — both node paths.
+            cell = cell.WithView(BuildCellEditor(hubAddress.Path, language, editorHeight),
                 CellCodeArea);
         }
         else if (!string.IsNullOrEmpty(codeConfig?.Code))
@@ -380,7 +382,7 @@ public static class CodeLayoutAreas
             // copy happen at CLICK time under the clicker's AccessContext.
             // An EDITOR gets no Edit button at all: their cell IS the editor (see
             // BuildContent) — there is no second mode to navigate to.
-            var sourcePath = hubAddress.ToString();
+            var sourcePath = hubAddress.Path;
             toolbar = toolbar.WithView(Controls.Button(LocalizationCatalog.Get("common.edit", locale))
                     .WithIconStart(FluentIcons.Edit())
                     .WithClickAction(ctx =>
@@ -845,7 +847,9 @@ public static class CodeLayoutAreas
         //     the kernel's imports/references, the script globals in scope).
         // Either way the editor completes exactly what that cell can actually compile, so
         // there is no longer a reason to leave standalone scripts without language services.
-        var sourcePath = host.Hub.Address.ToString();
+        // Address.Path, never ToString(): a hosted address stringifies as "path~host", and both
+        // LSP paths must be the plain node path.
+        var sourcePath = host.Hub.Address.Path;
         CodeEditorLanguageServerConfig? lspConfig = language == "csharp"
             ? new CodeEditorLanguageServerConfig(
                 NodeTypePath: OwnerPathOf(sourcePath),

--- a/src/MeshWeaver.Layout/CodeEditorControl.cs
+++ b/src/MeshWeaver.Layout/CodeEditorControl.cs
@@ -76,6 +76,17 @@ public record CodeEditorControl() : UiControl<CodeEditorControl>(ModuleSetup.Mod
     /// </summary>
     public IReadOnlyList<CodeEditorDiagnostic>? Diagnostics { get; init; }
 
+    /// <summary>
+    /// Opt-in AUTO-SAVE: the path of the Code MeshNode this editor edits IN PLACE. When set,
+    /// the renderer persists the (debounced) editor text into that node's
+    /// <c>CodeConfiguration.Code</c> through the process-wide <c>IMeshNodeStreamCache</c> —
+    /// the same circuit-side seam the markdown editor's auto-save uses
+    /// (<see cref="MarkdownEditorControl.AutoSaveAddress"/>), so the write carries the
+    /// viewer's own identity and every reader on the path observes the patch in order.
+    /// Null = no auto-save (default; the classic bind-and-Save flow).
+    /// </summary>
+    public string? AutoSaveAddress { get; init; }
+
     /// <summary>Returns a copy with <paramref name="value"/> as its initial editor content.</summary>
     /// <param name="value">The initial text content of the editor.</param>
     /// <returns>A new instance with the updated Value.</returns>
@@ -129,6 +140,11 @@ public record CodeEditorControl() : UiControl<CodeEditorControl>(ModuleSetup.Mod
     /// <returns>A new instance with the updated Diagnostics.</returns>
     public CodeEditorControl WithDiagnostics(IReadOnlyList<CodeEditorDiagnostic> diagnostics) =>
         this with { Diagnostics = diagnostics };
+    /// <summary>Returns a copy that AUTO-SAVES the (debounced) editor text into the Code node at
+    /// <paramref name="nodePath"/> — see <see cref="AutoSaveAddress"/>.</summary>
+    /// <param name="nodePath">Path of the Code MeshNode this editor edits in place.</param>
+    /// <returns>A new instance with the updated AutoSaveAddress.</returns>
+    public CodeEditorControl WithAutoSave(string nodePath) => this with { AutoSaveAddress = nodePath };
 }
 
 /// <summary>

--- a/test/MeshWeaver.AI.Test/CodeCellEditRightsTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellEditRightsTest.cs
@@ -80,7 +80,8 @@ public class CodeCellEditRightsTest(ITestOutputHelper output) : MonolithMeshTest
         return match!;
     }
 
-    private async Task<ButtonControl> RenderEditButton(string codePath)
+    private async Task<(ISynchronizationStream<JsonElement> Stream, StackControl Cell, StackControl Toolbar)>
+        RenderCell(string codePath)
     {
         var workspace = GetClient().GetWorkspace();
         var reference = new LayoutAreaReference(CodeLayoutAreas.ContentArea);
@@ -98,21 +99,40 @@ public class CodeCellEditRightsTest(ITestOutputHelper output) : MonolithMeshTest
         var toolbar = (StackControl)(await stream
             .GetControlStream(FindArea(cell, CodeLayoutAreas.CellToolbarArea))
             .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        return (stream, cell, toolbar);
+    }
+
+    private async Task<ButtonControl> RenderEditButton(string codePath)
+    {
+        var (stream, _, toolbar) = await RenderCell(codePath);
         var edit = await stream
             .GetControlStream(FindArea(toolbar, CodeLayoutAreas.EditButtonArea))
             .Should().Within(10.Seconds()).Match(c => c is ButtonControl);
         return (ButtonControl)edit!;
     }
 
+    private static bool HasArea(IContainerControl container, string id) =>
+        container.Areas.Any(a => a.Area?.ToString() is { } s
+            && (s == id || s.EndsWith("/" + id, StringComparison.Ordinal)));
+
     [Fact(Timeout = 60000)]
-    public async Task Editor_Gets_Direct_Edit_Navigation()
+    public async Task Editor_Gets_Inline_Editor_And_No_Edit_Button()
     {
-        // Default circuit: the DevLogin admin (claim role Admin ⇒ Update).
+        // Default circuit: the DevLogin admin (claim role Admin ⇒ Update). Edit mode IS the
+        // mode for an editor: the cell's code segment is the inline Monaco editor (auto-saving
+        // into this node), and there is NO Edit button — no second mode to navigate to.
         var codePath = await SeedExecutableCode();
-        var edit = await RenderEditButton(codePath);
-        edit.NavigateToHref.Should().NotBeNull(
-            "a viewer with Update permission navigates straight to the Edit area");
-        edit.NavigateToHref!.ToString().Should().Contain(CodeLayoutAreas.EditArea);
+        var (stream, cell, toolbar) = await RenderCell(codePath);
+
+        HasArea(toolbar, CodeLayoutAreas.EditButtonArea).Should().BeFalse(
+            "an editor's cell already IS the editor — a dedicated Edit button is retired");
+
+        var code = await stream
+            .GetControlStream(FindArea(cell, CodeLayoutAreas.CellCodeArea))
+            .Should().Within(10.Seconds()).Match(c => c is CodeEditorControl);
+        code.Should().BeOfType<CodeEditorControl>()
+            .Which.AutoSaveAddress.Should().Be(codePath,
+                "the inline editor persists its debounced text back into THIS node");
     }
 
     [Fact(Timeout = 60000)]

--- a/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
@@ -83,7 +83,7 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             && (s == id || s.EndsWith("/" + id, StringComparison.Ordinal)));
 
     [Fact(Timeout = 60000)]
-    public async Task Toolbar_ContainsRunAndEdit_NoCancel_NoOutputEmbed_BeforeFirstRun()
+    public async Task Toolbar_ContainsRun_NoCancel_NoOutputEmbed_BeforeFirstRun()
     {
         var codePath = await SeedExecutableCode("\"hi\"");
         var workspace = GetClient().GetWorkspace();
@@ -118,26 +118,27 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             IndexOf(CodeLayoutAreas.CellToolbarArea),
             "the toolbar moved to the BOTTOM of the cell, below the output segment");
 
-        // (a) Toolbar contains Run (and Edit); no Cancel while nothing runs.
+        // (a) Toolbar contains Run; no Cancel while nothing runs — and NO Edit button for the
+        // DevLogin admin: a viewer holding Update renders the cell's code segment as the inline
+        // editor (edit mode IS the mode), so there is no second mode to navigate to. The
+        // read-only viewer's copy-to-home Edit variant is pinned by CodeCellEditRightsTest.
         var toolbarArea = FindArea(cell, CodeLayoutAreas.CellToolbarArea);
         var toolbar = (StackControl)(await stream.GetControlStream(toolbarArea)
             .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
         HasArea(toolbar, CodeLayoutAreas.RunButtonArea).Should().BeTrue(
             "executable Code node must surface Run in the cell toolbar");
-        HasArea(toolbar, CodeLayoutAreas.EditButtonArea).Should().BeTrue(
-            "Edit moved into the cell toolbar as well");
+        HasArea(toolbar, CodeLayoutAreas.EditButtonArea).Should().BeFalse(
+            "an editor's cell already IS the editor — the dedicated Edit button is retired");
         HasArea(toolbar, CodeLayoutAreas.CancelButtonArea).Should().BeFalse(
             "no activity is running — Cancel must not render");
 
-        // The DevLogin admin holds Update on the node — Edit is the DIRECT
-        // navigation button (rights-gated; the no-rights dialog variant is
-        // pinned by CodeCellEditRightsTest).
-        var editControl = await stream
-            .GetControlStream(FindArea(toolbar, CodeLayoutAreas.EditButtonArea))
-            .Should().Within(10.Seconds()).Match(c => c is not null);
-        editControl.Should().BeOfType<ButtonControl>()
-            .Which.NavigateToHref.Should().NotBeNull(
-                "an editor's Edit button navigates straight to the Edit area");
+        // …and the code segment renders as the inline Monaco editor auto-saving into this node.
+        var codeControl = await stream
+            .GetControlStream(FindArea(cell, CodeLayoutAreas.CellCodeArea))
+            .Should().Within(10.Seconds()).Match(c => c is CodeEditorControl);
+        codeControl.Should().BeOfType<CodeEditorControl>()
+            .Which.AutoSaveAddress.Should().Be(codePath,
+                "the inline editor persists its debounced text back into THIS node");
 
         var runControl = await stream
             .GetControlStream(FindArea(toolbar, CodeLayoutAreas.RunButtonArea))

--- a/test/MeshWeaver.Graph.Test/CodeCellEditorTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeCellEditorTest.cs
@@ -1,0 +1,68 @@
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the pure rules of the EDIT-MODE code cell (<c>CodeLayoutAreas.BuildCellEditor</c>):
+/// a viewer holding Update renders the cell's code segment as an inline Monaco editor —
+/// edit mode IS the mode, there is no Edit button and no second page. The editor control must
+/// be DETERMINISTIC for a given node + seed (every auto-save echoes a node emission and
+/// re-renders the cell; a control that varied would re-mount Monaco under the viewer's cursor).
+/// </summary>
+public class CodeCellEditorTest
+{
+    [Fact]
+    public void Editor_AutoSavesIntoTheNode_AndBindsTheCellBuffer()
+    {
+        var editor = (CodeEditorControl)CodeLayoutAreas.BuildCellEditor(
+            "Course/Lesson/Source/Cell", "csharp", "300px");
+
+        editor.AutoSaveAddress.Should().Be("Course/Lesson/Source/Cell",
+            "the debounced text persists back into THIS node");
+        editor.DataContext.Should().Be(LayoutAreaReference.GetDataPointer(CodeLayoutAreas.CellBufferDataId),
+            "the editor binds the once-seeded cell buffer, never a per-render id");
+        editor.Height.Should().Be("300px");
+    }
+
+    [Fact]
+    public void CSharp_GetsLanguageServices_ScopedToTheOwner()
+    {
+        var editor = (CodeEditorControl)CodeLayoutAreas.BuildCellEditor(
+            "Course/Lesson/Source/Cell", "csharp", "300px");
+
+        editor.LanguageServer.Should().NotBeNull("C# cells get live Roslyn diagnostics + completions");
+        editor.LanguageServer!.NodeTypePath.Should().Be("Course/Lesson");
+        editor.LanguageServer.SourcePath.Should().Be("Course/Lesson/Source/Cell");
+    }
+
+    [Fact]
+    public void OtherLanguages_GetNoLanguageServer()
+    {
+        var editor = (CodeEditorControl)CodeLayoutAreas.BuildCellEditor(
+            "Course/Lesson/Source/Cell", "python", "300px");
+
+        editor.LanguageServer.Should().BeNull("only C# has the Roslyn-backed language service");
+    }
+
+    [Fact]
+    public void OwnerPath_IsTheNodeAboveSource_ElseTheParent()
+    {
+        CodeLayoutAreas.OwnerPathOf("Type/Source/File.cs").Should().Be("Type");
+        CodeLayoutAreas.OwnerPathOf("Course/Lesson/Source/Cell").Should().Be("Course/Lesson");
+        CodeLayoutAreas.OwnerPathOf("A/B").Should().Be("A");
+        CodeLayoutAreas.OwnerPathOf("A").Should().Be("A");
+    }
+
+    [Fact]
+    public void EditorHeight_FollowsTheSeed_WithinTheClamp()
+    {
+        CodeLayoutAreas.CellEditorHeight(null).Should().Be("96px", "an empty cell keeps the floor");
+        CodeLayoutAreas.CellEditorHeight("one line").Should().Be("96px");
+        CodeLayoutAreas.CellEditorHeight(string.Join("\n", new string[10])).Should().Be("210px",
+            "ten lines at Monaco's 19px plus the chrome");
+        CodeLayoutAreas.CellEditorHeight(string.Join("\n", new string[100])).Should().Be("480px",
+            "a long example clamps rather than swallowing the page");
+    }
+}


### PR DESCRIPTION
## What

For a viewer holding Update, a Code node's Content cell now renders its code segment as an inline Monaco editor — edit mode IS the mode:

- **LSP-backed for C#** (same owner-path derivation the Edit area uses, now shared via `OwnerPathOf`).
- **Auto-saved** into the node through the circuit-side `IMeshNodeStreamCache.Update` seam — `CodeEditorControl.WithAutoSave(nodePath)` + the same `AutoSaveHandler` lifecycle the markdown editor's auto-save uses, so the debounced write carries the viewer's own identity and preserves every other `CodeConfiguration` field.
- **Run persists the buffer first** (`RunFromBuffer`): the kernel executes the STORED code and the auto-save is debounced, so executing without the save runs code the viewer is no longer looking at. An unchanged buffer executes immediately.
- **No ✎ Edit button for editors** — there is no second mode to navigate to. Read-only viewers keep the fence rendering and the copy-to-home Edit dialog unchanged; the Edit area itself stays for deep links and metadata edits.

The editor control is deterministic for a given node + seed (stable buffer data id, height fixed from the seed via `CellEditorHeight`), so the re-render each auto-save echo triggers never re-mounts Monaco under the viewer's cursor.

## Why

The cell rendered the same read-only fence to everyone and hid editing behind a button and a separate page. This is the core half of the course-examples arc: Systemorph/education#137 installs every lesson's `Source/` cells into the learner's space, Systemorph/MeshWeaver.Plugins#469 routes lessons to that copy — and this makes the copy's cells theirs to edit in place, everywhere a Code cell renders.

## Tested

- `dotnet build -c Release -p:CIRun=true -warnaserror`: clean.
- `MeshWeaver.Graph.Test`: 1114/1114 (includes new `CodeCellEditorTest` pinning the pure rules: auto-save target, buffer binding, LSP owner scoping, height clamp).
- `MeshWeaver.AI.Test` cell suites (10/10): `CodeCellLayoutTest` now pins Run-without-Edit + the inline editor at `CellCode`; `CodeCellEditRightsTest` pins editor-gets-editor / read-only-gets-copy-to-home-dialog; run/cancel/output-capture flows re-verified against a live mesh (the Run test exercises the save-before-run path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)