### PR TITLE
feat(layout): explicit view fallback slot + Modules:Assemblies boot-pack loading

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -597,6 +597,16 @@ public static class MemexConfiguration
         /// </summary>
         public TBuilder ConfigureMemexMesh(IConfiguration configuration, bool isDevelopment = false)
         {
+            // Boot-time module packs: DLL paths listed under Modules:Assemblies are loaded into
+            // the default ALC BEFORE the container builds, and their MeshNodeProviderAttribute
+            // registrations (services + nodes + hub configuration) fold into this mesh — the
+            // per-deployment "which packs does this instance run" knob (Doc/Architecture/
+            // UiExtensibility). Empty/absent = no-op; a listed path that fails to load should
+            // fail loudly at startup, never silently run without the pack.
+            var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
+            if (moduleAssemblies is { Length: > 0 })
+                builder.InstallAssemblies(moduleAssemblies);
+
             // Read graph storage config
             var graphStorageConfig = configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();
             if (graphStorageConfig == null)

--- a/src/MeshWeaver.Blazor/BlazorViewRegistry.cs
+++ b/src/MeshWeaver.Blazor/BlazorViewRegistry.cs
@@ -51,7 +51,12 @@ public static class BlazorViewRegistry
         .AddData()
         .AddLayoutClient(c =>
             (configuration ?? (x => x))
-            .Invoke(c.WithView((i, s, a) => DefaultFormatting(c.Hub, i, s, a))))
+            .Invoke(c.WithView((i, s, a) => DefaultFormatting(c.Hub, i, s, a))
+                // The escaped-HTML fallback is the FALLBACK slot, not a view map: it is consulted
+                // only after every registered map — including view packs registered AFTER
+                // AddBlazor() — has declined. As a terminal arm inside DefaultFormatting it made
+                // registration order load-bearing and silently killed late-registered packs.
+                .WithFallbackView((i, s, a) => FallbackHtml(i, s, a))))
         .AddMeshTypes()
         .AddMarkdownTypes()
         .AddMarkdownExportTypes()
@@ -153,7 +158,10 @@ public static class BlazorViewRegistry
                 KpiStripControl kpiStrip => ControlView<KpiStripControl, KpiStripView>(kpiStrip, stream, area),
                 TowerControl tower => ControlView<TowerControl, TowerView>(tower, stream, area),
                 ComparisonBarsControl comparisonBars => ControlView<ComparisonBarsControl, ComparisonBarsView>(comparisonBars, stream, area),
-                _ => FallbackHtml(instance, stream, area),
+                // No match ⇒ DECLINE (null) so later-registered maps — view packs added after
+                // AddBlazor() — get their turn. The escaped-HTML fallback lives in the
+                // configuration's FallbackViewMap slot, consulted after every map declined.
+                _ => null,
             };
         }
         catch (Exception ex)

--- a/src/MeshWeaver.Layout/Client/LayoutClientConfiguration.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientConfiguration.cs
@@ -47,6 +47,23 @@ public record LayoutClientConfiguration(IMessageHub Hub)
 
     internal ImmutableList<ViewMap> ViewMaps { get; init; } = ImmutableList<ViewMap>.Empty;
 
+    /// <summary>
+    /// The LAST-resort view map, consulted only after every registered map declined. Kept OUTSIDE
+    /// <see cref="ViewMaps"/> so registration ORDER stops being load-bearing: the core registry's
+    /// default mapping used to end in a terminal fallback arm, which silently killed any view pack
+    /// registered after <c>AddBlazor()</c> — first-match-wins met a map that never declined.
+    /// </summary>
+    internal ViewMap? FallbackViewMap { get; init; }
+
+    /// <summary>
+    /// Returns a copy with <paramref name="viewMap"/> as the last-resort fallback (see
+    /// <see cref="FallbackViewMap"/>). The renderer host sets this once; view packs never do.
+    /// </summary>
+    /// <param name="viewMap">The fallback view map.</param>
+    /// <returns>A new instance with the fallback set.</returns>
+    public LayoutClientConfiguration WithFallbackView(ViewMap viewMap)
+        => this with { FallbackViewMap = viewMap };
+
 
     /// <summary>
     /// Returns a copy with <paramref name="viewMap"/> appended to the view-mapping chain.
@@ -71,14 +88,16 @@ public record LayoutClientConfiguration(IMessageHub Hub)
     }
 
     /// <summary>
