### PR TITLE
fix(#1455): a cached reduced stream whose SOURCE is dead is never served, and asking cannot spin

### DIFF
--- a/src/MeshWeaver.Data/ISynchronizationStream.cs
+++ b/src/MeshWeaver.Data/ISynchronizationStream.cs
@@ -88,6 +88,24 @@ public interface ISynchronizationStream : IDisposable
     IMessageHub Hub { get; }
     /// <summary>The hub that hosts the underlying data source backing this stream.</summary>
     IMessageHub Host { get; }
+
+    /// <summary>
+    /// The stream this one was reduced FROM, or <c>null</c> for a stream that is not a reduce of
+    /// another (a data source's primary stream, a combined stream, a remote mirror).
+    ///
+    /// <para>🚨 This exists because a reduced stream is its parent's SIBLING, not its child:
+    /// <c>WorkspaceStreams.CreateReducedStream</c> hosts the reduced stream's <c>sync/{id}</c>
+    /// sub-hub under <see cref="Host"/> and only registers it for disposal on the parent. Without
+    /// this link, "is this stream alive?" cannot see that the thing it mirrors is already dead —
+    /// the gap behind Systemorph/MeshWeaver#1455. Ask <c>StreamLiveness.IsUsable</c> rather than
+    /// walking this by hand.</para>
+    /// </summary>
+    internal ISynchronizationStream? Source { get; }
+
+    /// <summary>
+    /// Whether this stream has been disposed. Its store is completed and it will never emit again.
+    /// </summary>
+    internal bool IsDisposed { get; }
     /// <summary>Reads a per-stream value previously stashed under <paramref name="key"/>.</summary>
     /// <typeparam name="T">Expected value type.</typeparam>
     /// <param name="key">Key the value was stored under.</param>

--- a/src/MeshWeaver.Data/ISynchronizationStream.cs
+++ b/src/MeshWeaver.Data/ISynchronizationStream.cs
@@ -88,24 +88,6 @@ public interface ISynchronizationStream : IDisposable
     IMessageHub Hub { get; }
     /// <summary>The hub that hosts the underlying data source backing this stream.</summary>
     IMessageHub Host { get; }
-
-    /// <summary>
-    /// The stream this one was reduced FROM, or <c>null</c> for a stream that is not a reduce of
-    /// another (a data source's primary stream, a combined stream, a remote mirror).
-    ///
-    /// <para>🚨 This exists because a reduced stream is its parent's SIBLING, not its child:
-    /// <c>WorkspaceStreams.CreateReducedStream</c> hosts the reduced stream's <c>sync/{id}</c>
-    /// sub-hub under <see cref="Host"/> and only registers it for disposal on the parent. Without
-    /// this link, "is this stream alive?" cannot see that the thing it mirrors is already dead —
-    /// the gap behind Systemorph/MeshWeaver#1455. Ask <c>StreamLiveness.IsUsable</c> rather than
-    /// walking this by hand.</para>
-    /// </summary>
-    internal ISynchronizationStream? Source { get; }
-
-    /// <summary>
-    /// Whether this stream has been disposed. Its store is completed and it will never emit again.
-    /// </summary>
-    internal bool IsDisposed { get; }
     /// <summary>Reads a per-stream value previously stashed under <paramref name="key"/>.</summary>
     /// <typeparam name="T">Expected value type.</typeparam>
     /// <param name="key">Key the value was stored under.</param>

--- a/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
+++ b/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
@@ -12,7 +12,7 @@ namespace MeshWeaver.Data.Serialization;
 /// found to be insufficient and grew a parent guard; the two in <see cref="Workspace"/> did not,
 /// and one of them was character-for-character the predicate that had just been ruled inadequate
 /// (Systemorph/MeshWeaver#1455). A predicate that is copied is a predicate that diverges, so this
-/// is the only definition and <c>StreamLivenessTest</c> pins that every cache serves the same
+/// is the only definition and <c>StreamCacheLivenessTest</c> pins that every cache serves the same
 /// verdict.</para>
 ///
 /// <para>🚨 <b>A cached child is NOT a descendant of its parent, so "is the child alive?" is never
@@ -42,6 +42,13 @@ namespace MeshWeaver.Data.Serialization;
 internal static class StreamLiveness
 {
     /// <summary>
+    /// The chain is a reduce chain (primary → intermediate → leaf), so it is short by construction —
+    /// two or three links in every production shape. The bound exists only so a future cycle cannot
+    /// turn a liveness probe into a hang.
+    /// </summary>
+    private const int MaxChainDepth = 64;
+
+    /// <summary>
     /// True when <paramref name="stream"/> may be handed to a caller from a cache: it and every
     /// ancestor in its reduce chain are undisposed and hub-backed.
     /// </summary>
@@ -50,21 +57,60 @@ internal static class StreamLiveness
     /// source chain contains a disposed stream.</returns>
     public static bool IsUsable(ISynchronizationStream? stream)
     {
-        // The chain is a reduce chain (primary → intermediate → leaf), so it is short by
-        // construction — two or three links in every production shape. The bound exists only so a
-        // future cycle cannot turn a liveness probe into a hang.
+        if (stream is null)
+            return false;
+
         var current = stream;
-        for (var depth = 0; current is not null && depth < 64; depth++)
+        for (var depth = 0; depth < MaxChainDepth; depth++)
         {
-            if (current.IsDisposed)
+            if (current is IStreamLivenessSource { IsDisposed: true })
                 return false;
             if (current.Hub is not { } hub
                 || hub.RunLevel > MessageHubRunLevel.Started
                 || hub is MessageHub { IsDisposing: true })
                 return false;
-            current = current.Source;
+
+            // Walked off the end of the chain with every link alive — the only way to say yes.
+            if ((current as IStreamLivenessSource)?.Source is not { } parent)
+                return true;
+            current = parent;
         }
 
-        return stream is not null;
+        // 🚨 The cap is a guard against a cycle that should not exist, so reaching it means the
+        // chain is not something this predicate understands. FAIL CLOSED: an unverifiable stream is
+        // not served from cache. The caller falls through to a fresh reduce, which is correct
+        // whether the chain was merely long or genuinely circular.
+        return false;
     }
+}
+
+/// <summary>
+/// The liveness facts a reduced stream can answer about ITSELF and its source — deliberately a
+/// separate INTERNAL interface rather than members on the public
+/// <see cref="ISynchronizationStream"/>.
+///
+/// <para>Two reasons. Adding a member to a public interface breaks any downstream implementer, and
+/// MeshWeaver ships these assemblies as packages. And <see cref="Source"/> is not a consumer-facing
+/// concept: it exists so <see cref="StreamLiveness.IsUsable"/> can walk the reduce chain in one
+/// place, and a consumer walking it by hand is the ad-hoc predicate this whole change exists to
+/// remove.</para>
+/// </summary>
+internal interface IStreamLivenessSource
+{
+    /// <summary>
+    /// The stream this one was reduced FROM, or <c>null</c> for a stream that is not a reduce of
+    /// another (a data source's primary stream, a combined stream, a remote mirror).
+    ///
+    /// <para>🚨 A reduced stream is its parent's SIBLING, not its child:
+    /// <c>WorkspaceStreams.CreateReducedStream</c> hosts its <c>sync/{id}</c> sub-hub under the
+    /// parent's <c>Host</c> and only registers it for disposal on the parent. Without this link,
+    /// "is this stream alive?" cannot see that the thing it mirrors is already dead — the gap behind
+    /// Systemorph/MeshWeaver#1455.</para>
+    /// </summary>
+    ISynchronizationStream? Source { get; }
+
+    /// <summary>
+    /// Whether this stream has been disposed. Its store is completed and it will never emit again.
+    /// </summary>
+    bool IsDisposed { get; }
 }

--- a/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
+++ b/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
@@ -1,0 +1,70 @@
+﻿using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Data.Serialization;
+
+/// <summary>
+/// 🚨 THE ONE liveness predicate for a CACHED synchronization stream — used by every
+/// reference-keyed stream cache in the codebase, deliberately in exactly one place.
+///
+/// <para><b>Why one place.</b> Three caches ask the same question — <c>Workspace._localStreamCache</c>,
+/// <c>Workspace._remoteStreamCache</c> and <c>SynchronizationStream.sharedReduceCache</c> — and
+/// they had three hand-copied answers. When <c>ReduceShared</c> was added (#1425) its copy was
+/// found to be insufficient and grew a parent guard; the two in <see cref="Workspace"/> did not,
+/// and one of them was character-for-character the predicate that had just been ruled inadequate
+/// (Systemorph/MeshWeaver#1455). A predicate that is copied is a predicate that diverges, so this
+/// is the only definition and <c>StreamLivenessTest</c> pins that every cache serves the same
+/// verdict.</para>
+///
+/// <para>🚨 <b>A cached child is NOT a descendant of its parent, so "is the child alive?" is never
+/// sufficient.</b> <c>WorkspaceStreams.CreateReducedStream</c> builds the reduced stream's
+/// <c>sync/{id}</c> sub-hub under <c>stream.Host</c> — making it the parent's SIBLING — and merely
+/// registers it for disposal ON the parent. So when the parent dies the child stays alive for the
+/// whole teardown cascade, and a check that looks only at the child happily hands back a mirror of
+/// a dead source. Both observed failures of #1455 come from that one gap:</para>
+/// <list type="bullet">
+/// <item><description><b>During the cascade</b> — the cache serves the very same child. Its
+/// replay subject still hands out the last value it ever saw, and then nothing: no further
+/// emission (the source is gone) and no completion (the child is not disposed yet). A reader
+/// binds to it and hangs for its whole budget on a stale snapshot; a writer patches a stream
+/// nobody drains and is acked.</description></item>
+/// <item><description><b>After the cascade</b> — the child is disposed, so the cache evicts and
+/// re-reduces; but a reduce off a disposed parent is disposed on birth
+/// (<c>SynchronizationStream.RegisterForDisposal</c> disposes immediately once the parent is
+/// terminal), so the replacement fails the same check and the loop never terminates.</description></item>
+/// </list>
+///
+/// <para><b>The verdict.</b> A stream is usable when it and every ancestor in its reduce chain is
+/// undisposed and owns a hub that has not begun winding down. <see cref="MessageHub.IsDisposing"/>
+/// is checked as well as <see cref="IMessageHub.RunLevel"/> because hub shutdown is asynchronous:
+/// right after <c>Dispose()</c> the RunLevel still reads <c>Started</c> while hosted-hub creation
+/// is already frozen.</para>
+/// </summary>
+internal static class StreamLiveness
+{
+    /// <summary>
+    /// True when <paramref name="stream"/> may be handed to a caller from a cache: it and every
+    /// ancestor in its reduce chain are undisposed and hub-backed.
+    /// </summary>
+    /// <param name="stream">The stream to judge, or <c>null</c>.</param>
+    /// <returns><c>false</c> for <c>null</c>, for a disposed stream, and for a live stream whose
+    /// source chain contains a disposed stream.</returns>
+    public static bool IsUsable(ISynchronizationStream? stream)
+    {
+        // The chain is a reduce chain (primary → intermediate → leaf), so it is short by
+        // construction — two or three links in every production shape. The bound exists only so a
+        // future cycle cannot turn a liveness probe into a hang.
+        var current = stream;
+        for (var depth = 0; current is not null && depth < 64; depth++)
+        {
+            if (current.IsDisposed)
+                return false;
+            if (current.Hub is not { } hub
+                || hub.RunLevel > MessageHubRunLevel.Started
+                || hub is MessageHub { IsDisposing: true })
+                return false;
+            current = current.Source;
+        }
+
+        return stream is not null;
+    }
+}

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -21,7 +21,7 @@ namespace MeshWeaver.Data.Serialization;
 /// and reduced/derived streams are produced through the <see cref="ReduceManager"/>.
 /// </summary>
 /// <typeparam name="TStream">Type of the state carried by the stream.</typeparam>
-public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
+public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, IStreamLivenessSource
 {
     /// <summary>
     /// The stream reference, i.e. the unique identifier of the stream.
@@ -217,11 +217,19 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     private readonly object disposeLock = new();
     private readonly ILogger<SynchronizationStream<TStream>> logger;
 
-    /// <inheritdoc />
-    bool ISynchronizationStream.IsDisposed => isDisposed;
+    /// <summary>
+    /// The stream this one was reduced FROM — set by <c>WorkspaceStreams.CreateReducedStream</c>,
+    /// null for a stream that is not a reduce of another. INTERNAL on purpose: it exists so
+    /// <see cref="StreamLiveness.IsUsable"/> can walk the reduce chain in one place, and is exposed
+    /// through <see cref="IStreamLivenessSource"/> rather than the public stream contract.
+    /// </summary>
+    internal ISynchronizationStream? Source { get; init; }
 
     /// <inheritdoc />
-    public ISynchronizationStream? Source { get; init; }
+    ISynchronizationStream? IStreamLivenessSource.Source => Source;
+
+    /// <inheritdoc />
+    bool IStreamLivenessSource.IsDisposed => isDisposed;
 
     // Mirror of MeshWeaver.Mesh.Security.WellKnownUsers.System — Data sits below
     // Mesh.Contract in the project graph and cannot reference it. Same literal

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -150,10 +150,9 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 throw;
             }
 
-            // Same liveness contract as Workspace.GetStream: a cached child whose sub-hub is gone
-            // is replaced rather than handed out dead.
-            if (reduced.Hub?.RunLevel <= MessageHubRunLevel.Started
-                && reduced.Hub is not MessageHub { IsDisposing: true })
+            // Same liveness contract as Workspace.GetStream — literally the same predicate, so the
+            // two cannot drift apart again (they did: #1455).
+            if (StreamLiveness.IsUsable(reduced))
                 return (ISynchronizationStream<TReduced>)reduced;
 
             Remove(reference, lazy);
@@ -217,6 +216,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     private bool isDisposed;
     private readonly object disposeLock = new();
     private readonly ILogger<SynchronizationStream<TStream>> logger;
+
+    /// <inheritdoc />
+    bool ISynchronizationStream.IsDisposed => isDisposed;
+
+    /// <inheritdoc />
+    public ISynchronizationStream? Source { get; init; }
 
     // Mirror of MeshWeaver.Mesh.Security.WellKnownUsers.System — Data sits below
     // Mesh.Contract in the project graph and cannot reference it. Same literal

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -206,8 +206,7 @@ public class Workspace : IWorkspace
         {
             var stream = GetRemoteStreamUnchecked<TReduced, TReference>(owner, reference);
             var lease = LeaseRemoteStream(stream);
-            if (stream.Hub?.RunLevel <= MessageHubRunLevel.Started
-                && stream.Hub is not MessageHub { IsDisposing: true })
+            if (StreamLiveness.IsUsable(stream))
                 return (stream, lease);
             lease.Dispose();
         }
@@ -571,12 +570,10 @@ public class Workspace : IWorkspace
                     "Workspace {WorkspaceId} opened remote stream {StreamId} for {Owner} as {Identity}.",
                     Id, stream.StreamId, key.Item1, key.Item3);
 
