### PR TITLE
fix: a permission check that could not be ESTABLISHED answers so, instead of blocking the create

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -396,6 +396,48 @@ The user identity rides on the in-flight delivery's `AccessContext.ObjectId`; `R
 
 Two — and only two — blanket short-circuits exist before the fold: `WellKnownUsers.System` (→ `All | Sync | Compile`) and the mesh-node cache's hydrator identity `cache/mesh-node-cache` (→ `Read` only). **There is deliberately no global-admin short-circuit** — see "The Admin partition" above.
 
+### 🚨 The fold can produce NO answer, and that is a third outcome
+
+`GetEffectivePermissions` is a `CombineLatest` over the grant and policy reads of the target's scope
+and *every ancestor scope* — plus, through its `Zip` against the `Public` evaluation of the same
+path, a second copy of that same fold. `CombineLatest` emits only once **every** leg has emitted.
+
+A leg that **starves** never emits, never completes and never errors: `SyncedQueryMeshNodes` gates on
+`SeenInitial` over a merge containing a `Subject` that is never completed, so it can only stall. The
+fold therefore has **no terminal at all**, and a `.Take(1)` around it bounds the number of emissions
+rather than the wait. This is not hypothetical — it is the ordinary cross-silo shape, where the
+owning activation lives on a peer silo that is busy or has just gone away.
+
+Not every leg is like that, and the difference is deliberate. `ObserveGatedNodes` starts with
+`.StartWith(empty)` precisely so a slow leg cannot stall the fold — safe because a gate only ever
+*adds* `Read`. The grant and policy legs **must not** be seeded: "no grants yet" reads as a denial,
+which would be a silent wrong answer. So an unanswerable read cannot be projected onto the yes/no
+axis at all. It needs a third outcome:
+
+| Outcome | Means | Reported as |
+|---|---|---|
+| granted | the fold decided yes | operation proceeds |
+| denied | the fold decided no | `Unauthorized` — a statement about the caller's entitlements |
+| **could not be established** | the fold reached **no decision** | `NodeRejectionReason.Unavailable` → `Node{Creation,Deletion,Move}RejectionReason.Unavailable`, and `ErrorType.Unavailable` on the message gate |
+
+**Decision callers give the check a terminal; live subscribers do not.** `RlsNodeValidator` bounds
+its whole chain with `RowLevelSecurityOptions.PermissionEstablishmentBudget` (default 30 s —
+comfortably above any healthy cold fold, strictly below the 60 s hub `RequestTimeout`) and answers
+`Unavailable` past it. That is *not* a ceiling that turns a slow check into a denial: reporting a
+stalled read as a refusal sends a correctly-entitled caller to request permissions they already
+hold, and files an availability incident as a policy decision so nobody goes looking for the read
+that starved. It is still fail-**closed** — the operation does not proceed; it simply stops claiming
+to know why. Same vocabulary and the same reasoning as `CompilationStatus.Unavailable` for a starved
+*source* read, and as `PermissionCheckOutcome.Undetermined`, which already gives the message gate
+this distinction for a *faulted* fold.
+
+A live UI subscription is the opposite case and keeps no bound: it is not owed an answer by a
+deadline, and it must re-emit when the grants finally land.
+
+Before this existed, `CreateNodeRequest` simply sat `Executing` — 33 s in the reported case — until
+its *caller's* `RequestTimeout` ended it, which names the caller's impatience rather than the read
+that starved (#1446).
+
 ## Reactive update semantics
 
 When an `AccessAssignment` is created at scope `S`:

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -418,7 +418,13 @@ axis at all. It needs a third outcome:
 |---|---|---|
 | granted | the fold decided yes | operation proceeds |
 | denied | the fold decided no | `Unauthorized` — a statement about the caller's entitlements |
-| **could not be established** | the fold reached **no decision** | `NodeRejectionReason.Unavailable` → `Node{Creation,Deletion,Move}RejectionReason.Unavailable`, and `ErrorType.Unavailable` on the message gate |
+| **could not be established** | the fold reached **no decision** | `NodeRejectionReason.Unavailable` → `Node{Creation,Deletion,Move}RejectionReason.Unavailable` |
+
+The message gate has the same *vocabulary* but a narrower reach: `CheckPermissionOutcome` catches a
+**faulted** fold as `Undetermined` → `ErrorType.Unavailable`. It deliberately carries **no** bound
+(see its "No Timeout here" comment), so a **silent** starvation still parks a `[RequiresPermission]`
+delivery there. Giving the gate a terminal for that case changes the behaviour of every gated
+message and wants its own argument; the node-operation validator below is bounded today.
 
 **Decision callers give the check a terminal; live subscribers do not.** `RlsNodeValidator` bounds
 its whole chain with `RowLevelSecurityOptions.PermissionEstablishmentBudget` (default 30 s —

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-permission-check-that-never-answered.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-permission-check-that-never-answered.md
@@ -1,0 +1,30 @@
+---
+Name: A stuck permission check no longer freezes creating things
+Category: Fix
+Description: When the security layer cannot read a node's permissions, creating, moving or deleting there now fails immediately and says the check could not be established — instead of sitting silently until the request gives up.
+Icon: ShieldError
+Order: -20260813
+---
+
+# A stuck permission check no longer freezes creating things
+
+Creating a node runs a permission check first, and that check reads the grants and policies of the
+target's location and every location above it. Normally those reads are instant. When one of them
+cannot be answered — the copy of the data being asked for lives on a machine that is busy or has
+just gone away — the check produced **nothing at all**: no yes, no no, not even an error. And a
+create waiting on nothing waits forever.
+
+What you saw was a create, move or delete that simply never came back, and eventually an unhelpful
+"no response received" from the request itself — naming your own request as the thing that timed
+out rather than the read that stalled. Nothing in the failure pointed at the real cause, so the
+obvious next step was to try again, into exactly the same stall.
+
+Now the check has a definite ending. If it cannot be established within its budget, the operation
+stops and says so: **the permission check could not be established** — naming the location whose
+read did not answer. That is deliberately not the same as "access denied". Reporting a stalled read
+as a refusal is worse than useless: it tells you to go and request permissions you already have, and
+it hides an infrastructure problem behind what looks like a policy decision. The operation still
+does not go ahead — it simply stops pretending to know why, and retrying is now meaningful.
+
+A related gap closed with it: asking a node for your permissions could leave the question
+unanswered if the underlying read finished without producing a value. It now always answers.

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -3,7 +3,9 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace MeshWeaver.Graph.Security;
 
@@ -16,6 +18,7 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
     private readonly IMessageHub _hub;
     private readonly ILogger<RlsNodeValidator> _logger;
     private readonly IReadOnlyDictionary<string, INodeTypeAccessRule> _accessRules;
+    private readonly TimeSpan _establishmentBudget;
 
     /// <summary>
     /// Initializes a new instance of the row-level-security node validator.
@@ -33,6 +36,10 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
         _accessRules = accessRules
             .GroupBy(r => r.NodeType, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
+        // Genuinely optional configuration — a host that sets nothing gets the production default.
+        _establishmentBudget =
+            (hub.ServiceProvider.GetService<IOptions<RowLevelSecurityOptions>>()?.Value
+                ?? new RowLevelSecurityOptions()).PermissionEstablishmentBudget;
     }
 
     /// <summary>
@@ -115,14 +122,76 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
         // (synchronous, by contract) change-feed fan-out run inside that lock, which is one
         // half of the two-hub lock-order inversion. Placing it here rather than inside
         // CheckPermission covers the custom-rule path too.
+        var pathToCheck = PathToCheck(context);
+
         return CheckHubRule(context, userId)
             .SelectMany(hubResult => hubResult != null
                 ? Observable.Return<NodeValidationResult?>(hubResult)
                 : CheckCustomRule(context, userId))
             .SelectMany(customResult => customResult != null
                 ? Observable.Return(customResult)
-                : CheckPermission(context, userId, requiredPermission))
-            .TakeDecisionOutsideGate();
+                : CheckPermission(context, userId, requiredPermission, pathToCheck))
+            .TakeDecisionOutsideGate()
+            // 🚨 THE TERMINAL. Placed here rather than inside CheckPermission so it covers EVERY
+            // branch: CheckCustomRule's INodeTypeAccessRule implementations reach the same
+            // permission fold, and the denial path's ownerless-partition probe is a mesh read too.
+            // See UnestablishedCheck for why this chain otherwise has no terminal at all (#1446).
+            .Timeout(_establishmentBudget)
+            .Catch((Exception ex) =>
+                Observable.Return(UnestablishedCheck(context, userId, pathToCheck, ex)));
+    }
+
+    /// <summary>
+    /// The scope a decision is taken on: for a CREATE that is the PARENT (the node itself does not
+    /// exist yet and carries no grants), for everything else the node's own path.
+    /// </summary>
+    private static string PathToCheck(NodeValidationContext context)
+        => context.Operation == NodeOperation.Create
+            ? context.Node.GetParentPath() ?? context.Node.Path
+            : context.Node.Path;
+
+    /// <summary>
+    /// 🚨 The result when this validator reached NO decision — #1446, and the ONLY terminal the
+    /// chain above is guaranteed to have.
+    ///
+    /// <para>Everything on the way to a verdict can fail to produce ANY outcome. The fold behind
+    /// <c>GetEffectivePermissions</c> is a <c>CombineLatest</c> over the grant and policy reads of
+    /// the target's scope and every ancestor scope — and, through its <c>Zip</c> against the
+    /// <c>Public</c> evaluation of the same path, a second copy of that fold. A leg that STARVES
+    /// (the cross-silo case: the owning activation lives on a peer silo that never answers) never
+    /// emits, never completes and never errors — <c>SyncedQueryMeshNodes</c> gates on
+    /// <c>SeenInitial</c> over a merge containing a Subject that is never completed, so the leg can
+    /// only stall. <c>TakeDecisionOutsideGate</c>'s <c>Take(1)</c> bounds the number of EMISSIONS,
+    /// not the wait, so <c>RunCreationValidatorsObs</c>'s <c>Concat</c> then blocked on validator #1
+    /// with nothing left to end it: <c>CreateNodeRequest</c> sat <c>Executing</c> for 33 s until its
+    /// CALLER's <c>RequestTimeout</c> gave up — which reports the caller's impatience rather than
+    /// the read that starved.</para>
+    ///
+    /// <para>🚨 <b>This is not a ceiling that turns a slow check into a denial.</b> The answer past
+    /// the budget is UNAVAILABLE — neither a grant (unsafe) nor a denial (a lie that sends a
+    /// correctly-entitled caller to request permissions they already hold, and files an availability
+    /// incident as a policy decision so nobody looks for the read that starved). Same vocabulary and
+    /// the same reasoning as <c>CompilationStatus.Unavailable</c> for a starved SOURCE read (#1218),
+    /// and as <c>PermissionCheckOutcome.Undetermined</c>, which already gives the message GATE this
+    /// distinction for a FAULTED fold. A fault is folded in here for the same reason: it says the
+    /// check could not be established, not that access is refused. Still fail-CLOSED — the operation
+    /// does not proceed; it just stops claiming to know why.</para>
+    /// </summary>
+    private NodeValidationResult UnestablishedCheck(
+        NodeValidationContext context, string? userId, string pathToCheck, Exception cause)
+    {
+        _logger.LogWarning(cause,
+            "RLS: the {Operation} permission check on {Path} could NOT be established — the "
+            + "effective-permission read of {CheckedPath} for {UserId} did not answer within "
+            + "{Budget}. Reporting an availability failure, not a decision",
+            context.Operation, context.Node.Path, pathToCheck, userId ?? "(anonymous)",
+            _establishmentBudget);
+
+        return NodeValidationResult.Unavailable(
+            $"The {context.Operation} permission check for node '{context.Node.Path}' could not be "
+            + $"established: the effective-permission read of '{pathToCheck}' did not answer within "
+            + $"{_establishmentBudget.TotalSeconds:0}s. This is an availability failure, NOT a "
+            + "decision about your access — the operation was not evaluated and may be retried.");
     }
 
     private IObservable<NodeValidationResult?> CheckHubRule(NodeValidationContext context, string? userId)
