### PR TITLE
fix(#1470,#1471): the read layer stops collapsing distinguishable failures into absence

### DIFF
--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -308,6 +308,36 @@ public record GetDataResponse(object? Data, long Version)
     /// Error message if the request failed.
     /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Why <see cref="Data"/> is null, when the owner knows a reason the caller must be able to
+    /// tell apart from ordinary absence. Defaults to <see cref="DataAbsenceReason.Unspecified"/>,
+    /// which serialises away (<c>DefaultIgnoreCondition=WhenWritingDefault</c>) — only a
+    /// non-default reason travels, so nothing changes for the overwhelming majority of reads.
+    /// </summary>
+    public DataAbsenceReason Absence { get; init; }
+}
+
+/// <summary>
+/// Why a <see cref="GetDataResponse"/> carries no data. Exists because a null
+/// <see cref="GetDataResponse.Data"/> is NOT one fact: "there is nothing here" and "there is
+/// something here and it is being deleted" are different answers, and a caller that treats the
+/// second as the first re-creates what a user just deleted (Systemorph/MeshWeaver#1471).
+/// </summary>
+public enum DataAbsenceReason
+{
+    /// <summary>
+    /// No reason recorded — the ordinary case: data is present, or absent because there is
+    /// nothing at the reference.
+    /// </summary>
+    Unspecified,
+
+    /// <summary>
+    /// The entity exists but its DELETE is in flight, so the owner answered with its tombstone
+    /// rather than the stale content (<c>MeshDataSource.AddReadValidatorPipeline</c>). TRANSIENT
+    /// and directional — the next authoritative answer is "gone", never "here again".
+    /// </summary>
+    DeleteInProgress,
 }
 
 /// <summary>

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1815,6 +1815,17 @@ public static class DataExtensions
     /// <para>Silence on a LIVE hub is therefore preserved exactly as before — this change never
     /// makes a healthy read louder, only a dying one honest. The disposal arm needs no such gate:
     /// it cannot run except during teardown.</para>
+    ///
+    /// <para>🚨 <b>THREE terminals, ONE answer.</b> Besides the empty completion and this hub's
+    /// disposal, the read can FAULT with a <see cref="HubDisposingException"/> — the stream
+    /// refusing to exist because hosted-hub creation is frozen (an ancestor's disposal freezes the
+    /// whole subtree while this hub still reads <c>Started</c>). That fault used to be swallowed by
+    /// the catch-all into a <c>GetDataResponse{Error}</c>, which claimed the answer slot and turned
+    /// a transient teardown into a reported ABSENCE — #1470, and the reason
+    /// <see cref="ErrorType.ShuttingDown"/> never reached the caller in the CI red. It now takes
+    /// the same NACK path as the other two: the <c>Catch</c> re-throws a hub-disposal fault, and the
+    /// Subscribe's error arm answers it. All three terminals go through the SAME CAS, so a
+    /// completion racing a disposal racing a fault still yields exactly one answer.</para>
     /// </summary>
     private static IMessageDelivery HandleGetDataRequest(IMessageHub hub, IMessageDelivery<GetDataRequest> request)
     {
@@ -1839,8 +1850,27 @@ public static class DataExtensions
 
                 return GetDataResponseObservable(hub, request.Message.Reference, request.Message);
             })
-            .Catch<GetDataResponse, Exception>(ex =>
-                Observable.Return(new GetDataResponse(null, 0) { Error = ex.Message }))
+            // 🚨 A TEARDOWN FAULT IS NOT A READ RESULT — it must not be answerable as one.
+            // This Catch used to swallow EVERY exception into a GetDataResponse{Error}, and
+            // that fabricated "success" CLAIMED THE ONCE-ONLY ANSWER SLOT: the NACK below could
+            // no longer fire, GetMeshNode mapped the empty response to null, and its re-probe —
+            // which lives only in the OnError arm — never ran. So a read serviced by a hub whose
+            // hosted-hub creation is frozen was reported to the caller as "this node does not
+            // exist". In CI the message read verbatim `Error = Exception has been thrown by the
+            // target of an invocation` — the reflective Reduce wrapping
+            // SynchronizationStream's HubDisposingException (#1470). That is #1362 reproduced by
+            // its own fix: #1362 closed the case where the request produced NO answer; this was
+            // the same request producing a WRONG one, from the line above.
+            //
+            // A HubDisposingException is PROOF of a teardown (hosted-hub creation being frozen is
+            // the authoritative "this hub is part of a shutdown" signal — IMessageHub.IsShuttingDown
+            // — and the exception names the hub), so unlike the empty-completion arm below it needs
+            // no IsWindingDown gate: there is no healthy-hub case in which it is a lie. Rethrow so
+            // the terminal is decided in exactly one place — the error arm — and the CAS keeps it a
+            // single answer.
+            .Catch<GetDataResponse, Exception>(ex => HubDisposingException.IsHubDisposal(ex)
+                ? Observable.Throw<GetDataResponse>(ex)
+                : Observable.Return(new GetDataResponse(null, 0) { Error = ex.Message }))
             .Subscribe(
                 response =>
                 {
@@ -1848,6 +1878,23 @@ public static class DataExtensions
                     // state at 1 and keep shipping, exactly as before.
                     Interlocked.CompareExchange(ref state, 1, 0);
                     hub.Post(response, o => o.ResponseFor(request));
+                },
+                ex =>
+                {
+                    // Only a hub-disposal fault reaches here — every other exception was converted
+                    // to a value by the Catch above, so this arm cannot swallow an ordinary error.
+                    if (!TryClaimSilentTerminal())
+                        return;
+                    // 🚨 Name the ROOT cause, not the wrapper. The reflective reduce hands us a
+                    // TargetInvocationException whose own message is the useless "Exception has
+                    // been thrown by the target of an invocation" — the exact string the CI red
+                    // reported, which says nothing about what happened.
+                    var cause = FindHubDisposal(ex) ?? ex;
+                    NackSilentRead(hub, request,
+                        "the read faulted because the owning hub is shutting down — its hosted-hub "
+                        + "creation is frozen, so the data stream for this reference could not be "
+                        + $"created ({cause.GetType().Name}: {cause.Message}). Retry against the "
+                        + "fresh activation.");
                 },
                 () =>
                 {
@@ -1882,6 +1929,34 @@ public static class DataExtensions
                     + "shutting down and never produced a value. Retry against the fresh activation.");
         }));
         return request.Processed();
