### PR TITLE
fix(#1485): carry answerability across the packaging boundary — the routers stop NACKing heartbeats

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -9,7 +9,6 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
-using MeshWeaver.Reflection;
 using MeshWeaver.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -191,14 +190,14 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 logger.LogDebug("Orleans: {MessageType} → {Address} rejected as {ErrorType} — host is shutting down",
                     delivery.Message?.GetType().Name, address, nameof(ErrorType.ShuttingDown));
 
-                // Same NACK-once contract as RoutingServiceBase.PostNotFound (see MayAnswer), but
-                // DO classify the returned delivery either way so whoever finishes it can.
+                // Same NACK-once contract as RoutingServiceBase.PostNotFound — see AnswerPolicy —
+                // but DO classify the returned delivery either way so whoever finishes it can.
                 //
                 // 🚨 senderNacked is the POST's verdict, not the permission to post. FailedAndNacked
                 // means "the sender has been answered" and suppresses downstream reporting, so
                 // claiming it when SendDeliveryFailure could not post (no mesh hub) would leave an
                 // Observe(...) caller waiting out its full budget with the failure recorded nowhere.
-                var senderNacked = MayAnswer(delivery)
+                var senderNacked = delivery.MayAnswer()
                                    && SendDeliveryFailure(delivery, shutdownMessage, ErrorType.ShuttingDown);
 
                 return Observable.Return(senderNacked
@@ -264,7 +263,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                         // no one waiting, so the NACK is pure added traffic. Both matter most
                         // precisely here: dispatch fails in bulk while a silo is leaving, which is
                         // when the mesh can least afford an answering storm.
-                        if (MayAnswer(delivery))
+                        if (delivery.MayAnswer())
                             SendDeliveryFailure(delivery, $"Failed to deliver to {address}: {ex.Message}",
                                 shuttingDown ? ErrorType.ShuttingDown : ErrorType.Failed);
                         return Observable.Empty<IMessageDelivery>();
@@ -364,22 +363,6 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 }
             });
     }
-
-    /// <summary>
-    /// Whether a NACK may be sent for <paramref name="delivery"/> AT ALL — the routing layer's
-    /// answer-once contract, stated in one place so every path that gives up on a delivery
-    /// applies it identically (the same contract as <c>RoutingServiceBase.PostNotFound</c>).
-    ///
-    /// <para>Never answer a <see cref="DeliveryFailure"/>: the answer is itself a
-    /// <see cref="DeliveryFailure"/>, so answering one loops. Never answer a
-    /// <see cref="CanBeIgnoredAttribute"/> message: nobody is awaiting it, so the NACK is pure
-    /// added traffic — and it is added at exactly the worst moment, since the paths that give up
-    /// are shutdown and dispatch failure, when the volume of control messages is highest and the
-    /// process has least capacity. That is how a teardown turns into a failure storm.</para>
-    /// </summary>
-    private static bool MayAnswer(IMessageDelivery delivery) =>
-        delivery.Message is not DeliveryFailure
-        && delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() != true;
 
     /// <param name="delivery">The delivery that could not be routed.</param>
     /// <param name="message">The failure message returned to the sender.</param>

--- a/src/MeshWeaver.Documentation/Data/Architecture/ActionBlockWedgePrevention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActionBlockWedgePrevention.md
@@ -28,6 +28,38 @@ triggers a resubscribe/repost that fails again.
   it holds at *all* emit sites, permanently, enforced by a test — not re-checked by hand.)
 - Root-aligned, not a band-aid: it removes the *cause* of amplification.
 