@@ -164,11 +233,9 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
     }
 
     private IObservable<NodeValidationResult> CheckPermission(
-        NodeValidationContext context, string? userId, Permission requiredPermission)
+        NodeValidationContext context, string? userId, Permission requiredPermission,
+        string pathToCheck)
     {
-        var pathToCheck = context.Operation == NodeOperation.Create
-            ? context.Node.GetParentPath() ?? context.Node.Path
-            : context.Node.Path;
         var effectiveUserId = userId ?? WellKnownUsers.Anonymous;
 
         // 🚨 Permission.Sync is a write-authoriser that bypasses the content read-only cap: a

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -180,18 +180,25 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
     private NodeValidationResult UnestablishedCheck(
         NodeValidationContext context, string? userId, string pathToCheck, Exception cause)
     {
+        // Both roads lead here, and they are NOT the same defect: a stall means nothing answered,
+        // a fault means something answered badly. Saying "did not answer within 30s" about a
+        // NullReferenceException would point the reader at a starving peer silo that was never
+        // involved — the same mis-naming this fix exists to stop doing to the CALLER.
+        var why = cause is TimeoutException
+            ? $"did not answer within {_establishmentBudget.TotalSeconds:0}s"
+            : $"failed ({cause.GetType().Name}: {cause.Message})";
+
         _logger.LogWarning(cause,
             "RLS: the {Operation} permission check on {Path} could NOT be established — the "
-            + "effective-permission read of {CheckedPath} for {UserId} did not answer within "
-            + "{Budget}. Reporting an availability failure, not a decision",
-            context.Operation, context.Node.Path, pathToCheck, userId ?? "(anonymous)",
-            _establishmentBudget);
+            + "effective-permission read of {CheckedPath} for {UserId} {Why}. Reporting an "
+            + "availability failure, not a decision",
+            context.Operation, context.Node.Path, pathToCheck, userId ?? "(anonymous)", why);
 
         return NodeValidationResult.Unavailable(
             $"The {context.Operation} permission check for node '{context.Node.Path}' could not be "
-            + $"established: the effective-permission read of '{pathToCheck}' did not answer within "
-            + $"{_establishmentBudget.TotalSeconds:0}s. This is an availability failure, NOT a "
-            + "decision about your access — the operation was not evaluated and may be retried.");
+            + $"established: the effective-permission read of '{pathToCheck}' {why}. This is an "
+            + "availability failure, NOT a decision about your access — the operation was not "
+            + "evaluated and may be retried.");
     }
 
     private IObservable<NodeValidationResult?> CheckHubRule(NodeValidationContext context, string? userId)

