### PR TITLE
fix: drain the mesh after every other hosted service — closes the 8-issue shutdown-race family

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-shutdown-ordering.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-shutdown-ordering.md
@@ -1,0 +1,18 @@
+---
+Name: Clean portal shutdowns
+Category: Fix
+Description: The portal now finishes serving before the mesh is torn down, so a rolling update no longer produces a burst of shutdown errors.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Clean portal shutdowns
+
+Every time a portal was replaced during a deployment, the last moments of the old pod produced a
+burst of errors: requests that were still being served found the mesh already gone. The mesh was
+being shut down too early — before the web server had stopped accepting traffic — so anything still
+in flight ran against a portal that was half torn down.
+
+Shutdown now happens in the right order: the portal stops serving first, and only then does the mesh
+drain. A rolling update is quieter, and the errors that used to appear at the tail of every roll are
+gone.

--- a/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
+++ b/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
@@ -24,8 +24,14 @@ public record MeshHostApplicationBuilder : MeshBuilder
         this.RegisterMeshQueryCoreOnMeshHub();
         // Drain the mesh root hub (action blocks + IoPool + AsyncDisposeQueue) during host shutdown,
         // BEFORE the host disposes the scope — otherwise a late continuation hits the disposed Autofac
-        // scope and throws an unobserved ObjectDisposedException. Registered here (first) so it stops
-        // LAST, after dependent hosted services. See MeshTeardownHostedService.
+        // scope and throws an unobserved ObjectDisposedException.
+        //
+        // 🚨 The ordering does NOT come from registering here. Hosted services stop in reverse
+        // registration order, and on an ASP.NET Core host GenericWebHostService is registered by
+        // WebApplication.CreateBuilder — strictly before this ctor can run — so Kestrel and the
+        // Blazor circuits stop AFTER anything registered here. The drain therefore runs in
+        // IHostedLifecycleService.StoppedAsync, which the host invokes only once EVERY StopAsync
+        // has returned. See MeshTeardownHostedService for the full story (#1548 and family).
         Host.Services.AddHostedService<MeshTeardownHostedService>();
     }
 
@@ -56,8 +62,9 @@ public record MeshHostBuilder : MeshBuilder
         // disposed") on a pooled task nobody observes — the pre-existing "Catastrophic failure"
         // in Orleans TestCluster teardown (this legacy IHostBuilder path builds every
         // TestCluster silo and client via UseOrleansMeshServer/UseOrleansMeshClient).
-        // Registered FIRST so it stops LAST — after the silo and the other hosted services
-        // have stopped feeding the mesh. Pinned by MeshHostBuilderTeardownOrderingTest.
+        // The drain runs in IHostedLifecycleService.StoppedAsync — after the silo and EVERY
+        // other hosted service has stopped feeding the mesh, regardless of registration
+        // position. Pinned by MeshHostBuilderTeardownOrderingTest.
         Host.ConfigureServices((_, services) => services.AddHostedService<MeshTeardownHostedService>());
     }
 

--- a/src/MeshWeaver.Hosting/MeshTeardownHostedService.cs
+++ b/src/MeshWeaver.Hosting/MeshTeardownHostedService.cs
@@ -7,9 +7,9 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.Hosting;
 
 /// <summary>
-/// Drains the mesh root hub during host shutdown — BEFORE the host disposes the root
-/// <see cref="IServiceProvider"/> (which IS the hub's Autofac container, via
-/// <c>MessageHubServiceProviderFactory</c>).
+/// Drains the mesh root hub during host shutdown — AFTER every other hosted service has
+/// stopped feeding it, and BEFORE the host disposes the root <see cref="IServiceProvider"/>
+/// (which IS the hub's Autofac container, via <c>MessageHubServiceProviderFactory</c>).
 ///
 /// <para>Disposing a hub is reactive and returns immediately; the action blocks, offloaded
 /// <c>IIoPool</c> work, and the <c>AsyncDisposeQueue</c> drain asynchronously afterwards (see
@@ -20,27 +20,58 @@ namespace MeshWeaver.Hosting;
 /// already do this drain between <c>[Fact]</c>s; this hosted service brings the SAME ordered drain
 /// to the production hosts (Monolith + Orleans-distributed).</para>
 ///
