### PR TITLE
fix(#1474): the local sidecar serves the mesh REST verbs its own shells call

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -33,6 +33,10 @@ name: Clients
 #                                                         (control/skin vocabulary is DERIVED from it)
 #   src/MeshWeaver.Hosting.Grpc/Protos/**               → the canonical mesh.proto the python,
 #                                                         grpc-web and typescript clients generate from
+#   memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs   → clients/grpc-web/src/restContract.test.ts
+#   memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs        (BOTH backends must serve every /api/mesh
+#                                                         verb the client SDK posts to — an unmapped
+#                                                         one answers the SPA fallback with a 200)
 #
 # Filtering on "clients/**" alone made every one of those guards blind to the side that actually
 # changes: a server-only PR adds a key (or a control, or a proto field), CI stays green because
@@ -56,6 +60,8 @@ on:
       - "src/MeshWeaver.Messaging.Contract/Localization/Locales.cs"
       - "src/MeshWeaver.Blazor/BlazorViewRegistry.cs"
       - "src/MeshWeaver.Hosting.Grpc/Protos/**"
+      - "memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs"
+      - "memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs"
   push:
     branches: [main]
     paths:
@@ -65,6 +71,8 @@ on:
       - "src/MeshWeaver.Messaging.Contract/Localization/Locales.cs"
       - "src/MeshWeaver.Blazor/BlazorViewRegistry.cs"
       - "src/MeshWeaver.Hosting.Grpc/Protos/**"
+      - "memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs"
+      - "memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs"
 
 jobs:
   react:

--- a/clients/grpc-web/package-lock.json
+++ b/clients/grpc-web/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.47.0",
         "@bufbuild/protoc-gen-es": "^2.2.0",
+        "@types/node": "^22.20.1",
         "typescript": "^5.6.0",
         "vitest": "^4.1.9"
       }
@@ -550,6 +551,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@typescript/vfs": {
       "version": "1.6.4",
@@ -1292,6 +1303,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.2.1",

--- a/clients/grpc-web/package.json
+++ b/clients/grpc-web/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.47.0",
     "@bufbuild/protoc-gen-es": "^2.2.0",
+    "@types/node": "^22.20.1",
     "typescript": "^5.6.0",
     "vitest": "^4.1.9"
   }