--- a/src/MeshWeaver.Graph/Security/RowLevelSecurityOptions.cs
+++ b/src/MeshWeaver.Graph/Security/RowLevelSecurityOptions.cs
@@ -1,0 +1,30 @@
+namespace MeshWeaver.Graph.Security;
+
+/// <summary>
+/// Tunables for row-level security enforcement. Registered through the ordinary options pipeline
+/// (<c>services.Configure&lt;RowLevelSecurityOptions&gt;(...)</c>); every value has a production
+/// default, so a host that configures nothing behaves exactly as before.
+/// </summary>
+public sealed class RowLevelSecurityOptions
+{
+    /// <summary>
+    /// How long <see cref="RlsNodeValidator"/> waits for the effective-permission fold to reach a
+    /// verdict before reporting that the check could not be ESTABLISHED (#1446).
+    ///
+    /// <para>🚨 This is not a ceiling that turns a slow check into a denial — it is what gives the
+    /// check a TERMINAL at all. The fold is a <c>CombineLatest</c> over the grant and policy reads
+    /// of the target's scope and every ancestor scope; a leg that starves (the cross-silo case,
+    /// where the owning activation lives on a peer silo) never emits, never completes and never
+    /// errors, so the fold cannot produce any outcome, and the <c>.Take(1)</c> around it bounds the
+    /// number of emissions rather than the wait. Past this budget the validator answers
+    /// <see cref="Mesh.Services.NodeRejectionReason.Unavailable"/> — neither a grant nor a denial —
+    /// so the operation reports its own availability failure instead of sitting until its CALLER
+    /// gives up.</para>
+    ///
+    /// <para>Default 30 s: comfortably above any healthy cold fold (sub-second warm, low seconds
+    /// cold), and strictly below the 60 s hub <c>RequestTimeout</c> that would otherwise be the
+    /// only thing that ever ended the wait — which is the whole point, because a request killed by
+    /// its caller reports the caller's timeout rather than the read that starved.</para>
+    /// </summary>
+    public TimeSpan PermissionEstablishmentBudget { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -408,14 +408,33 @@ public static class AccessControlPipeline
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         var userId = ResolveIdentity(request, accessService) ?? WellKnownUsers.Anonymous;
 
+        // 🚨 EVERY terminal answers — #1362/#1364's rule, applied here too (#1446). The fold can
+        // complete WITHOUT emitting (an empty static seed plus an `enriched` leg that completes
+        // having produced nothing), and a Subscribe with no completion arm discards that terminal
+        // silently: the request is then owed a reply that nobody will ever post, and the caller
+        // learns about it only when its own RequestTimeout fires — naming the caller's impatience
+        // rather than the fold that produced nothing. DefaultIfEmpty turns "completed with no
+        // verdict" into an explicit one, so all three arms lead to exactly one Post.
         hub.GetEffectivePermissions(ownPath, userId)
             .Take(1)
+            .Select(perms => (Permission?)perms)
+            .DefaultIfEmpty(null)
             .Subscribe(perms =>
             {
-                logger?.LogDebug("[GP] reply hub={Hub} user={User} perms={Perms}", ownPath, userId, perms);
-                hub.Post(new GetPermissionResponse(perms), o => o.ResponseFor(request));
+                if (perms is null)
+                    logger?.LogWarning(
+                        "[GP] the permission fold for hub={Hub} user={User} COMPLETED without a "
+                        + "verdict — answering None rather than leaving the request unanswered",
+                        ownPath, userId);
+                else
+                    logger?.LogDebug("[GP] reply hub={Hub} user={User} perms={Perms}", ownPath, userId, perms);
+                hub.Post(new GetPermissionResponse(perms ?? Permission.None), o => o.ResponseFor(request));
             },
-            ex => logger?.LogWarning(ex, "[GP] stream error hub={Hub}", ownPath));
+            ex =>
+            {
+                logger?.LogWarning(ex, "[GP] stream error hub={Hub}", ownPath);
+                hub.Post(new GetPermissionResponse(Permission.None), o => o.ResponseFor(request));
+            });
 
         return request.Processed();
     }

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -110,7 +110,19 @@ public enum NodeCreationRejectionReason
     /// <summary>
     /// Node content validation failed.
     /// </summary>
