### PR TITLE
fix(graph): a cell that never ran shows no output pane at all

### DIFF
--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -24,7 +24,8 @@ namespace MeshWeaver.Graph;
 
 /// <summary>
 /// Layout views for Code nodes.
-/// - Content (default): the notebook cell, stacked CODE → TOOLBAR → OUTPUT. For a viewer holding
+/// - Content (default): the notebook cell, stacked CODE → TOOLBAR → OUTPUT (the output appears
+///   only once there IS a run to show). For a viewer holding
 ///   Update the code segment IS an inline Monaco editor with code completion (edit mode is the
 ///   mode — no Edit button, auto-saved, Run persists the buffer first); for everyone else it is
 ///   the read-only markdown code block. Run sits directly under the code it executes and directly
@@ -256,33 +257,29 @@ public static class CodeLayoutAreas
             BuildCellToolbar(hubAddress, codeConfig, isExecutable, language, lastActivity, canEdit),
             CellToolbarArea);
 
-        if (isExecutable)
+        // Output segment LAST — and ONLY once there IS a run to show: the latest activity's
+        // Progress area (log + status badge), directly beneath the toolbar that produced it.
+        // Jupyter-esque left accent + thin separator mark it as the cell's output; full width so
+        // its left edge lines up with the code and the toolbar above it.
+        //
+        // 🚨 A cell that has never run renders NO output segment at all. It used to render an
+        // italic "Not yet run." strip, which after the toolbar moved above it reads as a dead
+        // empty box hanging off the bottom of every unrun cell — a status nobody needs, directly
+        // under the accent Run button that is the answer to it. Absence says the same thing and
+        // says it quieter (maintainer feedback, 2026-08-13). The moment Run is pressed the node
+        // gains a LastActivityPath and the pane appears with the live log in it.
+        if (isExecutable && !string.IsNullOrEmpty(codeConfig?.LastActivityPath))
         {
-            // Output segment LAST: the LATEST activity's Progress area (log + status badge),
-            // directly beneath the toolbar that produced it. Jupyter-esque left accent + thin
-            // separator mark it as the cell's output; full width so its left edge lines up with
-            // the code and the toolbar above it.
             const string outputStyle =
                 "width: 100%; box-sizing: border-box; " +
                 "border-top: 1px solid var(--neutral-stroke-rest); " +
                 "border-left: 3px solid var(--accent-fill-rest); " +
                 "background: var(--neutral-layer-2); padding: 10px 12px;";
-            if (!string.IsNullOrEmpty(codeConfig?.LastActivityPath))
-            {
-                cell = cell.WithView(new LayoutAreaControl(
-                            new Address(codeConfig.LastActivityPath!),
-                            new LayoutAreaReference(ActivityLayoutAreas.ProgressArea))
-                        .WithStyle(outputStyle),
-                    CellOutputArea);
-            }
-            else
-            {
-                // Not yet run: a one-line subtle hint, not a large empty pane.
-                cell = cell.WithView(Controls.Body(host.Localize("ui.notYetRun"))
-                        .WithStyle($"display: block; {outputStyle} " +
-                                   "color: var(--neutral-foreground-hint); font-style: italic; font-size: 0.85rem;"),
-                    CellOutputArea);
-            }
+            cell = cell.WithView(new LayoutAreaControl(
+                        new Address(codeConfig!.LastActivityPath!),
+                        new LayoutAreaReference(ActivityLayoutAreas.ProgressArea))
+                    .WithStyle(outputStyle),
+                CellOutputArea);
         }
 
         stack = stack.WithView(cell, CellArea);

--- a/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
@@ -96,28 +96,24 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Should().Within(30.Seconds()).Match(c => c is StackControl s
                 && HasArea(s, CodeLayoutAreas.CellArea)))!;
 
