### PR TITLE
feat(blazor): self-contained Radzen view pack — no shell tags, one entry point

### DIFF
--- a/memex/Memex.Portal.Shared/App.razor
+++ b/memex/Memex.Portal.Shared/App.razor
@@ -31,7 +31,9 @@
     <link href="@(Configuration["Styles:StylesheetName"]).styles.css" rel="stylesheet" />
     <link href="_content/MeshWeaver.Blazor/fonts.css" rel="stylesheet" />
     <link href="_content/MeshWeaver.Blazor/standard-page-layout.css" rel="stylesheet" />
-    <link href="_content/Radzen.Blazor/css/material-base.css" rel="stylesheet" />
+    @* No pack tags here: view packs (Radzen, …) self-load their CSS/JS on first render via
+       _content/MeshWeaver.Blazor/assetLoader.js — the shell stays pack-free so a pack can be
+       added or dropped without touching it. *@
     <ImportMap />
     @if (hasInstance)
     {
@@ -45,8 +47,6 @@
     {
         <link rel="apple-touch-icon" sizes="180x180" href="@appleTouchIcon" />
     }
-    <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
-
     @*
         Load Monaco early, in parallel with HTML parsing, and expose a readiness
         Promise that Blazor.start() awaits below. BlazorMonaco 3.4 ships Monaco

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -980,8 +980,7 @@ public static class MemexConfiguration
         public TBuilder ConfigureMemexPortal() => (TBuilder)builder
             .ConfigureHub(mesh => mesh
                 .AddMeshTypes()
-                .AddRadzenDataGrid()
-                .AddRadzenCharts()
+                .AddRadzenViews()
                 .AddGoogleMaps()
                 .AddGraphViews()  // Also enables @ autocomplete in markdown editors
                 .AddChatViews()   // Register ThreadChatView
@@ -1296,20 +1295,20 @@ public static class MemexConfiguration
     }
 
     /// <summary>
-    /// Adds all MeshWeaver view assemblies (Blazor, Graph, Radzen, GoogleMaps) to the Razor components endpoint,
-    /// and excludes static-asset/infrastructure prefixes (_framework, _content, favicon.ico, auth, mcp, ...)
-    /// from ApplicationPage's root catch-all endpoint so asset misses fall through to 404 instead of the
-    /// HTML shell. The page templates themselves carry NO inline constraint — the Blazor Router would
-    /// interpret ":nonfile" as the built-in dot-rejecting constraint and break every mesh path ending
-    /// in a file extension (Document nodes).
+    /// Adds the MeshWeaver view assemblies that carry ROUTABLE pages (Blazor, Graph) to the Razor
+    /// components endpoint, and excludes static-asset/infrastructure prefixes (_framework, _content,
+    /// favicon.ico, auth, mcp, ...) from ApplicationPage's root catch-all endpoint so asset misses
+    /// fall through to 404 instead of the HTML shell. The page templates themselves carry NO inline
+    /// constraint — the Blazor Router would interpret ":nonfile" as the built-in dot-rejecting
+    /// constraint and break every mesh path ending in a file extension (Document nodes).
+    /// View packs (Radzen, GoogleMaps) do NOT belong here: this list is ROUTING discovery only, and
+    /// packs have no @page components — their views register through the WithView seam.
     /// </summary>
     public static RazorComponentsEndpointConventionBuilder AddMeshViews(
         this RazorComponentsEndpointConventionBuilder builder)
         => builder.AddAdditionalAssemblies(
                 typeof(ApplicationPage).Assembly,              // MeshWeaver.Blazor (includes ApplicationPage with catch-all route)
-                typeof(MeshNodeEditorView).Assembly,           // MeshWeaver.Blazor.Graph
-                typeof(RadzenChartView).Assembly,              // MeshWeaver.Blazor.Radzen
-                typeof(GoogleMapView).Assembly                 // MeshWeaver.Blazor.GoogleMaps
+                typeof(MeshNodeEditorView).Assembly            // MeshWeaver.Blazor.Graph
             )
             .ExcludeStaticAssetPaths();
 }

