### PR TITLE
fix(test): wait for the emission that carries the node, not the first Initial

### DIFF
--- a/test/MeshWeaver.Content.Test/CommentNodeLoadingTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentNodeLoadingTest.cs
@@ -86,6 +86,13 @@ public class CommentNodeLoadingTest(ITestOutputHelper output) : MonolithMeshTest
     [Fact(Timeout = 20000)]
     public async Task CommentNodes_AreDiscoverableByNamespaceQuery()
     {
+        // 🚨 NOT converted to a wait-for-the-items predicate like its neighbours (#1384). This
+        // asserts a COUNT over a whole namespace, and `Added` carries only the CHANGED items
+        // (MeshQuery.TryFilterDuplicateLiveChange; consumers accumulate — MeshNodeCollectionView
+        // does `current.Concat(change.Items)`). So "wait for one emission holding >= 6" is not
+        // satisfiable if the six trickle in as separate deltas — it would swap a fast, clear
+        // failure for a 20 s hang. Fixing this shape needs accumulation ACROSS emissions, which
+        // changes what the test asserts on; left deliberately for that separate change.
         var comments = (await MeshQuery
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{DocPartitionNamespace} nodeType:{CommentNodeType.NodeType}"))

--- a/test/MeshWeaver.Content.Test/CommentWithRepliesViewTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentWithRepliesViewTest.cs
@@ -242,9 +242,12 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
         // No hub initialization needed â€” RoutingMeshQueryProvider discovers
         // partitions via DiscoverNewProvidersAsync during the query.
 
-        // Static node read â€” no write before, catalog read is correct (no CQRS lag).
+        // Wait for the emission that CONTAINS the node, never the first Initial: the catalog
+        // hydrates asynchronously, so an early Initial can be empty and the node arrive as Added.
+        // ("No write before, so no CQRS lag" was the premise this carried; CQRS lag is not the only
+        // way an Initial is incomplete — see #1384.)
         var parentNode = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{CommentC1Path}"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items.FirstOrDefault();
+            .Should().Match(c => c.Items.Any(n => n.Path == CommentC1Path))).Items.First(n => n.Path == CommentC1Path);
         parentNode.Should().NotBeNull("Parent comment c1 should exist");
         parentNode!.Id.Should().Be("c1");
         parentNode.Namespace.Should().Be(DocPath + "/_Comment");
@@ -253,10 +256,10 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
         parentComment.Should().NotBeNull();
         Output.WriteLine($"Parent: Id={parentNode.Id}, Path={parentNode.Path}, Author={parentComment!.Author}");
 
-        // Static node read â€” no write before, catalog read is correct (no CQRS lag).
+        // Same wait-for-the-node shape as above.
         // (Per-node hub routing for nested replies returns the parent c1, not reply1.)
         var replyNode = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{ReplyPath}"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items.FirstOrDefault();
+            .Should().Match(c => c.Items.Any(n => n.Path == ReplyPath))).Items.First(n => n.Path == ReplyPath);
         replyNode.Should().NotBeNull("Reply node should exist");
         replyNode!.Id.Should().Be("reply1", "Reply Id should be the local file name, not the full path");
         replyNode.Namespace.Should().Be(CommentC1Path);
@@ -266,8 +269,9 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
         Output.WriteLine($"Reply: Id={replyNode.Id}, Path={replyNode.Path}, Author={replyComment!.Author}");
 
         // Load children of c1 via subtree query
+        // Wait for the snapshot that has reply1 — the assertion below is what we are waiting FOR.
         var children = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{CommentC1Path} scope:subtree"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