-    ValidationFailed
+    ValidationFailed,
+
+    /// <summary>
+    /// The create was NOT evaluated: a check it depends on could not be established (#1446) —
+    /// typically the security layer's grant/policy reads over the target's scope starving on a
+    /// cross-silo activation that never answers.
+    ///
+    /// <para>🚨 An availability failure, not a verdict. Before this existed the create had no way to
+    /// say so and simply sat Executing until the caller's <c>RequestTimeout</c> ended it, which
+    /// reports the caller's impatience rather than the read that starved. Retrying is meaningful
+    /// here in a way it never is for <see cref="ValidationFailed"/>.</para>
+    /// </summary>
+    Unavailable
 }
 
 /// <summary>
@@ -348,7 +360,13 @@ public enum NodeDeletionRejectionReason
     /// warnings (from <see cref="DeleteNodeResponse.Log"/>) and re-issue the request with
     /// <c>ConfirmWarnings=true</c> to proceed.
     /// </summary>
-    WarningsRequireConfirmation
+    WarningsRequireConfirmation,
+
+    /// <summary>
+    /// The delete was NOT evaluated: a check it depends on could not be established (#1446).
+    /// See <see cref="NodeCreationRejectionReason.Unavailable"/>.
+    /// </summary>
+    Unavailable
 }
 
 /// <summary>
@@ -653,7 +671,13 @@ public enum NodeMoveRejectionReason
     /// <summary>
     /// Move validation failed.
     /// </summary>