+    }
+
+    /// <summary>
+    /// The <see cref="HubDisposingException"/> inside <paramref name="exception"/> — itself, or the
+    /// first one down its inner-exception chain — or <c>null</c> when there is none. Mirrors
+    /// <see cref="HubDisposingException.IsHubDisposal"/>'s walk (same depth cap, same reason: a
+    /// handler fault reaches us WRAPPED, deepest observed
+    /// <c>TargetInvocationException → HubDisposingException</c>) but returns the exception so the
+    /// NACK can quote a cause that means something.
+    /// </summary>
+    private static Exception? FindHubDisposal(Exception? exception) => FindHubDisposal(exception, depth: 0);
+
+    private static Exception? FindHubDisposal(Exception? exception, int depth)
+    {
+        // depth caps the walk for the same reason IsHubDisposal caps its own: an exception graph is
+        // caller-supplied data, and AggregateException fan-out makes the traversal a tree.
+        if (depth > 16)
+            return null;
+        for (var e = exception; e is not null; e = e.InnerException)
+        {
+            if (e is HubDisposingException)
+                return e;
+            if (e is AggregateException agg)
+                foreach (var inner in agg.InnerExceptions)
+                    if (FindHubDisposal(inner, depth + 1) is { } found)
+                        return found;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-something-busy-no-longer-reads-as-something-gone.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-something-busy-no-longer-reads-as-something-gone.md
@@ -1,0 +1,36 @@
+---
+Name: Something busy no longer reads as something gone
+Category: Fix
+Description: Two ways the platform could report "this doesn't exist" when it actually meant "I couldn't look right now" — one of which let a replica re-create content you had just deleted.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Something busy no longer reads as something gone
+
+When you ask the platform for a page, a note or any other item, there are several honest answers.
+"Here it is." "There is nothing here." "It is being deleted right now." "I could not reach it just
+this second." Until now the last three all came back looking identical — as *nothing here* — and
+that turns a moment's disturbance into a statement of fact.
+
+Two consequences, both fixed.
+
+**A page being restarted no longer reports itself as missing.** Parts of the platform recycle
+routinely: after an update, after an edit that needs recompiling, whenever a page is moved between
+machines. Ask for something in the second or two while its owner is winding down, and the answer
+used to be "this does not exist" — with the real reason ("shutting down, ask again") replaced by an
+unreadable internal message. Anything that would have simply waited and retried instead concluded
+the item was gone. The recycle window now answers honestly, so the retry that was already built in
+actually happens and you get your content.
+
+**Replicated spaces no longer resurrect something you deleted.** When a space is mirrored to another
+instance, the mirror periodically compares both sides. If you deleted an item and the mirror looked
+in the moment between "delete accepted" and "delete finished", it saw *nothing here* and helpfully
+put the item back — from the copy the other side had not caught up on yet. Worse, the copy that came
+back could mask the deletion so it never reached the other instance at all, leaving the two sides
+permanently disagreeing. The mirror now recognises a delete in progress and stays out of its way,
+and it will no longer treat a failed lookup as evidence that something is absent — so a brief
+network hiccup can neither overwrite your newer content with an older copy nor delete the far side's.
+
+Nothing you can see changes when everything is healthy. What changes is what happens in the
+seconds when it is not.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -485,7 +485,16 @@ public static class MeshDataSourceExtensions
             if (cache?.IsDeleted == true
                 || recentlyDeleted?.IsRecentlyDeleted(hub.Address.Path) == true)
             {
-                hub.Post(new GetDataResponse(null, 0), o => o.ResponseFor(delivery));
+                // 🚨 SAY WHY IT IS NULL. This tombstone is null BY DESIGN, and for years it was
+                // indistinguishable on the wire from "there is nothing at this path" — so
+                // InstanceSyncWorker.PullOne read it as "absent ⇒ create it" and re-applied a node
+                // whose delete was still in flight (#1471). The reason field is what lets a caller
+                // that must not resurrect (a replicator, an importer, an upsert) tell the two
+                // apart; callers that legitimately treat both as absence (GetMeshNode's documented
+                // MeshNode? contract) are unaffected.
+                hub.Post(
+                    new GetDataResponse(null, 0) { Absence = DataAbsenceReason.DeleteInProgress },
+                    o => o.ResponseFor(delivery));
                 return Observable.Return(delivery.Processed());
             }
 

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -159,12 +159,29 @@ public sealed class InstanceSyncWorker : IDisposable
     {
         if (disposed) return;
         if (!InstanceSyncService.IsSyncablePath(evt.Path, SpacePath)) return;
-        // 🚨 The suppression slot swallows the echo of a pull-apply — and a pull-apply is a
-        // CreateOrUpdate, never a delete (see ApplyLocal). So a local Deleted event is by
-        // construction NOT that echo, and swallowing it drops the deletion from the manifest
-        // permanently: the remote keeps a node the user deleted here, with no reconciliation to
-        // re-derive it. Match on the kind so the slot can only consume what it could have caused.
-        if (evt.Kind != MeshChangeKind.Deleted && appliedInbound.TryRemove(evt.Path, out _)) return;
+        // 🚨 The slot is CONSUMED by whichever event arrives first, but only a NON-delete is
+        // SUPPRESSED. Those two used to be one act, and both couplings are wrong in a different
+        // direction:
+        //
+        //  * Consume-and-suppress together (the original) swallowed a local Deleted as if it were
+        //    the echo of a pull-apply. It never was — ApplyLocal is a CreateOrUpdate and cannot
+        //    produce a Deleted — and the deletion was then dropped from the manifest permanently,
+        //    leaving the remote holding a node the user deleted here.
+        //  * Suppress-and-consume together (leave the slot when a Deleted passes) LEAKS. The slot
+        //    is normally retired by its own echo, but a pull-apply that turns out to be a no-op
+        //    write produces NO echo at all, and the stale slot then swallows the next GENUINE
+        //    local change for that path — silent non-replication, which is worse.
+        //
+        // Consuming on a Deleted means the echo that follows is no longer suppressed and re-enters
+        // the manifest, where Coalesce (per path, latest wins) replaces the Deleted entry with it.
+        // That interleaving IS reachable — the apply's echo is a multi-hop round trip and a user
+        // delete can land inside it. It is nevertheless safe, but for ONE specific reason, which is
+        // therefore load-bearing: DrainOne resolves each entry against the CURRENT local state
+        // rather than trusting the recorded kind, so the node being gone makes the push degrade to
+        // a delete. If that ever changes, this comment is the thread to pull — and
+        // A_pending_content_change_pushes_a_DELETE_when_the_local_node_is_being_deleted pins it.
+        var hadPendingEcho = appliedInbound.TryRemove(evt.Path, out _);
+        if (hadPendingEcho && evt.Kind != MeshChangeKind.Deleted) return;
         if (lastKnownConfig is { Direction: InstanceSyncDirection.PullOnly }) return;
 
         // System scope: feed callbacks carry no ambient AccessContext (fails closed otherwise).
@@ -296,6 +313,14 @@ public sealed class InstanceSyncWorker : IDisposable
     /// delete in flight, which is heading for exactly that) degrades to a delete; an unreadable
     /// local node fails the ENTRY, which keeps it pending and surfaces on the node as LastError
     /// (see <see cref="DrainPending"/>) instead of silently destroying data.</para>
+    ///
+    /// <para>🚨 <b>Resolving against the CURRENT local state — not the recorded
+    /// <see cref="PendingChange.Kind"/> — is load-bearing beyond this method.</b> It is what makes
+    /// <see cref="OnLocalChange"/> safe to consume its echo-suppression slot on a Deleted: an echo
+    /// that then escapes suppression can coalesce OVER the Deleted manifest entry, and the only
+    /// thing that stops that resurrecting the remote copy is the read below reporting
+    /// <see cref="NodeReadStatus.Absent"/> / <see cref="NodeReadStatus.DeleteInProgress"/> and this
+    /// degrading to a delete. Do not "optimise" that read away for non-delete kinds.</para>
     /// </summary>
     private IObservable<bool> DrainOne(IRemoteMeshClient remote, InstanceSyncConfig cfg, PendingChange change)
     {

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -159,7 +159,12 @@ public sealed class InstanceSyncWorker : IDisposable
     {
         if (disposed) return;
         if (!InstanceSyncService.IsSyncablePath(evt.Path, SpacePath)) return;
-        if (appliedInbound.TryRemove(evt.Path, out _)) return;
+        // 🚨 The suppression slot swallows the echo of a pull-apply — and a pull-apply is a
+        // CreateOrUpdate, never a delete (see ApplyLocal). So a local Deleted event is by
+        // construction NOT that echo, and swallowing it drops the deletion from the manifest
+        // permanently: the remote keeps a node the user deleted here, with no reconciliation to
+        // re-derive it. Match on the kind so the slot can only consume what it could have caused.
+        if (evt.Kind != MeshChangeKind.Deleted && appliedInbound.TryRemove(evt.Path, out _)) return;
         if (lastKnownConfig is { Direction: InstanceSyncDirection.PullOnly }) return;
 
         // System scope: feed callbacks carry no ambient AccessContext (fails closed otherwise).
@@ -281,6 +286,17 @@ public sealed class InstanceSyncWorker : IDisposable
             });
     }
 
+    /// <summary>
+    /// Pushes one manifest entry. Same rule as <see cref="PullOne"/>, mirrored: the local read
+    /// decides between PUSH and DELETE-REMOTE, so it may not collapse its failure modes.
+    ///
+    /// <para>🚨 This used to read <c>GetMeshNode(...).Catch(_ =&gt; null)</c> and delete the REMOTE
+    /// node on any <c>null</c> — so a transient local read failure destroyed the remote copy.
+    /// "Deleted here" and "I could not look" are now different inputs: only a real absence (or a
+    /// delete in flight, which is heading for exactly that) degrades to a delete; an unreadable
+    /// local node fails the ENTRY, which keeps it pending and surfaces on the node as LastError
+    /// (see <see cref="DrainPending"/>) instead of silently destroying data.</para>
+    /// </summary>
     private IObservable<bool> DrainOne(IRemoteMeshClient remote, InstanceSyncConfig cfg, PendingChange change)
     {
         var remotePath = InstanceSyncService.RemapPath(change.Path, SpacePath, RemoteSpaceOf(cfg));
@@ -289,11 +305,22 @@ public sealed class InstanceSyncWorker : IDisposable
 
         // Push the node's CURRENT content; a node deleted since the change was observed
         // degrades to a delete.
-        return hub.GetMeshNode(change.Path, TimeSpan.FromSeconds(15))
-            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
-            .SelectMany(local => local is null
-                ? DeleteRemote(remote, remotePath)
-                : PushNode(remote, cfg, local).Select(_ => true));
+        return hub.GetMeshNodeOutcome(change.Path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+            .SelectMany(outcome => outcome.Status switch
+            {
+                NodeReadStatus.Present => PushNode(remote, cfg, outcome.Node!).Select(_ => true),
+                NodeReadStatus.Absent => DeleteRemote(remote, remotePath),
+                // The local delete is in flight; the authoritative next state is "gone", and the
+                // manifest holds a Deleted entry for it too. Pushing the delete now is idempotent.
+                NodeReadStatus.DeleteInProgress => DeleteRemote(remote, remotePath),
+                NodeReadStatus.Unavailable => Observable.Throw<bool>(new InvalidOperationException(
+                    $"Cannot push {change.Path}: the local node could not be read "
+                    + $"({outcome.Failure?.Message}). Leaving the change pending rather than "
+                    + "deleting the remote copy on evidence that does not exist.")),
+                // A status this switch predates — never destroy the remote on it.
+                _ => Observable.Throw<bool>(new InvalidOperationException(
+                    $"Cannot push {change.Path}: unhandled read outcome '{outcome.Status}'.")),
+            });
     }
 
     private static IObservable<bool> DeleteRemote(IRemoteMeshClient remote, string remotePath) =>
@@ -428,6 +455,23 @@ public sealed class InstanceSyncWorker : IDisposable
     /// content is dropped (convergence guard), and the local write registers the path in the
     /// consume-once suppression registry FIRST so its own change-feed echo never re-enters the
     /// manifest. Emits whether a local write happened.
+    ///
+    /// <para>🚨 <b>The local read decides whether to WRITE, so it may not collapse its failure
+    /// modes.</b> This used to read <c>GetMeshNode(...).Catch(_ =&gt; null)</c> and treat any
+    /// <c>null</c> as "not there ⇒ create it" — but that one <c>null</c> meant three different
+    /// things: genuine absence, the owner's delete-in-progress TOMBSTONE (null by design), and
+    /// "the read failed". So a node whose delete was in flight got re-applied — a resurrection of
+    /// what a user had just deleted — and a transient read failure would equally have clobbered a
+    /// live local node with an older remote copy. <see cref="NodeReadStatus"/> keeps the three
+    /// apart, and the switch below has to NAME each one it acts on — with the fall-through arm
+    /// being the one that does not write (Systemorph/MeshWeaver#1471).</para>
+    ///
+    /// <para>🚨 <b><c>lastSeenRemote</c> is stamped only once the hit has actually been dealt
+    /// with.</b> Stamping it up front made every bad decision PERMANENT: the stamp is what
+    /// <see cref="HasRemoteStampMoved"/> uses to skip a hit, so a failed apply — or a hit skipped
+    /// because the local delete was still in flight — was never looked at again, with no path back
+    /// to correctness short of a remote edit. A skip that is not a decision therefore leaves the
+    /// stamp alone and the next sweep re-decides.</para>
     /// </summary>
     private IObservable<bool> PullOne(IRemoteMeshClient remote, InstanceSyncConfig cfg, RemoteSearchHit hit) =>
         remote.Get(hit.Path).SelectMany(remoteNode =>
@@ -437,24 +481,62 @@ public sealed class InstanceSyncWorker : IDisposable
                 lastSeenRemote.TryRemove(hit.Path, out _);
                 return Observable.Return(false);
             }
-            lastSeenRemote[hit.Path] = (remoteNode.Version, remoteNode.LastModified);
             var localPath = InstanceSyncService.RemapPath(hit.Path, RemoteSpaceOf(cfg), SpacePath);
-            return hub.GetMeshNode(localPath, TimeSpan.FromSeconds(15))
-                .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
-                .SelectMany(local =>
+            // EmitNull, so an unanswered read arrives as Unavailable (indeterminate) instead of
+            // throwing and aborting the whole sweep. It is still NEVER read as absence.
+            return hub.GetMeshNodeOutcome(localPath, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+                .SelectMany(outcome => outcome.Status switch
                 {
-                    if (local is not null && service.ContentEquals(local, remoteNode))
-                        return Observable.Return(false);
-                    // Newest writer wins; ties keep the local side (the push direction owns it).
-                    if (local is not null && local.LastModified >= remoteNode.LastModified)
-                        return Observable.Return(false);
-                    var payload = InstanceSyncService.RebaseNode(remoteNode, localPath);
-                    appliedInbound[localPath] = 1;
-                    return ApplyLocal(payload)
-                        .Do(_ => logger?.LogDebug("Instance sync pulled {Path} from {Url}", localPath, cfg.RemoteUrl))
-                        .Select(_ => true)
-                        .Do(_ => { }, ex => appliedInbound.TryRemove(localPath, out _));
+                    NodeReadStatus.Present => Decide(outcome.Node!),
+                    NodeReadStatus.Absent => Apply(),
+                    // The local node is being deleted. Re-applying the remote copy would resurrect
+                    // it, and — because the apply registers the path in the echo-suppression slot —
+                    // could swallow the very Deleted event that has to be pushed to the remote.
+                    // Skip WITHOUT stamping: the next sweep decides against the settled state.
+                    NodeReadStatus.DeleteInProgress => Skip(
+                        "its local delete is still in flight"),
+                    // The read established nothing. "I could not look" is not "it is not there".
+                    NodeReadStatus.Unavailable => Skip(
+                        $"the local node could not be read ({outcome.Failure?.Message})"),
+                    // A status this switch predates. The conservative direction is the one that
+                    // does NOT write — but say so, because silence is how the three-way collapse
+                    // above stayed invisible for so long.
+                    _ => Skip($"unhandled read outcome '{outcome.Status}'"),
                 });
+
+            IObservable<bool> Decide(MeshNode local)
+            {
+                if (service.ContentEquals(local, remoteNode))
+                    return Settled(false);
+                // Newest writer wins; ties keep the local side (the push direction owns it).
+                if (local.LastModified >= remoteNode.LastModified)
+                    return Settled(false);
+                return Apply();
+            }
+
+            IObservable<bool> Apply()
+            {
+                var payload = InstanceSyncService.RebaseNode(remoteNode, localPath);
+                appliedInbound[localPath] = 1;
+                return ApplyLocal(payload)
+                    .Do(_ => logger?.LogDebug("Instance sync pulled {Path} from {Url}", localPath, cfg.RemoteUrl))
+                    .SelectMany(_ => Settled(true))
+                    .Do(_ => { }, ex => appliedInbound.TryRemove(localPath, out _));
+            }
+
+            // This remote stamp has been dealt with — record it so steady-state sweeps skip the hit.
+            IObservable<bool> Settled(bool applied)
+            {
+                lastSeenRemote[hit.Path] = (remoteNode.Version, remoteNode.LastModified);
+                return Observable.Return(applied);
+            }
+
+            IObservable<bool> Skip(string reason)
+            {
+                logger?.LogDebug("Instance sync {Config}: not pulling {Path} — {Reason}; "
+                                 + "the next sweep will re-decide", ConfigPath, localPath, reason);
+                return Observable.Return(false);
+            }
         });
 
     /// <summary>Applies a pulled node under the system identity — an infrastructure write, the

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1778,6 +1778,16 @@ public static class MeshNodeStreamExtensions
     /// </para>
     ///
     /// <para>
+    /// 🚨 The remaining collapse is deliberate and named: "genuinely absent", "being deleted"
+    /// and "could not be read" all arrive here as <c>null</c>, because that IS what most callers
+    /// want and changing this signature would sweep 100+ of them for no gain. A caller for which
+    /// those differ — anything that CREATES, re-applies or persists on absence — must read
+    /// <see cref="GetMeshNodeOutcome"/> instead, which is this same read with the distinction
+    /// kept. <c>InstanceSyncWorker.PullOne</c> is what happens otherwise: it re-created a node
+    /// whose delete was in flight (Systemorph/MeshWeaver#1471).
+    /// </para>
+    ///
+    /// <para>
     /// For a <b>live</b> single-node subscription that re-emits on every change,
     /// use <see cref="GetMeshNodeStream(IWorkspace, string)"/> instead â€” and stay
     /// subscribed (no <c>.Take(1)</c>). See <c>Doc/Architecture/AsynchronousCalls.md</c>.
@@ -1798,7 +1808,44 @@ public static class MeshNodeStreamExtensions
     public static IObservable<MeshNode?> GetMeshNode(this IMessageHub hub, string path,
         TimeSpan? timeout = null,
         ReadTimeoutBehavior onTimeout = ReadTimeoutBehavior.Throw)
-        => Observable.Create<MeshNode?>(observer =>
+        // ONE implementation, so the interrogable read and the convenience read can never drift:
+        // this is GetMeshNodeOutcome with the distinction discarded. Node is non-null exactly for
+        // Present, so every non-Present status maps to the null this method has always emitted.
+        => hub.GetMeshNodeOutcome(path, timeout, onTimeout).Select(outcome => outcome.Node);
+
+    /// <summary>
+    /// The same one-shot read as <see cref="GetMeshNode"/>, but reporting <b>why</b> — see
+    /// <see cref="NodeReadStatus"/>. Use this wherever "not there" would lead to a WRITE:
+    /// a create, an upsert, a replication apply, a re-persist. Those are precisely the callers
+    /// for which "absent", "being deleted" and "I could not read it" must not be the same input.
+    ///
+    /// <para>The mapping, in full:
+    /// <list type="bullet">
+    ///   <item><see cref="NodeReadStatus.Present"/> — a node came back.</item>
+    ///   <item><see cref="NodeReadStatus.Absent"/> — routing said
+    ///     <see cref="ErrorType.NotFound"/>, the owner answered with no data, or a read validator
+    ///     hid it (a hidden node is invisible by contract).</item>
+    ///   <item><see cref="NodeReadStatus.DeleteInProgress"/> — the owner answered with its delete
+    ///     tombstone (<c>GetDataResponse.Absence</c>).</item>
+    ///   <item><see cref="NodeReadStatus.Unavailable"/> — the delivery failed for any other
+    ///     reason, the payload would not materialise, or the budget elapsed under
+    ///     <see cref="ReadTimeoutBehavior.EmitNull"/>.</item>
+    /// </list>
+    /// Errors that <see cref="GetMeshNode"/> already surfaces still surface here as
+    /// <c>OnError</c>: <see cref="ErrorType.Unauthorized"/>, a second consecutive
+    /// <see cref="ErrorType.ShuttingDown"/>, and a timeout under
+    /// <see cref="ReadTimeoutBehavior.Throw"/>.</para>
+    /// </summary>
+    /// <param name="hub">The hub the caller holds (see <see cref="GetMeshNode"/>).</param>
+    /// <param name="path">The mesh path to read.</param>
+    /// <param name="timeout">Wall-clock budget for the read; defaults to 10 seconds.</param>
+    /// <param name="onTimeout">What happens when the budget elapses (see <see cref="GetMeshNode"/>).
+    /// <see cref="ReadTimeoutBehavior.EmitNull"/> yields <see cref="NodeReadStatus.Unavailable"/>
+    /// carrying the <see cref="TimeoutException"/> — indeterminate, never "absent".</param>
+    public static IObservable<NodeReadOutcome> GetMeshNodeOutcome(this IMessageHub hub, string path,
+        TimeSpan? timeout = null,
+        ReadTimeoutBehavior onTimeout = ReadTimeoutBehavior.Throw)
+        => Observable.Create<NodeReadOutcome>(observer =>
         {
             // 🚨 Never issue the read on the ROOT MESH HUB — the router. Mesh-singleton services
             // (plugin-catalog boot, log-incident ingest, credential resolvers) hold the DI-injected
@@ -1828,10 +1875,10 @@ public static class MeshNodeStreamExtensions
             // note above exists to prevent).
             var innerSubscription = new SerialDisposable();
 
-            void EmitOnce(MeshNode? node)
+            void EmitOnce(NodeReadOutcome outcome)
             {
                 if (Interlocked.Exchange(ref emitted, 1) != 0) return;
-                observer.OnNext(node);
+                observer.OnNext(outcome);
                 observer.OnCompleted();
             }
 
@@ -1901,8 +1948,12 @@ public static class MeshNodeStreamExtensions
                 {
                     // Logging must never mask the timeout it is reporting.
                 }
+                // EmitNull's contract is "indeterminate ⇒ the caller treats it as absent" — but the
+                // OUTCOME says what actually happened, so a caller that asked for the distinction
+                // still learns the read never established anything. GetMeshNode maps it to the
+                // null EmitNull has always emitted.
                 if (onTimeout == ReadTimeoutBehavior.EmitNull)
-                    EmitOnce(null);
+                    EmitOnce(NodeReadOutcome.Unavailable(new TimeoutException(message)));
                 else
                     EmitError(new TimeoutException(message));
             });
@@ -1938,12 +1989,21 @@ public static class MeshNodeStreamExtensions
                                 {
                                     if (d.Message is GetDataResponse resp)
                                     {
+                                        // 🚨 The owner said the node's DELETE is in flight — null BY DESIGN,
+                                        // not "there is nothing here" (MeshDataSource.AddReadValidatorPipeline's
+                                        // tombstone). Checked before the Error/absence branches because it is
+                                        // the one absence a caller must never answer with a create (#1471).
+                                        if (resp.Absence == DataAbsenceReason.DeleteInProgress)
+                                        {
+                                            EmitOnce(NodeReadOutcome.DeleteInProgress);
+                                            return;
+                                        }
                                         // A null-Data response carrying an Error is an application-level
                                         // read-validator verdict (INodeValidator → GetDataResponse{Error},
                                         // e.g. NodeHidden / a policy filter — see
                                         // MeshDataSource.AddReadValidatorPipeline). The documented contract is
                                         // that such a filtered node is INVISIBLE to the reader → resolve to
-                                        // null (indistinguishable from "not found", which is the point of
+                                        // absent (indistinguishable from "not found", which is the point of
                                         // hiding). A *genuine* access denial is enforced at the delivery layer
                                         // (AccessControlPipeline → DeliveryFailure{ErrorType.Unauthorized}) and
                                         // surfaces via the OnError branch below — it never arrives as a
@@ -1953,18 +2013,31 @@ public static class MeshNodeStreamExtensions
                                             hub.ServiceProvider.GetService<ILoggerFactory>()
                                                 ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
                                                 ?.LogDebug("GetMeshNode read-validator filtered {Path}: {Error}", path, resp.Error);
-                                            EmitOnce(null);
+                                            EmitOnce(NodeReadOutcome.Absent);
+                                            return;
+                                        }
+                                        if (resp.Data is null)
+                                        {
+                                            EmitOnce(NodeReadOutcome.Absent);
                                             return;
                                         }
                                         MeshNode? node = resp.Data as MeshNode;
                                         if (node == null && resp.Data is JsonElement je)
                                             node = je.Deserialize<MeshNode>(hub.JsonSerializerOptions);
-                                        EmitOnce(node);
+                                        // Data came back but would not materialise into a MeshNode. That is a
+                                        // failed read, NOT evidence the node is missing — the two used to be
+                                        // the same null.
+                                        EmitOnce(node is null
+                                            ? NodeReadOutcome.Unavailable(new InvalidOperationException(
+                                                $"GetMeshNode('{path}'): the owner returned data of type "
+                                                + $"'{resp.Data.GetType().Name}' which could not be read as a MeshNode."))
+                                            : NodeReadOutcome.Present(node));
                                     }
                                     else
                                     {
-                                        // Unexpected response — node not found / no handler.
-                                        EmitOnce(null);
+                                        // Not a GetDataResponse at all — the read established nothing.
+                                        EmitOnce(NodeReadOutcome.Unavailable(new InvalidOperationException(
+                                            $"GetMeshNode('{path}'): the answer was not a GetDataResponse.")));
                                     }
                                 }
                                 catch (Exception ex)
@@ -1972,7 +2045,7 @@ public static class MeshNodeStreamExtensions
                                     var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
                                         ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
                                     logger?.LogDebug(ex, "GetMeshNode callback failed for {Path}", path);
-                                    EmitOnce(null);
+                                    EmitOnce(NodeReadOutcome.Unavailable(ex));
                                 }
                             },
                             ex =>
@@ -2034,7 +2107,15 @@ public static class MeshNodeStreamExtensions
                                 }
 
                                 logger?.LogDebug(ex, "GetMeshNode delivery failed for {Path}", path);