-            // Check if cached stream is still alive. Hub.RunLevel alone is not
-            // sufficient because hub shutdown is async: right after stream.Dispose()
-            // is called, RunLevel is still Running even though disposal was triggered.
-            // Cast to the concrete type to access IsDisposing (not on interface).
-            if (stream.Hub?.RunLevel <= MessageHubRunLevel.Started
-                && stream.Hub is not MessageHub { IsDisposing: true })
+            // Check if the cached stream is still alive — the ONE shared predicate, so this cache
+            // cannot drift from the other two (StreamLiveness explains why it is not just a
+            // RunLevel probe, and why the stream's source chain counts too).
+            if (StreamLiveness.IsUsable(stream))
                 return (ISynchronizationStream<TReduced>)stream;
 
             // Dead — remove (if still ours) and retry. The TryRemove guards
@@ -644,10 +641,13 @@ public class Workspace : IWorkspace
 
         while (true)
         {
-            var lazy = _localStreamCache.GetOrAdd(reference,
-                _ => new Lazy<ISynchronizationStream>(
-                    () => ReduceLocalStream(reference, null),
-                    LazyThreadSafetyMode.ExecutionAndPublication));
+            // Constructed BEFORE the GetOrAdd so we can tell, by identity, whether the entry we
+            // ended up with is the one we just made. That single bit is what bounds the loop
+            // below — see the fall-through at the end.
+            var mine = new Lazy<ISynchronizationStream>(
+                () => ReduceLocalStream(reference, null),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+            var lazy = _localStreamCache.GetOrAdd(reference, mine);
 
             ISynchronizationStream stream;
             try
@@ -660,21 +660,37 @@ public class Workspace : IWorkspace
                 // failure (e.g. HubDisposingException from a hub that is winding down) would
                 // otherwise poison this reference for the workspace's life. Drop the faulted
                 // entry — only if it is still ours — and let the caller see the original fault.
-                ((ICollection<KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>>)_localStreamCache)
-                    .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(reference, lazy));
+                Remove(reference, lazy);
                 throw;
             }
 
