### PR TITLE
fix(#1469): chatting from a top-level page no longer resolves that page inside itself

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -159,6 +159,8 @@ public class MeshOperations
         if (string.IsNullOrEmpty(path))
             return path;
 
+        var contextPath = chat.Context?.Context;
+
         // Strip surrounding quotes (autocomplete wraps spaced paths in quotes)
         if (path.Length >= 2 && path[0] == '"' && path[^1] == '"')
             path = path[1..^1];
@@ -187,9 +189,8 @@ public class MeshOperations
                 if (Data.UcrPrefixResolver.PrefixToAreaMap.ContainsKey(firstSegment))
                 {
                     // Relative unified path like "content/My Report.md" — prepend context
-                    var contextPath = chat.Context?.Context;
                     if (!string.IsNullOrEmpty(contextPath))
-                        return $"@{contextPath}/{raw}";
+                        return PrependContext(contextPath, raw);
                     return path;
                 }
             }
@@ -199,17 +200,40 @@ public class MeshOperations
         }
 
         // Relative path — prepend context
-        var contextPath2 = chat.Context?.Context;
-        if (string.IsNullOrEmpty(contextPath2))
+        if (string.IsNullOrEmpty(contextPath))
             return path; // no context, return as-is
 
         // For unified refs like "content:file.docx", prepend context as address
         if (colonIndex > 0)
-            return $"@{contextPath2}/{raw}";
+            return PrependContext(contextPath, raw);
 
         // For simple names like "MyChild", prepend context
-        return $"@{contextPath2}/{raw}";
+        return PrependContext(contextPath, raw);
     }
+
+    /// <summary>
+    /// Prepends the chat context to a relative path — unless the path ALREADY IS the context (or
+    /// already starts with it at a segment boundary), in which case it is already absolute and
+    /// prepending would double it.
+    ///
+    /// <para>🚨 The doubling this guards against is not hypothetical: it produced
+    /// <c>felice.buergi/felice.buergi</c> on memex-cloud (#1469). The chat context chip for a user
+    /// sitting on their own home page is their PARTITION ROOT — a SINGLE segment — and
+    /// <see cref="ResolveContextPath"/> treats any single-segment token as relative (only a token
+    /// containing '/' takes the "multi-segment ⇒ already absolute" exit above). So the context path
+    /// shipped as an attachment came back through this method as <c>{context}/{context}</c>: a node
+    /// that cannot exist, whose <c>SubscribeRequest</c> the router answers <c>NotFound</c>. Every
+    /// user whose context is a sub-node (<c>ACME/Doc/…</c>) escapes earlier, which is why only
+    /// home-page chatters ever hit it.</para>
+    ///
+    /// <para>Same guard, same reason as <c>PathUtils.ResolveRelativePath</c>'s self-prefix check.
+    /// The trailing '/' makes it a SEGMENT match, so a sibling like <c>ACMEArchive</c> under
+    /// context <c>ACME</c> still resolves against the context rather than false-matching.</para>
+    /// </summary>
+    private static string PrependContext(string contextPath, string raw) =>
+        raw == contextPath || raw.StartsWith(contextPath + "/", StringComparison.Ordinal)
+            ? "@" + raw
+            : $"@{contextPath}/{raw}";
 
     /// <summary>
     /// Reads a node (or, for a <c>path/*</c> query, its direct children) and returns it as a

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-chatting-from-your-own-page-no-longer-looks-for-a-page-inside-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-chatting-from-your-own-page-no-longer-looks-for-a-page-inside-itself.md
@@ -1,0 +1,34 @@
+---
+Name: Chatting from your own page no longer looks for a page inside itself
+Category: Fix
+Description: When a conversation was anchored to a top-level page — most often your own home page — asking the assistant about that page sent it hunting for a page of the same name nested inside it. That page cannot exist, so the lookup always failed.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Chatting from your own page no longer looks for a page inside itself
+
+When you start a conversation somewhere in the workspace, the assistant is told which page you are
+on so it can read it and answer about it. Turning that "which page" into an actual lookup involves a
+small judgement: a short name like `Notes` means *the page called Notes, here, next to the one I am
+on*, while a longer address like `ACME/Reports/Notes` already says exactly where to look and should
+be used as written.
+
+The rule used to decide that by looking for a `/`. Anything without one was treated as a name
+relative to the current page — which is right almost everywhere, and wrong in exactly one place: at
+the very top of the workspace. A top-level page has no `/` in its address, so when the conversation
+was anchored to one and the assistant asked to read *that same page*, the rule helpfully placed it
+underneath itself and went looking for something like `yourname/yourname`.
+
+No such page can ever exist. The lookup failed every time, the assistant carried on without the
+content it had asked for, and nothing surfaced to say a read had been thrown away.
+
+This affected people whose conversations start from a top-level page — most commonly your own home
+page, which is why it showed up for some people and never for others. Conversations anchored deeper
+in the workspace were never affected.
+
+Reading the page a conversation is anchored to now resolves to that page, as written. Everything
+else is unchanged: a short name still resolves next to the current page, an address that already
+begins with the current page is left alone, and a sibling whose name merely starts with the same
+letters — `ACMEArchive` alongside `ACME` — is still treated as a sibling rather than mistaken for
+something already nested inside.