-                                EmitOnce(null);
+                                // 🚨 Only NotFound is evidence of absence — routing mints it for a path
+                                // that is not there, and NEVER falls back to an ancestor. Every other
+                                // delivery failure (Exception, Rejected, Failed, RoutingLoop …) means the
+                                // read did not happen, which says nothing about whether the node exists.
+                                // Both collapsed into the same null before, so a broken read was
+                                // indistinguishable from a missing node (#1471).
+                                EmitOnce(ex is DeliveryFailureException { Failure.ErrorType: ErrorType.NotFound }
+                                    ? NodeReadOutcome.Absent
+                                    : NodeReadOutcome.Unavailable(ex));
                             });
                 }
                 catch (Exception ex)
@@ -2042,7 +2123,7 @@ public static class MeshNodeStreamExtensions
                     var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
                         ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode");
                     logger?.LogDebug(ex, "GetMeshNode post failed for {Path}", path);
-                    EmitOnce(null);
+                    EmitOnce(NodeReadOutcome.Unavailable(ex));
                 }
             }
 

--- a/src/MeshWeaver.Mesh.Contract/NodeReadOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeReadOutcome.cs
@@ -1,0 +1,91 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Why a one-shot node read produced what it produced — the distinction
+/// <see cref="MeshNodeStreamExtensions.GetMeshNode"/>'s <c>MeshNode?</c> cannot carry.
+///
+/// <para>🚨 <b>"Not there" is three different facts, and a caller that acts on them
+/// identically corrupts data.</b> A node can be absent because it never existed, absent
+/// because its DELETE is in flight (the per-node hub's read tombstone answers <c>null</c>
+/// <em>by design</em> — <c>MeshDataSource.AddReadValidatorPipeline</c>), or "absent" only
+/// because the read itself failed. <c>InstanceSyncWorker.PullOne</c> collapsed all three into
+/// one <c>null</c> and read it as "create it": it re-applied a node a user had just deleted
+/// (Systemorph/MeshWeaver#1471), and, because a failed read is indistinguishable from an empty
+/// one, would equally have clobbered a live local node with an older remote copy.</para>
+///
+/// <para>Consume it with a <c>switch</c> expression, and make the fall-through arm the arm that
+/// does NOT write. C# cannot prove an enum switch exhaustive (an undeclared value is always
+/// possible, hence CS8509), so the compiler will not sweep call sites for you when a state is
+/// added here — what this type buys is that every consumer must NAME the states it acts on, so a
+/// new one cannot silently inherit "absent, therefore create".</para>
+/// </summary>
+public enum NodeReadStatus
+{
+    /// <summary>The node was read; <see cref="NodeReadOutcome.Node"/> holds it.</summary>
+    Present,
+
+    /// <summary>
+    /// The node is genuinely not there: routing answered <see cref="Messaging.ErrorType.NotFound"/>,
+    /// the owner answered with no data, or a read validator hid it (a filtered node is INVISIBLE
+    /// to the reader by contract — that is what hiding means).
+    /// </summary>
+    Absent,
+
+    /// <summary>
+    /// The node exists but its DELETE is in flight — the owning hub's read tombstone
+    /// (<c>RecentlyDeletedRegistry</c>) answered instead of the node. TRANSIENT and directional:
+    /// the next authoritative answer is "gone", never "here again". A caller must NOT re-create,
+    /// re-apply or re-persist the path on this — that is a resurrection of what a user just
+    /// deleted.
+    /// </summary>
+    DeleteInProgress,
+
+    /// <summary>
+    /// The read could not be completed: the owner faulted, the delivery failed for a reason other
+    /// than not-found, the payload could not be materialised, or the budget elapsed under
+    /// <see cref="ReadTimeoutBehavior.EmitNull"/>. <see cref="NodeReadOutcome.Failure"/> carries
+    /// the cause. This is NOT evidence about whether the node exists.
+    /// </summary>
+    Unavailable,
+}
+
+/// <summary>
+/// The outcome of a one-shot node read — <see cref="Status"/> plus whatever that status carries.
+/// Produced by <see cref="MeshNodeStreamExtensions.GetMeshNodeOutcome"/>;
+/// <see cref="MeshNodeStreamExtensions.GetMeshNode"/> is that same read with the distinction
+/// discarded (its documented <c>MeshNode?</c> contract), so the two can never drift apart.
+/// </summary>
+public sealed record NodeReadOutcome
+{
+    /// <summary>What the read established.</summary>
+    public required NodeReadStatus Status { get; init; }
+
+    /// <summary>The node — non-null exactly when <see cref="Status"/> is
+    /// <see cref="NodeReadStatus.Present"/>.</summary>
+    public MeshNode? Node { get; init; }
+
+    /// <summary>Why the read could not be completed; set only for
+    /// <see cref="NodeReadStatus.Unavailable"/>.</summary>
+    public Exception? Failure { get; init; }
+
+    /// <summary>The node was read.</summary>
+    /// <param name="node">The node that was read.</param>
+    /// <returns>A <see cref="NodeReadStatus.Present"/> outcome.</returns>
+    public static NodeReadOutcome Present(MeshNode node) =>
+        new() { Status = NodeReadStatus.Present, Node = node };
+
+    // Immutable singletons for the two states that carry no payload — a constant, never a cache
+    // (NoStaticState.md: "if it never takes a write after construction it's a constant").
+    /// <summary>The node is genuinely not there.</summary>
+    public static NodeReadOutcome Absent { get; } = new() { Status = NodeReadStatus.Absent };
+
+    /// <summary>The node's delete is in flight; the owner answered with its read tombstone.</summary>
+    public static NodeReadOutcome DeleteInProgress { get; } =
+        new() { Status = NodeReadStatus.DeleteInProgress };
+
+    /// <summary>The read could not be completed — this says nothing about whether the node exists.</summary>
+    /// <param name="failure">The cause, when one is available.</param>
+    /// <returns>An <see cref="NodeReadStatus.Unavailable"/> outcome.</returns>
+    public static NodeReadOutcome Unavailable(Exception? failure) =>
+        new() { Status = NodeReadStatus.Unavailable, Failure = failure };
+}