--- a/src/MeshWeaver.Blazor.Radzen/RadzenChartView.razor
+++ b/src/MeshWeaver.Blazor.Radzen/RadzenChartView.razor
@@ -7,7 +7,10 @@
 </HeadContent>
 
 <CascadingValue Value="@themeService">
-    @if (SeriesList != null && SeriesList.Any())
+    @* Gate on AssetsReady: RadzenChart invokes Radzen.Blazor.js via interop, and the pack
+       self-loads that script on first render (no App.razor tag) — rendering earlier would race
+       the script load. *@
+    @if (AssetsReady && SeriesList != null && SeriesList.Any())
     {
         <div style="@GetContainerStyle()">
             @if (Title != null && !string.IsNullOrEmpty(Title.ToString()))

--- a/src/MeshWeaver.Blazor.Radzen/RadzenPivotGridView.razor
+++ b/src/MeshWeaver.Blazor.Radzen/RadzenPivotGridView.razor
@@ -6,7 +6,9 @@
 </HeadContent>
 
 <CascadingValue Value="@themeService">
-    @if (Configuration != null && RawData != null && DataItemType != null)
+    @* AssetsReady: the pack self-loads Radzen's stylesheet + interop script on first render
+       (no App.razor tag) — see RadzenViewBase. *@
+    @if (AssetsReady && Configuration != null && RawData != null && DataItemType != null)
     {
         @RenderPivotGrid()
     }

--- a/src/MeshWeaver.Blazor.Radzen/RadzenViewBase.cs
+++ b/src/MeshWeaver.Blazor.Radzen/RadzenViewBase.cs
@@ -1,12 +1,16 @@
 using MeshWeaver.Blazor;
 using MeshWeaver.Layout;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using Radzen;
 
 namespace MeshWeaver.Blazor.Radzen;
 
 /// <summary>
-/// Base class for Radzen views that provides theme service functionality.
+/// Base class for Radzen views that provides theme service functionality and self-loads the
+/// pack's static assets (Radzen's base stylesheet + its classic interop script) on first render.
+/// The shell (App.razor) carries NO Radzen tags — the pack is fully self-contained, which is what
+/// makes it droppable/injectable as a view pack.
 /// </summary>
 public abstract class RadzenViewBase<TControl, TView> : BlazorView<TControl, TView>
     where TControl : UiControl
@@ -19,6 +23,13 @@ public abstract class RadzenViewBase<TControl, TView> : BlazorView<TControl, TVi
     protected bool isDarkMode;
 
     /// <summary>
+    /// True once Radzen's stylesheet and interop script are loaded in this document. Views gate
+    /// their Radzen components on this so no Radzen JS interop fires before the script exists.
+    /// The loader is memoized per document, so only the FIRST Radzen view on a page pays the load.
+    /// </summary>
+    protected bool AssetsReady { get; private set; }
+
+    /// <summary>
     /// Initializes the view and applies the Radzen theme matching the active dark/light mode.
     /// </summary>
     /// <returns>A task that completes when initialization is finished.</returns>
@@ -27,6 +38,26 @@ public abstract class RadzenViewBase<TControl, TView> : BlazorView<TControl, TVi
         await base.OnInitializedAsync();
         isDarkMode = await IsDarkModeAsync();
         themeService.SetTheme(GetRadzenTheme());
+    }
+
+    /// <summary>
+    /// Loads the pack's static assets once per document on first interactive render, then
+    /// re-renders with <see cref="AssetsReady"/> set so the Radzen components appear.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (!firstRender || AssetsReady)
+            return;
+        var loader = await JSRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/MeshWeaver.Blazor/assetLoader.js");
+        await using (loader)
+        {
+            await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/css/material-base.css", "css");
+            await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/Radzen.Blazor.js", "js");
+        }
+        AssetsReady = true;
+        StateHasChanged();
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Radzen/RadzenViewPackExtensions.cs
+++ b/src/MeshWeaver.Blazor.Radzen/RadzenViewPackExtensions.cs
@@ -1,0 +1,21 @@
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Blazor.Radzen;
+
+/// <summary>
+/// The Radzen view pack's single hub-side entry point. A view pack is a plain class library:
+/// component types plus this registration — no routable pages, no shell (App.razor) tags (the
+/// views self-load their static assets, see <see cref="RadzenViewBase{TControl,TView}"/>). The
+/// DI-side twin is <see cref="RadzenServiceExtensions.AddRadzenServices"/>; together they are the
+/// pack's complete surface, which is what makes it consumable via a ProjectReference today and via
+/// boot-time assembly loading (<c>MeshBuilder.InstallAssemblies</c>) tomorrow without changes here.
+/// </summary>
+public static class RadzenViewPackExtensions
+{
+    /// <summary>
+    /// Registers every Radzen-rendered control view on the hub configuration:
+    /// charts (<c>ChartControl</c>) and the pivot grid (<c>PivotGridControl</c>).
+    /// </summary>
+    public static MessageHubConfiguration AddRadzenViews(this MessageHubConfiguration config) =>
+        config.AddRadzenDataGrid().AddRadzenCharts();
+}

