### PR TITLE
fix(release): run the images job in the release environment so Azure OIDC works on tag runs

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -18,6 +18,15 @@ permissions:
 jobs:
   images:
     runs-on: ubuntu-latest
+    # 🚨 The `release` environment is what makes the Azure OIDC login work on TAG runs. The
+    # github-actions-deploy managed identity's federated credentials match on the token's
+    # `sub` claim, which for a plain tag run is `…:ref:refs/tags/v<X>` — a NEW subject per
+    # release, unmatchable by the exact-match credentials a user-assigned MI supports (the
+    # v3.0.0-rc1 run failed AADSTS700213 exactly this way). Running the job in an environment
+    # makes the subject the STABLE `repo:Systemorph/MeshWeaver:environment:release`, covered by
+    # the `gh-env-release` federated credential — same pattern as the memex/atioz/memex-cloud
+    # deploy environments.
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why

`release-images.yml`'s ACR-mirror step logs into Azure via OIDC. A tag run presents subject `repo:Systemorph/MeshWeaver:ref:refs/tags/v<X>` — a **new subject for every release** — and the `github-actions-deploy` user-assigned managed identity only supports exact-match federated credentials (`main` + the three deploy environments). The `v3.0.0-rc1` run failed `AADSTS700213` exactly here, after all four GHCR image pushes had succeeded.

## Fix

`environment: release` on the images job → the OIDC subject becomes the stable `repo:Systemorph/MeshWeaver:environment:release`, covered by the new `gh-env-release` federated credential (provisioned today, alongside the repo's `release` environment). Same pattern as the memex/atioz/memex-cloud deploy environments.

For rc1 itself a one-off `gh-tag-v3-0-0-rc1` credential was added so the existing tag's run could be re-run to green; this PR is what makes rc2 and every future tag work without per-tag credentials.

No What's New entry: release-pipeline internal, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)