### PR TITLE
fix: the chart can describe an HA portal, and two checks stop it drifting back

### DIFF
--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -1,0 +1,132 @@
+name: Chart Drift
+
+# Does the CLUSTER run what the chart describes?
+#
+# The scheduled caller for deploy/aks/scripts/check-chart-drift.sh. That script was written on
+# 2026-08-13 to detect exactly the class of failure that took memex.meshweaver.cloud down the next
+# day — and `git grep` across .github, deploy and tools found NO caller. It had never run once.
+#
+# 🛡️ THIS WORKFLOW MAY NOT SKIP. AGENTS.md → "A gate NEVER tests its own inputs": GitHub paints a
+# skipped job with the same grey tick as a passed one, so a drift check that quietly declines when
+# a credential is missing reports "no drift" on no evidence — strictly worse than not existing,
+# because it also tells you the cluster is fine. Hence:
+#
+#   * `preflight` asserts EVERY external input and fails RED naming exactly what to provision.
+#     It never asks "is the input present?" in order to decide whether to run.
+#   * `drift` runs `needs: [preflight]` with NO input-shaped `if:` and NO `continue-on-error:`.
+#   * check-chart-drift.sh itself treats an unreadable cluster as FAILURE, never as "no drift",
+#     and refuses to report success unless it actually compared a minimum number of fields.
+#
+# ⚠️ EXPECT THIS WORKFLOW TO BE RED UNTIL TWO THINGS ARE PROVISIONED. That is the design, not a
+# defect: the honest report of "drift detection is not wired up" is a failing check that names the
+# missing pieces, not a green one that checked nothing.
+#
+#   1. AKS command access for the CI identity. The AZURE_* OIDC secrets already exist (main-cd.yml
+#      uses them for ACR), but publishing images needs no cluster rights. The app registration
+#      behind secrets.AZURE_CLIENT_ID additionally needs a role granting
+#      `Microsoft.ContainerService/managedClusters/runCommand/action` on the cluster — "Azure
+#      Kubernetes Service Cluster User Role" plus "Azure Kubernetes Service RBAC Reader", scoped to
+#      the cluster resource, is enough (this check only ever issues `kubectl get`).
+#
+#   2. A SECRET-FREE per-env values file, committed. check-chart-drift.sh refuses to render with
+#      chart defaults — comparing against a chart nobody deployed produces confident nonsense — so
+#      it needs each environment's real overlay. Those overlays (values.memexcloud.yaml and its
+#      siblings) exist only on operators' disks today: they are not in this repo, and they are not
+#      committed to the private Systemorph/Memex repo either, because they carry OAuth client
+#      secrets and the Postgres password.
+#      The fix is NOT to commit them. This check compares the ConfigMap and the pod spec — it never
+#      reads a secret value — so what it needs is the non-secret half: commit
+#      `deployments/aks/<env>/values.<env>.public.yaml` to Systemorph/Memex (everything under
+#      `config:`, `persistence:`, `keda:`, `probes:`, `ingress:`; nothing under `secrets:`), and
+#      add a fine-grained read-only PAT for that repo as secrets.MEMEX_DEPLOY_REPO_TOKEN.
+#
+# Until both land, every run fails with the list above and nobody is misled about whether the
+# cluster matches the chart. Drift found by a run that DOES complete is reported the same way: red,
+# with each divergence classified CLUSTER-ONLY / CHART-ONLY / DIFFERS.
+
+on:
+  schedule:
+    # 06:15 UTC daily — before the working day, after the nightly self-update poll has settled.
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AKS_RESOURCE_GROUP: memex-aks-rg
+  AKS_CLUSTER: memexaks-cluster
+  DEPLOY_REPO: Systemorph/Memex
+
+jobs:
+  preflight:
+    name: Assert the inputs exist
+    runs-on: ubuntu-latest
+    steps:
+      # No `if:` anywhere in this job. It asserts and fails; it does not decide whether to run.
+      - name: Every external input, or a red build naming what to provision
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          MEMEX_DEPLOY_REPO_TOKEN: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+        run: |
+          missing=()
+          [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID        OIDC app registration for azure/login")
+          [ -n "$AZURE_TENANT_ID" ]       || missing+=("secrets.AZURE_TENANT_ID        the Systemorph AAD tenant")
+          [ -n "$AZURE_SUBSCRIPTION_ID" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID  the subscription holding $AKS_CLUSTER")
+          [ -n "$MEMEX_DEPLOY_REPO_TOKEN" ] || missing+=("secrets.MEMEX_DEPLOY_REPO_TOKEN  read-only PAT for $DEPLOY_REPO, where the per-env values.<env>.public.yaml overlays live (see this file's header — they must be committed there first, secret-free)")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::chart-drift cannot run — provision the following, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          echo "All external inputs are present."
+
+  drift:
+    name: ${{ matrix.env.ns }}
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - { ns: memex,       release: memex }
+          - { ns: memex-cloud, release: memexcloud }
+          - { ns: atioz,       release: atioz }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check out the per-env overlays
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.DEPLOY_REPO }}
+          token: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+          path: deploy-repo
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Compare ${{ matrix.env.ns }} against the rendered chart
+        run: |
+          ENV_DIR="deploy-repo/deployments/aks/${{ matrix.env.ns }}"
+          VALUES="$ENV_DIR/values.${{ matrix.env.release }}.public.yaml"
+          if [ ! -f "$VALUES" ]; then
+            echo "::error::$VALUES is missing. Commit the SECRET-FREE half of this environment's"
+            echo "  helm overlay there (config/persistence/keda/probes/ingress — nothing under"
+            echo "  secrets:). Rendering with chart defaults instead would compare the cluster"
+            echo "  against a chart nobody deployed, so this is a failure, not a fallback."
+            exit 1
+          fi
+          PATCH_ARG=""
+          [ -f "$ENV_DIR/portal-patch.json" ] && PATCH_ARG="--expect-patch $ENV_DIR/portal-patch.json"
+          deploy/aks/scripts/check-chart-drift.sh \
+            -n "${{ matrix.env.ns }}" -r "${{ matrix.env.release }}" \
+            --via aks-invoke -g "$AKS_RESOURCE_GROUP" --aks "$AKS_CLUSTER" \
+            -f deploy/helm/values.yaml -f "$VALUES" $PATCH_ARG

--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -107,6 +107,12 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: v3.16.3
+      # PyYAML is third-party — the script's compare phase imports it. Installed explicitly rather
+      # than relied on from the runner image; the script's preflight asserts it either way.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:

--- a/.github/workflows/chart-gate.yml
+++ b/.github/workflows/chart-gate.yml
@@ -1,0 +1,52 @@
+name: Chart Gate
+
+# Does the deployment chart describe a shape that can actually work?
+#
+# 🚨 WHY THIS WORKFLOW EXISTS. On 2026-08-14 memex.meshweaver.cloud served every request from ONE
+# pod, so any pod loss was a multi-minute 503 — and the chart in git had described that
+# impossibility for a month, unchallenged by any build:
+#
+#   deploy/aks/values.aks.yaml      keda.enabled: true, keda.minReplicas: 2, replicas.portal: 2
+#   templates/…/scaledobject.yaml   minReplicaCount: 2        ← asks for two pods
+#   templates/…/pdb.yaml            maxUnavailable: 1         ← budgets for two pods
+#   templates/…/deployment.yaml     replicas: 1  HARD-CODED   ← renders one pod
+#
+# `replicas.portal: 2` was consumed by NOTHING. helm renders that set without complaint, because
+# helm validates syntax, not sense. Nothing else in CI opens the chart at all.
+#
+# 🛡️ NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). Every input this job reads
+# is in this repository — the chart and the tracked values files. There is no secret, no cluster,
+# no network, and therefore NO condition under which the job may decline to run and still render a
+# tick. It carries no `continue-on-error:` and no input-shaped `if:`, it is not filtered by path
+# (a path filter turns "unrelated PR" into a skipped run, which is the same grey tick again), and
+# the script asserts a minimum number of rendered combinations before it may report success.
+#
+# 🔭 WHAT THIS CANNOT SEE, and what covers it instead. This gate compares the chart against ITSELF.
+# It cannot tell you whether the CLUSTER runs what the chart describes — the live memex-cloud
+# PodDisruptionBudget was a hand-applied `minAvailable: 2` the chart never produced, and its
+# ScaledObject carried `autoscaling.keda.sh/paused-replicas: "1"`, an annotation no chart has heard
+# of. That is deploy/aks/scripts/check-chart-drift.sh, which needs cluster credentials and the
+# private per-env values and so cannot be a pull-request gate; see chart-drift.yml for how it is
+# scheduled, and DeploymentAKS.md for running it by hand.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  invariants:
+    name: Chart invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+      - name: Render every values combination and assert it is self-consistent
+        run: deploy/aks/scripts/check-chart-invariants.sh

--- a/.github/workflows/chart-gate.yml
+++ b/.github/workflows/chart-gate.yml
@@ -48,5 +48,14 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: v3.16.3
+      # PyYAML is third-party. It ships on today's hosted runners, so nothing would fail today —
+      # which is precisely the reason to install it explicitly: a gate whose dependency is satisfied
+      # by luck of the runner image starts failing on an image bump, for a reason unrelated to the
+      # chart it is guarding. The script's preflight also asserts it, so a missing module names
+      # itself instead of surfacing as a traceback.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
       - name: Render every values combination and assert it is self-consistent
         run: deploy/aks/scripts/check-chart-invariants.sh

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -364,6 +364,36 @@ kubectl -n <env> patch deployment memex-portal-deployment --type json -p \
 `ScaledObject` with `minReplicaCount: 2` — you conclude the heal failed when it never ran.
 `kubectl get scaledobject -n <env>` first, and check `PAUSED`.
 
+#### 🚧 A PAUSED scaler is a FENCE — find out why before you remove it
+
+`autoscaling.keda.sh/paused-replicas: "<n>"` pins the deployment at `n`, **deletes the HPA**, and
+makes `minReplicaCount` inert. Nothing in any chart sets it, `kubectl get deploy` does not show it,
+and it survives every roll — so it reads as "this deployment is just single-replica" long after
+whoever applied it has moved on.
+
+**Nobody applies it for fun.** It is the most direct way to say "stop making new silos", so assume
+it is suppressing a multi-silo defect until you have evidence otherwise. `memex-cloud` carried one
+for **16 days** (2026-07-29 → 2026-08-14): it was applied 87 minutes after the second fix for
+**#694 — *cross-silo posts lose AccessContext: static content 500s on ~50% of requests with 2
+replicas*** — and 29 seconds after KEDA scaled the namespace back up. Removing it without reading
+that history is re-running the incident.
+
+Establish provenance before unpausing — the same way you would for any hand-applied field:
+
+```bash
+kubectl -n <env> get scaledobject <name> -o jsonpath='{range .metadata.managedFields[*]}{.manager} {.operation} {.time}{"\n"}{end}'
+kubectl -n <env> get scaledobject <name> -o jsonpath='{.status.lastActiveTime}{"\n"}'   # when it last scaled
+```
+
+`managedFields` gives you the writer (`kubectl-annotate`) and the timestamp; `lastActiveTime`
+immediately before it is the tell that someone watched it scale and stopped it. Then find what
+shipped or broke that day (`git log --since=<date> --until=<date+1>`, closed issues), and only
+unpause once you can name the defect and point at its fix. Treat the unpause as a **monitored
+experiment** with a rollback trigger, not a config tidy-up — a fix merged while the namespace was
+pinned has only ever been exercised in the transient two-silo window of a rollout, never in steady
+state. `check-chart-drift.sh` reports the annotation as CLUSTER-ONLY drift so it stops being
+invisible.
+
 ### Crash dumps: verify the MOUNT
 `DOTNET_DbgEnableMiniDump` + `DOTNET_DbgMiniDumpName=/data/dumps/…` do nothing without a volume at
 that path — `createdump` does not create directories, so the crash destroys its own evidence. The

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -384,11 +384,22 @@ in git looks right. Diff live mounts against the chart after every deploy.
   env vars while no pod mounts `/data/dumps`, so every production `exit=139` so far produced no
   dump. Applying the current chart fixes it; until then a `mkdir /data/dumps` on the `/data` PVC is
   a stopgap that puts heap-sized dumps on a shared 16Gi share instead of the size-bounded emptyDir.