--- a/clients/grpc-web/src/restContract.test.ts
+++ b/clients/grpc-web/src/restContract.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// EVERY BACKEND THAT SERVES A JS SHELL MUST SERVE THE VERBS THAT SHELL CALLS (issue #1474).
+//
+// There are two: the portal (`MeshApiEndpoints`) and the local sidecar (`Memex.LocalMesh`), and the
+// React Native app talks to both. The sidecar mapped only `render-markdown`, so `content/list` and
+// `upload` fell through its SPA fallback — which answers **200 with index.html**. The client then
+// throws inside JSON.parse, and the file browser reports a parse error instead of "this backend does
+// not serve that". A 404 would at least have been diagnosable; the fallback made it invisible.
+//
+// So the parity is asserted here rather than left to whoever notices: MESH_REST_PATHS is what the JS
+// shells post to, and both endpoint maps must contain every one.
+//
+// 🚨 These are cross-tree reads: .github/workflows/clients.yml must be triggered by both files, or
+// removing a verb server-side would not run this job. clients/react/src/ciTrigger.test.ts enforces it.
+
+const pkgRoot = process.cwd();
+
+/**
+ * The `/api/mesh/*` verbs a JS shell reaches over HTTP because the gRPC message bus does not carry
+ * them: a mesh QUERY is `IMeshQuery.Query`, a service call with no request type to post; content
+ * listing and upload move bytes that are not mesh nodes; the markdown render is the one Markdig
+ * pipeline. Every shell (portal, portal-next, react-native) posts to these.
+ */
+const MESH_REST_PATHS = {
+  queryNodes: "/api/mesh/query-nodes",
+  renderMarkdown: "/api/mesh/render-markdown",
+  contentList: "/api/mesh/content/list",
+  upload: "/api/mesh/upload",
+};
+
+const BACKENDS = {
+  "the portal (MeshApiEndpoints)": "../../memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs",
+  "the local sidecar (Memex.LocalMesh)": "../../memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs",
+};
+
+/**
+ * The route templates a C# endpoint map registers. Handles both shapes the sources use: an absolute
+ * `MapPost("/api/mesh/upload", …)` and a `MapGroup(prefix)` + relative `MapPost("/upload", …)`.
+ */
+function mappedRoutes(source: string): string[] {
+  const prefixes = [
+    ...[...source.matchAll(/RoutePrefix\s*=\s*"([^"]+)"/g)].map((m) => m[1]),
+    ...[...source.matchAll(/MapGroup\(\s*"([^"]+)"\s*\)/g)].map((m) => m[1]),
+    "", // absolute MapPost paths need no prefix
+  ];
+  const routes: string[] = [];
+  for (const m of source.matchAll(/\bMap(?:Post|Get)\(\s*"([^"]+)"/g))
+    for (const prefix of prefixes) routes.push(`${prefix}${m[1]}`);
+  return routes;
+}
+
+describe("both mesh backends serve every REST verb the client calls", () => {
+  for (const [name, file] of Object.entries(BACKENDS)) {
+    const source = readFileSync(resolve(pkgRoot, file), "utf8");
+    const routes = mappedRoutes(source);
+
+    it(`${name} — the route scrape found endpoints (a broken scrape must not pass vacuously)`, () => {
+      expect(routes).toContain("/api/mesh/render-markdown");
+    });
+
+    for (const [verb, path] of Object.entries(MESH_REST_PATHS))
+      it(`${name} maps ${verb} (${path})`, () => {
+        expect(
+          routes,
+          `${path} is not mapped by ${file}. An unmapped /api/mesh/* route does not 404 there — it ` +
+            `falls through to the SPA fallback and returns index.html with a 200, so the caller ` +
+            `fails inside JSON.parse with nothing pointing at the missing endpoint.`,
+        ).toContain(path);
+      });
+  }
+});

--- a/clients/react/src/ciTrigger.test.ts
+++ b/clients/react/src/ciTrigger.test.ts
@@ -22,6 +22,9 @@ const repoDir = resolve(process.cwd(), "../..");
 const repoRoot = repoDir.split(sep).join("/");
 const workflow = readFileSync(resolve(repoDir, ".github/workflows/clients.yml"), "utf8");
 
+/** Top-level trees OUTSIDE clients/ that a client test may legitimately read as a guard input. */
+const CROSS_TREE_ROOTS = ["src", "memex"];
+
 /**
  * The `paths:` list under each trigger. Parsed without a YAML dependency: find a `paths:` key, then
  * take the `- "…"` items that follow at a deeper indent.
@@ -71,7 +74,10 @@ function crossTreeReads(): string[] {
         // Compare in POSIX form — resolve() yields "\" on Windows, where a "/"-based startsWith
         // would silently match nothing and report every input as uncovered.
         const posix = abs.split(sep).join("/");
-        if (!posix.startsWith(`${repoRoot}/src/`)) return; // only reads that leave clients/
+        // Only reads that leave clients/. `memex/` counts as much as `src/`: the REST-parity guard
+        // reads the endpoint maps of BOTH backends (the portal's and the local sidecar's), and a
+        // verb removed there must redden the client that calls it.
+        if (!CROSS_TREE_ROOTS.some((root) => posix.startsWith(`${repoRoot}/${root}/`))) return;
         if (!statSync(abs, { throwIfNoEntry: false })) return; // and only ones that really resolve
         found.add(posix.slice(repoRoot.length + 1));
       };

--- a/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
+++ b/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
@@ -1,0 +1,184 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using MeshWeaver.AI;
+using MeshWeaver.Hosting;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+
+namespace Memex.LocalMesh;
+
+/// <summary>
+/// The sidecar's <c>/api/mesh/*</c> surface — the SAME verbs the portal exposes through
+/// <c>MeshApiEndpoints</c>, here ANONYMOUS (this host is same-origin and authenticates nobody).
+///
+/// <para>
+/// Every JS shell this backend serves out of <c>wwwroot</c> reaches these over plain HTTP because
+/// the gRPC message bus does not carry them: a mesh <b>query</b> is <c>IMeshQuery.Query</c>, a
+/// service call with no request type to post; content-collection listing and upload move bytes that
+/// are not mesh nodes; the markdown render is the one Markdig pipeline.
+/// </para>
+///
+/// <para>
+/// 🚨 An <c>/api/mesh/*</c> route this class does NOT map does not 404 — <c>MapFallbackToFile</c>
+/// answers it with <c>index.html</c> and a <b>200</b>, so the caller fails inside <c>JSON.parse</c>
+/// with nothing naming the missing endpoint. That is issue #1474: only <c>render-markdown</c> was
+/// mapped, so the React Native file browser was broken with no diagnosable symptom.
+/// <c>clients/grpc-web/src/restContract.test.ts</c> now asserts this map and the portal's cover
+/// every verb the client SDK posts to.
+/// </para>
+///
+/// <para>
+/// Operations issue on a <see cref="SessionHubFactory"/> session hub — never the root
+/// <c>mesh/{id}</c> hub, on which request-shaped work never answers.
+/// </para>
+/// </summary>
+public static class LocalMeshApiEndpoints
+{
+    /// <summary>Address segment for this host's shared anonymous operations hub.</summary>
+    private const string SessionPrefix = "local-api";
+
+    /// <summary>Maps the sidecar's mesh REST verbs. Call before <c>MapFallbackToFile</c>.</summary>
+    public static IEndpointRouteBuilder MapLocalMeshApi(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/mesh");
+
+        // Server-side Markdig render — the ONE markdown parser (the portal exposes this via
+        // MeshApiEndpoints/MeshOperations.RenderMarkdown, but that surface is MCP-auth-gated and
+        // portal-coupled). RenderMarkdown is a thin wrapper over the pure MarkdownViewLogic.Render
+        // pipeline, so the headless sidecar calls it directly — anonymous, no hub round-trip.
+        // Clients (portal-next + React-Native) POST {markdown, nodePath} and hydrate the returned
+        // HTML + codeSubmissions (splitRenderedHtml). This is what makes interactive markdown —
+        // inline @@ embeds and runnable code cells — resolve on the RN app.
+        group.MapPost("/render-markdown", async (
+            RenderMarkdownBody body, IServiceProvider services, CancellationToken ct) =>
+        {
+            var result = MarkdownViewLogic.Render(body.Markdown ?? string.Empty, body.NodePath, body.NodePath);
+            // The pure Markdig pass can't tell `@@node/path` (a node embed) from `@@node/area/id` — it has no
+            // catalog, so it emits a POSITIONAL address/area/id split. Resolve each layout-area marker's raw-path
+            // against the mesh's IPathResolver (the same longest-node-prefix resolution the portal does at runtime):
+            // when the WHOLE raw-path is itself a node (empty remainder), rewrite to a node/default-area embed so the
+            // client subscribes to the right node. Area/content/keyword embeds (non-empty remainder) keep the parser's
+            // resolution untouched. (A CHILD node that isn't independently addressable — e.g. a Code cell — stays a
+            // remainder and is left as-is; rendering those is a separate mesh-model concern.)
+            var resolver = RootHub(services).ServiceProvider.GetService<IPathResolver>();
+            var html = resolver is null ? result.Html : await ResolveLayoutAreaMarkers(result.Html, resolver, ct);
+            return Results.Json(new
+            {
+                html,
+                codeSubmissions = (result.CodeSubmissions ?? [])
+                    .Select(sub => new { id = sub.Id, language = sub.Language, code = sub.Code }),
+            });
+        });
+
+        // Full-node mesh query — the client's ONE query surface (there is no hub message for a
+        // query). Backs MeshSearch / MeshNodeCollection / NodeExport / the ThreadChat selectors.
+        group.MapPost("/query-nodes", (
+            QueryNodesBody body, IServiceProvider services, CancellationToken ct) =>
+            RunString(services, ct, ops => ops.QueryNodes(body.Query, body.Limit ?? 50)));
+
+        // Content-collection directory listing — the read half of the file browser. Path is
+        // "{node}/{collection}[/{dir}]".
+        group.MapPost("/content/list", (
+            PathBody body, IServiceProvider services, CancellationToken ct) =>
+            RunString(services, ct, ops => ops.ContentList(body.Path)));
+
+        // Binary upload — multipart, the write half of the file browser. DisableAntiforgery: this
+        // host has no antiforgery pipeline and no session to forge against.
+        group.MapPost("/upload", HandleUpload).DisableAntiforgery();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleUpload(
+        HttpContext http, IServiceProvider services, CancellationToken ct)
+    {
+        if (!http.Request.HasFormContentType)
+            return Results.BadRequest(new { error = "Content-Type must be multipart/form-data." });
+
+        var form = await http.Request.ReadFormAsync(ct);
+        var path = form["path"].FirstOrDefault();
+        var file = form.Files.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(path))
+            return Results.BadRequest(new { error = "Form field 'path' is required." });
+        if (file is null || file.Length == 0)
+            return Results.BadRequest(new { error = "Form file 'file' is required." });
+
+        using var ms = new MemoryStream();
+        await using (var stream = file.OpenReadStream())
+            await stream.CopyToAsync(ms, ct);
+
+        var bytes = ms.ToArray();
+        return await RunString(services, ct, ops => ops.Upload(path, bytes));
+    }
+
+    /// <summary>
+    /// Runs one <see cref="MeshOperations"/> verb on the session hub and ships its result.
+    /// MeshOperations returns either a JSON document or an <c>"Error: …"</c> sentinel string; both
+    /// are valid <c>application/json</c> the client branches on (mirrors the MCP-tool contract).
+    /// </summary>
+    private static async Task<IResult> RunString(
+        IServiceProvider services,
+        CancellationToken ct,
+        Func<MeshOperations, IObservable<string>> work)
+    {
+        var ops = new MeshOperations(SessionHub(services));
+        var result = await work(ops).FirstAsync().ToTask(ct);
+        return Results.Content(result, "application/json");
+    }
+
+    private static IMessageHub RootHub(IServiceProvider services) =>
+        services.GetRequiredService<IMessageHub>();
+
+    /// <summary>
+    /// The shared anonymous operations hub. This host resolves no identity, so there is one session
+    /// for the whole process — but it is still a <c>portal/…</c> hub, never the root mesh hub.
+    /// </summary>
+    private static IMessageHub SessionHub(IServiceProvider services)
+    {
+        var rootHub = RootHub(services);
+        var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(LocalMeshApiEndpoints));
+        return SessionHubFactory.Resolve(rootHub, SessionPrefix, SessionHubFactory.AnonymousSession, logger);
+    }
+
+    /// <summary>
+    /// Rewrites layout-area markers whose raw-path is a WHOLE node (empty remainder) to a
+    /// node/default-area embed, using the mesh's IPathResolver (longest-node-prefix). Leaves
+    /// area/content/keyword markers as the pure Markdig pass emitted them.
+    /// </summary>
+    private static async Task<string> ResolveLayoutAreaMarkers(string html, IPathResolver resolver, CancellationToken ct)
+    {
+        var matches = Regex.Matches(html, @"<div class='layout-area'[^>]*?data-raw-path='([^']*)'[^>]*?></div>");
+        if (matches.Count == 0)
+            return html;
+        var sb = new StringBuilder();
+        var last = 0;
+        foreach (Match m in matches)
+        {
+            sb.Append(html, last, m.Index - last);
+            var rawPath = HttpUtility.HtmlDecode(m.Groups[1].Value);
+            AddressResolution? res = null;
+            try { res = await resolver.ResolvePath(rawPath).FirstAsync().Timeout(TimeSpan.FromSeconds(5)).ToTask(ct); }
+            catch { /* unresolved / timed out — keep the parser's marker */ }
+            if (res is not null && !string.IsNullOrEmpty(res.Prefix) && string.IsNullOrEmpty(res.Remainder))
+                sb.Append($"<div class='layout-area' data-raw-path='{HttpUtility.HtmlAttributeEncode(rawPath)}' data-address='{HttpUtility.HtmlAttributeEncode(res.Prefix)}' data-area='' data-area-id=''></div>");
+            else
+                sb.Append(m.Value);
+            last = m.Index + m.Length;
+        }
+        sb.Append(html, last, html.Length - last);
+        return sb.ToString();
+    }
+
+    /// <summary>POST body for /api/mesh/render-markdown — mirrors MeshApiEndpoints.RenderMarkdownBody.</summary>
+    public record RenderMarkdownBody(string? Markdown, string? NodePath);
+
+    /// <summary>POST body for /api/mesh/query-nodes — mirrors MeshApiEndpoints.QueryNodesBody.</summary>
+    public record QueryNodesBody(string Query, int? Limit = null);
+
+    /// <summary>POST body for /api/mesh/content/list — mirrors MeshApiEndpoints.PathBody.</summary>
+    public record PathBody(string Path);
+}

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -1,8 +1,6 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Web;
+using Memex.LocalMesh;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph.Configuration;
@@ -10,8 +8,6 @@ using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Sqlite;
-using MeshWeaver.Markdown;
-using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Speech;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -102,31 +98,12 @@ app.MapGet("/static/{**path}", (HttpContext ctx, string path) =>
     return Results.Stream(stream, contentType);
 });
 