--- a/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
+++ b/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
@@ -107,6 +107,53 @@ public class ResolveContextPathTest
     }
 
     /// <summary>
+    /// 🚨 #1469. Asking for THE CONTEXT ITSELF must resolve to the context — not to a child of the
+    /// context named after the context.
+    ///
+    /// <para>The prod signature was <c>No node found at 'felice.buergi/felice.buergi'. Closest
+    /// ancestor is 'felice.buergi' (remainder='felice.buergi')</c>, three times in 20 hours and for
+    /// exactly one account. The chat's context chip is shipped to the agent as an attachment
+    /// (<c>ThreadChatView</c> → <c>AgentChatClient</c> → <c>MeshPlugin.Get("@{path}")</c> → here),
+    /// and the relative/absolute decision above keys on a <c>/</c>: a token WITHOUT one is treated
+    /// as relative. A single-segment mesh path is by definition a partition ROOT, so a user chatting
+    /// from their own home page had context == attachment == <c>{userId}</c> and the prepend
+    /// produced <c>{userId}/{userId}</c> — a node that cannot exist. Anyone anchored on a sub-node
+    /// (<c>Acme/AIConsulting/…</c>) takes the "multi-segment ⇒ already absolute" exit and never
+    /// doubled, which is exactly the observed scope. Nothing about it needs the dot in the id.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("felice.buergi", "@felice.buergi")]   // as AgentChatClient ships the context attachment
+    [InlineData("felice.buergi", "felice.buergi")]    // as a model would copy it out of the prompt
+    [InlineData("rbuergi", "@rbuergi")]               // no dot required
+    [InlineData("OrgA", "@OrgA")]
+    public void ContextEqualsPath_ResolvesToTheContext_NotToAChildOfItself(
+        string contextPath, string input)
+    {
+        var chat = new StubChat(new AgentContext { Context = contextPath });
+
+        MeshOperations.ResolveContextPath(chat, input)
+            .Should().Be("@" + contextPath,
+                "asking for the context node itself must resolve to that node, not to a "
+                + "non-existent child of it bearing the same name (#1469)");
+    }
+
+    /// <summary>
+    /// A path that already begins with the context at a SEGMENT boundary is already absolute —
+    /// prepending would double the shared prefix. The boundary matters: a sibling whose name merely
+    /// starts with the same characters is still relative.
+    /// </summary>
+    [Theory]
+    [InlineData("Acme/AIConsulting", "@Acme/AIConsulting/FinalReport", "@Acme/AIConsulting/FinalReport")]
+    [InlineData("Doc/Architecture", "@Doc/Architecture/content/file.md", "@Doc/Architecture/content/file.md")]
+    [InlineData("OrgA", "@OrgAArchive", "@OrgA/OrgAArchive")] // NOT a segment match — stays relative
+    public void SelfPrefixedPath_IsNotDoubled_ButOnlyOnASegmentBoundary(
+        string contextPath, string input, string expected)
+    {
+        var chat = new StubChat(new AgentContext { Context = contextPath });
+        MeshOperations.ResolveContextPath(chat, input).Should().Be(expected);
+    }
+
+    /// <summary>
     /// Minimal <see cref="IAgentChat"/> stub exposing only <see cref="IAgentChat.Context"/>.
     /// All other members throw â€” the method under test only reads Context.
     /// </summary>

--- a/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
+++ b/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
@@ -13,8 +13,8 @@ namespace MeshWeaver.AI.Test;
 /// <summary>
 /// Unit tests for <see cref="MeshOperations.ResolveContextPath"/>. Regression coverage for the
 /// 2026-04-15 prod bug where <c>CollaborationPlugin.SuggestEdit</c> / <c>AddComment</c> ignored