--- a/src/MeshWeaver.Blazor/wwwroot/assetLoader.js
+++ b/src/MeshWeaver.Blazor/wwwroot/assetLoader.js
@@ -1,0 +1,32 @@
+// Once-only loader for view-pack static assets (classic scripts + stylesheets that cannot ride
+// Blazor's per-component <HeadContent> — e.g. a third-party library script components invoke via
+// JS interop). Memoized per document: repeated ensure() calls for the same URL await the same
+// load, so every pack view can call it unconditionally on first render. This is what keeps pack
+// assets OUT of App.razor — the shell stays pack-free and a pack is droppable without touching it.
+const loads = new Map();
+
+export function ensure(url, kind) {
+  let p = loads.get(url);
+  if (p) return p;
+  p = new Promise((resolve, reject) => {
+    let el;
+    if (kind === "css") {
+      el = document.createElement("link");
+      el.rel = "stylesheet";
+      el.href = url;
+    } else {
+      el = document.createElement("script");
+      el.src = url;
+    }
+    el.onload = () => resolve(true);
+    el.onerror = () => {
+      // Evict the failed promise so a later render can retry (transient network blip);
+      // memoizing a failure would leave every future pack view permanently asset-less.
+      loads.delete(url);
+      reject(new Error("assetLoader: failed to load " + url));
+    };
+    document.head.appendChild(el);
+  });
+  loads.set(url, p);
+  return p;
+}


### PR DESCRIPTION
First slice of the injectable view-pack lane from the modularization program (artifact: WS2, third lane).

**What changes**
- New `_content/MeshWeaver.Blazor/assetLoader.js`: once-per-document memoized loader for pack assets that cannot ride per-component `<HeadContent>` (classic third-party scripts). Failed loads evict so a later render retries.
- `RadzenViewBase` self-loads `material-base.css` + `Radzen.Blazor.js` on first interactive render; both views gate on `AssetsReady` so Radzen JS interop cannot race the script. Pages without charts/pivots no longer fetch Radzen at all.
- `App.razor` loses both Radzen tags — the shell is pack-free, so a pack can be added or dropped without touching it.
- `AddRadzenViews()` becomes the pack's single hub entry; the pack (and GoogleMaps) leave `AddMeshViews()` — that list is routing discovery only, and neither assembly has `@page` components (verified by grep).

**Why**: the seam prototype for injectable packs (next: null-returning `DefaultFormatting` fallback + `InstallAssemblies` wiring, then the Analysis-views pack, settings tabs, and the Edu extraction per the month-scan).

**Verification**: `Memex.Portal.Shared` builds clean with `-c Release -warnaserror`. Behavior note: the first Radzen view on a page renders one beat later (asset load); no other user-visible change — no What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)