-// Server-side Markdig render (POST /api/mesh/render-markdown) — the ONE markdown parser (the web portal
-// exposes this via MeshApiEndpoints/MeshOperations.RenderMarkdown, but that surface is MCP-auth-gated and
-// portal-coupled). RenderMarkdown is a thin wrapper over the pure MarkdownViewLogic.Render pipeline, so the
-// headless sidecar calls it directly — anonymous, no hub round-trip. Clients (portal-next + React-Native)
-// POST {markdown, nodePath} and hydrate the returned HTML + codeSubmissions (splitRenderedHtml). This is
-// what makes interactive markdown — inline @@ embeds and runnable code cells — resolve on the RN app.
-app.MapPost("/api/mesh/render-markdown", async (RenderMarkdownBody body, CancellationToken ct) =>
-{
-    var result = MarkdownViewLogic.Render(body.Markdown ?? string.Empty, body.NodePath, body.NodePath);
-    // The pure Markdig pass can't tell `@@node/path` (a node embed) from `@@node/area/id` — it has no
-    // catalog, so it emits a POSITIONAL address/area/id split. Resolve each layout-area marker's raw-path
-    // against the mesh's IPathResolver (the same longest-node-prefix resolution the portal does at runtime):
-    // when the WHOLE raw-path is itself a node (empty remainder), rewrite to a node/default-area embed so the
-    // client subscribes to the right node. Area/content/keyword embeds (non-empty remainder) keep the parser's
-    // resolution untouched. (A CHILD node that isn't independently addressable — e.g. a Code cell — stays a
-    // remainder and is left as-is; rendering those is a separate mesh-model concern.)
-    var resolver = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IPathResolver>();
-    var html = resolver is null ? result.Html : await ResolveLayoutAreaMarkers(result.Html, resolver, ct);
-    return Results.Json(new
-    {
-        html,
-        codeSubmissions = (result.CodeSubmissions ?? [])
-            .Select(sub => new { id = sub.Id, language = sub.Language, code = sub.Code }),
-    });
-});
+// The mesh REST verbs the JS shells this host serves reach over plain HTTP — render-markdown,
+// query-nodes, content/list, upload. They live in LocalMeshApiEndpoints so a test can assert the
+// route table without booting the mesh: an /api/mesh/* route that is NOT mapped falls through to
+// MapFallbackToFile below and answers index.html with a 200, which the client can only report as a
+// JSON parse error (issue #1474).
+app.MapLocalMeshApi();
 
 // Speech-to-text (POST /api/speech/transcribe) — the SAME client contract the portal exposes
 // (Memex.Portal.Shared/Api/SpeechEndpoints), here anonymous on the local sidecar. Every shell served by