--- a/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the answer a <see cref="GetDataRequest"/> gets when the read FAULTS because its owner is
+/// tearing down: a transient <see cref="ErrorType.ShuttingDown"/> NACK — never a
+/// <see cref="GetDataResponse"/> the caller reads as "this node does not exist".
+///
+/// <para><b>The defect (#1470).</b> <c>DataExtensions.HandleGetDataRequest</c> caught EVERY
+/// exception into <c>GetDataResponse { Error = ex.Message }</c>. During teardown
+/// <c>SynchronizationStream</c>'s constructor legitimately refuses (it cannot own its sub-hub once
+/// hosted-hub creation is frozen) and throws <see cref="HubDisposingException"/>, which the
+/// reflective reduce wraps — so the CI log read verbatim
+/// <c>Error = Exception has been thrown by the target of an invocation.</c> That fabricated
+/// response CLAIMED THE ONCE-ONLY ANSWER SLOT: the <c>ShuttingDown</c> NACK could no longer be
+/// posted, <c>GetMeshNode</c> mapped the empty response to <c>null</c>, and its re-probe — which
+/// lives only in the <c>OnError</c> arm — never ran. A transient, retryable condition was rendered
+/// as a definitive absence.</para>
+///
+/// <para>It is #1362 reproduced by its own fix: #1362 closed the case where the request produced
+/// NO answer; this was the same request producing a WRONG one, from the line above.</para>
+///
+/// <para><b>How the window is held open</b> — the technique
+/// <c>SubscribeDuringRecycleTest</c> established, no sleeps and no racing: one un-answered response
+/// callback is parked on the owner, so its <c>Quiescing</c> phase cannot drain and the hub sits in
+/// the disposal window (creation frozen, message intake still open) for its whole quiesce budget.
+/// The test then WAITS until <c>RunLevel</c> has demonstrably reached <c>Quiescing</c> before
+/// reading — the state is verified, not timed.</para>
+/// </summary>
+public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private static readonly Address OwnerAddress = new("data-owner", "1");
+
+    private record Item(string Id, string Text);
+
+    /// <summary>Accepted by the owner and never answered — parks one pending response callback.</summary>
+    private record HoldRequest : IRequest<HoldResponse>;
+
+    private record HoldResponse;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData()
+            .WithTypes(typeof(HoldRequest), typeof(HoldResponse), typeof(Item));
+
+    [HubFact]
+    public async Task ReadThatFaultsOnTeardown_IsNackedShuttingDown_NotAnsweredAsAbsent()
+    {
+        var host = GetHost();
+
+        var owner = host.GetHostedHub(
+            OwnerAddress,
+            c => c.WithTypes(typeof(HoldRequest), typeof(HoldResponse), typeof(Item))
+                .WithHandler<HoldRequest>((_, d) => d.Processed())
+                .AddData(data => data.AddSource(source =>
+                    source.WithType<Item>(type => type
+                        .WithKey(i => i.Id)
+                        .WithInitialData(new[] { new Item("1", "one") }))))
+                // Plumbing fixture, no logged-in user: post as infrastructure, exactly like
+                // HubTestBase does for its own host/client hubs (never-null AccessContext).
+                .WithPostingIdentity(PostingIdentity.System));
+        owner.Should().NotBeNull();
+        await owner!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // The happy path first, so a later non-answer can never be blamed on the reference not
+        // resolving or the source not existing.
+        var warm = await host
+            .Observe<GetDataResponse>(
+                new GetDataRequest(new CollectionReference(nameof(Item))),
+                o => o.WithTarget(OwnerAddress))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        warm.Message.Data.Should().NotBeNull("the read must work before the teardown, or this test proves nothing");
+
+        // Park an un-answered callback so the Quiescing drain cannot complete: the owner then
+        // stays in the disposal window instead of racing through teardown in under a millisecond.
+        using var held = owner
+            .Observe<HoldResponse>(new HoldRequest(), o => o.WithTarget(OwnerAddress))
+            // Never throw from these callbacks — they run on the hub's scheduler, where an
+            // exception would be unobserved.
+            .Subscribe(
+                d => Output.WriteLine($"Hold callback answered unexpectedly: {d.Message}"),
+                ex => Output.WriteLine($"Hold callback released: {ex.GetType().Name}: {ex.Message}"));
+
+        host.Post(new DisposeRequest(), o => o.WithTarget(OwnerAddress));
+        await WaitForDisposalWindow(owner);
+
+        // 🔻 THE READ UNDER TEST. Creation is frozen, so building the reference's stream throws
+        // HubDisposingException — the exact production fault #1470 is about.
+        var read = host
+            .Observe<GetDataResponse>(
+                new GetDataRequest(new CollectionReference(nameof(Item))),
+                o => o.WithTarget(OwnerAddress))
+            .Select(d => (object?)d.Message)
+            // A DeliveryFailure arrives as OnError (DeliveryFailureException) — turn it into a
+            // value so ONE assertion covers both shapes and a hang is the only other outcome.
+            .Catch<object?, Exception>(ex => Observable.Return<object?>(ex))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        var answer = await read;
+        Output.WriteLine($"[TEST] answer: {answer}");
+
+        answer.Should().BeOfType<DeliveryFailureException>(
+            "a read that faulted because its owner is tearing down must be NACKed as transient. "
+            + "The pre-fix answer was a GetDataResponse whose Error read 'Exception has been thrown "
+            + "by the target of an invocation' — a fabricated success that GetMeshNode maps to null, "
+            + "i.e. the caller is told the node does not exist");
+        var failure = ((DeliveryFailureException)answer!).Failure;
+        failure.Should().NotBeNull();
+        failure!.ErrorType.Should().Be(ErrorType.ShuttingDown,
+            "the owner may reactivate — this is 'ask again', NOT 'gone'. It is also the only "
+            + "classification GetMeshNode's re-probe and MeshNodeStreamCache.IsTransientOwnerFailure "
+            + "act on");
+        failure.Message.Should().Contain("shutting down",
+            "MeshNodeStreamCache.IsTransientOwnerFailure classifies by this marker once the typed "
+            + "failure has been flattened into a message");
+        failure.Message.Should().Contain(nameof(HubDisposingException),
+            "the NACK must name the real cause — the stream refused to exist because hosted-hub "
+            + "creation is frozen. This also proves the test exercised the STREAM-CREATION refusal "
+            + "and was not answered by some other, already-fixed NACK path");
+        failure.Message.Should().NotContain("No node found",
+            "that phrase turns a retryable stall into a PROVABLE absence "
+            + "(MeshNodeStreamCache.IsMissingNodeFailure) — the exact confusion this NACK avoids");
+    }
+
+    /// <summary>
+    /// Waits until <paramref name="hub"/> has demonstrably entered the disposal window
+    /// (<see cref="MessageHubRunLevel.Quiescing"/> or later) — creation frozen, message intake
+    /// still open. Polling a PUBLIC state property, not a sleep: the test acts on a verified
+    /// state rather than hoping to hit a race.
+    /// </summary>
+    private static async Task WaitForDisposalWindow(IMessageHub hub)
+    {
+        for (var i = 0; i < 200 && hub.RunLevel < MessageHubRunLevel.Quiescing; i++)
+            await Task.Delay(10);
+        (hub.RunLevel >= MessageHubRunLevel.Quiescing).Should().BeTrue(
+            "the DisposeRequest must have moved the hub into its teardown phases — without that "
+            + $"this test never exercises the window it exists to pin (RunLevel={hub.RunLevel})");
+        (hub.RunLevel < MessageHubRunLevel.DisposeHostedHubs).Should().BeTrue(
+            "past DisposeHostedHubs the message service's own intake gate rejects everything, so "
+            + $"the read would never reach the data plugin (RunLevel={hub.RunLevel})");
+    }
+}