-/// the chat's context path â€” agents calling the tool with a relative path or bare display name
-/// had the request routed to a non-existent grain (e.g. "Final Report â€“ AI Readiness Assessment"),
+/// the chat's context path — agents calling the tool with a relative path or bare display name
+/// had the request routed to a non-existent grain (e.g. "Final Report – AI Readiness Assessment"),
 /// and the edits never applied.
 /// </summary>
 public class ResolveContextPathTest
@@ -50,7 +50,7 @@ public class ResolveContextPathTest
     [Fact]
     public void RelativeUnifiedPath_IsPrefixedWithContextPath()
     {
-        // "content/report.docx" â€” UCR prefix path; relative to context.
+        // "content/report.docx" — UCR prefix path; relative to context.
         var chat = new StubChat(new AgentContext { Context = "Acme/AIConsulting" });
 
         MeshOperations.ResolveContextPath(chat, "@content/report.docx")
@@ -61,7 +61,7 @@ public class ResolveContextPathTest
     [Fact]
     public void RelativeColonPath_IsPrefixedWithContextPath()
     {
-        // Legacy colon syntax: "content:file.md" â€” no slash before colon, so relative.
+        // Legacy colon syntax: "content:file.md" — no slash before colon, so relative.
         var chat = new StubChat(new AgentContext { Context = "Doc/Architecture" });
 
         MeshOperations.ResolveContextPath(chat, "@content:icon.svg")
@@ -155,7 +155,7 @@ public class ResolveContextPathTest
 
     /// <summary>
     /// Minimal <see cref="IAgentChat"/> stub exposing only <see cref="IAgentChat.Context"/>.
-    /// All other members throw â€” the method under test only reads Context.
+    /// All other members throw — the method under test only reads Context.
     /// </summary>
     private sealed class StubChat : IAgentChat
     {


### PR DESCRIPTION
Closes the **trigger** half of #1469 — the doubled path `felice.buergi/felice.buergi`.

## Root cause

`MeshOperations.ResolveContextPath` decides relative-vs-absolute by looking for a `/`: a token
**without** one is treated as a name relative to the chat's context. That is right everywhere
except at the top of the mesh, where a path *is* a single segment.

The chat's context chip is shipped to the agent as an attachment —
`ThreadChatView` → `AgentChatClient` → `MeshPlugin.Get("@{path}")` → `ResolveContextPath` — so when
the conversation is anchored to a **top-level node** (a user's own partition root, which is the
context chip on their home page) the same path came back through the resolver and was placed
underneath itself: `{context}/{context}`.

That is exactly the production diagnostic in #1469:

```
[ROUTE] NotFound: No node found at 'felice.buergi/felice.buergi'.
Closest ancestor is 'felice.buergi' (remainder='felice.buergi').
```

### Why only one account, 3 times in 20 h

The doubling needs the context path to be a **single segment**. A user anchored on a sub-node
(`ACME/Doc/…`) takes the existing "multi-segment ⇒ already absolute" exit and never doubles. The
only single-segment context in normal use is a user's own home. It fires once per submitted round
with such a context, not once per render — hence 3 in 20 h rather than continuously.

Nothing about it needs the dot in the id; `rbuergi` would double identically.

### Why it was silent

`AgentChatClient` skips attachment content starting with `"Not found"`, so the round carries on
without the content it asked for. Only the routing `NotFound` is logged; there is nothing for the
user to see or report.

## The fix

The same self-prefix guard `PathUtils.ResolveRelativePath` already carries for markdown links: do
not prepend when the path already **is** the context, or already starts with it **at a segment
boundary**. The boundary is load-bearing — a sibling like `OrgAArchive` under context `OrgA` stays
relative instead of false-matching.

## Verification

- `ResolveContextPathTest` — 18/18 green.
- **Fail-before demonstrated**: with the guard removed, exactly the doubling cases fail (3) and
  every other case still passes (11). Restoring the guard makes all 18 pass.
- `dotnet build src/MeshWeaver.AI -c Release -warnaserror --no-incremental` → 0 Warning(s), 0 Error(s).
- `WhatsNewEntryIntegrityTest` green for the new entry.

## Not in this PR

#1469 also frames a second, generic defect ("a `SubscribeRequest` to a missing path never
answers"). **That claim did not reproduce.** Measured on this branch's tree — Monolith, single-silo
Orleans and two-silo Orleans; client hub, silo-side cache hub and client-side cache hub; both the
"no ancestor" and the "ancestor exists, non-empty remainder" shapes — routing answers with a
terminal `DeliveryFailureException("No node found at …")` in **30–170 ms** every time. Details,
and the two real gaps found by reading that path, are in the issue thread rather than papered over
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