@@ -172,33 +149,6 @@ app.MapPost("/api/speech/transcribe", async (HttpContext http, ISpeechTranscribe
     }
 });
 
-// Rewrite layout-area markers whose raw-path is a WHOLE node (empty remainder) to a node/default-area embed,
-// using the mesh's IPathResolver (longest-node-prefix). Leaves area/content/keyword markers as the pure
-// Markdig pass emitted them. This makes a regular `@@node` embed resolve to the right node on the client.
-static async Task<string> ResolveLayoutAreaMarkers(string html, IPathResolver resolver, CancellationToken ct)
-{
-    var matches = Regex.Matches(html, @"<div class='layout-area'[^>]*?data-raw-path='([^']*)'[^>]*?></div>");
-    if (matches.Count == 0)
-        return html;
-    var sb = new StringBuilder();
-    var last = 0;
-    foreach (Match m in matches)
-    {
-        sb.Append(html, last, m.Index - last);
-        var rawPath = HttpUtility.HtmlDecode(m.Groups[1].Value);
-        AddressResolution? res = null;
-        try { res = await resolver.ResolvePath(rawPath).FirstAsync().Timeout(TimeSpan.FromSeconds(5)).ToTask(ct); }
-        catch { /* unresolved / timed out — keep the parser's marker */ }
-        if (res is not null && !string.IsNullOrEmpty(res.Prefix) && string.IsNullOrEmpty(res.Remainder))
-            sb.Append($"<div class='layout-area' data-raw-path='{HttpUtility.HtmlAttributeEncode(rawPath)}' data-address='{HttpUtility.HtmlAttributeEncode(res.Prefix)}' data-area='' data-area-id=''></div>");
-        else
-            sb.Append(m.Value);
-        last = m.Index + m.Length;
-    }
-    sb.Append(html, last, html.Length - last);
-    return sb.ToString();
-}
-
 var wwwroot = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
 if (File.Exists(Path.Combine(wwwroot, "index.html")))
     app.MapFallbackToFile("index.html"); // SPA fallback: any non-gRPC, non-file route → the packaged app
