### PR TITLE
fix(lsp): completions keep their rank — the editor stops re-alphabetising them

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -788,7 +788,7 @@ export function registerCompletionProvider(editorId, config) {
                     // with nothing typed. An index-derived key preserves that order and still lets
                     // Monaco's score lead once the user types. (Same fix as the C# completions'
                     // RankKey — see MeshNodeLanguageService.)
-                    sortText: item.sortKey || String(index).padStart(4, '0')
+                    sortText: item.sortKey || String(index).padStart(6, '0')   // width matches RankKey
                 };
 
                 // Attach command to notify C# when a suggestion is accepted

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -763,7 +763,7 @@ export function registerCompletionProvider(editorId, config) {
                 return { suggestions: [] };
             }
 
-            const suggestions = currentItems.map((item) => {
+            const suggestions = currentItems.map((item, index) => {
                 // filterText must match what the user typed (fullQuery includes the trigger char)
                 // Use insertText as filterText since that's what matches the typed pattern
                 const filterText = item.insertText || item.label;
@@ -782,7 +782,13 @@ export function registerCompletionProvider(editorId, config) {
                         value: item.description
                     } : undefined,
                     filterText: filterText,
-                    sortText: item.sortKey || displayLabel.toLowerCase()  // Use sortKey if provided, else alphabetical
+                    // 🚨 The server's ORDER is the ranking — never re-alphabetise it here. Monaco
+                    // sorts by (fuzzy score, sortText, label), so a lowercased label as sortText
+                    // discards whatever relevance the provider computed the moment the list opens
+                    // with nothing typed. An index-derived key preserves that order and still lets
+                    // Monaco's score lead once the user types. (Same fix as the C# completions'
+                    // RankKey — see MeshNodeLanguageService.)
+                    sortText: item.sortKey || String(index).padStart(4, '0')
                 };
 
                 // Attach command to notify C# when a suggestion is accepted

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -656,11 +656,15 @@ internal sealed class MeshNodeLanguageService(
     /// <summary>
     /// The sort key for a ranked completion: its position, zero-padded so a plain STRING compare
     /// (which is all an editor does with <c>sortText</c>) reproduces the numeric order —
-    /// <c>"0002" &lt; "0010"</c>, where <c>"2" &gt; "10"</c> would invert it. Four digits covers any
-    /// list an editor will show; beyond that the tail keeps its relative order under the same
-    /// width. Pure, so the ordering contract is testable without Roslyn.
+    /// <c>"000002" &lt; "000010"</c>, where <c>"2" &gt; "10"</c> would invert it.
+    ///
+    /// <para>The width is what makes that total, so it is chosen to outrun any caller rather than
+    /// any list a human reads: at the width boundary the padding STOPS and the contract inverts
+    /// again (<c>"10000" &lt; "9999"</c> ordinally). Six digits is far past the few hundred a
+    /// completion list is ever asked for, and past any plausible <c>maxResults</c> a caller
+    /// invents. Pure, so the ordering contract is testable without Roslyn.</para>
     /// </summary>
-    internal static string RankKey(int rank) => rank.ToString("D4", CultureInfo.InvariantCulture);
+    internal static string RankKey(int rank) => rank.ToString("D6", CultureInfo.InvariantCulture);
 
     private static CompletionKind MapTagsToKind(ImmutableArray<string> tags)
     {

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh;
@@ -482,7 +483,17 @@ internal sealed class MeshNodeLanguageService(
         }
         ranked = ranked.Take(maxResults);
 
+        // 🚨 The emitted SortText is OUR RANK, never Roslyn's — and that is the whole point.
+        // Roslyn's SortText is an ALPHABETICAL key (it exists to sort a list A→Z), and Monaco
+        // orders its suggest widget by (fuzzy score, sortText, label). Passing Roslyn's key
+        // through therefore threw away every ranking computed above the moment the widget
+        // opened: with nothing typed there is no fuzzy score to order by, so the list the user
+        // saw was strictly alphabetical — the usage and locality ranking, and the target-typing
+        // priority, all discarded. Emitting the rank as a zero-padded ordinal keeps Monaco in
+        // charge of relevance WHILE the user types (its score still dominates) and makes our
+        // order the tiebreak, which is exactly what a `.`-triggered list needs.
         var result = new List<CompletionEntry>();
+        var rank = 0;
         foreach (var item in ranked)
         {
             result.Add(new CompletionEntry(
@@ -491,7 +502,7 @@ internal sealed class MeshNodeLanguageService(
                 InsertText: item.DisplayText,
                 Detail: item.InlineDescription is { Length: > 0 } ? item.InlineDescription : null,
                 Documentation: null,
-                SortText: item.SortText));
+                SortText: RankKey(rank++)));
         }
 
         // Finally, this user's own history: what they accepted last time in this situation is
@@ -641,6 +652,15 @@ internal sealed class MeshNodeLanguageService(
         }
         return sb.ToString().TrimEnd();
     }
+
+    /// <summary>
+    /// The sort key for a ranked completion: its position, zero-padded so a plain STRING compare
+    /// (which is all an editor does with <c>sortText</c>) reproduces the numeric order —
+    /// <c>"0002" &lt; "0010"</c>, where <c>"2" &gt; "10"</c> would invert it. Four digits covers any
+    /// list an editor will show; beyond that the tail keeps its relative order under the same
+    /// width. Pure, so the ordering contract is testable without Roslyn.
+    /// </summary>
+    internal static string RankKey(int rank) => rank.ToString("D4", CultureInfo.InvariantCulture);
 
     private static CompletionKind MapTagsToKind(ImmutableArray<string> tags)
     {

--- a/test/MeshWeaver.Graph.Test/CompletionRankKeyTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompletionRankKeyTest.cs
@@ -1,0 +1,62 @@
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the sort key the language service emits with each completion.
+///
+/// <para>🚨 An editor does a plain STRING compare on <c>sortText</c> — Monaco orders its suggest
+/// widget by (fuzzy score, sortText, label). Two consequences, and this suite exists for both:</para>
+/// <list type="number">
+///   <item>The key must reproduce the server's RANK, not the alphabet. Emitting Roslyn's own
+///   <c>SortText</c> (an A→Z key) discarded every ranking the service computed — usage, locality,
+///   target-typing priority — the moment the list opened with nothing typed, which is exactly when
+///   ranking is all there is. The reported symptom was "ordering in autocomplete is alphabetical".</item>
+///   <item>The key must be ZERO-PADDED, or the string compare inverts the order at ten items
+///   (<c>"10" &lt; "2"</c>) — the classic off-by-a-decade that only shows up on longer lists.</item>
+/// </list>
+/// </summary>
+public class CompletionRankKeyTest
+{
+    [Fact]
+    public void RankKey_SortsNumerically_AsAString()
+    {
+        // The trap: without padding, "10" sorts BEFORE "2" and the eleventh suggestion jumps
+        // above the third.
+        string.CompareOrdinal(MeshNodeLanguageService.RankKey(2), MeshNodeLanguageService.RankKey(10))
+            .Should().BeNegative("rank 2 must sort above rank 10 under an ordinal compare");
+        string.CompareOrdinal(MeshNodeLanguageService.RankKey(0), MeshNodeLanguageService.RankKey(1))
+            .Should().BeNegative("the first suggestion sorts first");
+        string.CompareOrdinal(MeshNodeLanguageService.RankKey(99), MeshNodeLanguageService.RankKey(100))
+            .Should().BeNegative("and across every decade boundary");
+    }
+
+    [Fact]
+    public void RankKey_PreservesAnEntireRankedList()
+    {
+        var keys = Enumerable.Range(0, 200).Select(MeshNodeLanguageService.RankKey).ToArray();
+
+        keys.OrderBy(k => k, StringComparer.Ordinal).Should().Equal(keys,
+            "a ranked list must survive the editor's string sort in the order the server ranked it");
+        keys.Should().OnlyHaveUniqueItems("two suggestions sharing a key would order arbitrarily");
+    }
+
+    [Fact]
+    public void RankKey_IsCultureInvariant()
+    {
+        // A culture with non-ASCII digits would otherwise emit a key that no ordinal compare orders
+        // — the kind of defect that only appears on someone else's machine.
+        var previous = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture =
+                new System.Globalization.CultureInfo("ar-SA");
+            MeshNodeLanguageService.RankKey(7).Should().Be("0007");
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = previous;
+        }
+    }
+}

--- a/test/MeshWeaver.Graph.Test/CompletionRankKeyTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompletionRankKeyTest.cs
@@ -30,6 +30,10 @@ public class CompletionRankKeyTest
             .Should().BeNegative("the first suggestion sorts first");
         string.CompareOrdinal(MeshNodeLanguageService.RankKey(99), MeshNodeLanguageService.RankKey(100))
             .Should().BeNegative("and across every decade boundary");
+        // The width boundary is where padding stops and the contract would invert — the key must
+        // outrun any caller's maxResults, not merely any list a human scrolls.
+        string.CompareOrdinal(MeshNodeLanguageService.RankKey(9_999), MeshNodeLanguageService.RankKey(10_000))
+            .Should().BeNegative("ordering must survive the 9,999 → 10,000 boundary");
     }
 
     [Fact]
@@ -52,7 +56,7 @@ public class CompletionRankKeyTest
         {
             System.Globalization.CultureInfo.CurrentCulture =
                 new System.Globalization.CultureInfo("ar-SA");
-            MeshNodeLanguageService.RankKey(7).Should().Be("0007");
+            MeshNodeLanguageService.RankKey(7).Should().Be("000007");
         }
         finally
         {


### PR DESCRIPTION
## What

Each completion now carries **the server's rank** as its `sortText` (a zero-padded ordinal) instead of Roslyn's own `SortText`.

## Why

Maintainer report: *"ordering in autocomplete is alphabetical. should be by relevance ⇒ monaco to decide."*

The ranking was already there — `CompletionService.FilterItems` (exact > prefix > CamelCase hump, honouring target-typing priority) while the user types, and usage + locality when they have only pressed `.`. It was discarded at the last step: Roslyn's `SortText` is an **A→Z key**, and Monaco orders its suggest widget by `(fuzzy score, sortText, label)`. With nothing typed there is no score to lead with, so the widget re-sorted our ranked list alphabetically — which is precisely the case where ranking is all there is.

Emitting the rank keeps Monaco in charge of relevance *while typing* (its score still dominates) and makes our order the tiebreak. The overlay completion provider (mesh paths) had the identical defect in JS — `sortText: displayLabel.toLowerCase()` — and gets the identical fix.

## Why zero-padded

Editors compare `sortText` as a **string**: `"10" < "2"`, so an unpadded rank inverts the order at ten items — an off-by-a-decade that only shows up on longer lists. `CompletionRankKeyTest` pins that, the 200-item order, and culture invariance (a non-ASCII-digit culture would otherwise emit a key no ordinal compare orders).

## Tested

Full suites, not filters (a filtered run is how I put a red on main earlier today): `MeshWeaver.Graph.Test` **1117/1117**, `MeshWeaver.Autocomplete.Test` **155/155**, `MeshNodeLanguageServiceTest` **22/22**. Release build with `-p:CIRun=true -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)