-            // Same liveness contract as GetExternalClientSynchronizationStream: a cached stream
-            // whose sub-hub is gone (its parent was torn down, or a consumer disposed it) is
-            // replaced rather than handed out dead.
-            if (stream.Hub?.RunLevel <= MessageHubRunLevel.Started
-                && stream.Hub is not MessageHub { IsDisposing: true })
+            // 🚨 The child's OWN hub is never enough — the cached child is its parent's SIBLING.
+            // StreamLiveness.IsUsable walks the whole reduce chain; see its remarks for why, and
+            // for the two failures the child-only predicate produced here (Systemorph/MeshWeaver#1455).
+            if (StreamLiveness.IsUsable(stream))
                 return (ISynchronizationStream<TReduced>)stream;
 
-            ((ICollection<KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>>)_localStreamCache)
-                .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(reference, lazy));
+            Remove(reference, lazy);
+
+            // 🚨 A FRESH reduce that is ALREADY unusable means the SOURCE is gone, not that the
+            // cache entry went stale — and re-reducing can only mint another corpse. Retrying was
+            // an unbounded spin, each turn allocating a SynchronizationStream and its `sync/{id}`
+            // sub-hub; on a hub action block that is a permanent wedge plus a hub-allocation
+            // storm. Hand this one back instead: it is the plain, uncached reduce, which is
+            // exactly what a disposed source has always produced here and what ReduceShared falls
+            // through to for the same reason (SynchronizationStream.ReduceShared's parent guard).
+            // Its store is already completed, so a reader gets a terminal instead of a stale
+            // replay followed by eternal silence.
+            if (ReferenceEquals(lazy, mine))
+                return (ISynchronizationStream<TReduced>)stream;
+
+            // We lost the add race to another caller's entry and it was dead: drop it and let the
+            // next turn install ours. Every turn removes one entry, so this cannot spin.
         }