@@ -209,5 +159,8 @@ else
 
 app.Run();
 
-/// <summary>POST body for /api/mesh/render-markdown — mirrors MeshApiEndpoints.RenderMarkdownBody.</summary>
-internal sealed record RenderMarkdownBody(string? Markdown, string? NodePath);
+/// <summary>
+/// Exposed so a test project can reference this host and assert its route table (the mesh REST verbs
+/// in <see cref="Memex.LocalMesh.LocalMeshApiEndpoints"/>) without booting the mesh.
+/// </summary>
+public partial class Program;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-the-local-mesh-serves-search-and-files-too.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-the-local-mesh-serves-search-and-files-too.md
@@ -1,0 +1,18 @@
+---
+Name: The local mesh serves search and files too
+Category: Fix
+Description: Search, the file browser and uploads reached endpoints the local mesh never published, so they failed with a confusing parsing error.
+Icon: Sparkle
+Order: -20260814
+---
+
+# The local mesh serves search and files too
+
+The apps that run against the local mesh — the desktop apps and the packaged web app — ask it for
+searches, for a folder's contents and for uploads over the same web endpoints a hosted portal
+serves. The local mesh only published one of those. The rest quietly fell through to the app's own
+start page, which answered successfully with a web page, so the app reported a parsing error rather
+than a missing feature.
+
+The local mesh now publishes the same set as a portal does, and a check on both sides fails the
+build if one of them ever stops serving something the apps call.

