### PR TITLE
feat: Features:UiPacks — the compiled UI packs become deployment-switchable

### DIFF
--- a/memex/Memex.Portal.Monolith/Program.cs
+++ b/memex/Memex.Portal.Monolith/Program.cs
@@ -55,7 +55,7 @@ builder.UseMeshWeaver(
         var storageConfig = builder.Configuration.GetSection("Storage").Get<ContentCollectionConfig>();
 
         config = config
-            .ConfigureMemexPortal()
+            .ConfigureMemexPortal(builder.Configuration)
             .ConfigureMemexMesh(builder.Configuration, builder.Environment.IsDevelopment());
 
         // Register storage collection at mesh level for static file serving (monolith only)

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -73,6 +73,14 @@ namespace Memex.Portal.Shared;
 public static class MemexConfiguration
 {
     /// <summary>
+    /// Conditional fluent step: applies <paramref name="apply"/> only when
+    /// <paramref name="condition"/> holds — keeps feature-flagged registrations readable inside
+    /// long builder chains (the Features:UiPacks gates below).
+    /// </summary>
+    public static T If<T>(this T value, bool condition, Func<T, T> apply)
+        => condition ? apply(value) : value;
+
+    /// <summary>
     /// Configures web portal services for Memex.
     /// Pattern taken from MeshWeaver.Portal's SharedPortalConfiguration.
     /// </summary>
@@ -756,7 +764,7 @@ public static class MemexConfiguration
                 .AddCourses()
                 // Whole-course left-hand index for NODE-NATIVE courses (Edu/Lesson-shaped
                 // plugin partitions) — the same menu AddCourses gives its own course type.
-                .AddEducationNavigation()
+                .If(features.UiPacks.Education, b => b.AddEducationNavigation())
                 .AddPortalType()
                 .AddAI(serveFromPartition);
 
@@ -991,12 +999,20 @@ public static class MemexConfiguration
         /// <summary>
         /// Configures the portal with Graph views, Charts, GoogleMaps, and Radzen.
         /// </summary>
-        public TBuilder ConfigureMemexPortal() => (TBuilder)builder
+        public TBuilder ConfigureMemexPortal(IConfiguration configuration)
+        {
+            var features = configuration.GetSection(MemexFeatureOptions.SectionName)
+                .Get<MemexFeatureOptions>() ?? new MemexFeatureOptions();
+            return (TBuilder)builder
             .ConfigureHub(mesh => mesh
                 .AddMeshTypes()
-                .AddRadzenViews()
-                .AddAnalysisViews()
-                .AddGoogleMaps()
+                // The compiled view packs — each behind its Features:UiPacks flag so a deployment
+                // can switch it off by config (the AI-provider precedent). Registration order
+                // stopped being load-bearing with the fallback-slot seam, so a disabled pack
+                // simply leaves its controls to the fallback.
+                .If(features.UiPacks.Radzen, c => c.AddRadzenViews())
+                .If(features.UiPacks.Analysis, c => c.AddAnalysisViews())
+                .If(features.UiPacks.GoogleMaps, c => c.AddGoogleMaps())
                 .AddGraphViews()  // Also enables @ autocomplete in markdown editors
                 .AddChatViews()   // Register ThreadChatView
                 .AddUserProfileViews() // Register UserProfilePageView
@@ -1027,6 +1043,7 @@ public static class MemexConfiguration
                     return c.AddData().WithGraphTypes();
                 })
             );
+        }
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
+++ b/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
@@ -20,6 +20,15 @@ public sealed record MemexFeatureOptions
 
     public AiFeatureOptions Ai { get; init; } = new();
 
+    /// <summary>
+    /// Compiled UI view packs (charts/pivot, analysis views, maps) and the education runtime —
+    /// each a self-contained pack a deployment can switch OFF by config. The controls a disabled
+    /// pack would render fall to the escaped-HTML fallback; content plugins that need them should
+    /// declare it. On by default; the boot-time Modules:Assemblies lane later replaces these
+    /// flags with "which packs does this instance load at all".
+    /// </summary>
+    public UiPackFeatureOptions UiPacks { get; init; } = new();
+
     /// <summary>Static-repo → DB sync: which partitions are materialized into and served from the DB.</summary>
     public StaticRepoSyncFeatureOptions StaticRepoSync { get; init; } = new();
 
@@ -178,6 +187,24 @@ public sealed record AiProviderFeatureOptions
     public bool OpenRouter { get; init; } = true;
 
     public bool HasAny => Anthropic || AzureFoundry || AzureOpenAI || OpenAI || OpenAICompatible || OpenRouter;
+}
+
+public sealed record UiPackFeatureOptions
+{
+    /// <summary>Radzen charts + pivot grid (ChartControl / PivotGridControl).</summary>
+    public bool Radzen { get; init; } = true;
+
+    /// <summary>The analysis views (KpiStrip / Tower / ComparisonBars).</summary>
+    public bool Analysis { get; init; } = true;
+
+    /// <summary>Google Maps (GoogleMapControl).</summary>
+    public bool GoogleMaps { get; init; } = true;
+
+    /// <summary>
+    /// The education runtime (the course navigation contributor). Course CONTENT ships as the
+    /// Edu plugin regardless; this switches the compiled platform half.
+    /// </summary>
+    public bool Education { get; init; } = true;
 }
 
 public sealed record AiCliFeatureOptions

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -291,7 +291,7 @@ builder.UseOrleansMeshServer(address, silo =>
                 }
                 : null))
     .ConfigureMemexMesh(builder.Configuration, builder.Environment.IsDevelopment())
-    .ConfigureMemexPortal()
+    .ConfigureMemexPortal(builder.Configuration)
     // 🚨 Register the "storage" SOURCE collection at mesh level — the backing store that every
     // per-node MapContentCollection("x", "storage", …) mapping resolves against
     // (ContentService.ResolveMappedConfig looks the source up on the parent content service and


### PR DESCRIPTION
Closes the gap between pack *structure* and pack *switch*: `Radzen`, `Analysis`, `GoogleMaps`, and the compiled `Education` runtime are now each behind a `Features:UiPacks:*` flag (default on), so a deployment drops a module by config instead of recompiling. `ConfigureMemexPortal` gains an `IConfiguration` parameter (both portals pass `builder.Configuration`); a tiny `If()` combinator keeps the chains readable. The fallback-slot seam (#1537) is what makes a disabled pack safe — its controls fall to the escaped-HTML fallback instead of breaking resolution order.

Next step on this lane (per the modularization program): `Modules:Assemblies` boot-loading replaces flags with per-instance pack lists.

**Verification**: Monolith + Distributed build `-c Release -warnaserror` clean.

No What's New — defaults unchanged, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)