+
+        void Remove(WorkspaceReference key, Lazy<ISynchronizationStream> entry) =>
+            ((ICollection<KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>>)_localStreamCache)
+                .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(key, entry));
     }
 
     private ISynchronizationStream<TReduced> ReduceLocalStream<TReduced>(

--- a/src/MeshWeaver.Data/WorkspaceStreams.cs
+++ b/src/MeshWeaver.Data/WorkspaceStreams.cs
@@ -197,7 +197,15 @@ c => c
             reference,
             stream.ReduceManager.ReduceTo<TReduced>(),
             configuration
-        );
+        )
+        {
+            // 🚨 The link that makes this stream's liveness answerable. The sub-hub below is
+            // hosted on `stream.Host`, so it is the PARENT'S SIBLING and outlives the parent for
+            // the whole teardown cascade; without a way back to the parent, every cache that
+            // keys on the reference alone serves a mirror of a dead source (#1455). Read it
+            // through StreamLiveness.IsUsable, never by hand.
+            Source = stream
+        };
 
         stream.RegisterForDisposal(reducedStream);
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-stream-cache-dead-source.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-stream-cache-dead-source.md
@@ -1,0 +1,13 @@
+---
+Name: Pages no longer stall on a stream whose source went away
+Category: Fix
+Description: A cached data stream whose source was torn down is replaced instead of served, so a read gets an answer instead of a stale value and silence.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Pages no longer stall on a stream whose source went away
+
+When the data source behind a view was torn down and rebuilt, the portal could keep handing out a cached view of the source that had just disappeared. A page bound to it showed the last value it had seen and then went quiet forever — no update, no error, nothing to retry — and a save routed through the same path could report success while writing to a stream nobody was reading.
+
+Streams now know what they were derived from, so a view whose source is gone is rebuilt instead of reused, and a read against a source that is genuinely gone ends promptly rather than waiting out its full budget.