-/// <para>An <see cref="IHostedService.StopAsync"/> runs for every hosted service BEFORE the root
-/// provider is disposed, and it may legitimately <c>await</c> — so the drain happens at exactly the
-/// right point with no action-block deadlock. Registered FIRST (in the
-/// <c>MeshHostApplicationBuilder</c> ctor) so it stops LAST: the mesh drains only after the
-/// dependent hosted services (PG subscriptions, scheduled jobs) have stopped feeding it.</para>
+/// <para>🚨 <b>The drain runs in <see cref="StoppedAsync"/>, never in
+/// <see cref="StopAsync"/> — and that is the whole point of this type.</b> Hosted services stop
+/// in REVERSE registration order, so "register first ⇒ stop last" only holds against services
+/// registered later. It does <b>not</b> hold in an ASP.NET Core host: <c>GenericWebHostService</c>
+/// is registered by <c>WebApplication.CreateBuilder</c>, i.e. strictly BEFORE any
+/// <see cref="MeshHostApplicationBuilder"/> can register anything, so Kestrel — and with it every
+/// live HTTP request and Blazor circuit — stops <i>after</i> this service. Draining in
+/// <c>StopAsync</c> therefore tore the mesh down while the portal was still serving: late requests
+/// re-entered the disposed root hub's delivery pipeline, re-created hosted hubs
+/// (<c>Admin/PlatformVersion</c>), and re-subscribed Orleans streams on an already-stopped silo.
+/// Once the host then disposed the container, every one of those in-flight paths threw
+/// <see cref="ObjectDisposedException"/> from a disposed <c>LifetimeScope</c> — issues #1540,
+/// #1541, #1542, #1544, #1545, #1546, #1547, #1548 and #1560, all one root.</para>
+///
+/// <para><see cref="IHostedLifecycleService.StoppedAsync"/> is invoked only after EVERY
+/// <see cref="IHostedService.StopAsync"/> has returned — the web host's included — and still
+/// strictly before the host disposes the root provider. That is the exact window this drain
+/// needs, and unlike registration position it cannot be perturbed by what a consumer registers.
+/// Pinned by <c>MeshHostBuilderTeardownOrderingTest</c> and
+/// <c>MeshTeardownRunsAfterEveryOtherHostedServiceTest</c>.</para>
 /// </summary>
 public sealed class MeshTeardownHostedService(
     IServiceProvider services,
-    ILogger<MeshTeardownHostedService> logger) : IHostedService
+    ILogger<MeshTeardownHostedService> logger) : IHostedLifecycleService
 {
     /// <summary>Bounded drain budget — a stuck action block or leaked I/O slot completes the wait
     /// rather than hanging shutdown; the underlying defect surfaces via the hub's own diagnostics.</summary>
     private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(30);
 
     /// <inheritdoc />
+    public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <inheritdoc />
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Deliberately a no-op: the mesh must stay alive for every other hosted service's
+    /// <c>StopAsync</c> — most importantly the web host's, which is what stops Kestrel and the
+    /// Blazor circuits. The drain happens in <see cref="StoppedAsync"/>. See the type remarks.
+    /// </summary>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public async Task StoppedAsync(CancellationToken cancellationToken)
     {
-        // Resolve the mesh root hub lazily here (the scope is still alive during StopAsync).
+        // Resolve the mesh root hub lazily here (the scope is still alive during StoppedAsync).
         var mesh = services.GetService<IMessageHub>();
         if (mesh is null)
             return;

--- a/test/MeshWeaver.Hosting.Test/MeshTeardownRunsAfterEveryOtherHostedServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshTeardownRunsAfterEveryOtherHostedServiceTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the second half of the shutdown-ordering contract: the mesh root hub must stay ALIVE
+/// for every other hosted service's <c>StopAsync</c>, and drain only afterwards.
+///
+/// <para><b>The defect this pins.</b> <see cref="MeshTeardownHostedService"/> used to drain in
+/// <c>StopAsync</c>, relying on "registered first ⇒ stops last". That reasoning holds only
+/// against services registered LATER. It does not hold on an ASP.NET Core host, where
+/// <c>GenericWebHostService</c> is registered by <c>WebApplication.CreateBuilder</c> — strictly
+/// before <see cref="MeshHostApplicationBuilder"/>'s ctor can register anything — and therefore
+/// stops LAST. The portal consequently tore the mesh down while Kestrel was still serving:
+/// late HTTP requests and live Blazor circuits re-entered the disposed root hub's delivery
+/// pipeline, re-created hosted hubs, and re-subscribed Orleans streams on a stopped silo. When
+/// the host then disposed the root container, all of it threw <c>ObjectDisposedException</c>
+/// from a disposed Autofac <c>LifetimeScope</c> (#1540/#1541/#1542/#1544/#1545/#1546/#1547/
+/// #1548/#1560 — one root, eight filings).</para>
+///
+/// <para><see cref="EarlyRegisteredProbe"/> stands in for the web host: it is registered BEFORE
+/// the mesh builder, so it stops LAST, exactly like Kestrel. RED before the fix — it observed a
+/// hub at <c>RunLevel.Dead</c>.</para>
+/// </summary>
+public class MeshTeardownRunsAfterEveryOtherHostedServiceTest
+{
+    [Fact(Timeout = 60000)]
+    public async Task AHostedServiceThatStopsLast_StillSeesALiveMesh()
+    {
+        var hostBuilder = new HostBuilder();
+
+        // Registered BEFORE the mesh builder — so it stops LAST. This is the position
+        // GenericWebHostService occupies on every portal host.
+        hostBuilder.ConfigureServices(services =>
+        {
+            services.AddSingleton<EarlyRegisteredProbe>();
+            services.AddHostedService(sp => sp.GetRequiredService<EarlyRegisteredProbe>());
+        });
+
+        _ = new MeshHostBuilder(hostBuilder, new Address("mesh", "teardown-after-all"));
+        using var host = hostBuilder.Build();
+        await host.StartAsync();
+
+        var mesh = host.Services.GetRequiredService<IMessageHub>();
+        mesh.IsDisposing.Should().BeFalse("the mesh must be alive while the host runs");
+
+        await host.StopAsync();
+
+        var probe = host.Services.GetRequiredService<EarlyRegisteredProbe>();
+
+        probe.StopAsyncRan.Should().BeTrue("the probe's StopAsync must have run during shutdown");
+        probe.MeshWasDisposingAtStop.Should().BeFalse(
+            "a hosted service that stops LAST — Kestrel, and with it every in-flight HTTP request "
+            + "and Blazor circuit — must still find a LIVE mesh; draining before it is what let "
+            + "late traffic re-enter a disposed hub and resolve from a dying Autofac scope");
+        probe.MeshRunLevelAtStop.Should().Be(MessageHubRunLevel.Started,
+            "the mesh drain belongs in IHostedLifecycleService.StoppedAsync, which runs only after "
+            + "EVERY hosted service's StopAsync has returned");
+
+        // …and the original contract still holds: fully drained before the caller disposes the host.
+        mesh.RunLevel.Should().Be(MessageHubRunLevel.Dead,
+            "the drain must still be COMPLETE when StopAsync returns — the container disposal follows");
+    }
+
+    /// <summary>
+    /// Stands in for <c>GenericWebHostService</c>: registered before the mesh, therefore stopped
+    /// after it. Records what it saw of the mesh at that moment. Registered as a singleton in its
+    /// own right so the test can read the recording back off the container.
+    /// </summary>
+    private sealed class EarlyRegisteredProbe(IServiceProvider services) : IHostedService
+    {
+        public bool StopAsyncRan { get; private set; }
+        public bool MeshWasDisposingAtStop { get; private set; }
+        public MessageHubRunLevel MeshRunLevelAtStop { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            var mesh = services.GetRequiredService<IMessageHub>();
+            StopAsyncRan = true;
+            MeshWasDisposingAtStop = mesh.IsDisposing;
+            MeshRunLevelAtStop = mesh.RunLevel;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Eight auto-filed issues, one root.

## The defect

`MeshTeardownHostedService` drained the mesh in `StopAsync`, relying on *"registered first ⇒ stops last"*. Hosted services do stop in reverse registration order — but that only orders this service against ones registered **later**. On an ASP.NET Core host `GenericWebHostService` is registered by `WebApplication.CreateBuilder`, strictly before `MeshHostApplicationBuilder`'s ctor can register anything, so **Kestrel stops after the mesh drain**. The portal's actual stop order was:

```
BakeModeCompletion → DbVersionGate → Orleans silo → MESH DRAIN → Kestrel
```

For the whole tail of shutdown the portal was still serving against a disposed root hub and a stopped silo. Late traffic:

- re-entered the root hub's delivery pipeline → #1548
- re-created hosted hubs (`Admin/PlatformVersion`) → #1542, #1560, #1541
- re-subscribed Orleans streams, activating `PubSubRendezvousGrain`s on the stopped silo → #1544, #1545, #1546, #1547
- resolved placement directors mid-delivery → #1540

Then the host disposed the root container and every one of those in-flight paths threw `ObjectDisposedException` from a disposed Autofac `LifetimeScope`. That is why all eight filings share the same top frame (`LifetimeScope.ThrowDisposedException`) and the same minute on the same pods.

## The fix

Ordering, not suppression. `MeshTeardownHostedService` implements `IHostedLifecycleService` and drains in `StoppedAsync`, which the host invokes only after **every** `IHostedService.StopAsync` has returned — the web host's included — and still strictly before it disposes the root provider. Unlike registration position, that window cannot be perturbed by what a consumer registers.

No `catch (ObjectDisposedException)`, no widened bound, no retry: the work simply no longer outlives the container.

## Verification

- `MeshTeardownRunsAfterEveryOtherHostedServiceTest` (new) registers a probe **before** the mesh builder — the position Kestrel occupies — and asserts it still sees a live mesh in its `StopAsync`. Proven **RED on the previous shape** (probe observed `RunLevel.Dead`), green after.
- `MeshHostBuilderTeardownOrderingTest` (existing) still holds: `host.StopAsync()` runs the `StoppedAsync` phase, so the mesh is fully `Dead` when it returns.
- `MeshWeaver.Hosting.Test`: 168/168 green.
- `-c Release -warnaserror`: `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Monolith`, `MeshWeaver.Hosting.Test` — 0 errors, 0 warnings.

Fixes #1540, #1541, #1542, #1544, #1545, #1546, #1547, #1548, #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj