### PR TITLE
fix(#1318): a registry-only consumer learns a module changed by READING the registry, not by waiting

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -1,7 +1,7 @@
 ---
 Name: Plugin Update on Green Build
 Category: Architecture
-Description: A plugin repo's CI going green reaches every installation that uses it, without anyone polling a registry or opening the catalog. The webhook records the build as a mesh node; the catalog subscribes to that node and reacts per module, gated on content identity so a green run that changed nothing stays completely silent.
+Description: A plugin repo's CI going green reaches every installation that uses it, with nobody opening the catalog and no poll timer anywhere. An installation with GitHub access subscribes to a build node the webhook writes; an installation that installs from a registry reads that registry's own feed at startup. Both react per module, gated on content identity, so a build that changed nothing stays completely silent.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/><path d="m9 12 2 2 4-4"/></svg>
 ---
 
@@ -30,6 +30,53 @@ per installed module:  ModuleVersion changed?
    ├── no  ──▶ silent. no notification, no fetch, nothing.
    └── yes ──▶ opted in ? install the delta : raise an "Update available" reminder
 ```
+
+## 🚨 Two inputs, one decision — and which one your installation has
+
+The path above needs a **GitHub webhook on the plugin repo**. An installation that installs from a
+[registry](/Doc/Architecture/PluginRegistry) over HTTP deliberately holds no GitHub credential and
+receives no webhooks, so for a long time it had **no input at all**: `BuildCompletion` is constructed
+in exactly one place in the whole tree — the `workflow_run` webhook — and the watcher only opens a
+subscription once a catalog node names a source repo. Such an installation had neither, so the
+watcher was registered, live and completely inert, and `AutoUpdate` was a flag nothing ever fired.
+Its plugins stayed at the version they were installed at until an administrator pressed **Provision**.
+
+There are now two inputs, by deployment shape:
+
+| | learns from | how | when |
+|---|---|---|---|
+| **Registry instance** (holds the GitHub credential) | its plugin repos | `PluginUpdateWatcher` subscribes to `Admin/_Build/{owner}.{repo}` | on every green build |
+| **Consumer** (registry token, no GitHub) | its registry | `RegistryUpdateReconciler` **reads** `GET /api/plugins` | at startup |
+
+Both hand the per-module verdict to the same `PackageUpdateReconciler`, so they can never disagree
+about what "changed" means or about who opted into an unattended install. Both are registered
+unconditionally and each is inert on the deployment shape it does not serve.
+
+### Why the consumer READS instead of waiting to be told
+
+There is nothing for a consumer to subscribe to. The registry is a **different deployment with a
+different database**, so it shares no durable row; and there is no cross-process change feed either
+(`PostgreSqlChangeListener` is registered and never started). A signal would therefore mean a new
+push protocol — a subscription registry, a shared secret, an inbox — kept in step with the feed that
+already exists.
+
+It does not need one. `GET /api/plugins` already returns every package's `ModuleVersion`, which is
+the same content identity the install records carry, so **comparing the two answers the question
+outright**. That is the shape `BuildProtocolDriver.FollowGo` arrived at for the cross-cluster case:
+end on a fact you can read, not on a notification that cannot reach you.
+
+### 🚨 Not a poll timer
+
+The reconcile runs on an event the deployment already has — **this process starting** — and not on a
+clock. A timer answers "how stale am I willing to be", which is a question nobody asked, and it turns
+one misconfiguration into permanent background load.
+
+On these deployments the restart *is* the fan-out: plugin content and the framework image are
+published by the same CI, and the portals self-update onto each new image, so a green plugin build
+and a pod roll already arrive together. The honest bound is therefore **a consumer learns on its next
+boot** — plus immediately, on demand, whenever somebody opens the catalog page, which reads the same
+feed and offers the same **Update**. An installation that never restarts also never picks up
+framework fixes, which is a louder problem with its own alarm.
 
 ## Why a node and not a call
 
@@ -144,7 +191,7 @@ install-time seed.
 | Symptom | Cause |
 |---|---|
 | Nothing happens on a green build | The webhook does not send **Workflow runs**; or no catalog's `SourceRepoPath` matches the repo; or the run's conclusion was not `success` — only completed+successful runs are recorded; or the run was **not triggered by a push** (`workflow_run` also fires for `pull_request`, `schedule`, `workflow_dispatch`, … — none of those record); or the run was **not on the repository's default branch** — a green PR-branch build is unmerged code and is deliberately never recorded (fail-closed: a payload with no readable branch records nothing either). |
-| A notification per green run, nothing changed | A module's `manifest.lock` is missing or unparseable, so `ModuleVersion` is null and the legacy commit-sha comparison applies — every commit looks like a change. Fix the module's CI to emit the sidecar. |
+| A module never updates, and the log says it "has no module content identity" | The module's `manifest.lock` is missing or unparseable, so there is no `ModuleVersion` to compare and "has it changed" is unanswerable. A missing hash is the **absence of evidence**, not evidence of a change: treating it as changed would re-install the module on every green build of the repo *and* on every pod start, which is acting on the event rather than the content. It is refused, loudly, and the catalog card's manual **Update** stays available. Fix the module's CI to emit the sidecar. |
 | Build node updates but no installation reacts | The package is not installed on that instance. A catalog lists far more packages than any instance installs; only packages with an install record are considered. |
 
 The webhook **never throws** on a write failure: GitHub retries a non-2xx delivery, so an unhandled

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-registry-plugin-updates.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-13-registry-plugin-updates.md
@@ -1,0 +1,13 @@
+---
+Name: Plugin updates reach installations that install from a registry
+Category: Fix
+Description: An installation that gets its plugins from a registry now finds out when an installed plugin changed, instead of needing someone to notice and click.
+Icon: Sparkle
+Order: -20260813
+---
+
+# Plugin updates reach installations that install from a registry
+
+Until now, "a plugin changed" only ever reached an installation that received GitHub build notifications for the plugin's own repository. An installation that gets its plugins from a registry over HTTP — the setup that deliberately holds no GitHub credentials — had no way to find out at all: its plugins stayed at the version they were installed at until an administrator noticed and pressed Provision.
+
+Such an installation now checks the registry it already installs from, on startup, and compares what the registry is serving with what it has. A plugin that opted into automatic updates is brought up to date; anything else raises a notification on the plugin so an administrator can decide. A plugin whose content has not changed costs nothing, and an installation with no registry configured is unaffected.

--- a/src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs
@@ -1,0 +1,277 @@
+﻿using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// THE decision "this installed module changed — remind, or install it" — in one place, for every
+/// path that can learn a module changed.
+///
+/// <para>There are two such paths and they must never disagree:</para>
+/// <list type="bullet">
+///   <item><see cref="PluginUpdateWatcher"/> — a plugin repo's CI went green, learned from a
+///     <c>BuildCompletion</c> node a GitHub <c>workflow_run</c> webhook wrote. This is the
+///     REGISTRY's input: it is the installation that holds the GitHub credential and receives the
+///     hooks.</item>
+///   <item><see cref="RegistryUpdateReconciler"/> — the packages a registry is serving no longer
+///     match what is installed here, learned by READING the registry's own feed. This is the
+///     CONSUMER's input, and before it existed a registry-only installation had none at all
+///     (Systemorph/MeshWeaver#1318).</item>
+/// </list>
+///
+/// <para><b>A new build is NOT a change, and neither is a new feed read.</b> The gate is content
+/// identity per MODULE — <see cref="PackageManifest.ModuleVersion"/>, a hash over the module's
+/// sorted (path, file-hash) pairs — compared against the install record's. Equal ⇒ silence: no
+/// notification, no fetch. That comparison, and the install that follows it, are deliberately
+/// delegated to <see cref="CatalogLayoutAreas.InstallOrUpdate"/>, the very same call the Update
+/// button makes.</para>
+///
+/// <para><b>Reminder by default; unattended on opt-in.</b> A changed module raises a
+/// <c>Notification</c> satellite on the install record unless that record opted in
+/// (<see cref="PackageManifest.AutoUpdate"/>, stamped at install time from the deployment's
+/// <see cref="PluginCatalogOptions.AutoUpdateByDefault"/>). A commercial package is re-authorized
+/// against the principal recorded at install time on EVERY unattended apply (#830) — there is no
+/// user on a background reaction, so revoking that principal's admin must stop the syncing.</para>
+///
+/// <para>Reactive throughout, errors are logged rather than thrown: these are background
+/// reactions, and one unreachable package must not tear down the pass that serves the rest.</para>
+/// </summary>
+internal static class PackageUpdateReconciler
+{
+    /// <summary>
+    /// Reconciles every <paramref name="candidates"/> entry that this installation actually has an
+    /// install record for. Packages that are not installed here are skipped in silence — a catalog
+    /// lists far more than any one instance installs, so that is the common case.
+    /// </summary>
+    /// <param name="hub">The calling hub.</param>
+    /// <param name="source">The source the candidates came from, used to fetch a delta.</param>
+    /// <param name="sourceRef">The ref/sha the candidates were listed at.</param>
+    /// <param name="candidates">The packages the source is currently serving.</param>
+    /// <param name="provenance">One human phrase naming where this reconcile learned its facts,
+    /// e.g. <c>"Built from a1b2c3d"</c> or <c>"Served by registry 'memex'"</c>. It ends up in the
+    /// reminder a user reads, so it must say something a user can act on.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>Cold observable completing when every candidate has been considered.</returns>
+    public static IObservable<Unit> ReconcileInstalled(
+        IMessageHub hub,
+        IPackageSource source,
+        string sourceRef,
+        IReadOnlyList<PackageManifest> candidates,
+        string provenance,
+        ILogger? logger)
+    {
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (storage is null || candidates.Count == 0)
+            return Observable.Return(Unit.Default);
+
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+
+        // SEQUENTIAL (Concat), not a fan-out: each apply writes a partition's worth of nodes and
+        // may compile node types. The boot caller runs this on a cold pod, where a parallel
+        // fan-out is how you saturate it — the same call InstanceAutoRegistrationService.InstallAll
+        // already makes for the identical reason.
+        return candidates
+            .Select(pkg => ReconcileOne(
+                hub, storage, meshService, accessService, source, sourceRef, pkg, provenance, logger))
+            .ToObservable()
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync();
+    }
+
+    private static IObservable<Unit> ReconcileOne(
+        IMessageHub hub,
+        IStorageAdapter storage,
+        IMeshService meshService,
+        AccessService accessService,
+        IPackageSource source,
+        string sourceRef,
+        PackageManifest pkg,
+        string provenance,
+        ILogger? logger)
+    {
+        var recordPath = $"{PackageInstaller.InstalledPartition}/{pkg.Id}";
+        return storage.Read(recordPath, hub.JsonSerializerOptions)
+            .Take(1)
+            .Select(n => n?.ContentAs<PackageManifest>(hub.JsonSerializerOptions))
+            .Catch<PackageManifest?, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "Package update: reading install record {Path} failed; skipping {Id}.",
+                    recordPath, pkg.Id);
+                return Observable.Return<PackageManifest?>(null);
+            })
+            .SelectMany(record => record is null
+                // Not installed here → nothing to remind anyone about.
+                ? Observable.Return(Unit.Default)
+                : Decide(hub, meshService, accessService, source, sourceRef, pkg, record, recordPath,
+                    provenance, logger));
+    }
+
+    private static IObservable<Unit> Decide(
+        IMessageHub hub,
+        IMeshService meshService,
+        AccessService accessService,
+        IPackageSource source,
+        string sourceRef,
+        PackageManifest pkg,
+        PackageManifest record,
+        string recordPath,
+        string provenance,
+        ILogger? logger)
+    {
+        // 🚨 THE gate: content identity, not the event that woke us. Equal module hashes ⇒ nothing
+        // in this module changed ⇒ stay completely silent.
+        if (string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
+            return Observable.Return(Unit.Default);
+
+        // 🚨 A MISSING hash on either side is not evidence of a change — it is the ABSENCE of
+        // evidence, and the two must not be confused. Without a `manifest.lock` there is no content
+        // identity to compare, so "has it changed" is unanswerable; answering "yes" would act on the
+        // EVENT instead of the content, which is the one property this whole path is built on. Both
+        // callers would be wrong in the same way: the webhook would re-install the module on every
+        // green build of the repo (a doc-only commit elsewhere included), and the boot reconcile
+        // would re-install it on every single pod start.
+        //
+        // So: refuse, and say so. A module with no content identity can never auto-update, and that
+        // is an authoring defect in the module's CI (Doc/Architecture/PluginAuthoring) rather than
+        // something to paper over here — logged at Warning precisely so it does not become a quiet
+        // "my plugin never updates".
+        if (string.IsNullOrEmpty(pkg.ModuleVersion) || string.IsNullOrEmpty(record.ModuleVersion))
+        {
+            logger?.LogWarning(
+                "Package update: {Id} has no module content identity ({Side} moduleVersion is empty), "
+                + "so it cannot be reconciled and will NOT auto-update. Its CI must emit a "
+                + "manifest.lock sidecar; until then the catalog card's manual Update is the only "
+                + "path. {Provenance}",
+                pkg.Id,
+                string.IsNullOrEmpty(pkg.ModuleVersion) ? "the source's" : "the install record's",
+                provenance);
+            return Observable.Return(Unit.Default);
+        }
+
+        var detail = Describe(pkg, record);
+
+        logger?.LogInformation(
+            "Package update: {Id} has an update ({Old} → {New}; {Detail}); autoUpdate={Auto}. {Provenance}",
+            pkg.Id, record.ModuleVersion, pkg.ModuleVersion, detail, record.AutoUpdate, provenance);
+
+        return record.AutoUpdate
+            ? Apply(hub, meshService, accessService, source, sourceRef, pkg, record, recordPath,
+                provenance, detail, logger)
+            : Notify(
+                meshService, accessService, recordPath, pkg,
+                $"Update available: {pkg.Name ?? pkg.Id}",
+                $"A new build of {pkg.Name ?? pkg.Id} is available ({detail}). {provenance}.",
+                logger);
+    }
+
+    /// <summary>
+    /// What actually changed, for the reminder's message — computed without re-fetching anything:
+    /// the installed side is on the record (<c>InstalledFiles</c>), the candidate side rode in on
+    /// the catalog entry (<c>ManifestFiles</c>).
+    /// </summary>
+    private static string Describe(PackageManifest pkg, PackageManifest record)
+    {
+        var changed = 0;
+        var removed = 0;
+        if (record.InstalledFiles is { Count: > 0 } installed && pkg.ManifestFiles is { Count: > 0 } candidate)
+        {
+            foreach (var (path, hash) in candidate)
+                if (!installed.TryGetValue(path, out var old) || !string.Equals(old, hash, StringComparison.Ordinal))
+                    changed++;
+            foreach (var path in installed.Keys)
+                if (!candidate.ContainsKey(path))
+                    removed++;
+        }
+
+        return changed + removed > 0
+            ? $"{changed} file(s) changed, {removed} removed"
+            : "content changed";
+    }
+
+    /// <summary>
+    /// Unattended install of a changed module — reached only for a record that opted in.
+    ///
+    /// <para>Runs as SYSTEM: there is no user behind a background reaction, and the install writes
+    /// nodes. The record's <see cref="PackageManifest.AuthorizedBy"/> principal is what the
+    /// commercial-entitlement gate re-checks (#830), so a revoked admin stops the syncing and a
+    /// refusal surfaces as a notification rather than a silent skip.</para>
+    /// </summary>
+    private static IObservable<Unit> Apply(
+        IMessageHub hub,
+        IMeshService meshService,
+        AccessService accessService,
+        IPackageSource source,
+        string sourceRef,
+        PackageManifest pkg,
+        PackageManifest record,
+        string recordPath,
+        string provenance,
+        string detail,
+        ILogger? logger)
+    {
+        logger?.LogInformation(
+            "Package update: auto-updating {Id} to {Version} ({Detail}); authorized by {Principal}.",
+            pkg.Id, pkg.ModuleVersion, detail, record.AuthorizedBy ?? "(nobody)");
+
+        return Observable.Using(
+                accessService.ImpersonateAsSystem,
+                _ => CatalogLayoutAreas.InstallOrUpdate(
+                    hub, source, sourceRef, pkg, logger, record.AuthorizedBy))
+            .Do(result => logger?.LogInformation(
+                "Package update: {Id} auto-updated ({Written} written, {Unchanged} unchanged).",
+                pkg.Id, result.Written, result.Unchanged))
+            .Select(_ => Unit.Default)
+            .Catch((Exception ex) =>
+            {
+                if (ex is PackageAuthorizationException)
+                {
+                    logger?.LogWarning(
+                        "Package update: auto-update of {Id} REFUSED — {Reason}", pkg.Id, ex.Message);
+                    return Notify(
+                        meshService, accessService, recordPath, pkg,
+                        $"Update needs a Global Admin: {pkg.Name ?? pkg.Id}",
+                        $"A new build of {pkg.Name ?? pkg.Id} is available ({detail}), but it is a "
+                        + "commercial package and was not applied automatically. " + ex.Message,
+                        logger);
+                }
+
+                logger?.LogWarning(ex,
+                    "Package update: auto-update of {Id} failed; the card still offers a manual Update. {Provenance}",
+                    pkg.Id, provenance);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>Raises a system notification on the install record — the user-visible surface of an
+    /// update reminder, and of a refusal, which must never be a silent skip.</summary>
+    private static IObservable<Unit> Notify(
+        IMeshService meshService,
+        AccessService accessService,
+        string recordPath,
+        PackageManifest pkg,
+        string title,
+        string body,
+        ILogger? logger)
+        => Observable.Using(
+                accessService.ImpersonateAsSystem,
+                _ => NotificationService.CreateNotification(
+                    meshService, recordPath, title, body,
+                    NotificationType.System, targetNodePath: recordPath))
+            .Select(_ => Unit.Default)
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "Package update: raising the notification for {Id} failed.", pkg.Id);
+                return Observable.Return(Unit.Default);
+            });
+}

--- a/src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs
@@ -128,11 +128,6 @@ internal static class PackageUpdateReconciler
         string provenance,
         ILogger? logger)
     {
-        // 🚨 THE gate: content identity, not the event that woke us. Equal module hashes ⇒ nothing
-        // in this module changed ⇒ stay completely silent.
-        if (string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
-            return Observable.Return(Unit.Default);
-
         // 🚨 A MISSING hash on either side is not evidence of a change — it is the ABSENCE of
         // evidence, and the two must not be confused. Without a `manifest.lock` there is no content
         // identity to compare, so "has it changed" is unanswerable; answering "yes" would act on the
@@ -145,6 +140,10 @@ internal static class PackageUpdateReconciler
         // is an authoring defect in the module's CI (Doc/Architecture/PluginAuthoring) rather than
         // something to paper over here — logged at Warning precisely so it does not become a quiet
         // "my plugin never updates".
+        //
+        // 🚨 This is checked BEFORE the equality gate below, not after. `null == null` is *equal*,
+        // so an equality-first order would silently absorb the commonest shape of this defect — both
+        // sides missing a manifest.lock — into "nothing changed" and never say a word (Copilot catch).
         if (string.IsNullOrEmpty(pkg.ModuleVersion) || string.IsNullOrEmpty(record.ModuleVersion))
         {
             logger?.LogWarning(
@@ -157,6 +156,11 @@ internal static class PackageUpdateReconciler
                 provenance);
             return Observable.Return(Unit.Default);
         }
+
+        // 🚨 THE gate: content identity, not the event that woke us. Equal module hashes ⇒ nothing in
+        // this module changed ⇒ stay completely silent — no notification, and not one file fetched.
+        if (string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
+            return Observable.Return(Unit.Default);
 
         var detail = Describe(pkg, record);
 

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -48,6 +48,17 @@ public static class PluginCatalogConfigurationExtensions
                 .AddSingleton<PluginUpdateWatcher>()
                 .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
                     sp => sp.GetRequiredService<PluginUpdateWatcher>())
+                // 🚨 The watcher above is the REGISTRY's input — it needs a GitHub webhook and a
+                // catalog node naming a source repo, so on a registry-only consumer it opens zero
+                // subscriptions and is live-and-inert. That was the whole of #1318: such an
+                // installation could install but could never learn there was anything to install.
+                // This is the CONSUMER's input — it READS the registry feed it already
+                // authenticates to, at boot, instead of waiting for a webhook that cannot arrive.
+                // Both are registered unconditionally and both are inert on a deployment that is
+                // not the shape they serve; they hand the same decision to PackageUpdateReconciler.
+                .AddSingleton<RegistryUpdateReconciler>()
+                .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
+                    sp => sp.GetRequiredService<RegistryUpdateReconciler>())
                 // Resolves an inbound instance key to its instance + grant for the /api/plugins
                 // surface. Mesh-scoped singleton so its short-lived cache dies with the mesh
                 // (Doc/Architecture/NoStaticState) — a revoked grant must not outlive a test either.

--- a/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
@@ -61,10 +61,6 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
     /// second subscription for the same repository. Instance state — one per mesh.</summary>
     private readonly ConcurrentDictionary<string, byte> watched = new(StringComparer.Ordinal);
 
-    /// <summary>Catalog content by repository URL, so a reaction can rebuild the package source
-    /// without re-reading the catalog node. Instance state — one per mesh.</summary>
-    private readonly ConcurrentDictionary<string, PluginCatalogContent> watchedCatalogs = new(StringComparer.OrdinalIgnoreCase);
-
     /// <summary>Initializes a new instance of the <see cref="PluginUpdateWatcher"/> class.</summary>
     public PluginUpdateWatcher(IMessageHub hub, ILogger<PluginUpdateWatcher>? logger = null)
     {
@@ -145,8 +141,6 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
 
         // The canonical single-node read: one shared handle per path, live, authoritative.
         // Never QueryAsync — that index lags a write by design.
-        watchedCatalogs[content.SourceRepoPath!] = content;
-
         var sub = hub.GetMeshNodeStream(buildPath)
             .Select(n => n?.ContentAs<BuildCompletion>(hub.JsonSerializerOptions, logger))
             .Where(b => b is not null && b.HeadSha.Length > 0)
@@ -178,169 +172,39 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
 
         source.ListPackages(build.HeadSha)
             .Subscribe(
-                packages => ReconcileInstalled(packages, build),
+                packages => ReconcileInstalled(source, packages, build),
                 ex => logger?.LogWarning(ex,
                     "Plugin update watcher: listing packages of {Repo} at {Sha} failed.",
                     build.RepositoryUrl, build.HeadSha));
     }
 
-    private void ReconcileInstalled(IReadOnlyList<PackageManifest> packages, BuildCompletion build)
-    {
-        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
-        if (storage is null)
-            return;
-
-        foreach (var pkg in packages)
-        {
-            var recordPath = $"{PackageInstaller.InstalledPartition}/{pkg.Id}";
-            storage.Read(recordPath, hub.JsonSerializerOptions)
-                .Take(1)
-                .Select(n => n?.ContentAs<PackageManifest>(hub.JsonSerializerOptions))
-                // Not installed here → nothing to remind anyone about. A catalog lists far more
-                // packages than any one instance installs, so this is the common case.
-                .Where(record => record is not null)
-                .Subscribe(
-                    record => Reconcile(meshService, accessService, pkg, record!, recordPath, build),
-                    ex => logger?.LogWarning(ex,
-                        "Plugin update watcher: reading install record {Path} failed.", recordPath));
-        }
-    }
-
-    private void Reconcile(
-        IMeshService meshService, AccessService accessService,
-        PackageManifest pkg, PackageManifest record, string recordPath, BuildCompletion build)
-    {
-        // THE gate: content identity, not the build event. Equal module hashes ⇒ this green build
-        // changed nothing in this module ⇒ stay completely silent (no notification, no fetch).
-        if (string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
-            return;
-
-        // What actually changed, for the reminder's message. Available without re-fetching
-        // anything: the installed side is on the record (InstalledFiles), the candidate side rode
-        // in on the catalog entry (ManifestFiles).
-        var changed = 0;
-        var removed = 0;
-        if (record.InstalledFiles is { Count: > 0 } installed && pkg.ManifestFiles is { Count: > 0 } candidate)
-        {
-            foreach (var (path, hash) in candidate)
-                if (!installed.TryGetValue(path, out var old) || !string.Equals(old, hash, StringComparison.Ordinal))
-                    changed++;
-            foreach (var path in installed.Keys)
-                if (!candidate.ContainsKey(path))
-                    removed++;
-        }
-
-        var detail = changed + removed > 0
-            ? $"{changed} file(s) changed, {removed} removed"
-            : "content changed";
-
-        logger?.LogInformation(
-            "Plugin update watcher: {Id} has an update ({Old} → {New}; {Detail}); autoUpdate={Auto}.",
-            pkg.Id, record.ModuleVersion, pkg.ModuleVersion, detail, record.AutoUpdate);
-
-        if (ShouldAutoApply(record))
-        {
-            ApplyUpdate(accessService, meshService, pkg, record, recordPath, build, detail);
-            return;
-        }
-
-        Notify(
-            accessService, meshService, recordPath, pkg,
-            $"Update available: {pkg.Name ?? pkg.Id}",
-            $"A new build of {pkg.Name ?? pkg.Id} is available ({detail}). Built from {build.HeadSha[..Math.Min(7, build.HeadSha.Length)]}.");
-    }
-
-    /// <summary>Raises a system notification on the install record (the user-visible surface of an
-    /// update reminder — and of a refusal, which must never be a silent skip).</summary>
-    private void Notify(
-        AccessService accessService, IMeshService meshService, string recordPath,
-        PackageManifest pkg, string title, string body)
-        => Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => NotificationService.CreateNotification(
-                    meshService, recordPath, title, body,
-                    NotificationType.System, targetNodePath: recordPath))
+    /// <summary>
+    /// Hands the per-module decision to <see cref="PackageUpdateReconciler"/> — the SAME code the
+    /// consumer-side <see cref="RegistryUpdateReconciler"/> runs. The two paths differ only in how
+    /// they learned that something might have changed (a GitHub webhook here, a read of the
+    /// registry's feed there); what counts as a change, and who gets an unattended install rather
+    /// than a reminder, is one decision in one place (#1318).
+    /// </summary>
+    private void ReconcileInstalled(
+        IPackageSource source, IReadOnlyList<PackageManifest> packages, BuildCompletion build)
+        => PackageUpdateReconciler.ReconcileInstalled(
+                hub, source, build.HeadSha, packages,
+                $"Built from {build.HeadSha[..Math.Min(7, build.HeadSha.Length)]}", logger)
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex,
-                    "Plugin update watcher: raising the notification for {Id} failed.", pkg.Id));
+                    "Plugin update watcher: reconciling the installed packages of {Repo} failed.",
+                    build.RepositoryUrl));
 
     /// <summary>
-    /// The opt-in rule, extracted so it is pinnable on its own: a changed module installs
+    /// The opt-in rule, kept here so it stays pinnable on its own: a changed module installs
     /// unattended only for a record that opted in — by its own flag, stamped at install time from
-    /// the deployment default (<see cref="PackageInstaller.SeedAutoUpdate"/>). Pure.
+    /// the deployment default (<see cref="PackageInstaller.SeedAutoUpdate"/>). Pure, and the rule
+    /// <see cref="PackageUpdateReconciler"/> applies for BOTH the webhook-driven and the
+    /// registry-driven path.
     /// </summary>
     // Internal for the BuildCompletionSubscriptionTest pin (InternalsVisibleTo).
     internal static bool ShouldAutoApply(PackageManifest record) => record.AutoUpdate;
-
-    /// <summary>
-    /// Unattended install of a changed module — reached only for a record that opted in.
-    ///
-    /// <para>Delegates to the very same <see cref="CatalogLayoutAreas.InstallOrUpdate"/> the Update
-    /// button uses. That matters more than it looks: it keeps the manifest-diff fast path, the
-    /// shared-Source/Test full-install fallback, and above all the "nothing to sync" comparison in
-    /// ONE place, so the automatic path and the manual one can never disagree about what changed.</para>
-    ///
-    /// <para>Runs as SYSTEM: there is no user on a webhook-driven emission, and the install writes
-    /// nodes. Errors are logged, never thrown — this is a background reaction, and a fault here must
-    /// not tear down the subscription that serves every other package.</para>
-    ///
-    /// <para><b>Commercial packages are re-authorized here, every time (#830).</b> "No user on a
-    /// webhook emission" is precisely why this path was the hole: a priced package that was once an
-    /// install record kept updating itself with no permission check at all. The record carries the
-    /// principal that authorized its install
-    /// (<see cref="PackageManifest.AuthorizedBy"/>) and the installer re-checks that principal is
-    /// STILL a global admin — so revoking the admin stops the syncing, and a record that was never
-    /// admin-authorized (a free package that later acquired a price, an unattended install) is
-    /// refused rather than silently updated. A refusal surfaces as a notification on the record,
-    /// exactly like the reminder path.</para>
-    /// </summary>
-    private void ApplyUpdate(
-        AccessService accessService, IMeshService meshService, PackageManifest pkg,
-        PackageManifest record, string recordPath, BuildCompletion build, string detail)
-    {
-        var content = watchedCatalogs.TryGetValue(build.RepositoryUrl, out var c) ? c : null;
-        var source = content is null
-            ? null
-            : PackageSources.FromRepo(hub, content.SourceRepoPath, content.SourceSubdir, logger, nodeRepo: true);
-        if (source is null)
-        {
-            logger?.LogWarning(
-                "Plugin update watcher: {Id} is due an auto-update but its catalog source is unavailable.", pkg.Id);
-            return;
-        }
-
-        logger?.LogInformation(
-            "Plugin update watcher: auto-updating {Id} to {Version} ({Detail}); authorized by {Principal}.",
-            pkg.Id, pkg.ModuleVersion, detail, record.AuthorizedBy ?? "(nobody)");
-
-        Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => CatalogLayoutAreas.InstallOrUpdate(
-                    hub, source, build.HeadSha, pkg, logger, record.AuthorizedBy))
-            .Subscribe(
-                result => logger?.LogInformation(
-                    "Plugin update watcher: {Id} auto-updated ({Result}).", pkg.Id, result),
-                ex =>
-                {
-                    if (ex is PackageAuthorizationException)
-                    {
-                        logger?.LogWarning(
-                            "Plugin update watcher: auto-update of {Id} REFUSED — {Reason}", pkg.Id, ex.Message);
-                        Notify(
-                            accessService, meshService, recordPath, pkg,
-                            $"Update needs a Global Admin: {pkg.Name ?? pkg.Id}",
-                            $"A new build of {pkg.Name ?? pkg.Id} is available ({detail}), but it is a "
-                            + "commercial package and was not applied automatically. " + ex.Message);
-                        return;
-                    }
-                    logger?.LogWarning(ex,
-                        "Plugin update watcher: auto-update of {Id} failed; the card still offers a manual Update.",
-                        pkg.Id);
-                });
-    }
 
     private static (string Owner, string Repo) OctokitParse(string url)
     {

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -1,0 +1,179 @@
+﻿using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// How a REGISTRY-ONLY installation learns that an installed module changed — by READING the
+/// registry's own package feed, which is a fact it can obtain, instead of waiting for a
+/// notification that can never reach it (Systemorph/MeshWeaver#1318).
+///
+/// <para><b>What was broken.</b> The only mechanism that turned "a module changed" into "the
+/// instances that installed it find out" was <see cref="PluginUpdateWatcher"/>, which subscribes to
+/// a <c>BuildCompletion</c> node at <c>Admin/_Build/{owner}.{repo}</c>. Across the whole tree that
+/// node is constructed in exactly ONE place — <c>GitHubWebhookProcessor</c>, handling a GitHub
+/// <c>workflow_run</c> webhook. A consumer that installs over HTTP with an instance token holds no
+/// GitHub credential, receives no webhooks, and has no catalog node naming a source repo, so the
+/// watcher opened zero subscriptions: registered, live, and completely inert. Auto-update was
+/// therefore dead end to end on such an installation — <see cref="PackageManifest.AutoUpdate"/> was
+/// stamped at install time and nothing ever fired it, which is why a package left at an old version
+/// needed a human to click Provision.</para>
+///
+/// <para><b>Read the witness, do not wait to be told.</b> There is no cross-process change feed to
+/// wait on — <c>PostgreSqlChangeListener</c> is registered and never started — and the registry is
+/// a DIFFERENT deployment with a different database, so even a durable row is not shared. What IS
+/// shared is the authenticated feed this installation already installs from: <c>GET /api/plugins</c>
+/// returns every package's <see cref="PackageManifest.ModuleVersion"/>, the same content identity
+/// the install records carry. Comparing the two answers "has anything changed" outright, with no
+/// signal, no HMAC, no subscription registry to maintain, and no second wire protocol to keep in
+/// step with the first. That is the shape <c>BuildProtocolDriver.FollowGo</c> arrived at for the
+/// cross-cluster case (#1440/#1450): end on a fact you can read.</para>
+///
+/// <para>🚨 <b>No poll timer.</b> The reconcile runs on an event the deployment already has — this
+/// process starting — and not on a clock. #1366 removed a staleness clock for the same reason: a
+/// timer answers "how stale am I willing to be", which is a question nobody asked, and it turns one
+/// misconfiguration into a permanent background load. On these deployments the restart IS the
+/// fan-out: plugin content and the framework image are published by the same CI, and the portals
+/// self-update onto each new image, so a green plugin build and a pod roll already arrive together.
+/// The honest bound is therefore <b>a consumer learns on its next boot</b> — plus immediately, on
+/// demand, whenever a human opens the catalog page, which reads the same feed and offers the same
+/// Update. An installation that never restarts also never picks up framework fixes, which is a
+/// louder problem with its own alarm.</para>
+///
+/// <para><b>An installation with no registry keeps working.</b> With no registry configured this
+/// service resolves no registry source and does nothing at all — the git path stays correct for the
+/// registry instance itself, which legitimately reads GitHub and is served by
+/// <see cref="PluginUpdateWatcher"/>. The two are complements, not alternatives: the watcher is how
+/// the REGISTRY learns from GitHub, this is how a CONSUMER learns from the registry, and both hand
+/// the decision to the one <see cref="PackageUpdateReconciler"/> so they can never disagree about
+/// what "changed" means or about who opted into an unattended install.</para>
+///
+/// <para>Sequenced AFTER <see cref="InstanceAutoRegistrationService.Completed"/> — the same
+/// ordering idiom <see cref="ModuleDiscoveryService"/> uses, and for the same reason: both write
+/// through the same package partitions, and phase 2 of that service is what mints the instance key
+/// this one authenticates with. Instance-scoped, so its subscriptions live and die with the mesh.
+/// Reactive throughout.</para>
+/// </summary>
+public sealed class RegistryUpdateReconciler(
+    IMessageHub hub, ILogger<RegistryUpdateReconciler> logger)
+    : IHostedService, IDisposable
+{
+    private readonly CompositeDisposable subscriptions = new();
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Start();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => subscriptions.Dispose();
+
+    private void Start()
+    {
+        var options = hub.ServiceProvider.GetService<PluginCatalogOptions>() ?? new PluginCatalogOptions();
+        if (options.EffectiveRegistries.Count == 0)
+        {
+            logger.LogDebug(
+                "[RegistryUpdate] no registry configured — nothing to reconcile against. "
+                + "A registry instance learns from its own repos through the build watcher instead.");
+            return;
+        }
+
+        var autoRegistration = hub.ServiceProvider.GetService<InstanceAutoRegistrationService>();
+        // Ordering on the actual precondition, not a delay: the default install writes the same
+        // partitions and mints the instance key this reconcile authenticates with. A host that did
+        // not register that service has nothing to be behind.
+        var defaultsDone = autoRegistration?.Completed.Take(1).Select(_ => Unit.Default)
+            ?? Observable.Return(Unit.Default);
+
+        subscriptions.Add(defaultsDone
+            // Hop off whatever thread completed the default install before the reconcile chain runs.
+            .ObserveOn(TaskPoolScheduler.Default)
+            .SelectMany(_ => Reconcile(options))
+            // 🚨 SubscribeOn the thread pool, NOT the host-startup thread — the chain is synchronous
+            // up to its first genuinely-async leaf, so subscribing inline would run it ON the
+            // startup thread and re-enter the hub schedulers mid-init. Same fix, same reason, as
+            // InstanceAutoRegistrationService.
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[RegistryUpdate] the boot reconcile failed; installed packages keep their "
+                    + "current version and the catalog page still offers a manual Update.")));
+    }
+
+    /// <summary>
+    /// Reads each configured registry's feed and reconciles this installation's install records
+    /// against it. Registries are read SEQUENTIALLY: this runs on a cold starting pod, and an
+    /// apply writes a partition's worth of nodes.
+    /// </summary>
+    private IObservable<Unit> Reconcile(PluginCatalogOptions options)
+    {
+        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        if (tokenResolver is null)
+            return Observable.Return(Unit.Default);
+
+        return options.EffectiveRegistries
+            .Select(registry => ReconcileOne(registry, tokenResolver))
+            .ToObservable()
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync();
+    }
+
+    private IObservable<Unit> ReconcileOne(
+        PluginRegistryReference registry, RegistryTokenResolver tokenResolver)
+    {
+        var name = string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name;
+        var gitRef = string.IsNullOrWhiteSpace(registry.Ref) ? "HEAD" : registry.Ref;
+
+        return tokenResolver.ResolveToken(registry)
+            .Take(1)
+            .SelectMany(token =>
+            {
+                if (token.Length == 0)
+                    logger.LogWarning(
+                        "[RegistryUpdate] reading {Url} with NO instance key — only an open dev/e2e "
+                        + "registry will answer, so installed packages may not be reconciled.",
+                        registry.Url);
+
+                var source = new RegistryPackageSource(hub, registry.Url, token);
+                return source.ListPackages(gitRef)
+                    .Take(1)
+                    .SelectMany(packages =>
+                    {
+                        logger.LogInformation(
+                            "[RegistryUpdate] {Name} serves {Count} package(s) at {Ref} — "
+                            + "reconciling this installation's records against them.",
+                            name, packages.Count, gitRef);
+                        return PackageUpdateReconciler.ReconcileInstalled(
+                            hub, source, gitRef, packages,
+                            $"Served by registry '{name}'", logger);
+                    });
+            })
+            .Catch((Exception ex) =>
+            {
+                // One unreachable registry must not withhold the others, and must never be silent:
+                // "the store is empty and nobody said why" is the exact failure this issue began as.
+                logger.LogError(ex,
+                    "[RegistryUpdate] could not read the package feed of {Name} ({Url}) — installed "
+                    + "packages from it are NOT reconciled this boot.", name, registry.Url);
+                return Observable.Return(Unit.Default);
+            });
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/RegistryUpdateReconcileTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RegistryUpdateReconcileTest.cs
@@ -1,0 +1,230 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The CONSUMER half of plugin self-update (#1318): an installation that installs over HTTP from a
+/// registry — no GitHub credential, no webhooks — must be able to learn that an installed module
+/// changed.
+///
+/// <para><b>What was missing.</b> The only mechanism was <see cref="PluginUpdateWatcher"/>, which
+/// subscribes to a <c>BuildCompletion</c> node. That node is constructed in exactly ONE place in the
+/// whole tree — a GitHub <c>workflow_run</c> webhook — and the watcher only subscribes at all once a
+/// catalog node names a source repo. A registry-only consumer has neither, so the watcher was
+/// registered, live, and completely inert, and <see cref="PackageManifest.AutoUpdate"/> was a flag
+/// nothing ever fired.</para>
+///
+/// <para>The tests below pin the decision — which is now ONE decision for both paths — and the
+/// wiring that makes it run on a consumer.</para>
+/// </summary>
+public class RegistryUpdateReconcileTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // 🚨 A record's AutoUpdate is NOT taken from the manifest handed to the installer — it is
+    // SEEDED at install time from the deployment's default and then owned by the record
+    // (PackageInstaller.SeedAutoUpdate: `existingRecord?.AutoUpdate ?? options?.AutoUpdateByDefault`).
+    // Without this registration every record here would be created opted-OUT, which would make the
+    // reminder test below pass for the wrong reason — it would assert "nothing was installed"
+    // against a path that was never eligible to install.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog()
+            .ConfigureServices(services => services.AddSingleton(
+                new PluginCatalogOptions { AutoUpdateByDefault = true }));
+
+    private const string ModuleV1 = "cccccccccccccc01";
+    private const string ModuleV2 = "cccccccccccccc02";
+
+    private static IReadOnlyList<PackageFile> FilesAt(string moduleVersion, string notes, string commit) =>
+    [
+        new("Widget/index.json",
+            """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin.","minMeshVersion":"1.0.0"}}"""),
+        new("Widget/Notes.md", notes),
+        new("Widget/manifest.lock",
+            $$$"""{"schema":"mw-manifest/1","module":"Widget","moduleVersion":"{{{moduleVersion}}}","sourceCommit":"{{{commit}}}","files":{"Widget/index.json":"h-root-1","Widget/Notes.md":"h-notes-{{{moduleVersion}}}"}}"""),
+    ];
+
+    /// <summary>A stand-in for the registry feed: it serves a package list and records every fetch,
+    /// so a test can prove that NOTHING traveled.</summary>
+    private sealed class FeedSource(
+        IReadOnlyList<PackageManifest> catalog, IReadOnlyList<PackageFile> files) : IPackageSource
+    {
+        public readonly List<IReadOnlyCollection<string>?> Fetches = [];
+
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            Observable.Return(catalog);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+        {
+            Fetches.Add(null);
+            return Observable.Return(files);
+        }
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef, IReadOnlyCollection<string>? paths)
+        {
+            Fetches.Add(paths);
+            var wanted = paths is null ? null : new HashSet<string>(paths, StringComparer.Ordinal);
+            return Observable.Return<IReadOnlyList<PackageFile>>(
+                wanted is null ? files : files.Where(f => wanted.Contains(f.RelativePath)).ToList());
+        }
+    }
+
+    private static PackageManifest Pkg(string moduleVersion) => new()
+    {
+        Id = "Widget",
+        Name = "Widget Plugin",
+        Kind = PackageKind.NodeRepo,
+        TargetPartition = "Widget",
+        SourceFolder = "Widget",
+        Version = "commit-1",
+        ModuleVersion = moduleVersion,
+    };
+
+    private IObservable<MeshNode?> ReadRecord() =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read($"{PackageInstaller.InstalledPartition}/Widget", Mesh.JsonSerializerOptions)
+            .Take(1);
+
+    /// <summary>
+    /// 🚨 THE POINT OF THE ISSUE. A module whose content moved on at the registry, on a record that
+    /// opted into unattended updates, is brought up to date by a read of the feed alone — no
+    /// webhook, no <c>BuildCompletion</c>, no GitHub credential anywhere in the path.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AnOutdatedInstalledModule_IsBroughtUpToDate_FromTheFeedAlone()
+    {
+        await PackageInstaller.Install(
+                Mesh, Pkg(ModuleV1), FilesAt(ModuleV1, "# Notes v1", "c1"), "c1")
+            .FirstAsync().ToTask();
+
+        var source = new FeedSource([Pkg(ModuleV2)], FilesAt(ModuleV2, "# Notes v2", "c2"));
+
+        await PackageUpdateReconciler.ReconcileInstalled(
+                Mesh, source, "HEAD", [Pkg(ModuleV2)],
+                "Served by registry 'test'", null)
+            .FirstAsync().ToTask();
+
+        var record = await ReadRecord().ToTask();
+        record.Should().NotBeNull();
+        record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.ModuleVersion
+            .Should().Be(ModuleV2,
+                "reading the registry's own feed is how a consumer learns — before this, the only "
+                + "signal was a GitHub webhook that such an installation can never receive, so the "
+                + "record stayed on v1 until a human clicked Provision");
+
+        source.Fetches.Should().NotBeEmpty("the module changed, so the delta had to travel");
+        source.Fetches.Should().NotContain(f => f is null,
+            "a full-package fetch means the manifest diff was bypassed");
+    }
+
+    /// <summary>
+    /// The NEGATIVE property, and the one that matters most: the gate is content identity, not the
+    /// event. A boot reconcile runs on EVERY start, so a feed read that changed nothing must cost
+    /// nothing — otherwise every restart would re-install every package.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AFeedThatServesTheSameContent_FetchesNothing()
+    {
+        await PackageInstaller.Install(
+                Mesh, Pkg(ModuleV1), FilesAt(ModuleV1, "# Notes v1", "c1"), "c1")
+            .FirstAsync().ToTask();
+
+        var source = new FeedSource([Pkg(ModuleV1)], FilesAt(ModuleV1, "# Notes v1", "c2"));
+
+        await PackageUpdateReconciler.ReconcileInstalled(
+                Mesh, source, "HEAD", [Pkg(ModuleV1)],
+                "Served by registry 'test'", null)
+            .FirstAsync().ToTask();
+
+        source.Fetches.Should().BeEmpty(
+            "the module version matched, so the decision was made without fetching a single file — "
+            + "a boot-time reconcile that keyed off the READ instead of the CONTENT would re-install "
+            + "everything on every restart");
+    }
+
+    /// <summary>
+    /// Reminder is the default. A record that did NOT opt in must not be updated behind the
+    /// operator's back just because the reconcile now runs — the opt-in is the whole contract.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ARecordThatDidNotOptIn_IsRemindedRatherThanUpdated()
+    {
+        // Install under a deployment that does NOT opt in, so the record itself carries the
+        // opt-out — which is the thing under test, and the only thing the reconcile consults.
+        Mesh.ServiceProvider.GetRequiredService<PluginCatalogOptions>().AutoUpdateByDefault = false;
+
+        await PackageInstaller.Install(
+                Mesh, Pkg(ModuleV1), FilesAt(ModuleV1, "# Notes v1", "c1"), "c1")
+            .FirstAsync().ToTask();
+
+        var source = new FeedSource([Pkg(ModuleV2)], FilesAt(ModuleV2, "# Notes v2", "c2"));
+
+        await PackageUpdateReconciler.ReconcileInstalled(
+                Mesh, source, "HEAD", [Pkg(ModuleV2)], "Served by registry 'test'", null)
+            .FirstAsync().ToTask();
+
+        source.Fetches.Should().BeEmpty("no opt-in ⇒ nothing is installed, so nothing is fetched");
+
+        var record = await ReadRecord().ToTask();
+        record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.ModuleVersion
+            .Should().Be(ModuleV1, "the installed content is untouched — the user is reminded instead");
+    }
+
+    /// <summary>
+    /// A registry lists far more packages than any one instance installs. A package with no install
+    /// record here is not an update — it is somebody else's package, and must produce nothing.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task APackageThatIsNotInstalledHere_ProducesNothing()
+    {
+        var source = new FeedSource([Pkg(ModuleV2)], FilesAt(ModuleV2, "# Notes v2", "c2"));
+
+        await PackageUpdateReconciler.ReconcileInstalled(
+                Mesh, source, "HEAD", [Pkg(ModuleV2)],
+                "Served by registry 'test'", null)
+            .FirstAsync().ToTask();
+
+        source.Fetches.Should().BeEmpty("nothing is installed here, so there is nothing to reconcile");
+        (await ReadRecord().ToTask()).Should().BeNull("a reconcile must never INSTALL a new package");
+    }
+
+    /// <summary>
+    /// The wiring, pinned the same way the watcher's is. Registration alone does not start it — the
+    /// host starts only <c>IHostedService</c> registrations, and the hosted registration must
+    /// resolve the SAME mesh singleton rather than a second inert copy.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheConsumerReconcilerIsRegisteredHostedAndScopedToTheMesh()
+    {
+        var reconciler = Mesh.ServiceProvider.GetService<RegistryUpdateReconciler>();
+        reconciler.Should().NotBeNull("AddPluginCatalog registers the consumer-side reconciler");
+
+        Mesh.ServiceProvider.GetService<RegistryUpdateReconciler>()
+            .Should().BeSameAs(reconciler,
+                "mesh-scoped singleton — its subscriptions die with the mesh, never leak into the next test");
+
+        Mesh.ServiceProvider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Should().Contain(s => ReferenceEquals(s, reconciler),
+                "the IHostedService forward is what actually runs the boot reconcile");
+
+        // This mesh has no registry configured, which is the git-only / registry-instance shape:
+        // the service must be present and do nothing, so a deployment that never had a registry
+        // keeps working exactly as before.
+        Mesh.ServiceProvider.GetService<PluginCatalogOptions>()?.EffectiveRegistries.Count
+            .Should().Be(0);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/RegistryUpdateReconcileTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RegistryUpdateReconcileTest.cs
@@ -203,6 +203,49 @@ public class RegistryUpdateReconcileTest(ITestOutputHelper output) : MonolithMes
     }
 
     /// <summary>
+    /// 🚨 A module with NO content identity is refused LOUDLY, not absorbed into "nothing changed".
+    ///
+    /// <para>The ordering is the whole point, and it is easy to get backwards: <c>null == null</c> is
+    /// <i>equal</i>, so checking equality first silently swallows the commonest shape of this defect
+    /// — a module whose CI emits no <c>manifest.lock</c>, on both sides — and the operator is left
+    /// with a plugin that never updates and no line in the log saying why. The missing-identity check
+    /// therefore runs BEFORE the equality gate.</para>
+    ///
+    /// <para>It must still install nothing: a missing hash is the absence of evidence, not evidence
+    /// of a change, and treating it as a change would re-install the module on every single boot.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AModuleWithNoContentIdentity_InstallsNothing_AndSaysSo()
+    {
+        var noIdentity = Pkg(ModuleV1) with { ModuleVersion = null };
+
+        // 🚨 The record's hash comes from the module's `manifest.lock` FILE, not from the manifest
+        // handed to the installer — so a fixture that only blanks the manifest field installs a
+        // record that HAS a hash, and the test would then exercise the ordinary changed/unchanged
+        // path while claiming to exercise this one. The assertion below is what caught exactly that.
+        var withoutLock = FilesAt(ModuleV1, "# Notes v1", "c1")
+            .Where(f => !f.RelativePath.EndsWith("manifest.lock", StringComparison.Ordinal))
+            .ToList();
+
+        await PackageInstaller.Install(Mesh, noIdentity, withoutLock, "c1")
+            .FirstAsync().ToTask();
+
+        var record = await ReadRecord().ToTask();
+        record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.ModuleVersion
+            .Should().BeNullOrEmpty("the fixture only means anything if the record really has no hash");
+
+        var source = new FeedSource([noIdentity], FilesAt(ModuleV2, "# Notes v2", "c2"));
+
+        await PackageUpdateReconciler.ReconcileInstalled(
+                Mesh, source, "HEAD", [noIdentity], "Served by registry 'test'", null)
+            .FirstAsync().ToTask();
+
+        source.Fetches.Should().BeEmpty(
+            "there is no content identity to compare, so 'has it changed' is unanswerable — "
+            + "answering 'yes' would re-install this module on every pod start");
+    }
+
+    /// <summary>
     /// The wiring, pinned the same way the watcher's is. Registration alone does not start it — the
     /// host starts only <c>IHostedService</c> registrations, and the hosted registration must
     /// resolve the SAME mesh singleton rather than a second inert copy.


### PR DESCRIPTION
## The gap, stated exactly

`PluginUpdateWatcher` was the whole of "an installation finds out a module changed", and it works by
subscribing to a `BuildCompletion` node. Across the entire tree that node is constructed in **exactly
one place** — `GitHubWebhookProcessor`, handling a GitHub `workflow_run` webhook — and the watcher
only opens a subscription at all once a catalog node names a source repo.

An installation that installs from a registry over HTTP has **neither**: it deliberately holds no
GitHub credential, receives no webhooks, and has no catalog node. The watcher is registered
unconditionally, so on such an installation it was **live and inert** — zero subscriptions, forever.
Auto-update was dead end to end: `PackageManifest.AutoUpdate` is stamped at install time and nothing
ever fired it. That is why atioz's `Hosting` sat at its installed version until a human pressed
Provision — not a config gap, the absence of an input.

## What the consumer subscribes to: nothing. It **reads** the feed it already installs from.

There is nothing to subscribe to. The registry is a **different deployment with a different
database**, so no durable row is shared; and there is no cross-process change feed either —
`PostgreSqlChangeListener` is registered and never started in either partitioned-PG overload. A push
signal would therefore mean a second wire protocol (subscription registry, shared secret, inbox) kept
in step with the feed that already exists.

It does not need one. **`GET /api/plugins` already returns every package's `ModuleVersion`** — the
same content identity the install records carry — so comparing the two answers "has anything changed"
outright. That is precisely the shape `BuildProtocolDriver.FollowGo` arrived at for the cross-cluster
case (#1440/#1450): *end on a fact you can read, not on a notification that cannot reach you.*

`RegistryUpdateReconciler` does that, sequenced after `InstanceAutoRegistrationService.Completed` —
the ordering idiom `ModuleDiscoveryService` already uses, and necessary because that service writes
the same partitions and mints the instance key this one authenticates with.

### 🚨 No poll timer

It runs on an event the deployment already has — **this process starting** — not on a clock. #1366
removed a staleness clock for the same reason: a timer answers "how stale am I willing to be", a
question nobody asked, and turns one misconfiguration into permanent background load.

On these deployments **the restart *is* the fan-out**: plugin content and the framework image are
published by the same CI, and the portals self-update onto each new image, so a green plugin build
and a pod roll already arrive together. The honest bound, stated plainly: **a consumer learns on its
next boot** — plus immediately, on demand, whenever somebody opens the catalog page, which reads the
same feed and offers the same Update. An installation that never restarts also never picks up
framework fixes, which is a louder problem with its own alarm.

## One decision, two inputs

The per-module verdict moves into `PackageUpdateReconciler`, which **both** paths now call: content
identity as the gate (equal `ModuleVersion` ⇒ silent, not one file fetched), reminder by default,
unattended only for a record that opted in, and commercial re-authorization against the recorded
principal on every unattended apply (#830). The watcher keeps the webhook half and loses its copy of
the decision, so the two can never disagree about what "changed" means.

|  | learns from | how | when |
|---|---|---|---|
| **Registry instance** (holds the GitHub credential) | its plugin repos | subscribes to `Admin/_Build/{owner}.{repo}` | on every green build |
| **Consumer** (registry token, no GitHub) | its registry | **reads** `GET /api/plugins` | at startup |

### On `BuildCompletion` being live-and-inert

It stays registered and unconditional, **deliberately**. The inertness was never the defect — the
defect was that nothing else covered the consumer. The watcher is how a REGISTRY learns from GitHub;
this is how a CONSUMER learns from the registry. They are complements, and each is inert on the shape
it does not serve, at zero cost. Gating either on config would hide a misconfiguration rather than fix
one.

**An installation with no registry configured resolves no registry source and does nothing at all**,
so the git path stays exactly as it was for the registry instance, which legitimately reads GitHub.
That also keeps Plugins #460's git fallback honest: nothing here changes which source content comes
from, only whether anybody ever looks.

### A missing content hash is refused, loudly

A module with no `manifest.lock` has no content identity, so "has it changed" is unanswerable.
Answering "yes" would act on the **event** rather than the content — the webhook would re-install on
every green build of the repo, and the boot reconcile on every single pod start. It is refused and
logged at Warning naming the module and which side is empty, so it cannot become a quiet "my plugin
never updates". Recorded in the doc's failure-mode table.

## Verification

- `MeshWeaver.PluginCatalog.Test` — **277/277** (5 new), full project, `DOTNET_PROCESSOR_COUNT=4`.
- `MeshWeaver.Documentation.Test` — **20/20** (link integrity for the doc edit).
- `dotnet build -c Release -warnaserror` — clean, **0 warnings**.

The first run caught a real defect in my own test: `AutoUpdate` is **seeded from the deployment
default at install time**, not taken from the manifest handed to the installer
(`PackageInstaller.SeedAutoUpdate`). So the opt-in test failed honestly, *and* the reminder test had
been passing for the wrong reason — asserting "nothing was installed" against a path that was never
eligible to install. Both are now driven through the real seed.

The tests pin the decision (applies on change, fetches nothing on no-change, reminds without an
opt-in, ignores a package not installed here) and the wiring (mesh-scoped singleton + the
`IHostedService` forward that actually runs it — the same pin the watcher has, because registration
alone does not start it).

**Not covered by a test:** the HTTP hop itself. `RegistryUpdateReconciler` constructs its
`RegistryPackageSource` from options, so exercising it end to end needs a live registry; the feed read
is the already-proven `RegistryPackageSource` path (measured live: `GET /api/plugins` with atioz's
instance token → 200, 20 packages).

Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)