--- a/src/MeshWeaver.Hosting/SessionHubFactory.cs
+++ b/src/MeshWeaver.Hosting/SessionHubFactory.cs
@@ -1,0 +1,97 @@
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Materialises the per-caller hosted hub every API surface issues mesh operations on —
+/// <c>portal/{prefix}-{sessionId}-{instance}</c>.
+///
+/// <para>
+/// 🚨 This factory NEVER returns the root <c>mesh/{id}</c> hub. That hub is transient routing
+/// infrastructure, not a call target: request-shaped work issued on it never answers — the caller's
+/// queue stays empty at <c>RunLevel=Started</c> while the pending callback runs out its timeout,
+/// which reads misleadingly like "the target never replied". Every API surface (MCP, REST, gRPC,
+/// CLI) issues on a portal hub.
+/// </para>
+///
+/// <para>
+/// It lives here, below the transports, so that every surface shares ONE implementation and their
+/// routing semantics cannot drift: <c>MeshWeaver.Mcp</c>'s <c>SessionHubResolver</c> derives a
+/// session id from the HTTP context and calls in here, and the headless local sidecar
+/// (<c>Memex.LocalMesh</c>, which authenticates nobody and therefore has no session to derive)
+/// calls in with a fixed id rather than writing a third copy of this wiring.
+/// </para>
+/// </summary>
+public static class SessionHubFactory
+{
+    /// <summary>
+    /// Process-stable disambiguator appended to every session-hub address. With a stateless
+    /// transport (no ingress affinity), consecutive requests for the same caller land on DIFFERENT
+    /// replicas; without this suffix each replica would materialise a hub at the SAME
+    /// <c>portal/…</c> address and RegisterStream the same routed memory stream — every response
+    /// would fan out to all replicas' hubs. The suffix keeps each replica's routing anchor unique.
+    /// Immutable constant initialised once per process (never written at runtime).
+    /// </summary>
+    private static readonly string InstanceId = Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// Session segment used when no caller / session can be derived. Combined with
+    /// <see cref="InstanceId"/> this yields ONE process-stable shared anonymous hub at
+    /// <c>portal/{prefix}-anon-{instance}</c> — never the root mesh hub, and never a fresh hub per
+    /// request (which would leak a hub + routing registration on every anonymous call).
+    /// </summary>
+    public const string AnonymousSession = "anon";
+
+    /// <summary>
+    /// Materialises (or reuses) the hosted hub for <paramref name="sessionId"/> at
+    /// <c>portal/{prefix}-{sessionId}-{instance}</c>.
+    /// </summary>
+    /// <param name="rootHub">
+    /// The hub that HOSTS the returned child (typically the root mesh hub). Used only as the hosting
+    /// parent and as a service-provider handle — never as the hub a call is issued on.
+    /// </param>
+    /// <param name="prefix">Transport label used in the address segment: <c>"mcp"</c>, <c>"api"</c>, …</param>
+    /// <param name="sessionId">Caller/session segment; <see cref="AnonymousSession"/> when there is none.</param>
+    /// <param name="logger">Diagnostic sink.</param>
+    public static IMessageHub Resolve(IMessageHub rootHub, string prefix, string sessionId, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(rootHub);
+
+        var routingService = rootHub.ServiceProvider.GetRequiredService<IRoutingService>();
+        var address = AddressExtensions.CreatePortalAddress($"{prefix}-{sessionId}-{InstanceId}");
+        logger.LogInformation("Materialising {Prefix} session hub at {Address}", prefix, address);
+
+        // AddData() ensures the session hub has its own IWorkspace so MeshOperations.Compile can
+        // subscribe to the NodeType MeshNode stream and Update its compilationStatus through the
+        // canonical write path. RegisterStream wires routing so every response (Get / Search /
+        // Patch / ExecuteScript / …) lands back here.
+        return rootHub.GetHostedHub(
+            address,
+            sessionConfig => sessionConfig
+                .AddData()
+                // 🚨 Node CRUD from a session runs HERE, not on the mesh router. Without this opt-in
+                // MeshService falls back to the mesh hub and every create/move/delete executes on
+                // the router's action block, starving routing (see MeshExtensions.NodeOperationTarget).
+                .WithNodeOperationExecution()
+                .WithInitialization(hub =>
+                    hub.RegisterForDisposal(routingService.RegisterStream(hub))),
+            HostedHubCreation.Always)
+            ?? throw new InvalidOperationException(
+                $"Failed to materialise {prefix} session hub at {address}.");
+    }
+
+    /// <summary>
+    /// Sanitises a free-form id into a safe address segment: letters, digits, '-', '_'. Everything
+    /// else is replaced with '-' so hosted-hub grain-key lookup stays well-formed.
+    /// </summary>
+    public static string Sanitize(string s)
+    {
+        var chars = s.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '-').ToArray();
+        return new string(chars);
+    }
+}

--- a/src/MeshWeaver.Mcp/SessionHubResolver.cs
+++ b/src/MeshWeaver.Mcp/SessionHubResolver.cs
@@ -1,10 +1,7 @@
 using System.Security.Claims;
-using MeshWeaver.Data;
-using MeshWeaver.Mesh;
-using MeshWeaver.Mesh.Services;
+using MeshWeaver.Hosting;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mcp;
@@ -15,9 +12,10 @@ namespace MeshWeaver.Mcp;
 ///
 /// <para>
 /// Both transports must share this helper so their routing semantics stay
-/// identical — same address shape, same <see cref="DataExtensions.AddData(MessageHubConfiguration)"/>
-/// + <see cref="IRoutingService.RegisterStream(IMessageHub)"/> wiring, and the same
-/// guarantee that the returned hub is ALWAYS a <c>portal/…</c> hub.
+/// identical — same address shape, same wiring. This class is the HTTP half:
+/// it derives the session id from the request and hands off to
+/// <see cref="SessionHubFactory"/>, which owns the hub materialisation and is
+/// shared with the headless surfaces that have no <see cref="HttpContext"/>.
 /// </para>
 ///
 /// <para>
@@ -30,26 +28,6 @@ namespace MeshWeaver.Mcp;
 /// </summary>
 public static class SessionHubResolver
 {
-    /// <summary>
-    /// Process-stable disambiguator appended to every session-hub address. With the
-    /// stateless MCP transport (no ingress affinity), consecutive requests for the
-    /// same caller land on DIFFERENT replicas; without this suffix each replica would
-    /// materialise a hub at the SAME <c>portal/…</c> address and RegisterStream the
-    /// same routed memory stream — every response would fan out to all replicas'
-    /// hubs. The suffix keeps each replica's routing anchor unique. Immutable
-    /// constant initialised once per process (never written at runtime).
-    /// </summary>
-    private static readonly string InstanceId = Guid.NewGuid().ToString("N")[..8];
-
-    /// <summary>
-    /// Session-segment used when no caller / session can be derived from the request.
-    /// Combined with <see cref="InstanceId"/> this yields ONE process-stable shared
-    /// anonymous hub at <c>portal/{prefix}-anon-{instance}</c> — never the root mesh hub,
-    /// and never a fresh hub per request (which would leak a hub + routing registration
-    /// on every anonymous call).
-    /// </summary>
-    private const string AnonymousSession = "anon";
-
     /// <summary>
     /// Materialises (or reuses) a hosted hub for the calling user × protocol session
     /// at address <c>portal/{prefix}-{sessionId}-{instance}</c>. When no caller / session
@@ -75,7 +53,7 @@ public static class SessionHubResolver
             // 🚨 NEVER return rootHub here. It is the root mesh/{id} hub, on which
             // request-shaped work never answers. Anonymous callers share one stable
             // portal hub instead: it has the routing + lifetime mesh operations need.
-            sessionId = AnonymousSession;
+            sessionId = SessionHubFactory.AnonymousSession;
             logger.LogWarning(
                 "No {Prefix} session id resolvable from request — using the shared anonymous "
                 + "portal hub. Callers that authenticate (or send an Mcp-Session-Id header) "
@@ -83,28 +61,7 @@ public static class SessionHubResolver
                 prefix);
         }
 