--- a/test/MeshWeaver.Hosting.Monolith.Test/StreamCacheLivenessTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StreamCacheLivenessTest.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the liveness contract of the reference-keyed stream caches:
+/// <b>a cached reduced stream whose SOURCE is dead is never served</b>, and asking for one cannot
+/// spin.
+///
+/// <para><b>The defect (#1455).</b> <c>Workspace._localStreamCache</c> keyed on the
+/// <c>WorkspaceReference</c> alone and judged liveness from the cached stream's OWN sub-hub. But
+/// <c>WorkspaceStreams.CreateReducedStream</c> hosts that sub-hub on <c>stream.Host</c>, making the
+/// child the parent's SIBLING — it outlives the parent for the whole teardown cascade. The
+/// predicate was character-for-character the one <c>ReduceShared</c> had already been given a
+/// parent guard for (#1425), and it had no such guard. Both halves were measured on this exact
+/// fixture before the fix:</para>
+/// <list type="number">
+/// <item><description>Dispose the source, ask again → <b>the identical stream instance</b>
+/// (<c>same=True</c>, <c>hubRunLevel=Started</c>, <c>hubDisposing=False</c>), which replays the
+/// snapshot it last saw and then neither emits nor completes, ever.</description></item>
+/// <item><description>Wait for the cascade to dispose that child, ask again → <c>GetStream</c>
+/// <b>never returned</b>. A reduce off a disposed parent is disposed on birth
+/// (<c>SynchronizationStream.RegisterForDisposal</c>), so the replacement failed the same check
+/// and the retry loop went round forever, minting a <c>SynchronizationStream</c> and its
+/// <c>sync/{id}</c> sub-hub every turn. Confirmed with a temporary iteration cap that threw at 20
+/// turns.</description></item>
+/// </list>
+///
+/// <para>Disposing the data source's primary stream is the same lever
+/// <see cref="SilentReadNackTest"/> uses, and for the same reason: it is the one way to make a
+/// source permanently dead while the owning hub stays healthy and keeps serving messages.</para>
+/// </summary>
+public class StreamCacheLivenessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// 🚨 The window between "the source died" and "the cascade disposed its children" — the regime
+    /// the child-only predicate could not see at all.
+    ///
+    /// <para>The assertion is deliberately two-sided. The identity check names the defect (the
+    /// cache handed back the very same object); the terminal check names the HARM, and is the half
+    /// that would still fail if a future change made the cache mint a fresh stream that is somehow
+    /// still attached to the corpse. A reader wants an answer or an end — a stale replay followed
+    /// by permanent silence is the one outcome it cannot act on, because it is indistinguishable
+    /// from a source that is merely quiet.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task CachedStream_WhoseSourceIsDisposed_IsNeverServed()
+    {
+        var path = $"{TestPartition}/cache-liveness-window";
+        await NodeFactory.CreateNode(
+            new MeshNode("cache-liveness-window", TestPartition)
+            {
+                Name = "Cache Liveness Window",
+                NodeType = "Markdown"
+            }).Should().Emit();
+
+        var warm = await ReadNode(path).Should().Match(n => n is not null);
+        warm!.Path.Should().Be(path);
+
+        var owner = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        owner.Should().NotBeNull("the read above must have activated the owning per-node hub");
+        var workspace = owner!.GetWorkspace();
+
+        // Populate the cache while the source is healthy, and prove the entry is real by taking
+        // the same instance back on a second ask.
+        var cached = workspace.GetStream(new MeshNodeReference());
+        Assert.NotNull(cached);
+        Assert.Same(cached, workspace.GetStream(new MeshNodeReference()));
+
+        var dataSource = workspace.DataContext.GetDataSourceForType(typeof(MeshNode));
+        dataSource.Should().NotBeNull("the per-node hub owns a MeshNode data source");
+        // Assert.NotNull, not FluentAssertions: ISynchronizationStream is an IObservable, so
+        // `.Should()` binds the observable-assertion extension instead of the object one.
+        var primary = dataSource!.GetStreamForPartition(null);
+        Assert.NotNull(primary);
+        primary.Dispose();
+        Output.WriteLine("[TEST] disposed the MeshNode data-source stream — the cache's source is now dead");
+
+        var served = workspace.GetStream(new MeshNodeReference());
+        Assert.NotNull(served);
+        Assert.NotSame(cached, served);
+
+        // The stream that IS handed out must be terminal: completed, with nothing to replay.
+        // Before the fix this was `cached` itself, whose replay buffer still held the pre-disposal
+        // snapshot and whose store never completed — the assertion below timed out.
+        var terminal = await served!
+            .Select(x => (object?)x.Value)
+            .IsEmpty()
+            .Timeout(TimeSpan.FromSeconds(5))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        terminal.Should().BeTrue(
+            "a stream reduced from a dead source has no value to give and must say so by "
+            + "completing — a reader that gets a stale replay and then eternal silence has no way "
+            + "to tell 'gone' from 'quiet' and hangs for its whole budget");
+    }
+
+    /// <summary>
+    /// 🚨 The regime AFTER the cascade: the cached child is genuinely disposed, so the cache
+    /// correctly evicts — and every replacement it can build is disposed on birth. Re-reducing is
+    /// not a repair, and repeating it is not a strategy.
+    ///
+    /// <para>Before the fix this call never returned. The observation is bounded and runs off the
+    /// test thread so a regression fails in seconds rather than hanging the run — but note that a
+    /// failure here means the process is <b>spinning and allocating hubs</b>, so treat the whole
+    /// shard as compromised rather than just this test.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task GetStream_WhenEveryPossibleReduceIsBornDead_ReturnsInsteadOfRetrying()
+    {
+        var path = $"{TestPartition}/cache-liveness-cascade";
+        await NodeFactory.CreateNode(
+            new MeshNode("cache-liveness-cascade", TestPartition)
+            {
+                Name = "Cache Liveness Cascade",
+                NodeType = "Markdown"
+            }).Should().Emit();
+
+        var warm = await ReadNode(path).Should().Match(n => n is not null);
+        warm!.Path.Should().Be(path);
+
+        var owner = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        owner.Should().NotBeNull();
+        var workspace = owner!.GetWorkspace();
+
+        var cached = workspace.GetStream(new MeshNodeReference());
+        Assert.NotNull(cached);
+
+        var dataSource = workspace.DataContext.GetDataSourceForType(typeof(MeshNode));
+        var primary = dataSource!.GetStreamForPartition(null);
+        Assert.NotNull(primary);
+        primary.Dispose();
+
+        // Wait for the parent's teardown to reach the child it registered for disposal. Only then
+        // does the cache start evicting-and-replacing, which is the loop under test.
+        await Observable.Interval(TimeSpan.FromMilliseconds(25)).StartWith(0L)
+            .Where(_ => (cached!.Hub as MessageHub)?.IsDisposing == true
+                        || cached.Hub?.RunLevel > MessageHubRunLevel.Started)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        Output.WriteLine($"[TEST] cascade reached the cached child: RunLevel={cached!.Hub?.RunLevel}");
+
+        // Off the test thread and bounded: a regression is an unbounded spin, and the point of
+        // this test is that the call TERMINATES at all.
+        var resolved = await Observable
+            .Start(() => workspace.GetStream(new MeshNodeReference()), NewThreadScheduler.Default)
+            .Timeout(TimeSpan.FromSeconds(15))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(resolved);
+        Output.WriteLine("[TEST] GetStream returned instead of spinning");
+
+        var terminal = await resolved!
+            .Select(x => (object?)x.Value)
+            .IsEmpty()
+            .Timeout(TimeSpan.FromSeconds(5))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        terminal.Should().BeTrue(
+            "the only stream a dead source can produce is a completed one — handing it back is "
+            + "what the plain uncached reduce has always done, and is what ReduceShared's parent "
+            + "guard falls through to");
+    }
+
+    /// <summary>
+    /// 🚨 THE ANTI-DIVERGENCE GUARD. The two reference-keyed reduce caches —
+    /// <c>Workspace._localStreamCache</c> and <c>SynchronizationStream.sharedReduceCache</c> — must
+    /// return the SAME verdict about the same dead source.
+    ///
+    /// <para>They are separate caches with separate keys and separate call sites, and they have
+    /// already drifted once: #1425 gave <c>ReduceShared</c> a parent guard and recorded exactly why
+    /// the child-only predicate was inadequate, while the copy in <see cref="Workspace"/> kept it
+    /// for another four months. Sharing one <c>StreamLiveness.IsUsable</c> is the structural half
+    /// of the fix; this test is the half that fails if someone re-inlines a predicate into either
+    /// one.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task BothReduceCaches_AgreeThatADeadSourceIsNotServable()
+    {
+        var path = $"{TestPartition}/cache-liveness-agree";
+        await NodeFactory.CreateNode(
+            new MeshNode("cache-liveness-agree", TestPartition)
+            {
+                Name = "Cache Liveness Agreement",
+                NodeType = "Markdown"
+            }).Should().Emit();
+
+        var warm = await ReadNode(path).Should().Match(n => n is not null);
+        warm!.Path.Should().Be(path);
+
+        var owner = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        owner.Should().NotBeNull();
+        var workspace = owner!.GetWorkspace();
+
+        var dataSource = workspace.DataContext.GetDataSourceForType(typeof(MeshNode));
+        var primary = dataSource!.GetStreamForPartition(null);
+        Assert.NotNull(primary);
+
+        // Warm BOTH caches off the same primary: the shared intermediate that MeshDataSource's
+        // own-node factory reduces through, and the workspace's own entry for the leaf.
+        var sharedIntermediate = primary!.ReduceShared<InstanceCollection>(
+            new CollectionReference(nameof(MeshNode)));
+        Assert.NotNull(sharedIntermediate);
+        Assert.Same(sharedIntermediate,
+            primary.ReduceShared<InstanceCollection>(new CollectionReference(nameof(MeshNode))));
+
+        var localCached = workspace.GetStream(new MeshNodeReference());
+        Assert.NotNull(localCached);
+
+        primary.Dispose();
+
+        Assert.NotSame(sharedIntermediate,
+            primary.ReduceShared<InstanceCollection>(new CollectionReference(nameof(MeshNode))));
+        Assert.NotSame(localCached, workspace.GetStream(new MeshNodeReference()));
+    }
+}


