### PR TITLE
fix(layout): a missing reference is data — report it, don't dump the routing diagnostic (#1456)

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -60,6 +60,8 @@
   "redirect.dismiss": "Ausblenden",
   "error.accessDenied": "Zugriff verweigert",
   "error.accessDeniedHint": "Falls ein Zugriff bestehen sollte, bitte den Besitzer der Partition um Freigabe bitten.",
+  "error.missingReference": "Fehlender Verweis",
+  "error.missingReferenceHint": "Dieser Bereich verweist auf ein Element, das nicht existiert. Es wurde möglicherweise gelöscht, umbenannt oder nie erstellt — bitte den Autor, den Verweis zu korrigieren oder zu entfernen.",
   "error.identityUnavailable": "Ihr Konto konnte gerade nicht geprüft werden.",
   "error.identityUnavailableHint": "Das ist ein vorübergehendes Problem auf unserer Seite und liegt nicht an Ihrem Konto. Sie sind weiterhin angemeldet — bitte einen Moment warten und die Seite neu laden. Eine erneute Anmeldung hilft nicht.",
   "error.checkUnavailable": "Das konnte gerade nicht geladen werden.",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -60,6 +60,8 @@
   "redirect.dismiss": "Dismiss",
   "error.accessDenied": "Access denied",
   "error.accessDeniedHint": "If you believe you should have access, ask the partition owner to grant it.",
+  "error.missingReference": "Missing reference",
+  "error.missingReferenceHint": "This area refers to an item that does not exist. It may have been deleted, renamed, or never created — ask the author to fix or remove the reference.",
   "error.identityUnavailable": "We could not check your account just now.",
   "error.identityUnavailableHint": "This is a temporary problem on our side, not a problem with your account. You are still signed in — please wait a moment and reload the page. Signing in again will not help.",
   "error.checkUnavailable": "We could not load this just now.",

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-broken-link-no-longer-breaks-the-whole-view.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-a-broken-link-no-longer-breaks-the-whole-view.md
@@ -1,0 +1,19 @@
+---
+Name: A broken reference no longer breaks the whole view
+Category: Fix
+Description: A page pointing at something that no longer exists now says so in plain language, instead of showing an internal error message.
+Icon: Sparkle
+Order: -20260813
+---
+
+# A broken reference no longer breaks the whole view
+
+When a page referred to something that had been deleted, renamed, or never created — a slide missing
+from a presentation, an embedded view whose target is gone — the page showed a raw internal error
+message instead of an explanation. It was always in English, and it exposed wording meant for
+developers rather than readers.
+
+Such a page now shows a short, translated notice naming the item it could not find, so whoever
+maintains the content knows exactly what to fix. It is also clearly different from a page that is
+still loading, so nothing appears broken while it is simply not ready yet. And because a broken
+reference is a content problem rather than a system fault, it no longer raises an operational alert.

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -184,6 +184,35 @@ public static class AreaErrorClassifier
     }
 
     /// <summary>
