### PR TITLE
fix(test): IoPoolTest asserted a drain ordering it never established

### DIFF
--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -396,20 +396,41 @@ public class IoPoolTest
             "exactly leg A holds the permit; leg B must still be waiting on the gate");
 
         var drainDone = Task.Run(pool.Drain, TestContext.Current.CancellationToken);
+
+        // 🚨 ESTABLISH the ordering the assertions below depend on — do not assume it.
+        //
+        // `Task.Run` only SCHEDULES Drain; it says nothing about whether Drain has reached its
+        // `_poolCts.Cancel()`. Releasing leg A here — as this test used to — frees the only permit
+        // while the cancel may still be queued behind a busy thread pool, and SemaphoreSlim then
+        // legitimately hands that permit to the leg B waiter already queued on it. Leg B's
+        // `ct.ThrowIfCancellationRequested()` guard passes (nothing is cancelled yet), it subscribes,
+        // and the test fails on `legBSubscribed == 1` — reporting a product regression when the
+        // product did exactly the right thing. Observed on a loaded CI runner (six shards on one
+        // box); the assertion asserted an ordering the test never created.
+        //
+        // Leg B's TERMINATION is the observable proof that the cancel has happened: it is parked in
+        // `_gate.WaitAsync(linked)`, so `_poolCts.Cancel()` is what completes that wait as cancelled
+        // → OnCompleted → this `.Finally`. Waiting for it costs nothing when the pool is healthy and
+        // is what makes "the drain cancels BEFORE the permit is granted" true by construction rather
+        // than by scheduling luck. It does not deadlock: Drain blocks re-acquiring leg A's permit,
+        // which is independent of leg B's cancellation continuation.
+        Assert.True(legBTerminated.Wait(Timeout5),
+            "a leg the drain cancels MUST terminate (OnCompleted) so its .Finally runs — that callback "
+            + "is what releases RoutingGrain's in-flight route slot and advances OrderedRouteDispatcher's "
+            + "per-destination FIFO; swallowing the cancellation silently leaked both");
+
         releaseLegA.Set();
         await drainDone.WaitAsync(Timeout10, TestContext.Current.CancellationToken);
 
         Volatile.Read(ref legAReleasedCleanly).Should().Be(1,
             "leg A must have been RELEASED, not timed out — a timed-out wait would free the permit on "
             + "its own and leg B would no longer be parked on the gate, so the test would prove nothing");
+        // 🚨 THE REGRESSION GUARD — and it is now asserted on a cancellation that PROVABLY preceded
+        // the permit becoming free (see the wait above), so a pass means the drain refused leg B
+        // rather than merely outrunning it. Before the termination fix this never fired at all and
+        // the test hung to its timeout.
         Volatile.Read(ref legBSubscribed).Should().Be(0,
             "the drain cancels before the permit is granted, so leg B's source must never be subscribed");
-
-        // 🚨 THE REGRESSION GUARD. Before the fix this never fired and the test hung to its timeout.
-        Assert.True(legBTerminated.Wait(Timeout5),
-            "a leg the drain cancels MUST terminate (OnCompleted) so its .Finally runs — that callback "
-            + "is what releases RoutingGrain's in-flight route slot and advances OrderedRouteDispatcher's "
-            + "per-destination FIFO; swallowing the cancellation silently leaked both");
     }
 
     [Fact]


### PR DESCRIPTION
`IoPoolTest.Drain_terminates_a_SubscribeThroughPool_leg_it_cancels` went red on a loaded CI runner
(six shards on one box) with:

> Expected value to be 0 because the drain cancels before the permit is granted, so leg B's source
> must never be subscribed, but found 1.

**The product did nothing wrong. The test did.**

## Root cause

```csharp
var drainDone = Task.Run(pool.Drain, ...);   // only SCHEDULES Drain
releaseLegA.Set();                           // frees the only permit NOW
```

`Task.Run` says nothing about whether `Drain` has reached its `_poolCts.Cancel()`. Releasing leg A
frees the single permit while that cancel may still be queued behind a busy thread pool, and
`SemaphoreSlim` then legitimately hands the permit to the leg B waiter already queued on it. Leg B's
`ct.ThrowIfCancellationRequested()` guard passes — nothing is cancelled yet — so it subscribes,
**exactly as it should**.

The assertion "the drain cancels before the permit is granted" was describing an ordering that
nothing in the test created. It passed for years on scheduling luck.

## The fix — establish the ordering, don't assume it

Leg B's **termination** is the observable proof that the cancel has happened: leg B is parked in
`_gate.WaitAsync(linked)`, so `_poolCts.Cancel()` is precisely what completes that wait as cancelled
→ `OnCompleted` → its `.Finally`. Waiting for that *before* releasing leg A makes the premise true by
construction.

It cannot deadlock: `Drain` blocks re-acquiring leg A's permit, which is independent of leg B's
cancellation continuation. On a healthy pool the wait costs nothing.

The regression guard is unchanged and now means **more**: `legBSubscribed == 0` is asserted against a
cancellation that *provably* preceded the permit becoming free, so a pass means the drain **refused**
leg B rather than merely outran it.

## What this is not

No product change. No widened bound, no retry, no `Task.Delay`, nothing skipped — the race is removed
by ordering, which is the only thing that removes a race.

## Verification

`MeshWeaver.Hosting.Test` **15/15**, `-c Release -warnaserror` clean.

Found while triaging a red on #1458, whose diff cannot reach `IoPool` — RCA'd rather than re-run.
`main` is green, so this is a load-dependent flake main happened not to sample, not a main breakage.

**No What's New entry**: test-only, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)