--- a/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
@@ -75,9 +75,7 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
             .Observe<GetDataResponse>(
                 new GetDataRequest(new CollectionReference(nameof(Item))),
                 o => o.WithTarget(OwnerAddress))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
         warm.Message.Data.Should().NotBeNull("the read must work before the teardown, or this test proves nothing");
 
         // Park an un-answered callback so the Quiescing drain cannot complete: the owner then
@@ -90,12 +88,19 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
                 d => Output.WriteLine($"Hold callback answered unexpectedly: {d.Message}"),
                 ex => Output.WriteLine($"Hold callback released: {ex.GetType().Name}: {ex.Message}"));
 
+        // 🔻 ORDER BY CAUSATION, NOT BY WAITING. The owner's action block is single-threaded and
+        // FIFO — the guarantee the mesh hub itself relies on ("Reply + DisposeRequest(s) from the
+        // mesh hub so FIFO guarantees the caller sees the Ok before the deleted hubs tear down").
+        // DisposeRequest's handler calls Dispose(), whose very FIRST statement freezes hosted-hub
+        // creation SYNCHRONOUSLY; message intake stays open until DisposeHostedHubs. So a read
+        // posted after it, from the same sender to the same target, is dequeued INSIDE the window
+        // by construction. No poll, no sleep, no sampled property — and no wait that could fall
+        // through and let the test assert against a hub that never started disposing.
         host.Post(new DisposeRequest(), o => o.WithTarget(OwnerAddress));
-        await WaitForDisposalWindow(owner);
 
-        // 🔻 THE READ UNDER TEST. Creation is frozen, so building the reference's stream throws
+        // THE READ UNDER TEST. Creation is frozen, so building the reference's stream throws
         // HubDisposingException — the exact production fault #1470 is about.
-        var read = host
+        var answer = await host
             .Observe<GetDataResponse>(
                 new GetDataRequest(new CollectionReference(nameof(Item))),
                 o => o.WithTarget(OwnerAddress))
@@ -103,12 +108,16 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
             // A DeliveryFailure arrives as OnError (DeliveryFailureException) — turn it into a
             // value so ONE assertion covers both shapes and a hang is the only other outcome.
             .Catch<object?, Exception>(ex => Observable.Return<object?>(ex))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
+        Output.WriteLine($"[TEST] answer: {answer} (owner IsShuttingDown={owner.IsShuttingDown}, RunLevel={owner.RunLevel})");
 
-        var answer = await read;
-        Output.WriteLine($"[TEST] answer: {answer}");
+        // The window was real — read AFTER the fact, so this is a statement about what happened,
+        // not a gate that could pass before anything did.
+        owner.IsShuttingDown.Should().BeTrue(
+            "the read must have been served while the owner's hosted-hub creation was frozen — "
+            + "that IS the condition under test, and asserting it here means a routing change that "
+            + "broke the FIFO ordering would fail loudly instead of silently answering the read "
+            + $"from a healthy hub (RunLevel={owner.RunLevel})");
 
         answer.Should().BeOfType<DeliveryFailureException>(
             "a read that faulted because its owner is tearing down must be NACKed as transient. "
@@ -133,21 +142,4 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
             + "(MeshNodeStreamCache.IsMissingNodeFailure) — the exact confusion this NACK avoids");
     }
 
-    /// <summary>
-    /// Waits until <paramref name="hub"/> has demonstrably entered the disposal window
-    /// (<see cref="MessageHubRunLevel.Quiescing"/> or later) — creation frozen, message intake
-    /// still open. Polling a PUBLIC state property, not a sleep: the test acts on a verified
-    /// state rather than hoping to hit a race.
-    /// </summary>
-    private static async Task WaitForDisposalWindow(IMessageHub hub)
-    {
-        for (var i = 0; i < 200 && hub.RunLevel < MessageHubRunLevel.Quiescing; i++)
-            await Task.Delay(10);
-        (hub.RunLevel >= MessageHubRunLevel.Quiescing).Should().BeTrue(
-            "the DisposeRequest must have moved the hub into its teardown phases — without that "
-            + $"this test never exercises the window it exists to pin (RunLevel={hub.RunLevel})");
-        (hub.RunLevel < MessageHubRunLevel.DisposeHostedHubs).Should().BeTrue(
-            "past DisposeHostedHubs the message service's own intake gate rejects everything, so "
-            + $"the read would never reach the data plugin (RunLevel={hub.RunLevel})");
-    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteInProgressReadTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteInProgressReadTest.cs
@@ -48,8 +48,7 @@ public class DeleteInProgressReadTest(ITestOutputHelper output) : MonolithMeshTe
         var reader = GetClient(c => c.AddData());
 
         var present = await reader.GetMeshNodeOutcome(path, TimeSpan.FromSeconds(30))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
         present.Status.Should().Be(NodeReadStatus.Present);
         present.Node!.Path.Should().Be(path);
 
@@ -59,8 +58,7 @@ public class DeleteInProgressReadTest(ITestOutputHelper output) : MonolithMeshTe
         Output.WriteLine($"[TEST] tombstoned {path} — the row is still there, the delete is in flight");
 
         var inFlight = await reader.GetMeshNodeOutcome(path, TimeSpan.FromSeconds(30))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
         Output.WriteLine($"[TEST] outcome while the delete is in flight: {inFlight.Status}");
 
         inFlight.Status.Should().Be(NodeReadStatus.DeleteInProgress,
@@ -73,15 +71,13 @@ public class DeleteInProgressReadTest(ITestOutputHelper output) : MonolithMeshTe
         // everything DeleteInProgress.
         var absent = await reader
             .GetMeshNodeOutcome($"{TestPartition}/never-existed", TimeSpan.FromSeconds(30))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
         absent.Status.Should().Be(NodeReadStatus.Absent,
             "routing answers NotFound for a path with no node — that IS absence");
 
         // The convenience read keeps its documented MeshNode? contract exactly: both are null.
         var collapsed = await reader.GetMeshNode(path, TimeSpan.FromSeconds(30))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(TestContext.Current.CancellationToken);
+            .Should().Within(30.Seconds()).Emit();
         collapsed.Should().BeNull(
             "GetMeshNode is GetMeshNodeOutcome with the distinction discarded — callers that do "
             + "not ask for it see no behaviour change at all");

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteInProgressReadTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteInProgressReadTest.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins that a one-shot node read reports WHY it has nothing — specifically that the owner's
+/// delete-in-progress tombstone is distinguishable from genuine absence.
+///
+/// <para><b>The defect (#1471).</b> The tombstone answers <c>GetDataResponse(null, 0)</c>
+/// <em>by design</em> (<c>MeshDataSource.AddReadValidatorPipeline</c>): a read that lands after the
+/// delete has been recorded but before the row is gone must not serve stale content. On the wire
+/// that was byte-identical to "there is nothing at this path", so every caller collapsed the two.
+/// <c>InstanceSyncWorker.PullOne</c> read the collapsed <c>null</c> as "absent ⇒ create it" and
+/// re-applied a node the user had just deleted.</para>
+///
+/// <para>The window is reproduced exactly as production creates it: <c>HandleDeleteNodeRequest</c>
+/// marks the path in <see cref="RecentlyDeletedRegistry"/> SYNCHRONOUSLY, before it returns and
+/// therefore before the row is gone — so "marked, node still there" IS the in-flight state, not a
+/// simulation of it. No sleeps, no racing.</para>
+/// </summary>
+public class DeleteInProgressReadTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 60000)]
+    public async Task ReadOfANodeWhoseDeleteIsInFlight_SaysSo_InsteadOfClaimingAbsence()
+    {
+        var path = $"{TestPartition}/delete-in-flight";
+        await NodeFactory.CreateNode(
+            new MeshNode("delete-in-flight", TestPartition)
+            {
+                Name = "Being Deleted",
+                NodeType = "Markdown"
+            }).Should().Emit();
+
+        // Prove the happy path first, so a later "nothing" cannot be blamed on the node never
+        // having existed.
+        var warm = await ReadNode(path).Should().Match(n => n is not null);
+        warm!.Path.Should().Be(path);
+
+        var reader = GetClient(c => c.AddData());
+
+        var present = await reader.GetMeshNodeOutcome(path, TimeSpan.FromSeconds(30))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        present.Status.Should().Be(NodeReadStatus.Present);
+        present.Node!.Path.Should().Be(path);
+
+        // 🔻 Enter the delete-in-flight window.
+        var tombstones = Mesh.ServiceProvider.GetRequiredService<RecentlyDeletedRegistry>();
+        tombstones.MarkDeleted(path);
+        Output.WriteLine($"[TEST] tombstoned {path} — the row is still there, the delete is in flight");
+
+        var inFlight = await reader.GetMeshNodeOutcome(path, TimeSpan.FromSeconds(30))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        Output.WriteLine($"[TEST] outcome while the delete is in flight: {inFlight.Status}");
+
+        inFlight.Status.Should().Be(NodeReadStatus.DeleteInProgress,
+            "the owner ANSWERED — with its delete tombstone. Reporting that as Absent is what let "
+            + "a replicator read 'not there ⇒ create it' and resurrect a node the user just deleted");
+        inFlight.Node.Should().BeNull("there is deliberately no content to serve mid-delete");
+
+        // 🚨 And the other direction must not have merged either: a path that genuinely does not
+        // exist stays ABSENT. Without this, "distinguishable" could be satisfied by calling
+        // everything DeleteInProgress.
+        var absent = await reader
+            .GetMeshNodeOutcome($"{TestPartition}/never-existed", TimeSpan.FromSeconds(30))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        absent.Status.Should().Be(NodeReadStatus.Absent,
+            "routing answers NotFound for a path with no node — that IS absence");
+
+        // The convenience read keeps its documented MeshNode? contract exactly: both are null.
+        var collapsed = await reader.GetMeshNode(path, TimeSpan.FromSeconds(30))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+        collapsed.Should().BeNull(
+            "GetMeshNode is GetMeshNodeOutcome with the distinction discarded — callers that do "
+            + "not ask for it see no behaviour change at all");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
@@ -87,20 +87,7 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask(TestContext.Current.CancellationToken);
 
-        // Ordering gate, so the DisposeRequest cannot overtake the read: wait until the reader
-        // holds the outstanding callback AND the owner's action block has gone idle again. Those
-        // two together mean the delivery was accepted, handled, and answered with nothing — the
-        // exact state #1362 shows (HANDLER_EXIT state=Processed, no reply). Interval-probing a
-        // request/response-shaped fact is the sanctioned wait shape (WritingTests.md); it is not
-        // a sleep, and it fails loudly rather than silently proceeding.
-        await Observable.Interval(TimeSpan.FromMilliseconds(25)).StartWith(0L)
-            .Where(_ => reader.GetPendingRequestDiagnostics()
-                            .Contains("GetDataRequest@", StringComparison.Ordinal)
-                        && owner!.GetPendingRequestDiagnostics()
-                            .Contains("Queue(buffer=0,deferred=0,exec=0)", StringComparison.Ordinal))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(20))
-            .ToTask(TestContext.Current.CancellationToken);
+        await WaitUntilTheHandlerHasRunAndAnsweredNothing(reader);
         Output.WriteLine("[TEST] handler ran and answered nothing — now recycling the owner");
 
         Mesh.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