### PR DESCRIPTION
## It reproduces — in two regimes, both worse than the issue predicted

#1455 was filed as "confirmed by reading, not yet manifesting". It manifests. Both regimes were
measured on `MonolithMeshTestBase` by disposing a per-node hub's MeshNode data-source stream — the
same lever `SilentReadNackTest` already uses, and the one way to make a source permanently dead
while its owning hub stays healthy and keeps serving messages.

**1. During the teardown cascade — the cache hands back the identical instance.**

```
[PROBE] before: b2GrO10AWE6otqUitVOyng hub=sync/iwKvqZ_F6UaLlLWPDb6Ujw
[PROBE] disposed the primary
[PROBE] after:  b2GrO10AWE6otqUitVOyng hub=sync/iwKvqZ_F6UaLlLWPDb6Ujw same=True hubRunLevel=Started hubDisposing=False
[PROBE] emission: MeshNode { Id = cache-probe, … }      ← the stale snapshot, replayed
```

Its replay subject still serves the value it last saw, and then nothing: no further emission (the
source is gone) and no completion (the child is not disposed yet). A reader hangs on a stale value
for its whole budget — the exact outcome `ReduceShared`'s guard exists to prevent. Note the two
consumers of this cached path are `HandlePatchDataRequest` and `MeshNodeStreamHandle`'s own-node
read/Update, so a writer patches a stream nobody drains and is **acked**.

