### PR TITLE
fix(portal-next): pin the bundler to webpack so Next 16 stops blocking every CD publish

### DIFF
--- a/clients/portal-next/next.config.mjs
+++ b/clients/portal-next/next.config.mjs
@@ -12,6 +12,27 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  *   (@meshweaver/react) and the gRPC-web transport (@meshweaver/client-web) resolve to their
  *   SOURCE trees — no build/link step. `experimental.externalDir` lets SWC compile files
  *   outside this app directory.
+ *
+ * 🚨 BUNDLER: webpack, declared explicitly (`next build --webpack` / `next dev --webpack` in
+ * package.json). Next 16 made Turbopack the default and errors out on a `webpack` config with no
+ * `turbopack` config; the two remedies it offers — `turbopack: {}` or `--turbopack` — would both
+ * SILENTLY DROP the resolution rules below, which is worse than the error. Turbopack cannot express
+ * two of the three (measured against 16.3.0, not assumed):
+ *
+ *   1. resolve.alias      → `turbopack.resolveAlias` covers it, but only with paths RELATIVE to the
+ *                           turbopack root; an absolute path is read as a "server relative import"
+ *                           ("not implemented yet") and every alias fails.
+ *   2. resolve.extensionAlias → NO equivalent. `turbopack.resolveExtensions` is webpack's
+ *                           resolve.EXTENSIONS (what to append to an extensionless specifier), not
+ *                           extensionALIAS (rewrite an explicit `.js` to `.ts`/`.tsx`). With aliases
+ *                           relative and resolveExtensions set, a Turbopack build still dies on 51
+ *                           unresolved `./x.js` specifiers out of the renderer source.
+ *   3. resolve.modules    → NO equivalent in the `turbopack` option set at all. Without it, bare
+ *                           imports made FROM ../react and ../grpc-web have nowhere to resolve: the
+ *                           Docker build installs node_modules ONLY in portal-next (see Dockerfile).
+ *
+ * So this stays on webpack until Turbopack grows those hooks — at which point migrate all three
+ * together and re-run the Docker build, which is the only test that exercises rule 3.
  */
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -44,10 +65,11 @@ const nextConfig = {
   // to resolve modules the runtime bundle resolves fine. Type coverage is owned elsewhere by design:
   // portal-next's OWN code by `npm run typecheck` (tsconfig include = app/src/test only), and
   // @meshweaver/react by its own package CI — so we don't run the mis-scoped cross-package typecheck
-  // (or its ESLint companion) during the production image build. This is NOT ignoring real errors:
-  // it's declining to re-type-check vendored source through the wrong tsconfig.
+  // during the production image build. This is NOT ignoring real errors: it's declining to
+  // re-type-check vendored source through the wrong tsconfig.
+  // (Its former ESLint companion `eslint: { ignoreDuringBuilds: true }` is gone: Next 16 dropped
+  // built-in linting from `next build`, so the key is now an "Unrecognized key" warning, not config.)
   typescript: { ignoreBuildErrors: true },
-  eslint: { ignoreDuringBuilds: true },
   // Monorepo root for standalone output tracing (clients/) — server.js lands under
   // .next/standalone/portal-next/server.js (see Dockerfile). Top-level since Next 15
   // (was `experimental.outputFileTracingRoot` in 14).

--- a/clients/portal-next/package.json
+++ b/clients/portal-next/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Next.js + streaming-SSR variant of the MeshWeaver React portal — server-side area snapshot per request (stateless, no server-held streams), Suspense-streamed HTML, client live takeover over gRPC-web.",
   "scripts": {
-    "dev": "next dev -p 3300",
-    "build": "next build",
+    "dev": "next dev --webpack -p 3300",
+    "build": "next build --webpack",
     "start": "next start -p 3300",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/clients/portal-next/tsconfig.json
+++ b/clients/portal-next/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "preserve",
     "incremental": true,
     "plugins": [{ "name": "next" }],
-    "baseUrl": ".",
+    // No "baseUrl": TypeScript 7 removed it (TS5102). The "paths" entries below are already
+    // relative to this tsconfig, which is exactly what baseUrl "." resolved them against.
     "paths": {
       "@meshweaver/react/wire": ["../react/src/live/wire.ts"],
       "@meshweaver/react/accessError": ["../react/src/area/accessError.ts"],

--- a/clients/react/src/controls/inputs.tsx
+++ b/clients/react/src/controls/inputs.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from "react";
+// `JSX` is imported from "react", not taken from the global namespace: React 19's types no longer
+// declare a global JSX, and TypeScript 7 stopped tolerating the reference (TS2503).
+import type { JSX, ReactNode } from "react";
 import {
   Button,
   Checkbox,

--- a/clients/react/src/render/skins.tsx
+++ b/clients/react/src/render/skins.tsx
@@ -1,4 +1,6 @@
-import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
+// `JSX` is imported from "react", not taken from the global namespace: React 19's types no longer
+// declare a global JSX, and TypeScript 7 stopped tolerating the reference (TS2503).
+import type { CSSProperties, JSX, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,

--- a/clients/react/src/theme/ThemeToggle.tsx
+++ b/clients/react/src/theme/ThemeToggle.tsx
@@ -2,7 +2,9 @@
 // SiteSettingsPanel: the same three DesignThemeModes (Light / Dark / System), persisted under the
 // same localStorage key via useThemeMode.
 
-import type { ReactNode } from "react";
+// `JSX` is imported from "react", not taken from the global namespace: React 19's types no longer
+// declare a global JSX, and TypeScript 7 stopped tolerating the reference (TS2503).
+import type { JSX, ReactNode } from "react";
 import {
   Button,
   Menu,


### PR DESCRIPTION
## Why CD publishes nothing

`main-cd.yml`'s `Build + push portal-next image` leg fails, and promotion is all-or-nothing, so **no image set has published since run #3681 / `66822b3f` (2026-08-14 11:35Z)** — tag `3.0.0-rc2.ci.3681`. Every self-updating install is parked there, including on the `42P18` portal fix `de1d108c6`, which memex-cloud is working around with a live config override.

**Timeline** (established from the run history, not assumed):

| time (UTC) | what |
|---|---|
| 11:35 | CD run **#3681** on `66822b3f` — last run whose `promote` succeeded. Complete image set. |
| 11:44 | dependabot commit `688ce589b` bumps `next` `^15.5.22` → `^16.3.0` |
| 12:05 | **#1555 merged as `fcbfe8b2a` with the whole `Clients` workflow RED** — all 7 client jobs failing, `Portal-next (typecheck + test + build)` among them. `Consolidate test results` is the only *required* check, so nothing blocked it. |
| 12:25 | first CD run to actually build after the bump (`3cf807f3`) — portal-next leg **fails**, promote skipped |
| 13:00 | same on `de1d108c` |

So this is a new break with a precise cause, and the PR gate that would have caught it did run and did go red — it just is not required.

## Root cause

Next 16 makes Turbopack the default and hard-errors when a `webpack` config is present without a `turbopack` config. `clients/portal-next/Dockerfile` runs exactly one command, `npm run build`, so the leg dies at `next build` in 1.1 s.

## The fix, and why this shape

`next.config.mjs`'s webpack block does three things. Measured against 16.3.0 — not assumed from the docs — Turbopack can express **one**:

| behaviour | Turbopack |
|---|---|
| `resolve.alias` (the `@meshweaver/react*` + `@meshweaver/client-web` source-tree mapping) | `turbopack.resolveAlias` works, but **only with paths relative to the turbopack root**. An absolute path is read as a "server relative import" — *"not implemented yet"* — and all six aliases fail. |
| `resolve.extensionAlias` (`.js` → `.tsx/.ts/.js`, for the renderer's 309 ESM `.js` specifiers) | **No equivalent.** `resolveExtensions` is webpack's `resolve.extensions` (append to an *extensionless* specifier), not `extensionAlias`. With relative aliases *and* `resolveExtensions` set, a Turbopack build still dies on **51** unresolved `./x.js` specifiers. |
| `resolve.modules` (bare imports from the sibling sources → `portal-next/node_modules`) | **No equivalent in the option set at all.** This is what lets the Docker image install node_modules in `portal-next` only. |

So the app stays on webpack, **declared explicitly** — `next build --webpack` / `next dev --webpack`, the flag the error message itself names. The alternatives it also offers (`turbopack: {}` / `--turbopack`) would silence the error while silently dropping the aliasing, which is strictly worse than a failing build. A `next@15` pin was not taken: it reverts a dependabot major and only defers this.

Two Next-16 / TypeScript-7 leftovers from the same bump, both now fixed:

- `eslint: { ignoreDuringBuilds: true }` → an *"Unrecognized key"* warning on every build (Next 16 dropped built-in linting from `next build`). Removed.
- `baseUrl` → removed in TypeScript 7 (`TS5102`), which broke `npm run typecheck`. Dropped; the `paths` entries are already relative to the tsconfig, which is what `baseUrl "."` resolved them against. Three `JSX.Element`/`JSX.IntrinsicElements` references in `clients/react` then surfaced (`TS2503` — React 19's types no longer declare a global `JSX`); they now `import type { JSX } from "react"`.

## Verification — the build is the test

- **The image CD builds**: `docker build --platform linux/amd64 -f clients/portal-next/Dockerfile clients/` ✅ (7 min under emulation), then **run**: HTTP 200, 301 KB of server-rendered HTML with 432 Fluent class markers.
- **The three resolution behaviours provably survive, checked inside the shipped image** rather than inferred from a green build:
  - `react/` and `grpc-web/` ship **no node_modules**, and `@meshweaver/react` / `@meshweaver/client-web` are **not installed and not in the lockfile** — so the aliases are the only possible resolution path, and the build could not have succeeded with one dropped.
  - A literal unique to `clients/react/src/area/accessError.ts` (reachable only via `@meshweaver/react/accessError`) is in the server *and* client chunks → **alias**.
  - A literal unique to `clients/react/src/theme/githubMarkdown.ts` — reached only through the explicit `"../theme/githubMarkdown.js"` specifier — is in the chunks → **extensionAlias**.
  - Exactly one `react` under node_modules (`/app/portal-next/node_modules/react`, 19.2.8) → **resolve.modules / dedupe**.
- `npm run typecheck` clean · `npm test` 98/98 (portal-next) · 261/261 (clients/react, incl. the i18n drift guard).

## Not in this PR

The same bump left **the rest of the `Clients` workflow red on main**, from causes that are not this one and are each their own migration:

- `@meshweaver/react` — `@types/node` no longer picked up under TS 7 (`TS2591` on `node:fs` / `node:path` / `process`) in its own test files. *(Its `JSX` errors are fixed here.)*
- `@meshweaver/client` — TS 7 changed the `typescript` package's own surface: `transpileModule` / `ScriptTarget` / `ModuleKind` no longer resolve (`TS2339`).
- `Portal example` — the same `baseUrl` removal (`TS5102`), one line, in its tsconfig.
- `RN connector` / `RN web` — `npm ci` `ERESOLVE`: `@types/react@19.2.18` vs `react-native@0.76.5`'s `peerOptional @types/react@^18.2.6`.

None of them is on the CD path, so none of them blocks publication; fixing them is a separate scope call. **No What's New entry** — this is build/CI plumbing with no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