-    ValidationFailed
+    ValidationFailed,
+
+    /// <summary>
+    /// The move was NOT evaluated: a check it depends on could not be established (#1446).
+    /// See <see cref="NodeCreationRejectionReason.Unavailable"/>.
+    /// </summary>
+    Unavailable
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -3254,6 +3254,9 @@ public static class MeshExtensions
                     NodeRejectionReason.InvalidNodeType => NodeCreationRejectionReason.InvalidNodeType,
                     NodeRejectionReason.InvalidPath => NodeCreationRejectionReason.InvalidPath,
                     NodeRejectionReason.Unauthorized => NodeCreationRejectionReason.ValidationFailed,
+                    // 🚨 An unestablished check must NOT arrive as ValidationFailed (#1446) — that
+                    // is the collapse the distinction exists to prevent.
+                    NodeRejectionReason.Unavailable => NodeCreationRejectionReason.Unavailable,
                     _ => NodeCreationRejectionReason.ValidationFailed
                 };
                 return ((string?, NodeCreationRejectionReason)?)(result.ErrorMessage, reason);
@@ -3455,6 +3458,7 @@ public static class MeshExtensions
                     NodeRejectionReason.NodeNotFound => NodeDeletionRejectionReason.NodeNotFound,
                     NodeRejectionReason.HasChildren => NodeDeletionRejectionReason.HasChildren,
                     NodeRejectionReason.Unauthorized => NodeDeletionRejectionReason.ValidationFailed,
+                    NodeRejectionReason.Unavailable => NodeDeletionRejectionReason.Unavailable,
                     _ => NodeDeletionRejectionReason.ValidationFailed
                 };
                 return ((string?, NodeDeletionRejectionReason)?)(result.ErrorMessage, reason);
@@ -4293,6 +4297,7 @@ public static class MeshExtensions
                 {
                     NodeRejectionReason.NodeNotFound => NodeMoveRejectionReason.SourceNotFound,
                     NodeRejectionReason.Unauthorized => NodeMoveRejectionReason.ValidationFailed,
+                    NodeRejectionReason.Unavailable => NodeMoveRejectionReason.Unavailable,
                     _ => NodeMoveRejectionReason.ValidationFailed
                 };
                 return ((string?, NodeMoveRejectionReason)?)(result.ErrorMessage, reason);

--- a/src/MeshWeaver.Mesh.Contract/Services/INodeValidator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/INodeValidator.cs
@@ -133,6 +133,14 @@ public record NodeValidationResult(bool IsValid, string? ErrorMessage = null, No
     /// </summary>
     public static NodeValidationResult NotFound(string? path = null)
         => new(false, path != null ? $"Node not found at path: {path}" : "Node not found", NodeRejectionReason.NodeNotFound);
+
+    /// <summary>
+    /// Creates a "could not be established" result — the validator reached NO decision because a
+    /// read it depends on did not answer. See <see cref="NodeRejectionReason.Unavailable"/> for why
+    /// this must never be collapsed into <see cref="Unauthorized"/>.
+    /// </summary>
+    public static NodeValidationResult Unavailable(string message)
+        => new(false, message, NodeRejectionReason.Unavailable);
 }
 
 /// <summary>
@@ -215,7 +223,23 @@ public enum NodeRejectionReason
     /// <summary>
     /// The node is hidden from the user.
     /// </summary>
-    NodeHidden
+    NodeHidden,
+
+    /// <summary>
+    /// The validator reached NO decision: a read it depends on could not be established (#1446).
+    ///
+    /// <para>🚨 Deliberately distinct from <see cref="Unauthorized"/>, and the distinction is the
+    /// whole point. "Denied" is a statement about the caller's entitlements; this is a statement
+    /// about the infrastructure. Collapsing the two sends a correctly-entitled user to request
+    /// permissions they already hold, and — worse — makes an availability incident look like a
+    /// policy decision, so nobody goes looking for the read that starved. Same reasoning, and the
+    /// same vocabulary, as <c>CompilationStatus.Unavailable</c> (#1218) and
+    /// <c>PermissionCheckOutcome.Undetermined</c>.</para>
+    ///
+    /// <para>Still fail-CLOSED: the operation does not proceed. It simply stops claiming to know
+    /// why.</para>
+    /// </summary>
+    Unavailable
 }
 
 /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/StarvedPermissionReadTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StarvedPermissionReadTest.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Issue #1446 — <b>a permission check that could not be ESTABLISHED is not a decision, and a