**2. After the cascade — `GetStream` never returns.**

```
[PROBE] child now: runLevel=Dead disposing=True
[PROBE] again threw: InvalidOperationException: PROBE-SPIN: GetStream looped 20 times
```

A reduce off a disposed parent is disposed on birth (`RegisterForDisposal` disposes immediately once
the parent is terminal), so every replacement fails the same liveness check, is evicted, and is
re-made. Unbounded, minting a `SynchronizationStream` and its `sync/{id}` sub-hub every turn. On a
hub action block that is a permanent wedge *plus* a hub-allocation storm. (The `PROBE-SPIN` cap was
temporary instrumentation, removed.)

## The fix: the missing link, not a cleverer probe

The issue's general lesson is the whole of it — **a cached child is not a descendant of its parent,
so "is the child alive?" is never sufficient.** `CreateReducedStream` hosts the child's `sync/{id}`
hub on `stream.Host`, making it the parent's *sibling*; it merely registers it for disposal on the
parent. So the child cannot be asked about its source, because it had no way to reach it.

- `ISynchronizationStream` gains `Source` (set in `CreateReducedStream`) and `IsDisposed`. The file's
  own comment already named the gap: *"a consumer cannot even detect the corpse:
  `ISynchronizationStream` exposes no liveness/disposal member."*
