### PR TITLE
fix(test): CodeCellOutputCaptureTest waits for the post-run cell — un-reds main

### DIFF
--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -157,8 +157,20 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
             .First(a => a is not null
                 && (a == CodeLayoutAreas.CellArea
                     || a.EndsWith("/" + CodeLayoutAreas.CellArea, StringComparison.Ordinal)))!;
+        // Since #1468 an unrun cell renders NO output segment at all (the pane appears only once
+        // LastActivityPath is stamped), so the FIRST cell emission after subscribing may still be
+        // the pre-run shape. Wait for the emission that carries the output segment instead of
+        // snapshotting the first StackControl and probing it non-reactively — the old shape of
+        // this assertion turned the deliberate absence into "Sequence contains no matching
+        // element" and reddened main.
         var cell = (StackControl)(await stream.GetControlStream(cellArea)
-            .Should().Within(30.Seconds()).Match(c => c is StackControl))!;
+            .Should().Within(30.Seconds()).Match(c => c is StackControl s
+                && s.Areas.Any(a =>
+                {
+                    var name = a.Area?.ToString();
+                    return name == CodeLayoutAreas.CellOutputArea
+                        || (name?.EndsWith("/" + CodeLayoutAreas.CellOutputArea, StringComparison.Ordinal) ?? false);
+                })))!;
         var outputArea = cell.Areas
             .Select(a => a.Area?.ToString())
             .First(a => a is not null


### PR DESCRIPTION
**Main is red** since `41d662b23` on `CodeCellOutputCaptureTest.Run_Stamps_LastActivityPath_And_OutputSegment_Embeds_That_Path` (all three latest main runs, shard 4, deterministic local repro in 2 s).

**RCA — the blamed merge is innocent.** #1468 (`f1dba1216`) deliberately made an unrun cell render **no output segment** (absence instead of the italic 'Not yet run.' strip), updated `CodeCellLayoutTest`, and missed this AI.Test twin. #1468's merge run **reused an already-green tree and skipped every shard**, so the failure first executed on #1400's run and wore its blame. Verified both directions locally: the test fails at `f1dba1216` (pre-#1400) and the whole class passes 6/6 at `5582ec33f` with this fix.

**The defect in the test**: it snapshotted the *first* cell StackControl emission (post-#1468, legitimately the pre-run shape without an output child) and probed it with a non-reactive `.First()`. The fix folds the output segment's existence into the reactive `Match` — wait on the actual condition — leaving the embed assertion unchanged.

Test-only change; no What's New entry.

Unblocks: CD image builds, and PRs #1481 / #1483 / #1484 which all failed on this main red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)