@@ -172,14 +159,7 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
 
         // Same ordering gate as above — the read must be genuinely outstanding at a hub that has
         // already handled it before the teardown starts.
-        await Observable.Interval(TimeSpan.FromMilliseconds(25)).StartWith(0L)
-            .Where(_ => reader.GetPendingRequestDiagnostics()
-                            .Contains("GetDataRequest@", StringComparison.Ordinal)
-                        && owner!.GetPendingRequestDiagnostics()
-                            .Contains("Queue(buffer=0,deferred=0,exec=0)", StringComparison.Ordinal))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(20))
-            .ToTask(TestContext.Current.CancellationToken);
+        await WaitUntilTheHandlerHasRunAndAnsweredNothing(reader);
 
         Mesh.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
 
@@ -262,4 +242,35 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
             + "false one both lies and can beat a correct answer from another handler for the "
             + "same request (the layoutAreas regression)");
     }
+
+    /// <summary>
+    /// Blocks until the framework's OWN record shows the owner's handler ran to completion with no
+    /// reply — the state both teardown tests must reach before they may recycle the owner.
+    ///
+    /// <para>🚨 <b>The gate this replaces could not fail.</b> It asked for two things at
+    /// <c>t = 0</c>: that the reader holds a pending <c>GetDataRequest@</c> callback (true the
+    /// instant the read is subscribed, before anything is routed) and that the OWNER's queue reads
+    /// <c>Queue(buffer=0,deferred=0,exec=0)</c> — which is what an idle hub looks like BEFORE the
+    /// delivery ever arrives. Both were satisfied by a request still in flight, so the
+    /// <c>DisposeRequest</c> was free to overtake it. Its own comment claimed the gate was "the
+    /// request-fate ledger reaching <c>HANDLER_EXIT</c>"; the code never looked at the ledger. That
+    /// is what made <c>OwnerDisposedWithReadOutstanding_IsNacked_NotLeftHanging</c> red on main —
+    /// the read landed mid-teardown and exercised a DIFFERENT arm than the one asserted (#1470).</para>
+    ///
+    /// <para>The ledger IS available, just not through <c>GetPendingRequestDiagnostics</c>: it is
+    /// per hub TREE (a hosted hub shares its root's), and <c>GetDisposalDiagnostics</c> renders the
+    /// handler-side trail for every pending callback. So <c>HANDLER_EXIT</c> appearing there is the
+    /// owner's own record that it entered and left the handler — and the callback still being
+    /// pending is the record that it answered nothing. Polling a public snapshot for a specific,
+    /// positive fact is the sanctioned wait shape; it fails loudly instead of proceeding.</para>
+    /// </summary>
+    private static Task WaitUntilTheHandlerHasRunAndAnsweredNothing(IMessageHub reader) =>
+        Observable.Interval(TimeSpan.FromMilliseconds(25)).StartWith(0L)
+            .Select(_ => reader.GetDisposalDiagnostics())
+            .Where(diagnostics =>
+                diagnostics.Contains("GetDataRequest", StringComparison.Ordinal)
+                && diagnostics.Contains("HANDLER_EXIT", StringComparison.Ordinal))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(20))
+            .ToTask(TestContext.Current.CancellationToken);
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
@@ -30,6 +30,26 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// dedicated <c>HandleLayoutAreasRequest</c>. The claim must be TRUE, so the completion arm is now
 /// gated on the hub actually winding down, and <see cref="LiveOwner_WithASilentSource_IsNotNacked"/>
 /// pins that a healthy hub is never slandered.</para>
+///
+/// <para>🚨 <b>How the two teardown tests order the read before the recycle — and why there is no
+/// gate.</b> The gate that used to sit here COULD NOT FAIL: it asked, at <c>t = 0</c>, for a pending
+/// <c>GetDataRequest@</c> callback on the reader (true the instant the read is subscribed, before
+/// anything is routed) and for the OWNER's queue to read <c>Queue(buffer=0,deferred=0,exec=0)</c> —
+/// which is what an idle hub looks like BEFORE the delivery ever arrives. Both were satisfied by a
+/// request still in flight, so the <c>DisposeRequest</c> was free to overtake it. Its own comment
+/// claimed it waited for the request-fate ledger to reach <c>HANDLER_EXIT</c>; the code never looked
+/// at the ledger. That is what made
+/// <see cref="OwnerDisposedWithReadOutstanding_IsNacked_NotLeftHanging"/> red on main — the read
+/// landed mid-teardown and exercised a DIFFERENT arm than the one asserted (#1470).</para>
+///
+/// <para>Replacing it with an interval-probe would have been the same mistake in Rx clothing:
+/// polling a snapshot still samples a moment instead of subscribing a source, and the hub's run
+/// level and request-fate ledger have no observable form to subscribe. So the ordering is now
+/// CAUSED — the read and the <c>DisposeRequest</c> are posted from the SAME hub to the SAME target,
+/// and that hub's FIFO puts the read at the owner first. There is no wait left to fall through, and
+/// a violation cannot pass silently: were the recycle ever to overtake the read, the read would be
+/// answered by <c>HandleGetDataRequest</c>'s FAULT arm ("hosted-hub creation is frozen"), so the
+/// <c>"still outstanding"</c> assertion fails by name and says which arm actually ran.</para>
 /// </summary>
 public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -87,10 +107,14 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask(TestContext.Current.CancellationToken);
 
-        await WaitUntilTheHandlerHasRunAndAnsweredNothing(reader);
-        Output.WriteLine("[TEST] handler ran and answered nothing — now recycling the owner");
-
-        Mesh.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
+        // 🔻 ORDER BY CAUSATION, NOT BY WAITING — and post the recycle from the SAME hub that
+        // issued the read, so the two are ordered by that hub's own FIFO rather than by a race
+        // between two senders. The read is therefore handled (and answered with nothing) before
+        // the DisposeRequest is, which is the state this test exists to reach. See
+        // AssertTheHandlerRanAndAnsweredNothing for why the gate that used to sit here was worse
+        // than nothing.
+        Output.WriteLine("[TEST] read is outstanding — now recycling the owner");
+        reader.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
 
         var result = await answer;
         Output.WriteLine($"[TEST] answer: {result}");
@@ -157,11 +181,9 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
             .FirstAsync()
             .ToTask(TestContext.Current.CancellationToken);
 
-        // Same ordering gate as above — the read must be genuinely outstanding at a hub that has
-        // already handled it before the teardown starts.
-        await WaitUntilTheHandlerHasRunAndAnsweredNothing(reader);
-
-        Mesh.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
+        // Same ordering as above, caused the same way: the recycle is posted from the hub that
+        // issued the read, so its FIFO puts the read at the owner first.
+        reader.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
 
         var node = await read;
         var elapsed = DateTime.UtcNow - started;
@@ -243,34 +265,4 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
             + "same request (the layoutAreas regression)");
     }
 
