### PR TITLE
fix: type every upsert parameter so the compare-and-set write cannot 42P18

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-portals-no-longer-stall-before-becoming-ready.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-portals-no-longer-stall-before-becoming-ready.md
@@ -1,0 +1,24 @@
+---
+Name: Portals no longer stall before becoming ready
+Category: Fix
+Description: A database write the build coordinator makes on every pass could fail outright, leaving a portal stuck preparing its content types and never finishing startup.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Portals no longer stall before becoming ready
+
+Before a portal starts serving, one of its instances has to volunteer to prepare the content types
+everything else depends on. The instances agree on who does the work by writing a small coordination
+record to the database.
+
+That write could fail outright — not because of anything about the data, but because of how the
+write was described to PostgreSQL. Once the coordination record existed, every later attempt to
+update it was rejected, so nobody was ever chosen to do the work. The portal reported "preparing
+content types" and stayed there indefinitely: pages never loaded and the instance never became
+healthy.
+
+The write is now described precisely enough that PostgreSQL accepts it in every case, so the
+coordination proceeds, the content types get prepared, and the portal comes up. The problem only
+affected records the platform writes for itself, which is why it surfaced as a startup stall rather
+than as an error anyone could see while using the portal.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -533,7 +533,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
 
             // Build every upsert first (this is where the embedding calls happen), keeping the
             // caller's order, then window by target table.
-            var built = new List<(MeshNode Node, string Table, string Sql, IReadOnlyList<object> Parameters)>(ordered.Count);
+            var built = new List<(MeshNode Node, string Table, string Sql, IReadOnlyList<NpgsqlParameter> Parameters)>(ordered.Count);
             foreach (var node in ordered)
             {
                 var (sql, parameters) = await BuildUpsertAsync(node, options).ConfigureAwait(false);
@@ -560,8 +560,8 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                     foreach (var item in items)
                     {
                         var command = new NpgsqlBatchCommand(item.Sql);
-                        foreach (var value in item.Parameters)
-                            command.Parameters.AddWithValue(value);
+                        foreach (var parameter in item.Parameters)
+                            command.Parameters.Add(parameter);
                         batch.BatchCommands.Add(command);
                     }
                     await batch.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
@@ -626,8 +626,8 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     {
         var (sql, parameters) = await BuildUpsertAsync(node, options, expectedVersion).ConfigureAwait(false);
         await using var cmd = _dataSource.CreateCommand(sql);
-        foreach (var value in parameters)
-            cmd.Parameters.AddWithValue(value);
+        foreach (var parameter in parameters)
+            cmd.Parameters.Add(parameter);
         return await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false) > 0;
     }
 
@@ -654,6 +654,43 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         });
 
     /// <summary>
