### PR TITLE
ci: samples/Graph/Data joins the content gate — 12k never-type-checked lines

### DIFF
--- a/.github/samples-gate.allow
+++ b/.github/samples-gate.allow
@@ -1,0 +1,8 @@
+FutuRe/AmericasIns/LineOfBusiness compile
+FutuRe/AmericasIns/TransactionMapping compile
+FutuRe/AsiaRe/LineOfBusiness compile
+FutuRe/AsiaRe/TransactionMapping compile
+FutuRe/EuropeRe/LineOfBusiness compile
+FutuRe/EuropeRe/TransactionMapping compile
+Northwind/AnalyticsCatalog compile
+Northwind/Product compile

--- a/.github/scripts/stage-samples-gate.sh
+++ b/.github/scripts/stage-samples-gate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+SRC="$1"
+STAGE="$2"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+# The domain trees that carry runtime-compiled Source/*.cs and NodeType definitions. Infra/fixture
+# partitions (welcome, login, Admin, Agent, Type, ApiToken, VUser, Doc, MeshWeaver, TestSpace,
+# Brand, Architecture) are deliberately not gated — they hold no compilable content.
+# User is NOT gated: the gate mesh serves 'User' from a static node provider (AddMeshNodes), and
+# installing over a static-provider-served path is refused by design (MeshWeaver#1209).
+for name in ACME Northwind Cornerstone FutuRe PensionFund MathDemo PythonDemo Systemorph; do
+  if [ ! -d "$SRC/$name" ]; then echo "::error::samples gate: expected tree '$name' is missing"; exit 1; fi
+  mkdir -p "$STAGE/$name"
+  cp -R "$SRC/$name/." "$STAGE/$name/"
+  rm -f "$STAGE/$name/index.md"
+  # Uniform synthesized Space root: the FileSystem layout keeps roots as SIBLING jsons carrying
+  # persistence stamps (version/createdDate) that have no business in a fresh gate install.
+  printf '%s' "{\"\$type\":\"MeshNode\",\"id\":\"$name\",\"path\":\"$name\",\"mainNode\":\"$name\",\"name\":\"$name\",\"nodeType\":\"Space\",\"state\":\"Active\"}" > "$STAGE/$name/index.json"
+done
+echo "staged: $(find "$STAGE" -name '*.cs' | wc -l | tr -d ' ') .cs files, $(ls "$STAGE" | wc -l | tr -d ' ') packages"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1128,18 +1128,32 @@ jobs:
           if [ "$status" = "0" ]; then status=1; fi
         fi
         verdict="$(grep -m1 -- '^GATE FAILED' "$log" || true)"
+        # ── Second stage: the samples trees — the "12k lines of C# no build ever type-checks"
+        # from AGENTS.md. Same tester, same mechanics; .github/samples-gate.allow is its own
+        # one-way debt ratchet (seeded with the 8 cross-NodeType source defects the first run
+        # surfaced — a listed entry that starts passing fails the run until removed).
+        SSTAGE="${RUNNER_TEMP:-/tmp}/samples"
+        bash .github/scripts/stage-samples-gate.sh samples/Graph/Data "$SSTAGE"
+        slog="${RUNNER_TEMP:-/tmp}/samples-gate.log"
+        sstatus=0
+        if ! time dotnet "$TESTER" "$SSTAGE" --allow .github/samples-gate.allow 2>&1 | tee "$slog"; then
+          sstatus="${PIPESTATUS[0]}"
+          if [ "$sstatus" = "0" ]; then sstatus=1; fi
+        fi
+        sverdict="$(grep -m1 -- '^GATE FAILED' "$slog" || true)"
+        combined="$(printf '%s\n%s' "$verdict" "$sverdict" | grep . | head -1 || true)"
         {
           echo "failure<<GATE_EOF"
-          echo "$verdict"
+          echo "$combined"
           echo "GATE_EOF"
         } >> "$GITHUB_OUTPUT"
-        if [ "$status" != "0" ]; then
-          if [ -n "$verdict" ]; then
-            echo "::error::$verdict"
-          else
-            echo "::error::The doc gate failed before it produced a verdict — no check was judged. See this job's log."
+        if [ "$status" != "0" ] || [ "$sstatus" != "0" ]; then
+          [ -n "$verdict" ] && echo "::error::Doc stage: $verdict"
+          [ -n "$sverdict" ] && echo "::error::Samples stage: $sverdict"
+          if [ -z "$combined" ]; then
+            echo "::error::The content gate failed before it produced a verdict — no check was judged. See this job's log."
           fi
-          exit "$status"
+          exit 1
         fi
 
   licence-gate:

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -32,5 +32,11 @@
     <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.ServiceProvider\MeshWeaver.ServiceProvider.csproj" />
+    <!-- Import + GoogleMaps mirror the PORTAL's assembly surface: both portals reference them
+         PRECISELY so in-mesh sample/plugin source (Cornerstone/Pricing's Excel loader + map,
+         Northwind/Product) can compile at runtime. Without them the gate flags content the real
+         host compiles fine — the gate must judge against the surface content actually gets. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Import\MeshWeaver.Import.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.GoogleMaps\MeshWeaver.GoogleMaps.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Extends the doc-gate job (from #1483) with a second stage over the eight sample domain trees, per the modularization program.

**Mechanics**: `.github/scripts/stage-samples-gate.sh` stages each tree as a package root (synthesized Space roots — the FileSystem sibling roots carry persistence stamps that would trip the monotonic guard on a fresh install; `User` excluded by design, #1209), then the same `mw-plugin-test` pipeline runs with `.github/samples-gate.allow` as its own shrinking-only ratchet.

**Tester change**: `MeshWeaver.PluginTester` now references `MeshWeaver.Import` + `MeshWeaver.GoogleMaps` — mirroring the portals, which carry both precisely for these in-mesh compiles. Cornerstone/Pricing went red→green on exactly this.

**The seeded ratchet is 8 real defects**: cross-NodeType source references without `shared=` declarations (FutuRe LineOfBusiness/TransactionMapping ×6; Northwind Product + AnalyticsCatalog — CS0246 on sibling types). These would fail a portal recompile identically; fixing them shrinks the list.

**Local verification** (exact CI invocation): 8 packages, 32 NodeTypes, `GREEN — 8 known-debt failure(s) allowed (shrinking list)`, ~12 s wall clock — comfortably inside the job's existing budget.

No What's New — CI-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)