### PR TITLE
fix(clients): RN search works, RN REST ops carry the token, move/copy send real field names

### DIFF
--- a/clients/grpc-web/src/mesh.test.ts
+++ b/clients/grpc-web/src/mesh.test.ts
@@ -5,11 +5,31 @@ import { fakeMeshTransport } from "./testTransport";
 // Drives the ergonomic Mesh ops surface against the same in-memory Connect+Deliver fake the connection
 // tests use — proving search/get/watch/patch/create/delete/move/copy compose correctly over the transport.
 describe("Mesh ops (gRPC-web, in-memory)", () => {
-  it("search returns the query results", async () => {
-    const mesh = await Mesh.connect("memory://", { transport: fakeMeshTransport() });
+  it("search posts REST query-nodes with Bearer auth (the gRPC QueryRequest has no server handler — #1473)", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const fakeFetch = (async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ results: [{ path: "ACME/Stories/1" }] }), { status: 200 });
+    }) as typeof globalThis.fetch;
+    const mesh = await Mesh.connect("https://portal.example", {
+      transport: fakeMeshTransport(),
+      token: "mw_test",
+      fetch: fakeFetch,
+    });
     const results = await mesh.search("nodeType:Story namespace:ACME");
     expect(results).toHaveLength(1);
     expect(results[0].path).toBe("ACME/Stories/1");
+    expect(calls[0].url).toBe("https://portal.example/api/mesh/query-nodes");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer mw_test");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ query: "nodeType:Story namespace:ACME", limit: 50 });
+
+    // basePath folds into the mesh query syntax rather than a body field QueryNodesBody lacks.
+    await mesh.search("laptop", "ACME/Products", 10);
+    expect(JSON.parse(String(calls[1].init.body))).toEqual({
+      query: "laptop path:ACME/Products scope:subtree",
+      limit: 10,
+    });
     mesh.close();
   });
 
@@ -91,6 +111,23 @@ describe("Mesh ops (gRPC-web, in-memory)", () => {
     expect(targetOf("MoveNodeRequest")).toBe("ACME/A"); // the SOURCE (MeshOperations.Move parity)
     expect(targetOf("CopyNodeRequest")).toBe("ACME/A"); // the SOURCE
     expect(deliveries.some((d) => d.target === "mesh/main")).toBe(false);
+    mesh.close();
+  });
+
+  it("move/copy send the C# record field names SourcePath/TargetPath (issue #1475 — {source,target} never bound)", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    const mesh = await Mesh.connect("memory://", {
+      transport: fakeMeshTransport({
+        onDeliver: (d) => {
+          if (d.messageType === "MoveNodeRequest" || d.messageType === "CopyNodeRequest") bodies.push(d.message);
+        },
+      }),
+    });
+    await mesh.move("ACME/A", "ACME/B");
+    await mesh.copy("ACME/A", "ACME/C");
+    expect(bodies[0]).toMatchObject({ sourcePath: "ACME/A", targetPath: "ACME/B" });
+    expect(bodies[1]).toMatchObject({ sourcePath: "ACME/A", targetPath: "ACME/C" });
+    expect(bodies.every((b) => !("source" in b) && !("target" in b))).toBe(true);
     mesh.close();
   });
 });

--- a/clients/grpc-web/src/mesh.ts
+++ b/clients/grpc-web/src/mesh.ts
@@ -35,23 +35,35 @@ export function ownerOfNamespace(namespace: string): string {
   return segments.join("/");
 }
 
+/** REST reach-back for the ops that have no hub-message equivalent yet (search — see issue #1473). */
+export interface RestOptions {
+  /** The portal origin serving `/api/mesh/*` — same origin the gRPC-web transport dials. */
+  url: string;
+  /** Bearer token for `/api/mesh/*` (Bearer-only endpoints); omit for an anonymous sidecar. */
+  token?: string;
+  /** Custom fetch (RN seam); unary REST works with the platform fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
 export class Mesh {
   private readonly conn: MeshWebConnection;
   private readonly meshAddress: string;
+  private readonly rest?: RestOptions;
 
-  private constructor(conn: MeshWebConnection, meshAddress: string) {
+  private constructor(conn: MeshWebConnection, meshAddress: string, rest?: RestOptions) {
     this.conn = conn;
     this.meshAddress = meshAddress;
+    this.rest = rest;
   }
 
   static async connect(url: string, opts: MeshOptions = {}): Promise<Mesh> {
     const conn = await connectTransport(url, opts);
-    return new Mesh(conn, opts.meshAddress ?? "mesh/main");
+    return new Mesh(conn, opts.meshAddress ?? "mesh/main", { url, token: opts.token, fetch: opts.fetch });
   }
 
   /** Wrap an ALREADY-connected transport (e.g. the one a GrpcAreaSource renders from) in the ops surface. */
-  static from(connection: MeshWebConnection, meshAddress = "mesh/main"): Mesh {
-    return new Mesh(connection, meshAddress);
+  static from(connection: MeshWebConnection, meshAddress = "mesh/main", rest?: RestOptions): Mesh {
+    return new Mesh(connection, meshAddress, rest);
   }
 
   /** The underlying connection — pass to a GrpcAreaSource to render a live layout area. */
@@ -65,10 +77,33 @@ export class Mesh {
 
   // ---- reads ----------------------------------------------------------------
 
-  /** Free-text / structured mesh query (routes to vector or SQL server-side). */
+  /**
+   * Free-text / structured mesh query (routes to vector or SQL server-side). Goes over REST
+   * (`POST /api/mesh/query-nodes`) — the gRPC `QueryRequest` this used to post has NO server
+   * handler (issue #1473: every call waited out the 30 s observe timeout and returned empty;
+   * portal-next had already routed around it the same way). The protocol-native replacement is
+   * the planned live-subscribable `MeshQueryReference`; until it exists, REST is the one working
+   * query surface. `basePath` narrows via the mesh query syntax (`path:<base> scope:subtree`).
+   */
   async search(query: string, basePath?: string, limit = 50): Promise<Record<string, unknown>[]> {
-    const resp = await this.conn.observe(this.meshAddress, "QueryRequest", { query, basePath, limit }); // WIRE: query request type
-    return ((resp.message["results"] ?? resp.message["Results"]) as Record<string, unknown>[]) ?? [];
+    if (!this.rest?.url)
+      throw new Error(
+        "Mesh.search needs the portal's REST origin — construct via Mesh.connect(url, …) or pass Mesh.from(conn, addr, { url, token }).",
+      );
+    const doFetch = this.rest.fetch ?? globalThis.fetch;
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (this.rest.token) headers["authorization"] = `Bearer ${this.rest.token}`;
+    const composed = basePath ? `${query} path:${basePath} scope:subtree` : query;
+    const resp = await doFetch(`${this.rest.url.replace(/\/+$/, "")}/api/mesh/query-nodes`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query: composed, limit }),
+    });
+    if (!resp.ok) throw new Error(`query-nodes failed (${resp.status})`);
+    const text = await resp.text();
+    if (text.startsWith("Error:") || text.startsWith("Not found:")) throw new Error(text);
+    const parsed = JSON.parse(text) as { results?: Record<string, unknown>[] };
+    return Array.isArray(parsed.results) ? parsed.results : [];
   }
 
   /** Read a single node's current state (one snapshot off its live stream). */
@@ -153,12 +188,14 @@ export class Mesh {
 
   /** Move a node (and its satellites) — routed to the SOURCE node's hub (MeshOperations.Move parity). */
   async move(source: string, target: string): Promise<void> {
-    await this.conn.observe(source, "MoveNodeRequest", { source, target });
+    // Field names match the C# record MoveNodeRequest(SourcePath, TargetPath) — `{source,target}`
+    // never bound (no JsonPropertyName aliases; issue #1475).
+    await this.conn.observe(source, "MoveNodeRequest", { sourcePath: source, targetPath: target });
   }
 
   /** Copy a node to a new path — routed to the SOURCE node's hub. */
   async copy(source: string, target: string): Promise<void> {
-    await this.conn.observe(source, "CopyNodeRequest", { source, target });
+    await this.conn.observe(source, "CopyNodeRequest", { sourcePath: source, targetPath: target });
   }
 
   /**

--- a/clients/grpc-web/src/testTransport.ts
+++ b/clients/grpc-web/src/testTransport.ts
@@ -75,9 +75,9 @@ export function fakeMeshTransport(opts: FakeMeshOptions = {}) {
             case "EchoRequest":
               respond(out, d, { $type: "EchoResponse", text: d.message.text });
               break;
-            case "QueryRequest":
-              respond(out, d, { $type: "QueryResponse", results: [{ path: "ACME/Stories/1", name: "S1" }] });
-              break;
+            // No QueryRequest responder — the REAL server has no such handler (issue #1473), and
+            // faking one here is exactly how Mesh.search shipped posting into the void. Search is
+            // REST (`/api/mesh/query-nodes`); tests exercise it via an injected fetch.
             case "CreateNodeRequest": {
               const node = d.message.node as { path?: string; id?: string } | undefined;
               // An id containing "fail" answers a refused create — pins the surfaced-failure path.

--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -129,7 +129,7 @@ function AppInner() {
         setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
         // The full MeshOps over the same connection — renderMarkdown (server Markdig) + the per-view kernel
         // anchor the interactive markdown + runnable code cells; the kernel activity lives in CHAT's partition.
-        setMeshOps(buildMeshOps(l.connection, inst.url, CHAT?.namespacePath ?? ""));
+        setMeshOps(buildMeshOps(l.connection, inst.url, CHAT?.namespacePath ?? "", inst.token));
       })
       .catch((e) => { console.warn("[live] connect failed:", e?.message ?? String(e)); /* shell stays on the last-good source */ });
     return () => {

--- a/clients/react-native/src/liveOps.ts
+++ b/clients/react-native/src/liveOps.ts
@@ -18,11 +18,20 @@ import type {
   ThreadSubmitOptions,
 } from "@meshweaver/react/core";
 
+/** JSON headers + Bearer when a token is present — `/api/mesh/*` on a remote portal is
+ * Bearer-only (issue #1474: RN sent no token, so every REST op 401'd against real portals;
+ * the anonymous sidecar keeps working because an empty token adds no header). */
+function jsonHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers["authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
 /** Server-side Markdig render (POST {baseUrl}/api/mesh/render-markdown) — the ONE markdown parser. */
-async function renderMarkdown(baseUrl: string, markdown: string, nodePath?: string): Promise<RenderedMarkdown> {
+async function renderMarkdown(baseUrl: string, token: string, markdown: string, nodePath?: string): Promise<RenderedMarkdown> {
   const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/render-markdown`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: jsonHeaders(token),
     body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
   });
   if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
@@ -35,12 +44,13 @@ async function renderMarkdown(baseUrl: string, markdown: string, nodePath?: stri
 /**
  * Content-collection listing (`POST {baseUrl}/api/mesh/content/list`) — the read half of the file
  * browser. `path` is `{node}/{collection}[/{dir}]`. Same endpoint and same response shaping as
- * portal-next's listContent; the sidecar is same-origin and anonymous, so there is no bearer token.
+ * portal-next's listContent; the sidecar is same-origin and anonymous (empty token), while a
+ * remote portal needs the instance's Bearer token.
  */
-async function listContent(baseUrl: string, path: string): Promise<ContentListing> {
+async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
   const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/content/list`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: jsonHeaders(token),
     body: JSON.stringify({ path }),
   });
   const text = await resp.text();
@@ -55,11 +65,13 @@ async function listContent(baseUrl: string, path: string): Promise<ContentListin
 }
 
 /** Content upload (`POST {baseUrl}/api/mesh/upload`, multipart). */
-async function uploadContent(baseUrl: string, path: string, file: File): Promise<void> {
+async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
   const form = new FormData();
   form.append("path", path);
   form.append("file", file as unknown as Blob, (file as { name?: string }).name ?? "upload");
-  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/upload`, { method: "POST", body: form });
+  const headers: Record<string, string> = {};
+  if (token) headers["authorization"] = `Bearer ${token}`; // multipart: FormData sets content-type
+  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/upload`, { method: "POST", headers, body: form });
   const text = await resp.text();
   if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
 }
@@ -203,8 +215,10 @@ async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState
  * Build the RN MeshOps from a live connection. `partition` anchors the interactive-markdown kernel
  * activity (the viewer's home partition — CHAT.namespacePath on the anonymous sidecar).
  */
-export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, partition: string): MeshOps {
-  const mesh = Mesh.from(connection);
+export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, partition: string, token = ""): MeshOps {
+  // The REST reach-back (search + the helpers below) carries the instance's Bearer token; empty
+  // = the anonymous sidecar. Without it every REST op 401'd against a remote portal (#1474).
+  const mesh = Mesh.from(connection, "mesh/main", { url: baseUrl, token: token || undefined });
   return {
     watch: (path: string) => watchNode(mesh, path),
     startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
@@ -214,15 +228,15 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
     patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
     search: (query: string, basePath?: string, limit?: number) =>
       mesh.search(query, basePath, limit).catch(() => [] as Record<string, unknown>[]),
-    renderMarkdown: (markdown: string, nodePath?: string) => renderMarkdown(baseUrl, markdown, nodePath),
+    renderMarkdown: (markdown: string, nodePath?: string) => renderMarkdown(baseUrl, token, markdown, nodePath),
     startMarkdownKernel: (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, partition, cells),
     getNode: (path: string) => mesh.get(path).then((n) => n.raw as Record<string, unknown>).catch(() => null),
     createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
     // The file-browser and document-export ops. These are plain REST / mesh-request calls with no
     // browser-only dependency, so RN wires the SAME three the web shells do — without them the
     // FileBrowser and ExportDocument leaves could only ever render their "not available" state.
-    listContent: (path: string) => listContent(baseUrl, path),
-    uploadContent: (path: string, file: File) => uploadContent(baseUrl, path, file),
+    listContent: (path: string) => listContent(baseUrl, token, path),
+    uploadContent: (path: string, file: File) => uploadContent(baseUrl, token, path, file),
     exportDocument: (sourcePath: string, options: DocumentExportOptions) => exportDocument(mesh, sourcePath, options),
   };
 }

--- a/clients/typescript/src/mesh.ts
+++ b/clients/typescript/src/mesh.ts
@@ -26,25 +26,47 @@ export function ownerOfNamespace(namespace: string): string {
 export class Mesh {
   private readonly conn: MeshConnection;
   private readonly meshAddress: string;
+  private readonly restUrl: string;
+  private readonly token?: string;
 
-  private constructor(conn: MeshConnection, meshAddress: string) {
+  private constructor(conn: MeshConnection, meshAddress: string, restUrl: string, token?: string) {
     this.conn = conn;
     this.meshAddress = meshAddress;
+    this.restUrl = restUrl;
+    this.token = token;
   }
 
   static async connect(url: string, opts: MeshOptions = {}): Promise<Mesh> {
     const conn = await connectTransport(url, opts);
-    return new Mesh(conn, opts.meshAddress ?? "mesh/main");
+    return new Mesh(conn, opts.meshAddress ?? "mesh/main", url, opts.token);
   }
 
   close(): void {
     this.conn.close();
   }
 
-  /** Free-text / structured mesh query (routes to vector or SQL server-side). */
+  /**
+   * Free-text / structured mesh query (routes to vector or SQL server-side). Goes over REST
+   * (`POST /api/mesh/query-nodes`) — the gRPC `QueryRequest` this used to post has NO server
+   * handler (issue #1473: every call waited out the observe timeout and returned empty). The
+   * protocol-native replacement is the planned live-subscribable `MeshQueryReference`; until it
+   * exists, REST is the one working query surface. `basePath` narrows via the mesh query syntax
+   * (`path:<base> scope:subtree`).
+   */
   async search(query: string, basePath?: string, limit = 50): Promise<Record<string, unknown>[]> {
-    const resp = await this.conn.observe(this.meshAddress, "QueryRequest", { query, basePath, limit }); // WIRE: confirm query request type
-    return ((resp.message["results"] ?? resp.message["Results"]) as Record<string, unknown>[]) ?? [];
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    const composed = basePath ? `${query} path:${basePath} scope:subtree` : query;
+    const resp = await fetch(`${this.restUrl.replace(/\/+$/, "")}/api/mesh/query-nodes`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query: composed, limit }),
+    });
+    if (!resp.ok) throw new Error(`query-nodes failed (${resp.status})`);
+    const text = await resp.text();
+    if (text.startsWith("Error:") || text.startsWith("Not found:")) throw new Error(text);
+    const parsed = JSON.parse(text) as { results?: Record<string, unknown>[] };
+    return Array.isArray(parsed.results) ? parsed.results : [];
   }
 
   /** Read a single node's current state (one snapshot off its live stream). */
@@ -93,12 +115,14 @@ export class Mesh {
 
   /** Move a node (and its satellites) — routed to the SOURCE node's hub. */
   async move(source: string, target: string): Promise<void> {
-    await this.conn.observe(source, "MoveNodeRequest", { source, target });
+    // Field names match the C# record MoveNodeRequest(SourcePath, TargetPath) — `{source,target}`
+    // never bound (no JsonPropertyName aliases; issue #1475).
+    await this.conn.observe(source, "MoveNodeRequest", { sourcePath: source, targetPath: target });
   }
 
   /** Copy a node to a new path — routed to the SOURCE node's hub. */
   async copy(source: string, target: string): Promise<void> {
-    await this.conn.observe(source, "CopyNodeRequest", { source, target });
+    await this.conn.observe(source, "CopyNodeRequest", { sourcePath: source, targetPath: target });
   }
 
   /**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-mobile-search-and-sign-in-fixes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-mobile-search-and-sign-in-fixes.md
@@ -1,0 +1,15 @@
+---
+Name: Mobile search and signed-in portals work again
+Category: Fix
+Description: Search on the mobile app returns results instead of spinning, and connecting to a portal with an API token now works for markdown, files, and uploads.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Mobile search and signed-in portals work again
+
+Searching from the mobile app no longer spins for half a minute and comes back
+empty — search now uses the same query service the web portal uses. When you
+connect the mobile app to a portal with an API token, markdown rendering, the
+file browser, and uploads now sign their requests correctly instead of being
+rejected.


### PR DESCRIPTION
Fixes #1473 (client half), fixes #1474 (client half), fixes #1475 — the JS-client defects from the modularization investigation.

**Search** — `Mesh.search` in both SDKs posted a `QueryRequest` no server handles; RN searches spun 30 s and rendered empty. Now REST `POST /api/mesh/query-nodes` with Bearer auth (portal-next's proven route); `basePath` folds into the mesh query syntax. The fake transport's `QueryRequest` responder is **deleted** — a fake handler for a message the real server lacks is exactly how this shipped. Protocol-native follow-up stays open in #1473 (live-subscribable `MeshQueryReference`).

**RN auth** — `buildMeshOps` threads the instance token into search / render-markdown / content-list / upload (previously all 401'd against real portals; the anonymous sidecar is unchanged — empty token adds no header). The sidecar's missing `content/list`+`upload` mappings remain open under #1474.

**Wire shape** — `move`/`copy` sent `{source,target}` against records declaring `SourcePath`/`TargetPath` (never bound). Fixed in both SDKs; pinned by a new wire-shape test asserting the field names and the absence of the old ones.

**Verification** (Clients CI recipe, locally): grpc-web typecheck + 28/28 vitest; `@meshweaver/client` typecheck; react-native typecheck + 153/153 tests.

What's New entry included (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)