+            .Should().Match(c => c.Items.Any(n => n.Id == "reply1"))).Items;
         foreach (var child in children)
         {
             Output.WriteLine($"Subtree: Id={child.Id}, Path={child.Path}, NodeType={child.NodeType}");

--- a/test/MeshWeaver.Content.Test/MarkdownNodeIntegrationTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownNodeIntegrationTest.cs
@@ -333,8 +333,9 @@ public class MarkdownNodeIntegrationTest(ITestOutputHelper output) : MonolithMes
     [Fact(Timeout = 20000)]
     public async Task MeshWeaver_HasChildren()
     {
+        // Wait for the snapshot that contains the child asserted below, not the first Initial (#1384).
         var children = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("namespace:MeshWeaver"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
+            .Should().Match(c => c.Items.Any(n => n.Path == "MeshWeaver/Platform"))).Items;
 
         children.Should().NotBeEmpty("MeshWeaver should have children");
         // MeshWeaver has Documentation and Platform as direct children

--- a/test/MeshWeaver.Content.Test/NewCommentFlowTest.cs
+++ b/test/MeshWeaver.Content.Test/NewCommentFlowTest.cs
@@ -142,9 +142,12 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         Output.WriteLine($"Retrieved comment: Author={retrievedComment.Author}, Text='{retrievedComment.Text}'");
 
         // Assert Ã¢â‚¬â€ node should appear in namespace: query (this is how ReadView finds comments)
+        // Wait for the snapshot that contains the node just created. This one has a WRITE before it,
+        // so it carries genuine CQRS lag on top of the async catalog hydration — taking the first
+        // Initial here was the least defensible instance of the shape (#1384).
         var children = (await MeshQuery.Query<MeshNode>(
                 MeshQueryRequest.FromQuery($"namespace:{docPath} nodeType:{CommentNodeType.NodeType}"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
+            .Should().Match(c => c.Items.Any(n => n.Path == createdNode.Path))).Items;
 
         children.Should().Contain(n => n.Path == createdNode.Path,
             "New comment should appear in namespace: query (this is how the sidebar finds comments)");

--- a/test/MeshWeaver.Persistence.Test/DataContextIntegrationTest.cs
+++ b/test/MeshWeaver.Persistence.Test/DataContextIntegrationTest.cs
@@ -239,11 +239,24 @@ public class DataContextIntegrationTest : MonolithMeshTestBase
         // This test verifies that MeshNode.Content is correctly persisted
         // and can be loaded back from the persistence service
 
-        // Static node read — no write before, catalog read is correct (no CQRS lag).
+        // Wait for the emission that CONTAINS the node, exactly as the sibling
+        // MeshNode_ChildrenAvailable_ViaPersistence does — never the first Initial.
+        //
+        // 🚨 "No write before, so the catalog read is correct" (what this used to say) is the wrong
+        // premise: CQRS lag is not the only way an Initial can be incomplete. The catalog hydrates
+        // ASYNCHRONOUSLY from the storage adapter at startup, so a query subscribed early gets an
+        // Initial that simply does not have graph/story1 yet, and the rest arrives as Added. Taking
+        // .Items.FirstOrDefault() off that snapshot then asserted on null. The 10 s budget only
+        // decided how often the window was wide enough to lose — it is NOT the defect and is
+        // deliberately left where it is (issue #1384).
+        //
+        // The ChangeType filter is dropped rather than combined with the item check: the node may
+        // well arrive in a later Added rather than a second Initial, and requiring both would wait
+        // for an emission that never comes.
         var storyNode = (await MeshQuery
             .Query<MeshNode>(MeshQueryRequest.FromQuery("path:graph/story1"))
-            .Should().Match(c => c.ChangeType == QueryChangeType.Initial))
-            .Items.FirstOrDefault();
+            .Should().Match(c => c.Items.Any(n => n.Path == "graph/story1")))
+            .Items.First(n => n.Path == "graph/story1");
 
         // Assert - content should be available
         storyNode.Should().NotBeNull("Story node should exist in persistence");


### PR DESCRIPTION
Refs #1384 — fixes the `Persistence_StoryContentIsPreserved` member of that flake population, plus four more instances of the same shape.

## The defect

```csharp
.Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items.FirstOrDefault()
```

The catalog hydrates **asynchronously** from the storage adapter, so a query subscribed early gets an
`Initial` that does not yet contain `graph/story1`; the node then arrives as an `Added` delta, and
`FirstOrDefault()` on the empty snapshot asserted on `null`. The sibling in the same file,
`MeshNode_ChildrenAvailable_ViaPersistence`, already guards exactly this with `Items.Any(...)` — this
instance was missed.

**The 10 s budget is not the defect and is unchanged.** It only decided how often the window was wide
enough to lose. No retry, no widened timeout, no loosened assertion.

**The `ChangeType` check is dropped, not combined** with the item check: the node may arrive in a
later `Added` rather than a second `Initial`, so requiring both would wait for an emission that never
comes. That is why the sibling filters on items alone.

Folding the assertion into the predicate does not cost diagnostics — `Match` reports
`Last of N emission(s) was: …` on timeout, so a genuinely-missing node still shows what the source
actually produced.

## Fail-before — forced, not observed

I could not reproduce the CI timing on demand, so I constrained the interleaving instead: a synthetic
source emitting an **empty `Initial`, then the node 50 ms later as `Added`** — exactly the ordering
the race produces at random.

| predicate | result |
|---|---|
| old (`ChangeType == Initial`) | **fails**, with the CI message verbatim: `Expected value not to be <null> because Story node should exist in persistence` |
| new (`Items.Any(n => n.Path == …)`) | passes |

The scratch proof was removed before commit (it would test the assertions library, not the product).

## The sweep

Same shape across the file and its neighbours — **four more**, all waiting on one specific item, all
converted:

- `CommentWithRepliesViewTest` — parent, reply, subtree
- `NewCommentFlowTest` — the least defensible: it has a **write** before it, so genuine CQRS lag on
  top of the hydration window
- `MarkdownNodeIntegrationTest`

Three carried the *same copy-pasted premise* — "Static node read — no write before, catalog read is
correct (no CQRS lag)". That is one propagated mistake, not five independent ones, and the premise is
simply wrong: CQRS lag was never the only way an `Initial` can be incomplete.

## 🚨 One deliberately NOT converted, and why

`CommentNodeLoadingTest` asserts a **count over a namespace**, and `Added` carries only the *changed*
items (`MeshQuery.TryFilterDuplicateLiveChange`; consumers accumulate — `MeshNodeCollectionView` does
`current.Concat(change.Items)`). So "wait for one emission holding ≥ 6" is **unsatisfiable** if the
six trickle in as separate deltas: it would swap a fast, clear failure for a 20 s hang. I converted
it, realised the delta semantics made it unsound, and reverted it — the reasoning is recorded in-line
so the next reader does not repeat the attempt. That sub-shape needs accumulation *across* emissions,
which changes what the test asserts on.

**Not swept here, reported precisely instead:** `MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs` has
**10** sites of this shape (lines 222, 247, 270, 293, 316, 339, 412, 472, 843, 869, 1166). Most are
count-over-a-set (`results.Count.Should().Be(6)`), i.e. the same unsound-to-convert sub-shape — so
they need the accumulation treatment, not this one. That project also carries a live, *differently
caused* flake in #1384's ledger (`EuropeRe_AnnualReport_EmbeddedCharts`, a renderer-registration
race), so sweeping it here would make any FutuRe red after this PR ambiguous.

## Verification

- `dotnet build test/MeshWeaver.Persistence.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `dotnet build test/MeshWeaver.Content.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `dotnet test … --no-build --logger trx`, fresh `.trx` each:
  - `DataContextIntegrationTest` — **5/5 passed**
  - the four touched Content classes — **60 passed, 1 skipped** (the skip is pre-existing)

No What's New entry: test-only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