-- **Multi-replica HA**: needs Orleans `AzureTables` clustering wired on the Filesystem backend
-  (the portal currently registers the clustering table client only in the Azure-backend branch).
-- **Chart connection string**: `../helm/templates/memex-portal/secrets.yaml` hardcodes the
-  in-cluster pg host/user — hence the post-install secret patch in `deploy.sh`. Fix at the
-  chart-generator (AddMemex) so an external connection string flows from values.
+- ~~**Multi-replica HA**~~ (chart side done 2026-08-14): Orleans **AdoNet** clustering is the HA
+  provider (`Features:Orleans:Clustering`, legacy key `Deployment:Orleans:Clustering`), backed by a
+  dedicated `orleans` database the migration's `OrleansClusteringSetup` creates. The chart now
+  templates the replica count and omits `spec.replicas` entirely under KEDA so the HPA owns it;
+  `deploy/aks/scripts/check-chart-invariants.sh` asserts the prerequisites at render time. What
+  remains is per-environment and per-cluster, not chart work: each env's overlay must set
+  `keda.enabled`, and a paused `ScaledObject` still pins the count regardless (see "Scaling: KEDA
+  wins" above — check `PAUSED` before believing a replica number).
+- ~~**Chart connection string**~~ (fixed 2026-08-14): `../helm/templates/memex-portal/secrets.yaml`
+  and its migration counterpart now take `secrets.memex_{portal,migration}.ConnectionStrings__memex`
+  / `__orleans` from values, falling back to the in-cluster host only when unset. An env that
+  supplies them no longer needs the post-`helm` secret patch in `deploy.sh`. 🚨 Until an env's
+  values file DOES supply them, `helm upgrade` still re-renders the in-cluster host — and for
+  `__orleans` nothing patches it back, so an AdoNet namespace loses cluster membership. The chart
+  `fail`s the render if an external `ConnectionStrings__memex` is supplied without a matching
+  `__orleans`, so the half-configured case cannot ship silently.
 - **Secrets → Key Vault**: move the PG password, master key, and OAuth secrets into
   `meshweaverkeyvault` via the CSI Secrets Store add-on (enabled in `infra/modules/aks.bicep`).
 

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -29,8 +29,30 @@
 #   ConfigMap  memex-portal-config       every key and value
 #   Deployment memex-portal-deployment   the portal container's inline env (NAMES only — values
 #                                        are never printed, they hold tokens), envFrom refs,
-#                                        lifecycle.preStop, terminationGracePeriodSeconds, and
-#                                        the three probes
+#                                        lifecycle.preStop, terminationGracePeriodSeconds, the
+#                                        three probes, and the AVAILABILITY shape below
+#   PodDisruptionBudget / ScaledObject   existence and shape
+#
+# 🚨 THE AVAILABILITY SHAPE was added 2026-08-14, because the check as first written would have
+# MISSED the incident it was created in response to. On that day memex-cloud served every request
+# from ONE pod, and all three of the reasons were outside what this script looked at:
+#
+#   * spec.replicas               live 1; the chart hard-coded 1 too, so even a comparison agreed —
+#                                 which is why the CHART side of it is now gated separately by
+#                                 check-chart-invariants.sh, on every pull request.
+#   * PodDisruptionBudget         live `minAvailable: 2` over ONE healthy pod ⇒ disruptionsAllowed
+#                                 0 for ever. Hand-applied 2026-07-26 (kubectl-client-side-apply);
+#                                 the chart renders `maxUnavailable: 1`, a different object shape
+#                                 entirely. Nothing compared them.
+#   * ScaledObject                live, minReplicaCount 2 — and carrying the annotation
+#                                 `autoscaling.keda.sh/paused-replicas: "1"`, which PINS the
+#                                 deployment at one pod and deletes the HPA. The chart has never
+#                                 heard of that annotation. It is invisible in `kubectl get deploy`
+#                                 and it silently reverts `kubectl scale`.
+#
+# A drift checker that reads only the ConfigMap and the pod template is a drift checker that cannot
+# see availability. It reads all three now, and it reports a live `disruptionsAllowed: 0` as a
+# finding in its own right — that is an outage condition whether or not the chart agrees with it.
 #
 # Inline `env` and the ConfigMap are BOTH needed and neither is redundant: an inline env entry
 # OVERRIDES envFrom, so `kubectl set env` (defect 3) leaves the ConfigMap matching the render
@@ -148,8 +170,15 @@ fetch() { # $1 = resource
                    --command "kubectl -n $NS get $1 -o json" 2>"$WORK/kubectl.err" ;;
   esac
 }
-for res in "configmap/memex-portal-config" "deployment/memex-portal-deployment"; do
-  out="$WORK/live-$(echo "$res" | tr '/' '-').json"
+# The availability objects are fetched as LISTS, not by name, and that is deliberate. A named GET
+# of an object that does not exist fails, and "it does not exist" is a legitimate, expected answer
+# in a non-KEDA namespace — so a named GET forces the script to treat a real transport failure and
+# a real absence identically. A list GET always returns a valid List document when the transport
+# works (possibly with `items: []`) and invalid output when it does not, which keeps "no PDB here"
+# a POSITIVE finding while a broken connection stays RED.
+for res in "configmap/memex-portal-config" "deployment/memex-portal-deployment" \
+           "poddisruptionbudgets" "scaledobjects.keda.sh"; do
+  out="$WORK/live-$(echo "$res" | tr '/' '-' | tr '.' '-').json"
   if ! fetch "$res" > "$out" || ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$out" 2>/dev/null; then
     echo "::error::could not read $res from namespace '$NS' via --via $VIA. This is a FAILURE, not an absence of drift."
     [ -s "$WORK/kubectl.err" ] && sed 's/^/    /' "$WORK/kubectl.err"
@@ -164,10 +193,13 @@ python3 - \
   "$WORK/desired.yaml" \
   "$WORK/live-configmap-memex-portal-config.json" \
   "$WORK/live-deployment-memex-portal-deployment.json" \
-  "$EXPECT_PATCH" <<'PY'
+  "$EXPECT_PATCH" \
+  "$WORK/live-poddisruptionbudgets.json" \
+  "$WORK/live-scaledobjects-keda-sh.json" <<'PY'
 import json, sys, yaml
 
 desired_path, live_cm_path, live_dep_path, expect_patch = sys.argv[1:5]
+live_pdb_path, live_so_path = sys.argv[5:7]
 
 findings, comparisons = [], 0
 def finding(kind, what, detail=""):
@@ -308,9 +340,95 @@ for label, dv, lv in [
     else:
         finding("DIFFERS", label, f"chart {json.dumps(dv)} vs live {json.dumps(lv)}")
 
+# ---- 5. the AVAILABILITY shape: replicas, the budget, the autoscaler --------
+# Everything above describes ONE pod's configuration. None of it can tell you how many pods there
+# are, or whether anything is allowed to take one away — which is the entire difference between a
+# namespace that survives a node upgrade and one that 503s for minutes.
+def named(path, obj_name):
+    doc = json.load(open(path))
+    for item in doc.get("items", []) if isinstance(doc, dict) else []:
+        if (item.get("metadata") or {}).get("name") == obj_name:
+            return item
+    return None
+
+d_pdb = next((d for d in yaml.safe_load_all(open(desired_path))
+              if d and d.get("kind") == "PodDisruptionBudget"), None)
+d_so = next((d for d in yaml.safe_load_all(open(desired_path))
+             if d and d.get("kind") == "ScaledObject"), None)
+l_pdb = named(live_pdb_path, "memex-portal-pdb")
+l_so = named(live_so_path, "memex-portal-scaler")
+
+# 5a. spec.replicas. Under KEDA the chart renders NO replicas (the HPA owns the field), so a live
+# value is expected and is not drift — what matters then is the autoscaler's floor, checked below.
+comparisons += 1
+d_reps = (d_dep.get("spec") or {}).get("replicas")
+l_reps = (l_dep.get("spec") or {}).get("replicas")
+if d_so is not None and d_reps is not None:
+    finding("DIFFERS", "spec.replicas",
+            f"the chart renders replicas={d_reps} AND a ScaledObject. helm and the HPA would fight "
+            f"over the field on every upgrade — the chart must omit it under KEDA")
+elif d_so is None and d_reps != l_reps:
+    finding("DIFFERS", "spec.replicas", f"chart {d_reps} vs live {l_reps}")
+
+# 5b. the disruption budget — shape AND its live verdict.
+comparisons += 1
+if d_pdb is None and l_pdb is not None:
+    finding("CLUSTER-ONLY", "PodDisruptionBudget memex-portal-pdb",
+            f"live {json.dumps(l_pdb.get('spec'))} — hand-applied; `helm upgrade` DELETES it")
+elif d_pdb is not None and l_pdb is None:
+    finding("CHART-ONLY", "PodDisruptionBudget memex-portal-pdb",
+            "rendered but not running — nothing throttles voluntary disruption today")
+elif d_pdb is not None and l_pdb is not None:
+    d_spec = {k: v for k, v in (d_pdb.get("spec") or {}).items() if k != "selector"}
+    l_spec = {k: v for k, v in (l_pdb.get("spec") or {}).items() if k != "selector"}
+    if d_spec != l_spec:
+        finding("DIFFERS", "PodDisruptionBudget spec",
+                f"chart {json.dumps(d_spec, sort_keys=True)} vs live {json.dumps(l_spec, sort_keys=True)}. "
+                f"minAvailable and maxUnavailable are DIFFERENT OBJECT SHAPES, not two spellings — "
+                f"minAvailable set equal to the replica count allows zero disruptions for ever")
+
+# A live budget that permits nothing is an outage condition on its own terms — report it whether or
+# not the chart happens to agree, because agreeing with it would not make it survivable.
+comparisons += 1
+if l_pdb is not None:
+    st = l_pdb.get("status") or {}
+    if st.get("disruptionsAllowed") == 0:
+        finding("DIFFERS", "PodDisruptionBudget allows NO disruption",
+                f"live disruptionsAllowed=0 (currentHealthy={st.get('currentHealthy')}, "
+                f"desiredHealthy={st.get('desiredHealthy')}). Every node image-upgrade and every "
+                f"drain is blocked, indefinitely and silently. Either the budget is the wrong shape "
+                f"or there are fewer healthy pods than it requires")
+
+# 5c. the autoscaler — including the annotation that silently pins the replica count.
+comparisons += 1
+if d_so is None and l_so is not None:
+    finding("CLUSTER-ONLY", "ScaledObject memex-portal-scaler",
+            "live but not rendered — hand-applied; `helm upgrade` DELETES it (and with it the "
+            "replica floor). Set keda.enabled in the values instead")
+elif d_so is not None and l_so is None:
+    finding("CHART-ONLY", "ScaledObject memex-portal-scaler",
+            "rendered but not running — nothing is holding the replica floor")
+elif d_so is not None and l_so is not None:
+    for key in ("minReplicaCount", "maxReplicaCount"):
+        comparisons += 1
+        dv, lv = (d_so.get("spec") or {}).get(key), (l_so.get("spec") or {}).get(key)
+        if dv != lv:
+            finding("DIFFERS", f"ScaledObject {key}", f"chart {dv} vs live {lv}")
+
+comparisons += 1
+paused = ((l_so or {}).get("metadata") or {}).get("annotations", {}).get(
+    "autoscaling.keda.sh/paused-replicas")
+if paused is not None:
+    finding("CLUSTER-ONLY", "ScaledObject autoscaling.keda.sh/paused-replicas",
+            f"live '{paused}' — KEDA is PAUSED and pins the deployment at {paused} replica(s). The "
+            f"HPA is deleted while this is set, minReplicaCount is not enforced, and `kubectl scale` "
+            f"is silently reverted. Nothing in the chart sets this; remove the annotation to resume "
+            f"autoscaling (`kubectl annotate scaledobject memex-portal-scaler "
+            f"autoscaling.keda.sh/paused-replicas-`)")
+
 # ---- verdict ---------------------------------------------------------------
 # The evidence assertion: a run that compared (almost) nothing must not read as a pass.
-MIN = 20
+MIN = 25
 if comparisons < MIN:
     print(f"::error::only {comparisons} fields were compared (expected at least {MIN}) — the "
           f"objects are not the shape this check understands. Treating as FAILURE rather than "

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -374,7 +374,11 @@ elif d_so is None and d_reps != l_reps:
 comparisons += 1
 if d_pdb is None and l_pdb is not None:
     finding("CLUSTER-ONLY", "PodDisruptionBudget memex-portal-pdb",
-            f"live {json.dumps(l_pdb.get('spec'))} — hand-applied; `helm upgrade` DELETES it")
+            f"live {json.dumps(l_pdb.get('spec'))} — hand-applied, and NOT owned by the helm "
+            f"release. A `helm upgrade` whose values later render a PDB of this name does not adopt "
+            f"it: helm refuses an object without its ownership metadata ('invalid ownership "
+            f"metadata') and the upgrade FAILS. Express it in values (keda.enabled) and let the "
+            f"chart own it")
 elif d_pdb is not None and l_pdb is None:
     finding("CHART-ONLY", "PodDisruptionBudget memex-portal-pdb",
             "rendered but not running — nothing throttles voluntary disruption today")
@@ -403,8 +407,10 @@ if l_pdb is not None:
 comparisons += 1
 if d_so is None and l_so is not None:
     finding("CLUSTER-ONLY", "ScaledObject memex-portal-scaler",
-            "live but not rendered — hand-applied; `helm upgrade` DELETES it (and with it the "
-            "replica floor). Set keda.enabled in the values instead")
+            "live but not rendered — hand-applied, and NOT owned by the helm release, so the "
+            "replica floor this namespace depends on is invisible to every deploy. Helm will not "
+            "adopt it either: once values render a ScaledObject of this name the upgrade FAILS on "
+            "'invalid ownership metadata'. Set keda.enabled in the values instead")
 elif d_so is not None and l_so is None:
     finding("CHART-ONLY", "ScaledObject memex-portal-scaler",
             "rendered but not running — nothing is holding the replica floor")

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -123,7 +123,14 @@ missing=()
 [ -n "$RELEASE" ] || missing+=("-r <release>              the helm release name (e.g. memex, exampledb)")
 [ ${#VALUES[@]} -gt 0 ] || missing+=("-f <values.yaml>          at least one env values file — rendering with chart defaults compares against a chart nobody deployed. These live in the PRIVATE Systemorph/Memex repo.")
 command -v helm    >/dev/null 2>&1 || missing+=("helm                      not on PATH — brew install helm")
-command -v python3 >/dev/null 2>&1 || missing+=("python3                   not on PATH — needed to parse the manifests")
+if ! command -v python3 >/dev/null 2>&1; then
+  missing+=("python3                   not on PATH — needed to parse the manifests")
+# PyYAML is third-party, not stdlib. The compare phase below imports it, so assert it HERE: without
+# this the check dies mid-run with a traceback instead of naming what to install, and a dependency
+# that is present only by luck of the runner image is an unstated input.
+elif ! python3 -c "import yaml" >/dev/null 2>&1; then
+  missing+=("PyYAML                    python3 has no 'yaml' module — pip install pyyaml (or apt-get install python3-yaml)")
+fi
 [ -d "$CHART" ]   || missing+=("-c <chart-dir>            chart not found at '$CHART'")
 for v in ${VALUES[@]+"${VALUES[@]}"}; do
   [ -f "$v" ] || missing+=("-f '$v'                   values file does not exist")

--- a/deploy/aks/scripts/check-chart-invariants.py
+++ b/deploy/aks/scripts/check-chart-invariants.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Assert that ONE rendered manifest set describes a deployment that can actually work.
+
+Driven by check-chart-invariants.sh (see that file for why this exists). Reads a rendered
+`helm template` stream plus the PVC manifest, and reports every contradiction it finds —
+never just the first, so one run tells you the whole story.
+
+Exit 0 = self-consistent. Exit 1 = at least one contradiction, or too little was checked.
+"""
+import sys
+
+import yaml
+
+name, rendered_path, pvc_path = sys.argv[1:4]
+
+findings = []
+checks = 0
+
+
+def finding(what, detail):
+    findings.append((what, detail))
+
+
+def load_all(path):
+    with open(path) as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+docs = load_all(rendered_path)
+
+
+def by_kind(kind, obj_name=None):
+    out = [
+        d for d in docs
+        if d.get("kind") == kind
+        and (obj_name is None or (d.get("metadata") or {}).get("name") == obj_name)
+    ]
+    return out
+
+
+dep = next(iter(by_kind("Deployment", "memex-portal-deployment")), None)
+if dep is None:
+    print(
+        f"::error::[{name}] the render contains no memex-portal-deployment. Nothing could be "
+        f"checked — treating as FAILURE, because 'checked nothing' must never read as "
+        f"'found no contradiction'."
+    )
+    sys.exit(1)
+
+spec = dep.get("spec") or {}
+pod = ((spec.get("template") or {}).get("spec")) or {}
+containers = pod.get("containers") or []
+portal = next((c for c in containers if c.get("name") == "memex-portal"), None)
+if portal is None:
+    print(f"::error::[{name}] no container named 'memex-portal' in the rendered Deployment — FAILURE.")
+    sys.exit(1)
+
+scaled = next(iter(by_kind("ScaledObject", "memex-portal-scaler")), None)
+pdb = next(iter(by_kind("PodDisruptionBudget", "memex-portal-pdb")), None)
+cfg = next(iter(by_kind("ConfigMap", "memex-portal-config")), None)
+secret = next(iter(by_kind("Secret", "memex-portal-secrets")), None)
+
+chart_replicas = spec.get("replicas")
+scaled_min = ((scaled or {}).get("spec") or {}).get("minReplicaCount")
+
+# The floor that will actually apply once the objects are live.
+floor = scaled_min if scaled is not None else (chart_replicas if chart_replicas is not None else 1)
+
+# ---- 1. helm and the HPA must not both own spec.replicas -------------------
+checks += 1
+if scaled is not None and chart_replicas is not None:
+    finding(
+        "spec.replicas is rendered alongside a ScaledObject",
+        f"the chart sets replicas={chart_replicas} while KEDA's HPA also owns that field. Every "
+        f"`helm upgrade` would yank a scaled-out deployment back to {chart_replicas} until the HPA "
+        f"pushed it out again. Omit spec.replicas when keda.enabled.",
+    )
+
+# ---- 2. more than one pod means more than one Orleans silo -----------------
+checks += 1
+clustering = ((cfg or {}).get("data") or {}).get("Deployment__Orleans__Clustering", "Localhost")
+if floor > 1 and clustering.lower() == "localhost":
+    finding(
+        f"replica floor is {floor} but Orleans clustering is 'Localhost'",
+        "Localhost clustering is single-process membership — the replicas do not form ONE mesh, "
+        "they form one mesh EACH, and a grain call resolves against whichever pod the request "
+        "landed on. Set config.memex_portal.Deployment__Orleans__Clustering to AdoNet (or "
+        "AzureTables) in the same change that raises the floor.",
+    )
+
+# ---- 3. more than one pod means more than one writer per volume ------------
+checks += 1
+if floor > 1:
+    claims = {
+        v["persistentVolumeClaim"]["claimName"]
+        for v in (pod.get("volumes") or [])
+        if isinstance(v.get("persistentVolumeClaim"), dict)
+        and v["persistentVolumeClaim"].get("claimName")
+    }
+    modes = {
+        (d.get("metadata") or {}).get("name"): (d.get("spec") or {}).get("accessModes") or []
+        for d in load_all(pvc_path)
+        if d.get("kind") == "PersistentVolumeClaim"
+    }
+    for claim in sorted(claims):
+        if claim not in modes:
+            # The chart mounts claims it does not create; an env may provision them elsewhere.
+            # Not a contradiction in the chart — but say so, rather than silently passing it.
+            print(
+                f"  note [{name}]: claim '{claim}' is mounted but not declared in "
+                f"{pvc_path} — its access mode could not be checked here."
+            )
+            continue
+        if "ReadWriteMany" not in modes[claim]:
+            finding(
+                f"replica floor is {floor} but PVC '{claim}' is {'/'.join(modes[claim])}",
+                "every claim the portal mounts is SHARED state across replicas (/data holds the "
+                "DataProtection key ring, the NodeType assembly cache and the NuGet cache). A "
+                "ReadWriteOnce claim either pins both pods to one node or leaves the second "
+                "unschedulable. Use ReadWriteMany (azurefile-memex).",
+            )
+
+# ---- 4. AdoNet needs a membership connection string ------------------------
+checks += 1
+if clustering.lower() == "adonet":
+    keys = (secret or {}).get("stringData") or {}
+    if not keys.get("ConnectionStrings__orleans"):
+        finding(
+            "Orleans clustering is 'AdoNet' but no ConnectionStrings__orleans is rendered",
+            "the silo throws at startup ('Features:Orleans:Clustering=AdoNet but "
+            "ConnectionStrings:orleans is not set') and the namespace has no portal at all.",
+        )
+
+# ---- 5./6. the disruption budget --------------------------------------------
+checks += 1
+if pdb is not None:
+    pdb_spec = pdb.get("spec") or {}
+    if "minAvailable" in pdb_spec:
+        finding(
+            f"the PodDisruptionBudget uses minAvailable: {pdb_spec['minAvailable']}",
+            "minAvailable is not scale-invariant — it has to be re-tuned every time the replica "
+            "floor moves, and set equal to the floor it allows ZERO voluntary disruptions "
+            "(disruptionsAllowed: 0), which silently blocks every node image-upgrade and drain. "
+            "Use maxUnavailable: 1 — exactly one pod at a time, whether KEDA holds 2 or bursts "
+            "to 8.",
+        )
+    checks += 1
+    if floor < 2:
+        finding(
+            f"a PodDisruptionBudget is rendered but the replica floor is {floor}",
+            "over a single pod a budget can only do harm: minAvailable blocks all voluntary "
+            "disruption for ever, and maxUnavailable makes the ONLY serving pod evictable. Raise "
+            "the floor in the same change that introduces the budget.",
+        )
+
+# ---- 7. surge-first rolls ---------------------------------------------------
+checks += 1
+if scaled is not None:
+    rolling = ((spec.get("strategy") or {}).get("rollingUpdate")) or {}
+    if rolling.get("maxUnavailable") != 0:
+        finding(
+            f"strategy.rollingUpdate.maxUnavailable is {rolling.get('maxUnavailable')!r}, not 0",
+            "0 is what makes a roll surge-first: the old pod keeps serving until the new one "
+            "passes its probes. Above 0 a serving pod can be deleted before its replacement is "
+            "ready, which also makes the NodeType bake gate (PreWarm__GateReadiness) report "
+            "without protecting anything.",
+        )
+
+MIN_CHECKS = 5
+if checks < MIN_CHECKS:
+    print(
+        f"::error::[{name}] only {checks} invariants were evaluated (expected at least "
+        f"{MIN_CHECKS}) — the render is not the shape this check understands. Treating as FAILURE."
+    )
+    sys.exit(1)
+
+if not findings:
+    sys.exit(0)
+
+for what, detail in findings:
+    print(f"::error::[{name}] {what}")
+    print(f"                 {detail}")
+print(f"\n[{name}] {len(findings)} contradiction(s) across {checks} invariants.")
+sys.exit(1)

--- a/deploy/aks/scripts/check-chart-invariants.sh
+++ b/deploy/aks/scripts/check-chart-invariants.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Does the chart DESCRIBE a shape that can actually work?
+#
+#   deploy/aks/scripts/check-chart-invariants.sh
+#   exit 0 = every values combination in this repo renders a self-consistent deployment
+#   exit 1 = a combination renders a contradiction, or nothing could be checked
+#
+# 🚨 WHY THIS EXISTS — the companion to check-chart-drift.sh, and the half that can actually run
+# on every pull request.
+#
+# check-chart-drift.sh answers "does the CLUSTER run what the chart describes?" It needs cluster
+# credentials and the private per-env values, so it cannot be a PR gate. But the memex-cloud 503 of
+# 2026-08-14 did not need a cluster to detect: the CHART ITSELF described an impossibility, in git,
+# for a month, and no build ever looked.
+#
+#   deploy/aks/values.aks.yaml         keda.enabled: true, keda.minReplicas: 2, replicas.portal: 2
+#   templates/…/scaledobject.yaml      minReplicaCount: 2          ← wants two pods
+#   templates/…/pdb.yaml               maxUnavailable: 1           ← budgets for two pods
+#   templates/…/deployment.yaml        replicas: 1   HARD-CODED    ← renders one pod
+#
+# Three files asking for HA and one line vetoing it. `replicas.portal: 2` was consumed by nothing.
+# The rendered manifest set was internally contradictory and `helm template` was perfectly happy to
+# emit it, because helm validates syntax, not sense.
+#
+# WHAT IT CHECKS (rendered objects — no cluster, no secrets, no network):
+#   1. spec.replicas is ABSENT when a ScaledObject exists     helm and the HPA must not both own it
+#   2. a replica floor > 1 implies AdoNet/AzureTables         Localhost clustering cannot span pods
+#   3. a replica floor > 1 implies RWX on every portal claim  /data is shared state
+#   4. AdoNet implies ConnectionStrings__orleans is emitted   the silo throws at startup without it
+#   5. a PDB uses maxUnavailable, never minAvailable          minAvailable is not scale-invariant
+#   6. a PDB implies a replica floor > 1                      over one pod it blocks all or evicts all
+#   7. a ScaledObject implies strategy.maxUnavailable: 0      surge-first, or the roll drops traffic
+#
+# NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). Every input is IN THIS REPO:
+# the chart and the tracked values files. There is no secret to be absent, so there is no condition
+# under which this check may decline to run — and it asserts a minimum number of rendered
+# combinations before it is allowed to report success, so "checked nothing" can never read as
+# "found nothing wrong".
+set -uo pipefail
+
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd -- "$SELF_DIR/../../.." && pwd)"
+CHART="$REPO/deploy/helm"
+PVCS="$REPO/deploy/aks/manifests/portal-pvcs.yaml"
+
+fail=0
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$1" >> "$GITHUB_STEP_SUMMARY"; return 0; }
+report()  { echo "::error::$1"; summary "- ❌ $1"; fail=1; }
+ok()      { echo "$1";          summary "- ✅ $1"; }
+
+# ---------------------------------------------------------------------------
+# PREFLIGHT — assert the tools and files, and fail RED naming what is missing.
+# ---------------------------------------------------------------------------
+missing=()
+command -v helm    >/dev/null 2>&1 || missing+=("helm      not on PATH — brew install helm / azure/setup-helm")
+command -v python3 >/dev/null 2>&1 || missing+=("python3   not on PATH — needed to parse the rendered manifests")
+[ -d "$CHART" ] || missing+=("chart     not found at '$CHART'")
+[ -f "$PVCS" ]  || missing+=("pvcs      not found at '$PVCS' — the RWX assertion reads it")
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "::error::check-chart-invariants cannot run — provide the following:"
+  for m in "${missing[@]}"; do echo "  • $m"; done
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The values combinations this repo ships. Each is a real deployment shape someone installs, so
+# each must render a coherent one. Per-env overlays (Entra ids, hosts, connection strings) live in
+# the PRIVATE Systemorph/Memex repo and are NOT here — they can still break a namespace, which is
+# what check-chart-drift.sh is for. These are the shapes git can prove on its own.
+#
+# name|values files (colon-separated, relative to the repo root)
+# ---------------------------------------------------------------------------
+COMBOS=(
+  "self-host (neutral chart defaults)|deploy/helm/values.yaml"
+  "AKS overlay (memex / memex-cloud / atioz shared layer)|deploy/helm/values.yaml:deploy/aks/values.aks.yaml"
+  "memex-local (Colima k3s)|deploy/helm/values.yaml:deploy/homebrew/share/values.local.defaults.yaml"
+)
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+rendered=0
+for combo in "${COMBOS[@]}"; do
+  name="${combo%%|*}"
+  files="${combo#*|}"
+  args=( template release "$CHART" --namespace check )
+  bad_input=0
+  IFS=':' read -r -a paths <<< "$files"
+  for p in "${paths[@]}"; do
+    if [ ! -f "$REPO/$p" ]; then
+      report "combination '$name' names a values file that does not exist: $p"
+      bad_input=1
+    fi
+    args+=( -f "$REPO/$p" )
+  done
+  [ "$bad_input" -eq 1 ] && continue
+
+  out="$WORK/$(echo "$name" | tr -c 'a-zA-Z0-9' '-').yaml"
+  if ! helm "${args[@]}" > "$out" 2> "$out.err"; then
+    report "combination '$name' does not render at all — helm template FAILED:"
+    sed 's/^/    /' "$out.err"
+    continue
+  fi
+  rendered=$((rendered + 1))
+
+  if python3 "$SELF_DIR/check-chart-invariants.py" "$name" "$out" "$PVCS"; then
+    ok "$name — the rendered deployment is self-consistent"
+  else
+    fail=1
+  fi
+done
+
+# The evidence assertion: a run that rendered (almost) nothing must not read as a pass.
+if [ "$rendered" -lt "${#COMBOS[@]}" ]; then
+  report "only $rendered of ${#COMBOS[@]} values combinations rendered — treating as FAILURE rather than reporting 'no contradictions' on partial evidence"
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo
+  echo "All $rendered values combinations render a self-consistent deployment."
+fi
+exit "$fail"

--- a/deploy/aks/scripts/check-chart-invariants.sh
+++ b/deploy/aks/scripts/check-chart-invariants.sh
@@ -54,7 +54,15 @@ ok()      { echo "$1";          summary "- ✅ $1"; }
 # ---------------------------------------------------------------------------
 missing=()
 command -v helm    >/dev/null 2>&1 || missing+=("helm      not on PATH — brew install helm / azure/setup-helm")
-command -v python3 >/dev/null 2>&1 || missing+=("python3   not on PATH — needed to parse the rendered manifests")
+if ! command -v python3 >/dev/null 2>&1; then
+  missing+=("python3   not on PATH — needed to parse the rendered manifests")
+# PyYAML is a THIRD-PARTY module, not part of the standard library. It happens to be present on
+# GitHub's hosted runners today, which is exactly why it is asserted here: an unstated dependency
+# that works by luck breaks on a runner-image bump, and it would break as a Python traceback rather
+# than as a preflight naming what to install. A gate's dependencies are inputs like any other.
+elif ! python3 -c "import yaml" >/dev/null 2>&1; then
+  missing+=("PyYAML    python3 has no 'yaml' module — pip install pyyaml (or apt-get install python3-yaml)")
+fi
 [ -d "$CHART" ] || missing+=("chart     not found at '$CHART'")
 [ -f "$PVCS" ]  || missing+=("pvcs      not found at '$PVCS' — the RWX assertion reads it")
 if [ ${#missing[@]} -gt 0 ]; then

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -344,12 +344,21 @@ resources:
       memory: "16Gi"   # generous memory ceiling (half a 32 GiB node)
 
 # --- HA / replicas ----------------------------------------------------------
-# Launch 2 portal replicas by default (still needs cookie session affinity +
-# AdoNet Orleans clustering; both are configured). Bump to 3 for full 3-zone
-# spread. portal-ha-patch.yaml sets the same count — keep the two in sync (or
-# `kubectl scale deployment memex-portal-deployment --replicas=2`).
+# Launch 2 portal replicas (needs cookie session affinity + AdoNet Orleans
+# clustering + RWX on every claim; all three are configured below and asserted
+# at render time by .github/workflows/chart-gate.yml).
+#
+# ⚠️ Read ONLY when keda.enabled is false. With KEDA on — which is this file's
+# default — the HPA owns spec.replicas and the chart renders no such field, so
+# the floor that actually applies is keda.minReplicas below. This key is the
+# no-autoscaler fallback, kept equal to that floor so the two never disagree.
+#
+# 🚨 Until 2026-08-14 the chart consumed NEITHER: templates/memex-portal/
+# deployment.yaml hard-coded `replicas: 1`, so this value had sat here inert
+# since 2026-07-13 while memex-cloud served every request from a single pod
+# whose loss was a multi-minute 503.
 replicas:
-  portal: 2        # Blazor Server: initial count; KEDA (below) owns it once installed
+  portal: 2        # fallback when keda.enabled is false; KEDA's minReplicas owns it otherwise
   postgres: 1      # self-managed pg StatefulSet stays single-writer
 
 # --- KEDA autoscaling (portal) ---------------------------------------------

--- a/deploy/helm/templates/memex-migration/secrets.yaml
+++ b/deploy/helm/templates/memex-migration/secrets.yaml
@@ -8,13 +8,20 @@ metadata:
     app.kubernetes.io/component: "memex-migration"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 stringData:
-  ConnectionStrings__memex: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_migration.memex_postgres_password }};Database=memex"
+  # Same rule as the portal secret beside it: an external Postgres flows in from values, and the
+  # in-cluster StatefulSet is only the fallback. The migration is what CREATES the `orleans`
+  # database and its membership tables (OrleansClusteringSetup), so pointing it at the wrong server
+  # does not just fail the job — it leaves an AdoNet portal with no membership store to join.
+  ConnectionStrings__memex: {{ .Values.secrets.memex_migration.ConnectionStrings__memex | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_migration.memex_postgres_password }}"
-  MEMEX_URI: "postgresql://postgres:{{ .Values.secrets.memex_migration.memex_postgres_password }}@memex-postgres-service:5432/memex"
+  MEMEX_URI: {{ .Values.secrets.memex_migration.MEMEX_URI | default (printf "postgresql://postgres:%s@memex-postgres-service:5432/memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
   # Orleans membership tables live in a dedicated `orleans` DB on the same server;
   # the migration's OrleansClusteringSetup creates the DB + tables when this is
   # set. Emitted only for AdoNet (HA) deployments — mirrors the portal gate.
-  {{- if eq (.Values.config.memex_portal.Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
-  ConnectionStrings__orleans: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_migration.memex_postgres_password }};Database=orleans"
+  {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
+  {{- if and (not .Values.secrets.memex_migration.ConnectionStrings__orleans) .Values.secrets.memex_migration.ConnectionStrings__memex }}
+  {{- fail "AdoNet Orleans clustering with an EXTERNAL mesh database: set secrets.memex_migration.ConnectionStrings__orleans too, or the migration creates the membership tables on the in-cluster memex-postgres-service instead of the server the portal actually joins." }}
+  {{- end }}
+  ConnectionStrings__orleans: {{ .Values.secrets.memex_migration.ConnectionStrings__orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
   {{- end }}
 type: "Opaque"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -299,7 +299,29 @@ spec:
       app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "memex-portal"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
-  replicas: 1
+  # 🚨 Replicas are OWNED BY THE AUTOSCALER when KEDA is on — so the chart must not render this
+  # field there at all.
+  #
+  # This used to be a hard-coded `replicas: 1`, and that one line is why memex-cloud could not
+  # survive a pod loss. Everything else the HA shape needs was already true in that namespace —
+  # AdoNet Orleans clustering, a `ConnectionStrings:orleans` pointing at the Flexible Server, RWX
+  # Azure Files on every claim, a KEDA ScaledObject with minReplicaCount 2 — and the Deployment
+  # still declared ONE pod, because the chart had no way to say otherwise. `replicas.portal: 2` sat
+  # in deploy/aks/values.aks.yaml since 2026-07-13 consumed by NOTHING.
+  #
+  # Rendering it under KEDA would be worse than useless: helm and the HPA would then fight over the
+  # same field, and every `helm upgrade` would yank a scaled-out deployment back to the chart's
+  # number until the HPA pushed it out again. Omitting it is what hands ownership over cleanly —
+  # the HPA sets it, helm never touches it, and `minReplicaCount` (values: keda.minReplicas) is the
+  # single place the floor is written.
+  #
+  # Without KEDA the chart is the only writer, so it renders the value: 1 for a single-replica
+  # self-host (the default), higher for a fixed-size install that wants HA without an autoscaler.
+  # ⚠️ Above 1 the same prerequisites apply as for KEDA — AdoNet clustering and RWX on every claim
+  # (values.yaml → persistence). helm-template asserts both; see .github/workflows/chart-gate.yml.
+{{- if not (.Values.keda).enabled }}
+  replicas: {{ (.Values.replicas).portal | default 1 }}
+{{- end }}
   revisionHistoryLimit: 3
   # ⏱️ How long a rollout may be "not progressing" before k8s marks it ProgressDeadlineExceeded.
   #

--- a/deploy/helm/templates/memex-portal/pdb.yaml
+++ b/deploy/helm/templates/memex-portal/pdb.yaml
@@ -3,12 +3,28 @@
 # deployments (AKS). A single-replica self-host leaves KEDA off, where a PDB would only block node
 # maintenance, so it is templated out there.
 #
-# maxUnavailable: 1 lets a VOLUNTARY disruption (node image-upgrade, a manual drain) take at most
-# one portal pod at a time — the other keeps serving, and the departing silo leaves the Orleans
-# cluster gracefully within the 120s terminationGracePeriod. Together with the
-# cluster-autoscaler.kubernetes.io/safe-to-evict: "false" pod annotation (deployment.yaml), this is
-# what stops the zombie-silo churn: the autoscaler never evicts a portal pod for bin-packing, and
-# what disruption remains is throttled to one-at-a-time and graceful.
+# 🚨 maxUnavailable, NOT minAvailable — and that is the whole point of this file.
+#
+# memex-cloud ran a HAND-APPLIED `minAvailable: 2` (kubectl-client-side-apply, 2026-07-26) against
+# a Deployment stuck at ONE replica. `minAvailable: 2` with one healthy pod means
+# `disruptionsAllowed: 0` — permanently, and by arithmetic rather than by accident. Node
+# image-upgrades and drains simply could not proceed, and nothing reported it: a PDB that blocks
+# everything looks exactly like a PDB nothing has asked to evict.
+#
+# Even at the intended 2 replicas that shape stays wrong. `minAvailable: 2` demands BOTH pods, so
+# it still allows zero voluntary disruptions; you would have to re-tune it on every change to the
+# replica floor. `maxUnavailable: 1` is scale-invariant: exactly one pod may go at a time whether
+# KEDA is holding 2 or has burst to 8. The other keeps serving, and the departing silo leaves the
+# Orleans cluster gracefully within terminationGracePeriodSeconds (portal.drainSeconds, 1800s).
+#
+# Together with the cluster-autoscaler.kubernetes.io/safe-to-evict: "false" pod annotation
+# (deployment.yaml), this is what stops the zombie-silo churn: the autoscaler never evicts a portal
+# pod for bin-packing, and what disruption remains is throttled to one-at-a-time and graceful.
+#
+# ⚠️ A PDB is only ever as good as the replica count underneath it. Fixing the budget on a
+# single-replica deployment does not make it available — it makes the one pod EVICTABLE. Raise
+# replicas first (keda.minReplicas / replicas.portal), then let the budget do its job; the chart
+# renders both from the same `keda.enabled` switch so they cannot drift apart again.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -8,19 +8,36 @@ metadata:
     app.kubernetes.io/component: "memex-portal"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 stringData:
-  ConnectionStrings__memex: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_portal.memex_postgres_password }};Database=memex"
+  # 🚨 An EXTERNAL Postgres must be able to flow in from values, and until now it could not.
+  #
+  # This line used to hard-code the in-cluster StatefulSet unconditionally. Every AKS namespace
+  # runs against the Azure Postgres FLEXIBLE SERVER instead (`memex-postgres-statefulset` is scaled
+  # to 0/0 there), so each env's deploy.sh had to `kubectl patch` the rendered value back out again
+  # afterwards — the "chart connection string" entry under DEPLOY-RUNBOOK's known gaps.
+  #
+  # The patch-afterwards dance is not merely untidy, it is a live outage waiting on the next
+  # `helm upgrade`: helm REPLACES a Secret wholesale, so the render overwrites the working
+  # connection string and the portal points at a Postgres that is not running until the patch
+  # re-lands. And the `orleans` string below was never patched by anything at all — a
+  # `helm upgrade` on an AdoNet namespace pointed cluster membership at a dead host, which fails
+  # the silo at startup. Take the value from `secrets.memex_portal.ConnectionStrings__memex` when
+  # it is supplied; keep the in-cluster default when it is not (local k3s, compose, e2e).
+  ConnectionStrings__memex: {{ .Values.secrets.memex_portal.ConnectionStrings__memex | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=memex" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
   # Content indexing writes its tables into per-partition schemas in THIS same mesh database
   # (content_chunks/content_files alongside each partition's mesh_nodes) — no separate connection.
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_portal.memex_postgres_password }}"
-  MEMEX_URI: "postgresql://postgres:{{ .Values.secrets.memex_portal.memex_postgres_password }}@memex-postgres-service:5432/memex"
+  MEMEX_URI: {{ .Values.secrets.memex_portal.MEMEX_URI | default (printf "postgresql://postgres:%s@memex-postgres-service:5432/memex" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
   # ---- Orleans AdoNet clustering (HA / multi-replica) ----------------------
   # The silo THROWS at startup when Deployment:Orleans:Clustering=AdoNet but
   # ConnectionStrings:orleans is unset — so this MUST accompany the AdoNet flag.
   # Same Postgres server, a dedicated `orleans` database that the migration's
   # OrleansClusteringSetup creates + seeds with the membership tables. Emitted
   # ONLY for AdoNet; Localhost single-replica deployments omit it (no unused DB).
-  {{- if eq (.Values.config.memex_portal.Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
-  ConnectionStrings__orleans: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_portal.memex_postgres_password }};Database=orleans"
+  {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
+  {{- if and (not .Values.secrets.memex_portal.ConnectionStrings__orleans) .Values.secrets.memex_portal.ConnectionStrings__memex }}
+  {{- fail "AdoNet Orleans clustering with an EXTERNAL mesh database: set secrets.memex_portal.ConnectionStrings__orleans too. Silo membership would otherwise be pointed at the in-cluster memex-postgres-service, which an external-Postgres deployment does not run — the silo throws at startup and the namespace has no portal. Use the same server as ConnectionStrings__memex with Database=orleans (the migration's OrleansClusteringSetup creates it)." }}
+  {{- end }}
+  ConnectionStrings__orleans: {{ .Values.secrets.memex_portal.ConnectionStrings__orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
   {{- end }}
   # ---- AI provider keys (secret) -------------------------------------------
   # Conditionally emitted: a key is set ONLY when its value is non-empty, so the chart never

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -98,6 +98,22 @@ instancesAdmin:
   # Instances tab (→ Instances__GrafanaBaseUrl). Empty = the tab shows a configure-me hint
   # instead of links. Only meaningful where clusterRead is true (the company instance).
   grafanaBaseUrl: ""
+# ---- Fixed replica count (portal) ------------------------------------------
+# Read ONLY when keda.enabled is false — with KEDA on, the HPA owns spec.replicas and the chart
+# deliberately renders no such field (see templates/memex-portal/deployment.yaml).
+#
+# 1 is the self-host default. Raising it is an HA decision with two hard prerequisites, because a
+# second replica is a second Orleans SILO and a second writer on every volume:
+#   * config.memex_portal.Deployment__Orleans__Clustering must be "AdoNet" (or "AzureTables").
+#     "Localhost" clustering is single-process membership — two Localhost silos do not form one
+#     mesh, they form two, and grain calls resolve against whichever pod the request landed on.
+#   * every persistence.* claim must be ReadWriteMany. /data is shared state (DataProtection key
+#     ring, the NodeType assembly cache, the NuGet cache); a ReadWriteOnce claim either pins both
+#     pods to one node or leaves the second pod unschedulable.
+# Both are asserted at render time by .github/workflows/chart-gate.yml, so a values file that
+# raises this without them fails the build instead of the deployment.
+replicas:
+  portal: 1
 # ---- KEDA autoscaling (portal) --------------------------------------------
 # HA deployments autoscale the portal via a KEDA ScaledObject (templates/
 # memex-portal/scaledobject.yaml) instead of a fixed replica count. Off by
@@ -262,14 +278,28 @@ portalNext:
   # gRPC-web are ingress-routed), so this only affects SSR.
   portalOrigin: "http://memex-portal-service:8080"
 secrets:
+  # ---- Database connection strings -------------------------------------------
+  # Leave EMPTY to use the chart's in-cluster Postgres (memex-postgres-service) — the self-host /
+  # local-k3s / compose default. Set them to point at an EXTERNAL server (Azure Postgres Flexible
+  # Server, RDS, …); the chart then renders exactly what you supply, and the deployment no longer
+  # needs a post-`helm upgrade` `kubectl patch` to undo a hard-coded host.
+  #
+  # ConnectionStrings__orleans is the Orleans membership store — a dedicated `orleans` database on
+  # the SAME server, created by the migration's OrleansClusteringSetup. It is emitted only when
+  # config.memex_portal.Deployment__Orleans__Clustering is "AdoNet", and the chart REFUSES to
+  # render (helm `fail`) if you supply an external ConnectionStrings__memex without it — silently
+  # defaulting membership to an in-cluster host the deployment does not run is how an upgrade
+  # takes the whole namespace down.
   memex_postgres:
     memex_postgres_password: ""
   memex_migration:
     ConnectionStrings__memex: ""
+    ConnectionStrings__orleans: ""
     memex_postgres_password: ""
     MEMEX_URI: ""
   memex_portal:
     ConnectionStrings__memex: ""
+    ConnectionStrings__orleans: ""
     memex_postgres_password: ""
     MEMEX_URI: ""
     # AI provider keys — empty by default (neutral chart). Set in an overlay

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -146,10 +146,20 @@ deploy/aks/scripts/check-chart-drift.sh -n <NS> -r <release> \
   --expect-patch deploy/aks/envs/<env>/portal-patch.json
 ```
 
-It renders the chart, reads the live `memex-portal-config` and `memex-portal-deployment`, and
-classifies every difference as **CLUSTER-ONLY** (hand-applied — the next `helm upgrade` deletes
-it), **CHART-ONLY** (described but never applied — nobody is getting it), or **DIFFERS**. Secret
-values are never printed; inline `env` is compared by name only.
+It renders the chart, reads the live `memex-portal-config` and `memex-portal-deployment` plus the
+namespace's `PodDisruptionBudget` and `ScaledObject`, and classifies every difference as
+**CLUSTER-ONLY** (hand-applied — the next `helm upgrade` deletes it), **CHART-ONLY** (described
+but never applied — nobody is getting it), or **DIFFERS**. Secret values are never printed;
+inline `env` is compared by name only.
+
+The **availability shape** — `spec.replicas`, the budget, the autoscaler — is compared because
+without it the check cannot see an outage. On 2026-08-14 `memex-cloud` served every request from
+ONE pod, and none of the three reasons was a ConfigMap key: a hand-applied `minAvailable: 2`
+budget (the chart renders `maxUnavailable: 1`) sitting at `disruptionsAllowed: 0`, and a
+`ScaledObject` annotated `autoscaling.keda.sh/paused-replicas: "1"` — which pins the replica
+count, deletes the HPA, and silently reverts `kubectl scale`. A live `disruptionsAllowed: 0` is
+now reported on its own terms, whether or not the chart agrees with it: agreeing would not make
+it survivable.
 
 Two things to know before you trust a green run:
 
@@ -160,11 +170,36 @@ Two things to know before you trust a green run:
   `portal-patch.json` after `helm upgrade` (the CSI `envFrom`, extra volumes); pass it so those
   additions read as intentional. Anything cluster-only and *not* in that file is undeclared drift.
 
-It is a script and not a CI job on purpose: it needs cluster credentials, and a CI gate that
-skips when credentials are absent renders the same tick as one that passed — that would rebuild
-the very defect it is meant to catch. It fails RED when it cannot compare — an unreachable
-cluster, a failed render, or a rendered ConfigMap with no keys — rather than reporting "no
-drift" on no evidence.
+It fails RED when it cannot compare — an unreachable cluster, a failed render, or a rendered
+ConfigMap with no keys — rather than reporting "no drift" on no evidence.
+
+**Two callers, and neither may skip.** The script's inputs are cluster credentials and the
+per-env values, so it cannot be a pull-request gate: a gate that skips when a credential is
+absent renders the same tick as one that passed, which would rebuild the very defect it catches.
+It runs from `.github/workflows/chart-drift.yml` on a daily `schedule` (plus `workflow_dispatch`)
+behind a `preflight` job that asserts every external input and **fails red naming what to
+provision** — never an `if:` that decides whether to run. Expect it red until the CI identity has
+AKS `runCommand` rights and each environment's SECRET-FREE `values.<env>.public.yaml` is
+committed to the private deploy repo; that red is the honest report that drift detection is not
+wired up yet.
+
+### The chart must also agree with ITSELF — `check-chart-invariants.sh`
+
+Drift is only half of it. The `memex-cloud` outage above needed no cluster to detect: the chart
+in git described an impossibility. `deploy/aks/values.aks.yaml` asked for `keda.minReplicas: 2`,
+`scaledobject.yaml` rendered a floor of 2, `pdb.yaml` budgeted for two pods — and
+`deployment.yaml` hard-coded `replicas: 1`, so `replicas.portal: 2` had sat in values consumed by
+nothing for a month. `helm template` emits that set happily, because helm validates syntax, not
+sense.
+
+`deploy/aks/scripts/check-chart-invariants.sh` renders every values combination the repo ships
+and asserts the ones that matter: `spec.replicas` absent under KEDA (helm and the HPA must not
+both own it), a replica floor above 1 implying AdoNet clustering and `ReadWriteMany` on every
+portal claim, AdoNet implying a rendered `ConnectionStrings__orleans`, a budget using
+`maxUnavailable` rather than the not-scale-invariant `minAvailable`, a budget implying a floor
+above 1, and `strategy.maxUnavailable: 0` under KEDA. Every input is in this repository, so it
+runs unconditionally on every pull request (`.github/workflows/chart-gate.yml`) — no secret to be
+absent means no condition under which it may decline to run.
 
 ## Self-update ops — pausing, pinning, and the rules that bite
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-the-portal-can-be-described-as-more-than-one-copy.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-the-portal-can-be-described-as-more-than-one-copy.md
@@ -1,0 +1,40 @@
+---
+Name: Losing one portal machine no longer has to mean an outage
+Category: Fix
+Description: A portal could only ever be described as a single machine, so losing it meant minutes of downtime while a replacement started. The deployment description can now say "run two", and new checks stop it quietly drifting back.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Losing one portal machine no longer has to mean an outage
+
+A portal runs on machines, and until now the description that creates them could only ever say
+"one". That is fine right up until the moment the machine goes away — a routine upgrade of the
+underlying hardware, a maintenance drain, a crash — and then there is nothing left serving. The
+replacement has to start from cold, and starting a portal is not instant: it warms up its content
+before it accepts anyone. For the minutes that takes, the site is simply down.
+
+The unhappy part is that everything else needed to run two machines was already in place and had
+been for a month. The settings that let two copies find each other and share one workspace were
+configured; the rule that says "keep at least two running" was configured; the shared storage they
+would both write to was configured. One line in the deployment description said "one machine", and
+that line quietly won every argument. The setting that was supposed to raise the number was read by
+nothing at all.
+
+Two things changed. The description can now genuinely say how many copies to run, and when
+automatic scaling is in charge it steps back and lets the scaler decide rather than resetting the
+number on every update. And the rule that limits how many copies may be taken away at once is now
+written so that it stays correct as the number of copies changes — the old form had to be re-tuned
+by hand each time, and when it was not, it silently blocked every routine maintenance operation
+instead of permitting one at a time.
+
+The rest of the work is about not having to find this out the hard way again. A description that
+contradicts itself — asking for two copies in one place and one in another — now fails the build
+rather than being deployed and discovered later. And a separate check that compares what is
+actually running against what was described has been taught to look at availability at all: how
+many copies there are, whether anything is allowed to replace one, and whether automatic scaling
+has been paused. It could not see any of that before, which is why it had nothing to say the day it
+mattered.
+
+None of this changes anything you do on a portal. It changes how long a portal is unavailable when
+the machine underneath it goes away — from minutes, to nothing you would notice.


### PR DESCRIPTION
`memex.meshweaver.cloud` serves every request from **one** pod, so any pod loss is a multi-minute
503 — the replacement bakes its NodeTypes behind a readiness gate before it accepts traffic. This
PR is the **repo half**: the chart can now describe the HA shape, and two checks stop it drifting
back. **No cluster was touched.** The roll-out is a separate decision — runbook below.

> 🚧 **Merging this does not make anything HA, and the roll-out is not a rubber stamp.** The live
> namespace sits at one pod because KEDA was deliberately **paused** on 2026-07-29 to suppress
> **#694 — cross-silo posts lose AccessContext, static content 500s on ~50% of requests with 2
> replicas**. That cause has named fixes (all merged), but steady-state two-silo operation has not
> been re-tested on this namespace since. See **"Why KEDA was paused"** below — it is a blocking
> consideration for the roll, not for this PR.

## What the live cluster actually looks like

Read-only, 2026-08-14, via `az aks command invoke` on `memexaks-cluster` / `memex-aks-rg`.

| | `memex` | `memex-cloud` | `atioz` |
|---|---|---|---|
| `spec.replicas` | 1 | **1** | 1 |
| `maxSurge` / `maxUnavailable` | 1 / 0 | 1 / 0 | 1 / 0 |
| `terminationGracePeriodSeconds` | 1800 | 1800 | 1800 |
| PodDisruptionBudget | none | **`minAvailable: 2`, `disruptionsAllowed: 0`** (currentHealthy 1, desiredHealthy 2) | none |
| ScaledObject | none | present, min 2 / max 8 — **`autoscaling.keda.sh/paused-replicas: "1"`** | none |
| HPA | none | **none — KEDA deletes it while paused** | none |
| Orleans clustering | `Localhost` | **`AdoNet`** | `Localhost` |
| `ConnectionStrings__orleans` | absent | present → `Host=10.42.18.4;…;Database=orleans` (Flexible Server) | absent |
| PVCs | 3, all RWX `azurefile-memex` | 6, all RWX `azurefile-memex` | 4, all RWX `azurefile-memex` |
| `PreWarm__GateReadiness` (inline env) | `true` | `true` | `true` |
| `PreWarm__BatchBake` (inline env) | `true` | `true` | `true` |
| `startupProbe` | 10 × 1080 (3 h) | 10 × 1080 (3 h) | 10 × 1080 (3 h) |
| helm revisions | v1 (2026-06-04) | **v1 (2026-06-04)** | v1…v5 |

**After this PR** nothing in the cluster changes. What changes is what the chart can *say*: with
`keda.enabled` the portal Deployment renders **no `spec.replicas` at all**, so the KEDA HPA owns
the count and `keda.minReplicas` is the single place the floor is written; without KEDA it renders
`replicas.portal`. The PDB keeps `maxUnavailable: 1` and now documents why. `maxSurge: 1 /
maxUnavailable: 0` is untouched.

### Corrections to the brief this PR started from

- ✅ **`terminationGracePeriodSeconds` is already 1800 live** on all three namespaces. Already fixed
  and applied; not redone here.
- ✅ **The PDB is `minAvailable: 2` at `replicas: 1`** — confirmed, `disruptionsAllowed: 0`,
  hand-applied `kubectl-client-side-apply` 2026-07-26.
- ✅ **Bake-gated readiness is real.** `PreWarm__GateReadiness` reads `false` in the ConfigMap and
  **`true` in the Deployment's inline `env`**, which overrides `envFrom`. Reading the ConfigMap
  alone gives the wrong answer — exactly the trap `check-chart-drift.sh` was written for.
- ❌ **`replicas: 1` was not the whole story, and the missing prerequisites were not missing.**
  AdoNet clustering, the `orleans` connection string, and RWX on every claim are *already live* on
  `memex-cloud`. The Orleans membership tables exist (an AdoNet silo throws at startup without
  them, and the pod is `Running`). The proximate cause of one pod is **`autoscaling.keda.sh/paused-replicas: "1"`** on the ScaledObject — KEDA is *paused*, which pins the count, deletes the HPA,
  and silently reverts `kubectl scale`. The chart's hard-coded `replicas: 1` is the reason the
  cluster could never be brought back into line by a deploy; **the pause is why it is at 1 today**,
  and it was applied deliberately to suppress a two-replica defect — see "Why KEDA was paused".
- ❌ **The file is `deploy/aks/values.aks.yaml`, not `deploy/helm/values.aks.yaml`**, and it is a
  *reference* overlay — no env layers it. Every `deploy.sh` runs
  `helm upgrade -f ./helm/values.yaml -f ./values.<env>.yaml`. The authoritative per-env values are
  **not in this repo and not in the private `Systemorph/Memex` repo either** — they exist only on
  operators' disks, because they carry OAuth secrets and the PG password.
- ❌ **`check-chart-drift.sh` would have missed this incident entirely.** It compared the ConfigMap,
  inline env names, `envFrom`, `preStop`, the grace period and the three probes — never replicas,
  never the PDB, never the ScaledObject. Fixed here.
- ❌ **helm has run once on `memexcloud` and `memex`, but five times on `atioz`.**

## 🚧 Why KEDA was paused — and why unpausing is NOT a routine step

This is a fence question, so it was answered from `managedFields`, not inferred.

| when (UTC) | manager | what |
|---|---|---|
| 2026-07-13T15:27:45Z | `kubectl-client-side-apply` | ScaledObject created, min 2 / max 8 |
| 2026-07-22T13:44:01Z | `kubectl-patch` | `minReplicaCount` / `maxReplicaCount` changed |
| 2026-07-26T20:30:00Z | `kubectl-client-side-apply` | **PDB `minAvailable: 2`** (a different object) |
| **2026-07-29T20:37:11Z** | **`kubectl-annotate`** | **`paused-replicas: "1"`** |
| 2026-07-29T20:37:12Z | `keda` (status) | records `pausedReplicaCount: 1`, `lastActiveTime: 20:36:42Z` |

**The "PDB and pause are one intervention" hypothesis is FALSIFIED.** They are **3 days and 7
minutes** apart, written by different managers (`kubectl-client-side-apply` vs `kubectl-annotate`),
against different objects. They also point in opposite directions: `minAvailable: 2` is the shape
you write when you expect two pods and want both kept, and the pause abandons the second pod
entirely.

**But the concern underneath the hypothesis is CONFIRMED, with a named cause.** The pause correlates
with issue **#694 — "Cross-silo posts lose AccessContext: static content 500s on ~50% of requests
*with 2 replicas*"** to the hour:

- `#694` closed **2026-07-29T16:32:55Z**
- `#719` ("cross-silo reply routing — #694 layer 2") merged **2026-07-29T19:10:14Z**
- KEDA `lastActiveTime` **2026-07-29T20:36:42Z** — the scaler goes active, i.e. it scales
- **29 seconds later**, `paused-replicas: "1"` — 87 minutes after the layer-2 merge
- next day, 2026-07-30T20:40Z, in this repo: *"Gate OFF until core #694: two-silo roll window makes
  the sweep flake, gate stalls on FALSE regressions"*

The reading that fits every timestamp: someone spent 2026-07-29 fixing a **two-replica-only** defect,
watched KEDA scale back up that evening, and pinned the namespace at one pod while the fix
propagated. **It has stayed pinned for 16 days.** This was suppression of a real, user-visible
failure (500s on ~50% of requests), not a tidy-up.

**Was the root cause fixed, or only suppressed?** Fixed, in layers — and all of it is in the running
image:

| defect | fix | state |
|---|---|---|
| silos vote each other dead → `FailFast` (2026-07-15..22, full outage 07-20) | `ClusterMembershipOptions` 15 s × 5 + indirect probes (`ad84ef3a3`, 07-22) | merged |
| 4-replica MCP/auth failures | storage-direct auth + stateless MCP transport (#644, 07-25) | merged |
| cross-silo posts lose AccessContext → 500s at 2 replicas | #694 + #719 | closed 07-29 |
| starved cross-silo source discovery → false `CompileError`s | #1218 | **closed 2026-08-12** |

The strongest behavioural evidence is what operators have since done: the bake-gate stopgaps
(`PreWarm__GateReadiness=false`, `PreWarm__BatchBake=false`) that were live on 2026-08-11 have been
**reverted** — both read `true` on all three namespaces today, and the private deploy repo shows
active gate work through 2026-08-13. Re-arming that gate is the action you take when you believe
cross-silo discovery works again.

🚨 **What is still NOT established, and why step 2 is gated.** Every one of those fixes has only ever
been exercised in the **transient** two-silo window of a rollout. `memex-cloud` has not run
**steady-state** two silos since 2026-07-29, so "cross-silo works" is proven for a window that lasts
a bake, not for a permanent condition. And two issues describing multi-silo grain/circuit behaviour
are **OPEN**: **#1340** ("A roll kills every grain and circuit") and **#1348** ("Zero-disruption
rolls: bake-gated silo generations, activity-pinned grains").

**Therefore: unpausing is a monitored experiment, not a safe step.** It is not "we don't know why it
was paused" — we know precisely why, and the cause has named fixes. It is "the condition it
suppressed has never been re-tested in the shape you are about to create". The runbook's step 2
carries the watch list and the rollback trigger accordingly. **Whether to run that experiment on a
production portal is the user's call, not this PR's.**

## `helm template` diff

`helm template` for a *namespace* is not possible — the per-env values do not exist in any repo
(above). These are the three combinations the repo can render, each diffed against the same
combination rendered from the pre-change chart (`git archive HEAD~2`):

```
self-host  (values.yaml)                                   — 0 rendered values changed
memex-local (values.yaml + values.local.defaults.yaml)     — 0 rendered values changed
AKS        (values.yaml + deploy/aks/values.aks.yaml)      — 1 rendered value  changed:

--- before
+++ after
@@ Deployment/memex-portal-deployment
       app.kubernetes.io/instance: "memexcloud"
-  replicas: 1
   revisionHistoryLimit: 3
```

One line, in one object, only when `keda.enabled`. **Both single-replica paths are unchanged in
every rendered value** — the only textual difference in those two is the added explanatory comments
(inert; the API server never sees them). That is the proof this cannot disturb a self-host,
`memex-local` or compose install. The connection-string change likewise renders identically until an
env actually supplies the new values keys.

Guard verified both ways:

```
$ helm template … -f ext-db-without-orleans.yaml
Error: execution error at (memex/templates/memex-portal/secrets.yaml:38:6):
AdoNet Orleans clustering with an EXTERNAL mesh database: set
secrets.memex_portal.ConnectionStrings__orleans too. …
```

## The two checks

**`chart-gate.yml` → `check-chart-invariants.sh`** — runs on every PR, today, with no provisioning.
Renders all three values combinations the repo ships and asserts they agree with each other:
`spec.replicas` absent under KEDA; a floor > 1 implying AdoNet clustering and RWX on every portal
claim; AdoNet implying a rendered `ConnectionStrings__orleans`; the budget using `maxUnavailable`
not `minAvailable`; a budget implying a floor > 1; `strategy.maxUnavailable: 0` under KEDA. Every
input is in this repo — no secret to be absent means **no condition under which it can decline to
run and still render a tick**. It carries no `continue-on-error` and no `if:` at job or step level.

*A check that cannot fail is not a check*, so it was verified against the pre-change chart:

```
$ git stash-free revert of deployment.yaml, then:
::error::[AKS overlay] spec.replicas is rendered alongside a ScaledObject
   the chart sets replicas=1 while KEDA's HPA also owns that field …
EXIT=1
```

**`chart-drift.yml` → `check-chart-drift.sh`** — the script's **first caller** since it was added on
2026-08-13 (`git grep` across `.github`, `deploy`, `tools` found none). It now also compares the
availability shape, and run live against `memex-cloud` it reports all three defects:

```
CLUSTER-ONLY ScaledObject autoscaling.keda.sh/paused-replicas
   live '1' — KEDA is PAUSED and pins the deployment at 1 replica(s). The HPA is deleted while
   this is set, minReplicaCount is not enforced, and `kubectl scale` is silently reverted.
DIFFERS      PodDisruptionBudget allows NO disruption
   live disruptionsAllowed=0 (currentHealthy=1, desiredHealthy=2) …
DIFFERS      PodDisruptionBudget spec
   chart {"maxUnavailable": 1} vs live {"minAvailable": 2} …
```

🚨 **This workflow will be RED until two things are provisioned, and that is the design.** It needs
cluster credentials and per-env values, so it cannot be a PR gate — a gate that skips on a missing
credential renders the same tick as one that passed. Instead a `preflight` job asserts every
external input and **fails red naming exactly what to provision**; the `drift` job `needs` it and
runs unconditionally. A failing check that says "drift detection is not wired up" is the honest
report; a green one that checked nothing is the 26th instance of the pattern. **See "Blocking
prerequisites" below** — and if you would rather not carry a red daily run, delete the `schedule:`
block and keep `workflow_dispatch`; that is a deliberate choice to make, not something to leave
ambiguous.

---

# Roll-out runbook

**Recommended path: `kubectl` only. Do NOT `helm upgrade` `memex-cloud`.** Justification in
"What a `helm upgrade` would revert". Steps are ordered so the PDB is never fixed while there is
one pod — fixing it there would make the *only* serving pod evictable.

Prefix every command with the private-cluster transport:

```bash
AKS="az aks command invoke -g memex-aks-rg -n memexaks-cluster -o tsv --query logs --command"
```

### 0. Confirm the starting state (30 s)

```bash
$AKS "kubectl -n memex-cloud get deploy memex-portal-deployment -o custom-columns=REPLICAS:.spec.replicas,READY:.status.readyReplicas --no-headers"
$AKS "kubectl -n memex-cloud get pdb memex-portal-pdb -o custom-columns=MIN:.spec.minAvailable,MAX:.spec.maxUnavailable,ALLOWED:.status.disruptionsAllowed,HEALTHY:.status.currentHealthy --no-headers"
$AKS "kubectl -n memex-cloud get scaledobject memex-portal-scaler -o yaml | grep -A3 'annotations:'"
```

**Signal:** `1 1` · `2 <none> 0 1` · an `autoscaling.keda.sh/paused-replicas: "1"` annotation. If
any differs, stop and re-read — the state has moved since this PR was written.

### 1. Confirm a second pod can be scheduled

```bash
$AKS "kubectl get nodes -l workload=silos -o custom-columns=NAME:.metadata.name,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory --no-headers"
$AKS "kubectl describe node <the node NOT running the portal> | grep -A6 'Allocated resources'"
```

**Verified at time of writing** — the second pod both *fits* and *lands on the other node*:

- Two `silos` nodes exist. `…vmss00000r` runs the current `memex-cloud` portal; `…vmss00000l` is at
  **2679m/15740m CPU and 5618Mi/~59Gi memory requested**, so the portal's `cpu: 4` / `memory: 10Gi`
  request fits with room to spare.
- The live pod spec already carries a **topology spread constraint** —
  `maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: DoNotSchedule` over
  `app.kubernetes.io/component: memex-portal` — so the second replica **cannot** be co-scheduled on
  the same node as the first. That is what makes this real HA against a *node* loss, not just a pod
  loss. (Spread constraints are namespace-scoped, so `memex`'s portal on the same node does not
  count against it.)
- ⚠️ The flip side of `DoNotSchedule`: with only two `silos` nodes, if the second one is cordoned or
  full the new pod sits **`Pending`** rather than doubling up — step 2 then looks stuck rather than
  failed. `kubectl -n memex-cloud describe pod <pending>` names the reason.

### 2. Un-pause KEDA — a MONITORED EXPERIMENT, not a routine step

🚨 **Read "Why KEDA was paused" above before running this.** The pause was applied on
2026-07-29T20:37:11Z, 87 minutes after the second fix for **#694 — cross-silo posts lose
AccessContext, static content 500s on ~50% of requests with 2 replicas** — and 29 seconds after
KEDA scaled the namespace back up. It suppressed a real, user-visible failure. The named causes have
since been fixed (#694, #719, #644, #1218, the membership-tolerance widening), but **none of those
fixes has been exercised in steady-state two-silo operation on this namespace** — only in the
transient two-silo window of a rollout. Do this with someone watching, in a window where a rollback
is acceptable, not unattended.

```bash
$AKS "kubectl -n memex-cloud annotate scaledobject memex-portal-scaler autoscaling.keda.sh/paused-replicas-"
```

**Signal (immediate):** the HPA is re-created —

```bash
$AKS "kubectl -n memex-cloud get hpa; \
      kubectl -n memex-cloud get scaledobject memex-portal-scaler -o jsonpath='{range .status.conditions[*]}{.type}={.status} {end}{\"\n\"}'"
```

expect `keda-hpa-memex-portal-scaler` to exist and **no `Paused=True`** condition.

**Signal (1–5 min):** the deployment reaches 2/2.

```bash
$AKS "kubectl -n memex-cloud rollout status deployment/memex-portal-deployment --timeout=600s; \
      kubectl -n memex-cloud get pods -l app.kubernetes.io/component=memex-portal"
```

⏱️ The new pod holds `/health` red until its NodeType bake completes — `PreWarm__GateReadiness` and
`PreWarm__BatchBake` are both `true` (inline env). Batch bake is ~1 min for this mesh, and the
startupProbe budget is 10 × 1080 = 3 h, so a bake that has not finished in ~10 minutes is **wedged,
not slow** — read the pod log, do not wait it out.

🚨 **The watch list — these are the specific failures the pause was suppressing.** Keep this running
for at least 30 minutes after the second pod is Ready, and roll back at **R1** on any of them:

```bash
$AKS "kubectl -n memex-cloud logs deployment/memex-portal-deployment --all-containers --tail=400 | grep -iE 'told I am dead|AccessContext|SubscribeRequest|CS0246|No response received|Access denied'"
```

| signal | what it means | issue |
|---|---|---|
| `I have been told I am dead` | the two silos are voting each other out under load — the 2026-07-20 full-outage mode | `ClusterMembershipOptions` (07-22) |
| HTTP **500s on static content**, `AccessContext` / `Access denied` on reads that should succeed | **the exact #694 failure the pause suppressed** — cross-silo posts losing the caller's identity | #694 / #719 |
| `No response received … within 00:01:00 for request SubscribeRequest` | cross-silo subscribe starvation; a `p90` gap of exactly 60.0 s is its signature | #1218 |
| `CS0246: type or namespace not found` on a NodeType that compiled fine earlier | starved cross-silo source discovery producing FALSE regressions; with the bake gate armed this stalls rolls | #1218 |

**Signal (user-visible) — sample the 500 RATE, not a single 200.** #694 presented as ~50% of
requests failing, so one `curl` returning 200 proves nothing:

```bash
for i in $(seq 1 40); do curl -sS -o /dev/null -w '%{http_code}\n' https://memex.meshweaver.cloud/; done | sort | uniq -c
```

Expect `40 200`. **Any** non-200 in that sample is the #694 signature returning — roll back.

### 3. Only now, fix the PodDisruptionBudget

Do not do this before step 2 reports 2/2. `minAvailable: 2` at one pod blocks everything;
`maxUnavailable: 1` at one pod makes the only pod evictable. Both are wrong — the budget is only
correct once there are two pods.

**Patch it in place — do not delete and re-create.** A JSON patch applies both operations before
validation, so the object never transiently holds both fields (which the API rejects), and it
**keeps the existing `selector` untouched**. That matters: the live selector is already proven to
match the running pods (`currentHealthy: 1`), whereas a hand-typed replacement can silently select
nothing — a budget matching zero pods reports a healthy-looking `disruptionsAllowed` while
protecting nothing at all.

```bash
$AKS "kubectl -n memex-cloud patch pdb memex-portal-pdb --type=json -p '[{\"op\":\"remove\",\"path\":\"/spec/minAvailable\"},{\"op\":\"add\",\"path\":\"/spec/maxUnavailable\",\"value\":1}]'"
```

**Signal — this is the one that matters:**

```bash
$AKS "kubectl -n memex-cloud get pdb memex-portal-pdb -o custom-columns=MIN:.spec.minAvailable,MAX:.spec.maxUnavailable,ALLOWED:.status.disruptionsAllowed,HEALTHY:.status.currentHealthy,DESIRED:.status.desiredHealthy --no-headers"
```

expect `<none> 1 1 2 1`. **`ALLOWED` moving 0 → 1 is the proof** that node upgrades and drains are
no longer blocked, and `HEALTHY 2` confirms the budget still selects both pods.

If the API rejects the patch, fall back to `delete` + re-create from the chart's render
(`helm template … --show-only templates/memex-portal/pdb.yaml`) — and in that case verify the
selector against
`kubectl -n memex-cloud get deploy memex-portal-deployment -o jsonpath='{.spec.selector.matchLabels}'`
first, since the chart derives those labels from `.Chart.Name` and `.Release.Name`.

### 4. Re-run the drift check

```bash
deploy/aks/scripts/check-chart-drift.sh -n memex-cloud -r memexcloud \
  --via aks-invoke -g memex-aks-rg --aks memexaks-cluster \
  -f deploy/helm/values.yaml -f <your values.memexcloud.yaml> \
  --expect-patch <Memex repo>/deployments/aks/memex-cloud/portal-patch.json
```

**Signal:** the three availability findings quoted above are **gone**. The remaining
CLUSTER-ONLY / DIFFERS backlog (below) will still be reported — that is a separate, larger piece
of work, and the point of the check is that it is now visible rather than assumed away.

## Rollback

Both steps are independently reversible and neither loses data.

**R1 — re-pause KEDA (back to one pod).** This restores exactly the state that has been running
since 2026-07-29, so it is a return to a known-good configuration, not a leap:

```bash
$AKS "kubectl -n memex-cloud annotate scaledobject memex-portal-scaler autoscaling.keda.sh/paused-replicas=1 --overwrite"
```
Signal: `kubectl -n memex-cloud get deploy` returns to 1/1 and the HPA disappears (KEDA deletes it
while paused). If you roll back here, **say why in #1340 / #1348** — a second failure of
steady-state two-silo operation is the evidence those issues need, and re-pausing silently is how
this became a 16-day mystery the first time.

**R2 — if step 3 was already applied, delete the budget rather than restoring `minAvailable: 2`:**

```bash
$AKS "kubectl -n memex-cloud delete pdb memex-portal-pdb"
```
At one replica **no budget is strictly better than the old one**: `minAvailable: 2` did not protect
anything, it only blocked maintenance for ever. Do not restore it.

Rolling back the *repo* change is unnecessary for either — the chart is not applied by this
runbook, and reverting the PR would not change a single live object.

## What a `helm upgrade` would revert

Helm has run **exactly once** on this release (`sh.helm.release.v1.memexcloud.v1`, 2026-06-04).
Every write since is `kubectl-set` (image), `kubectl-rollout`, `unknown` (the self-updater) or
`kubectl-patch`. A live drift run reports **114 divergences across 150 compared fields**.

The decisive evidence is `helm get manifest memexcloud -n memex-cloud` — the manifest helm believes
it installed. Read against the live objects it says something stronger than any list of individual
keys:

| helm's recorded release (2026-06-04) | live today |
|---|---|
| `Deployment__Orleans__Clustering: "Localhost"` | **`AdoNet`** |
| **no `ConnectionStrings__orleans` at all** (the template gates it on AdoNet) | present → `Host=10.42.18.4;…;Database=orleans` |
| `memex-data` / `memex-users` are **`emptyDir`** | six **RWX PVCs** |
| `strategy.maxUnavailable: 1` | `0` |
| `replicas: 1` | 1 |
| no PDB, no ScaledObject | both, hand-applied |

🚨 **The entire Orleans clustering configuration this namespace depends on is invisible to the
helm release.** Helm thinks it installed a single-replica, `Localhost`-clustered, `emptyDir` portal
with no membership store. Everything that makes `memex-cloud` an AdoNet deployment was applied by
hand afterwards.

I am deliberately **not** enumerating exactly which live-only values an upgrade would destroy.
Whether a hand-applied ConfigMap key or inline `env` entry survives depends on helm's three-way
merge semantics per field type, and I could not verify that without running an upgrade — which is
the thing this section exists to avoid. What is certain and sufficient:

- **The release is two months and a chart-generation stale**, and it does not describe the
  deployment that is running. An upgrade is not "apply my one-line change" here; it is
  "reconcile 114 divergences at once, in production, blind".
- **`ConnectionStrings__orleans` is at risk either way.** With `Localhost` still in the values, the
  chart renders no orleans key at all; with AdoNet added, it renders one pointing at
  `memex-postgres-service` — which in this namespace is scaled **0/0**. Both outcomes leave an
  AdoNet silo without a reachable membership store, and a silo that cannot reach one throws at
  startup. Nothing in `deploy.sh` patches that key back (it patches only `ConnectionStrings__memex`).
- **`PreWarm__GateReadiness` and `PreWarm__BatchBake` are inline `env`, not ConfigMap** — and the
  ConfigMap disagrees with them (`GateReadiness` reads `false` there). Any reconciliation that moves
  them into the ConfigMap silently disarms the bake gate.

**⚠️ Caveat on the drift output itself.** It was produced rendering
`deploy/helm/values.yaml + deploy/aks/values.aks.yaml` as a stand-in, because the real
`values.memexcloud.yaml` exists only on operators' disks. The real overlay supplies many of the
ConfigMap keys reported, so **the ConfigMap findings are an upper bound**. The table above is taken
from `helm get manifest`, not from the approximation, so it stands on its own.

**One more hazard, specific to `keda.enabled`.** Helm's recorded release contains **no ScaledObject
and no PDB**, so `keda.enabled` was false in that namespace's values at the only helm run. Two
cases follow, and both argue the same way:

- If it is *still* false, my chart change is a **no-op for a `memex-cloud` upgrade** — the template
  renders `replicas: 1` exactly as before.
- If a `keda` block has been added to `values.memexcloud.yaml` since (untested — helm has not run
  again), an upgrade would newly render a ScaledObject and a PDB *of the same names as the
  hand-applied ones*, and **helm refuses to adopt objects it does not own**: the upgrade fails with
  `invalid ownership metadata` rather than reconciling them.

**Conclusion: the answer is "too much".** Take the narrow `kubectl` path above. Adopting
`memex-cloud` into helm is real, separate work: capture every cluster-only value into
`values.memexcloud.yaml`, label/annotate the hand-applied PDB and ScaledObject into the release (or
delete and let helm re-create them), then run the drift check until it comes back clean *before*
the upgrade, not after.

## Blocking prerequisites I could not satisfy in the repo

1. **The per-env values files are not in any repository.** `values.memexcloud.yaml` and its
   siblings live on operators' disks; they are not in this repo, and not committed to the private
   `Systemorph/Memex` repo (which has `deploy.sh`, `portal-patch.json`, `portal-ingress.yaml`,
   `portal-pvcs.yaml`, `tls.sh` per env — no values). **Consequence:** I could not "make
   `memex-cloud`'s values select" the HA shape, and `chart-drift.yml` cannot run. The unblock is to
   commit the **secret-free** half as `deployments/aks/<env>/values.<env>.public.yaml` — the drift
   check reads only the ConfigMap and pod spec, never a secret value.
2. **CI has no cluster access.** `secrets.AZURE_{CLIENT,TENANT,SUBSCRIPTION}_ID` exist (main-cd uses
   them for ACR), but publishing images needs no cluster rights. That app registration needs
   *Azure Kubernetes Service Cluster User Role* + *RBAC Reader* on `memexaks-cluster` for
   `runCommand`. I could not verify its current roles (the repo *variable* `AZURE_CLIENT_ID` is a
   stale 2024 value in a different subscription; the *secret* is not readable).
3. **`secrets.MEMEX_DEPLOY_REPO_TOKEN`** does not exist — a read-only fine-grained PAT for
   `Systemorph/Memex`.
4. **Orleans clustering tables: satisfied, verified empirically — but not self-healing.** An AdoNet
   silo throws at startup without them and the `memex-cloud` pod is `Running`, so the migration's
   `OrleansClusteringSetup` has run against the `orleans` database at some point. Not a blocker for
   this roll. ⚠️ Worth knowing: `memex-migration-deployment` is scaled to **0** in that namespace
   (`deploy.sh` scales it down — the data was restored from prod at its schema version), and
   `memex-postgres-statefulset` is **0/0**. So nothing re-creates those tables on a deploy; they
   exist because a past run made them. If the `orleans` database were ever lost, every silo would
   fail to start and the fix would be to run the migration deliberately with
   `ConnectionStrings__orleans` pointed at the Flexible Server.
5. **RWX: satisfied.** Every PVC in all three namespaces is already `ReadWriteMany` on
   `azurefile-memex`. Not a blocker.
6. 🚧 **Steady-state two-silo operation is unproven on this namespace — blocking for the ROLL, not
   for this PR.** KEDA was paused on 2026-07-29 to suppress #694 (cross-silo AccessContext loss →
   500s on ~50% of requests at 2 replicas). Every fix since — #694, #719, #644, #1218, the
   membership-tolerance widening — has only been exercised in the transient two-silo window of a
   rollout, because the namespace has run one pod ever since. **#1340** and **#1348**, both
   describing multi-silo grain/circuit behaviour, are still open. Unpausing is a monitored
   experiment with a named rollback trigger (runbook step 2), and whether to run it on a production
   portal is the user's decision.

## Verification

- `helm template` before/after for both renderable combinations — neutral byte-identical, AKS minus
  one line (above).
- `check-chart-invariants.sh` passes after, and **fails on the pre-change chart** (shown above).
- `check-chart-drift.sh` run live against `memex-cloud` — reports the three availability defects.
- Both workflows parse; asserted programmatically that no job or step carries `continue-on-error`
  or `if:`.
- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → `0 Warning(s),
  0 Error(s)`. `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` pass (2/2) — the only
  .NET-adjacent change is embedded documentation.
- **No cluster object was created, patched, scaled, annotated or deleted.** Every cluster
  interaction was `kubectl get` / `logs` through `az aks command invoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