-    /// <summary>
-    /// Blocks until the framework's OWN record shows the owner's handler ran to completion with no
-    /// reply — the state both teardown tests must reach before they may recycle the owner.
-    ///
-    /// <para>🚨 <b>The gate this replaces could not fail.</b> It asked for two things at
-    /// <c>t = 0</c>: that the reader holds a pending <c>GetDataRequest@</c> callback (true the
-    /// instant the read is subscribed, before anything is routed) and that the OWNER's queue reads
-    /// <c>Queue(buffer=0,deferred=0,exec=0)</c> — which is what an idle hub looks like BEFORE the
-    /// delivery ever arrives. Both were satisfied by a request still in flight, so the
-    /// <c>DisposeRequest</c> was free to overtake it. Its own comment claimed the gate was "the
-    /// request-fate ledger reaching <c>HANDLER_EXIT</c>"; the code never looked at the ledger. That
-    /// is what made <c>OwnerDisposedWithReadOutstanding_IsNacked_NotLeftHanging</c> red on main —
-    /// the read landed mid-teardown and exercised a DIFFERENT arm than the one asserted (#1470).</para>
-    ///
-    /// <para>The ledger IS available, just not through <c>GetPendingRequestDiagnostics</c>: it is
-    /// per hub TREE (a hosted hub shares its root's), and <c>GetDisposalDiagnostics</c> renders the
-    /// handler-side trail for every pending callback. So <c>HANDLER_EXIT</c> appearing there is the
-    /// owner's own record that it entered and left the handler — and the callback still being
-    /// pending is the record that it answered nothing. Polling a public snapshot for a specific,
-    /// positive fact is the sanctioned wait shape; it fails loudly instead of proceeding.</para>
-    /// </summary>
-    private static Task WaitUntilTheHandlerHasRunAndAnsweredNothing(IMessageHub reader) =>
-        Observable.Interval(TimeSpan.FromMilliseconds(25)).StartWith(0L)
-            .Select(_ => reader.GetDisposalDiagnostics())
-            .Where(diagnostics =>
-                diagnostics.Contains("GetDataRequest", StringComparison.Ordinal)
-                && diagnostics.Contains("HANDLER_EXIT", StringComparison.Ordinal))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(20))
-            .ToTask(TestContext.Current.CancellationToken);
 }

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
@@ -128,9 +128,15 @@ public class InstanceSyncPullTest(ITestOutputHelper output) : InstanceSyncTestBa
     ///
     /// <para>The window is the production one, created the production way: the delete handler marks
     /// <c>RecentlyDeletedRegistry</c> SYNCHRONOUSLY before the row goes, so "marked, node still
-    /// there" IS the in-flight state. The sweep is then observed by its own remote calls — a
-    /// <c>get</c> of the moved hit proves the sweep picked it up, and the NEXT <c>search</c> proves
-    /// that sweep ran to completion (sweeps never overlap: Defer + Repeat).</para>
+    /// there" IS the in-flight state.</para>
+    ///
+    /// <para>🚨 The assertion SUBSCRIBES the local node's own stream and requires that the
+    /// resurrected content never arrives on it — the sanctioned negative shape (<c>NotEmit</c>:
+    /// "the one place a fixed wait is correct — a 'nothing should happen' test has no positive
+    /// signal to await"). No interval probe, no <c>FirstAsync</c>, no sampled property: the window
+    /// spans ~10 pull sweeps at the test's 200 ms interval, and the closing assertion proves from
+    /// the remote's own call log that sweeps really did run — so the negative cannot pass because
+    /// nothing happened at all.</para>
     /// </summary>
     [Fact]
     public async Task Pull_does_not_resurrect_a_node_whose_delete_is_in_flight()
@@ -153,32 +159,27 @@ public class InstanceSyncPullTest(ITestOutputHelper output) : InstanceSyncTestBa
             Content = new MarkdownContent { Content = "remote v2" },
         }, DateTimeOffset.UtcNow.AddMinutes(1));
 
-        // Positive signal #1: the sweep fetched the moved hit.
         var getsBefore = Remote.Calls.Count(c => c is { Op: "get", Path: "pull6/doc" });
-        await Observable.Interval(50.Milliseconds()).StartWith(0L)
-            .Where(_ => Remote.Calls.Count(c => c is { Op: "get", Path: "pull6/doc" }) > getsBefore)
-            .FirstAsync().Timeout(30.Seconds()).ToTask();
-        // Positive signal #2: that sweep then RAN OUT — the next sweep's listing can only start
-        // after the previous one completed, so PullOne has finished deciding about this hit.
-        var searchesAfterGet = Remote.Calls.Count(c => c.Op == "search");
-        await Observable.Interval(50.Milliseconds()).StartWith(0L)
-            .Where(_ => Remote.Calls.Count(c => c.Op == "search") > searchesAfterGet)
-            .FirstAsync().Timeout(30.Seconds()).ToTask();
 
-        // Read through the node's own stream, NOT GetMeshNode: the tombstone is still up (the
-        // delete is still "in flight" for the whole test), and that is exactly what the read path
-        // is supposed to report. The stream is the authoritative view of what the workspace holds.
-        var local = await Mesh.GetHostedHub(new Address("test-reader-pull6"), c => c.AddData())!
+        // Subscribe the node's OWN stream — not GetMeshNode, whose tombstone answer is the thing
+        // under test, and not a sampled read. The resurrected content must never arrive on it.
+        await Mesh.GetHostedHub(new Address("test-reader-pull6"), c => c.AddData())!
             .GetMeshNodeStream("pull6/doc")
-            .Where(n => n is not null)
-            .FirstAsync().Timeout(30.Seconds()).ToTask();
+            .Select(MarkdownBody)
+            .Where(body => body == "remote v2")
+            .Should().NotEmit(3.Seconds(),
+                "the local delete is in flight — re-applying the remote copy resurrects content "
+                + "the user is deleting. 'remote v2' arriving here means PullOne read the delete "
+                + "tombstone as 'absent, therefore create'");
 
-        MarkdownBody(local).Should().Be("local v1",
-            "the local delete is in flight — re-applying the remote copy resurrects content the "
-            + "user is deleting. 'remote v2' here means PullOne read the delete tombstone as "
-            + "'absent, therefore create'");
+        // …and the window was not empty: the sweep really did fetch this hit and decide about it.
+        // Read after the fact from the remote's own call log — a statement about what happened,
+        // never a gate.
+        Remote.Calls.Count(c => c is { Op: "get", Path: "pull6/doc" }).Should().BeGreaterThan(getsBefore,
+            "without a sweep actually fetching the moved hit the negative assertion above would "
+            + "pass vacuously — nothing would have had the chance to resurrect anything");
 
-        var cfg = await Sync.ReadConfig("pull6", "partner").Timeout(10.Seconds()).ToTask();
+        var cfg = await Sync.ReadConfig("pull6", "partner").Should().Within(10.Seconds()).Emit();
         cfg!.LastError.Should().BeNull(
             "skipping a hit whose local delete is in flight is a normal, expected decision — not a "
             + "sync error, and not a reason to abort the sweep");

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
@@ -1,7 +1,11 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.InstanceSync.Test;
@@ -107,6 +111,77 @@ public class InstanceSyncPullTest(ITestOutputHelper output) : InstanceSyncTestBa
         await Task.Delay(1000, TestContext.Current.CancellationToken);
         (await ReadNode("pull4/remote-only").Timeout(10.Seconds()).ToTask())
             .Should().BeNull("PushOnly sources must not pull remote changes");
+    }
+
+    /// <summary>
+    /// 🚨 THE RESURRECTION GUARD (#1471). A local node whose DELETE is in flight must not be
+    /// re-applied by the pull sweep — not even when the remote copy is strictly newer.
+    ///
+    /// <para><c>PullOne</c> used to read the local side with
+    /// <c>GetMeshNode(...).Catch(_ =&gt; null)</c> and treat any <c>null</c> as "not there ⇒ create
+    /// it". That single <c>null</c> meant three things: genuine absence, the owner's
+    /// delete-in-progress TOMBSTONE (null by design), and "the read failed". So a delete in flight
+    /// was answered by re-creating the node — and, because the apply registers the path in the
+    /// consume-once echo-suppression slot, it could swallow the very <c>Deleted</c> event the push
+    /// side needs, leaving the remote holding a node the user deleted here
+    /// (<c>Local_delete_propagates_to_remote</c>'s CI timeout).</para>
+    ///
+    /// <para>The window is the production one, created the production way: the delete handler marks
+    /// <c>RecentlyDeletedRegistry</c> SYNCHRONOUSLY before the row goes, so "marked, node still
+    /// there" IS the in-flight state. The sweep is then observed by its own remote calls — a
+    /// <c>get</c> of the moved hit proves the sweep picked it up, and the NEXT <c>search</c> proves
+    /// that sweep ran to completion (sweeps never overlap: Defer + Repeat).</para>
+    /// </summary>
+    [Fact]
+    public async Task Pull_does_not_resurrect_a_node_whose_delete_is_in_flight()
+    {
+        await CreateSpace("pull6");
+        await CreateMarkdown("pull6/doc", "Doc", "local v1");
+        await AddConfiguredSource("pull6");
+        await WaitForConfig("pull6", "partner", c => c.InitialSyncAt is not null);
+        await WaitForRemote(r => r.Node("pull6/doc") is not null);
+
+        // 🔻 Enter the delete-in-flight window BEFORE the remote moves, so the sweep that picks the
+        // hit up can only ever see the tombstone.
+        var tombstones = Mesh.ServiceProvider.GetRequiredService<RecentlyDeletedRegistry>();
+        tombstones.MarkDeleted("pull6/doc");
+
+        // A strictly NEWER remote edit: without the fix this is applied unconditionally, because a
+        // null local read short-circuits both the content and the newest-writer comparison.
+        Remote.Seed(Remote.Node("pull6/doc")! with
+        {
+            Content = new MarkdownContent { Content = "remote v2" },
+        }, DateTimeOffset.UtcNow.AddMinutes(1));
+
+        // Positive signal #1: the sweep fetched the moved hit.
+        var getsBefore = Remote.Calls.Count(c => c is { Op: "get", Path: "pull6/doc" });
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => Remote.Calls.Count(c => c is { Op: "get", Path: "pull6/doc" }) > getsBefore)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        // Positive signal #2: that sweep then RAN OUT — the next sweep's listing can only start
+        // after the previous one completed, so PullOne has finished deciding about this hit.
+        var searchesAfterGet = Remote.Calls.Count(c => c.Op == "search");
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => Remote.Calls.Count(c => c.Op == "search") > searchesAfterGet)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        // Read through the node's own stream, NOT GetMeshNode: the tombstone is still up (the
+        // delete is still "in flight" for the whole test), and that is exactly what the read path
+        // is supposed to report. The stream is the authoritative view of what the workspace holds.
+        var local = await Mesh.GetHostedHub(new Address("test-reader-pull6"), c => c.AddData())!
+            .GetMeshNodeStream("pull6/doc")
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        MarkdownBody(local).Should().Be("local v1",
+            "the local delete is in flight — re-applying the remote copy resurrects content the "
+            + "user is deleting. 'remote v2' here means PullOne read the delete tombstone as "
+            + "'absent, therefore create'");
+
+        var cfg = await Sync.ReadConfig("pull6", "partner").Timeout(10.Seconds()).ToTask();
+        cfg!.LastError.Should().BeNull(
+            "skipping a hit whose local delete is in flight is a normal, expected decision — not a "
+            + "sync error, and not a reason to abort the sweep");
     }
 
     [Fact]

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncPushTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncPushTest.cs
@@ -3,6 +3,8 @@ using System.Reactive.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.InstanceSync.Test;
@@ -81,6 +83,57 @@ public class InstanceSyncPushTest(ITestOutputHelper output) : InstanceSyncTestBa
         await NodeFactory.DeleteNode("delta/temp").Timeout(30.Seconds()).ToTask();
 
         await WaitForRemote(r => r.Node("delta/temp") is null);