-        var routingService = rootHub.ServiceProvider.GetRequiredService<IRoutingService>();
-        var address = AddressExtensions.CreatePortalAddress($"{prefix}-{sessionId}-{InstanceId}");
-        logger.LogInformation("Materialising {Prefix} session hub at {Address}", prefix, address);
-
-        // AddData() ensures the session hub has its own IWorkspace so MeshOperations.Compile
-        // can subscribe to the NodeType MeshNode stream and Update its compilationStatus
-        // through the canonical write path. RegisterStream wires routing so every response
-        // (Get / Search / Patch / ExecuteScript / …) lands back here.
-        return rootHub.GetHostedHub(
-            address,
-            sessionConfig => sessionConfig
-                .AddData()
-                // 🚨 Node CRUD from an MCP session runs HERE, not on the mesh router. Without this
-                // opt-in MeshService falls back to the mesh hub and every create/move/delete
-                // executes on the router's action block, starving routing (see
-                // MeshExtensions.NodeOperationTarget).
-                .WithNodeOperationExecution()
-                .WithInitialization(hub =>
-                    hub.RegisterForDisposal(routingService.RegisterStream(hub))),
-            HostedHubCreation.Always)
-            ?? throw new InvalidOperationException(
-                $"Failed to materialise {prefix} session hub at {address}.");
+        return SessionHubFactory.Resolve(rootHub, prefix, sessionId, logger);
     }
 
     /// <summary>
@@ -146,9 +103,5 @@ public static class SessionHubResolver
     /// Sanitises a free-form id into a safe address segment: letters, digits, '-', '_'.
     /// Everything else is replaced with '-' so hosted-hub grain-key lookup stays well-formed.
     /// </summary>
-    public static string Sanitize(string s)
-    {
-        var chars = s.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '-').ToArray();
-        return new string(chars);
-    }
+    public static string Sanitize(string s) => SessionHubFactory.Sanitize(s);
 }

