### PR TITLE
fix(#1476): the JS packs honour AutoSaveAddress instead of dropping the edit

### DIFF
--- a/clients/react-native/src/autoSave.test.tsx
+++ b/clients/react-native/src/autoSave.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import TestRenderer, { type ReactTestRendererJSON } from "react-test-renderer";
+import {
+  AUTO_SAVE_DEBOUNCE_MS,
+  MeshOpsProvider,
+  RegistryProvider,
+  RenderArea,
+  ScopeProvider,
+  StaticAreaSource,
+  type AreaTree,
+  type MeshOps,
+  type UiControl,
+} from "@meshweaver/react/core";
+import { rnPack } from "./rnPack";
+
+// Issue #1476 — the native editors must persist an auto-saving control's edits too.
+//
+// `MarkdownEditor` and `CodeEditor` used to be THE SAME component in this pack, bound only to a
+// layout-area pointer. A control carrying `autoSaveAddress` has no pointer (it edits a mesh node in
+// place), so an edit went nowhere and nothing failed visibly. They now differ by which content field
+// they write, through the same `useAutoSave` the web pack uses.
+
+type Json = ReactTestRendererJSON;
+
+const NODE = "rbuergi/Notes/today";
+
+function fakeOps(patchCalls: { path: string; fields: Record<string, unknown> }[]): MeshOps {
+  return {
+    watch: () => ({ async *[Symbol.asyncIterator]() { await new Promise(() => {}); } }),
+    startThread: async () => ({ path: "p/_Thread/t1" }),
+    submitMessage: async () => "m1",
+    patch: (path: string, fields: Record<string, unknown>) => patchCalls.push({ path, fields }),
+  } as MeshOps;
+}
+
+function tree(control: Record<string, unknown>): AreaTree {
+  return { data: {}, areas: { main: control as unknown as UiControl } };
+}
+
+function renderAndType(control: Record<string, unknown>, ops: MeshOps, text: string) {
+  let root!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    root = TestRenderer.create(
+      <RegistryProvider pack={rnPack}>
+        <MeshOpsProvider ops={ops}>
+          <ScopeProvider source={new StaticAreaSource(tree(control))} area="main">
+            <RenderArea areaKey="main" />
+          </ScopeProvider>
+        </MeshOpsProvider>
+      </RegistryProvider>,
+    );
+  });
+  const input = find(root.toJSON() as Json, "TextInput");
+  TestRenderer.act(() => input!.props.onChangeText(text));
+  return root;
+}
+
+function find(node: Json | Json[] | null, type: string): Json | null {
+  if (node == null) return null;
+  if (Array.isArray(node)) {
+    for (const n of node) {
+      const hit = find(n, type);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (node.type === type) return node;
+  for (const c of node.children ?? []) {
+    const hit = find(c as Json, type);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("RN editors honour autoSaveAddress", () => {
+  it("MarkdownEditor patches MarkdownContent.Content after the typing pause", () => {
+    vi.useFakeTimers();
+    const calls: { path: string; fields: Record<string, unknown> }[] = [];
+    renderAndType(
+      { $type: "MarkdownEditor", label: "Notes", data: "# old", autoSaveAddress: NODE },
+      fakeOps(calls),
+      "# edited",
+    );
+    expect(calls, "must not write on every keystroke").toHaveLength(0);
+    TestRenderer.act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS));
+    expect(calls).toEqual([
+      { path: NODE, fields: { content: { content: "# edited", prerenderedHtml: null, codeSubmissions: null } } },
+    ]);
+  });
+
+  it("CodeEditor patches CodeConfiguration.Code — the two are no longer the same component", () => {
+    vi.useFakeTimers();
+    const calls: { path: string; fields: Record<string, unknown> }[] = [];
+    renderAndType(
+      { $type: "CodeEditor", label: "Code", data: "old();", autoSaveAddress: NODE },
+      fakeOps(calls),
+      "neu();",
+    );
+    TestRenderer.act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS));
+    expect(calls).toEqual([{ path: NODE, fields: { content: { code: "neu();" } } }]);
+  });
+
+  it("an editor without autoSaveAddress writes nothing", () => {
+    vi.useFakeTimers();
+    const calls: { path: string; fields: Record<string, unknown> }[] = [];
+    renderAndType({ $type: "CodeEditor", label: "Code", data: "x" }, fakeOps(calls), "y");
+    TestRenderer.act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS * 4));
+    expect(calls).toEqual([]);
+  });
+});

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -22,8 +22,10 @@ import {
   useScope,
   classifyIcon,
   str,
+  useAutoSave,
   useField,
   useOptions,
+  type AutoSaveKind,
   type ControlComponent,
   type EmbeddedAreaHandle,
   type LeafPack,
@@ -475,24 +477,38 @@ const MenuItem: ControlComponent = ({ control }) => {
 // ── code / markdown editors (native twins of controls/editors.tsx). Monaco is DOM-only; the web pack
 //    itself falls back to a plain <textarea> when Monaco isn't loaded — native uses the same shape: a
 //    monospace multiline TextInput, fully bound. ──────────────────────────────────────────────────
-const CodeEditor: ControlComponent = ({ control }) => {
-  const f = useField(control);
-  return (
-    <Labeled label={f.label}>
-      <TextInput
-        style={styles.codeInput}
-        value={s(f.value)}
-        editable={!f.disabled}
-        multiline
-        autoCapitalize="none"
-        autoCorrect={false}
-        spellCheck={false}
-        onChangeText={f.setValue}
-        onBlur={f.onBlur}
-      />
-    </Labeled>
-  );
-};
+//
+// AUTO-SAVE (issue #1476): a control carrying `autoSaveAddress` edits a mesh node IN PLACE and has no
+// binding pointer, so the ordinary field write goes nowhere — the edit stayed on screen and was never
+// persisted. `useAutoSave` (shared with the web pack, so the two cannot diverge) patches the node's
+// content after the typing pause; the two editors differ only in which content field they write.
+function textEditor(autoSaveKind: AutoSaveKind): ControlComponent {
+  return ({ control }) => {
+    const f = useField(control);
+    const autoSave = useAutoSave(control, autoSaveKind);
+    return (
+      <Labeled label={f.label}>
+        <TextInput
+          style={styles.codeInput}
+          value={s(f.value)}
+          editable={!f.disabled}
+          multiline
+          autoCapitalize="none"
+          autoCorrect={false}
+          spellCheck={false}
+          onChangeText={(v) => {
+            f.setValue(v);
+            autoSave?.(v);
+          }}
+          onBlur={f.onBlur}
+        />
+      </Labeled>
+    );
+  };
+}
+
+const CodeEditor = textEditor("code"); // → CodeConfiguration.Code
+const MarkdownEditor = textEditor("markdown"); // → MarkdownContent.Content
 
 const DiffEditor: ControlComponent = ({ control }) => {
   const original = s(useResolve(control.original ?? control.originalValue));
@@ -677,7 +693,7 @@ export const rnPack: LeafPack = {
     Date: DateInput,
     DateTime: DateTimeInput,
     MenuItem,
-    MarkdownEditor: CodeEditor,
+    MarkdownEditor,
     CodeEditor,
     Editor: CodeEditor,
     DiffEditor,

--- a/clients/react/src/controls/autoSave.test.tsx
+++ b/clients/react/src/controls/autoSave.test.tsx
@@ -1,0 +1,149 @@
+// Issue #1476 — an auto-saving editor's edits must reach the node.
+//
+// `MarkdownEditorControl.AutoSaveAddress` / `CodeEditorControl.AutoSaveAddress` name a mesh node the
+// editor edits IN PLACE. Such a control carries a literal value and NO binding pointer, so the
+// renderer's ordinary area-pointer `update` event has nothing to write to: the JS packs emitted it
+// anyway, the edit went nowhere, and nothing failed visibly — the text simply was not there after a
+// reload. These tests pin the write path and the patch shape.
+
+import { beforeAll, afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl } from "../core.js";
+import type { MeshNodeState, MeshOps, ThreadSubmitOptions } from "../live/meshOps.js";
+import { AUTO_SAVE_DEBOUNCE_MS, autoSaveContentPatch } from "./autoSave.js";
+
+// Monaco cannot run in jsdom; the control's own bound-textarea fallback renders instead, which is
+// the SAME binding — exactly what a non-DOM host (and React Native) uses.
+vi.mock("@monaco-editor/react", () => ({ default: null, Editor: null, DiffEditor: null }));
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => vi.useRealTimers());
+
+const NODE = "rbuergi/Notes/today";
+
+class FakeOps implements MeshOps {
+  readonly patchCalls: { path: string; fields: Record<string, unknown> }[] = [];
+  async *watch(path: string): AsyncIterableIterator<MeshNodeState> {
+    yield { path, content: {} };
+    await new Promise<void>(() => undefined);
+  }
+  async startThread(ns: string, _t: string, _o?: ThreadSubmitOptions) {
+    return { path: `${ns}/_Thread/x` };
+  }
+  async submitMessage(_p: string, _t: string, _o?: ThreadSubmitOptions) {
+    return "m";
+  }
+  patch(path: string, fields: Record<string, unknown>): void {
+    this.patchCalls.push({ path, fields });
+  }
+}
+
+function tree(control: Record<string, unknown>): AreaTree {
+  return { data: {}, areas: { main: control as unknown as UiControl } };
+}
+
+function renderEditor(control: Record<string, unknown>, ops: MeshOps | null) {
+  return render(<MeshAreaView source={new StaticAreaSource(tree(control))} rootArea="main" ops={ops ?? undefined} />);
+}
+
+function type(text: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+}
+
+describe("autoSaveContentPatch — the merge patch that persists the edit", () => {
+  it("writes MarkdownContent.Content and clears the caches derived from the OLD text", () => {
+    // prerenderedHtml is preferred by readers (ContentLayoutArea), so leaving it would render the
+    // text the user just replaced; codeSubmissions is extracted from the same stale text.
+    expect(autoSaveContentPatch("markdown", "# new")).toEqual({
+      content: { content: "# new", prerenderedHtml: null, codeSubmissions: null },
+    });
+  });
+
+  it("writes CodeConfiguration.Code and touches nothing else", () => {
+    // A merge patch leaves language / isExecutable / the polymorphic $type intact — the same
+    // "preserve every other field" contract CodeEditorView.razor's AutoSaveCode implements.
+    expect(autoSaveContentPatch("code", "var x = 1;")).toEqual({ content: { code: "var x = 1;" } });
+  });
+});
+
+describe("MarkdownEditor with autoSaveAddress", () => {
+  it("patches the named node after the typing pause", () => {
+    vi.useFakeTimers();
+    const ops = new FakeOps();
+    renderEditor({ $type: "MarkdownEditor", value: "# old", autoSaveAddress: NODE }, ops);
+
+    type("# edited");
+    expect(ops.patchCalls, "must not write on every keystroke").toHaveLength(0);
+
+    act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS));
+    expect(ops.patchCalls).toEqual([
+      { path: NODE, fields: { content: { content: "# edited", prerenderedHtml: null, codeSubmissions: null } } },
+    ]);
+  });
+
+  it("coalesces a burst of keystrokes into ONE write of the final text", () => {
+    vi.useFakeTimers();
+    const ops = new FakeOps();
+    renderEditor({ $type: "MarkdownEditor", value: "", autoSaveAddress: NODE }, ops);
+
+    type("a");
+    act(() => void vi.advanceTimersByTime(100));
+    type("ab");
+    act(() => void vi.advanceTimersByTime(100));
+    type("abc");
+    act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS));
+
+    expect(ops.patchCalls).toHaveLength(1);
+    expect((ops.patchCalls[0].fields.content as Record<string, unknown>).content).toBe("abc");
+  });
+
+  it("FLUSHES a pending edit when the editor unmounts — navigating away mid-pause must not lose it", () => {
+    vi.useFakeTimers();
+    const ops = new FakeOps();
+    const view = renderEditor({ $type: "MarkdownEditor", value: "", autoSaveAddress: NODE }, ops);
+
+    type("half a sentence");
+    act(() => view.unmount());
+
+    expect(ops.patchCalls).toHaveLength(1);
+    expect((ops.patchCalls[0].fields.content as Record<string, unknown>).content).toBe("half a sentence");
+  });
+});
+
+describe("CodeEditor with autoSaveAddress", () => {
+  it("patches CodeConfiguration.Code", () => {
+    vi.useFakeTimers();
+    const ops = new FakeOps();
+    renderEditor({ $type: "CodeEditor", value: "old();", autoSaveAddress: NODE, language: "csharp" }, ops);
+
+    type("neu();");
+    act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS));
+    expect(ops.patchCalls).toEqual([{ path: NODE, fields: { content: { code: "neu();" } } }]);
+  });
+});
+
+describe("an editor that did NOT opt in is untouched", () => {
+  it("writes nothing when there is no autoSaveAddress", () => {
+    vi.useFakeTimers();
+    const ops = new FakeOps();
+    renderEditor({ $type: "CodeEditor", value: "x" }, ops);
+
+    type("y");
+    act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS * 4));
+    expect(ops.patchCalls).toEqual([]);
+  });
+
+  it("does not crash a host with no mesh ops", () => {
+    vi.useFakeTimers();
+    renderEditor({ $type: "MarkdownEditor", value: "x", autoSaveAddress: NODE }, null);
+    type("y");
+    act(() => void vi.advanceTimersByTime(AUTO_SAVE_DEBOUNCE_MS * 4));
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+});