-    /// Tries each registered view map in order and returns the first non-null <see cref="ViewDescriptor"/> for the given instance.
+    /// Tries each registered view map in order and returns the first non-null <see cref="ViewDescriptor"/> for the given instance;
+    /// when every map declines, the host's <see cref="FallbackViewMap"/> (if any) produces the last-resort descriptor.
     /// </summary>
     /// <param name="instance">The view-model instance to resolve a view for.</param>
     /// <param name="stream">The synchronization stream for the area, or null.</param>
     /// <param name="area">The area name.</param>
-    /// <returns>The first matching <see cref="ViewDescriptor"/>, or null if no map matches.</returns>
+    /// <returns>The first matching <see cref="ViewDescriptor"/>, the fallback's descriptor, or null.</returns>
     public ViewDescriptor? GetViewDescriptor(object instance, ISynchronizationStream<JsonElement>? stream, string area) =>
-        ViewMaps.Select(m => m.Invoke(instance, stream, area)).FirstOrDefault(d => d is not null);
+        ViewMaps.Select(m => m.Invoke(instance, stream, area)).FirstOrDefault(d => d is not null)
+        ?? FallbackViewMap?.Invoke(instance, stream, area);
 
     /// <summary>Parameter key used to pass the view-model instance into a Blazor component's parameter dictionary.</summary>
     public const string ViewModel = nameof(ViewModel);

--- a/test/MeshWeaver.Layout.Test/ViewPackFallbackOrderingTest.cs
+++ b/test/MeshWeaver.Layout.Test/ViewPackFallbackOrderingTest.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the view-pack registration contract: a view map registered AFTER the host's default
+/// mapping still wins over the last-resort fallback, because the fallback lives in its own slot
+/// (<see cref="LayoutClientConfiguration.WithFallbackView"/>) consulted only once every map has
+/// declined. Before this contract existed, the core default mapping ended in a terminal
+/// fallback arm, so registration order was load-bearing: a pack registered after
+/// <c>AddBlazor()</c> was silently dead and its controls rendered as escaped HTML.
+/// </summary>
+public class ViewPackFallbackOrderingTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private sealed record PackControl;
+
+    [Fact]
+    public void LateRegisteredPackMap_WinsOverFallback_AndFallbackCatchesTheRest()
+    {
+        var config = new LayoutClientConfiguration(GetClient())
+            // The host's default mapping: declines what it does not know (returns null).
+            .WithView((_, _, _) => null)
+            // The host's last-resort fallback — its own slot, never part of the ordered maps.
+            .WithFallbackView((_, _, _) =>
+                new ViewDescriptor(typeof(string), new Dictionary<string, object?>()))
+            // A view pack registered AFTER the default mapping — the late-registration case.
+            .WithView((i, _, _) => i is PackControl
+                ? new ViewDescriptor(typeof(int), new Dictionary<string, object?>())
+                : null);
+
+        // A late-registered pack map must be consulted before the fallback.
+        var packDescriptor = config.GetViewDescriptor(new PackControl(), null, "area");
+        Assert.NotNull(packDescriptor);
+        Assert.Equal(typeof(int), packDescriptor!.Type);
+
+        // The fallback slot catches instances no map claims.
+        var fallbackDescriptor = config.GetViewDescriptor(new object(), null, "area");
+        Assert.NotNull(fallbackDescriptor);
+        Assert.Equal(typeof(string), fallbackDescriptor!.Type);
+    }
+}


### PR DESCRIPTION
The two structural blockers for injectable view packs (modularization program, WS2):

1. **Registration order stops being load-bearing**: the escaped-HTML fallback moves from `DefaultFormatting`'s terminal switch arm into a dedicated `FallbackViewMap` slot on `LayoutClientConfiguration` (`WithFallbackView`), consulted only after every registered map declined. Packs registered after `AddBlazor()` now work; before, they silently rendered as escaped HTML. `ViewPackFallbackOrderingTest` pins the contract.
2. **`Modules:Assemblies`** (configuration) now feeds `MeshBuilder.InstallAssemblies` — the existing boot-time loader that had zero call sites — making boot-time pack loading a per-deployment knob per [UI Extensibility](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md).

**Verification**: `Memex.Portal.Shared` `-c Release -warnaserror` clean; `MeshWeaver.Layout.Test` **421/421**; `MeshWeaver.Hosting.Blazor.Test` **402/402** (the suite most sensitive to view resolution).

No What's New — framework seam, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)