--- a/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
@@ -1,0 +1,69 @@
+using Memex.LocalMesh;
+using Memex.Portal.Shared.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The headless sidecar (<c>Memex.LocalMesh</c>) serves the SAME JS shells the portal does — the
+/// React Native app switches between them by instance URL — so it must map the same
+/// <c>/api/mesh/*</c> verbs those shells call.
+///
+/// <para>🚨 A missing route here is invisible from the client. <c>Memex.LocalMesh</c> ends with
+/// <c>MapFallbackToFile("index.html")</c>, so an unmapped <c>/api/mesh/*</c> POST does not 404 — it
+/// answers the SPA's HTML with a <b>200</b>, and the caller fails inside <c>JSON.parse</c> with
+/// nothing naming the missing endpoint. That is issue #1474: only <c>render-markdown</c> was mapped,
+/// so the file browser was broken against the sidecar with no diagnosable symptom.</para>
+///
+/// <para>The route table is asserted directly (no mesh, no SQLite, no gRPC) because the defect IS
+/// the absent route. <c>clients/grpc-web/src/restContract.test.ts</c> holds the other end: every verb
+/// the client SDK posts to must appear in BOTH backends' endpoint maps.</para>
+/// </summary>
+public class LocalMeshApiRoutesTest
+{
+    /// <summary>The verbs a JS shell reaches over HTTP because the gRPC bus does not carry them.</summary>
+    public static TheoryData<string> MeshRestVerbs =>
+    [
+        "/api/mesh/render-markdown",
+        "/api/mesh/query-nodes",
+        "/api/mesh/content/list",
+        "/api/mesh/upload",
+    ];
+
+    [Theory]
+    [MemberData(nameof(MeshRestVerbs))]
+    public void LocalMeshSidecar_MapsTheVerbTheShellsCall(string route)
+    {
+        MappedRoutes().Should().Contain(route,
+            "the local sidecar serves the same shells the portal does, and an unmapped /api/mesh/* " +
+            "route falls through to the SPA fallback with a 200 instead of failing visibly");
+    }
+
+    [Fact]
+    public void TheRouteScrape_FindsEndpoints()
+    {
+        // Guard the guard: if MapLocalMeshApi stopped registering anything (or the inspection broke),
+        // every assertion above would fail loudly rather than a single one passing vacuously.
+        MappedRoutes().Should().HaveCountGreaterThan(3);
+    }
+
+    [Fact]
+    public void TheSidecarVerbs_AreAllOnThePortalToo()
+    {
+        // Both hosts speak the same prefix, so a shell cannot need a different URL per backend.
+        MappedRoutes().Should().OnlyContain(r => r.StartsWith(MeshApiEndpoints.RoutePrefix + "/", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<string> MappedRoutes()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        app.MapLocalMeshApi();
+        return ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => "/" + endpoint.RoutePattern.RawText!.TrimStart('/'))
+            .ToList();
+    }
+}

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -11,6 +11,9 @@
     <!-- DbVersionHealthCheckTest drives the portal's own db_version health check: whether a
          cancellation raised by the CALLER is reported as a database verdict (#1183). -->
     <ProjectReference Include="..\..\memex\aspire\Memex.Portal.Distributed\Memex.Portal.Distributed.csproj" />
+    <!-- LocalMeshApiRoutesTest asserts the headless sidecar maps the same /api/mesh/* verbs the JS
+         shells call — an unmapped one there answers the SPA fallback with a 200, not a 404 (#1474). -->
+    <ProjectReference Include="..\..\memex\Memex.LocalMesh\Memex.LocalMesh.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <!-- OAuthCodeStoreTest runs against a full monolith mesh (the store persists
          authorization codes as mesh nodes — the multi-replica safety contract). -->


### PR DESCRIPTION
Closes #1474 (the sidecar half; #1487 has the client half and explicitly leaves this open).

## The defect

`Memex.LocalMesh` serves the packaged JS shells out of `wwwroot`, and those shells post four
`/api/mesh/*` verbs the gRPC message bus does not carry — a mesh query is `IMeshQuery.Query`, a
service call with no request type to post; content listing and upload move bytes that are not mesh
nodes; the markdown render is the one Markdig pipeline. The sidecar mapped **one** of them.

The reason nobody noticed is the failure mode. The host ends with `MapFallbackToFile("index.html")`,
so an unmapped `/api/mesh/*` POST does not 404 — it answers the SPA's own HTML with a **200**. The
caller fails inside `JSON.parse`, and the file browser reports a parse error rather than a missing
endpoint. A 404 would at least have been diagnosable.

This also completes #1473 for the sidecar: #1487 points the clients at
`POST /api/mesh/query-nodes`, which the sidecar did not serve — so against the RN app's *default*
instance, search would still have come back empty (200 + HTML → `JSON.parse` throws → the shell's
`.catch(() => [])` swallows it).

## The fix

- **`LocalMeshApiEndpoints.MapLocalMeshApi()`** maps `render-markdown`, `query-nodes`,
  `content/list` and `upload`, anonymously (this host resolves no identity), running
  `MeshOperations` on a session hub — never the root `mesh/{id}` hub, on which request-shaped work
  never answers.
- **`SessionHubFactory`** (`MeshWeaver.Hosting`) is the hub-materialisation half of
  `SessionHubResolver`, moved down below the transports. `SessionHubResolver`'s own doc says both
  transports must share it "so their routing semantics stay identical" — the headless sidecar has no
  `HttpContext` and so could not, and writing a third copy of `AddData` + `WithNodeOperationExecution`
  + `RegisterStream` is exactly what that comment warns against. `SessionHubResolver` keeps the HTTP
  half (deriving a session id from the request) and delegates.

## The guards — one per side

- **`LocalMeshApiRoutesTest`** asserts the sidecar's route table directly. No mesh, no SQLite, no
  gRPC: the defect IS the absent route, so the test builds the endpoint map and reads it.
- **`clients/grpc-web/src/restContract.test.ts`** holds the other end: every verb the JS shells post
  to must appear in **both** backends' endpoint maps (the portal's `MeshApiEndpoints` and the
  sidecar's). `clients.yml` is triggered by both sources, and `ciTrigger.test.ts` now recognises
  `memex/` as a cross-tree input root so that trigger cannot go stale.

## Fail-before

Renaming the three new routes to `/DISABLED-…` and rebuilding:

```
Failed LocalMeshApiRoutesTest.LocalMeshSidecar_MapsTheVerbTheShellsCall(route: "/api/mesh/upload")
  Expected collection {"/api/mesh/render-markdown", "/api/mesh/DISABLED-query-nodes", …}
  to contain "/api/mesh/upload" because the local sidecar serves the same shells the portal does…
Failed! - Failed: 3, Passed: 3
```

and `restContract.test.ts` goes red the same way, naming the file and explaining the 200-with-HTML
symptom. Restored: 6/6 and 10/10 green. Dropping one of the new `clients.yml` paths turns
`ciTrigger.test.ts` red, so the trigger genuinely covers the new cross-tree reads.

## Verification

- `dotnet build memex/Memex.LocalMesh -c Release -warnaserror --no-incremental` → 0 Warnings, 0 Errors
- `dotnet build src/MeshWeaver.Mcp -c Release -warnaserror` → 0 Warnings, 0 Errors
- `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` → 0 Warnings, 0 Errors;
  `LocalMeshApiRoutesTest` 6/6
- `clients/grpc-web`: `tsc --noEmit`, `tsc -p tsconfig.build.json --noEmit`, `vitest run` 37/37
- `clients/react`: `ciTrigger.test.ts` 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)