- **One** predicate — `StreamLiveness.IsUsable` — walks the reduce chain. All four hand-copied
  copies now call it: `Workspace._localStreamCache`, `Workspace._remoteStreamCache`,
  `AcquireRemoteStreamUnchecked`, and `ReduceShared`. For the two remote ones the walk is a no-op
  (`Source` is null), so this is deduplication there, not a behaviour change.
- `GetStream` stops retrying a reduce that can never be live. When the entry it just installed comes
  back unusable, the **source** is gone rather than the cache being stale, so it hands that stream
  back — the plain uncached reduce, which is what a disposed source has always produced here and
  what `ReduceShared:127` falls through to for the same recorded reason. Its store is already
  completed, so a reader gets a terminal instead of a stale replay followed by eternal silence.

## Verification

**Fail-before / pass-after.** All three new tests fail against unmodified `src/` with the tests kept
in place — two by timeout, one by `Assert.NotSame` — and pass with the fix.

```
Failed StreamCacheLivenessTest.GetStream_WhenEveryPossibleReduceIsBornDead_ReturnsInsteadOfRetrying [15 s]
Failed StreamCacheLivenessTest.BothReduceCaches_AgreeThatADeadSourceIsNotServable [1 m]
Failed StreamCacheLivenessTest.CachedStream_WhoseSourceIsDisposed_IsNeverServed [1 m]
Total tests: 3   Failed: 3
```

**Full project, not standalone** — a standalone green proves little for a cache/liveness race, and
#1425's first cut of this same predicate was caught only by a full-project run.
`MeshWeaver.Hosting.Monolith.Test` under `DOTNET_PROCESSOR_COUNT=4`: **672 passed, 3 skipped, 0
failed** (675). `dotnet build -c Release -warnaserror`: clean, 0 warnings.

The third test is the anti-divergence guard the issue asks for: it drives **both** reduce caches off
the same dead source and requires the same verdict, so re-inlining a predicate into either one reds.

Fixes #1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)