+    /// One positional upsert parameter, with its PostgreSQL type stated explicitly.
+    ///
+    /// <para>🚨 Never <c>AddWithValue</c> here. Npgsql sends a parameter whose type it does not know
+    /// — which is every <c>DBNull</c> — with the unspecified OID 0, delegating the decision to the
+    /// SERVER, which infers it from where the parameter is USED. The compare-and-set branch below
+    /// deliberately binds parameters it never references (<c>created_by</c> and <c>created_date</c>
+    /// are immutable, so the UPDATE omits them while the positional layout still carries them), and
+    /// for those there is nothing to infer from: PostgreSQL rejects the whole statement with
+    /// <c>42P18: could not determine data type of parameter $n</c>, naming whichever untyped
+    /// unreferenced parameter comes first. That is not a hypothetical — it wedged a production
+    /// portal's readiness, because the build-claim lock is written by the framework itself and so
+    /// carries no authorship at all, and every arbitration pass past the first (insert-only, where
+    /// every parameter IS referenced) failed forever: no builder elected, no NodeType bake, no
+    /// ready pod.</para>
+    ///
+    /// <para>Stating the type removes the dependence on inference for EVERY parameter and every
+    /// branch, so no later change to which columns a statement mentions can re-arm this. Fixing
+    /// only the two columns that happen to be unreferenced today would leave that trap set.</para>
+    /// </summary>
+    /// <param name="type">The column's PostgreSQL type.</param>
+    /// <param name="value">The value, or <c>null</c> for SQL NULL.</param>
+    /// <returns>An unnamed (positional) parameter carrying an explicit type.</returns>
+    private static NpgsqlParameter Typed(NpgsqlDbType type, object? value)
+        => new() { NpgsqlDbType = type, Value = value ?? DBNull.Value };
+
+    /// <summary>
+    /// The <c>embedding</c> parameter. pgvector's type has no <see cref="NpgsqlDbType"/> member, so
+    /// it is named directly — the data sources this adapter is built over all register the mapping
+    /// (<c>UseVector()</c>), and naming it means a NULL embedding is typed exactly like a present
+    /// one instead of relying on the column context.
+    /// </summary>
+    /// <param name="embedding">The embedding, or <c>null</c> when none was generated.</param>
+    /// <returns>An unnamed (positional) <c>vector</c> parameter.</returns>
+    private static NpgsqlParameter TypedVector(float[]? embedding)
+        => new() { DataTypeName = "vector", Value = embedding is null ? DBNull.Value : new Vector(embedding) };
+
+    /// <summary>
     /// The upsert for ONE node: its SQL text and its positional parameters, in order.
     /// Shared by <see cref="WriteAsyncCore"/> (one command) and <see cref="WriteMany"/>
     /// (one <see cref="NpgsqlBatchCommand"/> per node) so the two paths can never drift —
@@ -671,7 +708,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// exactly this version". The equality is what makes the write EXCLUSIVE rather than merely
     /// non-regressing — see the contract note on <see cref="IStorageAdapter.WriteIfVersion"/>.
     /// </param>
-    private async Task<(string Sql, IReadOnlyList<object> Parameters)> BuildUpsertAsync(
+    private async Task<(string Sql, IReadOnlyList<NpgsqlParameter> Parameters)> BuildUpsertAsync(
         MeshNode node, JsonSerializerOptions options, long? expectedVersion = null)
     {
         var ns = node.Namespace ?? "";
@@ -730,35 +767,36 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         // still apply — re-persisting an unchanged node is a legitimate, common shape. The alias is
         // required: inside ON CONFLICT DO UPDATE the target row is referenced by its range-table name,
         // and `{table}` is schema-qualified.
-        var parameters = new List<object>(21)
+        var parameters = new List<NpgsqlParameter>(21)
         {
-            ns,
-            node.Id,
-            (object?)node.Name ?? DBNull.Value,
-            (object?)node.Description ?? DBNull.Value,
-            (object?)node.NodeType ?? DBNull.Value,
-            (object?)node.Category ?? DBNull.Value,
-            (object?)node.Icon ?? DBNull.Value,
-            node.Order.HasValue ? node.Order.Value : DBNull.Value,
-            node.LastModified == default ? DateTimeOffset.UtcNow : node.LastModified,
-            node.Version,
-            (short)node.State,
-            (object?)contentJson ?? DBNull.Value,
-            (object?)node.DesiredId ?? DBNull.Value,
-            embeddingVector != null ? new Vector(embeddingVector) : DBNull.Value,
-            node.MainNode,
+            Typed(NpgsqlDbType.Text, ns),
+            Typed(NpgsqlDbType.Text, node.Id),
+            Typed(NpgsqlDbType.Text, node.Name),
+            Typed(NpgsqlDbType.Text, node.Description),
+            Typed(NpgsqlDbType.Text, node.NodeType),
+            Typed(NpgsqlDbType.Text, node.Category),
+            Typed(NpgsqlDbType.Text, node.Icon),
+            Typed(NpgsqlDbType.Integer, node.Order),
+            Typed(NpgsqlDbType.TimestampTz,
+                node.LastModified == default ? DateTimeOffset.UtcNow : node.LastModified),
+            Typed(NpgsqlDbType.Bigint, node.Version),
+            Typed(NpgsqlDbType.Smallint, (short)node.State),
+            Typed(NpgsqlDbType.Text, contentJson),   // bound as text, cast to jsonb in the statement
+            Typed(NpgsqlDbType.Text, node.DesiredId),
+            TypedVector(embeddingVector),
+            Typed(NpgsqlDbType.Text, node.MainNode),
         };
 
         // $16–$20 — only bound when the target is mesh_nodes (see writeSync above).
         if (writeSync)
         {
-            parameters.Add((short)node.SyncBehavior);
-            parameters.Add((object?)node.CreatedBy ?? DBNull.Value);
-            parameters.Add((object?)node.LastModifiedBy ?? DBNull.Value);
-            parameters.Add(node.CreatedDate == default ? DBNull.Value : node.CreatedDate);
-            parameters.Add(node.ExcludeFromContext is { Count: > 0 } efc
-                ? efc.ToArray()
-                : (object)DBNull.Value);
+            parameters.Add(Typed(NpgsqlDbType.Smallint, (short)node.SyncBehavior));
+            parameters.Add(Typed(NpgsqlDbType.Text, node.CreatedBy));
+            parameters.Add(Typed(NpgsqlDbType.Text, node.LastModifiedBy));
+            parameters.Add(Typed(NpgsqlDbType.TimestampTz,
+                node.CreatedDate == default ? null : node.CreatedDate));
+            parameters.Add(Typed(NpgsqlDbType.Array | NpgsqlDbType.Text,
+                node.ExcludeFromContext is { Count: > 0 } efc ? efc.ToArray() : null));
         }
 
         // The conflict action. Built AFTER the parameter list so the compare-and-set predicate can
@@ -774,9 +812,13 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         // the two backends must not disagree about what compare-and-set means.
         if (expectedVersion is > 0)
         {
-            parameters.Add(expectedVersion.Value);
+            parameters.Add(Typed(NpgsqlDbType.Bigint, expectedVersion.Value));
             // Mirrors the ON CONFLICT SET list exactly — created_by / created_date stay untouched
             // (insert-only there, absent here), so authorship survives a compare-and-set too.
+            // 🚨 That makes $17 and $19 BOUND BUT NEVER REFERENCED in this statement. Legal only
+            // because every parameter carries an explicit type (see Typed): an untyped one here has
+            // no usage to infer from and 42P18s the whole statement. Do not switch this list back
+            // to AddWithValue, and do not "tidy" the layout by assuming a bound parameter is used.
             var casSync = writeSync ? ",\n                sync_behavior = $16" : "";
             var casAuthor = writeSync ? ",\n                last_modified_by = $18" : "";
             var casExclude = writeSync ? ",\n                exclude_from_context = $20" : "";

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UpsertParameterTypingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UpsertParameterTypingTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The compare-and-set write path must not depend on PostgreSQL INFERRING a parameter's type.
+///
+/// <para><b>The defect.</b> <c>BuildUpsertAsync</c> lays its parameters out POSITIONALLY for the
+/// <c>INSERT … ON CONFLICT</c> form, and the compare-and-set form
+/// (<see cref="PostgreSqlStorageAdapter.WriteIfVersion"/> with a non-zero expected version) reuses
+/// that identical list against a plain <c>UPDATE</c>. That UPDATE deliberately omits
+/// <c>created_by</c> ($17) and <c>created_date</c> ($19) — authorship is immutable, set once at
+/// INSERT — so those two parameters are BOUND but never REFERENCED. PostgreSQL infers a
+/// parameter's type from where it is used, and a parameter that appears nowhere in the statement
+/// has no context to infer from. Npgsql's <c>AddWithValue(DBNull.Value)</c> sends the unspecified
+/// OID 0, so the server has nothing at all and fails the whole statement with
+/// <c>42P18: could not determine data type of parameter $17</c>.</para>
+///
+/// <para><b>Why only framework-written nodes.</b> A non-null <c>CreatedBy</c> makes Npgsql send the
+/// text OID, which the server accepts even for an unreferenced parameter. Only a node whose
+/// authorship is null — one the framework wrote for itself, such as the build-claim lock — reaches
+/// the untyped case. That is how this reached production as a portal-readiness wedge: every
+/// build-claim arbitration pass past the very first (which takes the insert-only path, where every
+/// parameter IS referenced) failed, so no builder was ever elected and the NodeType bake never
+/// started.</para>
+///
+/// <para><b>Fail-before.</b> Against the pre-fix adapter the first two tests throw
+/// <c>PostgresException 42P18</c> naming $17 and $19 respectively. The remaining tests pass both
+/// before and after: they pin the boundary of the defect — a REFERENCED <c>DBNull</c> infers fine,
+/// and the satellite layout references every parameter it binds — so the fix cannot be narrowed by
+/// accident later.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class UpsertParameterTypingTests(PostgreSqlFixture fixture)
+{
+    private readonly JsonSerializerOptions options = new();
+
+    private const string ClaimNamespace = "Admin/Build/_Claim";
+    private const string ClaimPath = "Admin/Build/_Claim/Claim";
+
+    /// <summary>
+    /// A node with every optional column populated EXCEPT the authorship pair — the shape the
+    /// framework writes for its own coordination nodes (the build claim, the GO marker).
+    /// </summary>
+    private static MeshNode SystemAuthoredNode(long version, string name) =>
+        new("Claim", ClaimNamespace)
+        {
+            Name = name,
+            Description = "every earlier optional column is set, so $17 is the FIRST untyped one",
+            NodeType = "Build",
+            Category = "coordination",
+            Icon = "/static/NodeTypeIcons/task-list.svg",
+            Order = 3,
+            LastModified = DateTimeOffset.UtcNow,
+            Version = version,
+            Content = new { claimedBy = "silo-a" },
+            DesiredId = "Claim",
+            ExcludeFromContext = new HashSet<string> { "create" },
+            // CreatedBy / LastModifiedBy / CreatedDate deliberately unset: nothing stamps
+            // authorship on a node the framework writes for itself.
+        };
+
+    /// <summary>
+    /// 🚨 THE PRODUCTION WEDGE. The build-claim arbiter commits through
+    /// <see cref="PostgreSqlStorageAdapter.WriteIfVersion"/> against the lock's current version, so
+    /// every pass after the lock row exists takes the compare-and-set UPDATE. Pre-fix this threw
+    /// <c>42P18 … parameter $17</c> on every pass — no builder elected, no bake, no readiness.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CompareAndSet_AppliesWhenAuthorshipIsNull()
+    {
+        await fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = fixture.StorageAdapter;
+
+        // The insert-only leg — the one that always worked, because the INSERT references every
+        // parameter it binds.
+        var created = await adapter.WriteIfVersion(SystemAuthoredNode(1, "held by silo-a"), 0, options)
+            .Should().Within(30.Seconds()).Emit();
+        created.Should().BeTrue();
+
+        // The heartbeat / re-grant leg — compare-and-set against the version just written.
+        var applied = await adapter.WriteIfVersion(SystemAuthoredNode(2, "held by silo-b"), 1, options)
+            .Should().Within(30.Seconds()).Emit();
+        applied.Should().BeTrue();
+
+        var stored = await adapter.Read(ClaimPath, options).Should().Within(30.Seconds()).Emit();
+        stored.Should().NotBeNull();
+        stored!.Name.Should().Be("held by silo-b");
+        stored.Version.Should().Be(2L);
+        // Authorship stays immutable — and absent, which is the whole point.
+        stored.CreatedBy.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The discriminator: with <see cref="MeshNode.CreatedBy"/> SET, $17 carries the text OID and
+    /// the server accepts it even unreferenced — so the failure moves to $19
+    /// (<c>created_date</c>), the other parameter the compare-and-set UPDATE binds without
+    /// referencing. This is what proves the defect is "unreferenced parameter, no type" rather
+    /// than "CreatedBy specifically": fixing one column would have left the other armed.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CompareAndSet_AppliesWhenOnlyCreatedDateIsMissing()
+    {
+        await fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = fixture.StorageAdapter;
+
+        static MeshNode Authored(long version, string name) =>
+            SystemAuthoredNode(version, name) with
+            {
+                CreatedBy = "system-security",
+                LastModifiedBy = "system-security",
+                // CreatedDate left at default → DBNull at $19.
+            };
+
+        var created = await adapter.WriteIfVersion(Authored(1, "first"), 0, options)
+            .Should().Within(30.Seconds()).Emit();
+        created.Should().BeTrue();
+
+        var applied = await adapter.WriteIfVersion(Authored(2, "second"), 1, options)
+            .Should().Within(30.Seconds()).Emit();
+        applied.Should().BeTrue();
+
+        var stored = await adapter.Read(ClaimPath, options).Should().Within(30.Seconds()).Emit();
+        stored!.Name.Should().Be("second");
+    }
+
+    /// <summary>
+    /// The compare-and-set REFUSAL must stay a refusal, not become an exception: a stale expected
+    /// version returns false and leaves the durable row alone. Typing the parameters must not
+    /// change that verdict — it is the whole cross-cluster exclusivity guarantee.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CompareAndSet_RefusesAStaleExpectedVersion()
+    {
+        await fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = fixture.StorageAdapter;
+
+        await adapter.WriteIfVersion(SystemAuthoredNode(5, "winner"), 0, options)
+            .Should().Within(30.Seconds()).Emit();
+
+        var refused = await adapter.WriteIfVersion(SystemAuthoredNode(6, "loser"), 4, options)
+            .Should().Within(30.Seconds()).Emit();
+        refused.Should().BeFalse();
+
+        var stored = await adapter.Read(ClaimPath, options).Should().Within(30.Seconds()).Emit();
+        stored!.Name.Should().Be("winner");
+    }
+
+    /// <summary>
+    /// The satellite (non-<c>mesh_nodes</c>) layout: 15 parameters plus the expected version, and
+    /// the compare-and-set UPDATE references all sixteen — sync_behavior, authorship and
+    /// exclude_from_context do not exist on a satellite table, so they are never bound. This path
+    /// therefore has NO unreferenced parameter and passed even pre-fix; the test pins that,
+    /// because the positional layout differs and the fix must hold for both shapes.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task CompareAndSet_AppliesOnASatelliteTable()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var partition = new PartitionDefinition
+        {
+            Namespace = "TypingOrg",
+            DataSource = "default",
+            Schema = "param_typing_test",
+            Versioned = true,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings(),
+        };
+        var (_, adapter) = await fixture.CreateSchemaAdapterAsync("param_typing_test", partition, ct);
+
+        static MeshNode Satellite(long version, string name) =>
+            new("alice_Access", "TypingOrg/_Access")
+            {
+                Name = name,
+                NodeType = "AccessAssignment",
+                MainNode = "TypingOrg",
+                Version = version,
+                Content = new { accessObject = "alice" },
+            };
+
+        var created = await adapter.WriteIfVersion(Satellite(1, "first"), 0, options)
+            .Should().Within(30.Seconds()).Emit();
+        created.Should().BeTrue();
+
+        var applied = await adapter.WriteIfVersion(Satellite(2, "second"), 1, options)
+            .Should().Within(30.Seconds()).Emit();
+        applied.Should().BeTrue();
+
+        var stored = await adapter.Read("TypingOrg/_Access/alice_Access", options)
+            .Should().Within(30.Seconds()).Emit();
+        stored!.Name.Should().Be("second");
+    }
+
+    /// <summary>
+    /// The falsifier for the obvious-but-wrong reading of the incident ("<c>DBNull</c> yields an
+    /// untyped parameter, so every optional column is armed"). Every optional column null, through
+    /// the ordinary upsert — and it applies, because the INSERT references each parameter and the
+    /// server infers each type from its target column. <c>DBNull</c> is not the defect; binding a
+    /// parameter the statement never mentions is.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task OrdinaryUpsert_AppliesWithEveryOptionalColumnNull()
+    {
+        await fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = fixture.StorageAdapter;
+
+        var bare = new MeshNode("Bare", "Admin");   // name, description, content, authorship … all null
+        await adapter.Write(bare, options).Should().Within(30.Seconds()).Emit();
+
+        var stored = await adapter.Read("Admin/Bare", options).Should().Within(30.Seconds()).Emit();
+        stored.Should().NotBeNull();
+        stored!.Name.Should().BeNull();
+        stored.CreatedBy.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## The wedge

`memex.meshweaver.cloud` (AKS ns `memex-cloud`) had portal pods that started, passed the DB gate,
and then never became ready — 60+ minutes at health check `NodeType bake in progress — enumerating
dynamic NodeTypes`, with this repeating indefinitely:

```
warn: MeshWeaver.Mesh.MeshNode[0]
      Build claim arbitration failed on Admin/Build
      Npgsql.PostgresException (0x80004005): 42P18: could not determine data type of parameter $17
         at MeshWeaver.Hosting.PostgreSql.PostgreSqlStorageAdapter.WriteAsyncCore(...)
```

No builder elected → no bake → readiness never arrives.

## Root cause

`BuildUpsertAsync` lays its parameters out **positionally** for the `INSERT … ON CONFLICT` form, and
the compare-and-set form (`WriteIfVersion` with a non-zero expected version) reuses that identical
list against a plain `UPDATE`. That UPDATE deliberately omits `created_by` ($17) and `created_date`
($19) — authorship is immutable, set once at INSERT — so **those two parameters are bound but never
referenced**.

PostgreSQL infers a parameter's type from where it is *used*. A parameter that appears nowhere in the
statement has nothing to infer from, and `AddWithValue(DBNull.Value)` sends the unspecified OID 0, so
the server has nothing at all → `42P18`.

A non-null `CreatedBy` makes Npgsql send the text OID, which the server accepts **even for an
unreferenced parameter**. So only a node the framework wrote *for itself*, carrying no authorship,
reaches the untyped case — and the build-claim lock is exactly that. The very first claim takes the
insert-only path (`expectedVersion == 0`), where every parameter IS referenced, which is why the
first pass worked and every subsequent one failed forever.

## What was verified, and what was falsified

The reported hypothesis was "`AddWithValue(DBNull.Value)` yields an untyped parameter, so every
optional column is armed". Only half of that holds, and the tests pin both halves:

| Path | Pre-fix | Why |
|---|---|---|
| CAS UPDATE, `mesh_nodes`, null authorship | **42P18 $17** | $17 bound, never referenced |
| CAS UPDATE, `mesh_nodes`, `CreatedBy` set, `CreatedDate` default | **42P18 $19** | $17 now typed → failure moves to the other unreferenced one |
| CAS UPDATE, satellite table (`access`) | **passes** | binds 15 + 1 and references all sixteen — never armed |
| Ordinary upsert, every optional column null | **passes** | every parameter referenced; the server infers each type from its target column |

So a `DBNull` is *not* the defect — binding a parameter the statement never mentions is. The
discriminator row (failure moving $17 → $19) is what proves it isn't `CreatedBy`-specific.

## The fix

Every upsert parameter now states its PostgreSQL type explicitly (`Typed` / `TypedVector`) instead of
relying on server-side inference — not just the two that happen to be unreferenced today. Fixing only
those two would leave the trap armed for the next change to which columns a statement mentions. The
`WriteMany` batch path shares the same builder and gets the same typing.

Deliberately **not** done (all band-aids): defaulting `CreatedBy` to a sentinel, catching the
exception, retrying, or disabling the build protocol.

Also surveyed the other positional-parameter commands (`PostgreSqlVersionQuery.WriteVersion`,
`PostgreSqlChunkedContentVectorStore`, `SavePartitionObjects`): each binds exactly the parameters its
statement references, so none carries this defect.

## Verification

- **Fail-before demonstrated** on the pre-fix tree: `UpsertParameterTypingTests` → 3 failed / 2
  passed, with `42P18 … parameter $17` and `42P18 … parameter $19` verbatim.
- **Pass-after**: 5/5.
- **Full `MeshWeaver.Hosting.PostgreSql.Test`**: **708 passed, 0 failed, 1 skipped** — covers the
  vector/embedding path (`DataTypeName = "vector"`), the batch writer, authorship persistence,
  `exclude_from_context`, and the satellite tables.
- `dotnet build … -c Release -warnaserror` clean (`0 Warning(s), 0 Error(s)`) for both the adapter
  and the test project.
- Real PostgreSQL throughout (Testcontainers `pgvector/pgvector:pg17`); no mocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