+### 🚨 The exemption must be read off the ENVELOPE, never the payload's CLR type
+
+**Issue #1485 — the exemption above was written seven times as `delivery.Message is DeliveryFailure
+|| delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()`, and on the routed path not one
+of them could ever match.** Every mesh delivery reaches a router as
+`delivery.Package(hub.JsonSerializerOptions)` (`MeshBuilder`) — the single call site of
+`IRoutingService.DeliverMessage` — and `Package` replaces the payload with `RawJson`. So the guards
+were inspecting `RawJson`, which is neither a `DeliveryFailure` nor `[CanBeIgnored]`. The trace tell
+is `RouteMessage: NotFound for RawJson → …`.
+
+The consequence is exactly the amplification this invariant forbids: a departed owner that is
+heart-beaten every `SyncStreamOptions` interval was answered with a `DeliveryFailure` every time, and
+a `DeliveryFailure` could be answered with another one. It affected **both** hosts equally — the
+comments claiming the two routers "both agree" were true only in that both were dead — and it reached
+one level above the routers too, in `MessageService.ReportFailure`, which reports whatever the route
+handler hands back and therefore also sees `RawJson`.
+
+The fix is `AnswerPolicy` (`src/MeshWeaver.Messaging.Contract/AnswerPolicy.cs`):
+`Package` stamps the *fact* "this payload must not be answered" onto the envelope's properties
+immediately before the type is erased (the same mechanism `IDiagnosticKeyed` already uses for the
+storm breaker), and every guard calls `delivery.MayAnswer()`, which reads the stamp and falls back to
+the CLR type for a delivery that never crossed a packaging boundary. Only the *suppressed* case is
+stamped, so ordinary traffic costs nothing and an unstamped delivery degrades to the old behaviour —
+never to "answer something you must not".
+
+**So when adding a new emit site: call `delivery.MayAnswer()`. A hand-written CLR-type check is a
+silent no-op anywhere downstream of a hub hop.** Pinned by
+`OrleansRouterAnswerOnceAfterPackagingTest`, `MonolithRouterAnswerOnceAfterPackagingTest` and
+`RoutingTailAnswerOnceAfterPackagingTest` — one per host plus the reporting tail, each of which
+fails on the pre-fix tree. This is also what the proposed `FailureExemptAtEveryEmitSite` test below
+would have caught years earlier, and it is the strongest argument for writing it.
+
 ## Invariant 2 — A subscription to a missing target dies after N, it does not retry forever
 
 The phantom `_Activity` storm and the rsalzmann subscribe-wedge were both **unbounded

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-routing-answer-once.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-routing-answer-once.md
@@ -1,0 +1,24 @@
+---
+Name: No more failure storms when a node or pod goes away
+Category: Fix
+Description: Routing no longer answers heartbeats and error replies with more error replies, which used to flood the portal during shutdown and node deletion.
+Icon: Sparkle
+Order: -20260814
+---
+
+# No more failure storms when a node or pod goes away
+
+When the mesh could not deliver a message, it replied to the sender with a delivery failure. That is
+right for a real request someone is waiting on, and wrong for two kinds of traffic: background
+keep-alive pings, which nobody is waiting for, and failure replies themselves, which produce another
+failure reply and go round in circles.
+
+Routing had always been written to skip both — but the check was looking at the wrong thing and
+never actually matched, on every routing path in both the single-process and clustered hosts. So a
+node that had been deleted, or a pod that was shutting down, generated a burst of pointless failure
+traffic at exactly the moment the portal had least capacity to carry it: pages that hung, background
+work that stalled, and in the worst case a restart.
+
+The check now travels with the message instead of being re-derived after the fact, so it works
+everywhere, and both hosts genuinely behave the same way. Real requests still get their answer
+immediately, so genuine errors surface just as fast as before.

--- a/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
@@ -88,7 +88,12 @@ internal class MonolithRoutingService(
         // makes it read as terminal, which is the CI 30003419841 wedge: erroring the sync stream on
         // this NACK killed the resubscribe latch and wedged every read of a mid-recycle NodeType.
         var errorType = isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound;
-        var senderNacked = delivery.Message is not DeliveryFailure
+        // The answer-once contract — see AnswerPolicy. 🚨 Read the ENVELOPE: this delivery came
+        // through MeshBuilder's delivery.Package(...), so its payload is RawJson and the CLR-type
+        // test this replaces could never match (#1485). It was also missing the [CanBeIgnored]
+        // half of the contract that every sibling guard carries, so a heartbeat reaching a node
+        // whose NodeType yields no hub configuration was answered even in principle.
+        var senderNacked = delivery.MayAnswer()
             && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs;
         if (senderNacked)
         {

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -7,7 +7,6 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
-using MeshWeaver.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
@@ -407,13 +406,11 @@ internal class RoutingGrain(
         ErrorType errorType)
     {
         if (delivery.Sender == null) return;
-        // [CanBeIgnored] messages (HeartBeatEvent, Shutdown/Dispose) are fire-and-forget: there is NO
-        // awaiting Observe callback to fail, so a DeliveryFailure for them is meaningless. It would be
-        // dropped as unhandled at the sender, or — for a permanently-gone owner that is heart-beaten
-        // every interval — re-posted forever, which IS the NotFound storm. Silently ignore, matching
-        // the monolith RoutingServiceBase.PostNotFound / NackRouteFailure guard so both routers agree.
-        if (delivery.Message is DeliveryFailure
-            || delivery.Message?.GetType().HasAttribute<CanBeIgnoredAttribute>() == true)
+        // The answer-once contract — see AnswerPolicy for what it forbids and why. 🚨 Read the
+        // ENVELOPE, never delivery.Message's CLR type: MeshBuilder hands the router
+        // delivery.Package(...), so by the time a route fails the payload is ALWAYS RawJson and the
+        // CLR-type test this guard used to make could not match on any routed delivery (#1485).
+        if (!delivery.MayAnswer())
             return;
         var failureDelivery = new MessageDelivery<DeliveryFailure>(
             new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -6,7 +6,6 @@ using MeshWeaver.Kernel;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
-using MeshWeaver.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -153,12 +152,12 @@ namespace MeshWeaver.Hosting
 
         private void NackRouteFailure(IMessageDelivery delivery, Exception ex)
         {
-            // [CanBeIgnored] messages (Shutdown/Dispose/HeartBeat) have no awaiting
-            // sender — a DeliveryFailure for them is meaningless and feeds the disposal
-            // ping-pong storm (see ReportFailure). Same rule as the Ignored-handler path.
+            // The answer-once contract — see AnswerPolicy. 🚨 Read the ENVELOPE, not
+            // delivery.Message's CLR type: MeshBuilder is the ONLY caller of
+            // IRoutingService.DeliverMessage and it packages, so this guard's payload is
+            // ALWAYS RawJson and the old CLR-type test never matched (#1485).
             // Also never post once the mesh is tearing down — the recipients are gone.
-            if (delivery.Message is DeliveryFailure
-                || delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
+            if (!delivery.MayAnswer()
                 || Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
                 return;
             // 🚨 Routing infrastructure's OWN post. ResponseFor carries the failed
@@ -355,8 +354,9 @@ namespace MeshWeaver.Hosting
                 "RouteMessage: NotFound for {MessageType} → {Address}. {FailureMessage}",
                 delivery.Message.GetType().Name, originalAddress, failureMessage);
 
-            var senderNacked = delivery.Message is not DeliveryFailure
-                && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
+            // The answer-once contract, read off the ENVELOPE — see AnswerPolicy and
+            // NackRouteFailure above for why the CLR-type test this replaces was dead (#1485).
+            var senderNacked = delivery.MayAnswer()
                 && Mesh.RunLevel < MessageHubRunLevel.DisposeHostedHubs;
             if (senderNacked)
             {

--- a/src/MeshWeaver.Messaging.Contract/AnswerPolicy.cs
+++ b/src/MeshWeaver.Messaging.Contract/AnswerPolicy.cs
@@ -1,0 +1,79 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The routing layer's ANSWER-ONCE contract: may a path that has given up on a delivery answer its
+/// sender with a <see cref="DeliveryFailure"/> at all? Stated ONCE here so every such path applies
+/// it identically, and — the reason this type exists — so the answer survives the TYPE ERASURE that
+/// <c>MessageDelivery.Package</c> performs on the way into the router.
+///
+/// <para><b>Two payloads must never be answered.</b> A <see cref="DeliveryFailure"/>, because the
+/// answer is itself a <see cref="DeliveryFailure"/> and answering one loops. A
+/// <see cref="CanBeIgnoredAttribute"/> message (<c>HeartBeatEvent</c>, <c>ShutdownRequest</c>,
+/// <c>DisposeRequest</c>), because it is fire-and-forget — there is NO awaiting <c>Observe</c>
+/// callback to fail, so the NACK is pure added traffic, and for a permanently-gone owner that is
+/// heart-beaten every interval it is re-posted forever, which IS the NotFound storm. Both matter
+/// most on exactly the paths that give up — shutdown and dispatch failure — when the volume of
+/// control traffic is highest and the process has the least capacity to carry it.</para>
+///
+/// <para>🚨 <b>Why a delivery PROPERTY and not a CLR-type test (issue #1485).</b> Every mesh
+/// delivery is handed to <c>IRoutingService.DeliverMessage</c> as
+/// <c>delivery.Package(hub.JsonSerializerOptions)</c>, which replaces the payload with
+/// <see cref="RawJson"/>. Guards written as <c>delivery.Message is DeliveryFailure</c> /
+/// <c>…HasAttribute&lt;CanBeIgnoredAttribute&gt;()</c> therefore inspect <c>RawJson</c> on the routed
+/// path and CANNOT match — five such guards, in both routers, were dead code, and the routers whose
+/// comments said they "both agree" agreed only in being uniformly dead. The cure is the one
+/// <c>Package</c> already uses for <see cref="IDiagnosticKeyed"/>: stamp the answer onto the
+/// ENVELOPE before the payload type is gone, and have the guards read the envelope.</para>
+///
+/// <para>🚨 <b>The FACT is stamped, never the type name.</b> A general-purpose "what was this?"
+/// oracle on the envelope invites downstream code to make parsing decisions from it; the single
+/// question the routing layer asks is "may I answer this", so that is the only thing recorded. And
+/// only the SUPPRESSED case is stamped: absence means "answerable", which keeps the stamp off the
+/// hot path for ordinary traffic and makes an unstamped delivery (one that never went through
+/// <c>Package</c>, or arrived pre-serialised from an external client) degrade to exactly the
+/// pre-#1485 CLR-type behaviour — never to "answer something you must not".</para>
+/// </summary>
+public static class AnswerPolicy
+{
+    /// <summary>
+    /// Delivery-property key under which <c>MessageDelivery.Package(...)</c> records that this
+    /// delivery's ORIGINAL payload must not be answered, immediately before that payload's type is
+    /// erased to <see cref="RawJson"/>.
+    ///
+    /// <para>🚨 The VALUE is never read — only the key's presence is. That is deliberate: a
+    /// delivery property crosses the gRPC/SignalR wire as JSON and comes back as a
+    /// <c>JsonElement</c> rather than the <see cref="bool"/> that was stamped (the same round-trip
+    /// <c>MessageStormBreaker.ResolvePayloadKey</c> documents for <see cref="IDiagnosticKeyed"/>),
+    /// so a value comparison would silently stop matching after a wire hop while a presence check
+    /// cannot.</para>
+    /// </summary>
+    public const string SuppressedProperty = "AnswerSuppressed";
+
+    /// <summary>
+    /// Whether a <see cref="DeliveryFailure"/> must NEVER be sent for this PAYLOAD. Answers from
+    /// the CLR type, so it is meaningful only BEFORE packaging — call it at the packaging boundary
+    /// (and as the fallback for a delivery that carries no stamp); everywhere downstream use
+    /// <see cref="MayAnswer"/>.
+    /// </summary>
+    /// <param name="message">The message payload, as posted.</param>
+    /// <returns>True when the payload is a <see cref="DeliveryFailure"/> or is marked
+    /// <see cref="CanBeIgnoredAttribute"/>.</returns>
+    public static bool IsAnswerSuppressed(object? message) =>
+        message is DeliveryFailure
+        || (message is not null
+            // Attribute.IsDefined — no array allocation, and the CLR caches the attribute metadata
+            // per type internally (the same call MemberInfoExtensions.HasAttribute makes).
+            && Attribute.IsDefined(message.GetType(), typeof(CanBeIgnoredAttribute), inherit: true));
+
+    /// <summary>
+    /// Whether the routing layer may answer <paramref name="delivery"/>'s sender with a
+    /// <see cref="DeliveryFailure"/>. Reads the stamp <c>Package</c> left on the envelope, and
+    /// falls back to the payload's CLR type for a delivery that never crossed a packaging boundary.
+    /// </summary>
+    /// <param name="delivery">The delivery a routing path has given up on.</param>
+    /// <returns>False for a <see cref="DeliveryFailure"/> or a <see cref="CanBeIgnoredAttribute"/>
+    /// payload — whether or not its type has since been erased to <see cref="RawJson"/>.</returns>
+    public static bool MayAnswer(this IMessageDelivery delivery) =>
+        !delivery.Properties.ContainsKey(SuppressedProperty)
+        && !IsAnswerSuppressed(delivery.Message);
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
@@ -189,6 +189,19 @@ public abstract record MessageDelivery : IMessageDelivery
             var serialized = JsonSerializer.Serialize(message, options ?? fallbackOptions);
             var rawJson = new RawJson(serialized);
             var packaged = WithMessage(rawJson);
+            // 🚨 Carry the payload's ANSWERABILITY across the type erasure — issue #1485, and the
+            // exact same reasoning as the IDENTITY stamp below. The routing layer's answer-once
+            // guards ("never NACK a DeliveryFailure, never NACK [CanBeIgnored] fire-and-forget
+            // control traffic") were written as CLR-type tests on delivery.Message; every mesh
+            // delivery reaches the router THROUGH THIS METHOD, so all of them were inspecting
+            // RawJson and none could ever match. The routers therefore NACKed heartbeats to a
+            // departed owner — which, re-posted every heartbeat interval, IS the NotFound storm the
+            // guards' own comments describe — and could answer a DeliveryFailure with a
+            // DeliveryFailure. Only the SUPPRESSED case is stamped, so ordinary traffic pays
+            // nothing and an unstamped delivery degrades to the old CLR-type check, never to
+            // "answer something you must not". See AnswerPolicy.
+            if (AnswerPolicy.IsAnswerSuppressed(message))
+                packaged = packaged.SetProperty(AnswerPolicy.SuppressedProperty, true);
             // 🚨 Carry the payload's IDENTITY across the type erasure. From here on the delivery
             // is `type=RawJson` and nothing downstream can tell WHAT it is about without parsing
             // the payload — which the receiving hub's storm breaker runs far too hot to do (it

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -650,8 +650,30 @@ public class MessageService : IMessageService
         }
         else
         {
-            logger.LogWarning("Suppressing DeliveryFailure reporting for response-less control message {MessageType} (ID: {MessageId}) in {Address}",
-                delivery.Message.GetType().Name, delivery.Id, Address);
+            // 🚨 Debug, and the level is part of the #1485 fix rather than a debugging tweak.
+            //
+            // COST: this branch used to be reached only by TYPED control traffic, because a packaged
+            // delivery could not match the CLR-type test above — so it was rare, and Warning was the
+            // right price. Now that the contract is read off the envelope it is reached once per
+            // SUPPRESSED delivery, and the moment that happens in bulk is precisely a pod shutdown:
+            // the Orleans shutdown branch fails every in-flight delivery, and prod (2026-08-10)
+            // measured 944 on a single dying pod. At Warning that is ~1k Loki lines per shutdown,
+            // billed forever, emitted exactly when the process has least capacity.
+            //
+            // VALUE: near zero. Suppression here is the DESIGNED outcome for a DeliveryFailure or a
+            // [CanBeIgnored] message, both of which are provably response-less — MayAnswer() is
+            // false for nothing else — so the line reports normal behaviour, not an anomaly. The
+            // storm it replaces (a posted NACK per message, each itself routed and logged) is the
+            // thing that was expensive; keeping a per-message Warning in its place would bank a
+            // fraction of the same bill for no diagnostic gain.
+            //
+            // 🚨 GetMessageType, not GetType().Name: the payload here is RawJson by construction, so
+            // the old call printed the literal string "RawJson" for every one of those lines. This
+            // reads the $type out of the JSON, which is the only way the line names what was
+            // actually suppressed.
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Suppressing DeliveryFailure reporting for response-less control message {MessageType} (ID: {MessageId}) in {Address}",
+                    GetMessageType(delivery), delivery.Id, Address);
         }
 
         return delivery;

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -456,7 +456,15 @@ public class MessageService : IMessageService
             && !(delivery.Message is RawJson rawJson
                  && !rawJson.Content.Contains(nameof(DeliveryFailure), StringComparison.Ordinal)))
             return false;
-        if (delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+        // 🚨 The answer-once contract off the ENVELOPE, not the CLR type (#1485). A cross-hub
+        // delivery arrives here as RawJson — which is exactly the case the RawJson clause above
+        // exists to admit — so the [CanBeIgnored] test this line used to make was dead for every
+        // delivery that had crossed a hub boundary, and a packaged HeartBeatEvent dropped at a
+        // disposing hub was NACKed through the parent: fire-and-forget traffic answered during
+        // teardown, which is precisely the storm shape. The content sniff above is KEPT as the
+        // fallback for a RawJson that never went through Package (an external client's
+        // pre-serialised frame carries no stamp).
+        if (!delivery.MayAnswer())
             return false;
         // The same "ONE request, ONE failure response" rule ReportFailure applies: an
         // authoritative, typed DeliveryFailure has already been posted for this delivery, so a
@@ -615,8 +623,15 @@ public class MessageService : IMessageService
         //    tests, which under the 2-core CI runner saturated the pipeline and timed the
         //    project out). Real requests still fail closed; only response-less control traffic
         //    is suppressed — the same rule the Ignored-handler path already applies below.
-        if (delivery.Message is not DeliveryFailure
-            && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+        //
+        // 🚨 Read the ENVELOPE, not delivery.Message's CLR type (#1485). This is the ROUTING TAIL's
+        // reporter as well as the on-target one: ReportRoutingFailure lands here with the delivery
+        // the mesh's route handler returned, and that handler is
+        // `IRoutingService.DeliverMessage(delivery.Package(...))` — so its payload is RawJson and
+        // the CLR-type test alone let a fire-and-forget heartbeat through. That mattered most on the
+        // one path where the router returns Failed synchronously: the Orleans shutdown branch. Fixing
+        // only the routers would have moved the very same storm one level up, into this method.
+        if (delivery.MayAnswer())
         {
             try
             {

--- a/test/MeshWeaver.Hosting.Monolith.Test/MonolithRouterAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MonolithRouterAnswerOnceAfterPackagingTest.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The MONOLITH half of the answer-once contract across the packaging boundary (issue #1485) —
+/// the Orleans half is
+/// <c>MeshWeaver.Hosting.Orleans.Test.OrleansRouterAnswerOnceAfterPackagingTest</c>.
+///
+/// <para><b>Why this test exists as its own file.</b> The routers' comments assert that they
+/// "both agree" on when a delivery may be answered, and #1485 was filed on the reading that the
+/// monolith guards sit BEFORE packaging and therefore still work. They do not: there is exactly
+/// ONE call site of <c>IRoutingService.DeliverMessage</c> (<c>MeshBuilder</c>), it packages, and
+/// BOTH implementations are behind it. So the two routers did agree — in being uniformly dead.
+/// A claim of agreement that nothing executes is how they drifted; this pins it on both sides.</para>
+///
+/// <para>Drives the REAL <c>IRoutingService</c> of a real monolith mesh (no mocks) with a delivery
+/// packaged exactly as <c>MeshBuilder</c> packages it, at an address that resolves to nothing —
+/// the <c>RoutingServiceBase.PostNotFound</c> path.</para>
+/// </summary>
+public class MonolithRouterAnswerOnceAfterPackagingTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private static readonly Address MissingTarget = new("doesnotexist", "missing-node");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        builder
+            .UseMonolithMesh()
+            .AddPartitionedInMemoryPersistence()
+            .AddGraph()
+            .AddMeshNodes(TestUsers.PublicAdminAccess());
+
+    /// <summary>
+    /// A packaged <see cref="HeartBeatEvent"/> and a packaged <see cref="DeliveryFailure"/> routed
+    /// to a NotFound address must NOT be answered; ordinary traffic must still be. The ordinary
+    /// message is dispatched LAST and to the SAME address, so it drains behind the other two
+    /// through the per-address activation FIFO — its NACK arriving is the deterministic proof that
+    /// the two before it were fully routed.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_WhileOrdinaryTrafficIs()
+    {
+        var nackedDeliveryIds = new ConcurrentQueue<string>();
+        var controlAnswered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controlId = string.Empty;
+
+        var client = GetClient(c => c.WithHandler<DeliveryFailure>((_, d) =>
+        {
+            nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
+            if (d.Message.Delivery.Id == controlId)
+                controlAnswered.TrySetResult();
+            return d.Processed();
+        }));
+
+        IMessageDelivery Packaged<TMessage>(TMessage message)
+        {
+            var packaged = new MessageDelivery<TMessage>(client.Address, MissingTarget, message,
+                    Mesh.JsonSerializerOptions)
+                .Package(Mesh.JsonSerializerOptions);
+            packaged.Message.Should().BeOfType<RawJson>(
+                "MeshBuilder packages every delivery before the router sees it — that erasure IS the defect");
+            return packaged;
+        }
+
+        var heartBeat = Packaged(new HeartBeatEvent());
+        var failure = Packaged(new DeliveryFailure(
+            new MessageDelivery<string>(client.Address, MissingTarget, "inner", Mesh.JsonSerializerOptions),
+            "inner failure"));
+        var control = Packaged("ordinary-payload");
+        controlId = control.Id;
+
+        await RoutingService.DeliverMessage(heartBeat).FirstAsync().ToTask();
+        await RoutingService.DeliverMessage(failure).FirstAsync().ToTask();
+        await RoutingService.DeliverMessage(control).FirstAsync().ToTask();
+
+        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        var answered = nackedDeliveryIds.Should().ContainSingle(
+            "answering a [CanBeIgnored] heartbeat re-posts forever against a permanently-gone owner "
+            + "(the NotFound storm), and answering a DeliveryFailure with a DeliveryFailure loops — "
+            + "while ordinary traffic must still get its NACK so hub.Observe fires OnError").Subject;
+        answered.Should().Be(control.Id);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/MonolithRouterAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MonolithRouterAnswerOnceAfterPackagingTest.cs
@@ -1,6 +1,6 @@
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
+using System.Reactive.Subjects;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -43,21 +43,20 @@ public class MonolithRouterAnswerOnceAfterPackagingTest(ITestOutputHelper output
     /// A packaged <see cref="HeartBeatEvent"/> and a packaged <see cref="DeliveryFailure"/> routed
     /// to a NotFound address must NOT be answered; ordinary traffic must still be. The ordinary
     /// message is dispatched LAST and to the SAME address, so it drains behind the other two
-    /// through the per-address activation FIFO — its NACK arriving is the deterministic proof that
-    /// the two before it were fully routed.
+    /// through the per-address activation FIFO — its answer is a real emission the assertion
+    /// subscribes for, never a period the test waits out.
     /// </summary>
-    [Fact(Timeout = 30000)]
+    [Fact(Timeout = 60000)]
     public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_WhileOrdinaryTrafficIs()
     {
-        var nackedDeliveryIds = new ConcurrentQueue<string>();
-        var controlAnswered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var controlId = string.Empty;
+        // ReplaySubject: the assertion subscribes after the dispatch and must still see the whole
+        // history of what the router answered.
+        var nacks = new ReplaySubject<string>();
+        var answeredSoFar = nacks.Scan(ImmutableList<string>.Empty, (answered, id) => answered.Add(id));
 
         var client = GetClient(c => c.WithHandler<DeliveryFailure>((_, d) =>
         {
-            nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
-            if (d.Message.Delivery.Id == controlId)
-                controlAnswered.TrySetResult();
+            nacks.OnNext(d.Message.Delivery.Id);
             return d.Processed();
         }));
 
@@ -76,18 +75,22 @@ public class MonolithRouterAnswerOnceAfterPackagingTest(ITestOutputHelper output
             new MessageDelivery<string>(client.Address, MissingTarget, "inner", Mesh.JsonSerializerOptions),
             "inner failure"));
         var control = Packaged("ordinary-payload");
-        controlId = control.Id;
 
-        await RoutingService.DeliverMessage(heartBeat).FirstAsync().ToTask();
-        await RoutingService.DeliverMessage(failure).FirstAsync().ToTask();
-        await RoutingService.DeliverMessage(control).FirstAsync().ToTask();
+        // Cold observables: the subscribe IS the dispatch. RouteInMesh runs inline on subscribe, so
+        // all three join the per-address activation FIFO in this order.
+        RoutingService.DeliverMessage(heartBeat).Subscribe(_ => { });
+        RoutingService.DeliverMessage(failure).Subscribe(_ => { });
+        RoutingService.DeliverMessage(control).Subscribe(_ => { });
 
-        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(20));
+        var answered = await answeredSoFar.Should().Within(30.Seconds())
+            .Match(a => a.Contains(control.Id),
+                "ordinary traffic must still get its NACK so hub.Observe fires OnError");
 
-        var answered = nackedDeliveryIds.Should().ContainSingle(
+        answered.Should().ContainSingle(
             "answering a [CanBeIgnored] heartbeat re-posts forever against a permanently-gone owner "
-            + "(the NotFound storm), and answering a DeliveryFailure with a DeliveryFailure loops — "
-            + "while ordinary traffic must still get its NACK so hub.Observe fires OnError").Subject;
-        answered.Should().Be(control.Id);
+            + "(the NotFound storm), and answering a DeliveryFailure with a DeliveryFailure loops").Subject
+            .Should().Be(control.Id);
+        answered.Should().NotContain(heartBeat.Id);
+        answered.Should().NotContain(failure.Id);
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansRouterAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansRouterAnswerOnceAfterPackagingTest.cs
@@ -1,6 +1,6 @@
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
+using System.Reactive.Subjects;
 using MeshWeaver.Connection.Orleans;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
@@ -33,24 +33,25 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// <see cref="IHostApplicationLifetime"/> drives the router into its shutdown branch (the branch
 /// that consults the guard), and a real <see cref="IMessageHub"/> sits at the sender's address so
 /// every assertion is made on the actual <see cref="DeliveryFailure"/> the router posts.</para>
+///
+/// <para>🚨 <b>Nothing here polls or samples.</b> The NACKs the router posts are pushed onto a
+/// <see cref="ReplaySubject{T}"/>, and the assertions SUBSCRIBE to a running fold of that stream via
+/// <c>.Should().Within(...).Match(...)</c> — the repo's reactive assertion idiom, which settles on
+/// the first emission satisfying the predicate. No <c>FirstAsync</c>, no <c>Take(1)</c>, no
+/// <c>TaskCompletionSource</c>, no sleep-then-inspect.</para>
 /// </summary>
 public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
 {
     private static readonly Address SenderAddress = new("portal", "answer-once-sender");
     private static readonly Address TargetAddress = new("SomeNamespace", "SomeNode");
 
-    /// <summary>Delivery ids the router answered with a <see cref="DeliveryFailure"/>.</summary>
-    private readonly ConcurrentQueue<string> nackedDeliveryIds = new();
-
     /// <summary>
-    /// Completes when the POSITIVE CONTROL has been answered. It is dispatched last through the
-    /// same serial path, so its NACK arriving is the proof that the two suppressed deliveries were
-    /// fully processed — no sleep, no "wait and hope".
+    /// Every delivery id the router answered with a <see cref="DeliveryFailure"/>, in order.
+    /// A <see cref="ReplaySubject{T}"/> so an assertion that subscribes AFTER the dispatch still
+    /// sees the whole history — the alternative (subscribe first, then dispatch) would make the
+    /// test's own ordering load-bearing for no benefit.
     /// </summary>
-    private readonly TaskCompletionSource controlAnswered =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-    private string controlDeliveryId = string.Empty;
+    private readonly ReplaySubject<string> nacks = new();
 
     private readonly IHostApplicationLifetime lifetime;
 
@@ -62,15 +63,22 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
         Services.AddSingleton<IMessageHub>(sp => sp.CreateMessageHub(SenderAddress, conf => conf
             .WithHandler<DeliveryFailure>((_, d) =>
             {
-                nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
-                if (d.Message.Delivery.Id == controlDeliveryId)
-                    controlAnswered.TrySetResult();
+                nacks.OnNext(d.Message.Delivery.Id);
                 return d.Processed();
             })
             .WithPostingIdentity(PostingIdentity.System)));
     }
 
     private IMessageHub Hub => ServiceProvider.GetRequiredService<IMessageHub>();
+
+    /// <summary>
+    /// The running list of everything answered so far. Subscribing to THIS and matching on
+    /// "the control has been answered" is what makes the assertion a positive signal rather than a
+    /// wait: the control is dispatched last down the same serial path, so the fold at the moment it
+    /// appears is the complete set of answers.
+    /// </summary>
+    private IObservable<ImmutableList<string>> AnsweredSoFar =>
+        nacks.Scan(ImmutableList<string>.Empty, (answered, id) => answered.Add(id));
 
     private OrleansRoutingService CreateRouter() =>
         // grainFactory: null — the shutdown branch never reaches placement (see the shutdown test).
@@ -92,6 +100,10 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
         return packaged;
     }
 
+    private IMessageDelivery PackagedInnerFailure() => Packaged(new DeliveryFailure(
+        new MessageDelivery<string>(SenderAddress, TargetAddress, "inner", Hub.JsonSerializerOptions),
+        "inner failure"));
+
     /// <summary>
     /// The mechanism, stated as an assertion so it cannot silently stop being true: after packaging
     /// the CLR-type guards the routing layer was written with are unreachable. Nothing in the fix
@@ -102,9 +114,7 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
     public void Packaging_ErasesTheGuardsInput()
     {
         var heartBeat = Packaged(new HeartBeatEvent());
-        var failure = Packaged(new DeliveryFailure(
-            new MessageDelivery<string>(SenderAddress, TargetAddress, "inner", Hub.JsonSerializerOptions),
-            "inner failure"));
+        var failure = PackagedInnerFailure();
 
         (heartBeat.Message is DeliveryFailure).Should().BeFalse();
         heartBeat.Message.GetType().HasAttribute<CanBeIgnoredAttribute>().Should().BeFalse(
@@ -117,9 +127,10 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
     /// The regression. A fire-and-forget <see cref="HeartBeatEvent"/> and a
     /// <see cref="DeliveryFailure"/> must NOT be answered, while ordinary traffic still is.
     ///
-    /// <para>Order matters and is the whole determinism story: the control is dispatched LAST
-    /// through the same synchronous branch and the same single-threaded hub, so once its NACK has
-    /// been handled any NACK for the two before it would already be in the queue.</para>
+    /// <para>Order is the whole determinism story: all three go through the same synchronous
+    /// shutdown branch and land on the same single-threaded hub, and the control goes LAST — so the
+    /// fold at the moment the control is answered already contains any answer the two before it
+    /// produced. Nothing waits for time to pass; the assertion settles on a real emission.</para>
     /// </summary>
     [Fact]
     public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_WhileOrdinaryTrafficIs()
@@ -128,23 +139,26 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
         lifetime.StopApplication();
 
         var heartBeat = Packaged(new HeartBeatEvent());
-        var failure = Packaged(new DeliveryFailure(
-            new MessageDelivery<string>(SenderAddress, TargetAddress, "inner", Hub.JsonSerializerOptions),
-            "inner failure"));
+        var failure = PackagedInnerFailure();
         var control = Packaged("ordinary-payload");
-        controlDeliveryId = control.Id;
 
-        await routing.DeliverMessage(heartBeat).FirstAsync().ToTask();
-        await routing.DeliverMessage(failure).FirstAsync().ToTask();
-        await routing.DeliverMessage(control).FirstAsync().ToTask();
+        // Cold observables: the subscribe IS the dispatch, and it runs inline here, so the three
+        // reach the hub in this order.
+        routing.DeliverMessage(heartBeat).Subscribe(_ => { });
+        routing.DeliverMessage(failure).Subscribe(_ => { });
+        routing.DeliverMessage(control).Subscribe(_ => { });
 
-        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var answered = await AnsweredSoFar.Should().Within(10.Seconds())
+            .Match(a => a.Contains(control.Id),
+                "ordinary traffic must still be answered — the fix must not silence real failures");
 
-        var answered = nackedDeliveryIds.Should().ContainSingle(
+        answered.Should().ContainSingle(
             "a [CanBeIgnored] control message has nobody awaiting it — for a permanently-gone owner "
             + "heart-beaten every interval, answering it IS the NotFound storm; and answering a "
-            + "DeliveryFailure with a DeliveryFailure loops. Ordinary traffic must still be answered.").Subject;
-        answered.Should().Be(control.Id);
+            + "DeliveryFailure with a DeliveryFailure loops").Subject
+            .Should().Be(control.Id);
+        answered.Should().NotContain(heartBeat.Id);
+        answered.Should().NotContain(failure.Id);
     }
 
     /// <summary>
@@ -159,9 +173,12 @@ public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
         var routing = CreateRouter();
         lifetime.StopApplication();
 
-        var result = await routing.DeliverMessage(Packaged(new HeartBeatEvent())).FirstAsync().ToTask();
+        var routed = new ReplaySubject<IMessageDelivery>();
+        routing.DeliverMessage(Packaged(new HeartBeatEvent())).Subscribe(routed.OnNext);
 
-        result.State.Should().Be(MessageDeliveryState.Failed);
+        var result = await routed.Should().Within(10.Seconds())
+            .Match(d => d.State == MessageDeliveryState.Failed);
+
         result.SenderWasNacked.Should().BeFalse(
             "nothing was posted, so the sender has NOT been answered — claiming otherwise suppresses "
             + "the only remaining report of the failure");

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansRouterAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansRouterAnswerOnceAfterPackagingTest.cs
@@ -1,0 +1,169 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the answer-once contract ACROSS THE PACKAGING BOUNDARY (issue #1485).
+///
+/// <para><b>The defect.</b> <c>MeshBuilder</c> hands the router
+/// <c>delivery.Package(hub.JsonSerializerOptions)</c>, which replaces the payload with
+/// <see cref="RawJson"/>. Every answer-once guard in the routing layer was written as a CLR-type
+/// test on <c>delivery.Message</c> — <c>is DeliveryFailure</c> / <c>HasAttribute&lt;CanBeIgnored&gt;</c>
+/// — so on the routed path it inspects <c>RawJson</c> and can never match. The router therefore
+/// NACKed heartbeats to a departed owner (the NotFound storm its own comments name) and could NACK
+/// a NACK.</para>
+///
+/// <para><b>The invariant.</b> A delivery's answerability is a property of the payload it was
+/// posted with, not of the envelope's current CLR type — so it must survive the erasure. The first
+/// test below is the mechanism made explicit (packaging really does erase the type), the rest are
+/// the behaviour.</para>
+///
+/// <para><b>No cluster, no mocks, no timing.</b> Same harness as
+/// <see cref="OrleansRoutingShutdownClassificationTest"/>: a real
+/// <see cref="IHostApplicationLifetime"/> drives the router into its shutdown branch (the branch
+/// that consults the guard), and a real <see cref="IMessageHub"/> sits at the sender's address so
+/// every assertion is made on the actual <see cref="DeliveryFailure"/> the router posts.</para>
+/// </summary>
+public class OrleansRouterAnswerOnceAfterPackagingTest : TestBase
+{
+    private static readonly Address SenderAddress = new("portal", "answer-once-sender");
+    private static readonly Address TargetAddress = new("SomeNamespace", "SomeNode");
+
+    /// <summary>Delivery ids the router answered with a <see cref="DeliveryFailure"/>.</summary>
+    private readonly ConcurrentQueue<string> nackedDeliveryIds = new();
+
+    /// <summary>
+    /// Completes when the POSITIVE CONTROL has been answered. It is dispatched last through the
+    /// same serial path, so its NACK arriving is the proof that the two suppressed deliveries were
+    /// fully processed — no sleep, no "wait and hope".
+    /// </summary>
+    private readonly TaskCompletionSource controlAnswered =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private string controlDeliveryId = string.Empty;
+
+    private readonly IHostApplicationLifetime lifetime;
+
+    public OrleansRouterAnswerOnceAfterPackagingTest(ITestOutputHelper output) : base(output)
+    {
+        lifetime = new HostBuilder().Build().Services.GetRequiredService<IHostApplicationLifetime>();
+        Services.AddSingleton(lifetime);
+        Services.AddSingleton<AccessService>();
+        Services.AddSingleton<IMessageHub>(sp => sp.CreateMessageHub(SenderAddress, conf => conf
+            .WithHandler<DeliveryFailure>((_, d) =>
+            {
+                nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
+                if (d.Message.Delivery.Id == controlDeliveryId)
+                    controlAnswered.TrySetResult();
+                return d.Processed();
+            })
+            .WithPostingIdentity(PostingIdentity.System)));
+    }
+
+    private IMessageHub Hub => ServiceProvider.GetRequiredService<IMessageHub>();
+
+    private OrleansRoutingService CreateRouter() =>
+        // grainFactory: null — the shutdown branch never reaches placement (see the shutdown test).
+        new(null!, ServiceProvider, ServiceProvider.GetRequiredService<ILogger<OrleansRoutingService>>());
+
+    /// <summary>
+    /// Packages exactly the way <c>MeshBuilder</c> does before calling
+    /// <c>IRoutingService.DeliverMessage</c> — this is the boundary under test.
+    /// </summary>
+    private IMessageDelivery Packaged<TMessage>(TMessage message)
+    {
+        var packaged = new MessageDelivery<TMessage>(SenderAddress, TargetAddress, message,
+                Hub.JsonSerializerOptions)
+            .Package(Hub.JsonSerializerOptions);
+        // Fail LOUD if packaging did not erase the type: every assertion below would otherwise pass
+        // for the wrong reason (a serialization error leaves the typed payload in place).
+        packaged.Message.Should().BeOfType<RawJson>(
+            "MeshBuilder packages every delivery before the router sees it — that erasure IS the defect");
+        return packaged;
+    }
+
+    /// <summary>
+    /// The mechanism, stated as an assertion so it cannot silently stop being true: after packaging
+    /// the CLR-type guards the routing layer was written with are unreachable. Nothing in the fix
+    /// changes this — the payload really is gone; what changes is that the routers no longer ask
+    /// the envelope's CLR type.
+    /// </summary>
+    [Fact]
+    public void Packaging_ErasesTheGuardsInput()
+    {
+        var heartBeat = Packaged(new HeartBeatEvent());
+        var failure = Packaged(new DeliveryFailure(
+            new MessageDelivery<string>(SenderAddress, TargetAddress, "inner", Hub.JsonSerializerOptions),
+            "inner failure"));
+
+        (heartBeat.Message is DeliveryFailure).Should().BeFalse();
+        heartBeat.Message.GetType().HasAttribute<CanBeIgnoredAttribute>().Should().BeFalse(
+            "RawJson carries no [CanBeIgnored] — the attribute belonged to the payload that was erased");
+        (failure.Message is DeliveryFailure).Should().BeFalse(
+            "a packaged DeliveryFailure is a RawJson, so `is DeliveryFailure` can never match on the routed path");
+    }
+
+    /// <summary>
+    /// The regression. A fire-and-forget <see cref="HeartBeatEvent"/> and a
+    /// <see cref="DeliveryFailure"/> must NOT be answered, while ordinary traffic still is.
+    ///
+    /// <para>Order matters and is the whole determinism story: the control is dispatched LAST
+    /// through the same synchronous branch and the same single-threaded hub, so once its NACK has
+    /// been handled any NACK for the two before it would already be in the queue.</para>
+    /// </summary>
+    [Fact]
+    public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_WhileOrdinaryTrafficIs()
+    {
+        var routing = CreateRouter();
+        lifetime.StopApplication();
+
+        var heartBeat = Packaged(new HeartBeatEvent());
+        var failure = Packaged(new DeliveryFailure(
+            new MessageDelivery<string>(SenderAddress, TargetAddress, "inner", Hub.JsonSerializerOptions),
+            "inner failure"));
+        var control = Packaged("ordinary-payload");
+        controlDeliveryId = control.Id;
+
+        await routing.DeliverMessage(heartBeat).FirstAsync().ToTask();
+        await routing.DeliverMessage(failure).FirstAsync().ToTask();
+        await routing.DeliverMessage(control).FirstAsync().ToTask();
+
+        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var answered = nackedDeliveryIds.Should().ContainSingle(
+            "a [CanBeIgnored] control message has nobody awaiting it — for a permanently-gone owner "
+            + "heart-beaten every interval, answering it IS the NotFound storm; and answering a "
+            + "DeliveryFailure with a DeliveryFailure loops. Ordinary traffic must still be answered.").Subject;
+        answered.Should().Be(control.Id);
+    }
+
+    /// <summary>
+    /// The delivery the router hands back must agree with what it actually did: a suppressed
+    /// delivery was NOT answered, so it must not claim <c>SenderWasNacked</c> — that flag is what
+    /// stops <c>MessageService</c> reporting the failure, and claiming it without posting converts
+    /// a routing failure into a silent one.
+    /// </summary>
+    [Fact]
+    public async Task SuppressedDelivery_DoesNotClaimTheSenderWasNacked()
+    {
+        var routing = CreateRouter();
+        lifetime.StopApplication();
+
+        var result = await routing.DeliverMessage(Packaged(new HeartBeatEvent())).FirstAsync().ToTask();
+
+        result.State.Should().Be(MessageDeliveryState.Failed);
+        result.SenderWasNacked.Should().BeFalse(
+            "nothing was posted, so the sender has NOT been answered — claiming otherwise suppresses "
+            + "the only remaining report of the failure");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
@@ -1,5 +1,6 @@
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Fixture;
 using Xunit;
@@ -32,9 +33,10 @@ public class RoutingTailAnswerOnceAfterPackagingTest(ITestOutputHelper output) :
     [Fact(Timeout = 60_000)]
     public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_ByTheRoutingTail()
     {
-        var nackedDeliveryIds = new ConcurrentQueue<string>();
-        var controlAnswered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var controlId = string.Empty;
+        // ReplaySubject: the assertion subscribes after the deliveries are submitted and must still
+        // see everything the tail answered.
+        var nacks = new ReplaySubject<string>();
+        var answeredSoFar = nacks.Scan(ImmutableList<string>.Empty, (answered, id) => answered.Add(id));
 
         var router = ServiceProvider.CreateMessageHub(RouterAddress, conf => conf
             .WithPostingIdentity(PostingIdentity.System)
@@ -64,9 +66,7 @@ public class RoutingTailAnswerOnceAfterPackagingTest(ITestOutputHelper output) :
             .WithPostingIdentity(PostingIdentity.System)
             .WithHandler<DeliveryFailure>((_, d) =>
             {
-                nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
-                if (d.Message.Delivery.Id == controlId)
-                    controlAnswered.TrySetResult();
+                nacks.OnNext(d.Message.Delivery.Id);
                 return d.Processed();
             }));
 
@@ -78,26 +78,25 @@ public class RoutingTailAnswerOnceAfterPackagingTest(ITestOutputHelper output) :
             return delivery;
         }
 
-        // Suppressed first, the positive control LAST: one action block, one queue, so the control's
-        // NACK arriving proves the two before it were fully processed.
+        // Suppressed first, the positive control LAST: one action block, one queue, so the fold at
+        // the moment the control is answered already contains anything the two before it produced.
         var heartBeat = Submit(new HeartBeatEvent());
         var failure = Submit(new DeliveryFailure(
             new MessageDelivery<string>(SenderAddress, UnreachableTarget, "inner", router.JsonSerializerOptions),
             "inner failure"));
-        var control = new MessageDelivery<string>(SenderAddress, UnreachableTarget, "ordinary-payload",
-            router.JsonSerializerOptions);
-        controlId = control.Id;
-        router.DeliverMessage(control);
+        var control = Submit("ordinary-payload");
 
-        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        var answered = await answeredSoFar.Should().Within(30.Seconds())
+            .Match(a => a.Contains(control.Id),
+                "an ordinary request that fails routing must still be reported to its sender");
 
-        var answered = nackedDeliveryIds.Should().ContainSingle(
+        answered.Should().ContainSingle(
             "the routing tail must apply the same answer-once contract as the router it reports for — "
             + "otherwise every suppressed NACK the router declines is simply re-posted here, and a pod "
-            + "shutdown still produces the failure storm").Subject;
-        answered.Should().Be(control.Id);
-        heartBeat.Id.Should().NotBe(control.Id);
-        failure.Id.Should().NotBe(control.Id);
+            + "shutdown still produces the failure storm").Subject
+            .Should().Be(control.Id);
+        answered.Should().NotContain(heartBeat.Id);
+        answered.Should().NotContain(failure.Id);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The ROUTING TAIL's half of the answer-once contract across the packaging boundary (issue #1485).
+///
+/// <para><b>Why fixing the routers alone is not enough.</b> A hub's route handler is
+/// <c>IRoutingService.DeliverMessage(delivery.Package(hub.JsonSerializerOptions))</c>
+/// (<c>MeshBuilder</c>), and whatever that handler returns comes back to <c>MessageService</c>'s
+/// not-on-target tail, which reports any <c>Failed</c> delivery the sender was not already told
+/// about. So the delivery <c>ReportFailure</c> inspects there is the PACKAGED one — payload
+/// <see cref="RawJson"/> — and its <c>[CanBeIgnored]</c> / <c>DeliveryFailure</c> test could not
+/// match either. Suppressing the NACK in the routers while leaving this site would simply move the
+/// same storm one level up.</para>
+///
+/// <para>The one path where this is reached in production is the router branch that returns
+/// <c>Failed</c> SYNCHRONOUSLY — <c>OrleansRoutingService</c>'s shutdown short-circuit, i.e. every
+/// pod shutdown. The route handler below returns exactly that shape (packaged, then
+/// <c>Failed(…, ShuttingDown)</c>) so the seam is exercised without a cluster.</para>
+/// </summary>
+public class RoutingTailAnswerOnceAfterPackagingTest(ITestOutputHelper output) : TestBase(output)
+{
+    private static readonly Address RouterAddress = new("mesh", "routing-tail");
+    private static readonly Address SenderAddress = new("client", "routing-tail-sender");
+    private static readonly Address UnreachableTarget = new("unreachable", "node");
+
+    [Fact(Timeout = 60_000)]
+    public async Task PackagedFireAndForgetAndNacks_AreNotAnswered_ByTheRoutingTail()
+    {
+        var nackedDeliveryIds = new ConcurrentQueue<string>();
+        var controlAnswered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controlId = string.Empty;
+
+        var router = ServiceProvider.CreateMessageHub(RouterAddress, conf => conf
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithRoutes(routes => routes.WithHandler(delivery =>
+            {
+                var targetWithoutHost = delivery.Target is not null ? delivery.Target with { Host = null } : null;
+                if (delivery.State != MessageDeliveryState.Submitted
+                    || targetWithoutHost is null
+                    || targetWithoutHost.Equals(routes.Hub.Address)
+                    // Anything not aimed at the unreachable address (notably the NACK we post back
+                    // to the sender) falls through to ordinary hosted-hub routing.
+                    || targetWithoutHost.Type != UnreachableTarget.Type)
+                    return Observable.Return(delivery);
+
+                // 🚨 EXACTLY what OrleansRoutingService's shutdown branch hands back: the delivery
+                // packaged the way MeshBuilder packages it, then Failed. The payload type the tail's
+                // guard used to test is gone by construction.
+                return Observable.Return(
+                    delivery.Package(routes.Hub.JsonSerializerOptions)
+                        .Failed($"Host is shutting down, cannot route to {targetWithoutHost}",
+                            ErrorType.ShuttingDown));
+            })));
+
+        // The sender lives under the router so the DeliveryFailure the tail posts (ResponseFor →
+        // target = delivery.Sender) reaches a real handler rather than vanishing.
+        router.GetHostedHub(SenderAddress, c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<DeliveryFailure>((_, d) =>
+            {
+                nackedDeliveryIds.Enqueue(d.Message.Delivery.Id);
+                if (d.Message.Delivery.Id == controlId)
+                    controlAnswered.TrySetResult();
+                return d.Processed();
+            }));
+
+        IMessageDelivery Submit<TMessage>(TMessage message)
+        {
+            var delivery = new MessageDelivery<TMessage>(SenderAddress, UnreachableTarget, message,
+                router.JsonSerializerOptions);
+            router.DeliverMessage(delivery);
+            return delivery;
+        }
+
+        // Suppressed first, the positive control LAST: one action block, one queue, so the control's
+        // NACK arriving proves the two before it were fully processed.
+        var heartBeat = Submit(new HeartBeatEvent());
+        var failure = Submit(new DeliveryFailure(
+            new MessageDelivery<string>(SenderAddress, UnreachableTarget, "inner", router.JsonSerializerOptions),
+            "inner failure"));
+        var control = new MessageDelivery<string>(SenderAddress, UnreachableTarget, "ordinary-payload",
+            router.JsonSerializerOptions);
+        controlId = control.Id;
+        router.DeliverMessage(control);
+
+        await controlAnswered.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        var answered = nackedDeliveryIds.Should().ContainSingle(
+            "the routing tail must apply the same answer-once contract as the router it reports for — "
+            + "otherwise every suppressed NACK the router declines is simply re-posted here, and a pod "
+            + "shutdown still produces the failure storm").Subject;
+        answered.Should().Be(control.Id);
+        heartBeat.Id.Should().NotBe(control.Id);
+        failure.Id.Should().NotBe(control.Id);
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RoutingTailAnswerOnceAfterPackagingTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Fixture;
 using Xunit;
 
@@ -97,5 +98,36 @@ public class RoutingTailAnswerOnceAfterPackagingTest(ITestOutputHelper output) :
         answered.Should().Be(control.Id);
         heartBeat.Id.Should().NotBe(control.Id);
         failure.Id.Should().NotBe(control.Id);
+    }
+
+    /// <summary>
+    /// 🚨 The stamp has to survive the JSON wire, because a participant proxy re-serializes the whole
+    /// envelope (<c>SignalRConnectionHub.DeliverMessage</c> / the gRPC registry) and the routers on
+    /// the far side apply the same contract to what comes back. This is also WHY
+    /// <see cref="AnswerPolicy.MayAnswer"/> checks the key's PRESENCE and never its value: an
+    /// <c>object</c>-valued delivery property is stamped as a <see cref="bool"/> and arrives as a
+    /// <c>JsonElement</c>, so a value comparison would quietly stop matching after exactly one hop —
+    /// the round-trip <c>MessageStormBreaker.ResolvePayloadKey</c> documents for the sibling
+    /// <c>DiagnosticKey</c> stamp.
+    /// </summary>
+    [Fact]
+    public void TheSuppressionStamp_SurvivesTheJsonWire()
+    {
+        var hub = ServiceProvider.CreateMessageHub(RouterAddress, conf => conf
+            .WithPostingIdentity(PostingIdentity.System));
+
+        var packaged = new MessageDelivery<HeartBeatEvent>(SenderAddress, UnreachableTarget,
+                new HeartBeatEvent(), hub.JsonSerializerOptions)
+            .Package(hub.JsonSerializerOptions);
+        packaged.MayAnswer().Should().BeFalse("the payload was [CanBeIgnored] before it was erased");
+
+        // Exactly the participant-proxy hop: serialize the whole envelope, deserialize it back.
+        var json = JsonSerializer.Serialize(packaged, hub.JsonSerializerOptions);
+        var roundTripped = JsonSerializer.Deserialize<IMessageDelivery>(json, hub.JsonSerializerOptions);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.MayAnswer().Should().BeFalse(
+            "the far side's routers apply the same answer-once contract, and by then BOTH the payload "
+            + "type and the value's CLR type are gone — only the property key remains");
     }
 }


### PR DESCRIPTION
Closes #1485.

## The defect

`MeshBuilder` is the **only** call site of `IRoutingService.DeliverMessage`, and it passes
`delivery.Package(routes.Hub.JsonSerializerOptions)`. `Package` replaces the payload with
`RawJson`. Every answer-once guard in the routing layer was a CLR-type test on
`delivery.Message` — `is DeliveryFailure` / `HasAttribute<CanBeIgnoredAttribute>()` — so on the
routed path it inspected `RawJson` and **could never match**.

Consequence: the routers DID NACK `[CanBeIgnored]` heartbeats to a departed owner — re-posted
every heartbeat interval, which *is* the NotFound storm the guards' own comments describe — and
COULD answer a `DeliveryFailure` with a `DeliveryFailure`.

## One thing in the issue was wrong

#1485 read the monolith `RoutingServiceBase` guards as sitting **before** packaging and therefore
still working, making the two routers "disagree in production". They do not. Both routers are
behind the same single packaging call, so the comment claiming they "both agree" was true only in
that **both were uniformly dead**. `MonolithRouterAnswerOnceAfterPackagingTest` is that claim made
executable — it fails on the pre-fix tree exactly like the Orleans one.

## The sweep found seven sites, not two

| Site | Note |
|---|---|
| `RoutingGrain.PostFailure` | in the issue |
| `OrleansRoutingService.MayAnswer` (2 call sites) | in the issue |
| `RoutingServiceBase.NackRouteFailure` | issue said this worked — it did not |
| `RoutingServiceBase.PostNotFound` | issue said this worked — it did not |
| `MonolithRoutingService.PostNotFound` | **also missing the `[CanBeIgnored]` clause outright** |
| `MessageService.NackThroughParent` | `[CanBeIgnored]` half dead behind its RawJson clause |
| `MessageService.ReportFailure` | **the routing TAIL** |

That last one matters most: `ReportRoutingFailure` reports whatever the mesh's route handler hands
back, and that handler *is* `DeliverMessage(delivery.Package(...))` — so fixing only the routers
would have moved the identical storm one level up, on the one path where a router returns `Failed`
synchronously (the Orleans shutdown short-circuit, i.e. every pod shutdown).

## The fix

Follows the precedent already inside `Package` for `IDiagnosticKeyed` (#1200): stamp the **fact**
onto the envelope immediately before the type is erased, and have every guard read the envelope via
`delivery.MayAnswer()` (new `AnswerPolicy`, in `MeshWeaver.Messaging.Contract`).

The *fact*, not the type name — the one question the routing layer asks is "may I answer this", and
a general-purpose type oracle on the envelope would invite the payload-parsing decisions this
codebase deliberately avoids. Only the **suppressed** case is stamped, so ordinary traffic pays
nothing and an unstamped delivery (never packaged, or pre-serialised by an external client) degrades
to exactly the old CLR-type behaviour — never to "answer something you must not". The property is
**presence-checked, never value-compared**: a delivery property crosses the gRPC/SignalR wire as
JSON and returns as a `JsonElement` rather than the `bool` that was stamped, which is the trap
`MessageStormBreaker.ResolvePayloadKey` documents for the sibling stamp.

## Fail-before, demonstrated

Each test was run on the pre-fix tree and is RED there — all three deliveries (heartbeat,
DeliveryFailure, ordinary control) were answered where exactly one should be:

- `OrleansRouterAnswerOnceAfterPackagingTest` — real `IHostApplicationLifetime`, real hub at the
  sender's address; `found 3`
- `MonolithRouterAnswerOnceAfterPackagingTest` — real monolith mesh, real `IRoutingService`;
  `found 3`
- `RoutingTailAnswerOnceAfterPackagingTest` — the Orleans shutdown branch's exact return shape
  (packaged, then `Failed`); `found 3` (verified by reverting just that guard and re-running)

Each also carries a positive control dispatched LAST through the same serial path, so "the
suppressed ones were processed" is proven rather than waited for. `Packaging_ErasesTheGuardsInput`
pins the mechanism itself.

## Verification

- `dotnet build -c Release -warnaserror`: `MeshWeaver.Messaging.Hub.Test`,
  `MeshWeaver.Hosting.Orleans.Test`, `MeshWeaver.Hosting.Monolith.Test` — 0 warnings, 0 errors
  (these transitively cover every touched src project and its dependents)
- `MeshWeaver.Messaging.Hub.Test` — 242/242
- `MeshWeaver.Hosting.Orleans.Test` routing suite — 19/19
- `MeshWeaver.Hosting.Monolith.Test` routing/NACK subset — 32/32
- `MeshWeaver.Documentation.Test` — 21/21 (doc edit + What's New node)

## Not in this PR

**#1486 is deliberately left open** — see the analysis posted there. Short version: its natural fix
(route the NACK through the same path forward traffic takes, instead of publishing straight to the
Orleans stream) is only *safe* once this PR has landed, because without the answer-once guard it
would create a real NACK loop. That is very likely why the direct stream publish exists at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