+/// create must not sit on it.</b>
+///
+/// <para><b>What happens.</b> Creating a node runs the security layer's grant and policy reads —
+/// <c>namespace:{scope}/_Access nodeType:AccessAssignment</c> and
+/// <c>namespace:{scope} id:_Policy nodeType:PartitionAccessPolicy</c> — over the target's scope and
+/// every ancestor scope. <c>PermissionEvaluator</c> folds them with
+/// <see cref="System.Reactive.Linq.Observable.CombineLatest{T1,T2,TResult}(IObservable{T1},IObservable{T2},Func{T1,T2,TResult})"/>,
+/// which emits only once EVERY leg has emitted. A leg that starves — the cross-silo case, where the
+/// owning activation lives on a peer silo that never answers — never emits, never completes and
+/// never errors: <c>SyncedQueryMeshNodes</c> gates on <c>SeenInitial</c> over a merge containing a
+/// Subject that is never completed, so the leg can only STALL. The fold therefore has no terminal at
+/// all, the <c>.Take(1)</c> in <c>RlsNodeValidator</c> bounds the number of emissions rather than the
+/// wait, and the validator <c>Concat()</c> in <c>RunCreationValidatorsObs</c> blocks on validator
+/// #1. Observed in the hub snapshot at teardown:</para>
+///
+/// <code>
+/// Hub portal/nodeops-… RunLevel=Started Disposal=Pending
+///   Queue(buffer=2, …) Executing(CreateNodeRequest, 33014ms)
+/// </code>
+///
+/// <para><b>Why the existing recovery does not cover it.</b> The faulted-query eviction (#1367) fixes
+/// the CACHE — a <c>Replay(1)</c> that latched a terminal is dropped so the next <c>GetQuery</c>
+/// opens a fresh upstream. It cannot help here twice over: a starved read has no terminal to latch,
+/// and the caller already blocked on the fold is not waiting on the cache entry.</para>
+///
+/// <para><b>The shape of the fix</b> is the one #1218 introduced for source discovery: an
+/// availability failure is reported AS an availability failure —
+/// <c>SourceDiscoveryUnavailableException</c> / <c>CompilationStatus.Unavailable</c> there,
+/// <see cref="NodeCreationRejectionReason.Unavailable"/> here — never mistaken for a verdict about
+/// the thing being checked. A create whose permission check could not be established answers
+/// "could not establish", which is neither a grant (unsafe) nor a denial (a lie that sends a
+/// correctly-entitled user to ask for permissions they already hold).</para>
+///
+/// <para>🚨 <b>Why <c>ConfigureMeshBase</c> and not <c>ConfigureMesh</c>.</b> The default test mesh
+/// adds a STATIC root grant for <c>Public</c> (<c>TestUsers.PublicAdminAccess</c>), and a static
+/// grant seeds <c>PermissionEvaluator</c>'s synchronous fast path so the synced legs are never
+/// awaited at all. Production has no such thing — <c>Public</c>'s grants are durable rows — and
+/// every user's fold <c>Zip</c>s against the <c>Public</c> evaluation of the same path, so in a real
+/// portal the starving legs gate EVERY caller's answer, statically-granted admins included. Opting
+/// out of the seed is what makes this suite model production rather than the harness.</para>
+/// </summary>
+public class StarvedPermissionReadTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "StarvedPermissionTest";
+
+    /// <summary>The scope whose grant/policy reads never answer — the create target's parent.</summary>
+    internal const string StarvedScope = $"{Partition}/Starved";
+
+    /// <summary>A sibling scope whose reads are healthy — the control.</summary>
+    private const string HealthyScope = $"{Partition}/Healthy";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Partition) { Name = "Starved Permission Test", NodeType = "Markdown" })
+            .ConfigureServices(services => services
+                // Mesh-scoped singleton (no static state) — it dies with the mesh.
+                .AddSingleton<StarvedSecurityQueryProvider>()
+                .AddSingleton<IMeshQueryProvider>(sp =>
+                    sp.GetRequiredService<StarvedSecurityQueryProvider>())
+                // Short establishment budget so the test spends seconds, not the production
+                // default, proving the property. Same device as #1218's SourceSnapshotTimeout.
+                .Configure<RowLevelSecurityOptions>(o =>
+                    o.PermissionEstablishmentBudget = TimeSpan.FromSeconds(5)));
+
+    /// <summary>
+    /// 🚨 THE PIN. Two creates, identical in every way except one: one target's scope has security
+    /// reads that never answer, the other's are healthy.
+    ///
+    /// <para><b>Before the fix</b> the starved create never answers at all — it sits Executing until
+    /// the caller's <c>RequestTimeout</c> gives up, which is a hang reported as the caller's fault
+    /// rather than the read's.</para>
+    ///
+    /// <para><b>After the fix</b> it answers <see cref="NodeCreationRejectionReason.Unavailable"/>
+    /// naming the check that could not be established. The healthy create is untouched.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task StarvedPermissionRead_AnswersUnavailable_WhileAHealthyScopeStillCreates()
+    {
+        // The two scopes exist before either is starved — their own creates are checked against
+        // the PARTITION scope, which is never starved.
+        await NodeFactory.CreateNode(new MeshNode("Starved", Partition)
+        {
+            Name = "Starved scope", NodeType = "Markdown"
+        }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("Healthy", Partition)
+        {
+            Name = "Healthy scope", NodeType = "Markdown"
+        }).Should().Within(30.Seconds()).Emit();
+
+        // ── The control: a healthy scope still creates, so the starve is what makes the
+        //    difference and not the fixture. ────────────────────────────────────────────────────
+        var healthy = await AwaitResponseAsync(
+            new CreateNodeRequest(new MeshNode("leaf", HealthyScope)
+            {
+                Name = "Healthy leaf", NodeType = "Markdown"
+            }));
+        healthy.Message.Success.Should().Be(true,
+            $"a healthy scope must be unaffected — got {healthy.Message.RejectionReason}: {healthy.Message.Error}");
+
+        // ── The pin: the starved scope ANSWERS, and says what it could not do. ─────────────────
+        var started = Stopwatch.StartNew();
+        var starved = await AwaitResponseAsync(
+            new CreateNodeRequest(new MeshNode("leaf", StarvedScope)
+            {
+                Name = "Starved leaf", NodeType = "Markdown"
+            }));
+        started.Stop();
+        Output.WriteLine(
+            $"=== STARVED CREATE → {starved.Message.RejectionReason}: {starved.Message.Error} "
+            + $"(after {started.Elapsed.TotalSeconds:0.0}s)");
+
+        starved.Message.Success.Should().Be(false);
+
+        // 1️⃣ An unestablished permission check is an AVAILABILITY failure, never a verdict.
+        starved.Message.RejectionReason.Should().Be(NodeCreationRejectionReason.Unavailable,
+            "the check never reached a decision, so reporting ValidationFailed/Unauthorized would "
+            + "send a correctly-entitled caller to request permissions they already hold — the same "
+            + "mistake #1218 fixed for a starved source read reported as a compile error");
+        starved.Message.Error.Should().Contain("could not be established",
+            "the message must name the true defect — the security read that did not answer");
+
+        // 2️⃣ …and it answered rather than sat. The bound is the ESTABLISHMENT budget configured
+        //    above; before the fix nothing bounded this and the caller's RequestTimeout was the
+        //    only thing that ever ended the wait.
+        (started.Elapsed < TimeSpan.FromSeconds(45)).Should().Be(true,
+            $"the create must answer on its own budget, not be killed by its caller — took {started.Elapsed}");
+    }
+}
+
+/// <summary>
+/// The cross-silo starvation stand-in, scoped to the SECURITY reads of exactly one node scope.
+/// Every other query gets an immediate empty <c>Initial</c> (well-behaved: exactly one Initial,
+/// never completes) so the rest of the mesh — node creation into the healthy scope included — keeps
+/// working, which is what makes the starve the only variable.
+///
+/// <para>🚨 It goes SILENT rather than throwing. A throwing query has a terminal, and a terminal
+/// propagates: the create fails fast today. Real cross-silo starvation is the silent shape — the
+/// owning activation lives on a peer silo and simply never answers — and that is the one with no
+/// terminal anywhere in the fold.</para>
+/// </summary>
+public sealed class StarvedSecurityQueryProvider : IMeshQueryProvider
+{
+    /// <inheritdoc />
+    public string Name => nameof(StarvedSecurityQueryProvider);
+
+    /// <inheritdoc />
+    public bool Matches(IReadOnlyList<string> queryNamespaces) => true;
+
+    /// <summary>
+    /// The grant and policy reads of <see cref="StarvedPermissionReadTest.StarvedScope"/> —
+    /// <c>namespace:{scope}/_Access nodeType:AccessAssignment</c> and
+    /// <c>namespace:{scope} id:_Policy nodeType:PartitionAccessPolicy</c>. Matched on the scope AND
+    /// a security node type, so ordinary reads and writes under the same subtree keep working;
+    /// ancestor scopes are NOT matched, so only the deepest leg of the scope walk starves — which is
+    /// enough, because <c>CombineLatest</c> holds the whole chain on it.
+    /// </summary>
+    private static bool IsStarvedSecurityRead(string? query) =>
+        query is not null
+        && query.Contains(StarvedPermissionReadTest.StarvedScope, StringComparison.OrdinalIgnoreCase)
+        && (query.Contains("nodeType:AccessAssignment", StringComparison.OrdinalIgnoreCase)
+            || query.Contains("nodeType:PartitionAccessPolicy", StringComparison.OrdinalIgnoreCase));
+
+    /// <inheritdoc />
+    public IObservable<QueryResultChange<T>> Query<T>(
+        MeshQueryRequest request, JsonSerializerOptions options)
+        => Observable.Create<QueryResultChange<T>>(observer =>
+        {
+            if (request.EffectiveQueries.Any(IsStarvedSecurityRead))
+                return Disposable.Empty;   // subscribed, and never heard from again
+
+            observer.OnNext(new QueryResultChange<T>
+            {
+                ChangeType = QueryChangeType.Initial,
+                Items = Array.Empty<T>(),
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+            return Disposable.Empty;
+        });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+        string basePath, string prefix, JsonSerializerOptions options,
+        AutocompleteMode mode = AutocompleteMode.RelevanceFirst,
+        int limit = 10,
+        string? contextPath = null,
+        string? context = null)
+        => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+    /// <inheritdoc />
+    public IObservable<T?> Select<T>(string path, string property, JsonSerializerOptions options)
+        => Observable.Return(default(T?));
+}


### PR DESCRIPTION
Fixes #1446.

## What the wait was waiting on, and why it could not arrive

`CreateNodeRequest` runs the security layer's grant and policy reads over the target's scope **and
every ancestor scope**:

```
namespace:{…}/Source/_Access  nodeType:AccessAssignment
namespace:{…}/Source          id:_Policy  nodeType:PartitionAccessPolicy
```

`PermissionEvaluator` folds them with `CombineLatest`, which emits only once **every** leg has
emitted — and through its `Zip` against the `Public` evaluation of the same path it depends on a
*second* copy of that same fold. A leg that **starves** — the cross-silo case this suite exists for,
where the owning activation lives on a peer silo that never answers — never emits, never completes
and never errors: `SyncedQueryMeshNodes` gates on `SeenInitial` over a merge containing a `Subject`
that is never completed, so it can only STALL.

So the fold has **no terminal at all**. `TakeDecisionOutsideGate`'s `Take(1)` bounds the number of
*emissions*, not the *wait*. `RunCreationValidatorsObs`'s `Concat` then blocked on validator #1 with
nothing left to end it — `Executing(CreateNodeRequest, 33014ms)`, ended only by the **caller's**
`RequestTimeout`, which names the caller's impatience rather than the read that starved.

Answering the three questions the issue poses:

| | |
|---|---|
| **Does the read have a terminal arm?** | The create handler's `Subscribe` has all three (plus the #981 backstop) — so terminals *are* handled. There simply is no terminal to handle. |
| **Can the thing it waits on still exist?** | No, and it cannot even *complete*: the merge behind `SeenInitial` includes a `Subject` that is never completed, so the leg can only stall. |
| **Does a failure get cached?** | No — #1367's eviction works, and the issue's own log shows it firing. It repairs the **cache**; the already-blocked caller is not waiting on a cache entry. |

## Why not just seed the legs

`ObserveGatedNodes` already does exactly that (`.StartWith(empty)`, explicitly "so a slow leg cannot
stall the whole fold") — safe because a gate only ever *adds* `Read`. The grant and policy legs must
**not** be seeded: "no grants yet" reads as a **denial**, i.e. the silent wrong answer. An
unanswerable read cannot be projected onto the yes/no axis at all. It needs a third outcome — which
is precisely what #1218 introduced for a starved *source* read (`CompilationStatus.Unavailable`),
and what `PermissionCheckOutcome.Undetermined` already gives the message gate for a *faulted* fold.

## The fix

`RlsNodeValidator` bounds its **whole chain** — placed at `Validate`, not inside `CheckPermission`,
so it covers every branch (the custom-rule path reaches the same fold; the denial path's
ownerless-partition probe is a mesh read too) — with
`RowLevelSecurityOptions.PermissionEstablishmentBudget` and answers
`NodeRejectionReason.Unavailable`, carried through to `Node{Creation,Deletion,Move}RejectionReason`.

Default **30 s**: comfortably above any healthy cold fold, and strictly below the 60 s hub
`RequestTimeout` — which is the point, since a request killed by its caller reports the wrong thing.

🚨 **This is not a ceiling that turns a slow check into a denial.** Reporting a stalled read as a
refusal sends a correctly-entitled caller to request permissions they already hold, and files an
availability incident as a policy decision so nobody looks for the read that starved. It stays
fail-**closed** — the operation does not proceed; it stops claiming to know *why*. A live UI
subscription is the opposite case and keeps **no** bound: it is not owed an answer by a deadline and
must re-emit when the grants finally land.

**Second never-answers hole, same family:** `HandleGetPermission` subscribed with onNext + onError
only, so a fold that **completed without emitting** discarded that terminal and the request was owed
a reply nobody would ever post — the #1362/#1364 shape. It now always answers.

## Verification — fail before, pass after

`StarvedPermissionReadTest` starves exactly those two reads for one scope while a **sibling scope
stays healthy** (the control that proves the starve is the only variable). It goes silent rather than
throwing — a throwing query has a terminal and fails fast today; real starvation is the silent shape.

Before, the create never answered, with the issue's own trace:

```
HANDLER_ENTER → CREATE_CHAIN_SUBSCRIBED path=StarvedPermissionTest/Starved/leaf → HANDLER_EXIT state=Processed
  ⇒ a handler was entered and no reply, completion or fault has been recorded since
[STALE-CALLBACK] CreateNodeRequest@(59864ms)
FAIL  System.TimeoutException : No response received … within 00:01:00  [60 s]
```

After: `Unavailable` in **5 s**, and the healthy scope still creates.

```
StarvedPermissionReadTest              Passed: 1, Failed: 0      (5 s)
MeshWeaver.Hosting.Monolith.Test       Passed: 666, Failed: 0, Skipped: 3   (7 m 34 s)
```

(The new test is confirmed *inside* that full-project run — `outcome="Passed"` in the TRX — not only
standalone.) `dotnet build -c Release -warnaserror --no-incremental` clean on `MeshWeaver.Mesh.Contract`,
`MeshWeaver.Graph`, `MeshWeaver.Hosting` and `MeshWeaver.Documentation`; `DocumentationLinkIntegrityTest` green.

## Deliberately NOT in scope

`AccessControlPipeline`'s message gate keeps its documented "No Timeout here". It already classifies
a **faulted** fold as `Undetermined` → `ErrorType.Unavailable`; giving it a terminal for a **silent**
one changes the behaviour of every `[RequiresPermission]` message and deserves its own argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)