-        // Cell frame: code + output segments with the toolbar at the BOTTOM
-        // (the composer bar — 2026-07-03 UX feedback).
+        // Cell frame: the code segment and the toolbar — and, before the first run, NOTHING else.
         var cell = (StackControl)(await stream
             .GetControlStream(FindArea(root, CodeLayoutAreas.CellArea))
             .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
         HasArea(cell, CodeLayoutAreas.CellToolbarArea).Should().BeTrue("the cell carries its own toolbar");
         HasArea(cell, CodeLayoutAreas.CellCodeArea).Should().BeTrue("the code sits inside the cell frame");
-        HasArea(cell, CodeLayoutAreas.CellOutputArea).Should().BeTrue(
-            "an executable cell always has an output segment attached beneath the code");
+        HasArea(cell, CodeLayoutAreas.CellOutputArea).Should().BeFalse(
+            "a cell that has never run renders NO output segment — an empty 'Not yet run' strip " +
+            "under the Run button is a status nobody needs; absence says it quieter");
 
-        // Order inside the frame: CODE, then the TOOLBAR, then the OUTPUT — Run sits directly
-        // under the code it executes and directly above the result it produced, so a reader never
-        // scrolls past the output to find the button.
+        // Order inside the frame: CODE, then the TOOLBAR — Run sits directly under the code it
+        // executes. (Output-below-toolbar is pinned by the run test, which has an output to order.)
         var areaOrder = cell.Areas.Select(a => a.Area?.ToString() ?? "").ToArray();
         int IndexOf(string id) => Array.FindIndex(areaOrder,
             a => a == id || a.EndsWith("/" + id, StringComparison.Ordinal));
         IndexOf(CodeLayoutAreas.CellCodeArea).Should().BeLessThan(
             IndexOf(CodeLayoutAreas.CellToolbarArea),
             "the toolbar attaches directly beneath the code it runs");
-        IndexOf(CodeLayoutAreas.CellToolbarArea).Should().BeLessThan(
-            IndexOf(CodeLayoutAreas.CellOutputArea),
-            "the output segment sits below the toolbar that produced it");
 
         // (a) Toolbar contains Run; no Cancel while nothing runs — and NO Edit button for the
         // DevLogin admin: a viewer holding Update renders the cell's code segment as the inline
@@ -146,13 +142,8 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Should().Within(10.Seconds()).Match(c => c is not null);
         runControl.Should().BeOfType<ButtonControl>("Run renders as a button control");
 
-        // Before the first run the output segment is the subtle hint,
-        // NOT an activity embed (and not a large empty pane).
-        var outputControl = await stream
-            .GetControlStream(FindArea(cell, CodeLayoutAreas.CellOutputArea))
-            .Should().Within(10.Seconds()).Match(c => c is not null);
-        outputControl.Should().NotBeOfType<LayoutAreaControl>(
-            "no run happened yet, so there is no activity Progress area to embed");
+        // …and nothing pretends to be output: with no run there is no activity Progress area to
+        // embed, so the cell simply ends after the toolbar (asserted above).
     }
 
     [Fact(Timeout = 120000)]
@@ -197,6 +188,19 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
                 && l.Address.ToString() == activityPath
                 && l.Reference.Area == ActivityLayoutAreas.ProgressArea))!;
         Output.WriteLine($"Output segment embeds Progress of {outputControl.Address}");
+
+        // …and it appears BELOW the toolbar that produced it — the reading order of the whole
+        // cell, pinned here because this is the state that actually has an output to order:
+        // CODE → TOOLBAR → OUTPUT.
+        var ranOrder = cell.Areas.Select(a => a.Area?.ToString() ?? "").ToArray();
+        int IndexIn(string id) => Array.FindIndex(ranOrder,
+            a => a == id || a.EndsWith("/" + id, StringComparison.Ordinal));
+        IndexIn(CodeLayoutAreas.CellCodeArea).Should().BeLessThan(
+            IndexIn(CodeLayoutAreas.CellToolbarArea),
+            "the toolbar attaches directly beneath the code it runs");
+        IndexIn(CodeLayoutAreas.CellToolbarArea).Should().BeLessThan(
+            IndexIn(CodeLayoutAreas.CellOutputArea),
+            "the result appears below the Run button that produced it");
 
         // (c) Cancel is present in the cell toolbar while the activity is Running.
         var toolbarArea = FindArea(cell, CodeLayoutAreas.CellToolbarArea);


### PR DESCRIPTION
## What

An executable Code cell that has never run rendered an italic **"Not yet run."** strip in its output segment. Now it renders **no output segment at all** — the cell ends after the toolbar. Press Run, the node gains a `LastActivityPath`, and the pane appears with the live log in it.

## Why

Maintainer feedback on the deployed cell: *"it looks like this when it was not run ⇒ say to run or hide it."* Once #1463 moved the toolbar above the output, that strip became a dead empty box hanging off the bottom of every unrun cell — a status nobody needs, sitting directly under the accent Run button that is the answer to it. Absence says the same thing and says it quieter.

## Tested

- `MeshWeaver.AI.Test` cell suites 10/10: `CodeCellLayoutTest` now asserts the output area is **absent** before the first run, and the run test — which actually has an output to order — pins the full reading order **CODE → TOOLBAR → OUTPUT** (it previously could only be asserted in the state where the output was an empty placeholder).
- `MeshWeaver.Graph.Test` 1114/1114.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)