+    /// The PATH that could not be resolved, pulled out of an <see cref="IsNodeGoneNotFound"/>
+    /// failure — or <c>null</c> when this is not that failure, or the path cannot be recovered.
+    ///
+    /// <para>Exists so a view can name the broken reference WITHOUT reproducing the framework
+    /// diagnostic around it. The raw message is
+    /// <c>"No node found at 'X'. Closest ancestor is 'Y' (remainder='Z')"</c>; only <c>X</c> means
+    /// anything to an author — "closest ancestor" and "remainder" are routing internals, and the
+    /// whole string is deliberately unlocalized because it is a framework diagnostic, not UI copy.
+    /// Both producers (<c>RoutingServiceBase</c> and <c>RoutingGrain</c>) emit that exact shape.</para>
+    /// </summary>
+    public static string? TryGetMissingNodePath(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            var msg = e.Message ?? string.Empty;
+            if (e is not DeliveryFailureException
+                || !msg.StartsWith("No node found", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var open = msg.IndexOf('\'');
+            if (open < 0)
+                continue;
+            var close = msg.IndexOf('\'', open + 1);
+            if (close > open + 1)
+                return msg[(open + 1)..close];
+        }
+        return null;
+    }
+
+    /// <summary>
     /// True when a raw <see cref="DeliveryFailure"/> message (NOT wrapped in a
     /// <see cref="DeliveryFailureException"/>) is a routing <b>NotFound</b> for a node/hub that no
     /// longer exists — or has not yet been created. This is the <see cref="IsNodeGoneNotFound"/>

--- a/src/MeshWeaver.Layout/AreaFrameClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaFrameClassifier.cs
@@ -35,6 +35,21 @@ public static class AreaFrameClassifier
     /// </summary>
     public const string CompileProgressId = "compile-progress";
 
+    /// <summary>
+    /// <see cref="UiControl.Id"/> of the frame an area serves when its content REFERENCES a node
+    /// that does not exist (<c>LayoutAreaHost.RenderRenderingError</c> on a routing
+    /// <c>ErrorType.NotFound</c>) — a deck manifest naming a slide that was never created,
+    /// an embed left pointing at a deleted node, a copied page whose relative reference does not
+    /// resolve in its new location. TERMINAL.
+    ///
+    /// <para>The THIRD state, and it is genuinely distinct from the other two (#1456). Against
+    /// <see cref="AreaNotFoundId"/>: the area itself is registered and rendering fine — it is the
+    /// DATA it points at that is absent, so "no renderer for this area" would send an author
+    /// looking in exactly the wrong place. Against <see cref="CompileProgressId"/>: nothing is
+    /// going to arrive, so a consumer that waits for this one waits forever.</para>
+    /// </summary>
+    public const string MissingReferenceId = "reference-missing";
+
     // The pre-id signal, kept as a fallback so a frame that lost its id on the way here (an
     // older peer, a control rebuilt from partial JSON) is still recognised. Never localize:
     // BuildNotFoundControl is deliberately English — it is a framework diagnostic, not UI copy.
@@ -59,6 +74,15 @@ public static class AreaFrameClassifier
     /// <param name="control">The rendered control, or <c>null</c>.</param>
     public static bool IsCompileProgress(UiControl? control)
         => HasFrameId(control, CompileProgressId);
+
+    /// <summary>
+    /// True for the frame an area serves when the content it renders REFERENCES a node that does
+    /// not exist. The reference is bad DATA — an author has to fix the manifest, the embed or the
+    /// link — so this is terminal, and deliberately NOT part of <see cref="IsTransientFrame"/>.
+    /// </summary>
+    /// <param name="control">The rendered control, or <c>null</c>.</param>
+    public static bool IsMissingReference(UiControl? control)
+        => HasFrameId(control, MissingReferenceId);
 
     /// <summary>
     /// True for a frame that is not the area's content and will be REPLACED without anyone

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -736,6 +736,15 @@ public record LayoutAreaHost : IDisposable
             // being rendered), not an engineering fault — Warning, so error dashboards
             // don't page / auto-file an incident for "user opened a node they cannot read".
             logger.LogWarning(ex, "Rendering denied for area {Area}: {Message}", area, ex.Message);
+        else if (AreaErrorClassifier.IsNodeGoneNotFound(ex))
+            // The area rendered fine; the DATA it points at is absent — a deck manifest naming a
+            // slide nobody created, an embed left behind by a delete, a copied page whose relative
+            // reference does not resolve where it now lives (#1456). That is an authoring fault to
+            // be fixed in content, not an engineering fault, so it logs at Warning for the same
+            // reason a denial does: it must not page or auto-file an incident. It stays LOGGED —
+            // the reference really is broken and somebody should fix it.
+            logger.LogWarning(ex, "Area {Area} references a node that does not exist: {MissingPath}",
+                area, AreaErrorClassifier.TryGetMissingNodePath(ex) ?? "(path not recoverable)");
         else
             logger.LogError(ex, "Rendering failed for area {Area}", area);
         try
@@ -763,11 +772,33 @@ public record LayoutAreaHost : IDisposable
     /// error panel carrying the exception message so the cause stays visible.
     /// </summary>
     private UiControl CreateRenderErrorControl(Exception ex)
-        => AreaErrorClassifier.IsAccessDenied(ex)
-            ? Controls.Markdown(
-                $"**{this.Localize("error.accessDenied")}**\n\n{this.Localize("error.accessDeniedHint")}")
-            : Controls.Markdown(
-                $"⚠️ **This area failed to render.**\n\n```\n{ex.Message}\n```");
+    {
+        if (AreaErrorClassifier.IsAccessDenied(ex))
+            return Controls.Markdown(
+                $"**{this.Localize("error.accessDenied")}**\n\n{this.Localize("error.accessDeniedHint")}");
+
+        // A reference to a node that does not exist is DATA, not a programming error. Render a
+        // localized frame that names the broken path — never the routing diagnostic wrapped around
+        // it ("Closest ancestor is … remainder=…"), which is framework-internal and must not reach
+        // an end user. Stamped with the well-known id so a consumer can tell this THIRD state from
+        // "the area does not exist" (area-not-found) and "the area is still compiling"
+        // (compile-progress) — see AreaFrameClassifier (#1456, following #1420).
+        if (AreaErrorClassifier.IsNodeGoneNotFound(ex))
+        {
+            var missing = AreaErrorClassifier.TryGetMissingNodePath(ex);
+            var body = this.Localize("error.missingReferenceHint");
+            if (!string.IsNullOrEmpty(missing))
+                body = $"{body}\n\n`{missing}`";
+            return new MarkdownControl($"**{this.Localize("error.missingReference")}**\n\n{body}")
+            {
+                Id = AreaFrameClassifier.MissingReferenceId
+            };
+        }
+
+        // `error.areaFailed` already existed in both catalogs; this banner was hard-coded English.
+        return Controls.Markdown(
+            $"⚠️ **{this.Localize("error.areaFailed")}**\n\n```\n{ex.Message}\n```");
+    }
 
     /// <summary>
     /// Reactive render of a top-level area whose generator is an observable of

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -60,6 +60,8 @@
   "redirect.dismiss": "Ausblenden",
   "error.accessDenied": "Zugriff verweigert",
   "error.accessDeniedHint": "Falls ein Zugriff bestehen sollte, bitte den Besitzer der Partition um Freigabe bitten.",
+  "error.missingReference": "Fehlender Verweis",
+  "error.missingReferenceHint": "Dieser Bereich verweist auf ein Element, das nicht existiert. Es wurde möglicherweise gelöscht, umbenannt oder nie erstellt — bitte den Autor, den Verweis zu korrigieren oder zu entfernen.",
   "error.identityUnavailable": "Ihr Konto konnte gerade nicht geprüft werden.",
   "error.identityUnavailableHint": "Das ist ein vorübergehendes Problem auf unserer Seite und liegt nicht an Ihrem Konto. Sie sind weiterhin angemeldet — bitte einen Moment warten und die Seite neu laden. Eine erneute Anmeldung hilft nicht.",
   "error.checkUnavailable": "Das konnte gerade nicht geladen werden.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -60,6 +60,8 @@
   "redirect.dismiss": "Dismiss",
   "error.accessDenied": "Access denied",
   "error.accessDeniedHint": "If you believe you should have access, ask the partition owner to grant it.",
+  "error.missingReference": "Missing reference",
+  "error.missingReferenceHint": "This area refers to an item that does not exist. It may have been deleted, renamed, or never created — ask the author to fix or remove the reference.",
   "error.identityUnavailable": "We could not check your account just now.",
   "error.identityUnavailableHint": "This is a temporary problem on our side, not a problem with your account. You are still signed in — please wait a moment and reload the page. Signing in again will not help.",
   "error.checkUnavailable": "We could not load this just now.",

--- a/test/MeshWeaver.Hosting.Monolith.Test/MissingReferenceAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MissingReferenceAreaTest.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Issue #1456 — <b>an area whose content REFERENCES a node that does not exist</b>.
+///
+/// <para>Production symptom: <c>fail: Rendering failed for area Present</c> with
+/// <c>DeliveryFailureException: No node found at 'ClientDelta/Abschlusspraesentation/04-extraktion'.
+/// Closest ancestor is 'ClientDelta/Abschlusspraesentation' (remainder='04-extraktion')</c>. Two
+/// things were wrong with that, and neither is "the exception happened":</para>
+/// <list type="number">
+///   <item>the routing diagnostic — a FRAMEWORK-INTERNAL string — was rendered verbatim into the
+///     page, in hard-coded English, inside a code fence;</item>
+///   <item>it logged at <c>Error</c>, which auto-files an incident. A deck manifest naming a slide
+///     nobody created is bad DATA. Somebody should fix it; nobody should be paged for it.</item>
+/// </list>
+///
+/// <para>So the area now serves a localized frame that names the broken path and nothing else, and
+/// — following #1420 — stamps a well-known <see cref="UiControl.Id"/> so the state is
+/// mechanically distinguishable from the two that already existed. All three are rendered here and
+/// cross-asserted, because the whole value of the marker is that a CONSUMER can tell them apart:</para>
+/// <list type="bullet">
+///   <item><b>missing reference</b> — the area rendered; the node it points at is absent. TERMINAL.</item>
+///   <item><b>compiling</b> — the instance's NodeType is still building. TRANSIENT.</item>
+///   <item><b>area not found</b> — no renderer is registered for this area at all. TERMINAL.</item>
+/// </list>
+/// </summary>
+public class MissingReferenceAreaTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The node whose area renders a reference to something that was never created.</summary>
+    private const string DeckPath = "decks/Abschlusspraesentation";
+
+    /// <summary>The referenced slide — deliberately NEVER created. This is the broken reference.</summary>
+    private const string MissingSlidePath = "decks/Abschlusspraesentation/04-extraktion";
+
+    /// <summary>The instance whose hub carries the compilation-in-progress overlay.</summary>
+    private const string OverlaidPath = "decks/Overlaid";
+
+    /// <summary>The NodeType the overlaid instance waits on — held at <c>Compiling</c>.</summary>
+    private const string PendingTypePath = "decks/PendingType";
+
+    /// <summary>A plain node hub with no overlay — used for the "genuinely no renderer" direction.</summary>
+    private const string PlainPath = "decks/Plain";
+
+    private const string PresentArea = "Present";
+    private const string UnregisteredArea = "KeyMetrics";
+
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(90);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(180);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddMeshNodes(MeshNode.FromPath(DeckPath) with
+            {
+                Name = "Abschlusspraesentation",
+                State = MeshNodeState.Active,
+                // The production shape of the defect: the area reads a node named by the deck's
+                // content. Nothing created that node, so the read faults with the routing NotFound
+                // — exactly as the manifest-driven slide read did in the incident. The read is NOT
+                // wrapped in a catch: the point is that the FRAMEWORK classifies the failure.
+                HubConfiguration = config => config.AddLayout(layout => layout
+                    .WithView(PresentArea, (LayoutAreaHost host, RenderingContext _) =>
+                        host.Workspace.GetMeshNodeStream(MissingSlidePath)
+                            .Select(node => (UiControl?)Controls.Markdown(
+                                $"Slide: {node?.Name ?? "(none)"}"))))
+            })
+            .AddMeshNodes(MeshNode.FromPath(OverlaidPath) with
+            {
+                Name = "Overlaid",
+                State = MeshNodeState.Active,
+                HubConfiguration = NodeTypeEnrichmentHelpers
+                    .CreateCompilationInProgressConfiguration(PendingTypePath, OverlaidPath)
+            })
+            .AddMeshNodes(MeshNode.FromPath(PlainPath) with
+            {
+                Name = "Plain",
+                State = MeshNodeState.Active,
+                HubConfiguration = config => config
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>
+    /// The defect itself. Before the fix this frame carried the raw routing diagnostic; the area
+    /// now reports the broken reference as its own classified state.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AreaReferencingAMissingNode_RendersAClassifiedMissingReferenceFrame()
+    {
+        var control = await Render(DeckPath, PresentArea);
+
+        AreaFrameClassifier.IsMissingReference(control).Should().BeTrue(
+            "the area rendered — it is the NODE it references that is absent, and that has to be "
+            + "mechanically distinguishable from the other two placeholder states");
+        AreaFrameClassifier.IsAreaNotFound(control).Should().BeFalse(
+            "the Present renderer IS registered — reporting 'area not found' would send an author "
+            + "hunting for a missing renderer instead of a missing node");
+        AreaFrameClassifier.IsCompileProgress(control).Should().BeFalse();
+        AreaFrameClassifier.IsTransientFrame(control).Should().BeFalse(
+            "a broken reference is data an author must fix — a waiter must not sit on it forever");
+    }
+
+    /// <summary>
+    /// What the VIEWER reads. The path is what an author needs; "Closest ancestor" / "remainder="
+    /// are routing internals that must never reach a page, and the banner must come from the
+    /// localization catalog rather than being hard-coded English.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheFrameNamesTheBrokenPath_ButNeverTheRoutingDiagnostic()
+    {
+        var control = await Render(DeckPath, PresentArea);
+
+        var markdown = (control as MarkdownControl)?.Markdown?.ToString() ?? string.Empty;
+        markdown.Should().Contain(MissingSlidePath,
+            "the broken path is the one part of the failure an author can act on");
+        markdown.Should().NotContain("Closest ancestor",
+            "the routing diagnostic is framework-internal and must never reach an end user");
+        markdown.Should().NotContain("remainder=");
+        markdown.Should().Contain("Missing reference",
+            "the banner comes from the localization catalog (error.missingReference), so a German "
+            + "viewer gets German instead of a hard-coded English string");
+    }
+
+    /// <summary>
+    /// The three-way coupling, rendered end-to-end. Each classifier is asserted against ALL THREE
+    /// frames, so a marker that stopped being emitted — or started matching everything — fails here
+    /// rather than months later in whichever consumer latched the wrong state.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task MissingReference_Compiling_AndAreaNotFound_AreMechanicallyDistinguishable()
+    {
+        await CreateCompilingType();
+
+        var missingReference = await Render(DeckPath, PresentArea);
+        var compiling = await Render(OverlaidPath, UnregisteredArea);
+        var areaNotFound = await Render(PlainPath, UnregisteredArea);
+
+        AreaFrameClassifier.IsMissingReference(missingReference).Should().BeTrue();
+        AreaFrameClassifier.IsMissingReference(compiling).Should().BeFalse();
+        AreaFrameClassifier.IsMissingReference(areaNotFound).Should().BeFalse();
+
+        AreaFrameClassifier.IsCompileProgress(compiling).Should().BeTrue();
+        AreaFrameClassifier.IsCompileProgress(missingReference).Should().BeFalse();
+        AreaFrameClassifier.IsCompileProgress(areaNotFound).Should().BeFalse();
+
+        AreaFrameClassifier.IsAreaNotFound(areaNotFound).Should().BeTrue();
+        AreaFrameClassifier.IsAreaNotFound(missingReference).Should().BeFalse();
+        AreaFrameClassifier.IsAreaNotFound(compiling).Should().BeFalse();
+
+        // Only the compiling one is a promise; the other two are verdicts.
+        AreaFrameClassifier.IsTransientFrame(compiling).Should().BeTrue();
+        AreaFrameClassifier.IsTransientFrame(missingReference).Should().BeFalse();
+        AreaFrameClassifier.IsTransientFrame(areaNotFound).Should().BeFalse();
+    }
+
+    private async Task CreateCompilingType()
+        => await MeshService.CreateNode(MeshNode.FromPath(PendingTypePath) with
+        {
+            Name = "PendingType",
+            NodeType = "NodeType",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { CompilationStatus = CompilationStatus.Compiling }
+        }).Should().Emit();
+
+    /// <summary>
+    /// Renders one area through the layout client — the exact path the GUI drives — and waits for
+    /// the first frame that carries a control for it.
+    /// </summary>
+    private async Task<UiControl?> Render(string addressPath, string area)
+    {
+        var client = GetClient();
+        var reference = new LayoutAreaReference(area);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(addressPath), reference);
+        try
+        {
+            var control = await stream
+                .GetControlStream(reference.Area!)
+                .Should().Within(60.Seconds())
+                .Match(c => c is not null,
+                    $"{area} on {addressPath} must produce SOME frame — a hub that produces none is "
+                    + "the eternal spinner these placeholders exist to prevent");
+            Output.WriteLine($"{addressPath}/{area} → {control?.GetType().Name} (Id={control?.Id})");
+            return control;
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -99,6 +99,37 @@ public class AreaErrorClassifierTest
         => AreaErrorClassifier.IsNodeGoneNotFound(new InvalidOperationException("No node found at X")).Should().BeFalse(
             "only a routing DeliveryFailure counts — a coincidental message on some other exception must not");
 
+    // ── TryGetMissingNodePath: name the broken reference, never the routing internals (#1456) ──
+
+    /// <summary>
+    /// The path is the one part of the diagnostic an author can act on. "Closest ancestor" and
+    /// "remainder=" are routing internals — the extractor must hand back the path ALONE so a view
+    /// can name it without reproducing the framework string around it.
+    /// </summary>
+    [Fact]
+    public void TryGetMissingNodePath_ReturnsThePathWithoutTheRoutingTail()
+        => AreaErrorClassifier.TryGetMissingNodePath(Failure(
+                "No node found at 'ClientDelta/Abschlusspraesentation/04-extraktion'. Closest ancestor is "
+                + "'ClientDelta/Abschlusspraesentation' (remainder='04-extraktion').", ErrorType.NotFound))
+            .Should().Be("ClientDelta/Abschlusspraesentation/04-extraktion");
+
+    [Fact]
+    public void TryGetMissingNodePath_NullWhenTheMessageCarriesNoQuotedPath()
+        => AreaErrorClassifier.TryGetMissingNodePath(
+            Failure("No node found at Foo/Bar", ErrorType.NotFound)).Should().BeNull(
+            "an unquoted form gives nothing safe to show — better to omit the path than to guess at it");
+
+    [Fact]
+    public void TryGetMissingNodePath_NullForOtherFailures()
+    {
+        AreaErrorClassifier.TryGetMissingNodePath(
+            Failure("Access denied: user lacks Read on 'X/Y'", ErrorType.Unauthorized)).Should().BeNull();
+        AreaErrorClassifier.TryGetMissingNodePath(
+            new InvalidOperationException("No node found at 'X/Y'.")).Should().BeNull(
+            "only a routing DeliveryFailure counts, exactly as for IsNodeGoneNotFound");
+        AreaErrorClassifier.TryGetMissingNodePath(null).Should().BeNull();
+    }
+
     // ── TryGetInitializationFailureReason: a FAILED hub → render the reason, terminal, no retry (#323) ──
 
     [Theory]

--- a/test/MeshWeaver.Layout.Test/AreaFrameClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaFrameClassifierTest.cs
@@ -90,10 +90,66 @@ public class AreaFrameClassifierTest
         var content = Controls.Markdown("### Total Premium\n\n1,234");
         AreaFrameClassifier.IsAreaNotFound(content).Should().BeFalse();
         AreaFrameClassifier.IsCompileProgress(content).Should().BeFalse();
+        AreaFrameClassifier.IsMissingReference(content).Should().BeFalse();
         AreaFrameClassifier.IsTransientFrame(content).Should().BeFalse();
 
         AreaFrameClassifier.IsAreaNotFound(null).Should().BeFalse();
         AreaFrameClassifier.IsCompileProgress(null).Should().BeFalse();
+        AreaFrameClassifier.IsMissingReference(null).Should().BeFalse();
         AreaFrameClassifier.IsTransientFrame(null).Should().BeFalse();
+    }
+
+    // ── The THIRD state (#1456): the area renders, its REFERENCE is broken ────────────────
+
+    private static MarkdownControl MissingReferenceFrame() =>
+        new("**Missing reference**\n\nThis area refers to an item that does not exist.\n\n`ClientDelta/Abschlusspraesentation/04-extraktion`")
+        {
+            Id = AreaFrameClassifier.MissingReferenceId
+        };
+
+    /// <summary>
+    /// The distinction the whole class exists for, now three-way. A broken reference is TERMINAL
+    /// like "area not found" (nothing will replace it) but it is NOT "area not found": the area is
+    /// registered and rendering — the data it points at is absent. Conflating them sends an author
+    /// hunting for a missing renderer instead of a missing node.
+    /// </summary>
+    [Fact]
+    public void MissingReferenceFrame_IsItsOwnState_TerminalButNotAreaNotFound()
+    {
+        var frame = MissingReferenceFrame();
+        AreaFrameClassifier.IsMissingReference(frame).Should().BeTrue();
+        AreaFrameClassifier.IsAreaNotFound(frame).Should().BeFalse(
+            "the area exists and rendered — it is the referenced NODE that does not");
+        AreaFrameClassifier.IsCompileProgress(frame).Should().BeFalse(
+            "nothing is building — a waiter must not treat this as 'not yet'");
+        AreaFrameClassifier.IsTransientFrame(frame).Should().BeFalse(
+            "a broken reference is data an author must fix — nothing is going to replace it");
+    }
+
+    /// <summary>The other two frames must not answer to the new predicate.</summary>
+    [Fact]
+    public void TheThreeStatesAreMutuallyExclusive()
+    {
+        AreaFrameClassifier.IsMissingReference(NotFoundFrame()).Should().BeFalse();
+        AreaFrameClassifier.IsMissingReference(CompileProgressFrame()).Should().BeFalse();
+        AreaFrameClassifier.IsAreaNotFound(MissingReferenceFrame()).Should().BeFalse();
+        AreaFrameClassifier.IsCompileProgress(MissingReferenceFrame()).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 The same wire trap as <see cref="FrameIdSurvivesTheWire_WhereIdIsAJsonElementNotAString"/>,
+    /// asserted for the new state too — a CLR `is string` check would pass every test above and
+    /// answer "no" for every frame that actually reached a client.
+    /// </summary>
+    [Fact]
+    public void MissingReferenceIdSurvivesTheWire_AsAJsonElement()
+    {
+        var wireId = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(AreaFrameClassifier.MissingReferenceId));
+        wireId.Should().NotBeOfType<string>();
+
+        var frame = Controls.Markdown("**Missing reference**").WithId(wireId);
+        AreaFrameClassifier.IsMissingReference(frame).Should().BeTrue();
+        AreaFrameClassifier.IsTransientFrame(frame).Should().BeFalse();
     }
 }


### PR DESCRIPTION
Fixes #1456.

## What was actually wrong

Nothing crashed. `LayoutAreaHost` already catches a faulted render and shows a visible frame. Two *other* things were wrong:

1. **The routing diagnostic became page copy.** `CreateRenderErrorControl` dumped `ex.Message` into a code fence, so `No node found at '…'. Closest ancestor is '…' (remainder='…')` — a framework-internal string — was rendered to the viewer, in hard-coded English.
2. **It logged at `Error`**, which auto-files an incident (that is how this issue got opened). A deck manifest naming a slide nobody created is bad **data**. Somebody should fix it; nobody should be paged for it.

`AreaErrorClassifier.IsNodeGoneNotFound` — the exact predicate for this — **already existed**, and the Blazor client already used it to render a graceful placeholder. The server-side render path just never consulted it: it branched only on `IsAccessDenied`. So most of this change is wiring an existing classification into the one place that skipped it.

## Three states, following #1420 exactly

`AreaFrameClassifier` gains `MissingReferenceId = "reference-missing"` + `IsMissingReference`, matched through the **same `HasFrameId` helper** that compares `Id`'s **rendered text**, not its CLR type. `Id` is `object?`, so a frame off the sync stream carries a `JsonElement` there — an `is string` check answers "no" for every real client-side frame while passing every unit test built from fresh controls. There is a dedicated test asserting the new id survives that round-trip.

| State | Id | Meaning | Transient? |
|---|---|---|---|
| **Missing reference** | `reference-missing` | the area rendered; the **node it references** is absent | no — an author must fix the data |
| **Compiling** | `compile-progress` | the instance's NodeType is still building | **yes** |
| **Area does not exist** | `area-not-found` | no renderer is registered for this area | no |

It is deliberately **not** in `IsTransientFrame`: the area rendered, and nothing is going to replace what it points at. Conflating it with `area-not-found` would send an author hunting for a missing *renderer* instead of a missing *node*.

`TryGetMissingNodePath` extracts the path **alone** so the frame can name the broken reference without reproducing "Closest ancestor" / "remainder=" around it.

## Not a catch-and-continue

The reference is **reported** — visibly in the page and in the log. Only the precise typed routing NotFound takes this branch; every other exception keeps the generic panel, so a transient hub miss can never be mis-rendered as "permanently gone".

The `Error → Warning` change applies to this one classified case only. It matches what `IsExpectedUserActionFailure` has always said about `"No node found"` and what the adjacent access-denied branch already does. It is not a verbosity tweak — an authoring fault must not page.

## i18n

`error.missingReference` / `error.missingReferenceHint` added to both server catalogs **and** mirrored into `clients/react/src/i18n/`. All four files verified identical — 915 keys, same sorted keys and same per-key values, which is exactly what `localize.test.ts` asserts (`node_modules` is not installed in this worktree, so the invariant was checked directly). While in that method, the hard-coded English fallback banner now uses `error.areaFailed`, which already existed in both catalogs.

## Verification

**Fail-before/pass-after, actually run** — reverted *only* `LayoutAreaHost.cs` (keeping the new API so the tests still compile) and re-ran: **3/3 FAIL**. Restored: **7/7 pass** (my 3 plus the 4 #1420 regression tests, so the compiling/not-found distinction is intact).

The end-to-end test renders all three states on a real mesh through the layout client — the path the GUI drives — and cross-asserts every classifier against every frame. Captured output:

```
decks/Abschlusspraesentation/Present → MarkdownControl (Id=reference-missing)
decks/Overlaid/KeyMetrics            → StackControl    (Id=compile-progress)
decks/Plain/KeyMetrics               → MarkdownControl (Id=area-not-found)
```

…driven by a genuine routing failure, not a synthesised exception:

```
[Warning] RoutingServiceBase RouteMessage: NotFound → decks/Abschlusspraesentation/04-extraktion.
  No node found at '…'. Closest ancestor is '…' (remainder='04-extraktion').
[Warning] LayoutAreaHost Area Present references a node that does not exist:
  decks/Abschlusspraesentation/04-extraktion
```

`Rendering failed for area` at `Error`: **0 occurrences**.

Also green: `AreaFrameClassifierTest` + `AreaErrorClassifierTest` (79), `LocalizationTest` (56), `WhatsNewEntryIntegrityTest`, `DocumentationLinkIntegrityTest`. `-c Release -warnaserror` clean for `MeshWeaver.Layout`, `MeshWeaver.Documentation`, and the three touched test projects.

## Note on the issue's framing

The linked hypothesis that this was #1371's copy-time embed cause did not hold up: the failure path here is the area's own node read, not an embed rewrite. Copy-time embed rewriting still does not exist, so a copied deck whose slides were not copied produces exactly this shape — which is one more reason the frame names the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