--- a/clients/react/src/controls/autoSave.ts
+++ b/clients/react/src/controls/autoSave.ts
@@ -1,0 +1,99 @@
+// AUTO-SAVING EDITORS — the client half of `MarkdownEditorControl.AutoSaveAddress` /
+// `CodeEditorControl.AutoSaveAddress`.
+//
+// An auto-save editor is NOT bound to a layout-area `/data` pointer: the control carries a literal
+// value and the node path it edits, and the renderer is expected to write the debounced text back to
+// that node itself. Blazor does exactly this — `MarkdownEditorView` / `CodeEditorView` push the
+// debounced text through the process-wide `IMeshNodeStreamCache`.
+//
+// 🚨 The JS packs did not (issue #1476). They emitted the standard area-pointer `update` event, which
+// for an auto-save editor has no pointer to write to — so the event went nowhere, the edit was never
+// persisted, and NOTHING failed visibly: the text stayed on screen until the view was reloaded. This
+// module is that missing write path, shared by the web (Monaco) and React Native packs so the two
+// cannot implement it differently — the control-parity ratchets only assert `$type` registration and
+// are blind to a per-control contract like this one.
+
+import { useCallback, useEffect, useRef } from "react";
+import type { UiControl } from "../area/types.js";
+import { useMeshOps, type MeshOps } from "../live/meshOps.js";
+import { str } from "./common.js";
+
+/** Debounce window before an edit is persisted — the Blazor AutoSaveHandler's 500 ms throttle. */
+export const AUTO_SAVE_DEBOUNCE_MS = 500;
+
+/** Which content shape the edited node carries. */
+export type AutoSaveKind = "markdown" | "code";
+
+/**
+ * The RFC 7396 merge patch that persists `text` into the node's content.
+ *
+ * `MarkdownContent.Content` / `CodeConfiguration.Code` are the fields Blazor writes. A merge patch
+ * touches only those, so every other content field — and the polymorphic `$type` — survives, which
+ * is stricter than the Blazor markdown path (it replaces the whole content object and drops the
+ * metadata with it).
+ *
+ * The two DERIVED markdown fields are cleared deliberately: `prerenderedHtml` and `codeSubmissions`
+ * are caches of the previous text, and a reader prefers `prerenderedHtml` when present
+ * (`ContentLayoutArea`), so leaving them would render the text the user just replaced. Blazor clears
+ * them too, by virtue of constructing a fresh `MarkdownContent`.
+ */
+export function autoSaveContentPatch(kind: AutoSaveKind, text: string): Record<string, unknown> {
+  return kind === "code"
+    ? { content: { code: text } }
+    : { content: { content: text, prerenderedHtml: null, codeSubmissions: null } };
+}
+
+/** The node path an auto-saving editor writes to, or "" when the control did not opt in. */
+export function autoSaveAddressOf(control: UiControl): string {
+  return str(control.autoSaveAddress);
+}
+
+/**
+ * The debounced writer for an auto-saving editor: feed it every keystroke; it patches the node at
+ * `control.autoSaveAddress` once the typing pauses. Returns null when the control did not opt in (or
+ * the host has no mesh ops), so a caller can keep its ordinary pointer binding.
+ *
+ * A pending edit is FLUSHED on unmount rather than dropped — navigating away mid-debounce is exactly
+ * when "my last sentence did not save" happens, and a merge patch is idempotent so an extra write is
+ * harmless.
+ */
+export function useAutoSave(control: UiControl, kind: AutoSaveKind): ((value: string) => void) | null {
+  const ops = useMeshOps();
+  const address = autoSaveAddressOf(control);
+
+  // Refs so the flush-on-unmount effect never re-runs (and never cancels a live debounce) when the
+  // parent re-renders with a new ops object.
+  const opsRef = useRef<MeshOps | null>(ops);
+  opsRef.current = ops;
+  const addressRef = useRef(address);
+  addressRef.current = address;
+  const kindRef = useRef(kind);
+  kindRef.current = kind;
+
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending = useRef<string | null>(null);
+
+  const flush = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    const text = pending.current;
+    pending.current = null;
+    if (text === null || !addressRef.current || !opsRef.current) return;
+    opsRef.current.patch(addressRef.current, autoSaveContentPatch(kindRef.current, text));
+  }, []);
+
+  useEffect(() => flush, [flush]); // flush whatever is pending when the editor goes away
+
+  const save = useCallback(
+    (value: string) => {
+      pending.current = value;
+      if (timer.current !== null) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, AUTO_SAVE_DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  return address && ops ? save : null;
+}

--- a/clients/react/src/controls/monaco.tsx
+++ b/clients/react/src/controls/monaco.tsx
@@ -20,6 +20,7 @@ import { Text, Textarea } from "@fluentui/react-components";
 import type { Json, UiControl } from "../area/types.js";
 import { useBindingPointer, useEmit, useResolve, useScope } from "../area/context.js";
 import { useThemeMode } from "../theme/themeMode.js";
+import { useAutoSave, type AutoSaveKind } from "./autoSave.js";
 import { str } from "./common.js";
 
 type MonacoModule = typeof import("@monaco-editor/react");
@@ -41,18 +42,30 @@ function useMonaco(): MonacoModule | null {
   return mod;
 }
 
-/** Bound editable value — CodeEditor/MarkdownEditor bind `value` (the Blazor ViewModel.Value), with
- *  `data` tolerated for hand-written trees. Writes go back through the standard update event. */
-function useValueBinding(control: UiControl): { value: string; setValue: (v: string) => void; onBlur: () => void } {
+/**
+ * Bound editable value — CodeEditor/MarkdownEditor bind `value` (the Blazor ViewModel.Value), with
+ * `data` tolerated for hand-written trees. Writes go back through the standard update event.
+ *
+ * When the control opted into AUTO-SAVE (`autoSaveAddress`), the debounced text is ALSO patched into
+ * that node. Such a control carries a literal value and no binding pointer, so the update event
+ * alone wrote nowhere and the edit was silently lost (issue #1476). Both paths run: a control can
+ * legitimately be pointer-bound and auto-saving at once.
+ */
+function useValueBinding(
+  control: UiControl,
+  autoSaveKind: AutoSaveKind,
+): { value: string; setValue: (v: string) => void; onBlur: () => void } {
   const bound = control.value ?? control.data;
   const value = str(useResolve(bound));
   const pointer = useBindingPointer(bound);
+  const autoSave = useAutoSave(control, autoSaveKind);
   const emit = useEmit();
   const { area } = useScope();
   return {
     value,
     setValue: (v: string) => {
       if (pointer) emit({ kind: "update", area, pointer, value: v });
+      autoSave?.(v);
     },
     onBlur: () => emit({ kind: "blur", area }),
   };
@@ -108,10 +121,20 @@ export function monacoSettings(
 
 const monoFallbackStyle: CSSProperties = { fontFamily: "var(--fontFamilyMonospace)", minHeight: 180 };
 
-function MonacoValueEditor({ control, forceLanguage, wordWrapDefault }: { control: UiControl; forceLanguage?: string; wordWrapDefault?: boolean }): ReactNode {
+function MonacoValueEditor({
+  control,
+  autoSaveKind,
+  forceLanguage,
+  wordWrapDefault,
+}: {
+  control: UiControl;
+  autoSaveKind: AutoSaveKind;
+  forceLanguage?: string;
+  wordWrapDefault?: boolean;
+}): ReactNode {
   const monaco = useMonaco();
   const { resolved } = useThemeMode();
-  const binding = useValueBinding(control);
+  const binding = useValueBinding(control, autoSaveKind);
   // Resolve every bindable prop unconditionally (hooks must not be short-circuited).
   const language = useResolve(control.language);
   const theme = useResolve(control.theme);
@@ -171,11 +194,13 @@ function MonacoValueEditor({ control, forceLanguage, wordWrapDefault }: { contro
 }
 
 export function CodeEditorView({ control }: { control: UiControl }): ReactNode {
-  return <MonacoValueEditor control={control} />;
+  // Auto-save target: CodeConfiguration.Code (CodeEditorView.razor's AutoSaveCode).
+  return <MonacoValueEditor control={control} autoSaveKind="code" />;
 }
 
 export function MarkdownEditorView({ control }: { control: UiControl }): ReactNode {
-  return <MonacoValueEditor control={control} forceLanguage="markdown" wordWrapDefault />;
+  // Auto-save target: MarkdownContent.Content (MarkdownEditorView.razor's AutoSaveContentAsync).
+  return <MonacoValueEditor control={control} autoSaveKind="markdown" forceLanguage="markdown" wordWrapDefault />;
 }
 
 export function DiffEditorView({ control }: { control: UiControl }): ReactNode {

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -73,6 +73,16 @@ export {
 // Field/option binding + string coercion — shared by ALL leaf packs (the RN pack used to
 // re-implement these because they weren't exported from the core).
 export { str, useClick, useField, useOptions, useText, type Field } from "./controls/common.js";
+// Auto-saving editors (MarkdownEditorControl / CodeEditorControl `autoSaveAddress`): the debounced
+// write path a node-bound editor needs, shared by every leaf pack so the web and native editors
+// cannot persist differently — or, as before #1476, not at all.
+export {
+  AUTO_SAVE_DEBOUNCE_MS,
+  autoSaveAddressOf,
+  autoSaveContentPatch,
+  useAutoSave,
+  type AutoSaveKind,
+} from "./controls/autoSave.js";
 // .NET-style value formatting and the PURE pivot (cross-tab) model. Renderer-free on purpose: both
 // the Fluent pack and the React Native pack aggregate and format through THESE, so a pivot total is
 // computed by one implementation rather than one per platform.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-edits-in-auto-saving-editors-are-kept.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-edits-in-auto-saving-editors-are-kept.md
@@ -1,0 +1,16 @@
+---
+Name: Edits in auto-saving editors are kept
+Category: Fix
+Description: On the React and mobile front-ends, typing in an editor that saves as you go looked fine but never wrote anything back.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Edits in auto-saving editors are kept
+
+Some editors save as you go rather than behind a Save button — the ones that edit a page or a code
+file directly. On the React and mobile front-ends those edits went nowhere. The text stayed on
+screen, nothing reported a problem, and the work was gone the next time the view loaded.
+
+They now write back the way the main portal does: a short pause in typing saves the text, a burst of
+keystrokes becomes one save, and anything still unsaved is written out when you navigate away.


### PR DESCRIPTION
Closes #1476.

## The defect

`MarkdownEditorControl.AutoSaveAddress` / `CodeEditorControl.AutoSaveAddress` name a mesh node the
editor edits **in place**; Blazor persists the debounced text through the process-wide
`IMeshNodeStreamCache` (`MarkdownEditorView.razor`, `Monaco/CodeEditorView.razor`).

`clients/react/src/controls/monaco.tsx` had no handling for it. It emitted the standard area-pointer
`update` event — and an auto-save control carries a **literal** value and no binding pointer, so
`useBindingPointer` returned undefined and the write was a no-op. Nothing threw, nothing logged; the
text stayed on screen until the view reloaded, at which point the edit was simply gone. The React
Native pack had the same gap, and additionally mapped `MarkdownEditor` and `CodeEditor` to the *same*
component, so it could not have written to the two different content fields even with the plumbing.

## The fix

`useAutoSave` in `clients/react/src/controls/autoSave.ts`, exported from `@meshweaver/react/core` so
both leaf packs share ONE implementation:

| control | patch |
|---|---|
| MarkdownEditor | `{ content: { content, prerenderedHtml: null, codeSubmissions: null } }` |
| CodeEditor | `{ content: { code } }` |

A merge patch touches only that field, so every other content member and the polymorphic `$type`
survive — stricter than the Blazor markdown path, which builds a fresh `MarkdownContent` and drops
the metadata with it. The two derived markdown fields are cleared **deliberately**: they are caches
of the previous text, and a reader prefers `prerenderedHtml` when present (`ContentLayoutArea`), so
leaving them would render the text the user just replaced.

A pending edit is **flushed on unmount** rather than dropped — navigating away mid-debounce is
exactly when "my last sentence did not save" happens, and a merge patch is idempotent.

The RN pack's two editors are now separate components (they differ only in which content field they
write).

## Why a new test rather than the parity ratchet

`clients/react/src/render/parity.test.ts` asserts `$type` registration, not per-control semantics, so
it is blind to this class — as the issue notes. Both packs therefore get a behavioural test that
drives the editor and asserts the write: debounce, coalescing a keystroke burst into one write of the
final text, flush-on-unmount, and no write when the control did not opt in.

## Fail-before

Removing the `autoSave?.(v)` call from `monaco.tsx` → **4 of 8** red in
`clients/react/src/controls/autoSave.test.tsx` (`expected [] to deeply equal [ { …(2) } ]`).
Removing it from `rnPack.tsx` → **2 of 3** red in `clients/react-native/src/autoSave.test.tsx`.
Restored: 8/8 and 3/3.

## Verification

- `clients/react`: `npm run typecheck`, `npm test` (35 files / 261 tests), `npm run build`
- `clients/react-native`: `npx tsc --noEmit`, `npx vitest run` (16 files / 156 tests)

No server-side change, so no localization surface; no new user-visible string (the editors' own
labels are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
