### PR TITLE
fix(blazor): assetLoader duplicate-tag guard + Radzen asset-load retry

### DIFF
--- a/src/MeshWeaver.Blazor.Radzen/RadzenViewBase.cs
+++ b/src/MeshWeaver.Blazor.Radzen/RadzenViewBase.cs
@@ -1,6 +1,7 @@
 using MeshWeaver.Blazor;
 using MeshWeaver.Layout;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Radzen;
 
@@ -40,24 +41,42 @@ public abstract class RadzenViewBase<TControl, TView> : BlazorView<TControl, TVi
         themeService.SetTheme(GetRadzenTheme());
     }
 
+    private bool assetsLoading;
+
     /// <summary>
-    /// Loads the pack's static assets once per document on first interactive render, then
-    /// re-renders with <see cref="AssetsReady"/> set so the Radzen components appear.
+    /// Loads the pack's static assets once per document, then re-renders with
+    /// <see cref="AssetsReady"/> set so the Radzen components appear. NOT gated on
+    /// <c>firstRender</c>: a failed load (network blip, circuit reconnect) is caught and logged,
+    /// and the next render retries — the loader module evicts a failed promise, so retry is real.
+    /// A first-render-only attempt would leave the view permanently blank after one transient
+    /// failure (review finding on the introducing PR).
     /// </summary>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
-        if (!firstRender || AssetsReady)
+        if (AssetsReady || assetsLoading)
             return;
-        var loader = await JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/MeshWeaver.Blazor/assetLoader.js");
-        await using (loader)
+        assetsLoading = true;
+        try
         {
-            await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/css/material-base.css", "css");
-            await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/Radzen.Blazor.js", "js");
+            var loader = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/MeshWeaver.Blazor/assetLoader.js");
+            await using (loader)
+            {
+                await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/css/material-base.css", "css");
+                await loader.InvokeVoidAsync("ensure", "_content/Radzen.Blazor/Radzen.Blazor.js", "js");
+            }
+            AssetsReady = true;
+            StateHasChanged();
         }
-        AssetsReady = true;
-        StateHasChanged();
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Radzen pack assets failed to load; retrying on the next render");
+        }
+        finally
+        {
+            assetsLoading = false;
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor/wwwroot/assetLoader.js
+++ b/src/MeshWeaver.Blazor/wwwroot/assetLoader.js
@@ -8,15 +8,31 @@ const loads = new Map();
 export function ensure(url, kind) {
   let p = loads.get(url);
   if (p) return p;
+  // The asset may already be in the document from OUTSIDE this module — a host page tag or an
+  // earlier non-module load. Appending again would double-execute a script, so detect by the
+  // element's RESOLVED url (el.src / el.href are absolute; the caller's url may be relative).
+  const absolute = new URL(url, document.baseURI).href;
+  const existing =
+    kind === "css"
+      ? [...document.querySelectorAll("link[rel='stylesheet']")].some((el) => el.href === absolute)
+      : [...document.querySelectorAll("script[src]")].some((el) => el.src === absolute);
+  if (existing) {
+    p = Promise.resolve(true);
+    loads.set(url, p);
+    return p;
+  }
   p = new Promise((resolve, reject) => {
     let el;
     if (kind === "css") {
       el = document.createElement("link");
       el.rel = "stylesheet";
       el.href = url;
-    } else {
+    } else if (kind === "js") {
       el = document.createElement("script");
       el.src = url;
+    } else {
+      reject(new Error("assetLoader: unknown kind '" + kind + "' for " + url + " — use 'css' or 'js'"));
+      return;
     }
     el.onload = () => resolve(true);
     el.onerror = () => {


### PR DESCRIPTION
Addresses both Copilot review findings on #1501 (merged before the review landed):

1. **Duplicate tags**: `ensure()` resolves immediately when the asset already exists in the document from outside the module, comparing resolved URLs (relative caller vs absolute element property). Unknown `kind` values now reject loudly instead of silently becoming scripts.
2. **Permanent blank on transient failure**: `RadzenViewBase` catches + logs a failed load and retries on the next render instead of attempting only on `firstRender` — the loader module evicts failed promises so the retry actually reloads.

Verified: pack builds clean with `-c Release -warnaserror`. No What's New — internal hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)