### PR TITLE
docs: UI extensibility and cross-renderer authoring, plus the /ui-extensibility skill

### DIFF
--- a/content/ai/Skill/ui-extensibility.md
+++ b/content/ai/Skill/ui-extensibility.md
@@ -1,0 +1,84 @@
+---
+nodeType: Skill
+name: /ui-extensibility
+description: Extend MeshWeaver UI the right way — pick the lane (in-mesh layout-area source, compiled view pack, or core), register through the real seams, and make every addition render on Blazor, Next.js, and React Native alike.
+icon: Layout
+category: Skills
+order: 16
+---
+
+Extending the UI never means "add a page to the portal". It means picking one of three lanes and
+registering through an existing seam. Read [UI Extensibility](/Doc/Architecture/UiExtensibility)
+for the architecture and [Writing UI for Every Renderer](/Doc/GUI/CrossRendererAuthoring) for the
+cross-client rules before writing anything.
+
+# 1. Pick the lane — the decision tree
+
+1. **Can the feature be expressed as controls?** (layout areas, dialogs, menus, forms, grids —
+   no JS interop, no third-party component library, no root-DI service, no hosted service)
+   → **Lane 1: in-mesh layout-area source in a content plugin.** The default; installable and
+   removable without a deploy; renders on every client for free. Follow
+   [/layout-area](/Skill/layout-area). Remember the in-mesh limits — public framework surface
+   only, per-hub configuration only.
+2. **Does it need JS interop or a third-party component library?**
+   → **Lane 2: a view pack** — a plain class library with component types plus one registration
+   entry point. No routable pages, no App.razor tags, no router work.
+3. **Is it a generic renderer of a framework control that every deployment wants?**
+   → **Lane 3: core.** This is rare. The portal gained a hard-wired feature registration every
+   ~3 days for a month; one built-in was retired into its plugin nine days after being added.
+   Default to lanes 1–2.
+
+# 2. The view-pack recipe (lane 2)
+
+Model: `MeshWeaver.Blazor.Radzen`.
+
+- One hub entry point: `AddXxxViews(this MessageHubConfiguration c)` doing
+  `c.WithType(typeof(XControl)).AddViews(l => l.WithView<XControl, XView>())` per control.
+- **Register BEFORE `AddBlazor()`** — view maps are first-match-wins and the core default mapping
+  is terminal; a pack registered after it is silently dead.
+- **Assets are self-loaded, never shell tags**: per-component stylesheets via `<HeadContent>`;
+  classic third-party scripts via the memoized `_content/MeshWeaver.Blazor/assetLoader.js` in the
+  pack's view base class, gating the components on an `AssetsReady` flag.
+- **Never ship copies of contract assemblies** — compile against the host's
+  `MeshWeaver.Layout`/`MeshWeaver.Blazor`; a same-named second copy is the silent-null trap-door.
+- Root DI is only for services components `[Inject]` and hosted services; everything else rides
+  hub configuration.
+
+# 3. New control — definition of done
+
+A control is done when it renders on EVERY client, not when the Blazor view works:
+
+1. Immutable control record (geometry/derivation computed server-side ON the record — the
+   `TowerControl.Layout()` pattern), plus `WithType(typeof(XControl))` registration.
+2. Blazor view via the pack seam.
+3. React renderer in `clients/react/src/controls/` — the Blazor-parity ratchet
+   (`clients/react/src/render/parity.test.ts`) turns the Clients workflow red until it exists;
+   never alias or placeholder it.
+4. React Native `rnPack` entry (`clients/react-native/src/parity.test.ts` is its ratchet).
+5. Optional MAUI `MauiViewRegistry.Register` entry.
+6. Every user-visible string: `host.Localize` key in BOTH
+   `src/MeshWeaver.Messaging.Hub/Localization/strings.{en,de}.json` AND mirrored into
+   `clients/react/src/i18n/` (the drift guard fails otherwise).
+7. A `Doc/GUI` gallery page with an executable `--render` cell — the doc gate compiles and
+   renders it on every PR.
+
+# 4. Cross-renderer rules (the ones that bite)
+
+- Controls only — hand-built HTML renders as an opaque blob on JS shells.
+- The portable interaction surface is click / blur / close-dialog / bound-field edits. More than
+  that is a framework feature, not an area feature.
+- Semantic parity is NOT guaranteed by the type ratchets: verify a control's write-path semantics
+  exist in the JS pack before depending on them (the `AutoSaveAddress` lesson — edits silently
+  didn't persist on JS shells).
+- Menus are `$Menu:*` areas in the stream — chrome expressed as controls needs no parity work.
+
+# 5. Rollout
+
+Merged is not shipped. Lane 1 reaches instances through the plugin registry
+([Plugin Registry](/Doc/Architecture/PluginRegistry),
+[Plugin Update On Green Build](/Doc/Architecture/PluginUpdateOnGreenBuild)); a plugin in
+`PluginCatalog:InstallByDefault` installs unattended on a NEW instance's first boot. Lane 2 rides
+the image and activates via platform configuration
+([Feature Flags](/Doc/Architecture/FeatureFlags)). Standing up a new instance end to end is
+[Deployment](/Doc/Architecture/Deployment) — wire plugin grants and the install-by-default list as
+part of provisioning, or the instance boots bare.

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -1,0 +1,149 @@
+---
+Name: UI Extensibility
+Category: Architecture
+Description: The three lanes for shipping UI — in-mesh layout-area source, compiled view packs, and core — the seams each one plugs into, the DI layering, and the limits.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M17.5 14v7M14 17.5h7"/></svg>
+---
+
+MeshWeaver UI has exactly one contract: a **layout area emits a tree of typed controls**, and every
+renderer — Blazor Server, the React shells (portal-next and React Native), MAUI — draws that tree.
+Extending the UI therefore never means "add a page to the portal". It means one of three things,
+and picking the right one is most of the work. This page is the architecture of that choice; the
+author-facing rules for making a view render on every client are in
+[Writing UI for Every Renderer](/Doc/GUI/CrossRendererAuthoring), and the hands-on layout-area
+procedure is the [/layout-area](/Skill/layout-area) skill.
+
+## The three lanes
+
+### Lane 1 — layout-area source in a content plugin (the default)
+
+UI ships as **in-mesh C# source** (`Source/*.cs` under a NodeType), compiled at runtime in the
+portal and delivered by a content plugin — the same way `Store`, `Chess`, and `Publish/Slide` ship
+interactive UIs of four-digit line counts with zero compiled components. This is the default
+because it is the only lane that is installable, updatable, and removable **without a deploy**, and
+because a control tree renders on the React and native shells for free.
+
+What this lane can carry: layout areas, dialogs, menus, click/edit interactions, data binding —
+everything expressible in the controls language. What it cannot carry, by construction:
+
+- **JS interop or third-party component libraries** — there is no path from in-mesh source to the
+  browser's script world.
+- **Root-DI services and hosted services** — runtime-compiled node types get per-hub configuration
+  (`MeshNode.HubConfiguration`) only; the host container is sealed at startup. Control-plane
+  watchers (the exercise-validation shape) stay compiled.
+- **Cross-hub type registration** for polymorphic routing.
+- **Internal framework surface** — in-mesh compiles see public types only.
+
+If a feature fits inside those limits, it belongs in this lane. Reaching for lane 2 "because C# in
+a project is more comfortable" recreates the hard-wiring this page exists to stop.
+
+### Lane 2 — a compiled view pack (a plain class library)
+
+When a view genuinely needs JS interop or a third-party component library, it ships as a **view
+pack**: a plain class library holding component types (compiled from `.razor` at the pack author's
+build) plus one registration entry point. The portal has essentially no routable content — every
+mesh path renders through the catch-all pages — so a pack never touches the router, never adds
+pages, and never edits the HTML shell.
+
+`MeshWeaver.Blazor.Radzen` is the reference implementation:
+
+```csharp
+// The pack's single hub-side entry point — charts + pivot grid views.
+public static MessageHubConfiguration AddRadzenViews(this MessageHubConfiguration config) =>
+    config.AddRadzenDataGrid().AddRadzenCharts();
+
+// Each registration is the standard view seam:
+public static MessageHubConfiguration AddRadzenCharts(this MessageHubConfiguration config) =>
+    config.WithType(typeof(ChartControl))
+        .AddViews(layout => layout.WithView<ChartControl, RadzenChartView>());
+```
+
+A pack's static assets never go into `App.razor`. Assets that can ride Blazor's per-component
+`<HeadContent>` (theme stylesheets) do; classic third-party scripts load through the shared
+once-per-document loader (`_content/MeshWeaver.Blazor/assetLoader.js`), gated by the pack's view
+base class — `RadzenViewBase` loads `Radzen.Blazor.js` on first interactive render and its views
+render their Radzen components only once `AssetsReady` is true. The shell stays pack-free, pages
+that never show a chart never fetch Radzen, and a pack is droppable by deleting one registration
+line.
+
+Two load-bearing rules for pack authors:
+
+1. **Register before `AddBlazor()`.** View maps are first-match-wins and the core registry's
+   default mapping is currently terminal (its fallback never declines), so a pack registered after
+   the core mapping is silently dead. The portal's composition does this correctly today; treat it
+   as a contract until the planned explicit-priority fix lands.
+2. **Never ship copies of contract assemblies.** The pack compiles against the host's
+   `MeshWeaver.Layout` / `MeshWeaver.Blazor` and binds to them at load time. A same-named type from
+   a second copy is the platform's documented trap-door class — values silently read as absent.
+
+**DI layering.** The only thing a view pack genuinely needs in the *root* container is services its
+components `[Inject]` (the Blazor circuit resolves from the host container) and any hosted
+services. Everything else — view maps, hub services — rides hub configuration, which per-user
+portal hubs re-run on creation. Packs are wired by a `ProjectReference` today; the same entry
+points are consumable by boot-time assembly loading (`MeshBuilder.InstallAssemblies`, which folds a
+pack's registrations in before the container builds) once that loader is wired to configuration —
+the pack does not change between the two.
+
+### Lane 3 — core
+
+Core is for **generic renderers of framework controls** (the DataGrid, the form controls, Markdown,
+containers) and the shell (navigation, chat, reconnect, auth). The bar for adding to core is "every
+deployment wants this and it renders a framework-level control". History says the bar is applied
+too loosely: a scan of one month found a new feature registration hard-wired into the portal
+composition roughly **every three days**, and one built-in node type was added and then retired in
+favour of its plugin within nine days. When in doubt, lanes 1 and 2 are reversible; lane 3 is a
+permanent tax on the composition root.
+
+## The seams, in one table
+
+| You want to contribute… | Seam | Registered on |
+|---|---|---|
+| A renderer for a control | `AddViews(l => l.WithView<TControl, TView>())` | hub configuration (pack entry point) |
+| A named area on a node type | `LayoutDefinition.WithView(name, generator)` | the NodeType's configuration — in-mesh or compiled |
+| Default areas on every node | `AddDefaultLayoutAreas()` composition | core only — extending it puts your area on *every node in the mesh*; prefer a NodeType-scoped area |
+| A left-rail navigation for a node family | `INodeNavigationProvider` | DI singleton (pack) — claimed by node shape at render time |
+| A settings tab | `AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(...))` | hub configuration (pack or plugin hub config) |
+| Node-menu entries / presentation | `AddNodeMenuItems(...)`; menu presentation is editable data (`MenuPresentationOverlay`) | hub configuration / mesh data |
+| A home-screen tab | a `HomeTab` node | mesh data — no code at all |
+| Hub behaviour for a node type | `MeshNode.HubConfiguration` | works from in-mesh plugins at runtime |
+| Root services + nodes from a DLL | `MeshNodeProviderAttribute` + `MeshBuilder.InstallAssemblies` | boot time only |
+
+## What cannot be extended today
+
+Honesty section — these are the known walls, so nobody burns a day rediscovering them:
+
+- **HTTP endpoints.** There is no endpoint-contribution seam; `app.Map*()` calls live in the portal
+  composition. (This is what keeps the course-asset endpoint compiled in the portal.)
+- **Runtime `.razor` from mesh content.** The in-mesh compile pipeline is C#-only — there is no
+  Razor engine at runtime, and collectible recompiles would fight the Blazor renderer's
+  type-identity caching. Precompiled packs are the answer, not runtime Razor.
+- **Post-start pack loading.** View-map lists are consulted when a hub builds, but the *sources* of
+  those lists are frozen at startup today. The mutable pack registry that lifts this is planned;
+  until then packs load at boot.
+
+## Rolling out to deployments
+
+An extension is not shipped when it merges — it is shipped when instances run it. The path differs
+by lane, and platform configuration decides both:
+
+- **Lane 1 (content plugin)**: the plugin reaches every instance through the registry —
+  [Plugin Registry](/Doc/Architecture/PluginRegistry) covers grants and tokens,
+  [Deploying Plugin Changes](/Doc/Architecture/DeployingPluginChanges) the change path, and
+  [Plugin Update On Green Build](/Doc/Architecture/PluginUpdateOnGreenBuild) the auto-update
+  opt-in. A plugin listed in an instance's `PluginCatalog:InstallByDefault` installs unattended on
+  first boot — which is how a **new instance** gets its UI without a human clicking Install.
+- **Lane 2 (view pack)**: today the pack rides the image, and whether it *activates* is platform
+  configuration — see [Feature Flags](/Doc/Architecture/FeatureFlags) for the `Features:*` surface
+  the composition consults. Once boot-time loading is wired, the pack list itself becomes per-
+  deployment configuration on the same surface.
+- **Standing up a new instance end to end** — configuration order, secrets, DNS/TLS, plugin
+  wiring — is [Deployment](/Doc/Architecture/Deployment) (index),
+  [Deployment Options](/Doc/Architecture/DeploymentOptions), and for the shared cluster
+  [AKS Deployment](/Doc/Architecture/DeploymentAKS). Wire the plugin grants and
+  `InstallByDefault` list **as part of instance provisioning**, not as an afterthought — an
+  instance provisioned without them boots with a bare portal and no path to its UI.
+
+Related pages: [User Interface](/Doc/Architecture/UserInterface) ·
+[Layout Areas](/Doc/GUI/LayoutAreas) · [GUI Data Binding](/Doc/GUI/DataBinding) ·
+[Plugins](/Doc/Architecture/Plugins) ·
+[Writing UI for Every Renderer](/Doc/GUI/CrossRendererAuthoring)

--- a/src/MeshWeaver.Documentation/Data/GUI/CrossRendererAuthoring.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/CrossRendererAuthoring.md
@@ -1,0 +1,129 @@
+---
+Name: Writing UI for Every Renderer
+Category: GUI
+Description: How to author layout areas and controls so they render on Blazor, Next.js (portal-next), React Native, and MAUI alike — what auto-inherits, the parity ratchets, the new-control checklist, and the known per-renderer gaps.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="13" height="9" rx="1"/><rect x="16" y="8" width="6" height="11" rx="1"/><path d="M6 17h5M8.5 13v4"/></svg>
+---
+
+MeshWeaver UI is **server-driven**: a layout area computes a tree of typed controls in a per-node
+hub, and every client renders that tree — Blazor Server, the Next.js shell (portal-next), the React
+Native app, and MAUI. Because the tree is the contract, *most UI work inherits into every client
+automatically*. This page is the author's guide to keeping it that way: what you get for free, the
+rules that preserve it, and the exact checklist when you add a new control.
+
+The architecture of the extension lanes is [UI Extensibility](/Doc/Architecture/UiExtensibility);
+the layout-area procedure itself is the [/layout-area](/Skill/layout-area) skill.
+
+## What auto-inherits — and why
+
+The JS shells are not ports of the Blazor portal. They subscribe to the same live streams the
+Blazor renderer uses: a `SubscribeRequest` with a `LayoutAreaReference` yields versioned frames
+(full, then JSON patches), and interactions flow back as the same small event set. Everything that
+lives *in the control tree* therefore renders everywhere with zero client work:
+
+- layout areas, containers, grids, tabs, markdown, DataGrids, forms and their two-way bindings;
+- dialogs and click actions (`WithClickAction`, `DialogControl`);
+- **menus** — the node/mesh/AI menus are `$Menu:*` areas *inside the same stream*, i.e. protocol
+  data, not client code. This is the model case: chrome expressed as controls needs no parity work,
+  ever.
+
+What does **not** inherit is anything outside the tree: shell-level access gates, and any semantics
+a client must implement per control (see the parity section).
+
+## The five rules
+
+1. **Controls only, never markup.** `Controls.Html` with hand-built markup renders as an opaque
+   blob on the JS shells at best. Structured data goes through `Controls.DataGrid`, composition
+   through `Controls.Stack` / `Controls.LayoutGrid` — the same rule the
+   [/layout-area](/Skill/layout-area) skill states for Blazor, with double force here.
+
+2. **Geometry and derivation live in the control, not the view.** If a visual needs computed
+   layout, compute it server-side into the control record so every renderer draws the *result*.
+   The analysis controls are the precedent: `TowerControl.Layout()` resolves the band geometry in
+   `MeshWeaver.Layout`, and the Blazor, React, and MAUI views all render the same resolved rows.
+   A view that derives geometry client-side has to be written four times — and will drift.
+
+3. **Check semantic parity before relying on advanced control behaviour.** The parity ratchets
+   (below) guarantee every control *type* has a renderer in every pack — they cannot guarantee
+   every *behaviour*. Real example: `MarkdownEditorControl.AutoSaveAddress` was implemented in
+   Blazor and silently ignored by the JS packs — edits in auto-save views did not persist there,
+   and nothing failed. When your area depends on a control's write-path or side-effect semantics,
+   verify the JS pack implements it (or file the gap) before shipping.
+
+4. **Localize through the catalog — and mirror the keys.** Server-rendered text uses
+   `host.Localize("key")` with the key in both `strings.en.json` and `strings.de.json`
+   (`src/MeshWeaver.Messaging.Hub/Localization/`). 🚨 Every new key has a **second home**:
+   `clients/react/src/i18n/` bundles a byte-identical copy so the JS shells resolve synchronously,
+   and `localize.test.ts` is a drift guard asserting key-and-value equality — add a key server-side
+   only and the `Clients` workflow goes red while a JS client would render the raw key. Prefer
+   glyphs over words where possible, and see [Localization](/Doc/Architecture/Localization) for the
+   `[Translation]` attribute path for declaration-bound text.
+
+5. **Stay inside the interaction surface.** The events every client speaks are: click, blur,
+   close-dialog, and field edits (a JSON patch against the bound pointer). An interaction that
+   needs more than these — drag, keyboard chords, scroll observation — is a *framework/pack*
+   feature, not something a layout area can express portably.
+
+## Known per-renderer gaps (as of 2026-08)
+
+Be honest with yourself about these when designing a view:
+
+| Capability | Blazor | portal-next / RN |
+|---|---|---|
+| Monaco completions + live diagnostics | yes | value binding only — no LSP yet |
+| CollaborativeMarkdown annotations (accept/reject, threads) | yes | read-only render |
+| `AutoSaveAddress` editors | yes | gap — tracked, verify before relying on it |
+| Content bytes (`/api/content`) behind auth in `<img>` | cookie session | needs the signed-URL work |
+
+Every control *type* renders on every shell — the packs pass a zero-missing, zero-placeholder
+ratchet — so the gaps above are semantic, not structural, and each is on the universal-protocol
+work list.
+
+## Adding a new control: the checklist
+
+A new control is not done when the Blazor view renders. The definition of done:
+
+1. **The control record** in `MeshWeaver.Layout` (or your view pack): an immutable record deriving
+   from `UiControl`, with any visual derivation as a server-side method on the record (rule 2). Add
+   a `Controls.X(...)` factory only if the control is framework-level.
+2. **Serialization registration**: `config.WithType(typeof(XControl))` wherever the views register
+   — an unregistered `$type` degrades to an untyped `JsonElement` and renders empty.
+3. **The Blazor view**: via the pack seam
+   (`AddViews(l => l.WithView<XControl, XView>())`) for packs, or the core registry for
+   framework controls.
+4. **The React renderer**: a component in `clients/react/src/controls/` wired into the render
+   registry. The Blazor-parity ratchet (`clients/react/src/render/parity.test.ts`) scrapes the
+   core registry's control list and **fails on any missing or placeholder entry** — a new core
+   control turns the `Clients` workflow red until the React side exists. That is deliberate: the
+   ratchet is what keeps "renders everywhere" true. React-side patterns:
+   [React](/Doc/GUI/React) · [React Custom Controls](/Doc/GUI/ReactCustomControls).
+5. **The React Native pack**: the `rnPack` entry plus its own parity test
+   (`clients/react-native/src/parity.test.ts`). RN consumes the shared renderer core, so most
+   controls are a thin mapping; native-feeling leaves (HTML, editors) have RN-specific views.
+6. **MAUI** (optional but cheap): a `MauiViewRegistry.Register<XControl, XView>()` entry — see
+   [MAUI Data Binding](/Doc/GUI/DataBindingMaui).
+7. **Localization** of any user-visible strings per rule 4 — both catalogs, both homes.
+8. **A gallery/doc page** under `Doc/GUI` with an executable `--render` cell, so the control is
+   discoverable and its example is compiled and rendered by the doc gate on every PR.
+
+For steps 4–5 the wire shape matters: the client sees your control as camelCase JSON with a
+`$type` discriminator, patches arrive as RFC 6902 against the area document, and collection keys
+arrive JSON-encoded. The protocol reference lives in the repo at
+`clients/react/docs/live-protocol.md`.
+
+## Testing across renderers
+
+- **Server-side**: a layout-area render test (the `Tests` area pattern that `mw-plugin-test`
+  executes, or an `AreaProbe`-based test) proves the control tree materializes — this covers every
+  renderer's *input*.
+- **JS shells**: the two parity ratchets prove coverage; component-level tests live next to the
+  React controls (vitest). The shells' own suites (portal-next, RN) run in the `Clients` workflow
+  on every PR.
+- **What a green Blazor test does not prove**: any behaviour in rule 3's category. If the JS pack
+  lacks the semantic, no existing test fails — which is exactly why the checklist puts the React
+  renderer in the definition of done rather than in a follow-up.
+
+Related: [UI Extensibility](/Doc/Architecture/UiExtensibility) ·
+[Layout Areas](/Doc/GUI/LayoutAreas) · [GUI Data Binding](/Doc/GUI/DataBinding) ·
+[React](/Doc/GUI/React) · [React Custom Controls](/Doc/GUI/ReactCustomControls) ·
+[Localization](/Doc/Architecture/Localization)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-ui-extensibility-docs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-ui-extensibility-docs.md
@@ -1,0 +1,16 @@
+---
+Name: UI extensibility guide, for every renderer
+Category: Feature
+Description: New documentation on extending the UI — plugins, view packs, and how to write views that render on the web portal, Next.js, and the mobile app alike — plus the /ui-extensibility skill.
+Icon: Sparkle
+Order: -20260814
+---
+
+# UI extensibility guide, for every renderer
+
+Two new documentation pages explain how to extend the platform's UI: which of the three lanes a
+feature belongs in (content plugin, view pack, or core), the seams each one plugs into, and how to
+roll an extension out to deployments. A companion page covers writing views that render on the web
+portal, the Next.js shell, and the mobile app alike — what inherits automatically, the parity
+checklists, and the definition of done for a new control. The new /ui-extensibility skill gives
+agents the same guidance in procedure form.


### PR DESCRIPTION
From the modularization program: the author-facing documentation for the injectable-UI direction.

- **Doc/Architecture/UiExtensibility** — the three lanes (content-plugin layout-area source / compiled view pack / core), the seams table, the Radzen-modeled pack recipe (register-before-AddBlazor ordering contract, self-loaded assets, no copied contract assemblies), DI layering, the cannot-extend-today list, and rollout via platform configuration (FeatureFlags, plugin registry `InstallByDefault` for unattended **new-instance** provisioning, Deployment pages).
- **Doc/GUI/CrossRendererAuthoring** — writing views that render on **Next.js (portal-next) and React Native** as well as Blazor: what auto-inherits, the five rules, the per-renderer gap table, and the new-control definition of done including both parity ratchets and the dual-home i18n keys.
- **/ui-extensibility skill** — the procedure form for agents.

**Verification**: `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` green; skill catalog/round-trip/section tests 10/10. The doc-gate job additionally compiles the Doc tree on this PR.

What's New entry included (Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)