+    }
+
+    /// <summary>
+    /// 🚨 THE COUPLING GUARD. A pending NON-DELETE manifest entry whose local node is being deleted
+    /// must push a DELETE to the remote — never the content.
+    ///
+    /// <para>This pins what makes <c>OnLocalChange</c>'s echo-suppression slot safe to consume on a
+    /// <c>Deleted</c> event. Doing so lets the pull-apply's echo escape suppression, and because
+    /// the manifest coalesces per path with the latest entry winning, that echo can replace the
+    /// <c>Deleted</c> entry with a content change. The remote still converges on the deletion for
+    /// exactly ONE reason: <c>DrainOne</c> resolves every entry against the CURRENT local state
+    /// instead of trusting the recorded kind, so a node that is gone degrades the push to a delete.
+    /// That is a real coupling between two methods, and the sort of thing a later "we already know
+    /// the kind, skip the read" refactor removes without noticing — hence a test rather than a
+    /// comment.</para>
+    ///
+    /// <para>Note this is a REGRESSION GUARD, not a fail-before test: the pre-fix code reached the
+    /// same delete through the collapsed <c>null</c> it is the point of this PR to remove. Its job
+    /// is to stop the property being lost in the future, now that something else leans on it.</para>
+    ///
+    /// <para>The setup is deterministic and production-shaped: the remote is offline so the
+    /// manifest ACCUMULATES a content entry, and the delete is put in flight with the same
+    /// synchronous tombstone the delete handler writes — which emits no change event, so the
+    /// manifest keeps its non-delete entry. That is exactly the escaped-echo shape, without having
+    /// to win a race to produce it.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_pending_content_change_pushes_a_DELETE_when_the_local_node_is_being_deleted()
+    {
+        await CreateSpace("theta");
+        await CreateMarkdown("theta/doc", "Doc", "v1");
+        await AddConfiguredSource("theta");
+        await WaitForConfig("theta", "partner", c => c.InitialSyncAt is not null);
+        await WaitForRemote(r => r.Node("theta/doc") is not null);
+
+        // Offline: the content change accumulates instead of draining immediately.
+        Remote.Unreachable = true;
+        await Mesh.GetWorkspace().GetMeshNodeStream("theta/doc")
+            .Update(n => n with { Content = new MarkdownContent { Content = "v2" } })
+            .Should().Within(30.Seconds()).Emit();
+        var offline = await WaitForConfig("theta", "partner", c => c.PendingChanges.Count == 1);
+        offline.PendingChanges[0].Kind.Should().NotBe(MeshChangeKind.Deleted,
+            "the entry under test is a CONTENT change — the delete fast-path in DrainOne would "
+            + "make this test pass without ever reading the local node");
+
+        // 🔻 The delete goes in flight. MarkDeleted is what the delete handler does synchronously,
+        // and it emits no change event — so the manifest keeps its non-delete entry.
+        Mesh.ServiceProvider.GetRequiredService<RecentlyDeletedRegistry>().MarkDeleted("theta/doc");
+
+        Remote.Unreachable = false;
+        await WaitForRemote(r => r.Node("theta/doc") is null);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1470 and #1471 together — they are one defect shape: **the read layer collapsing distinguishable failures into an absence the caller cannot interrogate.**

---

## ⚠️ Data loss, found on the way: a failed *local* read deleted the *remote* node

Calling this out on its own because it is the most valuable thing in the PR and it is **not** what either issue was about — someone searching for data loss should find it here, not buried under "InstanceSync".

`InstanceSyncWorker.DrainOne` pushed a pending change by reading the local node and treating *any* `null` as "deleted here, so delete it there":

```csharp
hub.GetMeshNode(change.Path, TimeSpan.FromSeconds(15))
    .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))   // ← any failure
    .SelectMany(local => local is null
        ? DeleteRemote(remote, remotePath)                                  // ← destroys the remote copy
        : PushNode(remote, cfg, local).Select(_ => true));
```

So a transient local read failure — an unreachable owner, a recycling hub, a timeout — **deleted the other instance's copy of the node**. There is no recovery path: the remote row is gone and the manifest entry is drained as successful.

Now only real absence (or a delete already in flight, which is heading for exactly that) degrades to a delete. An unreadable local node fails the **entry**, which keeps it pending and surfaces on the node as `LastError` — the mechanism that already exists for a rejected entry — instead of silently destroying data.

---

## #1470 — a read serviced by a hub in teardown was reported as "node does not exist"

`HandleGetDataRequest`'s catch-all swallowed **every** exception into `GetDataResponse { Error = ex.Message }`. During teardown `SynchronizationStream`'s constructor legitimately refuses (it cannot own its sub-hub once hosted-hub creation is frozen) and throws `HubDisposingException`, which the reflective reduce wraps — hence the CI log's verbatim `Error = Exception has been thrown by the target of an invocation.`

That fabricated response **claimed the once-only answer slot**: the `ShuttingDown` NACK was never posted, `GetMeshNode` mapped the empty response to `null`, and the re-probe — which lives only in the `OnError` arm — never ran.

This is #1362 reproduced by its own fix. #1362 closed the case where the request produced *no* answer; this was the same request producing a *wrong* one, one line up. The fix keeps #1362 intact: a hub-disposal fault re-throws and the Subscribe's **error arm** answers it, going through the **same CAS** as the completion and disposal arms — three terminals, still exactly one answer. It needs no `IsWindingDown` gate (unlike the empty-completion arm, whose over-broad first version regressed `LayoutAreaRetrievalTest`): a `HubDisposingException` *is* proof of a teardown and names the hub. The NACK quotes the **unwrapped** cause, so the message says something.

## #1471 — InstanceSync re-applied a node that was being deleted

`PullOne` read `GetMeshNode(...).Catch(_ => null)` and read any `null` as "absent, therefore create". That one `null` meant three things: genuine absence, the **delete-in-progress tombstone** (`null` by design), and *any* read failure.

The distinction is now real at the type level, from the wire to the caller:

| | |
|---|---|
| `GetDataResponse.Absence` (`DataAbsenceReason`) | the tombstone says why it is null. Default `Unspecified` serialises away, so nothing else changes. |
| `NodeReadOutcome` / `NodeReadStatus` `{Present, Absent, DeleteInProgress, Unavailable}` | returned by the new `hub.GetMeshNodeOutcome(...)` |
| `GetMeshNode` | is now **that same read with the distinction discarded** — one implementation, so they cannot drift; its documented `MeshNode?` contract is unchanged for all ~54 existing call sites |

Plus: `PullOne` stamps `lastSeenRemote` only once a hit is actually **dealt with**. Stamping before the apply is what made one bad decision permanent (`HasRemoteStampMoved` then skipped the hit forever).

And the echo-suppression slot now only *suppresses* what it could have caused — a pull-apply is a `CreateOrUpdate`, never a delete — while being *consumed* by whatever arrives first, so it cannot outlive its apply and swallow a later genuine change. See the [review thread](https://github.com/Systemorph/MeshWeaver/pull/1504#discussion_r3782652307) for the interleaving that makes this safe and the coupling it now depends on.

No retry, no delay, no re-query, no widened catch anywhere.

## Fail-before, demonstrated

Each test was run against a tree with only the corresponding fix reverted:

| Test | Pre-fix result |
|---|---|
| `ReadDuringDisposalWindowTest` (new, `MeshWeaver.Data.Test`) | `GetDataResponse { Error = Exception has been thrown by the target of an invocation. }` — the CI symptom verbatim |
| `DeleteInProgressReadTest` (new, `MeshWeaver.Hosting.Monolith.Test`) | outcome is `Absent`, not `DeleteInProgress` |
| `InstanceSyncPullTest.Pull_does_not_resurrect_a_node_whose_delete_is_in_flight` (new) | the sweep overwrites `"local v1"` with `"remote v2"` — the resurrection |

Both new scenarios are deterministic, and neither waits:
- The teardown window is entered by **causation**, not by polling — the read and the `DisposeRequest` are posted from the same hub to the same target, so that hub's FIFO puts the read at the owner first (`Dispose()` freezes creation synchronously on its first statement; intake stays open until `DisposeHostedHubs`). The run log confirms it: `owner IsShuttingDown=True, RunLevel=Quiescing`. A violation cannot pass silently — the read would be answered by the fault arm and the `"still outstanding"` assertion fails by name.
- The delete window is created the way production creates it: the delete handler marks `RecentlyDeletedRegistry` **synchronously**, before the row is gone.

`A_pending_content_change_pushes_a_DELETE_when_the_local_node_is_being_deleted` is added as a **regression guard, not a fail-before test** (labelled as such in its doc): it pins the `DrainOne` property that the echo-slot fix now leans on.

## Also: `SilentReadNackTest`'s ordering gate was vacuous — confirmed

Its own comment claimed it waited for the request-fate ledger to reach `HANDLER_EXIT`. The code never looked at the ledger; it matched at **t = 0**, because a pending callback exists the instant the read subscribes and `Queue(buffer=0,deferred=0,exec=0)` is what an idle hub looks like *before* the delivery arrives. So the `DisposeRequest` was free to overtake the read — which is exactly how the test went red on main, landing the read mid-teardown and exercising a different arm than the one asserted. The gate is gone; the ordering is caused instead.

## Verification

- `Data.Test` 374/374 · `Graph.Test` 1114/1114 · `InstanceSync.Test` 26/26 (incl. `Local_delete_propagates_to_remote`) · Monolith read tests 4/4
- `-c Release -warnaserror`, one project per invocation, `0 Error(s)` for every touched project and every dependent of the changed APIs (`AI`, `Blazor.Portal`, `PluginCatalog`, `Social`, `Courses`, `Markdown.Export`, `ContentCollections.Indexing.Graph`, `Hosting`)

## Two findings left as follow-ups rather than scope creep

1. **The hub has no observable lifecycle surface.** `RunLevel` is a plain property and `DisposalCompleted` fires only at the *end* of teardown, so "this hub has entered the disposal window" cannot be subscribed — only sampled. This branch avoids needing it (ordering by causation), but the gap is real; closing it means adding a run-level observable to `IMessageHub`/`MessageHub`, which is a core-framework change.
2. **`InstanceSyncTestBase.WaitForConfig` / `WaitForRemote` are interval probes** shared by every test in that project — same defect class as the loop this PR removed, but pre-existing. The clean fix is an observable call/store stream on `FakeRemoteMesh` (a test double, so it is cheap).

I also surveyed the other ~54 `GetMeshNode` call sites for the same "absent ⇒ write" shape. Only three branch on `null` at all (`BrandingResolver`, `EventSubscriptionRunner`, `AccessGrantNotifier`) and all three *skip* rather than create, so none needed migrating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
