### PR TITLE
fix(#1538): repair double-encoded text repo-wide, per run

### DIFF
--- a/memex/Memex.Portal.Shared/Social/ApiCredentialNodeType.cs
+++ b/memex/Memex.Portal.Shared/Social/ApiCredentialNodeType.cs
@@ -10,7 +10,7 @@ namespace Memex.Portal.Shared.Social;
 /// NodeType definition for <see cref="PlatformCredential"/>. Instances live under
 /// <c>{profilePath}/_ApiCredentials/{platform}</c> and are read/written exclusively
 /// by the Social subsystem + the LinkedIn/X connect endpoints. Access control:
-/// readable/writable only by Admins and the profile owner â€” wired via a satellite
+/// readable/writable only by Admins and the profile owner — wired via a satellite
 /// access rule in the hosting app (Memex security config). This file only registers
 /// the type shape.
 /// </summary>

--- a/src/MeshWeaver.AI/LanguageModelNodeType.cs
+++ b/src/MeshWeaver.AI/LanguageModelNodeType.cs
@@ -12,20 +12,20 @@ namespace MeshWeaver.AI;
 ///
 /// <para>Two surfaces feed this:</para>
 /// <list type="bullet">
-///   <item><b>Platform models</b> â€” <see cref="LanguageModelCatalogOptions.Sources"/>
+///   <item><b>Platform models</b> — <see cref="LanguageModelCatalogOptions.Sources"/>
 ///         entries pair a config section (e.g. <c>Anthropic</c>) with a
 ///         provider label. <see cref="BuiltInLanguageModelProvider"/>
 ///         reads <c>{section}:Models[]</c> from <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>
 ///         at static-node-provider time and emits one
 ///         <c>nodeType:LanguageModel</c> MeshNode per entry under
 ///         <see cref="RootNamespace"/>.</item>
-///   <item><b>Bring-your-own models</b> â€” anyone can create a node of this
+///   <item><b>Bring-your-own models</b> — anyone can create a node of this
 ///         type at any path with <see cref="ModelDefinition"/> content; the
 ///         chat picker discovers it via the same synced query that finds
 ///         agents (<c>nodeType:Agent|LanguageModel</c>).</item>
 /// </list>
 ///
-/// <para>Public-read by default â€” model identity and provider are not
+/// <para>Public-read by default — model identity and provider are not
 /// secrets. Credentials live behind <see cref="ModelDefinition.ApiKeySecretRef"/>
 /// in a secret store, never in the node content itself.</para>
 /// </summary>
@@ -127,9 +127,9 @@ public static class LanguageModelNodeType
             // service from meshHub.ServiceProvider, not from their own
             // hub's DI scope.
             services.TryAddSingleton<ModelDiscoveryService>();
-            // ðŸš¨ Plain AddSingleton (not TryAddEnumerable): TryAddEnumerable
+            // 🚨 Plain AddSingleton (not TryAddEnumerable): TryAddEnumerable
             // dedupes by impl-type AND ServiceLifetime AND ImplementationFactory
-            // â€” combinations that occasionally suppress the registration in
+            // — combinations that occasionally suppress the registration in
             // ways that left BuiltInLanguageModelProvider invisible to DI
             // resolution while BuiltInAgentProvider (using plain AddSingleton)
             // worked. Match the AgentProvider pattern so both follow the
@@ -144,7 +144,7 @@ public static class LanguageModelNodeType
             if (!dbSynced)
             {
                 services.AddSingleton<IStaticNodeProvider>(sp => sp.GetRequiredService<BuiltInLanguageModelProvider>());
-                // Partition routing â€” the same instance feeds the routing core's
+                // Partition routing — the same instance feeds the routing core's
                 // "Model" partition. The partition's StaticNodeStorageAdapter is
                 // its storage of record; no SeedIfAbsent fan-in required. Skipped when
                 // the partition is DB-synced (PG serves it instead).
@@ -168,7 +168,7 @@ public static class LanguageModelNodeType
     /// Adds a catalog source: a config section to scan for <c>Models[]</c>
     /// when populating the <c>nodeType:LanguageModel</c> partition.
     ///
-    /// <para>Idempotent on (sectionName, providerName) â€” safe to call from
+    /// <para>Idempotent on (sectionName, providerName) — safe to call from
     /// multiple <c>builder.ConfigureServices</c> blocks. Mutates the
     /// <see cref="LanguageModelCatalogOptions"/> singleton directly
     /// instead of using the <c>IOptions&lt;T&gt;</c> Configure pipeline,

--- a/src/MeshWeaver.AI/ThreadMessageNodeType.cs
+++ b/src/MeshWeaver.AI/ThreadMessageNodeType.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.AI;
 /// <summary>
 /// Constants, configuration, and MeshNode definition for ThreadMessage node types.
 /// ThreadMessage nodes are child nodes of Thread nodes containing individual messages.
-/// Each ThreadMessage hub manages its own persistence exclusively via AddMeshDataSource â€”
+/// Each ThreadMessage hub manages its own persistence exclusively via AddMeshDataSource —
 /// no external code should access ThreadMessage persistence via IMeshService or IMeshQuery.
 /// </summary>
 public static class ThreadMessageNodeType
@@ -60,7 +60,7 @@ public static class ThreadMessageNodeType
 
     /// <summary>
     /// Creates a MeshNode definition for the ThreadMessage node type.
-    /// HubConfiguration includes AddMeshDataSource â€” the hub owns persistence exclusively.
+    /// HubConfiguration includes AddMeshDataSource — the hub owns persistence exclusively.
     /// </summary>
     public static MeshNode CreateMeshNode() => new(NodeType)
     {

--- a/src/MeshWeaver.Graph/Configuration/ActivityNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityNodeType.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.Graph.Configuration;
 
 /// <summary>
 /// Provides configuration for Activity nodes in the graph.
-/// Activity nodes are system-generated satellite nodes â€” excluded from search and create contexts.
+/// Activity nodes are system-generated satellite nodes — excluded from search and create contexts.
 /// Access is delegated to the MainNode (parent) via SatelliteAccessRule.
 /// </summary>
 public static class ActivityNodeType
@@ -54,7 +54,7 @@ public static class ActivityNodeType
         // Activity hubs host the kernel directly: SubmitCodeRequest etc. land here,
         // run inside this hub's action block, and write progress to the same
         // ActivityLog node via DataChangeRequest.Update on the local workspace.
-        // Replaces the legacy `kernel/*` standalone hub addressing â€” replies route
+        // Replaces the legacy `kernel/*` standalone hub addressing — replies route
         // through the standard MeshNode path instead of three special routing rules.
         HubConfiguration = config => config
             .AddActivityViews()

--- a/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
@@ -15,7 +15,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// Provides configuration for ApiToken nodes in the graph.
 /// Tokens are satellites of User nodes, stored at User/{userId}/_Api/{hashPrefix}.
 /// An index at ApiToken/{hashPrefix} enables fast validation routing.
-/// Creation uses standard CreateNodeRequest with nodeType=ApiToken â€” the RLS validator
+/// Creation uses standard CreateNodeRequest with nodeType=ApiToken — the RLS validator
 /// maps this to Permission.Api via GetPermissionForNodeType.
 /// </summary>
 public static class ApiTokenNodeType
@@ -35,13 +35,13 @@ public static class ApiTokenNodeType
     {
         builder.AddMeshNodes(CreateMeshNode());
         builder.AddAutocompleteExcludedTypes(NodeType);
-        // Access control: GetPermissionForNodeType maps "ApiToken" â†’ Permission.Api
+        // Access control: GetPermissionForNodeType maps "ApiToken" → Permission.Api
         // The RLS validator checks Permission.Api on the MainNode (User path)
-        // Same pattern as Thread â†’ Permission.Thread and Comment â†’ Permission.Comment.
+        // Same pattern as Thread → Permission.Thread and Comment → Permission.Comment.
         //
         // Register all ApiToken domain + message types in the hub's type registry so
         // they serialize correctly across silos (Orleans). Mirrors CommentNodeType /
-        // ThreadNodeType which do the same â€” without this, cross-silo CreateNodeRequest
+        // ThreadNodeType which do the same — without this, cross-silo CreateNodeRequest
         // for nodeType=ApiToken fails with "NodeType 'ApiToken' is not registered"
         // because the receiving silo can't deserialize the typed payload.
         builder.ConfigureHub(config => config
@@ -77,7 +77,7 @@ public static class ApiTokenNodeType
     /// <summary>
     /// Validates an API token. Routes to ApiToken/{hashPrefix}, follows index to User/{userId}/_Api/{hash}.
     /// Results are cached for 5 minutes.
-    /// Sync handler â€” composes via <c>IObservable</c> + <c>Subscribe</c>; no <c>await</c>.
+    /// Sync handler — composes via <c>IObservable</c> + <c>Subscribe</c>; no <c>await</c>.
     /// </summary>
     private static IMessageDelivery HandleValidateToken(
         IMessageHub hub,
@@ -93,7 +93,7 @@ public static class ApiTokenNodeType
 
         var hash = ValidateTokenRequest.HashToken(rawToken);
 
-        // Read own MeshNode via one-shot GetDataRequest â€” true request/response, no
+        // Read own MeshNode via one-shot GetDataRequest — true request/response, no
         // lingering subscription. Posts to self (hub.Address); the handler's Subscribe
         // runs on the event loop after this returns, so no deadlock.
         //
@@ -128,7 +128,7 @@ public static class ApiTokenNodeType
                         return Observable.Empty<Unit>();
                     }
 
-                    // Cross-hub one-shot read for the actual token node â€” GetDataRequest
+                    // Cross-hub one-shot read for the actual token node — GetDataRequest
                     // routes to the owning per-node hub via the mesh. Re-impersonate
                     // as System for this read too: the AsyncLocal context that the
                     // outer Observable.Using set may not be alive when the SelectMany
@@ -175,7 +175,7 @@ public static class ApiTokenNodeType
                     // Include the roles captured on the ApiToken at creation time.
                     // UserContextMiddleware stamps these onto AccessContext.Roles so
                     // SecurityService.GetEffectivePermissions can resolve them via
-                    // the claim-based role path on per-node hubs â€” where the
+                    // the claim-based role path on per-node hubs — where the
                     // synced AccessAssignment query is intentionally not registered
                     // (SecurityServiceExtensions:44-50, recursion avoidance).
                     var response = ValidateTokenResponse.Ok(

--- a/src/MeshWeaver.Graph/Configuration/ApprovalNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ApprovalNodeType.cs
@@ -10,7 +10,7 @@ namespace MeshWeaver.Graph.Configuration;
 
 /// <summary>
 /// Provides configuration for Approval nodes in the graph.
-/// Approval nodes are system-generated â€” excluded from search and create contexts.
+/// Approval nodes are system-generated — excluded from search and create contexts.
 /// Access is delegated to the MainNode (parent) via SatelliteAccessRule.
 /// </summary>
 public static class ApprovalNodeType

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -46,7 +46,7 @@ public static class CodeNodeType
 
     /// <summary>
     /// Creates a MeshNode definition for the Code node type.
-    /// Code nodes are primary content (source files), not satellite metadata â€”
+    /// Code nodes are primary content (source files), not satellite metadata —
     /// they are browsable, addressable, and first-class children of their NodeType.
     /// </summary>
     public static MeshNode CreateMeshNode() => new(NodeType)
@@ -201,7 +201,7 @@ public static class CodeNodeType
                 o => o.ResponseFor(request));
         }
 
-        // One-shot read of this hub's own MeshNode via GetDataRequest (posted to self) â€”
+        // One-shot read of this hub's own MeshNode via GetDataRequest (posted to self) —
         // true request/response, no SubscribeRequest+immediate-unsubscribe. Handler
         // itself returns Processed() immediately; the callback below fires when the
         // response arrives.
@@ -241,7 +241,7 @@ public static class CodeNodeType
 
                 var submissionId = request.Message.SubmissionId ?? Guid.NewGuid().ToString("N");
 
-                // Create an ActivityLog MeshNode for this run â€” scripts'
+                // Create an ActivityLog MeshNode for this run — scripts'
                 // Log.LogInformation(...) calls will append to it, and callers
                 // subscribe via GetRemoteStream<MeshNode, MeshNodeReference> to
                 // watch progress live. Created via IMeshService.CreateNode so it
@@ -250,10 +250,10 @@ public static class CodeNodeType
                 // The Activity hub also HOSTS the kernel: ActivityNodeType.HubConfiguration
                 // adds AddKernelSubHubHandlers, so SubmitCodeRequest sent to the activity
                 // path lands inside the activity's own action block. Replies route
-                // through the standard MeshNode chain â€” no `kernel/*` standalone hub.
+                // through the standard MeshNode chain — no `kernel/*` standalone hub.
                 // Activities live under {ActivityParentPath}/_Activity/{guid}.
                 // ActivityParentPath defaults to the partition root (the user's home)
-                // when null â€” every script run shows up in the user's activity feed,
+                // when null — every script run shows up in the user's activity feed,
                 // and the satellite path is shallow enough that routing materialises
                 // it reliably. The originating Code node is preserved on MainNode
                 // + ActivityLog.HubPath, so the link back is intact regardless of
@@ -266,7 +266,7 @@ public static class CodeNodeType
                 // The "{viewer}" sentinel at any layer expands to the calling
                 // user's home (so docs partition can route runs into whoever's
                 // browsing them). Resolution composes into the create-activity
-                // chain â€” the per-partition lookup is async (workspace query)
+                // chain — the per-partition lookup is async (workspace query)
                 // so we keep it observable end-to-end.
                 var accessService = hub.ServiceProvider.GetService<MeshWeaver.Messaging.AccessService>();
                 var viewerHome = accessService?.Context?.ObjectId
@@ -289,7 +289,7 @@ public static class CodeNodeType
                         var activityId = submissionId;
                         var activityNamespace = $"{activityParentPath}/_Activity";
                         var activityPath = $"{activityNamespace}/{activityId}";
-                        // MainNode points to the activity's PARENT â€” the user's
+                        // MainNode points to the activity's PARENT — the user's
                         // home or configured target. SatelliteAccessRule delegates
                         // access to MainNode, so this must be a node the viewer
                         // can read. ActivityLog.HubPath preserves the originating
@@ -317,8 +317,8 @@ public static class CodeNodeType
                             // Node created. Fire SubmitCodeRequest at the Activity
                             // hub (which now hosts the kernel handlers). Forward
                             // the caller-supplied Inputs so the script can read
-                            // them off the `Inputs` global â€” the canonical channel
-                            // for script-templated operations (export, importâ€¦).
+                            // them off the `Inputs` global — the canonical channel
+                            // for script-templated operations (export, import…).
                             // C# runs in-process on the Activity hub's Roslyn kernel; a foreign language
                             // routes to the worker that owns its runtime (see ResolveKernelAddress).
                             var submitTarget = ResolveKernelAddress(code.Language, activityPath);
@@ -375,13 +375,13 @@ public static class CodeNodeType
                             // Stamp Last{ExecutedAt,ExecutedBy,ActivityPath} onto
                             // the Code MeshNode so the Content area can show
                             // "Last executed: <when> by <who>" and embed the last
-                            // activity's Progress area for the Output pane â€”
+                            // activity's Progress area for the Output pane —
                             // without separately querying activity children.
                             try
                             {
                                 var workspace = hub.GetWorkspace();
                                 var stampLogger = logger;
-                                // .Subscribe is mandatory: Update is Observable.Create â€”
+                                // .Subscribe is mandatory: Update is Observable.Create —
                                 // the partition write only runs on Subscribe. Discarding
                                 // the observable silently drops the stamp.
                                 workspace.GetMeshNodeStream().Update(curr =>

--- a/src/MeshWeaver.Graph/Configuration/KernelNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/KernelNodeType.cs
@@ -35,7 +35,7 @@ public static class KernelNodeType
             // Register kernel message types at mesh level so JSON deserialization
             // works wherever a kernel-handler hub lives (Activity hub, markdown
             // view sub-hub, future hosts). The legacy
-            // `RouteAddressToHostedHub("kernel", â€¦)` rule is gone â€” kernel work
+            // `RouteAddressToHostedHub("kernel", …)` rule is gone — kernel work
             // runs inside the Activity MeshNode hub, addressed via its node path.
             .ConfigureHub(AddKernelTypes)
             .ConfigureServices(services =>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRelease.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRelease.cs
@@ -13,7 +13,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// of type <c>Release</c> at <c>{nodeTypePath}/Release/{version}</c>;
 /// immutable once committed.
 ///
-/// <para>Releases are first-class durable artefacts â€” the GUI's Create-Release
+/// <para>Releases are first-class durable artefacts — the GUI's Create-Release
 /// button triggers a compile activity, and on success the watcher writes a
 /// new Release MeshNode with the compiled <see cref="AssemblyPath"/> + the
 /// markdown <see cref="Notes"/> the user authored. Old releases stay on disk
@@ -63,7 +63,7 @@ public record NodeTypeRelease
     public long? AssemblyStoreVersion { get; init; }
 
     /// <summary>
-    /// Author-written release notes â€” free-form markdown body shown at the top
+    /// Author-written release notes — free-form markdown body shown at the top
     /// of the Release detail view and in the release-history list. Sourced from
     /// <c>NodeTypeDefinition.ReleaseNotes</c> at compile time and copied here
     /// so the release is a self-contained snapshot (later edits to the
@@ -99,11 +99,11 @@ public record NodeTypeRelease
     /// <summary>
     /// Filesystem path of the compiled DLL for this release (set when the
     /// compile activity terminated <c>Succeeded</c>; null on failure).
-    /// Stable per <c>(NodeTypePath, Version)</c> â€” overwriting in place is
+    /// Stable per <c>(NodeTypePath, Version)</c> — overwriting in place is
     /// safe; deleting other versions' DLLs is forbidden because their ALCs
     /// may still be holding the file handles for live instances.
     /// <para>
-    /// ðŸš¨ Local-process hint only â€” not cross-silo durable. For cross-silo
+    /// 🚨 Local-process hint only — not cross-silo durable. For cross-silo
     /// activation, use <see cref="AssemblyCollection"/> + <see cref="AssemblyContentPath"/>:
     /// every silo fetches the bytes from the same content-collection blob, no
     /// shared filesystem required.
@@ -148,7 +148,7 @@ public record NodeTypeRelease
 
     /// <summary>
     /// Path to the <c>NodeTypeCompilation</c> activity that produced this
-    /// release â€” link to the live message log + diagnostics. Set even on
+    /// release — link to the live message log + diagnostics. Set even on
     /// failed releases so triagers can drill into the Roslyn output.
     /// </summary>
     public string? CompilationActivityPath { get; init; }

--- a/src/MeshWeaver.Graph/Configuration/NotificationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationNodeType.cs
@@ -5,7 +5,7 @@ namespace MeshWeaver.Graph.Configuration;
 
 /// <summary>
 /// Provides configuration for Notification nodes in the graph.
-/// Notification nodes are system-generated â€” excluded from search and create contexts.
+/// Notification nodes are system-generated — excluded from search and create contexts.
 /// </summary>
 public static class NotificationNodeType
 {

--- a/src/MeshWeaver.Graph/Configuration/ReleaseNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ReleaseNodeType.cs
@@ -9,7 +9,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// <summary>
 /// Registers <c>Release</c> as a first-class NodeType. Release MeshNodes live
 /// at <c>{nodeTypePath}/Release/{version}</c> and carry a
-/// <see cref="NodeTypeRelease"/> content payload â€” the compiled assembly path,
+/// <see cref="NodeTypeRelease"/> content payload — the compiled assembly path,
 /// the markdown release notes, the source-input snapshot, and a link to the
 /// compile activity that produced them.
 ///

--- a/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
@@ -44,7 +44,7 @@ public static class RoleNodeType
             .AddDefaultLayoutAreas()
     };
 
-    // Inline SVGs for the four built-in roles â€” rendered directly by MeshNodeImageHelper.IsInlineSvg.
+    // Inline SVGs for the four built-in roles — rendered directly by MeshNodeImageHelper.IsInlineSvg.
     // Each uses a 20x20 rounded-square badge matching shield.svg's visual language, with a distinct
     // hue per role so they read at a glance in menus, thumbnails, and permission pickers.
     private const string AdminIcon =
@@ -79,7 +79,7 @@ public static class RoleNodeType
     {
         private static readonly MeshNode[] Nodes =
         [
-            // Read-only policy for the Role namespace â€” built-in roles are unmodifiable
+            // Read-only policy for the Role namespace — built-in roles are unmodifiable
             new("_Policy", "Role")
             {
                 NodeType = "PartitionAccessPolicy",

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -706,7 +706,7 @@ internal class NavigationService : INavigationService
         var settled = false;
         var subscribeReturned = false;
 
-        // Reactive load â€” Subscribe, never await (every async bit through a hub
+        // Reactive load — Subscribe, never await (every async bit through a hub
         // round-trip is a deadlock surface; see Doc/Architecture/AsynchronousCalls.md).
         LoadNodeWithPreRenderedHtml(resolution)
             .Subscribe(node =>
@@ -900,7 +900,7 @@ internal class NavigationService : INavigationService
 
     /// <summary>
     /// Loads the MeshNode for the resolved address. If the node has MarkdownContent
-    /// but no PreRenderedHtml, generates it and persists back. Reactive â€” no await
+    /// but no PreRenderedHtml, generates it and persists back. Reactive — no await
     /// on hub round-trips (100% deadlock; see Doc/Architecture/AsynchronousCalls.md).
     /// </summary>
     private IObservable<MeshNode?> LoadNodeWithPreRenderedHtml(AddressResolution resolution) =>
@@ -1005,7 +1005,7 @@ internal class NavigationService : INavigationService
 
     /// <summary>
     /// Records a navigation activity for the "Recently Viewed" dashboard section.
-    /// Posts TrackActivityRequest to the hub â€” handled asynchronously on a sub-hub.
+    /// Posts TrackActivityRequest to the hub — handled asynchronously on a sub-hub.
     /// </summary>
     private void TrackNavigationActivity(MeshNode node)
     {

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -17,7 +17,7 @@ namespace MeshWeaver.Mesh;
 /// it, a warning is logged via <see cref="ILoggerFactory"/> resolved from the
 /// supplied <see cref="IServiceProvider"/>. This catches the cold-observable bug
 /// where a caller invokes a side-effect-on-subscribe API (e.g.
-/// <c>workspace.GetMeshNodeStream().Update(...)</c>) without subscribing â€” the
+/// <c>workspace.GetMeshNodeStream().Update(...)</c>) without subscribing — the
 /// side effect silently never runs and the caller has no compile-time signal.
 /// </summary>
 internal sealed class RequireSubscribeObservable<T> : IObservable<T>
@@ -48,12 +48,12 @@ internal sealed class RequireSubscribeObservable<T> : IObservable<T>
             var logger = _services.GetService<ILoggerFactory>()
                 ?.CreateLogger("MeshWeaver.Mesh.RequireSubscribe");
             logger?.LogWarning(
-                "Fire-and-forget callsite detected: '{What}' returned a cold IObservable that was never subscribed â€” the side effect did NOT run. Add .Subscribe(_ => {{ }}, ex => logger.LogWarning(ex, ...)) at the callsite. See Doc/Architecture/AsynchronousCalls.md â†’ 'Subscribe is mandatory'.",
+                "Fire-and-forget callsite detected: '{What}' returned a cold IObservable that was never subscribed — the side effect did NOT run. Add .Subscribe(_ => {{ }}, ex => logger.LogWarning(ex, ...)) at the callsite. See Doc/Architecture/AsynchronousCalls.md → 'Subscribe is mandatory'.",
                 _what);
         }
         catch
         {
-            // Finalizer must never throw â€” service provider may already be disposed.
+            // Finalizer must never throw — service provider may already be disposed.
         }
     }
 }
@@ -64,7 +64,7 @@ internal sealed class RequireSubscribeObservable<T> : IObservable<T>
 /// path matching the workspace's hub address it also targets own; otherwise it
 /// targets the remote per-node hub via <c>workspace.GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c>.
 /// Implements <see cref="IObservable{MeshNode}"/> so existing <c>.Where</c>/<c>.Select</c>
-/// read consumers keep working unchanged. Writers call <see cref="Update"/> â€” which
+/// read consumers keep working unchanged. Writers call <see cref="Update"/> — which
 /// returns an <see cref="IObservable{MeshNode}"/> that the caller MUST Subscribe to.
 /// The Update side effect runs on Subscribe; errors flow to <c>OnError</c>. No
 /// fire-and-forget at any callsite.
@@ -147,7 +147,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         if (IsOwn)
             return (_workspace.GetStream(new MeshNodeReference())
                     ?? throw new InvalidOperationException(
-                        "MeshNode stream is not available â€” the workspace has no MeshNodeReference reducer."),
+                        "MeshNode stream is not available — the workspace has no MeshNodeReference reducer."),
                 Disposable.Empty);
         // 🚨 Open the remote MeshNode subscription under the system identity.
         // Reading MeshNode content is infrastructure (routing, path resolution,
@@ -532,7 +532,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// <summary>
     /// Applies <paramref name="update"/> to the targeted MeshNode and returns an
     /// <see cref="IObservable{MeshNode}"/> that emits the post-update node on the first
-    /// emission past the pre-update snapshot. <b>Caller MUST Subscribe</b> â€” the cold
+    /// emission past the pre-update snapshot. <b>Caller MUST Subscribe</b> — the cold
     /// observable's side effect runs on Subscribe, errors flow to <c>OnError</c>.
     /// <list type="bullet">
     ///   <item><description><b>Own</b> (no path or path == hub address): writes through
@@ -755,7 +755,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         {
             var refStream = _workspace.GetStream(new MeshNodeReference())
                 ?? throw new InvalidOperationException(
-                    "MeshNode stream is not available â€” the workspace has no MeshNodeReference reducer.");
+                    "MeshNode stream is not available — the workspace has no MeshNodeReference reducer.");
 
             var dataSource = _workspace.DataContext.GetDataSourceForType(typeof(MeshNode));
             if (dataSource == null)
@@ -781,7 +781,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // terminal-segment Id alone is non-deterministic when multiple instances
             // share the same Id; match on the full Path so the OWN node is always
             // resolved correctly. When neither path is available, fall back to
-            // FirstOrDefault â€” only legacy single-instance shapes hit this branch.
+            // FirstOrDefault — only legacy single-instance shapes hit this branch.
             var targetPath = _path ?? _workspace.Hub.Address.Path;
 
             // 🚨 Echo detection is WRITE-IDENTITY-based, never emission-count-based.
@@ -1660,9 +1660,9 @@ public static class MeshNodeStreamExtensions
     /// <para>
     /// The returned <see cref="MeshNodeStreamHandle"/> implements
     /// <see cref="IObservable{MeshNode}"/> so all existing read consumers (Where/Select
-    /// chains) keep working. Writers call <c>.Update(update)</c> on the same handle â€”
+    /// chains) keep working. Writers call <c>.Update(update)</c> on the same handle —
     /// returns <c>IObservable&lt;MeshNode&gt;</c> that callers MUST Subscribe to. No
-    /// fire-and-forget; subscribe with <c>(_ =&gt; â€¦, ex =&gt; logger.LogWarning(ex, â€¦))</c>.
+    /// fire-and-forget; subscribe with <c>(_ =&gt; …, ex =&gt; logger.LogWarning(ex, …))</c>.
     /// </para>
     /// </summary>
     public static MeshNodeStreamHandle GetMeshNodeStream(this IWorkspace workspace)
@@ -1671,21 +1671,21 @@ public static class MeshNodeStreamExtensions
     /// <summary>
     /// Reactive handle to a MeshNode at <paramref name="path"/>. Path-aware:
     /// <list type="number">
-    ///   <item><description><b>Own hub</b> â€” when <paramref name="path"/> matches the
+    ///   <item><description><b>Own hub</b> — when <paramref name="path"/> matches the
     ///     workspace's hub address: handle reads/writes via the local
     ///     <see cref="MeshNodeReference"/> reducer + data source primary stream.</description></item>
-    ///   <item><description><b>Cross-hub via <see cref="IMeshNodeStreamCache"/></b> â€” when
+    ///   <item><description><b>Cross-hub via <see cref="IMeshNodeStreamCache"/></b> — when
     ///     a cache is registered on the workspace's hub: routes reads through
     ///     <c>cache.GetStream(path)</c> and writes through <c>cache.Update(path, fn)</c>.
     ///     One shared upstream subscription process-wide; writes are observed
     ///     by every reader on the same path.</description></item>
-    ///   <item><description><b>Remote (fallback)</b> â€” when no cache is registered:
+    ///   <item><description><b>Remote (fallback)</b> — when no cache is registered:
     ///     subscribes to and writes through the owning per-node hub via
     ///     <c>workspace.GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c>.</description></item>
     /// </list>
     /// Callers Subscribe (read) or call <c>.Update(update).Subscribe(...)</c> (write).
     /// If the node does not exist at <paramref name="path"/>, the per-node hub never
-    /// activates and the remote subscription does not emit â€” bound reads with
+    /// activates and the remote subscription does not emit — bound reads with
     /// <c>.Take(1).Timeout(...)</c> and treat absence as "not found".
     /// </summary>
     public static MeshNodeStreamHandle GetMeshNodeStream(this IWorkspace workspace, string path)
@@ -1737,15 +1737,15 @@ public static class MeshNodeStreamExtensions
 
     /// <summary>
     /// Forwarder that delegates to <see cref="MeshNodeStreamHandle.Update"/>. Returns
-    /// <see cref="IObservable{MeshNode}"/>; CALLERS MUST SUBSCRIBE â€” the cold observable's
+    /// <see cref="IObservable{MeshNode}"/>; CALLERS MUST SUBSCRIBE — the cold observable's
     /// side effect runs on Subscribe, errors flow to <c>OnError</c>.
     /// <para>
-    /// Prefer <c>workspace.GetMeshNodeStream().Update(update)</c> at new callsites â€” uniform
+    /// Prefer <c>workspace.GetMeshNodeStream().Update(update)</c> at new callsites — uniform
     /// read/write API on a single handle. This forwarder is kept so the existing 30+
     /// callsites can migrate incrementally.
     /// </para>
     /// </summary>
-    [Obsolete("Use workspace.GetMeshNodeStream(path?).Update(update).Subscribe(...) â€” uniform read/write API; callers must subscribe so writes can't be silently dropped.")]
+    [Obsolete("Use workspace.GetMeshNodeStream(path?).Update(update).Subscribe(...) — uniform read/write API; callers must subscribe so writes can't be silently dropped.")]
     public static IObservable<MeshNode> UpdateMeshNode(this IWorkspace workspace,
         Func<MeshNode, MeshNode> update,
         string? nodePath = null)
@@ -1756,7 +1756,7 @@ public static class MeshNodeStreamExtensions
     /// <summary>
     /// One-shot read of the <see cref="MeshNode"/> at <paramref name="path"/> via
     /// the owning per-node hub's <see cref="MeshNodeReference"/> reducer. Posts a
-    /// <see cref="GetDataRequest"/> + registers a callback â€” true request/response,
+    /// <see cref="GetDataRequest"/> + registers a callback — true request/response,
     /// no <c>SubscribeRequest</c>, no lingering subscription. Use this instead of
     /// <c>workspace.GetMeshNodeStream(path).Take(1)</c> for handlers / helpers /
     /// click actions that just need the current value once.
@@ -1789,7 +1789,7 @@ public static class MeshNodeStreamExtensions
     ///
     /// <para>
     /// For a <b>live</b> single-node subscription that re-emits on every change,
-    /// use <see cref="GetMeshNodeStream(IWorkspace, string)"/> instead â€” and stay
+    /// use <see cref="GetMeshNodeStream(IWorkspace, string)"/> instead — and stay
     /// subscribed (no <c>.Take(1)</c>). See <c>Doc/Architecture/AsynchronousCalls.md</c>.
     /// </para>
     /// </summary>
@@ -1862,7 +1862,7 @@ public static class MeshNodeStreamExtensions
             var cts = new CancellationTokenSource(budget);
             var emitted = 0;
             // Inner hub.Observe subscription tracker. Captured so the returned
-            // disposable can tear it down â€” without this, the outer CTS-timeout
+            // disposable can tear it down — without this, the outer CTS-timeout
             // path emits null and the outer observer disposes, but the inner
             // Subscribe keeps the hub-level callback registered, surfacing as
             // a "pending callback at dispose" Quiescing-watchdog failure.

--- a/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
@@ -44,7 +44,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
     /// <summary>
     /// Client config that adds layout / data so subscribers can use
     /// <c>workspace.GetRemoteStream(...)</c>. Without <see cref="Layout.LayoutExtensions.AddLayoutClient"/>,
-    /// <c>GetWorkspace()</c> throws "AddData was not called" â€” and posting from
+    /// <c>GetWorkspace()</c> throws "AddData was not called" — and posting from
     /// the mesh hub directly leaves <c>SubscribeRequest</c> without a return route.
     /// </summary>
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
@@ -97,7 +97,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
 
     /// <summary>
     /// Polling progress: a script writes 4 log lines spaced ~150 ms apart. Subscribers
-    /// of the ActivityLog stream must see the message count grow GRADUALLY â€” not just
+    /// of the ActivityLog stream must see the message count grow GRADUALLY — not just
     /// the final 4-message snapshot. Proves the Activity-hosted kernel publishes
     /// intermediate snapshots via <c>DataChangeRequest.Update</c> as the script runs,
     /// instead of buffering everything until the script returns.
@@ -139,7 +139,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
         // that moment; the count of messages grows monotonically.
         var workspace = GetClient().GetWorkspace();
         // Stream every distinct message-count. Close as soon as we observe the
-        // terminal snapshot (4 messages) by using TakeUntil â€” and re-include
+        // terminal snapshot (4 messages) by using TakeUntil — and re-include
         // that final emission via the wrapping Concat.
         var counts = workspace
             .GetMeshNodeStream(exec.ActivityLog!)
@@ -154,10 +154,10 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
             .ToList()
             .Should().Within(30.Seconds()).Emit();
 
-        // Gradual streaming â†’ at least 3 distinct snapshots before we hit 4.
+        // Gradual streaming → at least 3 distinct snapshots before we hit 4.
         // (We allow batching of two adjacent log calls but not all-at-once.)
         snapshots.Should().HaveCountGreaterThanOrEqualTo(3,
-            "ActivityLog should publish intermediate snapshots as messages land â€” " +
+            "ActivityLog should publish intermediate snapshots as messages land — " +
             "not buffer everything until script completion. Snapshots seen: [" +
             string.Join(", ", snapshots) + "]");
         snapshots.Last().Should().Be(4, "terminal snapshot must contain all 4 log lines");
@@ -190,7 +190,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
         exec.ActivityLog.Should().NotBeNullOrEmpty();
 
         // Stream the log until Status flips out of Running. Before-throw must be
-        // present even though the script raised â€” Log is best-effort and survives.
+        // present even though the script raised — Log is best-effort and survives.
         var workspace = GetClient().GetWorkspace();
         var observed = (await workspace
             .GetMeshNodeStream(exec.ActivityLog!)

--- a/test/MeshWeaver.AI.Test/AgentChatClientDeadlockTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentChatClientDeadlockTest.cs
@@ -40,7 +40,7 @@ namespace MeshWeaver.AI.Test;
 [Collection(ConcurrencyStressCollection.Name)]
 public class AgentChatClientDeadlockTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
@@ -55,29 +55,29 @@ public class AgentChatClientDeadlockTest(ITestOutputHelper output) : MonolithMes
 
     /// <summary>
     /// SHOULD-FAIL-IF: <c>LoadOrderedAgentsAsync</c> bridges <c>hub.GetMeshNode(contextPath)</c>
-    /// via <c>.ToTask()</c> + <c>await</c> â€” that pattern deadlocks the hub ActionBlock when
+    /// via <c>.ToTask()</c> + <c>await</c> — that pattern deadlocks the hub ActionBlock when
     /// multiple concurrent callers are in flight.
     /// </summary>
     [Fact]
     public async Task GetOrderedAgentsAsync_WithContextPath_ConcurrentCallers_DoNotDeadlock()
     {
         // ProductLaunch carries NodeType="ACME/Project", which exercises the
-        // single-node-lookup branch (not "Agent" / not "Markdown") â€” the exact branch
+        // single-node-lookup branch (not "Agent" / not "Markdown") — the exact branch
         // that contained the await-on-hub.GetMeshNode bug.
         const string ContextPath = "ACME/ProductLaunch";
 
-        // Pre-flight: confirm the test data is loaded â€” if this fails the test setup
+        // Pre-flight: confirm the test data is loaded — if this fails the test setup
         // is wrong, not the production code under test.
         var contextNode = await MeshQuery.QueryAsync<MeshNode>($"path:{ContextPath}",
             ct: TestContext.Current.CancellationToken)
             .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
-        contextNode.Should().NotBeNull("ProductLaunch fixture node missing â€” test data setup broke");
+        contextNode.Should().NotBeNull("ProductLaunch fixture node missing — test data setup broke");
         contextNode!.NodeType.Should().Be("ACME/Project");
 
         // Fire 8 concurrent GetOrderedAgentsAsync chains against fresh AgentChatClient
         // instances. Each chain re-runs the contextPath single-node lookup. A deadlock
         // in that lookup makes one of the hub pumps stall; under load several stall
-        // in a row. WaitAsync(15s) bounds the wait â€” under deadlock it throws TimeoutException.
+        // in a row. WaitAsync(15s) bounds the wait — under deadlock it throws TimeoutException.
         async Task RunOne(int idx)
         {
             var client = new AgentChatClient(Mesh.ServiceProvider);
@@ -97,7 +97,7 @@ public class AgentChatClientDeadlockTest(ITestOutputHelper output) : MonolithMes
 
     /// <summary>
     /// SHOULD-FAIL-IF: the contextPath single-node lookup blocks the hub even for a
-    /// single sequential caller (the trivial repro of the deadlock â€” every fresh
+    /// single sequential caller (the trivial repro of the deadlock — every fresh
     /// <c>AgentChatClient</c> kicks off the same hub round-trip on activation).
     /// </summary>
     [Fact]
@@ -128,13 +128,13 @@ public class AgentChatClientDeadlockTest(ITestOutputHelper output) : MonolithMes
     /// <summary>
     /// SHOULD-FAIL-IF: the single-node lookup path is invoked and hangs even when the
     /// context node has a NodeType that is filtered out (Markdown / Agent). The fix
-    /// is in the lookup itself, not the post-lookup filter â€” the code still runs the
+    /// is in the lookup itself, not the post-lookup filter — the code still runs the
     /// hub round-trip before deciding to discard the result.
     /// </summary>
     [Fact]
     public async Task GetOrderedAgentsAsync_WithMarkdownContext_DoesNotDeadlock()
     {
-        // Use a known Markdown node from the test data â€” TestDoc/ParentDoc.md.
+        // Use a known Markdown node from the test data — TestDoc/ParentDoc.md.
         const string ContextPath = "TestDoc/ParentDoc";
         var contextNode = await MeshQuery.QueryAsync<MeshNode>($"path:{ContextPath}",
             ct: TestContext.Current.CancellationToken)
@@ -153,7 +153,7 @@ public class AgentChatClientDeadlockTest(ITestOutputHelper output) : MonolithMes
             Node = contextNode,
         });
 
-        // No assertion on agents content â€” the existence check is "did the call return".
+        // No assertion on agents content — the existence check is "did the call return".
         await client.GetOrderedAgentsAsync()
             .WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
     }

--- a/test/MeshWeaver.AI.Test/AgentChatClientTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentChatClientTest.cs
@@ -45,7 +45,7 @@ public class AgentChatClientTest : MonolithMeshTestBase
             .AddFileSystemPersistence(TestDataPath)
             .AddGraph()
             // AddAI registers Agent NodeType + AgentConfiguration content type so
-            // .md files with `nodeType: Agent` deserialise into AgentConfiguration â€”
+            // .md files with `nodeType: Agent` deserialise into AgentConfiguration —
             // without this AgentPickerProjection.ProjectAgents filters them all out.
             .AddAI()
             .ConfigureDefaultNodeHub(config => config.AddDefaultLayoutAreas());
@@ -68,7 +68,7 @@ public class AgentChatClientTest : MonolithMeshTestBase
         var expectedNodeType = "ACME/Project";
         var expectedTodoAgentPath = "ACME/Project/TodoAgent";
 
-        // Static node read â€” no write before, catalog read is correct (no CQRS lag).
+        // Static node read — no write before, catalog read is correct (no CQRS lag).
         var productLaunchNode = await MeshQuery.QueryAsync<MeshNode>($"path:{contextPath}", ct: TestContext.Current.CancellationToken).FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         productLaunchNode.Should().NotBeNull("ProductLaunch node should exist in test data");
 
@@ -80,7 +80,7 @@ public class AgentChatClientTest : MonolithMeshTestBase
         // Act - Create AgentChatClient using the mesh's service provider
         var chatClient = new AgentChatClient(Mesh.ServiceProvider);
 
-        // 1. Initialize then SetContext â€” SetContext re-inits the subscription with
+        // 1. Initialize then SetContext — SetContext re-inits the subscription with
         //    the context node's space partition, which is what brings in that space's
         //    own agents at namespace:{space}/Agent (exact membership, no scope walk).
         chatClient.Initialize(contextPath);
@@ -121,7 +121,7 @@ public class AgentChatClientTest : MonolithMeshTestBase
         // Arrange - Use a path that should have agents in hierarchy
         var contextPath = "ACME";
 
-        // Static node read â€” no write before, catalog read is correct (no CQRS lag).
+        // Static node read — no write before, catalog read is correct (no CQRS lag).
         var acmeNode = await MeshQuery.QueryAsync<MeshNode>($"path:{contextPath}", ct: TestContext.Current.CancellationToken).FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         acmeNode.Should().NotBeNull("ACME node should exist in test data");
 

--- a/test/MeshWeaver.AI.Test/AgentWriteFailureTests.cs
+++ b/test/MeshWeaver.AI.Test/AgentWriteFailureTests.cs
@@ -29,7 +29,7 @@ namespace MeshWeaver.AI.Test;
 /// Comprehensive failure-mode tests for the agent write tools (Create, Update, Patch).
 ///
 /// Rationale: when an agent sends malformed input, the tool MUST return a speaking
-/// error string â€” never an empty string, never a silent success, never a stream-
+/// error string — never an empty string, never a silent success, never a stream-
 /// breaking write. These tests enumerate the failure shapes we see in the wild:
 /// invalid JSON, null content, missing required fields, empty identifiers,
 /// schema-violating content, and unknown paths.
@@ -41,7 +41,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
 
     public AgentWriteFailureTests(ITestOutputHelper output) : base(output) { }
 
-    // Share Mesh/ServiceProvider across all [Fact]s in this class â€” see
+    // Share Mesh/ServiceProvider across all [Fact]s in this class — see
     // MonolithMeshTestBase.ShareMeshAcrossTests for the rationale (~190 MiB native
     // heap leak per per-test mesh otherwise).
     protected override bool ShareMeshAcrossTests => true;
@@ -92,14 +92,14 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
         foreach (var input in inputs)
         {
             (await plugin.Create(input)).Should().NotBeNullOrWhiteSpace(
-                because: $"Create('{input}') must never return empty â€” downstream streams depend on non-empty responses");
+                because: $"Create('{input}') must never return empty — downstream streams depend on non-empty responses");
             (await plugin.Update(input)).Should().NotBeNullOrWhiteSpace(
                 because: $"Update('{input}') must never return empty");
             (await plugin.Delete(input)).Should().NotBeNullOrWhiteSpace(
                 because: $"Delete('{input}') must never return empty");
         }
 
-        // Patch has a second argument â€” try each combination too
+        // Patch has a second argument — try each combination too
         foreach (var input in inputs)
         {
             (await plugin.Patch("@ACME/nonexistent", input)).Should().NotBeNullOrWhiteSpace();
@@ -108,7 +108,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
     }
 
     // =========================================================================
-    // CREATE â€” failure modes
+    // CREATE — failure modes
     // =========================================================================
 
     [Fact]
@@ -156,7 +156,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
             @namespace = "ACME",
             name = "Bad Content",
             nodeType = TestNodeType,
-            // TestProduct.Price is decimal â€” passing an object forces a shape mismatch
+            // TestProduct.Price is decimal — passing an object forces a shape mismatch
             content = new { name = "X", price = new { nested = "object" }, quantity = 1 }
         });
 
@@ -168,7 +168,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
     }
 
     // =========================================================================
-    // UPDATE â€” failure modes (each entry failure must NOT halt the batch)
+    // UPDATE — failure modes (each entry failure must NOT halt the batch)
     // =========================================================================
 
     [Fact]
@@ -226,7 +226,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
         var result = await plugin.Update(updateJson);
 
         result.Should().Contain("Error");
-        result.Should().Contain("name", because: "empty name corrupts UI â€” error must call it out");
+        result.Should().Contain("name", because: "empty name corrupts UI — error must call it out");
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
         result.Should().Contain("schema", because: "error must include the recovery schema");
         result.Should().Contain("price");
 
-        // Seed is intact â€” rejected update must not overwrite persisted data
+        // Seed is intact — rejected update must not overwrite persisted data
         (await plugin.Get($"@ACME/{uniqueId}")).Should().Contain("Widget");
     }
 
@@ -317,7 +317,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
     }
 
     // =========================================================================
-    // PATCH â€” failure modes
+    // PATCH — failure modes
     // =========================================================================
 
     [Fact]
@@ -350,7 +350,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
 
         var result = await plugin.Patch($"@ACME/{uniqueId}", "{ not json");
 
-        // Either "Invalid JSON:" or a generic "Error:" is acceptable â€” what matters is
+        // Either "Invalid JSON:" or a generic "Error:" is acceptable — what matters is
         // that it's a speaking error and not an empty string or silent success.
         result.Should().NotBeNullOrWhiteSpace();
         (result.Contains("Invalid JSON") || result.Contains("Error")).Should().BeTrue(
@@ -427,7 +427,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
     }
 
     // =========================================================================
-    // STREAM HEALTH â€” rejected writes must leave persisted state unchanged
+    // STREAM HEALTH — rejected writes must leave persisted state unchanged
     // =========================================================================
 
     [Fact]
@@ -457,7 +457,7 @@ public class AgentWriteFailureTests : MonolithMeshTestBase
 
         // After all rejected attempts, the seeded content must still be intact
         var after = await plugin.Get(path);
-        after.Should().Contain("Widget", because: "the seed must survive all rejected writes â€” streams stay healthy");
+        after.Should().Contain("Widget", because: "the seed must survive all rejected writes — streams stay healthy");
     }
 
     // -------------------------------------------------------------------------

--- a/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
+++ b/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
@@ -29,7 +29,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// Integration tests verifying that SetAttachments() â†’ BuildMessageWithContextAsync()
+/// Integration tests verifying that SetAttachments() → BuildMessageWithContextAsync()
 /// loads attachment content and places it before the user message in the assembled prompt.
 /// </summary>
 public class AttachmentContextTest : MonolithMeshTestBase
@@ -38,7 +38,7 @@ public class AttachmentContextTest : MonolithMeshTestBase
 
     public AttachmentContextTest(ITestOutputHelper output) : base(output) { }
 
-    // Share Mesh/ServiceProvider across all [Fact]s in this class â€” saves the
+    // Share Mesh/ServiceProvider across all [Fact]s in this class — saves the
     // ~190 MiB native heap that would otherwise leak per test method.
     protected override bool ShareMeshAcrossTests => true;
 
@@ -163,7 +163,7 @@ public class AttachmentContextTest : MonolithMeshTestBase
         var agentChat = new AgentChatClient(Mesh.ServiceProvider);
         await agentChat.Initialize("ACME").WhenInitialized.FirstAsync().ToTask(ct);
 
-        // Static node read â€” no write before, catalog read is correct (no CQRS lag).
+        // Static node read — no write before, catalog read is correct (no CQRS lag).
         var contextNode = await MeshQuery.QueryAsync<MeshNode>("path:ACME", null, ct).FirstOrDefaultAsync(ct);
         contextNode.Should().NotBeNull();
 
@@ -314,7 +314,7 @@ public class AttachmentContextTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Verifies the full ordering: agent instructions â†’ context â†’ attachments â†’ user message.
+    /// Verifies the full ordering: agent instructions → context → attachments → user message.
     /// </summary>
     [Fact]
     public async Task PromptAssembly_FullOrdering_InstructionsContextAttachmentsUserMessage()

--- a/test/MeshWeaver.AI.Test/AutocompleteStreamProviderTests.cs
+++ b/test/MeshWeaver.AI.Test/AutocompleteStreamProviderTests.cs
@@ -22,7 +22,7 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class AutocompleteStreamProviderTests
 {
-    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ Single provider, incremental snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ──────────────────────── Single provider, incremental snapshots ────────────────────────
 
     /// <summary>Single provider emits one snapshot per item and the final snapshot contains every item.</summary>
     [Fact]
@@ -70,7 +70,7 @@ public class AutocompleteStreamProviderTests
         snapshots[^1].Select(i => i.Label).Should().Equal("high", "mid", "low");
     }
 
-    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ Multiple providers, fast-then-slow â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ──────────────────────── Multiple providers, fast-then-slow ────────────────────────
 
     /// <summary>With a fast and a slow provider, fast items appear in early snapshots and slow ones merge in later.</summary>
     [Fact]
@@ -88,7 +88,7 @@ public class AutocompleteStreamProviderTests
         var done = new TaskCompletionSource();
         using var sub = sut.Stream("foo", null).Subscribe(snapshots.Add, () => done.TrySetResult());
 
-        // Fast provider streams first â€” wait for both items to be reflected.
+        // Fast provider streams first — wait for both items to be reflected.
         fast.Emit(new AutocompleteItem("local-a", "local-a", Priority: 90));
         fast.Emit(new AutocompleteItem("local-b", "local-b", Priority: 80));
         fast.Complete();
@@ -97,7 +97,7 @@ public class AutocompleteStreamProviderTests
         // Snapshot must contain only fast items at this point.
         snapshots[^1].Select(i => i.Label).Should().Equal("local-a", "local-b");
 
-        // Slow provider emits later â€” final snapshot has all four.
+        // Slow provider emits later — final snapshot has all four.
         slow.Emit(new AutocompleteItem("remote-a", "remote-a", Priority: 70));
         slow.Emit(new AutocompleteItem("remote-b", "remote-b", Priority: 60));
         slow.Complete();
@@ -117,7 +117,7 @@ public class AutocompleteStreamProviderTests
             $"snapshot count never reached {expected} within timeout");
     }
 
-    /// <summary>An exception thrown by one provider does not terminate the merged stream â€” other providers keep emitting.</summary>
+    /// <summary>An exception thrown by one provider does not terminate the merged stream — other providers keep emitting.</summary>
     [Fact]
     public async Task FailingProvider_DoesNotKillTheStream()
     {
@@ -143,7 +143,7 @@ public class AutocompleteStreamProviderTests
         snapshots[^1].Select(i => i.Label).Should().Equal("a", "b");
     }
 
-    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ Top-N truncation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ──────────────────────── Top-N truncation ────────────────────────
 
     /// <summary>Top-N truncation drops items whose priority falls below the current Nth-ranked item.</summary>
     [Fact]
@@ -168,7 +168,7 @@ public class AutocompleteStreamProviderTests
         snapshots[^1].Select(i => i.Label).Should().Equal("d", "b");
     }
 
-    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ Monaco-style: varying input over time â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ──────────────────────── Monaco-style: varying input over time ────────────────────────
 
     /// <summary>Sequential subscriptions with different queries each receive their own snapshot stream without leakage between queries.</summary>
     [Fact]
@@ -217,9 +217,9 @@ public class AutocompleteStreamProviderTests
 
         sub.Dispose();
 
-        // Try to emit more after disposal â€” provider tolerates the closed downstream.
+        // Try to emit more after disposal — provider tolerates the closed downstream.
         try { provider.Emit(new AutocompleteItem("b", "b", Priority: 20)); }
-        catch { /* downstream queue may be closed â€” that's the disposal signal */ }
+        catch { /* downstream queue may be closed — that's the disposal signal */ }
 
         // Allow any in-flight scheduled work to drain
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -228,7 +228,7 @@ public class AutocompleteStreamProviderTests
             "after disposal, no further snapshots reach the (now disposed) observer");
     }
 
-    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ Test doubles â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ──────────────────────── Test doubles ────────────────────────
 
     /// <summary>
     /// Provider whose <c>GetItems</c> observable emits a GROWING snapshot each time
@@ -236,7 +236,7 @@ public class AutocompleteStreamProviderTests
     /// calls <see cref="Complete"/>. Each snapshot is the running accumulation — the
     /// snapshot contract: providers emit their current best <see cref="IReadOnlyCollection{T}"/>,
     /// the aggregator merges + sorts. The backing <see cref="Subject{T}"/> IS the
-    /// observable â€” no async-enumerable bridge needed.
+    /// observable — no async-enumerable bridge needed.
     /// </summary>
     private sealed class ScriptedProvider : IAutocompleteProvider
     {

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -59,8 +59,8 @@ public class ChatClientCredentialResolverTest : AITestBase
         var modelPath = $"{modelNs}/{modelId}";
 
         // Legacy shape: a LanguageModel node carrying the key directly on
-        // its content (no ProviderRef). The resolver's last rung â€”
-        // "model-node" â€” picks this up.
+        // its content (no ProviderRef). The resolver's last rung —
+        // "model-node" — picks this up.
         await MeshService.CreateNode(new MeshNode(modelId, modelNs)
         {
             NodeType = LanguageModelNodeType.NodeType,
@@ -72,7 +72,7 @@ public class ChatClientCredentialResolverTest : AITestBase
                 Provider = "Anthropic",
                 ApiKeySecretRef = "sk-legacy-on-model-node",
                 Endpoint = "https://legacy.example/v1/messages",
-                // No ProviderRef â€” resolver should fall through to model fields.
+                // No ProviderRef — resolver should fall through to model fields.
                 ProviderRef = null,
             }
         }).Should().Within(15.Seconds()).Emit();
@@ -84,7 +84,7 @@ public class ChatClientCredentialResolverTest : AITestBase
 
         var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
         resolver.EnsureSubscription();
-        // Poll the resolver's public surface â€” robust against OnNext
+        // Poll the resolver's public surface — robust against OnNext
         // ordering vs the warmup observable above.
         var resolution = await Observable.Interval(TimeSpan.FromMilliseconds(50))
             .Select(_ => resolver.Resolve(modelId))

--- a/test/MeshWeaver.AI.Test/CollaborationPluginGrainFailureTest.cs
+++ b/test/MeshWeaver.AI.Test/CollaborationPluginGrainFailureTest.cs
@@ -25,7 +25,7 @@ namespace MeshWeaver.AI.Test;
 /// truly-async Post + RegisterCallback + TCS pattern (see
 /// <c>Doc/Architecture/AsynchronousCalls</c>). Routing failures propagate back through
 /// the callback as a <c>DeliveryFailure</c> and the plugin returns a user-actionable
-/// error string â€” never <c>hub.AwaitResponse</c>, which would deadlock the hub.
+/// error string — never <c>hub.AwaitResponse</c>, which would deadlock the hub.
 /// </summary>
 public class CollaborationPluginGrainFailureTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -96,7 +96,7 @@ public class CollaborationPluginGrainFailureTest(ITestOutputHelper output) : Mon
     }
 
     /// <summary>
-    /// Plugin-level coverage for <c>AddComment</c> â€” same early-exit contract as
+    /// Plugin-level coverage for <c>AddComment</c> — same early-exit contract as
     /// <see cref="SuggestEdit_NonResolvablePath_ReturnsDocumentNotFound"/>.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -116,7 +116,7 @@ public class CollaborationPluginGrainFailureTest(ITestOutputHelper output) : Mon
     }
 
     /// <summary>
-    /// Minimal <see cref="IAgentChat"/> stub â€” <c>CollaborationPlugin</c> only reads
+    /// Minimal <see cref="IAgentChat"/> stub — <c>CollaborationPlugin</c> only reads
     /// <c>Context</c> (possibly null) and <c>Context.Path</c> for the author field.
     /// All other members throw.
     /// </summary>

--- a/test/MeshWeaver.AI.Test/DelegationDeadlockTest.cs
+++ b/test/MeshWeaver.AI.Test/DelegationDeadlockTest.cs
@@ -20,7 +20,7 @@ namespace MeshWeaver.AI.Test;
 /// FunctionInvokingChatClient drove the sub-thread's enumeration via <c>await foreach</c>
 /// on the grain's message-handler stack. Each <c>MoveNextAsync</c> continuation captured
 /// the grain's SynchronizationContext. Any sub-thread continuation that needed to post
-/// back through that same scheduler wedged it â€” the grain was stuck inside the awaiting
+/// back through that same scheduler wedged it — the grain was stuck inside the awaiting
 /// tool call.
 ///
 /// Fix contract: the sub-thread drain must run on ThreadPool with
@@ -70,17 +70,17 @@ public class DelegationDeadlockTest
     });
 
     /// <summary>
-    /// REPRO â€” sub-thread drain must not capture the caller's SynchronizationContext.
+    /// REPRO — sub-thread drain must not capture the caller's SynchronizationContext.
     ///
     /// We invoke the tool on a single-threaded pump that models the Orleans grain
     /// scheduler. Inside the sub-thread's enumeration body, we record whether the
     /// current thread is a ThreadPool thread.
     ///
     /// Today (buggy): the `async IAsyncEnumerable` shape runs enumeration
-    /// continuations on the caller's pump â†’ <c>IsThreadPoolThread</c> is false. Under
+    /// continuations on the caller's pump → <c>IsThreadPoolThread</c> is false. Under
     /// Orleans, that's the deadlock.
     ///
-    /// After fix (Task.Run + ConfigureAwait(false)): the drain runs on ThreadPool â†’
+    /// After fix (Task.Run + ConfigureAwait(false)): the drain runs on ThreadPool →
     /// <c>IsThreadPoolThread</c> is true, and the grain scheduler stays free.
     /// </summary>
     [Fact]
@@ -98,7 +98,7 @@ public class DelegationDeadlockTest
         {
             // Record where the enumeration is actually running. This is the code path
             // that, under Orleans, would post UpdateThreadMessageContent back through
-            // the parent hub â€” if it runs on the grain scheduler, we deadlock.
+            // the parent hub — if it runs on the grain scheduler, we deadlock.
             enumerationOnThreadPool.TrySetResult(
                 System.Threading.Thread.CurrentThread.IsThreadPoolThread);
             yield return "done";
@@ -107,7 +107,7 @@ public class DelegationDeadlockTest
 
         var tool = CreateTool((a, t, c, ct) => AsObservable(Execute(a, t, c, ct)));
 
-        // Invoke the tool on the pump â€” this is how FunctionInvokingChatClient
+        // Invoke the tool on the pump — this is how FunctionInvokingChatClient
         // would invoke it from a grain message handler.
         await pump.RunAsync(() => tool.InvokeAsync(Args(), ct).AsTask())
             .WaitAsync(10.Seconds(), ct);
@@ -150,7 +150,7 @@ public class DelegationDeadlockTest
 
     /// <summary>
     /// Single-threaded synchronization context that serializes all continuations
-    /// onto one thread â€” models an Orleans grain scheduler / message hub pump.
+    /// onto one thread — models an Orleans grain scheduler / message hub pump.
     /// </summary>
     private sealed class SingleThreadSyncContext : SynchronizationContext, IDisposable
     {
@@ -169,7 +169,7 @@ public class DelegationDeadlockTest
             foreach (var item in queue.GetConsumingEnumerable())
             {
                 try { item.cb(item.state); }
-                catch { /* swallow â€” callbacks carry their own error plumbing via TCS */ }
+                catch { /* swallow — callbacks carry their own error plumbing via TCS */ }
             }
         }
 

--- a/test/MeshWeaver.AI.Test/DelegationIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/DelegationIntegrationTest.cs
@@ -145,7 +145,7 @@ public class DelegationIntegrationTest : MonolithMeshTestBase
         agents.Should().Contain(a => a.Name == "Coordinator", "Coordinator agent should be loaded from .md file");
         agents.Should().Contain(a => a.Name == "Worker", "Worker agent should be loaded from .md file");
 
-        // Act: Send a message â€” Coordinator should delegate to Worker
+        // Act: Send a message — Coordinator should delegate to Worker
         var messages = new List<ChatMessage>
         {
             new(ChatRole.User, "What is the capital of France?")
@@ -215,7 +215,7 @@ public class DelegationIntegrationTest : MonolithMeshTestBase
 
     /// <summary>
     /// Verifies that the Worker's result (from its isolated thread) appears
-    /// as a FunctionResultContent in the Coordinator's thread â€” proving
+    /// as a FunctionResultContent in the Coordinator's thread — proving
     /// that Worker's thread is in the namespace of Coordinator's thread.
     /// </summary>
     [Fact(Timeout = 120_000)]

--- a/test/MeshWeaver.AI.Test/DelegationTest.cs
+++ b/test/MeshWeaver.AI.Test/DelegationTest.cs
@@ -254,7 +254,7 @@ public class DelegationTest
 
         // Assert: Sessions are isolated (different instances)
         childSession.Should().NotBeSameAs(parentSession,
-            "child session should be isolated from parent â€” B runs in its own namespace within A's execution");
+            "child session should be isolated from parent — B runs in its own namespace within A's execution");
 
         // Assert: Delegation was executed with correct parameters
         capturedAgentName.Should().Be("AgentB");
@@ -271,7 +271,7 @@ public class DelegationTest
 
         responseTexts.Should().NotBeEmpty("parent agent A should produce a response after delegation");
 
-        // The parent's final text should contain B's response (relayed via tool result â†’ summary)
+        // The parent's final text should contain B's response (relayed via tool result → summary)
         var fullResponse = string.Join(" ", responseTexts);
         fullResponse.Should().Contain(AgentBResponseText,
             "A's response should include B's delegation result");

--- a/test/MeshWeaver.AI.Test/InboxToolIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/InboxToolIntegrationTest.cs
@@ -72,7 +72,7 @@ public class InboxToolIntegrationTest : AITestBase
         return base.ConfigureClient(configuration).AddLayoutClient();
     }
 
-    // â”€â”€â”€ check_inbox via the AIFunction surface â”€â”€â”€
+    // ─── check_inbox via the AIFunction surface ───
 
     [Fact]
     public async Task CheckInbox_NoPending_ReturnsNoNewMessages()
@@ -135,7 +135,7 @@ public class InboxToolIntegrationTest : AITestBase
 
         // Lock IsExecuting=true BEFORE appending so the server-side watcher
         // doesn't drain the queue during our setup. We're simulating "agent is
-        // mid-stream" â€” the real flow has the agent already executing when
+        // mid-stream" — the real flow has the agent already executing when
         // follow-ups arrive, and check_inbox is the only path that promotes
         // them out of PendingUserMessages.
         // Atomically enter mid-execution WITH all three queued (one own-stream write).
@@ -192,7 +192,7 @@ public class InboxToolIntegrationTest : AITestBase
             "once a message has been delivered to the agent it must NOT be redelivered on the next call");
     }
 
-    // â”€â”€â”€ Mid-execution: in-flight message delivered inline, NO output-cell split â”€â”€â”€
+    // ─── Mid-execution: in-flight message delivered inline, NO output-cell split ───
 
     /// <summary>
     /// While a round is streaming into response cell R1, a follow-up message arrives and the
@@ -373,7 +373,7 @@ public class InboxToolIntegrationTest : AITestBase
             afterRound.IngestedMessageIds.Should().Contain(id, "no follow-up may be lost");
     }
 
-    // â”€â”€â”€ Cancel-then-restart: ESC with pending messages â”€â”€â”€
+    // ─── Cancel-then-restart: ESC with pending messages ───
 
     [Fact]
     public async Task Cancel_WithPendingMessages_DispatchesNextRoundAfterCleanup()
@@ -449,7 +449,7 @@ public class InboxToolIntegrationTest : AITestBase
         var u1 = roundStart.IngestedMessageIds[0];
         var initialMsgsCount = roundStart.Messages.Count;
 
-        // Cancel â€” no follow-ups queued.
+        // Cancel — no follow-ups queued.
         // Cancel via stream.Update (see RequestViaStreamUpdate.md). Awaiting
         // the post-update emission asserts the write actually landed.
         var cancelled = await client.GetWorkspace().GetMeshNodeStream(threadPath)
@@ -665,7 +665,7 @@ public class InboxToolIntegrationTest : AITestBase
         ingestedTexts.Should().BeEquivalentTo(texts, client.JsonSerializerOptions);
     }
 
-    // â”€â”€â”€ ViewModel projection â”€â”€â”€
+    // ─── ViewModel projection ───
 
     [Fact]
     public void ExtractPendingTexts_EmptyThread_ReturnsEmpty()
@@ -699,7 +699,7 @@ public class InboxToolIntegrationTest : AITestBase
         texts.Should().BeEmpty();
     }
 
-    // â”€â”€â”€ Helpers â”€â”€â”€
+    // ─── Helpers ───
 
     private async Task<string> SeedEmptyThreadAsync(CancellationToken ct)
     {
@@ -731,7 +731,7 @@ public class InboxToolIntegrationTest : AITestBase
         await ReadNode(threadPath).Should().Within(60.Seconds()).Emit();
         // Resolve the hub through the mesh service.
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-        // GetHub is internal â€” we use the same trick as ThreadExecution: the
+        // GetHub is internal — we use the same trick as ThreadExecution: the
         // routed hub becomes accessible by sending a no-op delivery and
         // reading back the workspace. Easier: spin up a hosted hub at the
         // address.
@@ -909,12 +909,12 @@ public class InboxToolIntegrationTest : AITestBase
         return ids;
     }
 
-    // â”€â”€â”€ Fake chat client + factory â”€â”€â”€
+    // ─── Fake chat client + factory ───
 
     /// <summary>
     /// Slow fake that delays ~5 s in the streaming path so tests can race in
     /// follow-up submissions and ESC during the in-flight turn. 1.5 s wasn't
-    /// enough headroom on slow CI runners â€” the in-flight round could finish
+    /// enough headroom on slow CI runners — the in-flight round could finish
     /// before the test had time to submit the queued u2 + assert.
     /// </summary>
     private sealed class InboxFakeChatClient : IChatClient

--- a/test/MeshWeaver.AI.Test/InboxToolUnitTest.cs
+++ b/test/MeshWeaver.AI.Test/InboxToolUnitTest.cs
@@ -11,13 +11,13 @@ namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Pure-logic tests for <see cref="InboxTool.Drain"/> and
-/// <see cref="InboxTool.FormatToolResult"/>. No hub, no async â€” exercises the
+/// <see cref="InboxTool.FormatToolResult"/>. No hub, no async — exercises the
 /// state-transition contract that the integration tests then verify
 /// end-to-end.
 /// </summary>
 public class InboxToolUnitTest
 {
-    // â”€â”€â”€ Drain â”€â”€â”€
+    // ─── Drain ───
 
     [Fact]
     public void Drain_EmptyPending_ReturnsEmptyResult_LeavesThreadUnchanged()
@@ -62,7 +62,7 @@ public class InboxToolUnitTest
         result.UpdatedThread.PendingUserMessages.Should().BeEmpty();
         result.UpdatedThread.IngestedMessageIds.Should().ContainInOrder("u1", "u2");
         result.UpdatedThread.IsExecuting.Should().BeTrue(
-            "drain must not flip the executing flag â€” the agent is still running");
+            "drain must not flip the executing flag — the agent is still running");
         result.UpdatedThread.Messages.Should().ContainInOrder(new[] { "u1", "r1", "u2" },
             "drain doesn't reorder Messages");
     }
@@ -91,7 +91,7 @@ public class InboxToolUnitTest
     [Fact]
     public void Drain_PendingNotInUserMessageIds_StillReturnedAtEnd()
     {
-        // Defensive case â€” pending entry whose id was never registered. We must
+        // Defensive case — pending entry whose id was never registered. We must
         // not silently drop it, otherwise it would survive forever.
         var orphan = new ThreadMessage { Role = "user", Text = "orphan text" };
         var thread = new MeshThread
@@ -114,7 +114,7 @@ public class InboxToolUnitTest
         var thread = new MeshThread
         {
             UserMessageIds = ImmutableList.Create("u1"),
-            // u1 is somehow already ingested (defensive â€” race tolerance) but
+            // u1 is somehow already ingested (defensive — race tolerance) but
             // also pending. Drain should not produce duplicates.
             IngestedMessageIds = ImmutableList.Create("u1"),
             PendingUserMessages = ImmutableDictionary<string, ThreadMessage>.Empty
@@ -156,7 +156,7 @@ public class InboxToolUnitTest
         Assert.Throws<ArgumentNullException>(() => InboxTool.Drain(null!));
     }
 
-    // â”€â”€â”€ FormatToolResult â”€â”€â”€
+    // ─── FormatToolResult ───
 
     [Fact]
     public void FormatToolResult_Empty_NoNewMessages()
@@ -205,7 +205,7 @@ public class InboxToolUnitTest
         result.Should().Contain("3. third follow-up");
     }
 
-    // â”€â”€â”€ Drain semantics for the inbox design â”€â”€â”€
+    // ─── Drain semantics for the inbox design ───
     //
     // The inbox is the unified ingestion point. AppendUserInput writes to
     // PendingUserMessages + UserMessageIds only. Drain moves the queue into
@@ -281,12 +281,12 @@ public class InboxToolUnitTest
         result.DrainedMessages[1].Should().BeSameAs(m2);
     }
 
-    // â”€â”€â”€ GUI-perspective â”€â”€â”€
+    // ─── GUI-perspective ───
     //
     // The chat view binds to MeshThread.PendingUserMessages (queued / "not yet
     // picked up") and MeshThread.Messages (submitted / "picked up by inbox").
     // These tests pin the visible state transitions so a regression in
-    // either AppendUserInput (writes pending) or Drain (moves pendingâ†’messages)
+    // either AppendUserInput (writes pending) or Drain (moves pending→messages)
     // surfaces as a unit-test failure instead of a runtime visual glitch.
 
     [Fact]
@@ -305,12 +305,12 @@ public class InboxToolUnitTest
         {
             UserMessageIds = ImmutableList.Create("u1"),
             PendingUserMessages = ImmutableDictionary<string, ThreadMessage>.Empty.Add("u1", msg),
-            // No Messages entry yet â€” inbox hasn't picked it up.
+            // No Messages entry yet — inbox hasn't picked it up.
         };
 
         thread.Messages.Should().BeEmpty("queued message must not be in Messages until the inbox picks it up");
         thread.PendingUserMessages.Should().ContainKey("u1",
-            "queued message lives in PendingUserMessages â€” the GUI renders it from this dict");
+            "queued message lives in PendingUserMessages — the GUI renders it from this dict");
         thread.PendingUserMessages["u1"].Text.Should().Be("hello");
     }
 
@@ -329,9 +329,9 @@ public class InboxToolUnitTest
         var afterPickup = InboxTool.Drain(thread).UpdatedThread;
 
         afterPickup.PendingUserMessages.Should().NotContainKey("u1",
-            "after pickup, the id leaves PendingUserMessages â€” GUI removes the queued visual");
+            "after pickup, the id leaves PendingUserMessages — GUI removes the queued visual");
         afterPickup.Messages.Should().Contain("u1",
-            "after pickup, the id appears in Messages â€” GUI renders the materialised cell");
+            "after pickup, the id appears in Messages — GUI renders the materialised cell");
         afterPickup.IngestedMessageIds.Should().Contain("u1",
             "ingestion is tracked so a re-fire of the watcher doesn't double-dispatch");
     }
@@ -367,7 +367,7 @@ public class InboxToolUnitTest
     public void GuiPerspective_MidStreamSubmit_VisibleInPendingDuringExecution()
     {
         // Round 1 is running (IsExecuting=true, response cell r1 active). A new
-        // user submission lands while streaming â€” it must show up in
+        // user submission lands while streaming — it must show up in
         // PendingUserMessages as a queued cell, NOT in Messages yet (the
         // currently-streaming response cell continues uninterrupted).
         var threadBefore = new MeshThread
@@ -390,9 +390,9 @@ public class InboxToolUnitTest
         threadAfterSubmit.IsExecuting.Should().BeTrue("the current round keeps running");
         threadAfterSubmit.ActiveMessageId.Should().Be("r1", "current response cell still streaming");
         threadAfterSubmit.Messages.Should().NotContain("u2",
-            "follow-up is NOT yet visible in Messages â€” GUI shows it as 'queued'");
+            "follow-up is NOT yet visible in Messages — GUI shows it as 'queued'");
         threadAfterSubmit.PendingUserMessages.Should().ContainKey("u2",
-            "follow-up is visible in PendingUserMessages â€” GUI renders the queued cell");
+            "follow-up is visible in PendingUserMessages — GUI renders the queued cell");
 
         // The agent's check_inbox tool drains the new pending entry. The same
         // response cell r1 continues; u2 moves into Messages between u1/r1
@@ -402,7 +402,7 @@ public class InboxToolUnitTest
         afterPickup.IsExecuting.Should().BeTrue("drain doesn't tear the round down");
         afterPickup.ActiveMessageId.Should().Be("r1", "still streaming to r1");
         afterPickup.Messages.Should().Contain("u2",
-            "follow-up has moved into Messages â€” GUI flips it from 'queued' to 'submitted'");
+            "follow-up has moved into Messages — GUI flips it from 'queued' to 'submitted'");
         afterPickup.PendingUserMessages.Should().NotContainKey("u2",
             "follow-up is no longer queued");
         afterPickup.IngestedMessageIds.Should().Contain("u2",

--- a/test/MeshWeaver.AI.Test/KernelStdoutCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/KernelStdoutCaptureTest.cs
@@ -15,7 +15,7 @@ namespace MeshWeaver.AI.Test;
 /// Unit tests for the kernel's stdout-capture pipeline: <see cref="LoggerTextWriter"/>
 /// (line-buffered TextWriter that flushes each completed line as a LogInformation
 /// entry) and <see cref="CapturingTextWriter"/> (process-wide Console.Out hook that
-/// routes to an AsyncLocal target). No mesh / no kernel â€” this is a pure check that
+/// routes to an AsyncLocal target). No mesh / no kernel — this is a pure check that
 /// the building blocks behave as <c>KernelExecutor</c> expects.
 /// </summary>
 public class KernelStdoutCaptureTest
@@ -42,7 +42,7 @@ public class KernelStdoutCaptureTest
         writer.Write("Hel");
         writer.Write("lo, ");
         writer.Write("World");
-        logger.Messages.Should().BeEmpty("no newline yet â€” should be buffered");
+        logger.Messages.Should().BeEmpty("no newline yet — should be buffered");
 
         writer.Write('\n');
         logger.Messages.Should().ContainSingle().Which.Should().Contain("Hello, World");
@@ -100,7 +100,7 @@ public class KernelStdoutCaptureTest
     public async Task CapturingTextWriter_AsyncLocal_Isolates_Concurrent_Captures()
     {
         // Two concurrent "scripts" each capture into their own writer. Output
-        // from one must not leak into the other â€” the AsyncLocal target is what
+        // from one must not leak into the other — the AsyncLocal target is what
         // makes this safe across thread-pool continuations. A naive global swap
         // of Console.Out would mix the two streams.
         var captureA = new StringWriter();

--- a/test/MeshWeaver.AI.Test/LanguageModelNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/LanguageModelNodeTypeTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// Tests covering the <c>nodeType:LanguageModel</c> surface â€” the platform
+/// Tests covering the <c>nodeType:LanguageModel</c> surface — the platform
 /// reads <see cref="LanguageModelCatalogOptions.Sources"/> at mesh init
 /// time and emits one static <see cref="LanguageModelNodeType.NodeType"/>
 /// MeshNode per <c>{section}:Models[]</c> entry under
@@ -27,7 +27,7 @@ public class LanguageModelNodeTypeTest
     [Fact]
     public void Constants_NamespaceAndNodeType_AreStable()
     {
-        // Public mesh-query contract â€” anyone typing `namespace:Model
+        // Public mesh-query contract — anyone typing `namespace:Model
         // nodeType:LanguageModel` in a search box depends on these not
         // silently shifting.
         LanguageModelNodeType.NodeType.Should().Be("LanguageModel");
@@ -88,7 +88,7 @@ public class LanguageModelNodeTypeTest
     public void Provider_TwoSourcesShareModelId_FirstWins()
     {
         // Two providers (e.g. Azure Claude + Direct Anthropic) both
-        // advertise claude-sonnet-4-6 â€” the lower-Order source wins. The
+        // advertise claude-sonnet-4-6 — the lower-Order source wins. The
         // picker shows it once, attributed to the winner.
         var provider = MakeProvider(
             new Dictionary<string, string?>
@@ -96,7 +96,7 @@ public class LanguageModelNodeTypeTest
                 ["Anthropic:Models:0"] = "claude-sonnet-4-6",
                 ["Direct:Models:0"] = "claude-sonnet-4-6"
             },
-            // Order matters â€” registered order = de-dup precedence.
+            // Order matters — registered order = de-dup precedence.
             new LanguageModelCatalogSource("Anthropic", "Azure Claude", 1),
             new LanguageModelCatalogSource("Direct", "Direct Anthropic", 99));
 
@@ -161,7 +161,7 @@ public class LanguageModelNodeTypeTest
     [Fact]
     public void Provider_SectionWithEmptyOrWhitespaceModels_SkipsThem()
     {
-        // Aspire/AppHost env var defaults can be empty strings â€” the
+        // Aspire/AppHost env var defaults can be empty strings — the
         // provider must skip them, not emit nodes with empty ids.
         var provider = MakeProvider(
             new Dictionary<string, string?>
@@ -185,7 +185,7 @@ public class LanguageModelNodeTypeTest
     public void Provider_MissingSection_NoCrash_NoNodes()
     {
         // Catalog source registered but the corresponding config section
-        // absent â€” provider warns + skips, doesn't throw.
+        // absent — provider warns + skips, doesn't throw.
         var provider = MakeProvider(
             new Dictionary<string, string?>(),
             new LanguageModelCatalogSource("MissingProvider", "Missing", 1));

--- a/test/MeshWeaver.AI.Test/MarkdownReferenceExtractorTest.cs
+++ b/test/MeshWeaver.AI.Test/MarkdownReferenceExtractorTest.cs
@@ -10,7 +10,7 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class MarkdownReferenceExtractorTest
 {
-    #region ExtractReferences â€” Direct @path syntax
+    #region ExtractReferences — Direct @path syntax
 
     [Fact]
     public void ExtractReferences_DirectPath_ExtractsPath()
@@ -62,7 +62,7 @@ public class MarkdownReferenceExtractorTest
 
     #endregion
 
-    #region ExtractReferences â€” Parentheses @(path) syntax
+    #region ExtractReferences — Parentheses @(path) syntax
 
     [Fact]
     public void ExtractReferences_ParenthesesPath_ExtractsPath()
@@ -86,7 +86,7 @@ public class MarkdownReferenceExtractorTest
 
     #endregion
 
-    #region ExtractReferences â€” Quoted @"path" syntax
+    #region ExtractReferences — Quoted @"path" syntax
 
     [Fact]
     public void ExtractReferences_QuotedPath_ExtractsPath()
@@ -100,7 +100,7 @@ public class MarkdownReferenceExtractorTest
 
     #endregion
 
-    #region ExtractReferences â€” Filtering known commands
+    #region ExtractReferences — Filtering known commands
 
     [Fact]
     public void ExtractReferences_AgentCommand_IsFiltered()
@@ -130,7 +130,7 @@ public class MarkdownReferenceExtractorTest
 
     #endregion
 
-    #region ExtractReferences â€” Overlap handling and priority
+    #region ExtractReferences — Overlap handling and priority
 
     [Fact]
     public void ExtractReferences_ParenthesesTakesPriorityOverDirect()
@@ -160,7 +160,7 @@ public class MarkdownReferenceExtractorTest
 
     #endregion
 
-    #region ExtractReferences â€” Edge cases
+    #region ExtractReferences — Edge cases
 
     [Fact]
     public void ExtractReferences_Null_ReturnsEmpty()

--- a/test/MeshWeaver.AI.Test/McpReadYourWritesTest.cs
+++ b/test/MeshWeaver.AI.Test/McpReadYourWritesTest.cs
@@ -36,7 +36,7 @@ namespace MeshWeaver.AI.Test;
 /// not the same as returning correct content. If `MeshOperations` ever reverts
 /// to a query-based content read (which goes through a lagged read-side index),
 /// these tests catch it deterministically in single-process and flake in
-/// distributed setups â€” either way, a real regression signal.
+/// distributed setups — either way, a real regression signal.
 ///
 /// Covers: Get (existing node + post-Create + post-Patch + not-found),
 /// Patch (merges with current content, not cached / indexed value),
@@ -52,7 +52,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
 
     public McpReadYourWritesTest(ITestOutputHelper output) : base(output) { }
 
-    // Share Mesh/ServiceProvider across all [Fact]s in this class â€” saves the
+    // Share Mesh/ServiceProvider across all [Fact]s in this class — saves the
     // ~190 MiB native heap that would otherwise leak per test method.
     protected override bool ShareMeshAcrossTests => true;
 
@@ -92,7 +92,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
         var create = await plugin.Create(SeedJson(id, "Original", 1.00m, 1));
         create.Should().StartWith("Created:");
 
-        // Immediate read â€” no artificial delay. A query-based read path would
+        // Immediate read — no artificial delay. A query-based read path would
         // sometimes return "Not found" here because the read-side index hasn't
         // caught up with the write yet. GetRemoteStream goes to the owning hub's
         // workspace so the read always reflects the write.
@@ -123,7 +123,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
         var plugin = CreatePlugin();
         var id = $"grim-{Guid.NewGuid():N}";
 
-        // GetRemoteStream is a live subscription â€” without a Timeout guard it
+        // GetRemoteStream is a live subscription — without a Timeout guard it
         // would hang forever on a non-existent node. This test pins the
         // 10-second budget the production code sets.
         var got = await plugin.Get($"@ACME/{id}");
@@ -140,7 +140,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
         await plugin.Create(SeedJson(id, "Original", 1.00m, 1));
 
         // The critical window: Patch reads current content to merge with new
-        // fields. A query-based read here races the Create write â€” with stale
+        // fields. A query-based read here races the Create write — with stale
         // data it would fail "node not found" or overwrite with an old version.
         var patched = await plugin.Patch($"@ACME/{id}", "{\"icon\":\"<svg/>\"}");
         patched.Should().StartWith("Patched:",
@@ -186,7 +186,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
         var id = $"upri-{Guid.NewGuid():N}";
         await plugin.Create(SeedJson(id, "Original", 1.00m, 1));
 
-        // Fetch the created node as the agent would â€” then send it back with
+        // Fetch the created node as the agent would — then send it back with
         // updated fields. Update's implementation does not read pre-state
         // (full replacement semantics), so it's here to assert the round-trip
         // still works end-to-end after our CQRS refactor.
@@ -220,13 +220,13 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     {
         var plugin = CreatePlugin();
         // TestProduct is the NodeType; an instance of it exercises the "node has a
-        // NodeType â†’ resolve its diagnostics" path which is the real agent use case.
+        // NodeType → resolve its diagnostics" path which is the real agent use case.
         var id = $"diag-{Guid.NewGuid():N}";
         await plugin.Create(SeedJson(id, "Diag", 1m, 1));
 
         var result = await plugin.GetDiagnostics($"@ACME/{id}");
         result.Should().Contain("nodeTypePath",
-            because: "GetDiagnostics on an instance resolves to its NodeType â€” refactor must preserve this shape");
+            because: "GetDiagnostics on an instance resolves to its NodeType — refactor must preserve this shape");
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     public async Task ExecuteScript_ForIsExecutableCodeNode_DispatchesAfterFileSystemRoundTrip()
     {
         // Seed the script directly via IMeshService (the "created through
-        // IMeshService" path per our testing rule â€” script nodes skip the MCP
+        // IMeshService" path per our testing rule — script nodes skip the MCP
         // plugin Create so we're not tangling the test with Create semantics).
         var id = $"exec-{Guid.NewGuid():N}";
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
@@ -290,7 +290,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     }
 
     // NOTE: There used to be an `ExecuteScript_ForBrokenScript_ReportsErrorStatus`
-    // test here â€” it was removed because the premise didn't match the API contract.
+    // test here — it was removed because the premise didn't match the API contract.
     // ExecuteScriptResponse only carries dispatch status (Success/Failure of the
     // kernel handing off the work). Runtime exceptions inside the script land in
     // the OUTPUT AREA, not in the response. A test for runtime-error surfacing must
@@ -300,7 +300,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     /// A script that targets a node which is not flagged executable must be rejected
     /// up-front (no kernel dispatch, no silent success). Reject is a synchronous
     /// path: HandleExecuteScript reads the local workspace, sees IsExecutable=false,
-    /// and posts the error response â€” should be milliseconds. Anything slower means
+    /// and posts the error response — should be milliseconds. Anything slower means
     /// an await/deadlock has slipped into the read path.
     ///
     /// <para>Pre-#841 this test asserted the DEFECT: ExecuteScript was fire-and-forget, so
@@ -311,7 +311,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     /// and the "sleep then check nothing happened" probe is gone.</para>
     /// </summary>
     // Timeout includes the cold class init for the first [Fact] in this
-    // ShareMeshAcrossTests class â€” building the SP + AddGraph + AddAI is
+    // ShareMeshAcrossTests class — building the SP + AddGraph + AddAI is
     // ~3-7s alone.
     [Fact]
     public async Task ExecuteScript_ForNonExecutableCodeNode_ReportsError()
@@ -360,7 +360,7 @@ public class McpReadYourWritesTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Minimal IAgentChat stub â€” MeshPlugin only reads ExecutionContext + Context,
+    /// Minimal IAgentChat stub — MeshPlugin only reads ExecutionContext + Context,
     /// so nulls are fine. Duplicated from other tests so each file is self-contained.
     /// </summary>
     private sealed class MinimalChat : IAgentChat

--- a/test/MeshWeaver.AI.Test/McpReturnTimingTest.cs
+++ b/test/MeshWeaver.AI.Test/McpReturnTimingTest.cs
@@ -26,14 +26,14 @@ namespace MeshWeaver.AI.Test;
 /// every <see cref="MeshPlugin"/> method must return within a bounded time.
 /// The original incident was <c>Patch</c> timing out at 30 s because an
 /// exception in the Subscribe callback left the TCS unresolved. This test
-/// suite guards every public method from that pattern â€” the test itself
+/// suite guards every public method from that pattern — the test itself
 /// asserts a much shorter deadline than a hang, so any regression fails
 /// the build instead of sitting on a 30 s xUnit timeout.
 ///
 /// Covers: <c>Get</c>, <c>Search</c>, <c>Create</c>, <c>Update</c>,
 /// <c>Patch</c>, <c>Delete</c>, <c>Move</c>, <c>Copy</c>,
 /// <c>GetDiagnostics</c>, <c>Recycle</c>. <c>NavigateTo</c> / <c>GetBaseUrl</c>
-/// are trivial string returns â€” no hub traffic â€” so not covered here.
+/// are trivial string returns — no hub traffic — so not covered here.
 /// <c>ExecuteScript</c> needs an actual kernel and lives in
 /// OrleansKernelProgressTest.
 ///
@@ -74,7 +74,7 @@ public class McpReturnTimingTest : MonolithMeshTestBase
         var completed = await Task.WhenAny(call, Task.Delay(budgetMs));
         if (completed != call)
             throw new Xunit.Sdk.XunitException(
-                $"{methodName} did not return within {budgetMs} ms â€” suspect an unresolved TaskCompletionSource " +
+                $"{methodName} did not return within {budgetMs} ms — suspect an unresolved TaskCompletionSource " +
                 $"or an un-awaited Subscribe callback in the MCP plugin. See PatchWorkspaceAckTest's " +
                 $"cached-display incident for the canonical pattern.");
         return await call;
@@ -108,7 +108,7 @@ public class McpReturnTimingTest : MonolithMeshTestBase
     {
         var plugin = CreatePlugin();
         // Narrow search to a specific path scope so we don't enumerate the whole
-        // test mesh â€” the budget guarantee is about the Search API itself returning,
+        // test mesh — the budget guarantee is about the Search API itself returning,
         // not about how fast it can scan every provider in a large cluster.
         var id = $"search-{Guid.NewGuid():N}";
         await SeedAsync(plugin, id);
@@ -212,7 +212,7 @@ public class McpReturnTimingTest : MonolithMeshTestBase
     public async Task GetDiagnostics_ReturnsWithinBudget()
     {
         var plugin = CreatePlugin();
-        // Non-existent path is valid input â€” we're testing the timing, not the result.
+        // Non-existent path is valid input — we're testing the timing, not the result.
         var call = plugin.GetDiagnostics($"@ACME/doesnotexist-{Guid.NewGuid():N}");
         var result = await BoundedAsync(call, nameof(plugin.GetDiagnostics));
         result.Should().NotBeNull();
@@ -231,7 +231,7 @@ public class McpReturnTimingTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Minimal IAgentChat stub â€” MeshPlugin only reads ExecutionContext + Context,
+    /// Minimal IAgentChat stub — MeshPlugin only reads ExecutionContext + Context,
     /// so we can return nulls without breaking anything. Duplicated locally instead
     /// of shared across tests so each test file is self-contained.
     /// </summary>

--- a/test/MeshWeaver.AI.Test/MeshOperationsUploadTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshOperationsUploadTest.cs
@@ -23,7 +23,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// Integration tests for <see cref="MeshOperations.Upload"/> â€” the shared core
+/// Integration tests for <see cref="MeshOperations.Upload"/> — the shared core
 /// that backs the MCP <c>upload</c> tool and the REST <c>POST /api/mesh/upload</c>
 /// endpoint. Driving the core directly gives full coverage of every payload
 /// shape (picture, document, nested path) without booting a TestServer.
@@ -37,7 +37,7 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class MeshOperationsUploadTest : MonolithMeshTestBase
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” same rationale as MeshPluginContentAccessTest.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — same rationale as MeshPluginContentAccessTest.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
@@ -55,7 +55,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
             .AddGraph()
             .AddAI()
             // Per-node FileSystem content collection. IsEditable=true must be set
-            // explicitly â€” the field defaults to false (matches bool type-default to
+            // explicitly — the field defaults to false (matches bool type-default to
             // survive WhenWritingDefault serialization).
             .ConfigureDefaultNodeHub(config =>
             {
@@ -69,7 +69,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
                     BasePath = contentDir,
                     Settings = new Dictionary<string, string> { ["BasePath"] = contentDir },
                 };
-                // Second collection â€” same shape, but read-only. Lets us assert that
+                // Second collection — same shape, but read-only. Lets us assert that
                 // Upload refuses to write into a non-editable collection. IsEditable
                 // defaults to false; we leave it unset.
                 var readOnlyConfig = new ContentCollectionConfig
@@ -88,7 +88,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
     // ---- Helpers ---------------------------------------------------------
 
     /// <summary>The hub the upload core resolves <c>IPathResolver</c> /
-    /// <c>IContentService</c> from â€” same one tests use to issue requests.</summary>
+    /// <c>IContentService</c> from — same one tests use to issue requests.</summary>
     private MeshOperations Ops() => new(GetClient());
 
     private async Task<string> CreateTestNode(string suffix)
@@ -105,7 +105,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
 
     private static byte[] MakePng()
     {
-        // 1Ã—1 transparent PNG â€” a real PNG signature is what content-type sniffers
+        // 1×1 transparent PNG — a real PNG signature is what content-type sniffers
         // look at, and any byte-equality assertion still works on this minimal payload.
         return
         [
@@ -164,7 +164,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
         json.GetProperty("bytes").GetInt32().Should().Be(bytes.Length);
         json.GetProperty("path").GetString().Should().Be($"{nodePath}/content/logo.png");
 
-        // Byte-for-byte verification on disk â€” the upload tool's reason for being.
+        // Byte-for-byte verification on disk — the upload tool's reason for being.
         var disk = DiskPath(nodePath, "logo.png");
         File.Exists(disk).Should().BeTrue();
         File.ReadAllBytes(disk).Should().Equal(bytes);
@@ -206,7 +206,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
     [Fact]
     public async Task Upload_Docx_RoundTripsBytes()
     {
-        // Random bytes with a .docx extension â€” the upload tool is content-agnostic;
+        // Random bytes with a .docx extension — the upload tool is content-agnostic;
         // we want to prove a "real-sized" document blob survives the round-trip exactly.
         var nodePath = await CreateTestNode("docx");
         var bytes = MakeRandomBytes(64 * 1024); // 64 KB
@@ -237,7 +237,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
     public async Task Upload_Pdf_RoundTripsBytes()
     {
         var nodePath = await CreateTestNode("pdf");
-        // Mix a real PDF magic header with random payload â€” exercises the binary path
+        // Mix a real PDF magic header with random payload — exercises the binary path
         // and gives a sniffable signature.
         var pdf = new byte[8 * 1024];
         RandomNumberGenerator.Fill(pdf);
@@ -255,7 +255,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
     /// <summary>
     /// MCP's <c>Upload</c> tool decodes <c>base64Content</c> and forwards to the
     /// same <see cref="MeshOperations.Upload"/>. Run the same flow here to prove
-    /// the two transports stay in sync â€” both produce the same on-disk bytes
+    /// the two transports stay in sync — both produce the same on-disk bytes
     /// and the same response shape.
     /// </summary>
     [Fact]
@@ -300,7 +300,7 @@ public class MeshOperationsUploadTest : MonolithMeshTestBase
     public async Task Upload_MissingFilename_ReturnsError()
     {
         var nodePath = await CreateTestNode("nofile");
-        // Path ends in collection only, no filename â€” Upload must reject early.
+        // Path ends in collection only, no filename — Upload must reject early.
         var result = await Ops().Upload($"{nodePath}/content/", MakePng()).Should().Emit();
         result.Should().StartWith("Error:");
     }

--- a/test/MeshWeaver.AI.Test/MeshPluginContentAccessTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginContentAccessTest.cs
@@ -35,7 +35,7 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class MeshPluginContentAccessTest : MonolithMeshTestBase
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
@@ -127,7 +127,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Tests content:collectionName/filename.txt (with slash) Ã¢â‚¬â€ explicit collection name.
+    /// Tests content:collectionName/filename.txt (with slash) — explicit collection name.
     /// </summary>
     [Fact]
     public async Task Get_ContentReference_WithExplicitCollection_ReturnsFileContent()
@@ -240,8 +240,8 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Same as above but quotes wrap the WHOLE relative portion after content/ Ã¢â‚¬â€
-    /// i.e. content/"name" vs "content/name" Ã¢â‚¬â€ both shapes appear in agent output.
+    /// Same as above but quotes wrap the WHOLE relative portion after content/ —
+    /// i.e. content/"name" vs "content/name" — both shapes appear in agent output.
     /// </summary>
     [Fact]
     public async Task Get_AbsolutePath_QuotesAroundContentSegment_ReturnsFileContent()
@@ -271,7 +271,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Tolerance matrix Ã¢â‚¬â€ every shape we've actually observed an agent or autocomplete
+    /// Tolerance matrix — every shape we've actually observed an agent or autocomplete
     /// emit for the SAME spaced file. They must all return the file content. Keep this
     /// table extended with new shapes the agents come up with in the wild.
     /// {NODE} is replaced with the per-test node path so the parameterization stays
@@ -310,7 +310,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Yet another shape an agent (or model) sometimes emits: @"content/some path" Ã¢â‚¬â€ the
+    /// Yet another shape an agent (or model) sometimes emits: @"content/some path" — the
     /// quote sits right after @ and wraps everything that follows. Same fix applies
     /// (strip every quote), this just nails the regression.
     /// </summary>
@@ -344,7 +344,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
     /// must return the spaced file "Input Markus Apr 15.txt", and the InsertText that
     /// the autocomplete suggests must round-trip through MeshPlugin.Get and return the
     /// file content. This exercises the full chat pipeline: case-insensitive fuzzy
-    /// match Ã¢â€ â€™ quoted-reference InsertText Ã¢â€ â€™ ResolvePath Ã¢â€ â€™ file lookup.
+    /// match → quoted-reference InsertText → ResolvePath → file lookup.
     /// </summary>
     [Fact]
     public async Task Autocomplete_RoundTrip_LowercaseQuery_QuotedInsertText_GetsContent()
@@ -361,7 +361,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
 
         var client = GetClient();
 
-        // Step 1 Ã¢â‚¬â€ autocomplete, lowercase, treats node as the chat context.
+        // Step 1 — autocomplete, lowercase, treats node as the chat context.
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(TimeSpan.FromSeconds(10));
         var acResponse = await client.Observe(new AutocompleteRequest("@markus", nodePath), o => o.WithTarget(new Address(nodePath))).FirstAsync().ToTask(cts.Token);
@@ -378,7 +378,7 @@ public class MeshPluginContentAccessTest : MonolithMeshTestBase
         // The InsertText for a spaced filename is wrapped in quotes by FormatInsertText.
         match.InsertText.Should().Contain("\"", "spaced filenames are quoted in the InsertText");
 
-        // Step 2 Ã¢â‚¬â€ feed the InsertText (verbatim, including quotes) into MeshPlugin.Get,
+        // Step 2 — feed the InsertText (verbatim, including quotes) into MeshPlugin.Get,
         // pretending the agent received it via attachment. Strip trailing whitespace the
         // way the chat input would when treating it as an @reference.
         var insertedRef = match.InsertText.TrimEnd();

--- a/test/MeshWeaver.AI.Test/MeshPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginTest.cs
@@ -822,7 +822,7 @@ public class MeshPluginTest : MonolithMeshTestBase
                 configuration = "config => config.WithContentType<ThisTypeDoesNotExist>()"
             }
         });
-        // Wrap "type" â†’ "$type" for JsonPolymorphic
+        // Wrap "type" → "$type" for JsonPolymorphic
         createJson = createJson.Replace("\"type\":", "\"$type\":");
         await plugin.Create(createJson);
 
@@ -926,7 +926,7 @@ public class MeshPluginTest : MonolithMeshTestBase
         }
         catch { /* expected */ }
 
-        // Get the NodeType itself â€” response should include compilationError.
+        // Get the NodeType itself — response should include compilationError.
         var result = await plugin.Get($"@{nodeTypePath}");
         result.Should().NotBeNullOrEmpty();
 

--- a/test/MeshWeaver.AI.Test/ModelDiscoveryServiceTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelDiscoveryServiceTest.cs
@@ -18,7 +18,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// Tests for <see cref="ModelDiscoveryService"/> â€” the hierarchical
+/// Tests for <see cref="ModelDiscoveryService"/> — the hierarchical
 /// walk over namespace ancestors AND NodeType ancestors. Asserts that:
 /// <list type="bullet">
 ///   <item>(a) <c>GetModelsAtNode</c> returns the satellite at one path.</item>
@@ -92,7 +92,7 @@ public class ModelDiscoveryServiceTest : AITestBase
         var owner = $"org-{Guid.NewGuid():N}";
         var child = $"{owner}/Project1";
 
-        // Two providers â€” one at the org level, one at the child level.
+        // Two providers — one at the org level, one at the child level.
         await CreateUserProvider(owner, "Anthropic", "claude-sonnet-4-6");
         await CreateUserProvider(child, "OpenAI", "gpt-4o-mini");
 
@@ -130,7 +130,7 @@ public class ModelDiscoveryServiceTest : AITestBase
     {
         // Resolving the service from the mesh hub's ServiceProvider must
         // succeed. The contract is that callers reach into the top-level
-        // mesh hub for this â€” never their own per-thread/per-exec hub
+        // mesh hub for this — never their own per-thread/per-exec hub
         // (which may be blocked by an in-flight handler).
         var fromMesh = Mesh.ServiceProvider.GetService<ModelDiscoveryService>();
         fromMesh.Should().NotBeNull("ModelDiscoveryService is registered as a top-level singleton");

--- a/test/MeshWeaver.AI.Test/ModelNodeRepoRegistrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelNodeRepoRegistrationTest.cs
@@ -108,7 +108,7 @@ public class ModelNodeRepoRegistrationTest : AITestBase
 
         snapshot.Should().Contain(n => n.Path == "Provider/Anthropic"
             && n.NodeType == ModelProviderNodeType.NodeType,
-            "the synced query routes through every IMeshQueryProvider â€” static nodes must surface");
+            "the synced query routes through every IMeshQueryProvider — static nodes must surface");
     }
 
     [Fact]

--- a/test/MeshWeaver.AI.Test/ModelProviderEmissionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderEmissionTest.cs
@@ -22,7 +22,7 @@ public class ModelProviderEmissionTest
     [Fact]
     public void Emits_OneModelProviderPerCatalogSource_WithFullCredentials()
     {
-        // Config â†’ ModelProvider node: ApiKey, Endpoint, Models all flow in.
+        // Config → ModelProvider node: ApiKey, Endpoint, Models all flow in.
         // ModelProvider is NOT WithPublicRead, so the key is only visible to
         // callers with Permission.Api on the root namespace (system / admin).
         // Public LanguageModel siblings still carry no key (asserted below).
@@ -114,7 +114,7 @@ public class ModelProviderEmissionTest
             var def = node.Content.Should().BeOfType<ModelDefinition>().Subject;
             def.Provider.Should().Be("Anthropic");
             def.ProviderRef.Should().Be("Provider/Anthropic");
-            def.ApiKeySecretRef.Should().BeNull("LanguageModel nodes are publicly readable â€” no secrets here");
+            def.ApiKeySecretRef.Should().BeNull("LanguageModel nodes are publicly readable — no secrets here");
         });
     }
 

--- a/test/MeshWeaver.AI.Test/ModelProviderIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderIntegrationTest.cs
@@ -22,7 +22,7 @@ namespace MeshWeaver.AI.Test;
 /// <summary>
 /// Integration tests covering the user-owned ModelProvider + LanguageModel
 /// flow against a real Monolith mesh. Exercises the same path the chat
-/// client takes: ModelDefinition.ProviderRef â†’ ModelProvider node â†’
+/// client takes: ModelDefinition.ProviderRef → ModelProvider node →
 /// (Endpoint, ApiKey) via <see cref="ChatClientCredentialResolver"/>.
 /// </summary>
 public class ModelProviderIntegrationTest : AITestBase
@@ -81,7 +81,7 @@ public class ModelProviderIntegrationTest : AITestBase
         await MeshService.CreateNode(modelNode).Should().Within(20.Seconds()).Emit();
 
         // 3. Pre-warm the resolver's snapshot via the same workspace.GetQuery
-        //    the resolver uses internally â€” see SyncedMeshNodeQueries.md. The
+        //    the resolver uses internally — see SyncedMeshNodeQueries.md. The
         //    user's own providers live in their dotfile namespace ({user}/_Memex),
         //    so warm via userPath, not currentPath (which targets the shared
         //    _Provider satellite).
@@ -90,7 +90,7 @@ public class ModelProviderIntegrationTest : AITestBase
                 AgentPickerProjection.BuildModelQueries(userPath: userId))
             .Should().Within(15.Seconds()).Match(s => s.Any(n => n.Path == modelPath));
 
-        // 4. Resolve and verify. Poll via Observable.Interval â€” the
+        // 4. Resolve and verify. Poll via Observable.Interval — the
         //    resolver's internal IngestSnapshot is driven by the same
         //    cached observable, but the OnNext order between our
         //    Take(1) above and the resolver's subscription is not
@@ -101,7 +101,7 @@ public class ModelProviderIntegrationTest : AITestBase
         var resolution = await Observable.Interval(TimeSpan.FromMilliseconds(50))
             .Select(_ => resolver.Resolve(modelId))
             .Should().Within(10.Seconds()).Match(r => r.ApiKey != null);
-        resolution.ApiKey.Should().Be(rawKey, "resolver follows ProviderRef â†’ ModelProvider.ApiKey");
+        resolution.ApiKey.Should().Be(rawKey, "resolver follows ProviderRef → ModelProvider.ApiKey");
         resolution.Endpoint.Should().Be("https://api.anthropic.com/v1/messages");
         resolution.Source.Should().StartWith("providerRef:");
     }
@@ -109,7 +109,7 @@ public class ModelProviderIntegrationTest : AITestBase
     [Fact]
     public async Task Resolver_MissingProvider_ReturnsMissing()
     {
-        // Model node without a ProviderRef and no parent provider â€”
+        // Model node without a ProviderRef and no parent provider —
         // resolver should report Missing so the factory falls back to IOptions.
         var orphanId = $"orphan-model-{Guid.NewGuid():N}";
         var modelNs = $"{ModelProviderNodeType.RootNamespace}/NoSuchProvider";
@@ -142,7 +142,7 @@ public class ModelProviderIntegrationTest : AITestBase
     {
         var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
         resolver.EnsureSubscription();
-        // Wait via the same synced observable the resolver subscribes to â€”
+        // Wait via the same synced observable the resolver subscribes to —
         // once it emits any Initial snapshot, the resolver has been
         // notified too (same cache id, same upstream).
         await Workspace.GetQuery(AgentPickerProjection.ModelsQueryId, AgentPickerProjection.BuildModelQueries())

--- a/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
@@ -24,7 +24,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// End-to-end tests for <see cref="ModelProviderService"/> â€” the reactive
+/// End-to-end tests for <see cref="ModelProviderService"/> — the reactive
 /// CRUD surface backing the user's Models settings tab. Asserts that
 /// CreateProvider lays down the canonical
 /// <c>{userId}/_Memex/{provider}</c> + N child LanguageModel nodes, that
@@ -39,7 +39,7 @@ public class ModelProviderServiceTest : AITestBase
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             // Register the Anthropic catalog source so ModelProviderService.CreateProvider
-            // can look up its DefaultModelIds â€” the service auto-creates one
+            // can look up its DefaultModelIds — the service auto-creates one
             // LanguageModel child per default id.
             .AddLanguageModelCatalogSource(new LanguageModelCatalogSource(
                 SectionName: "Anthropic",

--- a/test/MeshWeaver.AI.Test/PatchDataRequestTest.cs
+++ b/test/MeshWeaver.AI.Test/PatchDataRequestTest.cs
@@ -24,7 +24,7 @@ namespace MeshWeaver.AI.Test;
 /// Unit coverage for the new <see cref="PatchDataRequest"/> + handler. This is the
 /// user-facing partial-update primitive: a caller posts a JSON merge patch against
 /// a <see cref="WorkspaceReference"/> on some target hub; the handler applies the
-/// merge to the stream's current value and commits via <c>stream.Update</c> â€” no
+/// merge to the stream's current value and commits via <c>stream.Update</c> — no
 /// pre-existing subscription required, no client-side read needed.
 ///
 /// Covers: applies a partial patch, leaves omitted fields intact, post-patch
@@ -67,7 +67,7 @@ public class PatchDataRequestTest : MonolithMeshTestBase
 
         var path = $"ACME/{id}";
 
-        // Post the PatchDataRequest with only { name: "Patched" } â€” the hub handler
+        // Post the PatchDataRequest with only { name: "Patched" } — the hub handler
         // applies this as a merge patch on its own MeshNode workspace stream.
         var patchJson = JsonSerializer.Serialize(new { name = "Patched" });
         var patchResp = (await Mesh.Observe(
@@ -86,9 +86,9 @@ public class PatchDataRequestTest : MonolithMeshTestBase
         node!.Name.Should().Be("Patched",
             because: "PatchDataRequest merged only the 'name' field");
         node.NodeType.Should().Be(TestNodeType,
-            because: "NodeType was not in the patch â€” must be preserved");
+            because: "NodeType was not in the patch — must be preserved");
         node.Content.Should().NotBeNull(
-            because: "Content was not in the patch â€” must be preserved");
+            because: "Content was not in the patch — must be preserved");
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/PatchWorkspaceAckTest.cs
+++ b/test/MeshWeaver.AI.Test/PatchWorkspaceAckTest.cs
@@ -30,14 +30,14 @@ namespace MeshWeaver.AI.Test;
 /// <summary>
 /// Regression coverage for the 2026-04-14 cached-display incident: agent reported a
 /// successful Patch on FinalReport, persistence committed, but the in-memory workspace
-/// stream kept emitting the stale node â€” Blazor views displayed the old content until
+/// stream kept emitting the stale node — Blazor views displayed the old content until
 /// grain deactivation / circuit close re-loaded from persistence.
 ///
-/// Root cause was in <c>HandleUpdateNodeRequest</c> (<c>MeshExtensions.cs:679</c>) â€”
+/// Root cause was in <c>HandleUpdateNodeRequest</c> (<c>MeshExtensions.cs:679</c>) —
 /// the workspace-refresh <c>DataChangeRequest</c> was fire-and-forget, and the
 /// <c>UpdateNodeResponse.Ok</c> went out before the workspace observed the change.
 /// The fix uses Post + RegisterCallback inline (no TCS, no await) so Ok is sent only
-/// after the workspace acks â€” and DataChangeStatus.Failed / DeliveryFailure paths
+/// after the workspace acks — and DataChangeStatus.Failed / DeliveryFailure paths
 /// surface as <c>UpdateNodeResponse.Fail</c> so the caller sees actual errors.
 ///
 /// These tests also stress concurrent patches: a deadlock in the plugin layer would
@@ -53,7 +53,7 @@ namespace MeshWeaver.AI.Test;
 [Collection(ConcurrencyStressCollection.Name)]
 public class PatchWorkspaceAckTest : MonolithMeshTestBase
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     private const string TestNodeType = nameof(TestProduct);
@@ -91,7 +91,7 @@ public class PatchWorkspaceAckTest : MonolithMeshTestBase
 
     /// <summary>
     /// The cache-bug regression: after Patch returns Ok, the next Get must reflect the
-    /// new state immediately. Before the HandleUpdateNodeRequest fix this would race â€”
+    /// new state immediately. Before the HandleUpdateNodeRequest fix this would race —
     /// Get could read the stale workspace cache because Ok was returned before the
     /// DataChangeRequest fan-out had been observed by the workspace.
     /// </summary>
@@ -106,7 +106,7 @@ public class PatchWorkspaceAckTest : MonolithMeshTestBase
         var patched = await plugin.Patch($"@{path}", $"{{\"name\":\"{newName}\"}}");
         patched.Should().StartWith("Patched:", because: "valid patch must succeed");
 
-        // Immediately after Ok, Get must see the new state â€” no fresh page-load required.
+        // Immediately after Ok, Get must see the new state — no fresh page-load required.
         var got = await plugin.Get($"@{path}");
         got.Should().Contain(newName,
             because: "the workspace must already reflect the patch when Ok is returned " +
@@ -166,7 +166,7 @@ public class PatchWorkspaceAckTest : MonolithMeshTestBase
 
     /// <summary>
     /// Negative scenario: patching with an empty name (which existing validator rejects)
-    /// must surface as a "Error: cannot patch ... 'name' is empty" error â€” not silent
+    /// must surface as a "Error: cannot patch ... 'name' is empty" error — not silent
     /// success, not a deadlock, not a stale workspace.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -234,7 +234,7 @@ public class PatchWorkspaceAckTest : MonolithMeshTestBase
     /// Stress / deadlock regression: 10 concurrent Patch calls on independent nodes
     /// must all complete within the timeout window. Before the no-await refactor of
     /// the plugin layer (commit d165533c8) the await hub.AwaitResponse pattern would
-    /// deadlock the hub scheduler under any concurrent load â€” this test would hang
+    /// deadlock the hub scheduler under any concurrent load — this test would hang
     /// past its method timeout.
     /// </summary>
     [Fact(Timeout = 60000)]
@@ -254,13 +254,13 @@ public class PatchWorkspaceAckTest : MonolithMeshTestBase
         sw.Stop();
 
         results.Should().AllSatisfy(r => r.Should().StartWith("Patched:",
-            because: "every concurrent patch must complete successfully â€” a deadlock would manifest as timeout"));
+            because: "every concurrent patch must complete successfully — a deadlock would manifest as timeout"));
         sw.Elapsed.Should().BeLessThan(45.Seconds(),
             because: "10 trivial patches in parallel should finish well under the timeout; if it's close, we likely have lock contention even without full deadlock");
     }
 
     /// <summary>
-    /// Minimal IAgentChat stub â€” MeshPlugin only reads ExecutionContext and Context.
+    /// Minimal IAgentChat stub — MeshPlugin only reads ExecutionContext and Context.
     /// </summary>
     private sealed class MinimalChat : IAgentChat
     {

--- a/test/MeshWeaver.AI.Test/PersistentThreadTest.cs
+++ b/test/MeshWeaver.AI.Test/PersistentThreadTest.cs
@@ -17,7 +17,7 @@ namespace MeshWeaver.AI.Test;
 
 public class PersistentThreadTest
 {
-    #region Thread Record â€” PersistentThreadId & ProviderType
+    #region Thread Record — PersistentThreadId & ProviderType
 
     [Fact]
     public void Thread_PersistentThreadId_DefaultIsNull()

--- a/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
+++ b/test/MeshWeaver.AI.Test/ResolveContextPathTest.cs
@@ -21,10 +21,10 @@ public class ResolveContextPathTest
 {
     /// <summary>Absolute paths (leading <c>@/</c> or multi-segment <c>@</c>) are returned unchanged.</summary>
     [Theory]
-    [InlineData("@/Acme/AIConsulting/FinalReport", "@Acme/AIConsulting/FinalReport")] // absolute @/ â†’ keeps path
-    [InlineData("/Acme/AIConsulting/FinalReport", "@Acme/AIConsulting/FinalReport")] // absolute / â†’ rewrites to @
-    [InlineData("@OrgA/Doc", "@OrgA/Doc")] // multi-segment already looks absolute â†’ returned as-is
-    [InlineData("@Doc/Architecture/content:file.svg", "@Doc/Architecture/content:file.svg")] // colon with slash before â†’ absolute
+    [InlineData("@/Acme/AIConsulting/FinalReport", "@Acme/AIConsulting/FinalReport")] // absolute @/ → keeps path
+    [InlineData("/Acme/AIConsulting/FinalReport", "@Acme/AIConsulting/FinalReport")] // absolute / → rewrites to @
+    [InlineData("@OrgA/Doc", "@OrgA/Doc")] // multi-segment already looks absolute → returned as-is
+    [InlineData("@Doc/Architecture/content:file.svg", "@Doc/Architecture/content:file.svg")] // colon with slash before → absolute
     public void AbsolutePaths_AreReturnedUnchanged(string input, string expected)
     {
         var chat = new StubChat(new AgentContext { Context = "Acme/AIConsulting" });

--- a/test/MeshWeaver.AI.Test/SchemaValidationTest.cs
+++ b/test/MeshWeaver.AI.Test/SchemaValidationTest.cs
@@ -129,7 +129,7 @@ public class SchemaValidationTest : MonolithMeshTestBase
 
     #endregion
 
-    #region Content Validation â€” Valid Content
+    #region Content Validation — Valid Content
 
     [Fact]
     public async Task Create_WithValidContent_Succeeds()
@@ -173,7 +173,7 @@ public class SchemaValidationTest : MonolithMeshTestBase
 
     #endregion
 
-    #region Update â€” Null Content Rejection
+    #region Update — Null Content Rejection
 
     [Fact]
     public async Task Update_WithNullContent_ReturnsValidationErrorAndSchema()
@@ -192,7 +192,7 @@ public class SchemaValidationTest : MonolithMeshTestBase
         });
         (await plugin.Create(createJson)).Should().StartWith("Created:");
 
-        // Update with content explicitly set to null â€” should be rejected
+        // Update with content explicitly set to null — should be rejected
         var updateJson = JsonSerializer.Serialize(new object[]
         {
             new
@@ -237,7 +237,7 @@ public class SchemaValidationTest : MonolithMeshTestBase
         });
         (await plugin.Create(createJson)).Should().StartWith("Created:");
 
-        // Update without including the content key at all â€” also rejected
+        // Update without including the content key at all — also rejected
         var updateJson = JsonSerializer.Serialize(new object[]
         {
             new

--- a/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
+++ b/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
@@ -59,7 +59,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         Log.LogInformation("Boom!");
         MeshWeaver.Layout.Controls.Html(
             "<div style='font-size:48px;text-align:center;animation:pulse 1s infinite'>" +
-            "ðŸŽ† ðŸŽ‡ ðŸŽ† ðŸŽ‡ ðŸŽ†" +
+            "🎆 🎇 🎆 🎇 🎆" +
             "</div>")
         """;
 
@@ -132,7 +132,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             .Should().Within(30.Seconds()).Emit();
 
         observations.Should().HaveCountGreaterThanOrEqualTo(3,
-            "subscribers should observe at least 3 distinct snapshots before the terminal one â€” "
+            "subscribers should observe at least 3 distinct snapshots before the terminal one — "
             + "single-tick delivery would mean the executor blocked the activity hub. Observed: ["
             + string.Join(", ", observations.Select(o => $"{o.Count}@{o.ElapsedMs}ms")) + "]");
 
@@ -145,7 +145,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     /// Cancel-via-property: per the Activity Control Plane pattern
     /// (Doc/Architecture/ActivityControlPlane.md), users cancel a running
     /// activity by patching its content's <c>RequestedStatus = Cancelled</c>
-    /// â€” NOT by posting a CancelXRequest message. The Activity hub watches its
+    /// — NOT by posting a CancelXRequest message. The Activity hub watches its
     /// own MeshNodeReference and dispatches the internal cancellation when it
     /// observes the patch.
     /// </summary>
@@ -155,13 +155,13 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         // Script uses Task.Delay(ms, Ct) so the Ct global (rebound per
         // submission) actually interrupts the wait mid-flight when the user
         // patches RequestedStatus = Cancelled. The delay is generous (15 s)
-        // because it is interrupted the instant cancellation lands â€” when the
+        // because it is interrupted the instant cancellation lands — when the
         // cancel path works the script never sleeps the full duration, so a
         // long delay costs ~nothing. The window has to cover the whole cancel
-        // round-trip (test observes "starting" â†’ patch RequestedStatus â†’
-        // control-plane watcher â†’ CancelScriptRequest â†’ CTS trips); the prior
+        // round-trip (test observes "starting" → patch RequestedStatus →
+        // control-plane watcher → CancelScriptRequest → CTS trips); the prior
         // 800 ms raced that chain, especially behind a cold Roslyn compile.
-        // When the cancel mechanism is genuinely broken the test still fails â€”
+        // When the cancel mechanism is genuinely broken the test still fails —
         // via the Status assertion below, just after the delay elapses.
         var (codePath, _) = await SeedExecutableCode("""
             Log.LogInformation("starting");
@@ -198,7 +198,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         // the internal cancel, the script throws OperationCanceledException, and
         // the Activity Status flips out of Running.
         // 30 s covers the broken-cancel case too: if cancellation never lands
-        // the script runs its full 15 s delay then completes â€” the terminal
+        // the script runs its full 15 s delay then completes — the terminal
         // emission still arrives and the Status assertion below reports the
         // real failure ("found Succeeded") instead of an opaque timeout.
         var terminal = (await activityStream
@@ -245,7 +245,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         // Code node in `rbuergi` (the test partition), but configured to
         // route activities to the {viewer}'s home. The DevLogin admin user
         // has ObjectId = "Roland" (see TestUsers.Admin), so {viewer}
-        // resolves to "Roland" â€” independent of where the Code node lives.
+        // resolves to "Roland" — independent of where the Code node lives.
         var id = $"viewerdemo-{Guid.NewGuid():N}";
         var path = $"{UserHome}/{id}";
         var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
@@ -287,7 +287,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             .Should().Within(60.Seconds()).Emit()).Message;
         var activityPath = respMessage.ActivityLog!;
 
-        // Wait for the LastActivityPath stamp to land â€” the workspace.UpdateMeshNode
+        // Wait for the LastActivityPath stamp to land — the workspace.UpdateMeshNode
         // call inside HandleExecuteScript happens after CreateNode acks but
         // doesn't block ExecuteScriptResponse, so subscribe and wait for it.
         var workspace = GetClient().GetWorkspace();
@@ -306,8 +306,8 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     /// <summary>
     /// End-to-end check that <c>#r "nuget:..."</c> directives still work after
     /// the .NET-Interactive removal. Pulls MathNet.Numerics from nuget.org and
-    /// uses one of its types â€” proves the full pipeline (NuGetDirectiveParser
-    /// â†’ INuGetAssemblyResolver â†’ MetadataReference â†’ CSharpScript +
+    /// uses one of its types — proves the full pipeline (NuGetDirectiveParser
+    /// → INuGetAssemblyResolver → MetadataReference → CSharpScript +
     /// AssemblyLoadContext probing for transitive deps) compiles, resolves,
     /// and runs against a real third-party package.
     ///
@@ -339,7 +339,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
 
         final!.Status.Should().Be(ActivityStatus.Succeeded,
             "MathNet.Numerics should resolve from nuget.org and the script should compile + run");
-        // erf(1) â‰ˆ 0.8427... â€” the script logs this twice (once via Log, once
+        // erf(1) ≈ 0.8427... — the script logs this twice (once via Log, once
         // as the return value which the kernel echoes onto the activity log).
         final.Messages.Select(m => m.Message)
             .Should().Contain(m => m.Contains("0.8427") || m.Contains("erf"),
@@ -351,8 +351,8 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     /// that resolves against the repo's OWN built nupkgs in <c>dist/packages/</c>
     /// (registered as the <c>mesh-local</c> source in <c>nuget.config</c> with a
     /// packageSourceMapping that pins <c>MeshWeaver.*</c> there). This is the
-    /// "our nuget storage" path: scripts can <c>#r "nuget:MeshWeaver.X, â€¦"</c>
-    /// and the resolver picks them up locally â€” no network round-trip, no
+    /// "our nuget storage" path: scripts can <c>#r "nuget:MeshWeaver.X, …"</c>
+    /// and the resolver picks them up locally — no network round-trip, no
     /// nuget.org outage flake, deterministic for CI.
     ///
     /// <para>Skipped when <c>dist/packages/MeshWeaver.Application.Styles.3.0.0-preview1.nupkg</c>
@@ -363,7 +363,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     [Fact]
     public async Task NuGetDirective_ResolvesAgainstLocalMeshFeed_AndScriptUsesIt()
     {
-        // dist/packages/ is gitignored â€” populated locally by `dotnet pack` and on
+        // dist/packages/ is gitignored — populated locally by `dotnet pack` and on
         // CI by the publish workflow's pack step. When absent, surface the reason
         // via the test output and exit cleanly so an unprepared CI run surfaces
         // the missing-artefact signal instead of a misleading resolver error.
@@ -381,7 +381,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         var (codePath, _) = await SeedExecutableCode("""
             #r "nuget:MeshWeaver.Application.Styles, 3.0.0-preview1"
             using MeshWeaver.Application.Styles;
-            // FluentIcons is a static surface from MeshWeaver.Application.Styles â€”
+            // FluentIcons is a static surface from MeshWeaver.Application.Styles —
             // touching it proves the assembly was actually loaded into the script ALC.
             var icon = FluentIcons.Add();
             Log.LogInformation("Resolved icon: {Name}", icon.Id);
@@ -418,7 +418,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     }
 
     /// <summary>
-    /// Re-running creates a NEW activity. The previous activity is untouched â€”
+    /// Re-running creates a NEW activity. The previous activity is untouched —
     /// historical runs accumulate as siblings under <c>{codePath}/_Activity/*</c>.
     /// </summary>
     [Fact]

--- a/test/MeshWeaver.AI.Test/ThreadAgentIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadAgentIntegrationTest.cs
@@ -29,7 +29,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// End-to-end integration test for the full thread â†’ agent â†’ response flow.
+/// End-to-end integration test for the full thread → agent → response flow.
 /// Uses a fake IChatClient to avoid real AI API calls while testing
 /// the complete pipeline: thread creation, message persistence,
 /// agent initialization, streaming response, and reply storage.
@@ -57,7 +57,7 @@ public class ThreadAgentIntegrationTest : MonolithMeshTestBase
 
     public ThreadAgentIntegrationTest(ITestOutputHelper output) : base(output) { }
 
-    // Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.
+    // Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.
     protected override bool ShareMeshAcrossTests => true;
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
@@ -425,7 +425,7 @@ public class ThreadAgentIntegrationTest : MonolithMeshTestBase
         response1.ToString().Trim().Should().NotBeNullOrEmpty();
         response2.ToString().Trim().Should().NotBeNullOrEmpty();
 
-        // Thread persistence is now via MeshNodes â€” no separate IChatPersistenceService
+        // Thread persistence is now via MeshNodes — no separate IChatPersistenceService
     }
 
     #endregion

--- a/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
@@ -28,7 +28,7 @@ namespace MeshWeaver.AI.Test;
 /// Verifies that <c>Submit</c>/<c>CreateThreadAndSubmit</c>/<c>Resubmit</c> drive
 /// the server watcher to create output cells and commit ingested state,
 /// fully via Post + RegisterCallback + workspace stream subscriptions (no QueryAsync writes from the code path).
-/// Test assertions use QueryAsync/FirstAsync â€” allowed per AGENTS.md for test code only.
+/// Test assertions use QueryAsync/FirstAsync — allowed per AGENTS.md for test code only.
 /// </summary>
 public class ThreadSubmissionIntegrationTest : AITestBase
 {
@@ -64,7 +64,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         return base.ConfigureClient(configuration).AddLayoutClient();
     }
 
-    // â”€â”€â”€ Submit into existing thread â”€â”€â”€
+    // ─── Submit into existing thread ───
 
     [Fact]
     public async Task Submit_ExistingThread_UserMessageIngested_OutputCellAppears()
@@ -90,7 +90,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         committed.UserMessageIds.Should().ContainInOrder(committed.IngestedMessageIds[0]);
     }
 
-    // â”€â”€â”€ CreateThreadAndSubmit â”€â”€â”€
+    // ─── CreateThreadAndSubmit ───
 
     [Fact]
     public async Task CreateThreadAndSubmit_CreatesThreadAndFirstRound()
@@ -117,7 +117,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         committed.Messages.Should().HaveCount(2);
     }
 
-    // â”€â”€â”€ Batched ingestion â”€â”€â”€
+    // ─── Batched ingestion ───
 
     [Fact]
     public async Task Submit_ThreeRapidSubmissions_AllIngestedIntoOneRound()
@@ -146,7 +146,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         var final = await ReadThread(threadPath);
         final.IngestedMessageIds.Should().HaveCount(3, "all three user messages should be ingested");
         // ImmutableList<string> on both sides — plain strings, no polymorphism, so JsonSerializerOptions.Default.
-        // Set-equal to UserMessageIds â€” dispatch is one user message per round
+        // Set-equal to UserMessageIds — dispatch is one user message per round
         // (Claude-Code-style turn structure), so the response cells interleave
         // with user cells in Messages, but UserMessageIds is the authoritative
         // list of user-input ids and must match IngestedMessageIds as a set.
@@ -154,7 +154,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         final.UserMessageIds.Should().HaveCount(3);
     }
 
-    // â”€â”€â”€ Resubmit: truncates after the replayed message, new round dispatches â”€â”€â”€
+    // ─── Resubmit: truncates after the replayed message, new round dispatches ───
 
     [Fact]
     public async Task Resubmit_TruncatesAfterReplayedMessage_NewRoundCreated()
@@ -179,7 +179,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
             u1,
             newUserText: "First, revised");
 
-        // The intermediate "truncated" state (Messages=[u1], IngestedMessageIds=[]) is racy â€”
+        // The intermediate "truncated" state (Messages=[u1], IngestedMessageIds=[]) is racy —
         // the server watcher dispatches the new round almost immediately after the truncation
         // commits, often before we can observe it. Instead assert the end state: u1 is
         // ingested again, a NEW response cell (!= r1) follows, and IsExecuting is back to false.
@@ -196,7 +196,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         afterResubmit.UserMessageIds.Should().ContainSingle().Which.Should().Be(u1);
     }
 
-    // â”€â”€â”€ Failure recovery: error renders as an assistant response cell â”€â”€â”€
+    // ─── Failure recovery: error renders as an assistant response cell ───
 
     [Fact]
     public async Task SubmissionFailure_RecordsErrorAsOutputCell_InThreadMessages()
@@ -237,7 +237,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         content.Text.Should().Contain("network timeout");
     }
 
-    // â”€â”€â”€ Tool-call scenario: 3 rapid submits during a 1s "tool call" â”€â”€â”€
+    // ─── Tool-call scenario: 3 rapid submits during a 1s "tool call" ───
 
     [Fact]
     public async Task Submit_ThreeMessagesDuringActiveRound_QueuedThenBatchedIntoSecondRound()
@@ -249,7 +249,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         // This gives us a deterministic window to submit u2/u3/u4 while round 1 is still executing.
         var slowModel = "slow-model";
 
-        // Submit u1 â€” triggers round 1.
+        // Submit u1 — triggers round 1.
         client.SubmitMessage(
             threadPath, "First",
             modelName: slowModel, createdBy: "rbuergi@systemorph.com");
@@ -283,7 +283,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         }
 
         // Observe: during round 1 execution, all three new user ids should appear in Messages
-        // and UserMessageIds, but NOT yet in IngestedMessageIds â€” the server holds them back
+        // and UserMessageIds, but NOT yet in IngestedMessageIds — the server holds them back
         // because the thread is busy.
         // Registration budget only — nothing below depends on "within 3s"
         // semantics (the assertions explicitly tolerate round 1 having already
@@ -314,11 +314,11 @@ public class ThreadSubmissionIntegrationTest : AITestBase
 
         // Inbox-pattern dispatch: every entry in PendingUserMessages is drained
         // into a single round (one response cell per inbox drain). u1 lands while
-        // the thread is idle â†’ round 1 drains {u1}, creates r1. u2/u3/u4 land
-        // during round 1 â†’ they pile up in PendingUserMessages. When round 1
+        // the thread is idle → round 1 drains {u1}, creates r1. u2/u3/u4 land
+        // during round 1 → they pile up in PendingUserMessages. When round 1
         // ends, the watcher fires once and round 2 drains {u2, u3, u4} into a
         // single response cell r2. Final shape: [u1, r1, u2, u3, u4, r2].
-        // Not every input cell gets its own response cell â€” the design
+        // Not every input cell gets its own response cell — the design
         // explicitly batches mid-round submits into the next round.
         final.Messages.Should().HaveCount(6, "4 user cells + 2 response cells");
         final.Messages[0].Should().Be(u1, "u1 first");
@@ -327,10 +327,10 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         final.Messages.Should().Contain(final.UserMessageIds);
         var responseIds = final.Messages.Except(final.UserMessageIds).ToList();
         responseIds.Should().HaveCount(2,
-            "one response cell per inbox drain â€” round 1 drains {u1}, round 2 drains {u2,u3,u4}");
+            "one response cell per inbox drain — round 1 drains {u1}, round 2 drains {u2,u3,u4}");
     }
 
-    // â”€â”€â”€ Queue-don't-cancel: new input during execution waits until round completes â”€â”€â”€
+    // ─── Queue-don't-cancel: new input during execution waits until round completes ───
 
     [Fact]
     public async Task Submit_DuringExecution_QueuedUntilRoundCompletes_ThenNextRoundDispatches()
@@ -350,7 +350,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
             timeoutMs: 30_000);
 
         // Submit u2 while round 1 is still executing. Queue-don't-cancel: the current round
-        // is NOT aborted â€” it completes naturally (tool calls finish, response persists).
+        // is NOT aborted — it completes naturally (tool calls finish, response persists).
         // The watcher holds u2 back until IsExecuting flips to false, then dispatches round 2.
         client.SubmitMessage(
             threadPath, "Second",
@@ -367,7 +367,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         final.Messages.Should().HaveCount(4);
     }
 
-    // â”€â”€â”€ Single submit must produce exactly one response cell â”€â”€â”€
+    // ─── Single submit must produce exactly one response cell ───
 
     /// <summary>
     /// Repro for the prod symptom: ONE submit produces TWO "Generating response" rounds.
@@ -524,7 +524,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
         (userCell!.Content as ThreadMessage)!.AgentName.Should().Be("Assistant");
     }
 
-    // â”€â”€â”€ Helpers â”€â”€â”€
+    // ─── Helpers ───
 
     private async Task<string> SeedEmptyThread()
     {
@@ -572,7 +572,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
             .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
             .Match(t => predicate(t!)))!;
 
-    // â”€â”€â”€ Fake chat client (minimal) â”€â”€â”€
+    // ─── Fake chat client (minimal) ───
 
     private sealed class FakeChatClient : IChatClient
     {
@@ -600,7 +600,7 @@ public class ThreadSubmissionIntegrationTest : AITestBase
     }
 
     /// <summary>
-    /// Slow variant â€” delays ~1 second in the streaming response so tests can observe
+    /// Slow variant — delays ~1 second in the streaming response so tests can observe
     /// the IsExecuting=true state window and submit additional messages during a round.
     /// </summary>
     private sealed class SlowFakeChatClient : IChatClient

--- a/test/MeshWeaver.AI.Test/ThreadSubmissionUnitTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSubmissionUnitTest.cs
@@ -15,7 +15,7 @@ namespace MeshWeaver.AI.Test;
 /// </summary>
 public class ThreadSubmissionUnitTest
 {
-    // â”€â”€â”€ FindUnprocessedUserMessages â”€â”€â”€
+    // ─── FindUnprocessedUserMessages ───
 
     [Fact]
     public void FindUnprocessedUserMessages_NoUsers_ReturnsEmpty()
@@ -85,7 +85,7 @@ public class ThreadSubmissionUnitTest
         result.Should().ContainInOrder("u3");
     }
 
-    // â”€â”€â”€ PlanNextRound â”€â”€â”€
+    // ─── PlanNextRound ───
 
     [Fact]
     public void PlanNextRound_Busy_ReturnsNull()

--- a/test/MeshWeaver.AI.Test/UnifiedContentAccessTest.cs
+++ b/test/MeshWeaver.AI.Test/UnifiedContentAccessTest.cs
@@ -398,7 +398,7 @@ public class UnifiedContentAccessTest(ITestOutputHelper output) : HubTestBase(ou
     // MeshOperations.TryResolveUnifiedPathAsync splits the path into addressPart="Acme/AIConsulting"
     // and remainder="content/Diskussion Thomas Final Report.docx", then posts
     //   GetDataRequest(new UnifiedReference("content/Diskussion Thomas Final Report.docx"))
-    // to the address. The user observed a 10-second AwaitResponse timeout â€” symptom said
+    // to the address. The user observed a 10-second AwaitResponse timeout — symptom said
     // "no response received". These tests pin down whether the GetDataRequest handler returns at
     // all for the slash-format default-collection lookup, with and without spaces.
 
@@ -414,7 +414,7 @@ public class UnifiedContentAccessTest(ITestOutputHelper output) : HubTestBase(ou
             var host = GetHostWithFileProvider(testDir, defaultCollection: true);
             var client = GetClient();
 
-            // Slash format with NO collection segment â€” what the agent actually emits.
+            // Slash format with NO collection segment — what the agent actually emits.
             var response = await client.Observe(new GetDataRequest(new UnifiedReference("content/report.txt")), o => o.WithTarget(CreateHostAddress())).Should().Emit();
 
             response.Message.Error.Should().BeNull();
@@ -479,7 +479,7 @@ public class UnifiedContentAccessTest(ITestOutputHelper output) : HubTestBase(ou
     public async Task GetDataRequest_ContentSlashFormat_MissingDefaultCollection_ReturnsErrorNotTimeout()
     {
         // The prod hub for /Acme/AIConsulting may not have AddContentCollections() registered
-        // under the default "content" name. The handler must return a clear error response â€” not
+        // under the default "content" name. The handler must return a clear error response — not
         // hang and force AwaitResponse to time out.
         GetHost(); // baseline host with NO file content provider configured
         var client = GetClient();

--- a/test/MeshWeaver.Acme.Test/TodoCreateFlowTest.cs
+++ b/test/MeshWeaver.Acme.Test/TodoCreateFlowTest.cs
@@ -301,7 +301,7 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
             }
             else
             {
-                Output.WriteLine($"Create area returned {anyControl!.GetType().Name} instead of StackControl â€” acceptable for custom NodeTypes");
+                Output.WriteLine($"Create area returned {anyControl!.GetType().Name} instead of StackControl — acceptable for custom NodeTypes");
             }
         }
         finally

--- a/test/MeshWeaver.Acme.Test/TodoDataChangeWorkflowTest.cs
+++ b/test/MeshWeaver.Acme.Test/TodoDataChangeWorkflowTest.cs
@@ -548,7 +548,7 @@ public class TodoDataChangeWorkflowTest(ITestOutputHelper output) : MonolithMesh
         var deletedNode = originalNode with { State = MeshNodeState.Deleted };
         await UpdateNodeViaStream(deletedNode).Should().Emit();
 
-        // Verify the state changed (stream read â€” no catalog lag)
+        // Verify the state changed (stream read — no catalog lag)
         var updatedNode = await ReadNode(todoPath)
             .Should().Within(60.Seconds()).Match(n => n is not null && n.State == MeshNodeState.Deleted);
         updatedNode.Should().NotBeNull("Node should still exist after soft delete");
@@ -567,7 +567,7 @@ public class TodoDataChangeWorkflowTest(ITestOutputHelper output) : MonolithMesh
         var activeQuery = "path:ACME/ProductLaunch/Todo nodeType:ACME/Project/Todo state:Active scope:subtree";
 
         // Capture the initial active set + the original todo from the same
-        // Query subscription â€” initial emission is the full snapshot.
+        // Query subscription — initial emission is the full snapshot.
         var initialItems = await MeshQuery
             .Query<MeshNode>(MeshQueryRequest.FromQuery(activeQuery))
             .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
@@ -581,7 +581,7 @@ public class TodoDataChangeWorkflowTest(ITestOutputHelper output) : MonolithMesh
         var deletedNode = originalNode! with { State = MeshNodeState.Deleted };
         await UpdateNodeViaStream(deletedNode).Should().Emit();
 
-        // Wait for the catalog to reflect the state change â€” Query emits a
+        // Wait for the catalog to reflect the state change — Query emits a
         // Removed/Updated delta when DefinePersona stops matching state:Active.
         var paths = await ObserveQueryPathSet(activeQuery)
             .Should().Within(60.Seconds()).Match(set => !set.Contains(todoPath));
@@ -602,7 +602,7 @@ public class TodoDataChangeWorkflowTest(ITestOutputHelper output) : MonolithMesh
         var activeQuery = "path:ACME/ProductLaunch/Todo nodeType:ACME/Project/Todo state:Active scope:subtree";
         var deletedQuery = "path:ACME/ProductLaunch/Todo nodeType:ACME/Project/Todo state:Deleted scope:subtree";
 
-        // Capture original from the live active set (set query â€” Query is correct).
+        // Capture original from the live active set (set query — Query is correct).
         var initialActive = await MeshQuery
             .Query<MeshNode>(MeshQueryRequest.FromQuery(activeQuery))
             .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)

--- a/test/MeshWeaver.Content.Test/CollaborativeEditingReplyTest.cs
+++ b/test/MeshWeaver.Content.Test/CollaborativeEditingReplyTest.cs
@@ -159,7 +159,7 @@ public class CollaborativeEditingReplyTest(ITestOutputHelper output) : MonolithM
     }
 
     /// <summary>
-    /// Full workflow: create comment â†’ create reply â†’ update reply text â†’ verify via Query.
+    /// Full workflow: create comment → create reply → update reply text → verify via Query.
     /// </summary>
     [Fact]
     public async Task FullWorkflow_Comment_Reply_Edit()

--- a/test/MeshWeaver.Content.Test/CommentWithRepliesViewTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentWithRepliesViewTest.cs
@@ -90,7 +90,7 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
     /// <summary>
     /// Loads the CollaborativeEditing.md document's Overview area.
     /// This triggers the full rendering pipeline including comments sidebar
-    /// where comment c1 has a reply â€” the scenario that caused OperationCanceledException.
+    /// where comment c1 has a reply — the scenario that caused OperationCanceledException.
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task CollaborativeEditingDocument_Overview_ShouldRender()
@@ -204,7 +204,7 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
 
     /// <summary>
     /// Renders the Overview area for a comment (c6) that has NO replies.
-    /// Baseline test â€” should always work. (c2 has replies in the sample data
+    /// Baseline test — should always work. (c2 has replies in the sample data
     /// even though the original test name suggested otherwise — c6 is the only
     /// genuinely childless comment.)
     /// </summary>
@@ -239,7 +239,7 @@ public class CommentWithRepliesViewTest(ITestOutputHelper output) : MonolithMesh
     [Fact(Timeout = 30000)]
     public async Task Persistence_CommentWithReply_ShouldLoadCorrectly()
     {
-        // No hub initialization needed â€” RoutingMeshQueryProvider discovers
+        // No hub initialization needed — RoutingMeshQueryProvider discovers
         // partitions via DiscoverNewProvidersAsync during the query.
 
         // Wait for the emission that CONTAINS the node, never the first Initial: the catalog

--- a/test/MeshWeaver.Content.Test/MarkdownNodeIntegrationTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownNodeIntegrationTest.cs
@@ -1030,7 +1030,7 @@ DateTime.Now.ToString()
         roundTripped.CodeSubmissions![0].Code.Should().Be(content.CodeSubmissions[0].Code);
     }
 
-    // RepairMarkdownContent_* tests removed â€” the MarkdownNodeType.RepairMarkdownContent hook
+    // RepairMarkdownContent_* tests removed — the MarkdownNodeType.RepairMarkdownContent hook
     // and MeshDataSource.WithNodeConverter pipeline they covered no longer exist in the codebase.
 
     #endregion

--- a/test/MeshWeaver.Content.Test/NewCommentFlowTest.cs
+++ b/test/MeshWeaver.Content.Test/NewCommentFlowTest.cs
@@ -111,7 +111,7 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
             PrimaryNodePath = docPath,
             MarkerId = markerId,
             Author = "TestAuthor",
-            Text = "",  // Empty initially Ã¢â‚¬â€ user edits after creation
+            Text = "",  // Empty initially — user edits after creation
             Status = CommentStatus.Active
         };
         var commentNode = new MeshNode(commentId, docPath)
@@ -125,15 +125,15 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         commentNode.Path.Should().Be($"{docPath}/{commentId}",
             "MeshNode(commentId, docPath) should produce Path = docPath/commentId");
 
-        // Act Ã¢â‚¬â€ create the node (same as meshCatalog.CreateNodeAsync in BuildNewCommentForm)
+        // Act — create the node (same as meshCatalog.CreateNodeAsync in BuildNewCommentForm)
         var createdNode = await NodeFactory.CreateNode(commentNode).Should().Emit();
 
-        // Assert Ã¢â‚¬â€ node should be retrievable
+        // Assert — node should be retrievable
         createdNode.Should().NotBeNull("CreateNodeAsync should return the created node");
         createdNode.Path.Should().Be($"{docPath}/{commentId}");
         Output.WriteLine($"Created node path: {createdNode.Path}");
 
-        // Assert Ã¢â‚¬â€ node should be retrievable via per-node stream
+        // Assert — node should be retrievable via per-node stream
         var retrieved = await ReadNode(createdNode.Path!).Should().Emit();
         retrieved.Should().NotBeNull("Comment should be retrievable after creation");
         var retrievedComment = retrieved!.Content.Should().BeOfType<Comment>().Subject;
@@ -141,7 +141,7 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         retrievedComment.Text.Should().BeEmpty("Comment was created with empty text");
         Output.WriteLine($"Retrieved comment: Author={retrievedComment.Author}, Text='{retrievedComment.Text}'");
 
-        // Assert Ã¢â‚¬â€ node should appear in namespace: query (this is how ReadView finds comments)
+        // Assert — node should appear in namespace: query (this is how ReadView finds comments)
         // Wait for the snapshot that contains the node just created. This one has a WRITE before it,
         // so it carries genuine CQRS lag on top of the async catalog hydration — taking the first
         // Initial here was the least defensible instance of the shape (#1384).
@@ -262,7 +262,7 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         Output.WriteLine($"Sending DataChangeRequest to WRONG address: {docAddress}");
         await client.Observe(new DataChangeRequest().WithUpdates(updatedNode), o => o.WithTarget(docAddress)).Should().Emit(); // BUG: targeting parent instead of comment
 
-        // Verify comment text did NOT change (still empty) Ã¢â‚¬â€ via per-node stream
+        // Verify comment text did NOT change (still empty) — via per-node stream
         // The wrong-target DataChange may race with the comment hub's MeshNodeReference
         // reducer activation — when the doc hub's workspace and the comment hub haven't
         // synced ownership, the cross-path update can fire before being rejected, causing
@@ -352,7 +352,7 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Full end-to-end test: Create comment Ã¢â€ â€™ Edit text Ã¢â€ â€™ Reload (re-query) Ã¢â€ â€™ Verify persistence.
+    /// Full end-to-end test: Create comment → Edit text → Reload (re-query) → Verify persistence.
     /// This simulates the complete user flow.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -402,9 +402,9 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         Output.WriteLine("3. Updating comment text via NodeFactory.UpdateNodeAsync...");
         await NodeFactory.UpdateNode(editedNode).Should().Emit();
 
-        // 4. "Reload"Ã¢â‚¬â€ read content via the per-node MeshNodeReference stream.
+        // 4. "Reload"— read content via the per-node MeshNodeReference stream.
         // QueryAsync would race the eventually-consistent catalog and return stale.
-        Output.WriteLine("4. Simulating reloadÃ¢â‚¬â€ reading content via per-node stream...");
+        Output.WriteLine("4. Simulating reload— reading content via per-node stream...");
         var reloaded = await Mesh.GetMeshNode(created.Path!, ReadNodeTimeout)
             .Should()
             .Within(ReadNodeTimeout)
@@ -418,7 +418,7 @@ public class NewCommentFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         reloadedComment.MarkerId.Should().Be(markerId);
         Output.WriteLine($"   Reloaded comment: Text='{reloadedComment.Text}', Author={reloadedComment.Author}");
 
-        // 5. Also verify via namespace: query (how ReadView finds comments) Ã¢â‚¬â€ wait
+        // 5. Also verify via namespace: query (how ReadView finds comments) — wait
         // for the catalog to surface the comment under the doc namespace.
         Output.WriteLine("5. Verifying via namespace: query...");
         var nsQuery = $"namespace:{docPath} nodeType:{CommentNodeType.NodeType}";

--- a/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
+++ b/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
@@ -480,7 +480,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         ids.Should().NotContain("TransactionMapping", "Search should not return the TransactionMapping sibling node");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Layout Area Catalog Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Layout Area Catalog ──
 
     [Fact(Timeout = ColdCompileTimeoutMs)]
     public async Task GroupAnalysis_LayoutAreas_ShouldRenderCatalog()
@@ -547,7 +547,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             "Default area for Analysis hub should be 'LayoutAreas' (profitability catalog), not 'Overview'");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Local Analysis Hub (EuropeRe) Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Local Analysis Hub (EuropeRe) ──
 
     [Fact(Timeout = ColdCompileTimeoutMs)]
     public async Task EuropeRe_KeyMetrics_ShouldHaveNonZeroData()
@@ -564,7 +564,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         var control = await GetControl("FutuRe/EuropeRe/Analysis", "KeyMetrics", unwrap: true);
         var md = AssertMarkdownWithNonZeroNumbers(control, "EuropeRe KeyMetrics currency");
         md.Should().Contain(" EUR", "EuropeRe amounts should be labeled with EUR, not CHF");
-        md.Should().NotContain(" CHF", "EuropeRe should not show CHF Ã¢â‚¬â€ its currency is EUR");
+        md.Should().NotContain(" CHF", "EuropeRe should not show CHF — its currency is EUR");
     }
 
     [Fact(Timeout = ColdCompileTimeoutMs)]
@@ -611,7 +611,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         control.Should().BeOfType<ChartControl>("QuarterlyTrend should be a chart");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Group Analysis Hub (FutuRe/Analysis) Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Group Analysis Hub (FutuRe/Analysis) ──
 
     /// <summary>
     /// Diagnostic: check whether PartitionedHubDataSource actually receives data from child hubs.
@@ -707,7 +707,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         await InitializeChildAnalysisHubs();
 
         var control = await GetControl("FutuRe/Analysis", "ProfitabilityTable", unwrap: true);
-        // Group profitability table renders Ã¢â‚¬â€ data may arrive asynchronously from child BU hubs.
+        // Group profitability table renders — data may arrive asynchronously from child BU hubs.
         // Verify the markdown structure (headers and totals) rather than requiring non-zero data,
         // since PartitionedHubDataSource data flow depends on test execution order.
         var mdControl = control.Should().BeOfType<MarkdownControl>(
@@ -773,7 +773,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         control.Should().BeOfType<HtmlControl>("AnnualProfitabilityWaterfall should return an HtmlControl with SVG");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Business Unit Layout Areas Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Business Unit Layout Areas ──
 
     /// <summary>
     /// Verifies that the EuropeRe Search area renders with child nodes.
@@ -828,7 +828,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             + "definitions like LineOfBusiness/TransactionMapping are excluded by design)");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Node Existence Verification Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Node Existence Verification ──
 
     /// <summary>
     /// Verifies that all FutuRe NodeType definitions exist.
@@ -878,7 +878,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         ids.Should().Contain("Group");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Report Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Report ──
 
     /// <summary>
     /// Verifies that the AnnualReport node exists and its Overview area renders.
@@ -905,7 +905,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             "AnnualReport Overview should render the report content");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ AnnualReport Diagnostic Tests Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── AnnualReport Diagnostic Tests ──
 
     /// <summary>
     /// Diagnostic: verify that the AnnualReport Overview contains @@() layout area references
@@ -993,7 +993,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         foreach (var path in paths)
         {
             var resolution = await pathResolver.ResolvePath(path).Should().Emit();
-            Output.WriteLine($"  {path} Ã¢â€ â€™ Prefix='{resolution?.Prefix}', Remainder='{resolution?.Remainder}'");
+            Output.WriteLine($"  {path} → Prefix='{resolution?.Prefix}', Remainder='{resolution?.Remainder}'");
 
             resolution.Should().NotBeNull($"Path '{path}' should resolve");
             resolution!.Prefix.Should().Be("FutuRe/Analysis", $"'{path}' should resolve to FutuRe/Analysis hub");
@@ -1001,7 +1001,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Diagnostic: simulate the full PathBasedLayoutArea chain Ã¢â‚¬â€ resolve path, then get the
+    /// Diagnostic: simulate the full PathBasedLayoutArea chain — resolve path, then get the
     /// chart control at the resolved address/area.
     /// </summary>
     [Fact(Timeout = ColdCompileTimeoutMs)]
@@ -1024,7 +1024,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         control.Should().NotBeNull("KeyMetrics should render when accessed via path resolution");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ EuropeRe AnnualReport Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── EuropeRe AnnualReport ──
 
     /// <summary>
     /// Verifies that the EuropeRe AnnualReport Overview contains @@() layout area references
@@ -1063,7 +1063,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             Output.WriteLine($"  Area '{childKey}': {childControl?.GetType().Name}");
 
             // Accept either MarkdownControl (legacy) or CollaborativeMarkdownControl
-            // (current Overview area output Ã¢â‚¬â€ read+comment+edit container).
+            // (current Overview area output — read+comment+edit container).
             var markdown = childControl switch
             {
                 MarkdownControl mc => mc.Markdown?.ToString(),
@@ -1110,7 +1110,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         foreach (var path in paths)
         {
             var resolution = await pathResolver.ResolvePath(path).Should().Emit();
-            Output.WriteLine($"  {path} Ã¢â€ â€™ Prefix='{resolution?.Prefix}', Remainder='{resolution?.Remainder}'");
+            Output.WriteLine($"  {path} → Prefix='{resolution?.Prefix}', Remainder='{resolution?.Remainder}'");
 
             resolution.Should().NotBeNull($"Path '{path}' should resolve");
             resolution!.Prefix.Should().Be("FutuRe/EuropeRe/Analysis",
@@ -1119,7 +1119,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Simulates the full PathBasedLayoutArea chain for EuropeRe Ã¢â‚¬â€ resolve path, then get the
+    /// Simulates the full PathBasedLayoutArea chain for EuropeRe — resolve path, then get the
     /// chart control at the resolved address/area. Since EuropeRe charts work individually,
     /// this should succeed and proves the @@() embedding pipeline works end-to-end.
     /// </summary>
@@ -1135,7 +1135,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         resolution.Prefix.Should().Be("FutuRe/EuropeRe/Analysis");
         resolution.Remainder.Should().Be("KeyMetrics");
 
-        // Get the control at the resolved address/area Ã¢â‚¬â€ this is what PathBasedLayoutArea does
+        // Get the control at the resolved address/area — this is what PathBasedLayoutArea does
         var control = await GetControl(resolution.Prefix, resolution.Remainder!,
             waitForData: false, timeoutSeconds: 15);
 
@@ -1151,7 +1151,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
         }
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Activity Logs Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Activity Logs ──
 
     /// <summary>
     /// Verifies that activity log nodes can be queried via IMeshService.
@@ -1172,7 +1172,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             Output.WriteLine($"  [{log.Category}] {log.User?.DisplayName} - {log.HubPath} ({log.Status})");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Hub Initialization Diagnostic Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Hub Initialization Diagnostic ──
 
     /// <summary>
     /// Reproduces browser behavior: navigates to FutuRe/Analysis WITHOUT pre-initializing
@@ -1182,13 +1182,13 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
     [Fact(Timeout = ColdCompileTimeoutMs)]
     public async Task Group_HubInitialization_ShouldSucceedWithoutPreInit()
     {
-        // Do NOT call InitializeChildAnalysisHubs() Ã¢â‚¬â€ reproduce browser behavior
+        // Do NOT call InitializeChildAnalysisHubs() — reproduce browser behavior
         var control = await GetControl("FutuRe/Analysis", "KeyMetrics",
             waitForData: false, timeoutSeconds: 15);
         control.Should().NotBeNull("FutuRe/Analysis hub should initialize without pre-starting child hubs");
     }
 
-    // Ã¢â€â‚¬Ã¢â€â‚¬ Helpers Ã¢â€â‚¬Ã¢â€â‚¬
+    // ── Helpers ──
 
     /// <summary>
     /// Pre-initializes child BU analysis hubs (EuropeRe, AmericasIns) so their data
@@ -1297,7 +1297,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             // Each WithView creates a child area at parentKey/N; Toolbar puts content last.
             // Apply waitForData at every level: HasNonTrivialData returns true for
             // non-MarkdownControl (StackControl passes immediately), so only the leaf
-            // MarkdownControl actually waits Ã¢â‚¬â€ using a single subscription per key.
+            // MarkdownControl actually waits — using a single subscription per key.
             for (var depth = 0; depth < 3 && control is StackControl stack && stack.Areas?.Count > 0; depth++)
             {
                 var childArea = stack.Areas.Last();
@@ -1310,7 +1310,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
                     .Should().Within(timeoutSeconds.Seconds())
                     .Match(x => x is not null && !IsNotYetTheArea(x)
                                 && (!waitForData || HasNonTrivialData(x)));
-                Output.WriteLine($"  Ã¢â€ â€™ {control?.GetType().Name}");
+                Output.WriteLine($"  → {control?.GetType().Name}");
             }
         }
         else if (waitForData && !HasNonTrivialData(control))
@@ -1388,7 +1388,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
 
         markdown.Should().NotBeNullOrWhiteSpace($"{context} markdown should not be empty");
 
-        // Extract numbers from the markdown Ã¢â‚¬â€ look for formatted numbers like "78,750,000"
+        // Extract numbers from the markdown — look for formatted numbers like "78,750,000"
         var numbers = System.Text.RegularExpressions.Regex.Matches(markdown, @"[\d,]+\.\d+|[\d,]+")
             .Cast<System.Text.RegularExpressions.Match>()
             .Select(m => m.Value.Replace(",", ""))

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentLayoutAreasTest.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// Tests for AccessAssignmentLayoutAreas â€” verifies that workspace.RequestChange
+/// Tests for AccessAssignmentLayoutAreas — verifies that workspace.RequestChange
 /// correctly updates the MeshNode stream, enabling reactive UI updates
 /// for ToggleDenied, RemoveRole, and AddRole operations.
 /// </summary>
@@ -88,13 +88,13 @@ public class AccessAssignmentLayoutAreasTest(ITestOutputHelper output) : HubTest
         var initial = AccessControlLayoutArea.DeserializeAssignment(node)!;
         initial.Roles[0].Denied.Should().BeFalse("initial state should be not-denied");
 
-        // Act â€” toggle denied
+        // Act — toggle denied
         var roles = initial.Roles.ToList();
         roles[0] = roles[0] with { Denied = true };
         var updatedNode = node with { Content = initial with { Roles = roles } };
         _ = workspace.RequestChange(DataChangeRequest.Update([updatedNode]));
 
-        // Assert â€” stream should reflect the change
+        // Assert — stream should reflect the change
         var updatedNodes = await nodeStream!
             .Should().Within(5.Seconds()).Match(items =>
             {

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationProgressTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationProgressTest.cs
@@ -73,7 +73,7 @@ public class NavigationProgressTest
 
         _hub.Configuration.Returns(new MessageHubConfiguration(null, new Address("test", "nav")));
 
-        // Empty mesh query by default â€” node-loading path is best-effort.
+        // Empty mesh query by default — node-loading path is best-effort.
         // Empty observable so the chain in LoadNodeWithPreRenderedHtml completes
         // with node = null (Catch falls through to Observable.Return(null)).
         _meshQuery.Query<MeshNode>(Arg.Any<MeshQueryRequest>(), Arg.Any<JsonSerializerOptions>())
@@ -229,8 +229,8 @@ public class NavigationProgressTest
     [Fact]
     public async Task Status_AllEmissions_HaveNonEmptyMessage()
     {
-        // Drive the service through a full lifecycle: init â†’ resolve ok â†’ navigate
-        // to a path that will NOT resolve â†’ retries â†’ NotFound. Every emission
+        // Drive the service through a full lifecycle: init → resolve ok → navigate
+        // to a path that will NOT resolve → retries → NotFound. Every emission
         // along the way must carry a non-empty message.
         _navigationManager.SetUri("http://localhost/ACME/Project");
         _pathResolver.ResolveNavigationPath("ACME/Project")
@@ -252,7 +252,7 @@ public class NavigationProgressTest
 
         emissions.Should().NotBeEmpty();
         emissions.Should().OnlyContain(s => !string.IsNullOrWhiteSpace(s.Message),
-            "no emission â€” including intermediate ones â€” may render as an empty spinner");
+            "no emission — including intermediate ones — may render as an empty spinner");
     }
 
     // -- Test #7: retries in flight must NOT emit NotFound / null context --------
@@ -261,7 +261,7 @@ public class NavigationProgressTest
     public async Task Status_WhenResolutionFailsInitially_DoesNotEmitNotFoundUntilRetriesExhausted()
     {
         // Initial attempt returns null and we schedule retries. The user should
-        // keep seeing "Looking upâ€¦" during the retry window â€” not a flash of
+        // keep seeing "Looking up…" during the retry window — not a flash of
         // "Page Not Found" followed by the real answer.
         _navigationManager.SetUri("http://localhost/does/not/exist");
         _pathResolver.ResolveNavigationPath(Arg.Any<string>())
@@ -287,7 +287,7 @@ public class NavigationProgressTest
             "while retrying, the status remains 'Looking up'");
     }
 
-    // -- Test #8: retry succeeds â†’ never show NotFound --------------------------
+    // -- Test #8: retry succeeds → never show NotFound --------------------------
 
     [Fact]
     public void Status_WhenResolutionFailsOnFirstAttempt_ThenSucceeds_NeverEmitsNotFound()

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -1217,8 +1217,8 @@ public class NavigationServiceTest
     public async Task OnLocationChanged_SatelliteNode_CurrentNamespacePointsAtMainNode()
     {
         // User browses to a thread under Acme/AIConsulting. The thread node's MainNode
-        // points back at the parent that owns it, so CurrentNamespace â€” which downstream
-        // chat/autocomplete/attachment code uses to resolve relative paths â€” must surface
+        // points back at the parent that owns it, so CurrentNamespace — which downstream
+        // chat/autocomplete/attachment code uses to resolve relative paths — must surface
         // the main node, not the satellite path.
         var service = CreateService();
         const string SatellitePath = "Acme/AIConsulting/_Thread/abc-123";

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -22,9 +22,9 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 
 /// <summary>
 /// End-to-end tests for the explicit compile pipeline:
-///   CreateReleaseRequest â†’ IsUpToDate check â†’ CompileWatcher â†’ Release node.
+///   CreateReleaseRequest → IsUpToDate check → CompileWatcher → Release node.
 ///
-/// The automatic MeshChangeFeed â†’ TryTriggerRecompile path has been removed.
+/// The automatic MeshChangeFeed → TryTriggerRecompile path has been removed.
 /// All compilation is now triggered explicitly via CreateReleaseRequest.
 /// </summary>
 public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestBase(output), IDisposable
@@ -77,13 +77,13 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
     /// <summary>
     /// Explicit compile flow (the new canonical shape post-2026-05-05):
     ///   1. Create NodeType + Code source.
-    ///   2. Send CreateReleaseRequest â†’ should trigger compilation (not IsUpToDate).
+    ///   2. Send CreateReleaseRequest → should trigger compilation (not IsUpToDate).
     ///   3. Wait for V1 release node.
-    ///   4. CreateReleaseRequest again â†’ should return AlreadyUpToDate = true.
+    ///   4. CreateReleaseRequest again → should return AlreadyUpToDate = true.
     ///   5. Modify source code to V2.
-    ///   6. CreateReleaseRequest â†’ should re-compile (sources changed).
+    ///   6. CreateReleaseRequest → should re-compile (sources changed).
     ///   7. Wait for V2 release node.
-    ///   8. Create fresh instance â†’ must serve V2 layout.
+    ///   8. Create fresh instance → must serve V2 layout.
     /// </summary>
     [Fact(Timeout = 60000)]
     public async Task CodeEdit_ExplicitRelease_IsUpToDate_RecompilesOnSourceChange()
@@ -126,19 +126,19 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
             Output.WriteLine($"    {m.Message}");
 
         // 3. Trigger V1 compilation. The per-NodeType hub's
-        // InstallCompileWatcher kickoff also flips Pending â†’ Compile on first
+        // InstallCompileWatcher kickoff also flips Pending → Compile on first
         // activation when HasUsableBuild is false; either path is acceptable so
         // long as a real V1 Release lands. We send CreateReleaseRequest both as
         // the canonical explicit trigger AND to wait for the compile to settle.
         // AlreadyUpToDate may legitimately be true here if the kickoff beat us
-        // to first compile â€” what we check is that V1 release is produced.
+        // to first compile — what we check is that V1 release is produced.
         var v1Response = await SendCreateRelease(NodeTypePath, force: false);
         v1Response.Success.Should().BeTrue("CreateReleaseRequest should succeed");
 
         var v1Release = await WaitForNewRelease(NodeTypePath, knownReleases: []);
         Output.WriteLine($"=== V1 release at {v1Release} ===");
 
-        // 4. CreateReleaseRequest again without changes â†’ AlreadyUpToDate.
+        // 4. CreateReleaseRequest again without changes → AlreadyUpToDate.
         var dupResponse = await SendCreateRelease(NodeTypePath, force: false);
         dupResponse.AlreadyUpToDate.Should().BeTrue("sources unchanged since V1 compile");
         Output.WriteLine("=== STEP dup AlreadyUpToDate OK ===");
@@ -155,7 +155,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
         v1Html.Should().Contain("MARKER_V1", "V1 release must be served");
         Output.WriteLine("=== STEP MARKER_V1 verified ===");
 
-        // 6. Modify the source to V2. Live remote stream â€” path is known, no
+        // 6. Modify the source to V2. Live remote stream — path is known, no
         // index lag (per CqrsAndContentAccess.md).
         var sourceClient = GetClient(c => c.AddData());
         var codeNode = await sourceClient.GetWorkspace()
@@ -178,7 +178,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
             .Match(n => n?.Content is NodeTypeDefinition d && d.IsDirty);
         Output.WriteLine("=== STEP IsDirty observed ===");
 
-        // 7. Explicitly trigger V2 compilation â€” sources changed, should recompile.
+        // 7. Explicitly trigger V2 compilation — sources changed, should recompile.
         var v2Response = await SendCreateRelease(NodeTypePath, force: false);
         Output.WriteLine($"=== STEP V2 SendCreateRelease returned (AlreadyUpToDate={v2Response.AlreadyUpToDate}) ===");
         v2Response.Success.Should().BeTrue("CreateReleaseRequest should succeed after source change");
@@ -190,13 +190,13 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
 
         // 8. Create a fresh instance and verify it serves V2.
         //
-        // ðŸš¨ Wait for the MESH HUB's workspace to see the V2 release on the NodeType
+        // 🚨 Wait for the MESH HUB's workspace to see the V2 release on the NodeType
         // BEFORE creating the new instance. The activation path
         // (NodeTypeEnrichmentHelpers.EnrichWithNodeType) reads the NodeType MeshNode
-        // from meshHub.GetWorkspace().GetMeshNodeStream(nodeType) â€” that workspace's
+        // from meshHub.GetWorkspace().GetMeshNodeStream(nodeType) — that workspace's
         // cache is updated asynchronously by DataChangedEvent fan-out from the
         // per-NodeType hub. A subscription on a SEPARATE client (e.g. WaitForNewReleaseAsync
-        // above) only confirms the per-NodeType hub flipped â€” NOT that the mesh hub's
+        // above) only confirms the per-NodeType hub flipped — NOT that the mesh hub's
         // cache observed the change. Creating instance2 before the mesh hub's view
         // catches up causes EnrichWithNodeType to read the stale V1 AssemblyLocation
         // and bind instance2 to the V1 assembly for its entire lifetime
@@ -226,8 +226,8 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
     ///   1. Compile V1, capture V1 release path.
     ///   2. Modify source to V2, compile V2 (V2 is now the latest release).
     ///   3. Pin <c>RequestedReleasePath</c> to V1 on the NodeType.
-    ///   4. Create a fresh instance â€” must serve V1 (the pinned release), not V2 (latest).
-    ///   5. Clear the pin â†’ fresh instance must serve V2 again.
+    ///   4. Create a fresh instance — must serve V1 (the pinned release), not V2 (latest).
+    ///   5. Clear the pin → fresh instance must serve V2 again.
     ///
     /// All node mutations (Source update, recompile trigger, pin set / clear) go
     /// through <c>workspace.GetMeshNodeStream(path).Update(...)</c> on the shared
@@ -330,7 +330,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
         await WaitForMeshHubView(pinTypePath,
             n => n?.Content is NodeTypeDefinition d && d.RequestedReleasePath == v1Release);
 
-        // 5. Fresh instance â€” pinned path means V1 must be served even though V2 is latest.
+        // 5. Fresh instance — pinned path means V1 must be served even though V2 is latest.
         await NodeFactory.CreateNode(new MeshNode("pinnedInstance", $"{TestPartition}/PinType")
         {
             Name = "Pinned Instance",
@@ -345,7 +345,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
             $"{TestPartition}/PinType/pinnedInstance",
             html => html.Contains("MARKER_V1"));
         pinnedHtml.Should().Contain("MARKER_V1",
-            "RequestedReleasePath pins to V1 â€” instance must serve V1 even though V2 is latest");
+            "RequestedReleasePath pins to V1 — instance must serve V1 even though V2 is latest");
         pinnedHtml.Should().NotContain("MARKER_V2",
             "pinned release V1 must not leak V2's body");
 
@@ -1159,7 +1159,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
             .Select(d => d.Message)
             .Should().Within(TimeSpan.FromSeconds(30)).Emit();
         // Wait for compile to complete (status = Ok or Error) before returning.
-        // Live remote stream (GetMeshNodeStream(path)) â€” NOT Query, which
+        // Live remote stream (GetMeshNodeStream(path)) — NOT Query, which
         // is index-lagged and can miss the post-compile tick (per the CQRS
         // feedback note + Doc/Architecture/CqrsAndContentAccess.md). Path is
         // known here, so the live stream is the right primitive.
@@ -1181,7 +1181,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
     /// Reads the Overview area and waits for an <see cref="HtmlControl"/> whose
     /// data matches <paramref name="matches"/>. Used by V2 reads where the per-node
     /// hub may emit a stale (V1) snapshot first while the new release's
-    /// HubConfiguration is still propagating â€” taking <c>FirstAsync(x is HtmlControl)</c>
+    /// HubConfiguration is still propagating — taking <c>FirstAsync(x is HtmlControl)</c>
     /// would race the first stale emission and fail the assertion before the
     /// V2-bound re-render lands.
     /// </summary>
@@ -1204,7 +1204,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
     /// <summary>
     /// Waits for a fresh <c>Release</c> MeshNode whose path differs from any in
     /// <paramref name="knownReleases"/>. Reads <see cref="NodeTypeDefinition.LatestReleasePath"/>
-    /// off the live <see cref="GetMeshNodeStream"/> â€” atomic with the post-compile
+    /// off the live <see cref="GetMeshNodeStream"/> — atomic with the post-compile
     /// status flip, so by the time CompilationStatus settles to Ok the new path
     /// is already on the NodeType. Avoids the lagged <c>Query</c> namespace
     /// scan over <c>Release/*</c>.
@@ -1230,7 +1230,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
     /// and that cache is updated asynchronously by DataChangedEvent fan-out
     /// from the per-NodeType hub. A separate client's view (e.g. a fresh test
     /// reader subscribed via <c>GetClient(...)</c>) is a different
-    /// <c>ISynchronizationStream</c> on a different scheduler â€” seeing the
+    /// <c>ISynchronizationStream</c> on a different scheduler — seeing the
     /// write there does NOT imply the mesh hub's cache has caught up. Per
     /// <c>HubConfiguration</c> being captured once at activation, an instance
     /// created before mesh hub catches up is bound to the stale snapshot for

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteLayoutAreaIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteLayoutAreaIntegrationTest.cs
@@ -137,7 +137,7 @@ public class DeleteLayoutAreaIntegrationTest(ITestOutputHelper output) : Monolit
     /// <summary>
     /// Replicates the exact production pattern the Delete click handler must use:
     /// <c>hub.Post(new DeleteNodeRequest(...)) + hub.RegisterCallback(...)</c>.
-    /// No <c>await</c> on the delete path â€” the callback drives a <see cref="TaskCompletionSource{T}"/>
+    /// No <c>await</c> on the delete path — the callback drives a <see cref="TaskCompletionSource{T}"/>
     /// which the test awaits at the xunit boundary only. A blocked hub cannot produce a callback,
     /// so the 10 s WaitAsync guard fails the test instead of hanging forever.
     /// </summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteNodeBehaviorTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteNodeBehaviorTest.cs
@@ -19,17 +19,17 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <summary>
 /// Comprehensive coverage for the four-phase <see cref="DeleteNodeRequest"/> orchestrator:
 /// <list type="number">
-/// <item><description><b>Collect</b> â€” root + (recursive) descendants.</description></item>
-/// <item><description><b>Permission</b> â€” every node must have <see cref="Permission.Delete"/>.</description></item>
-/// <item><description><b>Validate</b> â€” per-node <see cref="INodeValidator"/> chain;
+/// <item><description><b>Collect</b> — root + (recursive) descendants.</description></item>
+/// <item><description><b>Permission</b> — every node must have <see cref="Permission.Delete"/>.</description></item>
+/// <item><description><b>Validate</b> — per-node <see cref="INodeValidator"/> chain;
 /// errors block; warnings block without <see cref="DeleteNodeRequest.ConfirmWarnings"/>.</description></item>
-/// <item><description><b>Commit</b> â€” bulk delete via storage adapter; all-or-nothing.</description></item>
+/// <item><description><b>Commit</b> — bulk delete via storage adapter; all-or-nothing.</description></item>
 /// </list>
 ///
 /// Negative paths each assert (a) the correct <see cref="NodeDeletionRejectionReason"/>
 /// and (b) that the <see cref="DeleteNodeResponse.Log"/> <see cref="ActivityLog"/>
 /// lists every offending path so the UI can show the full picture. Positive paths
-/// additionally verify that the deletion was atomic â€” nothing is written to storage
+/// additionally verify that the deletion was atomic — nothing is written to storage
 /// on a blocked delete, and on success every path really is gone.
 ///
 /// Fully reactive: a <see cref="DeleteNodeRequest"/> round-trip is observed via
@@ -44,7 +44,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
 
     private static readonly string Root = TestPartition + "/delparent";
 
-    // â”€â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Helpers ───────────────────────────────────────────────────────────
 
     private async Task SeedTree()
     {
@@ -120,7 +120,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
     private static bool LogMentions(DeleteNodeResponse r, string path) =>
         r.Log?.Messages.Any(m => m.Message.Contains(path, StringComparison.Ordinal)) == true;
 
-    // â”€â”€â”€ Phase 1: collection + basic reasons â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Phase 1: collection + basic reasons ──────────────────────────────
 
     [Fact(Timeout = 20_000)]
     public async Task Leaf_Delete_SucceedsAndRemovesNode()
@@ -197,7 +197,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
         response.Log.Messages.Should().Contain(m => m.Message.Contains("not found"));
     }
 
-    // â”€â”€â”€ Phase 2: permission checks â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Phase 2: permission checks ────────────────────────────────────────
 
     [Fact(Timeout = 20_000)]
     public async Task NoDeletePermission_OnRoot_Fails_Unauthorized_AndLogsPath()
@@ -206,7 +206,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
             new MeshNode("locked", TestPartition) { Name = "Locked", NodeType = "Markdown" })
             .Should().Within(30.Seconds()).Emit();
 
-        // Dedicated client hub whose AccessService is scoped to nobody â€”
+        // Dedicated client hub whose AccessService is scoped to nobody —
         // the access context flows with the outbound message as Sender identity.
         var restrictedClient = GetClient();
         var clientAccess = restrictedClient.ServiceProvider.GetRequiredService<AccessService>();
@@ -221,9 +221,9 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
         var path = $"{TestPartition}/locked";
 
         // The [RequiresPermission(Permission.Delete)] gate on DeleteNodeRequest runs at the
-        // envelope layer and denies without invoking the handler â€” the observable OnErrors
+        // envelope layer and denies without invoking the handler — the observable OnErrors
         // with a DeliveryFailure. Either that, or the in-handler Phase 2 check fires and we
-        // get a DeleteNodeResponse.Fail â€” the invariant that matters for this test is: no
+        // get a DeleteNodeResponse.Fail — the invariant that matters for this test is: no
         // matter which gate trips, the node is NOT deleted. Materialize folds either outcome
         // (OnNext failed-response OR OnError) into a value we can assert reactively.
         var notification = await restrictedClient
@@ -246,7 +246,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
                 "denial must produce either a failed response or a DeliveryFailureException");
         }
 
-        // Restore admin context so the existence check can actually see the node â€”
+        // Restore admin context so the existence check can actually see the node —
         // the shared AccessService singleton was flipped to nodelete-user above and
         // MeshQuery applies RLS.
         clientAccess.SetHostIdentity(TestUsers.Admin);
@@ -255,7 +255,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
             "node must not be deleted when caller lacks Delete permission");
     }
 
-    // â”€â”€â”€ Phase 3: validator-based rejection â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Phase 3: validator-based rejection ──────────────────────────────
 
     [Fact(Timeout = 20_000)]
     public async Task Validator_RejectsRoot_Fails_ValidationFailed_LogsNodePath()
@@ -319,7 +319,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
         }, System.Text.Json.JsonSerializerOptions.Default);
     }
 
-    // â”€â”€â”€ Phase 3: warnings + ConfirmWarnings round-trip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Phase 3: warnings + ConfirmWarnings round-trip ────────────────────
 
     [Fact(Timeout = 20_000)]
     public async Task Warnings_WithoutConfirm_Block_AndLogWarning()
@@ -365,7 +365,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
         await WaitForNodeAbsence($"{TestPartition}/warny2");
     }
 
-    // â”€â”€â”€ Phase 4: bulk atomicity + ActivityLog â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Phase 4: bulk atomicity + ActivityLog ─────────────────────────────
 
     [Fact(Timeout = 20_000)]
     public async Task Recursive_Delete_Log_ListsAllAffectedPathsAndSucceeded()
@@ -380,7 +380,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
         response.Log.Start.Should().BeBefore(response.Log.End!.Value);
     }
 
-    // â”€â”€â”€ Custom test validators (wired in ConfigureMesh) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ─── Custom test validators (wired in ConfigureMesh) ──────────────────
 
     public sealed class BlockingValidator : INodeValidator
     {
@@ -414,7 +414,7 @@ public class DeleteNodeBehaviorTest(ITestOutputHelper output) : MonolithMeshTest
     }
 
     /// <summary>
-    /// Use <see cref="ConfigureMeshBase"/> (no root-level Publicâ†’Admin) so the
+    /// Use <see cref="ConfigureMeshBase"/> (no root-level Public→Admin) so the
     /// permission-denied test can actually observe a denial. The admin user gets
     /// explicit access via <see cref="SetupAccessRightsAsync"/>.
     /// </summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
@@ -341,7 +341,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         moved!.Path.Should().Be(dst);
         moved.Name.Should().Be("Move Test");
 
-        // Catalog-bound wait Ã¢â‚¬â€ ReadNode(src) would falsely succeed via the
+        // Catalog-bound wait — ReadNode(src) would falsely succeed via the
         // TestPartition ancestor's MeshNodeReference reducer.
         var paths = await WaitForQueryPathSet(subtreeQuery,
             set => !set.Contains(src) && set.Contains(dst));
@@ -435,7 +435,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         response.Message.Node.Should().NotBeNull();
         response.Message.Node!.Path.Should().Be(dst);
 
-        // Catalog-bound check Ã¢â‚¬â€ ReadNode on src would falsely succeed via
+        // Catalog-bound check — ReadNode on src would falsely succeed via
         // the TestPartition ancestor.
         var paths = await WaitForQueryPathSet(subtreeQuery,
             set => !set.Contains(src) && set.Contains(dst));
@@ -668,7 +668,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         foreach (var node in nodes)
             Output.WriteLine($"Found with namespace: {node.Path}");
 
-        // Assert: namespace: only checks 1 level deep Ã¢â‚¬â€ Code nodes are at depth 2 (ACME/Project/Source/id)
+        // Assert: namespace: only checks 1 level deep — Code nodes are at depth 2 (ACME/Project/Source/id)
         nodes.Should().BeEmpty("namespace: only finds immediate children; Code nodes are 2 levels deep");
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPullActionsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPullActionsTest.cs
@@ -19,18 +19,18 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <summary>
 /// Compile-guard test for the <c>LinkedInPullActions</c> Code piece that lives
 /// under <c>Systemorph/LinkedInProfile/Source/</c> in the production mesh. The
-/// body inlined here is the authoritative production source â€” keep it in
+/// body inlined here is the authoritative production source — keep it in
 /// lockstep so any drift (missing <c>using</c>, syntax slip, wrong interface
 /// shape) fails CI instead of the user-facing LinkedIn dashboard.
 ///
 /// Regression for 2026-04-22 incident: the Code piece shipped without
 /// <c>using System.Threading.Tasks;</c>, the <c>Task</c>/<c>Task&lt;&gt;</c>
 /// helper method signatures failed to resolve, and the whole NodeType stopped
-/// compiling â€” the dashboard rendered the raw compiler diagnostic.
+/// compiling — the dashboard rendered the raw compiler diagnostic.
 /// </summary>
 public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     private const string NodeTypePath = "Systemorph/LinkedInProfile";
@@ -41,7 +41,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
     {
         var workspace = Mesh.GetWorkspace();
 
-        // Register the NodeType with the PullPastPosts layout area wired in â€”
+        // Register the NodeType with the PullPastPosts layout area wired in —
         // this is the exact Configuration string that lives in prod.
         await NodeFactory.CreateNode(new MeshNode("LinkedInProfile", "Systemorph")
         {
@@ -59,14 +59,14 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
 
         // Wait for the kickoff compile to settle BEFORE adding sources +
         // triggering. The per-NodeType hub's `InstallCompileWatcher` runs its
-        // one-shot kickoff the moment the hub activates â€” long before any
+        // one-shot kickoff the moment the hub activates — long before any
         // `CreateCodeAsync` lands, so the kickoff Roslyn compiles the
         // Configuration string against an empty source set and either errors
         // out or produces an assembly missing `LinkedInPullActions`.
         //
-        // ðŸš¨ Why this matters for the trigger: if `RequestedReleaseAt` is
+        // 🚨 Why this matters for the trigger: if `RequestedReleaseAt` is
         // written while kickoff `Status == Compiling`, `ReleaseRequestWatcher`'s
-        // status guard absorbs the trigger â€” it stamps
+        // status guard absorbs the trigger — it stamps
         // `LastReleaseRequestHandledAt` but keeps Status at Compiling (no
         // fresh Pending flip), so no second compile ever fires. The
         // watermark wait below then matches against the kickoff's release
@@ -77,7 +77,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
         // 2026-05-21 (prod EventCalendar regression). With no kickoff the
         // NodeType created above sits in Status=null until the test
         // explicitly drives a compile via RequestedReleaseAt below. No
-        // initial-state wait is needed â€” just plant the sources and
+        // initial-state wait is needed — just plant the sources and
         // trigger the watcher.
 
         await CreateCode("LinkedInProfile", LinkedInProfileSource).Should().Within(30.Seconds()).Emit();
@@ -86,7 +86,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
         // Trigger an explicit recompile AFTER kickoff settled AND both source
         // nodes exist. `RequestedReleaseAt > LastReleaseRequestHandledAt` is
         // observed by `InstallReleaseRequestWatcher`; with Status now
-        // Ok/Error (not Compiling) the watcher flips Pending â†’ the compile
+        // Ok/Error (not Compiling) the watcher flips Pending → the compile
         // pipeline runs Roslyn against the now-visible Code sources.
         var triggerAt = DateTimeOffset.UtcNow;
         await workspace.GetMeshNodeStream(NodeTypePath).Update(curr =>
@@ -104,7 +104,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
 
         // Wait for the compile that handled this trigger to settle on Ok with
         // a release path. The handled-at watermark + Ok status guarantees the
-        // currently-active release was produced by THIS trigger â€” not the
+        // currently-active release was produced by THIS trigger — not the
         // kickoff release we explicitly invalidated by re-triggering.
         await workspace.GetMeshNodeStream(NodeTypePath)
             .Should().Within(60.Seconds())
@@ -129,7 +129,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
         // Render the PullPastPosts area. In the test mesh LinkedInPublisher is
         // NOT registered in DI, so the area hits its "publisher is null" branch
         // and returns a MarkdownControl describing the missing dependency.
-        // That branch still exercises the full compile of the Code piece â€”
+        // That branch still exercises the full compile of the Code piece —
         // which is what we're guarding.
         var control = await RenderArea(instancePath, "PullPastPosts");
 
@@ -155,7 +155,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(path), reference);
 
-        // Match the LinkedInTelemetry / CompilationPending timeout budget â€”
+        // Match the LinkedInTelemetry / CompilationPending timeout budget —
         // 60s caps below the cold-cache compile + activation pipeline on CI.
         var control = await stream
             .GetControlStream(reference.Area!)
@@ -275,7 +275,7 @@ public class LinkedInPullActionsTest(ITestOutputHelper output) : MonolithMeshTes
             {
                 var t = (text ?? "").ReplaceLineEndings(" ").Trim();
                 if (t.Length == 0) return "(untitled)";
-                return t.Length > 80 ? t[..80] + "â€¦" : t;
+                return t.Length > 80 ? t[..80] + "…" : t;
             }
         }
         """;

--- a/test/MeshWeaver.Hosting.Monolith.Test/LinkedInTelemetryImportTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LinkedInTelemetryImportTest.cs
@@ -25,29 +25,29 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 ///
 /// Regression for 2026-04-23 incident: the Code piece shipped a broken
 /// <c>string.Join</c> call that hit the new .NET 9 params-Span overload
-/// ambiguity â€” the entire LinkedInProfile NodeType stopped compiling and the
+/// ambiguity — the entire LinkedInProfile NodeType stopped compiling and the
 /// dashboard rendered the raw compiler diagnostic. The existing
 /// <c>LinkedInProfileLayoutAreaTest</c> only covered the simpler stub source
 /// so it stayed green while prod broke.
 ///
 /// The body inlined in <see cref="LinkedInTelemetryImportSource"/> below is the
-/// authoritative production source â€” keep it in lockstep with the Code piece.
+/// authoritative production source — keep it in lockstep with the Code piece.
 /// </summary>
 public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    /// <summary>Share Mesh/SP across [Fact]s â€” see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
     protected override bool ShareMeshAcrossTests => true;
 
     // The reactive `.Should().Within(...)` waits below add up to the cold-cache
-    // compile wait (45 s) + the post-compile render wait (45 s) â€” the instance
+    // compile wait (45 s) + the post-compile render wait (45 s) — the instance
     // hub's cold activation (assembly load from the FileSystemAssemblyStore +
     // applying the compiled NodeType Configuration that registers the
     // ImportTelemetry view) is the slow leg on a cold CI agent, so the render
     // wait must be as generous as the compile wait. Widen the dispose watchdog
     // deadlines past that worst case (90 s of waits) so a legitimately slow
     // Roslyn/activation cold start isn't reported as a hung test by DisposeAsync.
-    // ðŸš¨ The [Fact(Timeout=â€¦)] below MUST exceed the SUM of the internal waits
-    // (and sit at/under TestHardDeadline) â€” a 60 s cap fired BEFORE the render
+    // 🚨 The [Fact(Timeout=…)] below MUST exceed the SUM of the internal waits
+    // (and sit at/under TestHardDeadline) — a 60 s cap fired BEFORE the render
     // wait could complete on CI, killing the test mid-activation (the prior
     // 26721963847 failure at the render wait). Keep these three in lockstep.
     protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(110);
@@ -59,10 +59,10 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
     // Per-session cache directory so a stale Systemorph_LinkedInProfile.dll
     // locked by a prior test process can't break compilation. The default
     // bin/.mesh-cache is shared across runs and triggers
-    // UnauthorizedAccessException â†’ IOException("file is being used by
+    // UnauthorizedAccessException → IOException("file is being used by
     // another process") on Windows, after which the dynamic LayoutAreas
     // piece never compiles and Overview falls back to an empty render.
-    // Stable cache directory â€” the timestamped-subdir cache (a3ab9909e)
+    // Stable cache directory — the timestamped-subdir cache (a3ab9909e)
     // gives each compile its own subdir so prior-process DLLs aren't touched.
     private static readonly string CacheDirectory = System.IO.Path.Combine(
         System.IO.Path.GetTempPath(),
@@ -114,7 +114,7 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
             }
         }).Should().Emit();
 
-        // ðŸš¨ Race workaround: wait for the NodeType compile to reach a terminal
+        // 🚨 Race workaround: wait for the NodeType compile to reach a terminal
         // status BEFORE opening the area's GetRemoteStream. The LayoutAreaHost's
         // WithInitialization fires asynchronously via a posted InitializeHubRequest
         // (LayoutAreaHost.cs:140); if the client's SubscribeRequest is processed
@@ -124,7 +124,7 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
         // beforehand ensures the per-instance hub + LayoutAreaHost are fully
         // initialised when the test's own subscription lands. Framework-level
         // fix needs the SubscribeRequest reply to await init completion.
-        // 45 s budget for the Roslyn cold-cache compile â€” a cold CI agent (or a
+        // 45 s budget for the Roslyn cold-cache compile — a cold CI agent (or a
         // cold local run) can take that long before the NodeType reaches a terminal
         // CompilationStatus. The class soft/hard deadlines above are widened to give
         // this legitimately-slow path room.
@@ -134,7 +134,7 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
                 && (d.CompilationStatus == CompilationStatus.Ok
                     || d.CompilationStatus == CompilationStatus.Error));
 
-        // The NodeType must compile cleanly â€” render the Import area to trigger
+        // The NodeType must compile cleanly — render the Import area to trigger
         // the compile, then assert we got back a Stack containing the form.
         var control = await RenderArea(instancePath, "ImportTelemetry");
 
@@ -173,9 +173,9 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
         var control = await stream
             .GetControlStream(reference.Area!)
             .Do(c => Output.WriteLine($"[{DateTime.UtcNow:O}] GetControlStream emission: {c?.GetType().Name ?? "null"}"))
-            // 45 s (was 25 s): the cold instance-hub activation â€” assembly load
+            // 45 s (was 25 s): the cold instance-hub activation — assembly load
             // from the FileSystemAssemblyStore plus applying the compiled NodeType
-            // Configuration that registers ImportTelemetry â€” is the slow leg on a
+            // Configuration that registers ImportTelemetry — is the slow leg on a
             // cold CI agent and overran 25 s (CI 26721963847 failed exactly here).
             // The [Fact] timeout + class deadlines above are widened to keep this
             // generous render budget inside the test's hard cap.
@@ -349,7 +349,7 @@ public class LinkedInTelemetryImportTest(ITestOutputHelper output) : MonolithMes
                     catch { skipped++; }
 
                     reportProgress:
-                    // Report progress every row for the first 10, then every 5th â€” keeps the
+                    // Report progress every row for the first 10, then every 5th — keeps the
                     // UI responsive without flooding the data stream on huge CSVs.
                     if (i <= 10 || i % 5 == 0)
                     {

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
@@ -94,12 +94,12 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
     [Fact]
     public async Task CreateNode_PathResolverFindsIt()
     {
-        // Resolve before create Ã¢â‚¬â€ should not find it
+        // Resolve before create — should not find it
         var before = await PathResolver.ResolvePath("feed-resolve-1").Should().Emit();
 
         await CreateTestNode("feed-resolve-1");
 
-        // After create Ã¢â‚¬â€ cache was invalidated/pre-warmed by change event
+        // After create — cache was invalidated/pre-warmed by change event
         var after = await PathResolver.ResolvePath("feed-resolve-1").Should().Emit();
         after.Should().NotBeNull();
         after!.Prefix.Should().Contain("feed-resolve-1");
@@ -117,7 +117,7 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
 
         await DeleteTestNode(created.Path);
 
-        // After delete Ã¢â‚¬â€ cache evicted, resolver should not find it at that exact path
+        // After delete — cache evicted, resolver should not find it at that exact path
         var gone = await PathResolver.ResolvePath(created.Path).Should().Emit();
         (gone == null || gone.Prefix != created.Path).Should().BeTrue(
             "deleted node should not resolve to its exact path");
@@ -129,7 +129,7 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
         // Create parent
         var parent = await CreateTestNode("nest-parent-1");
 
-        // Resolve nested path Ã¢â‚¬â€ caches partial match (parent with remainder)
+        // Resolve nested path — caches partial match (parent with remainder)
         var partial = await PathResolver.ResolvePath($"{parent.Path}/nest-child-1").Should().Emit();
 
         // Create child

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeAuditingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeAuditingTest.cs
@@ -85,9 +85,9 @@ public class MeshNodeAuditingTest(ITestOutputHelper output) : MonolithMeshTestBa
         }
 
         updated.CreatedDate.Should().Be(originalCreatedDate,
-            "CreatedDate is immutable â€” only LastModified should move");
+            "CreatedDate is immutable — only LastModified should move");
         updated.CreatedBy.Should().Be("alice@example.com",
-            "CreatedBy is immutable â€” reflects the original author");
+            "CreatedBy is immutable — reflects the original author");
         updated.LastModifiedBy.Should().Be("bob@example.com",
             "UpdatedBy in the request stamps LastModifiedBy on the node");
         updated.LastModified.Should().BeAfter(originalCreatedDate,

--- a/test/MeshWeaver.Hosting.Monolith.Test/UserActivityAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/UserActivityAreaTest.cs
@@ -93,7 +93,7 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
         var typeNode = Mesh.ServiceProvider.FindStaticNode("User");
         typeNode.Should().NotBeNull("User node type should be registered as a static node");
         typeNode!.HubConfiguration.Should().NotBeNull(
-            "User node type should be registered via AddGraph() Ã¢â€ â€™ AddUserType() with HubConfiguration");
+            "User node type should be registered via AddGraph() → AddUserType() with HubConfiguration");
     }
 
     /// <summary>
@@ -120,7 +120,7 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
         node.Should().NotBeNull("Oliver user node should exist in samples/Graph/Data/User/TestUser.json");
         node!.NodeType.Should().Be("User");
 
-        // Enrich with node type Ã¢â‚¬â€ this should attach HubConfiguration
+        // Enrich with node type — this should attach HubConfiguration
         var enriched = await resolver.ResolveConfiguration(node).Should().Emit();
         enriched.HubConfiguration.Should().NotBeNull(
             "After resolution, User node should have HubConfiguration from UserNodeType");
@@ -165,7 +165,7 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
         var value = await stream.Should().Within(TimeSpan.FromSeconds(15)).Emit();
 
         value.Should().NotBe(default(JsonElement),
-            "Activity area should render for User/TestUser Ã¢â‚¬â€ AddUserActivityViews() must be invoked");
+            "Activity area should render for User/TestUser — AddUserActivityViews() must be invoked");
     }
 
     /// <summary>
@@ -221,12 +221,12 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
     /// <summary>
     /// Simulates the production onboarding flow: creates a User node at runtime
     /// (not pre-registered via AddMeshNodes), then verifies the Activity area resolves.
-    /// This tests the path: persistence Ã¢â€ â€™ MeshCatalog.ResolvePathAsync Ã¢â€ â€™ routing Ã¢â€ â€™ hub creation.
+    /// This tests the path: persistence → MeshCatalog.ResolvePathAsync → routing → hub creation.
     /// </summary>
     [Fact(Timeout = 15000)]
     public async Task ActivityArea_WorksForRuntimeCreatedUser()
     {
-        // Arrange Ã¢â‚¬â€ create a user node at runtime (simulating onboarding)
+        // Arrange — create a user node at runtime (simulating onboarding)
         var username = $"RuntimeUser_{Guid.NewGuid():N}"[..20];
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
@@ -242,7 +242,7 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
             }).Should().Within(15.Seconds()).Emit();
         }
 
-        // Act Ã¢â‚¬â€ request the Activity area (same as Index.razor does)
+        // Act — request the Activity area (same as Index.razor does)
         var client = GetClient();
         var userAddress = new Address("User", username);
 
@@ -260,12 +260,12 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
 
         // Assert
         value.Should().NotBe(default(JsonElement),
-            "Activity area should render for a runtime-created User node Ã¢â‚¬â€ " +
-            "this simulates the production onboarding Ã¢â€ â€™ Index.razor flow");
+            "Activity area should render for a runtime-created User node — " +
+            "this simulates the production onboarding → Index.razor flow");
     }
 
     /// <summary>
-    /// Also verify the Overview area works (baseline Ã¢â‚¬â€ this uses AddDefaultLayoutAreas).
+    /// Also verify the Overview area works (baseline — this uses AddDefaultLayoutAreas).
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task OverviewArea_CanBeResolved_ForUserRoland()
@@ -285,7 +285,7 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
         var value = await stream.Should().Within(TimeSpan.FromSeconds(15)).Emit();
 
         value.Should().NotBe(default(JsonElement),
-            "Overview area should render for User/TestUser Ã¢â‚¬â€ AddDefaultLayoutAreas() must be invoked");
+            "Overview area should render for User/TestUser — AddDefaultLayoutAreas() must be invoked");
     }
 }
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationCompletesFastTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationCompletesFastTest.cs
@@ -18,9 +18,9 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///
 /// <list type="number">
 ///   <item><c>MessageHubGrain.OnActivateAsync</c> only handled <c>onNext</c> and
-///   <c>onError</c> on the activation chain's <c>Subscribe</c> â€” when the source
+///   <c>onError</c> on the activation chain's <c>Subscribe</c> — when the source
 ///   completed without ever emitting a usable node (catalog couldn't find it,
-///   no provider claimed the partition, â€¦), <c>_hubReady</c> stayed pending and
+///   no provider claimed the partition, …), <c>_hubReady</c> stayed pending and
 ///   <c>DeliverMessage</c>'s <c>WaitAsync(30 s)</c> burned the budget.</item>
 ///   <item><c>MeshQuery.MergeProviderObservables</c> subscribed to every
 ///   provider regardless of <see cref="IMeshQueryProvider.Matches"/>, so a
@@ -33,7 +33,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// non-existent path must surface failure within seconds, never the 30 s
 /// grain-timeout window. The old behaviour blocked at exactly 30 000 ms; the
 /// fix surfaces an <c>InvalidOperationException</c> ("No MeshNode resolvable
-/// for address â€¦") within ~1 s.</para>
+/// for address …") within ~1 s.</para>
 /// </summary>
 public class GrainActivationCompletesFastTest(ITestOutputHelper output)
     : OrleansTestBase<DynamicCompilationSiloConfigurator>(output)
@@ -41,7 +41,7 @@ public class GrainActivationCompletesFastTest(ITestOutputHelper output)
     /// <summary>
     /// Caps the test budget well below the 30 s grain <c>WaitAsync</c>. If
     /// activation hangs (the prod symptom), the cancellation token fires inside
-    /// this window and the test fails â€” distinguishing "activation hung"
+    /// this window and the test fails — distinguishing "activation hung"
     /// (CancellationException) from "activation failed cleanly"
     /// (DeliveryFailureException with the new "No MeshNode resolvable" text).
     /// </summary>
@@ -72,23 +72,23 @@ public class GrainActivationCompletesFastTest(ITestOutputHelper output)
                 .ToTask(ct);
         };
 
-        // Two acceptable outcomes â€” both prove the fix:
+        // Two acceptable outcomes — both prove the fix:
         //   * DeliveryFailureException surfaced from the framework's NotFound /
         //     "No MeshNode resolvable" path (the typical shape).
         //   * Plain TimeoutException at the framework's response budget (also
         //     short-circuit-friendly because the grain's _hubReady was failed
         //     before that budget elapsed).
         // What we MUST NOT see is the wall clock crossing the 30 s grain
-        // boundary â€” that's the prod hang signature.
+        // boundary — that's the prod hang signature.
         await act.Should().ThrowAsync<Exception>();
         sw.Stop();
 
         sw.Elapsed.Should().BeLessThan(
             FastFailBudget,
-            "activation against a non-existent path must fail fast (catalog completes empty â†’ " +
-            "_hubReady.TrySetException) â€” never block on the 30 s MessageHubGrain.DeliverMessage " +
+            "activation against a non-existent path must fail fast (catalog completes empty → " +
+            "_hubReady.TrySetException) — never block on the 30 s MessageHubGrain.DeliverMessage " +
             $"WaitAsync. Actual: {sw.Elapsed.TotalSeconds:0.0}s.");
 
-        Output.WriteLine($"PASSED â€” failed in {sw.Elapsed.TotalMilliseconds:0}ms (well under 30 000 ms grain timeout)");
+        Output.WriteLine($"PASSED — failed in {sw.Elapsed.TotalMilliseconds:0}ms (well under 30 000 ms grain timeout)");
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansApiTokenTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansApiTokenTest.cs
@@ -18,8 +18,8 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 
 /// <summary>
 /// Orleans integration test for API token creation and validation.
-/// Uses standard CreateNodeRequest with nodeType=ApiToken Ã¢â‚¬â€ same satellite pattern
-/// as Thread/Comment. The RLS validator maps ApiToken Ã¢â€ â€™ Permission.Api.
+/// Uses standard CreateNodeRequest with nodeType=ApiToken — same satellite pattern
+/// as Thread/Comment. The RLS validator maps ApiToken → Permission.Api.
 /// </summary>
 public class OrleansApiTokenTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
 {
@@ -44,7 +44,7 @@ public class OrleansApiTokenTest(ITestOutputHelper output) : OrleansSharedTestBa
         var hash = ValidateTokenRequest.HashToken(rawToken);
         var hashPrefix = hash[..12];
 
-        // Create token as satellite of User node Ã¢â‚¬â€ same pattern as Thread
+        // Create token as satellite of User node — same pattern as Thread
         var userId = "TestUser";
         var tokenNode = new MeshNode(hashPrefix, $"User/{userId}/_Api")
         {
@@ -62,7 +62,7 @@ public class OrleansApiTokenTest(ITestOutputHelper output) : OrleansSharedTestBa
             }
         };
 
-        // Act Ã¢â‚¬â€ standard CreateNodeRequest (same as Thread creation)
+        // Act — standard CreateNodeRequest (same as Thread creation)
         var response = await client.Observe(new CreateNodeRequest(tokenNode), o => o.WithTarget(meshAddress)).FirstAsync().ToTask(ct);
 
         response.Message.Success.Should().BeTrue(response.Message.Error ?? "");
@@ -92,7 +92,7 @@ public class OrleansApiTokenTest(ITestOutputHelper output) : OrleansSharedTestBa
         }
         catch (Exception)
         {
-            // Expected Ã¢â‚¬â€ grain activation fails because node doesn't exist
+            // Expected — grain activation fails because node doesn't exist
         }
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCacheUpdateMultiSiloTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCacheUpdateMultiSiloTest.cs
@@ -18,11 +18,11 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 
 /// <summary>
 /// Two-silo cluster, no client. The test driver issues
-/// <c>cache.Update</c> against a silo's <see cref="IMeshNodeStreamCache"/> â€”
+/// <c>cache.Update</c> against a silo's <see cref="IMeshNodeStreamCache"/> —
 /// the cache hub's <c>UpdateRemote</c> posts <c>PatchDataRequest</c> to the
 /// owning per-node hub, which Orleans hashes onto one of the two silos.
 ///
-/// <para>This pins the cross-silo path of <c>cache.Update</c> â€” the same flow
+/// <para>This pins the cross-silo path of <c>cache.Update</c> — the same flow
 /// a portal silo exercises when it rotates a credential on a node activated
 /// on a different silo. The previous client-based variant of this test
 /// conflated cross-process notifier scoping with the cache.Update flow.</para>
@@ -72,7 +72,7 @@ public class OrleansCacheUpdateMultiSiloTest : IClassFixture<TwoSiloCacheUpdateF
 
         // 2. Rotate the ApiKey via cache.Update on the silo's
         //    IMeshNodeStreamCache. The cache hub posts PatchDataRequest to
-        //    the per-node hub at providerPath â€” Orleans routes to whichever
+        //    the per-node hub at providerPath — Orleans routes to whichever
         //    silo owns that grain key. With AddAI on both silos the
         //    caller's JsonSerializerOptions know ModelProviderConfiguration,
         //    so the lambda receives typed Content.
@@ -85,7 +85,7 @@ public class OrleansCacheUpdateMultiSiloTest : IClassFixture<TwoSiloCacheUpdateF
         }, siloHub.JsonSerializerOptions)
         .Take(1).Timeout(30.Seconds()).ToTask(ct);
 
-        // 3. Read the node back through GetMeshNodeStream â€” the authoritative
+        // 3. Read the node back through GetMeshNodeStream — the authoritative
         //    single-node primitive. The persistence sampler debounces saves
         //    by ~200 ms, so poll until the sk-rotated value surfaces.
         var workspace = siloHub.GetWorkspace();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansChatTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansChatTest.cs
@@ -28,7 +28,7 @@ using MeshThread = MeshWeaver.AI.Thread;
 
 namespace MeshWeaver.Hosting.Orleans.Test;
 
-// TODO: needs custom shared fixture â€” uses ChatSiloConfigurator with AddFileSystemPersistence(SamplesGraphData),
+// TODO: needs custom shared fixture — uses ChatSiloConfigurator with AddFileSystemPersistence(SamplesGraphData),
 // which the SharedOrleansFixture does not configure.
 /// <summary>
 /// End-to-end chat test on Orleans infrastructure with FileSystem persistence.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCommentTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCommentTest.cs
@@ -26,12 +26,12 @@ using Xunit;
 
 namespace MeshWeaver.Hosting.Orleans.Test;
 
-// TODO: needs custom shared fixture â€” uses CommentSiloConfigurator with AddFileSystemPersistence(SamplesGraphData)
+// TODO: needs custom shared fixture — uses CommentSiloConfigurator with AddFileSystemPersistence(SamplesGraphData)
 // and a CommentClientConfigurator (custom client wiring), which the SharedOrleansFixture does not configure.
 /// <summary>
 /// Orleans integration test for CreateCommentRequest.
 /// Follows the same pattern as OrleansChatTest: GetRemoteStream for reactive verification,
-/// GetDataRequest for content verification â€” no QueryAsync.
+/// GetDataRequest for content verification — no QueryAsync.
 /// </summary>
 public class OrleansCommentTest(ITestOutputHelper output) : TestBase(output)
 {
@@ -128,7 +128,7 @@ public class OrleansCommentTest(ITestOutputHelper output) : TestBase(output)
                 Author = "TestAuthor"
             }, o => o.WithTarget(docAddress)).FirstAsync().ToTask(ct);
 
-        // 2) Verify response (no deadlock â€” handler is non-blocking)
+        // 2) Verify response (no deadlock — handler is non-blocking)
         var commentResponse = response.Message as CreateCommentResponse;
         commentResponse.Should().NotBeNull("Expected CreateCommentResponse, got {0}", response.Message?.GetType().Name ?? "(null)");
         commentResponse!.Success.Should().BeTrue("Error: {0}", commentResponse.Error ?? "");

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationFlowTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationFlowTest.cs
@@ -30,7 +30,7 @@ using MeshThread = MeshWeaver.AI.Thread;
 
 namespace MeshWeaver.Hosting.Orleans.Test;
 
-// TODO: needs custom shared fixture â€” uses DelegationSiloConfigurator with a custom
+// TODO: needs custom shared fixture — uses DelegationSiloConfigurator with a custom
 // DelegationToolFakeChatClientFactory whose tool-calling behavior is essential to the test.
 // Migration would require either swapping the chat factory per-test (violates structural-only
 // rule) or a dedicated shared fixture variant.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationTest.cs
@@ -34,10 +34,10 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// Delegation tests using the PRODUCTION ChatClientAgentFactory pipeline.
 /// The test factory extends ChatClientAgentFactory so delegation tools,
 /// MeshPlugin, and function calling middleware are all registered automatically.
-/// This tests the real delegation flow: agent calls delegate_to_agent â†’
-/// sub-thread created â†’ sub-agent executes â†’ result propagates back.
+/// This tests the real delegation flow: agent calls delegate_to_agent →
+/// sub-thread created → sub-agent executes → result propagates back.
 /// </summary>
-// TODO: needs custom shared fixture â€” uses DelegationProductionSiloConfigurator with
+// TODO: needs custom shared fixture — uses DelegationProductionSiloConfigurator with
 // DelegationTestAgentFactory which extends ChatClientAgentFactory. Per the existing comment,
 // the SwappableChatClientFactory pattern doesn't work for ChatClientAgentFactory subclasses.
 /// <summary>
@@ -249,7 +249,7 @@ public class OrleansDelegationTest(ITestOutputHelper output) : TestBase(output)
 }
 
 /// <summary>
-/// Test factory that extends ChatClientAgentFactory â€” gets delegation tools,
+/// Test factory that extends ChatClientAgentFactory — gets delegation tools,
 /// MeshPlugin, and middleware automatically from the production pipeline.
 /// Only overrides CreateChatClient to return a fake.
 /// </summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansGetDataRequestPropagationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansGetDataRequestPropagationTest.cs
@@ -20,7 +20,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// separate client's repeated <c>GetDataRequest</c> polls?
 ///
 /// <para>
-/// Polling pattern â€” each call creates a fresh per-call reduce stream wrapper.
+/// Polling pattern — each call creates a fresh per-call reduce stream wrapper.
 /// If the framework has a SetCurrentRequest race in the per-call reduce
 /// pipeline, polls return Data=null indefinitely. The monolith counterpart
 /// passes; this checks the Orleans grain boundary doesn't introduce the bug.
@@ -34,7 +34,7 @@ public class OrleansGetDataRequestPropagationTest(ITestOutputHelper output) : Or
         var ct = new CancellationTokenSource(50.Seconds()).Token;
         Output.WriteLine("[test] start");
 
-        // 1. Create node a (plain Markdown â€” same NodeType as the working
+        // 1. Create node a (plain Markdown — same NodeType as the working
         //    Orleans 3-node test). Use a creator client to avoid mixing roles.
         var aId = $"poll-a-{Guid.NewGuid():N}";
         var pathA = $"TestUser/{aId}";
@@ -52,7 +52,7 @@ public class OrleansGetDataRequestPropagationTest(ITestOutputHelper output) : Or
         Output.WriteLine($"[test] CreateNode succeeded: {pathA}");
 
         // 2. Read via polled GetDataRequest from a SEPARATE client. Retry the
-        //    initial read â€” grain activation + MeshDataSource init runs lazily.
+        //    initial read — grain activation + MeshDataSource init runs lazily.
         var reader = GetClient($"reader-{Guid.NewGuid():N}", "TestUser");
         MeshNode? initial = null;
         for (var i = 0; i < 50; i++)

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansGraphDataTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansGraphDataTest.cs
@@ -24,7 +24,7 @@ using Xunit;
 using System.Reactive.Threading.Tasks;
 namespace MeshWeaver.Hosting.Orleans.Test;
 
-// TODO: needs custom shared fixture Ã¢â‚¬â€ uses GraphDataSiloConfigurator with
+// TODO: needs custom shared fixture — uses GraphDataSiloConfigurator with
 // AddFileSystemPersistence(SamplesGraphData), which the SharedOrleansFixture does not configure.
 /// <summary>
 /// Integration tests that verify Orleans routing works end-to-end

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansHostedHubRoutingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansHostedHubRoutingTest.cs
@@ -31,7 +31,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///   <item><see cref="RoutingGrain.RouteMessage"/> resolves the path, gets the
 ///   per-thread <see cref="MessageHubGrain"/>, calls <c>DeliverMessage</c>.</item>
 ///   <item>The grain's hub (configured by Thread's NodeType
-///   <see cref="ThreadNodeType.CreateMeshNode"/> ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ <c>HubConfiguration</c> ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢
+///   <see cref="ThreadNodeType.CreateMeshNode"/> → <c>HubConfiguration</c> →
 ///   <see cref="ThreadExecution.AddThreadExecution"/>) handles the message and
 ///   posts a response.</item>
 ///   <item>The response routes back to the client memory stream and the test
@@ -39,7 +39,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// </list>
 ///
 /// <para>
-/// If this test fails, the basic "post ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ per-grain hub ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ response" round trip
+/// If this test fails, the basic "post → per-grain hub → response" round trip
 /// is broken. Many of the 17 ailing Orleans tests build on top of this round
 /// trip, so a green here is the prerequisite for diagnosing them.
 /// </para>
@@ -51,7 +51,7 @@ public class OrleansHostedHubRoutingTest(ITestOutputHelper output) : OrleansShar
 
     /// <summary>
     /// Foundation: the per-thread grain hub answers a request that has a synchronous
-    /// handler. Proves "client ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Orleans routing ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ per-grain hub ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ ResponseFor"
+    /// handler. Proves "client → Orleans routing → per-grain hub → ResponseFor"
     /// works end-to-end without any LLM, hosted-sub-hub, or watcher in the picture.
     /// </summary>
     [Fact]
@@ -62,7 +62,7 @@ public class OrleansHostedHubRoutingTest(ITestOutputHelper output) : OrleansShar
 
         // 1. Create the Thread node so the per-thread grain has something to activate
         //    against. Use BuildThreadNode (NOT BuildThreadWithMessages) so no auto-execute
-        //    fires ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â we only want the hub to come up with the Thread NodeType's
+        //    fires — we only want the hub to come up with the Thread NodeType's
         //    HubConfiguration applied.
         var threadNode = ThreadNodeType.BuildThreadNode("TestUser", "Routing test (no LLM)", "TestUser");
         var threadPath = threadNode.Path!;
@@ -74,10 +74,10 @@ public class OrleansHostedHubRoutingTest(ITestOutputHelper output) : OrleansShar
             .FirstAsync().ToTask(ct);
         createResp.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
 
-        // 2. Post GetDataRequest at the per-thread address â€” generic round-trip
+        // 2. Post GetDataRequest at the per-thread address — generic round-trip
         //    that exercises the same routing layer and returns a response from
         //    the per-thread grain. Replaces the legacy MeshThread.RequestedCancellationAt flip
-        //    routing test (cancellation is now stream-update only â€” see
+        //    routing test (cancellation is now stream-update only — see
         //    RequestViaStreamUpdate.md).
         Output.WriteLine($"[Act] Posting GetDataRequest to {threadPath}");
         var response = await client.Observe(
@@ -105,7 +105,7 @@ public class OrleansHostedHubRoutingTest(ITestOutputHelper output) : OrleansShar
     /// on the Thread hub by <see cref="ThreadExecution.AddThreadExecution"/>. The handler
     /// calls <c>UpdateMeshNode</c> to push the new message id onto <see cref="MeshThread.Messages"/>
     /// and then posts a response. After the response arrives, a fresh GetDataRequest must
-    /// see the appended message id ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â if it doesn't, the per-grain workspace's
+    /// see the appended message id — if it doesn't, the per-grain workspace's
     /// <see cref="MeshNodeReference"/> reducer is not picking up local writes (which is
     /// the suspected root cause of the 17 polling-based test failures).
     /// </para>
@@ -137,7 +137,7 @@ public class OrleansHostedHubRoutingTest(ITestOutputHelper output) : OrleansShar
         //    HandleSubmitMessage runs `workspace.UpdateMeshNode(...)` to add
         //    the new user + response ids to MeshThread.Messages. Asserting
         //    on Messages.Count growing is the canary for "local workspace
-        //    write visible to grain-direct read" â€” the bug class behind the
+        //    write visible to grain-direct read" — the bug class behind the
         //    polling failures.
         Output.WriteLine("[Act] SubmitMessage");
         client.SubmitMessage(

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansKernelProgressTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansKernelProgressTest.cs
@@ -18,7 +18,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// End-to-end coverage of a script's logger output propagating through the
 /// <c>ActivityLog</c> stream. A script posted via <see cref="SubmitCodeRequest"/>
 /// calls <c>Log.LogInformation("...")</c>; subscribers to the activity log's
-/// <c>MeshNodeReference</c> stream see each message land â€” same shape as Thread
+/// <c>MeshNodeReference</c> stream see each message land — same shape as Thread
 /// streams.
 ///
 /// Replaces the earlier <c>IProgress&lt;string&gt; Progress</c>-based tests; that

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansMarkdownExportTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansMarkdownExportTest.cs
@@ -28,11 +28,11 @@ using Xunit;
 using System.Reactive.Threading.Tasks;
 namespace MeshWeaver.Hosting.Orleans.Test;
 
-// TODO: needs custom shared fixture â€” uses MarkdownExportSiloConfigurator with AddMarkdownExport(),
+// TODO: needs custom shared fixture — uses MarkdownExportSiloConfigurator with AddMarkdownExport(),
 // which the SharedOrleansFixture does not configure.
 /// <summary>
 /// End-to-end Orleans tests for the markdown PDF / DOCX export pipeline. Exercises the full
-/// cross-hub serialization path: client hub â†’ routing â†’ node hub â†’ handler â†’ response back.
+/// cross-hub serialization path: client hub → routing → node hub → handler → response back.
 /// Regression guard for the InvalidCastException users hit when <c>$type</c> discriminators
 /// disagreed between hubs (full name on server, short name on mesh registry).
 /// </summary>
@@ -154,7 +154,7 @@ public class OrleansMarkdownExportTest(ITestOutputHelper output) : TestBase(outp
 
     /// <summary>
     /// Reproduces the user-facing <c>NotSupportedException</c> from
-    /// <c>LayoutExtensions.GetStream&lt;UiControl&gt;</c> â€” the client hub must deserialize a
+    /// <c>LayoutExtensions.GetStream&lt;UiControl&gt;</c> — the client hub must deserialize a
     /// polymorphic <see cref="UiControl"/> JSON payload whose <c>$type</c> is
     /// <c>ExportDocumentControl</c>. If the client's type registry doesn't know that subtype,
     /// <c>PolymorphicTypeInfoResolver</c> can't build the JsonDerivedType mapping and
@@ -172,7 +172,7 @@ public class OrleansMarkdownExportTest(ITestOutputHelper output) : TestBase(outp
             "# Hello\n\nFor layout-stream test.", cts.Token);
         Output.WriteLine($"Created Markdown node: {nodePath}");
 
-        // Subscribe to the ExportPdf layout area â€” this is what the portal does when the
+        // Subscribe to the ExportPdf layout area — this is what the portal does when the
         // user clicks "Export to PDF". The server renders an ExportDocumentControl; the
         // client must deserialize it as UiControl via PolymorphicTypeInfoResolver.
         var workspace = client.GetWorkspace();
@@ -191,7 +191,7 @@ public class OrleansMarkdownExportTest(ITestOutputHelper output) : TestBase(outp
 
         control.Should().NotBeNull("the ExportPdf area must render a UiControl");
         control.Should().BeOfType<ExportDocumentControl>(
-            "the $type discriminator must resolve to ExportDocumentControl â€” if client " +
+            "the $type discriminator must resolve to ExportDocumentControl — if client " +
             "type-registry is missing the type, deserialization falls back to the base " +
             "UiControl and throws NotSupportedException");
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansMeshChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansMeshChangeFeedTest.cs
@@ -85,7 +85,7 @@ public class OrleansMeshChangeFeedTest(ITestOutputHelper output) : OrleansShared
             data = je.Deserialize<MeshNode>(ClientMesh.JsonSerializerOptions);
         data.Should().NotBeNull("child node should be reachable via routing");
         data!.Path.Should().Be(childPath);
-        Output.WriteLine("PASSED Ã¢â‚¬â€ CreateNode immediately routable");
+        Output.WriteLine("PASSED — CreateNode immediately routable");
     }
 
     /// <summary>
@@ -140,12 +140,12 @@ public class OrleansMeshChangeFeedTest(ITestOutputHelper output) : OrleansShared
         var subThreadPath = await CreateNodeAsync(client, subThreadNode, threadPath, ct);
         Output.WriteLine($"Sub-thread created: {subThreadPath}");
 
-        // NOW submit to the sub-thread Ã¢â‚¬â€ this is where routing failed before
+        // NOW submit to the sub-thread — this is where routing failed before
         // (stale cache sent the request to the parent message grain)
         client.SubmitMessage(
             subThreadPath,
             "Hello sub-thread",
             contextPath: "TestUser");
-            Output.WriteLine("PASSED Ã¢â‚¬â€ sub-thread AppendUserMessage routed correctly");
+            Output.WriteLine("PASSED — sub-thread AppendUserMessage routed correctly");
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansNodeChangePropagationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansNodeChangePropagationTest.cs
@@ -36,15 +36,15 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///
 /// Exercises the FULL production flow:
 /// 1. Client creates a thread (like ThreadChatView.SendMessageAsync)
-/// 2. Client submits a message (ThreadInput.AppendUserInput Ã¢â€ â€™ thread grain)
+/// 2. Client submits a message (ThreadInput.AppendUserInput → thread grain)
 /// 3. Thread grain creates user + response cells via Observable
 /// 4. Execution starts on _Exec hosted hub (streaming loop via InvokeAsync)
-/// 5. Top-level agent calls Create tool (MeshPlugin) Ã¢â€ â€™ NodeChangeEntry generated
-/// 6. Top-level agent delegates to sub-agent Ã¢â€ â€™ sub-thread created, SubmitMessage posted
-/// 7. Sub-agent calls Patch tool Ã¢â€ â€™ NodeChangeEntry generated in sub-thread
-/// 8. Sub-thread completes Ã¢â€ â€™ server-internal SubmitMessageResponse.UpdatedNodes propagates up
-/// 9. Parent merges node changes via ForwardNodeChange Ã¢â€ â€™ aggregated with min/max versions
-/// 10. Parent completes Ã¢â€ â€™ final NodeChangeEntry list on response message
+/// 5. Top-level agent calls Create tool (MeshPlugin) → NodeChangeEntry generated
+/// 6. Top-level agent delegates to sub-agent → sub-thread created, SubmitMessage posted
+/// 7. Sub-agent calls Patch tool → NodeChangeEntry generated in sub-thread
+/// 8. Sub-thread completes → server-internal SubmitMessageResponse.UpdatedNodes propagates up
+/// 9. Parent merges node changes via ForwardNodeChange → aggregated with min/max versions
+/// 10. Parent completes → final NodeChangeEntry list on response message
 ///
 /// This test specifically validates:
 /// - No deadlocks in the delegation chain (execution hub, TCS resolution, callbacks)
@@ -95,28 +95,28 @@ public class OrleansNodeChangePropagationTest(ITestOutputHelper output) : Orlean
             });
 
     /// <summary>
-    /// Full chain: top agent calls Create Ã¢â€ â€™ delegates Ã¢â€ â€™ sub-agent calls Patch Ã¢â€ â€™ NodeChangeEntry propagates.
+    /// Full chain: top agent calls Create → delegates → sub-agent calls Patch → NodeChangeEntry propagates.
     /// Tests for deadlocks: the execution hub (InvokeAsync) blocks during streaming;
     /// delegation TCS resolution must not require the blocked scheduler.
     /// </summary>
     [Fact(Timeout = 60000)]
     public async Task Delegation_NodeChanges_PropagateFromSubThread()
     {
-        // Pull IMessageHub from the silo's container â€” ChatClientAgentFactory needs it
+        // Pull IMessageHub from the silo's container — ChatClientAgentFactory needs it
         // so MeshPlugin tools (Create/Patch/delegate_to_agent) get wired into every test agent.
         var siloHub = ((InProcessSiloHandle)Fixture.Cluster.Silos[0]).SiloHost.Services
             .GetRequiredService<IMessageHub>();
         Fixture.ChatFactory.SetInner(new NodeChangeTestChatClientFactory(siloHub));
         var client = GetClient();
 
-        // 1. Create thread Ã¢â‚¬â€ exactly like ThreadChatView.SendMessageAsync does
+        // 1. Create thread — exactly like ThreadChatView.SendMessageAsync does
         var threadNode = ThreadNodeType.BuildThreadNode("TestUser", "NodeChange propagation test", "TestUser");
         var threadPath = await CreateNode(client, threadNode, "TestUser");
         Output.WriteLine($"Thread created: {threadPath}");
 
         // 2. Messages observed reactively after submit (live replaying stream).
 
-        // 3. Submit message Ã¢â‚¬â€ triggers the ToolCallDelegatingChatClient which:
+        // 3. Submit message — triggers the ToolCallDelegatingChatClient which:
         //    Turn 1: calls Create (creates a Markdown node)
         //    Turn 2: calls delegate_to_agent (Executor)
         //    Turn 3: returns summary text after delegation completes
@@ -125,7 +125,7 @@ public class OrleansNodeChangePropagationTest(ITestOutputHelper output) : Orlean
             threadPath,
             "Create a doc and delegate updates to Executor",
             contextPath: "TestUser");
-            Output.WriteLine("ThreadInput.AppendUserInput succeeded Ã¢â‚¬â€ submission queued");
+            Output.WriteLine("ThreadInput.AppendUserInput succeeded — submission queued");
 
         // 4. Wait for message IDs (live replaying stream — observe after submit)
         var msgIds = await ObserveThreadMessages(client, threadPath)
@@ -133,7 +133,7 @@ public class OrleansNodeChangePropagationTest(ITestOutputHelper output) : Orlean
         msgIds.Should().HaveCount(2);
         Output.WriteLine($"Message IDs: [{string.Join(", ", msgIds)}]");
 
-        // 5. Wait for execution to complete Ã¢â‚¬â€ poll response message
+        // 5. Wait for execution to complete — poll response message
         //    If the delegation chain deadlocks, this times out.
         var responsePath = $"{threadPath}/{msgIds[1]}";
         // Wait until the response cell has tool calls AND text AND the propagated
@@ -215,7 +215,7 @@ public class OrleansNodeChangePropagationTest(ITestOutputHelper output) : Orlean
             "parent response should have aggregated UpdatedNodes from both Create and sub-thread Patch");
         Output.WriteLine($"UpdatedNodes on parent response: {responseMsg.UpdatedNodes.Count} entries");
         foreach (var entry in responseMsg.UpdatedNodes)
-            Output.WriteLine($"  {entry.Operation}: {entry.Path} v{entry.VersionBefore}Ã¢â€ â€™v{entry.VersionAfter}");
+            Output.WriteLine($"  {entry.Operation}: {entry.Path} v{entry.VersionBefore}→v{entry.VersionAfter}");
 
         // The same node (test-doc-nodechange) was Created by parent and Patched by sub-thread.
         // Aggregation should give: min(VersionBefore), max(VersionAfter)
@@ -225,7 +225,7 @@ public class OrleansNodeChangePropagationTest(ITestOutputHelper output) : Orlean
         var docChange = docChanges[0];
         (docChange.VersionAfter ?? 0).Should().BeGreaterThan(docChange.VersionBefore ?? 0,
             "aggregated version should show progression from create to patch");
-        Output.WriteLine($"Aggregated: {docChange.Path} {docChange.Operation} v{docChange.VersionBefore}Ã¢â€ â€™v{docChange.VersionAfter}");
+        Output.WriteLine($"Aggregated: {docChange.Path} {docChange.Operation} v{docChange.VersionBefore}→v{docChange.VersionAfter}");
     }
 
     // Resubmit_AfterExecution_DoesNotDeadlock was split out into its own class
@@ -302,7 +302,7 @@ internal class ToolCallDelegatingChatClient : IChatClient
         IEnumerable<ChatMessage> messages, ChatOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Delegate to non-streaming for simplicity Ã¢â‚¬â€ the framework handles both
+        // Delegate to non-streaming for simplicity — the framework handles both
         var response = await GetResponseAsync(messages, options, cancellationToken);
         var msg = response.Messages.First();
         var functionCalls = msg.Contents.OfType<FunctionCallContent>().ToList();
@@ -404,7 +404,7 @@ internal class PatchToolChatClient : IChatClient
 /// Factory: top-level agents (Navigator/Orchestrator/IsDefault) get
 /// <see cref="ToolCallDelegatingChatClient"/>; sub-agents (Worker/Executor)
 /// get <see cref="PatchToolChatClient"/>. Extends <see cref="ChatClientAgentFactory"/>
-/// so MeshPlugin's Create/Patch/delegate_to_agent tools are wired into every agent â€”
+/// so MeshPlugin's Create/Patch/delegate_to_agent tools are wired into every agent —
 /// otherwise the fake chat clients stream <c>FunctionCallContent</c> for tools the
 /// agent doesn't have and <c>FunctionInvokingChatClient</c> never executes them
 /// (responseMsg.ToolCalls would stay empty).
@@ -461,7 +461,7 @@ public class NodeChangePropagationSiloConfigurator : ISiloConfigurator, IHostCon
         };
         return
         [
-            // Namespace must end in "/_Access" â€” see SecurityService.ComputeScopeRoles.
+            // Namespace must end in "/_Access" — see SecurityService.ComputeScopeRoles.
             new("Public_Access", "User/_Access")
             {
                 NodeType = "AccessAssignment",

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansPortalFlowTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansPortalFlowTest.cs
@@ -17,7 +17,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 
 /// <summary>
 /// Orleans integration: portal/side-panel chat flow end-to-end.
-/// Uses <see cref="ThreadFlow"/> â€” the GUI-shaped static primitives â€” so
+/// Uses <see cref="ThreadFlow"/> — the GUI-shaped static primitives — so
 /// the test stays in lockstep with what the user actually sees. NO inline
 /// re-implementation of the flow.
 ///
@@ -52,7 +52,7 @@ public class OrleansPortalFlowTest(ITestOutputHelper output) : OrleansSharedTest
         Output.WriteLine($"Thread: {threadPath}");
 
         // Step 2: Submit via the GUI path + wait for the round to complete.
-        // ThreadFlow.SubmitAndWait returns the response message id â€”
+        // ThreadFlow.SubmitAndWait returns the response message id —
         // the server-allocated cell at Messages[^1] after IsExecuting flips
         // back to false.
         var responseMsgId = await ThreadFlow.SubmitAndWait(
@@ -62,7 +62,7 @@ public class OrleansPortalFlowTest(ITestOutputHelper output) : OrleansSharedTest
         Output.WriteLine($"Round complete. Response cell: {responseMsgId}");
 
         // Step 3: Verify the cells. Same workspace.GetMeshNodeStream
-        // primitive â€” read via ThreadFlow.ReadMessage.
+        // primitive — read via ThreadFlow.ReadMessage.
         var finalThread = await ThreadFlow.ReadThread(
             client, threadPath,
             t => t.Messages.Count >= 2).FirstAsync().ToTask(ct);
@@ -81,16 +81,16 @@ public class OrleansPortalFlowTest(ITestOutputHelper output) : OrleansSharedTest
 
     /// <summary>
     /// Mimics real user behavior: type and submit several messages rapidly
-    /// in succession. The user doesn't wait for each round to finish â€” they
+    /// in succession. The user doesn't wait for each round to finish — they
     /// pile up. The submission watcher's contract: every pending message
     /// gets ingested into <see cref="MeshThread.Messages"/> with a response.
     ///
     /// Flow:
-    /// 1. Submit msg1 â†’ claim round 1, dispatch
+    /// 1. Submit msg1 → claim round 1, dispatch
     /// 2. Submit msg2 immediately (lands in <see cref="MeshThread.PendingUserMessages"/>
     ///    while round 1 is running)
     /// 3. Submit msg3 immediately (joins the queue)
-    /// 4. Round 1 completes â†’ watcher dispatches round 2 with the entire
+    /// 4. Round 1 completes → watcher dispatches round 2 with the entire
     ///    pending queue drained ([msg2, msg3] share one response cell per
     ///    <see cref="ThreadSubmission.PlanNextRound"/> semantics)
     /// 5. Final state: every submitted text appears as a satellite cell,
@@ -108,7 +108,7 @@ public class OrleansPortalFlowTest(ITestOutputHelper output) : OrleansSharedTest
         var threadPath = createResp.Message.Node!.Path!;
         Output.WriteLine($"Thread: {threadPath}");
 
-        // Rapid-fire three submits â€” mimics a user typing follow-ups
+        // Rapid-fire three submits — mimics a user typing follow-ups
         // without waiting for the agent. Submits 2 + 3 should land in
         // PendingUserMessages while round 1 is still running, then
         // drain into round 2 as a single multi-message round.
@@ -133,7 +133,7 @@ public class OrleansPortalFlowTest(ITestOutputHelper output) : OrleansSharedTest
         Output.WriteLine($"UserMessageIds: [{string.Join(", ", finalThread.UserMessageIds)}]");
 
         // Verify every submitted text is present in the satellite cells.
-        // Reactive Merge across the user-cell streams â€” each stream is the
+        // Reactive Merge across the user-cell streams — each stream is the
         // GUI primitive ThreadFlow.ReadMessage (workspace.GetMeshNodeStream
         // + Where + Take(1)) which completes once the cell text is present.
         // .ToList() aggregates after every stream completes; .FirstAsync()

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubThreadRoutingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubThreadRoutingTest.cs
@@ -144,7 +144,7 @@ public class OrleansSubThreadRoutingTest(ITestOutputHelper output) : OrleansShar
         Output.WriteLine($"Sub-thread created: {createdSubThreadPath}");
         createdSubThreadPath.Should().Be(subThreadPath);
 
-        // 4. Submit message to the sub-thread Ã¢â‚¬â€ this is the critical routing test!
+        // 4. Submit message to the sub-thread — this is the critical routing test!
         // The sub-thread is 6 segments deep. The RoutingGrain must resolve this
         // to the correct grain key and propagate access context.
         var subTwoMessages = ObserveThreadMessages(client, subThreadPath)
@@ -190,7 +190,7 @@ public class OrleansSubThreadRoutingTest(ITestOutputHelper output) : OrleansShar
 
     /// <summary>
     /// Verifies that access context propagates correctly when creating and accessing
-    /// nodes at deeply nested paths. Uses the real submission flow (SubmitMessage Ã¢â€ â€™ cells)
+    /// nodes at deeply nested paths. Uses the real submission flow (SubmitMessage → cells)
     /// to create intermediate nodes, then creates a sub-thread under them.
     /// </summary>
     [Fact(Timeout = 60000)]

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubscribeRequestNotFoundSurfaceTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubscribeRequestNotFoundSurfaceTest.cs
@@ -17,14 +17,14 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///
 /// <para><b>What we pin:</b></para>
 /// <list type="number">
-///   <item><b>Not-found path</b> â€” subscribing to a layout area on a non-existent
+///   <item><b>Not-found path</b> — subscribing to a layout area on a non-existent
 ///   address must surface <c>OnError</c> within a few seconds with a
 ///   "No node found" message, NOT spin forever. Catches the regression where
 ///   <c>RoutingGrain</c> failed to route <c>DeliveryFailure</c> back to the
 ///   portal/client hub before the portal-type early-exit check was added.</item>
-///   <item><b>Success path</b> â€” subscribing to a layout area on an existing address
+///   <item><b>Success path</b> — subscribing to a layout area on an existing address
 ///   (the seeded "TestUser" node) must produce at least one data emission within a
-///   few seconds. Confirms the full "RoutingGrain â†’ MessageHubGrain â†’ layout area"
+///   few seconds. Confirms the full "RoutingGrain → MessageHubGrain → layout area"
 ///   path works before testing the failure case.</item>
 /// </list>
 ///
@@ -32,7 +32,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// The routing paths differ:</para>
 /// <list type="bullet">
 ///   <item>Monolith: <c>RoutingServiceBase.PostNotFound</c> posts directly back
-///   to the caller's hub â€” no cross-process hop.</item>
+///   to the caller's hub — no cross-process hop.</item>
 ///   <item>Orleans: <c>RoutingGrain.RouteMessage</c> returns <see cref="MessageDeliveryState.Failed"/>;
 ///   <c>OrleansRoutingService.DeliverViaGrainAsync</c> reads the failure and calls
 ///   <c>SendDeliveryFailure</c>; the failure must then route from the mesh hub back
@@ -44,12 +44,12 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 public class OrleansSubscribeRequestNotFoundSurfaceTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
 {
     // -------------------------------------------------------------------------
-    // FAILURE path: non-existent address â†’ OnError within a few seconds
+    // FAILURE path: non-existent address → OnError within a few seconds
     // -------------------------------------------------------------------------
 
     /// <summary>
     /// Subscribing to a layout area on a non-existent address must surface
-    /// <c>OnError</c> within a few seconds with a "No node found" message â€”
+    /// <c>OnError</c> within a few seconds with a "No node found" message —
     /// NOT spin forever waiting on the framework's 30 s RequestTimeout. The
     /// test fails closed (20 s timeout on the OnError wait) so a regression
     /// into the swallowed-timeout shape is loud.
@@ -59,7 +59,7 @@ public class OrleansSubscribeRequestNotFoundSurfaceTest(ITestOutputHelper output
     {
         var client = GetClient("notfound-" + Guid.NewGuid().ToString("N")[..8]);
 
-        // Address with NO node at all and no ancestor â€” catalog resolves to null.
+        // Address with NO node at all and no ancestor — catalog resolves to null.
         var address = new Address("doesnotexist", "missing-instance-" + Guid.NewGuid().ToString("N")[..8]);
         var reference = new LayoutAreaReference("Overview");
 
@@ -80,7 +80,7 @@ public class OrleansSubscribeRequestNotFoundSurfaceTest(ITestOutputHelper output
         firstNotification.Kind.Should().Be(NotificationKind.OnError,
             "the stream must surface OnError (not spin) when the target address routes to NotFound. " +
             "If this fails, OrleansRoutingService.SendDeliveryFailure / RoutingGrain is dropping " +
-            "the DeliveryFailure response and the SubscribeRequest's Observe is timing out â€” " +
+            "the DeliveryFailure response and the SubscribeRequest's Observe is timing out — " +
             "exactly the symptom that caused the /rbuergi Orleans endless-spinner regression.");
 
         var captured = firstNotification.Exception;
@@ -95,13 +95,13 @@ public class OrleansSubscribeRequestNotFoundSurfaceTest(ITestOutputHelper output
     }
 
     // -------------------------------------------------------------------------
-    // SUCCESS path: existing address â†’ data within a few seconds
+    // SUCCESS path: existing address → data within a few seconds
     // -------------------------------------------------------------------------
 
     /// <summary>
     /// Subscribing to a layout area on an existing seeded address ("TestUser")
     /// must produce at least one data emission within a few seconds. This confirms
-    /// the full Orleans routing â†’ grain activation â†’ layout area rendering path
+    /// the full Orleans routing → grain activation → layout area rendering path
     /// works, so a failing not-found test can't be blamed on missing plumbing.
     /// </summary>
     [Fact]
@@ -129,6 +129,6 @@ public class OrleansSubscribeRequestNotFoundSurfaceTest(ITestOutputHelper output
             $"expected data from {address}/Overview, got error: {firstNotification.Exception?.Message}");
         firstNotification.Kind.Should().Be(NotificationKind.OnNext,
             "a layout area stream on an existing address must emit data, not hang. " +
-            "If this fails, the Orleans routing â†’ MessageHubGrain activation â†’ layout area path is broken.");
+            "If this fails, the Orleans routing → MessageHubGrain activation → layout area path is broken.");
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreeNodePropagationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreeNodePropagationTest.cs
@@ -22,11 +22,11 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// Topology:
 /// </para>
 /// <code>
-///        a (owning per-grain hub at TestUser/a â€” full mesh-node setup
+///        a (owning per-grain hub at TestUser/a — full mesh-node setup
 ///           via the standard Markdown NodeType: AddMeshDataSource +
 ///           AddDefaultLayoutAreas + persistence)
 ///       / \
-///      â†•   â†•   (two streams: bâ†”a, câ†”a â€” both subscribe to a's MeshNode
+///      ↕   ↕   (two streams: b↔a, c↔a — both subscribe to a's MeshNode
 ///     b     c    via workspace.GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;)
 /// </code>
 ///
@@ -34,21 +34,21 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// Flow under test:
 /// </para>
 /// <list type="number">
-///   <item>Create node <c>a</c> via <c>CreateNodeRequest</c> â€” the routing layer
+///   <item>Create node <c>a</c> via <c>CreateNodeRequest</c> — the routing layer
 ///   activates the per-grain hub with the Markdown NodeType's full configuration.</item>
 ///   <item>Two test clients <c>b</c> and <c>c</c> each open a remote
 ///   <see cref="MeshNodeReference"/> stream to <c>a</c>'s address.</item>
-///   <item>Both receive the initial snapshot â€” proves cross-grain subscription works.</item>
-///   <item><c>c</c> calls <c>.Update(...)</c> on its stream â€” the synchronization
+///   <item>Both receive the initial snapshot — proves cross-grain subscription works.</item>
+///   <item><c>c</c> calls <c>.Update(...)</c> on its stream — the synchronization
 ///   protocol carries the patch through Orleans routing to <c>a</c>'s grain hub.</item>
 ///   <item><c>a</c>'s MeshDataSource validates and applies the patch, then
 ///   broadcasts the change.</item>
-///   <item><c>b</c>'s subscription must observe the new state â€” propagation
+///   <item><c>b</c>'s subscription must observe the new state — propagation
 ///   through the owning grain.</item>
 /// </list>
 ///
 /// <para>
-/// Counterpart: <c>ThreeNodePropagationTest</c> in the monolith suite passes â€”
+/// Counterpart: <c>ThreeNodePropagationTest</c> in the monolith suite passes —
 /// proves the bug is Orleans-specific. This test is the focused canary for
 /// the cross-grain stream propagation cluster.
 /// </para>
@@ -71,7 +71,7 @@ public class OrleansThreeNodePropagationTest(ITestOutputHelper output) : Orleans
         //    first inbound message (the GetRemoteStream subscriptions below).
         //    Using Markdown NodeType pulls in the full mesh-node setup
         //    (AddMeshDataSource + AddDefaultLayoutAreas via ConfigureDefaultNodeHub)
-        //    so the per-grain hub has the complete data layer wired up â€” same
+        //    so the per-grain hub has the complete data layer wired up — same
         //    as production.
         var creator = GetClient($"creator-{Guid.NewGuid():N}", "TestUser");
         var createResp = await creator.Observe(
@@ -109,7 +109,7 @@ public class OrleansThreeNodePropagationTest(ITestOutputHelper output) : Orleans
         await WaitFor(() => { lock (bSnapshots) return bSnapshots.Contains("A0"); }, 20.Seconds(), ct);
         Output.WriteLine($"[b] received initial 'A0'");
 
-        // 7. Wait for c's initial snapshot too â€” needed before .Update so the
+        // 7. Wait for c's initial snapshot too — needed before .Update so the
         //    transform sees the latest current.
         var cSnapshots = new List<string?>();
         using var subC = streamFromC
@@ -130,7 +130,7 @@ public class OrleansThreeNodePropagationTest(ITestOutputHelper output) : Orleans
         streamFromC.Update(current => current with { Name = "A1" })
             .Subscribe(_ => { }, ex => Output.WriteLine($"[c] update error: {ex.Message}"));
 
-        // 9. B's subscription must observe the new state â€” propagation via a's grain.
+        // 9. B's subscription must observe the new state — propagation via a's grain.
         await WaitFor(() => { lock (bSnapshots) return bSnapshots.Contains("A1"); }, 30.Seconds(), ct);
         lock (bSnapshots) bSnapshots.Should().Contain("A1",
             "b's subscription must observe c's update via a's grain broadcast");

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansUserOwnedModelTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansUserOwnedModelTest.cs
@@ -96,7 +96,7 @@ public class OrleansUserOwnedModelTest(ITestOutputHelper output) : OrleansShared
         modelResp.Message.Success.Should().BeTrue(modelResp.Message.Error ?? "");
         modelResp.Message.Node!.Path.Should().Be(modelPath);
 
-        // 3. Verify the resolver can see both nodes â€” read through the
+        // 3. Verify the resolver can see both nodes — read through the
         //    SAME synced query (AgentPickerProjection-shape) that
         //    ChatClientCredentialResolver subscribes to. Asserting via the
         //    resolver's read path means we're testing what the resolver
@@ -171,7 +171,7 @@ public class OrleansUserOwnedModelTest(ITestOutputHelper output) : OrleansShared
             .FirstAsync().ToTask(ct);
 
         // Subscribe to a synced query scoped to the owner's Model subtree
-        // â€” the picker's default scope:selfAndAncestors query walks UP from
+        // — the picker's default scope:selfAndAncestors query walks UP from
         // currentPath, so a sibling subtree like {userId}/Model isn't
         // visible by default. This explicit subtree query is what
         // ChatClientCredentialResolver.WatchPartition uses internally.
@@ -198,7 +198,7 @@ public class OrleansUserOwnedModelTest(ITestOutputHelper output) : OrleansShared
 
     // The rotate-via-cache.Update flow is now exercised by
     // OrleansCacheUpdateMultiSiloTest under a clean 2-silo (no-client)
-    // fixture â€” that mirrors prod, where a silo issues cache.Update against
+    // fixture — that mirrors prod, where a silo issues cache.Update against
     // a node whose owning per-node hub is activated on a different silo.
     // The previous single-silo+client variant of this test conflated
     // cross-process IDataChangeNotifier scoping with the cache.Update flow

--- a/test/MeshWeaver.Hosting.Orleans.Test/PartitionRootActivationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PartitionRootActivationTest.cs
@@ -20,8 +20,8 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// <para>Scenario: a user (or org) partition is registered with the
 /// <see cref="MeshWeaver.Mesh.Services.IPartitionStorageProvider"/> but has
 /// NO MeshNode in the primary <c>mesh_nodes</c> table at the bare partition
-/// path â€” content lives only in satellites (<c>_UserActivity</c>,
-/// <c>_Access</c>, â€¦). The path resolver's storage step returns
+/// path — content lives only in satellites (<c>_UserActivity</c>,
+/// <c>_Access</c>, …). The path resolver's storage step returns
 /// <c>(null, 0)</c>; only the partition-root fallback can produce a
 /// resolution for the bare path.</para>
 ///
@@ -32,7 +32,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// subscribes with <c>Where(r =&gt; r.Node is not null)</c>, so the null-Node
 /// resolution was filtered out, the source observable never emitted,
 /// <c>_hubReady</c> stayed pending forever, and every <c>DeliverMessage</c>
-/// to that grain (the user's home address â€” <c>/rbuergi</c>, <c>/sglauser</c>)
+/// to that grain (the user's home address — <c>/rbuergi</c>, <c>/sglauser</c>)
 /// timed out at exactly 30 s with "Response did not arrive on time".</para>
 ///
 /// <para>This test pings a bare partition path with no MeshNode and asserts
@@ -43,7 +43,7 @@ public class PartitionRootActivationTest(ITestOutputHelper output)
     : OrleansTestBase<PartitionRootSiloConfigurator>(output)
 {
     /// <summary>
-    /// Tight budget â€” pre-fix prod symptom was a 30 s Orleans response timeout
+    /// Tight budget — pre-fix prod symptom was a 30 s Orleans response timeout
     /// because the grain's <c>_hubReady</c> never completed. Post-fix the
     /// activation chain synthesizes a placeholder MeshNode for the partition
     /// root and the ping responds in &lt; 1 s. 5 s leaves comfortable headroom
@@ -68,7 +68,7 @@ public class PartitionRootActivationTest(ITestOutputHelper output)
         // A bare partition-root path. With InMemoryPartitionStorageProvider
         // (the silo's partition provider, registered via
         // AddPartitionedInMemoryPersistence), every non-empty first segment
-        // matches â€” exactly the prod shape after the hosted-service seed
+        // matches — exactly the prod shape after the hosted-service seed
         // pass registers user partitions. No MeshNode is ever written at the
         // bare path; pre-fix this stranded grain activation.
         var partitionRoot = $"partitionroot-{Guid.NewGuid():N}";
@@ -76,7 +76,7 @@ public class PartitionRootActivationTest(ITestOutputHelper output)
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         // Ping the grain at the bare partition path. PingRequest is the
-        // canonical hub-readiness probe â€” handled by the default hub config
+        // canonical hub-readiness probe — handled by the default hub config
         // installed via ConfigureDefaultNodeHub (no NodeType required).
         //
         // The budget is spent via .Timeout(), not a CancellationToken, and the
@@ -107,17 +107,17 @@ public class PartitionRootActivationTest(ITestOutputHelper output)
         // the 30 s Orleans response promise).
         response.Should().NotBeNull(
             "the partition-root fallback must synthesize a MeshNode so MessageHubGrain " +
-            "activates â€” null Node strands activation on Where(r.Node is not null), and " +
+            "activates — null Node strands activation on Where(r.Node is not null), and " +
             "DeliverMessage burns the 30 s Orleans response budget on every request " +
             "(prod symptom: /rbuergi start screen blank, 30 s 'Response did not arrive on time')");
 
         sw.Elapsed.Should().BeLessThan(
             FastBudget,
-            "ping against a bare-partition root must respond fast â€” pre-fix this hung " +
+            "ping against a bare-partition root must respond fast — pre-fix this hung " +
             $"the full 30 s grain timeout. Actual: {sw.Elapsed.TotalSeconds:0.0}s.");
 
         Output.WriteLine(
-            $"PASSED â€” bare partition '{partitionRoot}' activated in {sw.Elapsed.TotalMilliseconds:0}ms");
+            $"PASSED — bare partition '{partitionRoot}' activated in {sw.Elapsed.TotalMilliseconds:0}ms");
     }
 }
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSatelliteFanOutTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSatelliteFanOutTests.cs
@@ -85,7 +85,7 @@ public class CrossPartitionSatelliteFanOutTests
         return partitions;
     }
 
-    // â”€â”€ Thread fan-out â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Thread fan-out ──────────────────────────────────────────────────
 
     [Fact(Timeout = 60000)]
     public async Task NodeTypeThread_WithNamespace_QueriesThreadsTable()
@@ -132,7 +132,7 @@ public class CrossPartitionSatelliteFanOutTests
         allResults.Should().OnlyContain(n => n.NodeType == "Thread");
     }
 
-    // â”€â”€ Comment fan-out â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Comment fan-out ─────────────────────────────────────────────────
 
     [Fact(Timeout = 60000)]
     public async Task NodeTypeComment_WithNamespace_QueriesAnnotationsTable()
@@ -174,7 +174,7 @@ public class CrossPartitionSatelliteFanOutTests
         allComments.Should().OnlyContain(n => n.NodeType == "Comment");
     }
 
-    // â”€â”€ Activity fan-out â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Activity fan-out ────────────────────────────────────────────────
 
     [Fact(Timeout = 60000)]
     public async Task NodeTypeActivity_WithNamespace_QueriesActivitiesTable()
@@ -217,7 +217,7 @@ public class CrossPartitionSatelliteFanOutTests
         allActivities.Should().OnlyContain(n => n.NodeType == "Activity");
     }
 
-    // â”€â”€ Mixed: nodeType without namespace fans out correctly â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Mixed: nodeType without namespace fans out correctly ─────────
 
     [Fact(Timeout = 60000)]
     public async Task NodeTypeOnly_WithoutNamespace_EachPartitionResolvesCorrectTable()
@@ -249,7 +249,7 @@ public class CrossPartitionSatelliteFanOutTests
             State = MeshNodeState.Active,
         }, _options).Should().Within(30.Seconds()).Emit();
 
-        // Query without namespace â€” each adapter should resolve to threads table
+        // Query without namespace — each adapter should resolve to threads table
         var parser = new QueryParser();
         var query = parser.Parse("nodeType:Thread sort:LastModified-desc");
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSearchTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSearchTests.cs
@@ -283,7 +283,7 @@ public class CrossPartitionSearchTests
         }
     }
 
-    // â”€â”€ Stored Procedure: search_across_schemas â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Stored Procedure: search_across_schemas ──────────────────────
 
     [Fact(Timeout = 60000)]
     public async Task StoredProc_SearchAcrossSchemas_ReturnsAllOrgs()
@@ -643,7 +643,7 @@ public class CrossPartitionSearchTests
             new PostgreSqlStorageOptions { ConnectionString = _fixture.ConnectionString },
             partitions: null);
 
-    // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Helpers ──────────────────────────────────────────────────────
 
     private async Task PopulateSearchableSchemasAsync(IEnumerable<string> schemas, CancellationToken ct)
     {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionThreadQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionThreadQueryTests.cs
@@ -23,7 +23,7 @@ public class CrossPartitionThreadQueryTests
 {
     private readonly PostgreSqlFixture _fixture;
 
-    // Must use CamelCase to match hub serialization (Thread.CreatedBy â†’ "createdBy" in JSONB)
+    // Must use CamelCase to match hub serialization (Thread.CreatedBy → "createdBy" in JSONB)
     private readonly JsonSerializerOptions _options = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
@@ -25,7 +25,7 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// giving them full permissions across all partitions.
 ///
 /// Bug: Onboarding.razor was calling AddUserRoleAsync(username, "PlatformAdmin", "Admin", username)
-/// â€” correct namespace but wrong role ("PlatformAdmin" instead of "Admin").
+/// — correct namespace but wrong role ("PlatformAdmin" instead of "Admin").
 /// Fix: AddUserRoleAsync(username, Role.Admin.Id, "Admin", username)
 /// </summary>
 [Collection("PostgreSql")]
@@ -291,7 +291,7 @@ public class FirstUserOnboardingTests
             "here is what made every onboarder a 'first user' (gate bypass + root-grant misfire)");
     }
 
-    // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Helpers ──────────────────────────────────────────────────────
 
     private async Task PopulateSearchableSchemasAsync(IEnumerable<string> schemas, CancellationToken ct)
     {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/GlobalAdminSpaceSearchTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/GlobalAdminSpaceSearchTests.cs
@@ -164,7 +164,7 @@ public class GlobalAdminSpaceSearchTests
             "GammaOrg should be hidden — no partition_access");
     }
 
-    // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Helpers ──────────────────────────────────────────────────────
 
     private async Task PopulateSearchableSchemasAsync(IEnumerable<string> schemas, CancellationToken ct)
     {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ObserveQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ObserveQueryTests.cs
@@ -16,7 +16,7 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// <summary>
 /// Tests that Query correctly receives change notifications
 /// through the full PostgreSQL LISTEN/NOTIFY pipeline:
-/// DB trigger â†’ pg_notify â†’ PostgreSqlChangeListener â†’ DataChangeNotifier â†’ Query
+/// DB trigger → pg_notify → PostgreSqlChangeListener → DataChangeNotifier → Query
 /// </summary>
 [Collection("PostgreSqlIsolated")]
 public class ObserveQueryTests : IAsyncLifetime
@@ -173,7 +173,7 @@ public class ObserveQueryTests : IAsyncLifetime
 
         // Subscribe TWICE on the same stream:
         //   (a) capture the Initial emission for the in-scope sanity check
-        //   (b) filter to emissions actually carrying a Contoso/Team item â€”
+        //   (b) filter to emissions actually carrying a Contoso/Team item —
         //       the assertion target. Counting raw emissions (the old shape)
         //       trips on pg_notify duplicate `Updated` events for in-scope
         //       nodes (Story1 update echoes) that are unrelated to whether
@@ -195,7 +195,7 @@ public class ObserveQueryTests : IAsyncLifetime
         await Task.Delay(1000, TestContext.Current.CancellationToken);
 
         // Assert: the in-scope Initial fired exactly once, and no emission
-        // carried a Contoso/Team item â€” that's the actual scope-filter claim.
+        // carried a Contoso/Team item — that's the actual scope-filter claim.
         initialChanges.Should().ContainSingle();
         initialChanges[0].Items.Should().ContainSingle(n => n.Id == "Story1");
         outOfScopeChanges.Should().BeEmpty(

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/QuerySyntaxTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/QuerySyntaxTests.cs
@@ -357,7 +357,7 @@ public class QuerySyntaxTests
         var meshConfig = new MeshConfiguration(typeNodes);
 
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter, meshConfiguration: meshConfig);
-        // Use "create" context â€” Bug is only excluded from "search", not "create"
+        // Use "create" context — Bug is only excluded from "search", not "create"
         var request = MeshQueryRequest.FromQuery("namespace:ACME/Project context:create");
 
         var results = await CollectResults(query, request);
@@ -463,7 +463,7 @@ public class QuerySyntaxTests
         var results = await CollectResults(query, request);
 
         // 3 stories sorted: Claims Dashboard, Claims Processing, User Authentication
-        // Limit 2 â†’ first two.
+        // Limit 2 → first two.
         results.Should().HaveCount(2);
         results[0].Name.Should().Be("Claims Dashboard");
         results[1].Name.Should().Be("Claims Processing");
@@ -485,14 +485,14 @@ public class QuerySyntaxTests
 
     #endregion
 
-    #region Pipe Alternation (`field:A|B|C`) â€” pushed down as `IN (...)`
+    #region Pipe Alternation (`field:A|B|C`) — pushed down as `IN (...)`
 
     [Fact]
     public async Task PipeAlternation_NodeType_ReturnsAllListedTypes()
     {
         await SeedTestData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
-        // Equivalent to nodeType:(Story OR Bug) â€” concise grep-style form.
+        // Equivalent to nodeType:(Story OR Bug) — concise grep-style form.
         var request = MeshQueryRequest.FromQuery("nodeType:Story|Bug path:ACME scope:descendants");
 
         var results = await CollectResults(query, request);
@@ -528,7 +528,7 @@ public class QuerySyntaxTests
 
         var results = await CollectResults(query, request);
 
-        // Story1 and Bug1 exist; Missing doesn't â€” IN(...) returns the existing two.
+        // Story1 and Bug1 exist; Missing doesn't — IN(...) returns the existing two.
         results.Should().HaveCount(2);
         results.Select(n => n.Path).Should().BeEquivalentTo(
             new[] { "ACME/Project/Story1", "ACME/Project/Bug1" }, JsonSerializerOptions.Default);
@@ -543,7 +543,7 @@ public class QuerySyntaxTests
     {
         await SeedTestData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
-        // Routing-layer canonical form â€” "longest matching path wins" in one
+        // Routing-layer canonical form — "longest matching path wins" in one
         // round-trip. Pin this contract: backends MUST emit ORDER BY length(...)
         // and respect descending direction so MeshCatalog.FindBestPersistenceMatch
         // can rely on a single query for prefix resolution.
@@ -553,7 +553,7 @@ public class QuerySyntaxTests
         var results = await CollectResults(query, request);
 
         // All three exact paths should hit (the 'ACME' top-level node won't exist
-        // since SeedTestDataAsync seeds children only â€” verify ordering of the rest).
+        // since SeedTestDataAsync seeds children only — verify ordering of the rest).
         results.Should().NotBeEmpty();
         // Among the existing results, longest path must come first.
         for (var i = 1; i < results.Count; i++)
@@ -567,7 +567,7 @@ public class QuerySyntaxTests
         await SeedTestData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
         // The single canonical form for routing-layer prefix lookup:
-        // path:a|b|c sort:length(path)-desc limit:1 â†’ one row back, the deepest.
+        // path:a|b|c sort:length(path)-desc limit:1 → one row back, the deepest.
         var request = new MeshQueryRequest
         {
             Query = "path:ACME/Project/Story1|ACME/Project|ACME sort:length(path)-desc",
@@ -585,7 +585,7 @@ public class QuerySyntaxTests
     {
         await SeedTestData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
-        // Generic SQL-function selector â€” verifies the function-call syntax isn't
+        // Generic SQL-function selector — verifies the function-call syntax isn't
         // hard-coded to length() and works for the other allow-listed functions.
         var request = MeshQueryRequest.FromQuery(
             "nodeType:Story sort:lower(name) path:ACME scope:descendants");

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceNamespaceVisibilityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceNamespaceVisibilityTests.cs
@@ -97,7 +97,7 @@ public class SpaceNamespaceVisibilityTests
         await SeedSpace();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
 
-        // This is how the namespace picker queries â€” root-level nodes
+        // This is how the namespace picker queries — root-level nodes
         var request = MeshQueryRequest.FromQuery("namespace:", "alice");
         var results = await Query(query, request);
 
@@ -132,7 +132,7 @@ public class SpaceNamespaceVisibilityTests
         var results = await Query(query, request);
 
         results.Should().Contain(n => n.Path == "Acme",
-            "Space root node must appear in context:create queries â€” " +
+            "Space root node must appear in context:create queries — " +
             "otherwise the namespace picker won't show it");
     }
 }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SyncedQueryPgTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SyncedQueryPgTest.cs
@@ -17,8 +17,8 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// <summary>
 /// Verifies the synced-query pipeline shape used by
 /// <see cref="MeshWeaver.Graph.SyncedQueryMeshNodes"/> works against PostgreSQL:
-/// <c>Query</c> â†’ fold Initial / Added / Updated / Removed into a
-/// path â†’ <see cref="MeshNode"/> dictionary â†’ emit values. PG drives the
+/// <c>Query</c> → fold Initial / Added / Updated / Removed into a
+/// path → <see cref="MeshNode"/> dictionary → emit values. PG drives the
 /// Update / Delete events through pg_notify so we can verify the dict folds
 /// correctly without the in-memory race the MeshQueryEngine exhibits.
 /// </summary>

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadMessageChatTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadMessageChatTests.cs
@@ -364,7 +364,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
             .Should().Within(30.Seconds()).Be(1L);
     }
 
-    #region Query tests â€” verifying PostgreSqlMeshQuery finds threads in satellite tables
+    #region Query tests — verifying PostgreSqlMeshQuery finds threads in satellite tables
 
     /// <summary>
     /// Seeds multiple threads under User/alice/_Thread and verifies that
@@ -377,7 +377,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
         var ct = TestContext.Current.CancellationToken;
 
         // Seed threads with unique ids so the assertion can target them
-        // specifically â€” the schema is shared across tests in this class and
+        // specifically — the schema is shared across tests in this class and
         // other tests write threads under "User/alice/_Thread" too. Filtering
         // by the ids we just wrote keeps this test isolated from sibling
         // accumulation without paying for a per-test schema cleanup.
@@ -409,7 +409,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
 
         var results = await Query(query, request, ct);
 
-        // Filter to the threads we just wrote, then assert specifics â€” the
+        // Filter to the threads we just wrote, then assert specifics — the
         // assertion is now insensitive to other tests' leftover rows.
         var ours = results.Where(n => n.Id == id1 || n.Id == id2).ToList();
         ours.Should().HaveCount(2, "should find both threads in the satellite table");
@@ -419,7 +419,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
 
     /// <summary>
     /// Verifies that "nodeType:Thread" (without namespace) finds threads in
-    /// the satellite table â€” each user sees their own threads only.
+    /// the satellite table — each user sees their own threads only.
     /// </summary>
     [Fact(Timeout = 30000)]
     public async Task QueryThreads_ByNodeTypeOnly_FindsOwnThreads()
@@ -569,11 +569,11 @@ public class ThreadMessageChatTests : IAsyncLifetime
 
     #endregion
 
-    #region User scope visibility tests â€” users see own threads, not others'
+    #region User scope visibility tests — users see own threads, not others'
 
     /// <summary>
     /// Grants a user Admin (full) access on their own User/{userId} scope
-    /// in the effective permissions table â€” same as UserScopeGrantHandler does at runtime.
+    /// in the effective permissions table — same as UserScopeGrantHandler does at runtime.
     /// </summary>
     private async Task GrantUserScopeAsync(string userId, CancellationToken ct)
     {
@@ -613,7 +613,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Bob cannot see Alice's threads â€” the user scope clause restricts visibility
+    /// Bob cannot see Alice's threads — the user scope clause restricts visibility
     /// to User/{userId}/... paths.
     /// </summary>
     [Fact(Timeout = 30000)]
@@ -629,7 +629,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
             Content = new MeshThread()
         }, _options).Should().Within(30.Seconds()).Emit();
 
-        // Query as bob â€” should NOT see alice's thread
+        // Query as bob — should NOT see alice's thread
         var query = new PostgreSqlMeshQuery(_threadAdapter);
         var request = MeshQueryRequest.FromQuery(
             "nodeType:Thread namespace:User/alice/_Thread", userId: "bob");
@@ -682,12 +682,12 @@ public class ThreadMessageChatTests : IAsyncLifetime
 
     #endregion
 
-    #region Path resolution â€” FindBestPrefixMatchAsync for ThreadMessage
+    #region Path resolution — FindBestPrefixMatchAsync for ThreadMessage
 
     /// <summary>
     /// Verifies that FindBestPrefixMatchAsync resolves a ThreadMessage path
     /// to the exact ThreadMessage node (not the parent Thread with remainder).
-    /// This is critical for LayoutAreaView routing â€” the message hub must be
+    /// This is critical for LayoutAreaView routing — the message hub must be
     /// created with ThreadMessage configuration, not Thread configuration.
     /// </summary>
     [Fact(Timeout = 30000)]
@@ -733,7 +733,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
 
     #endregion
 
-    #region End-to-end chat flow â€” simulates HandleSubmitMessage persistence
+    #region End-to-end chat flow — simulates HandleSubmitMessage persistence
 
     /// <summary>
     /// Simulates the full HandleSubmitMessage persistence flow:
@@ -862,7 +862,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
         GetJsonProp(userJson, "role").Should().Be("user");
         GetJsonProp(userJson, "text").Should().Be("Hello from e2e");
 
-        // Response message content â€” should have streamed text
+        // Response message content — should have streamed text
         var respResults = await Query(query, MeshQueryRequest.FromQuery($"path:{threadPath}/{responseMsgId}", userId: "alice"), ct);
         respResults.Should().HaveCount(1);
         var respJson = respResults[0].Content is JsonElement rje ? rje
@@ -883,7 +883,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
         return null;
     }
 
-    #region Table routing â€” Thread and ThreadMessage nodes go to the "threads" table
+    #region Table routing — Thread and ThreadMessage nodes go to the "threads" table
 
     /// <summary>
     /// Verifies that both Thread and ThreadMessage nodes are written to the "threads"
@@ -957,7 +957,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
             .Should().Be(0, "Thread should NOT be in mesh_nodes");
 
         // Read back and verify content (Content arrives as JsonElement since _options
-        // doesn't have the MeshWeaver type registry â€” extract properties directly)
+        // doesn't have the MeshWeaver type registry — extract properties directly)
         var readThread = await _threadAdapter.Read(
             $"{threadNs}/{threadId}", _options).Should().Within(30.Seconds()).Emit();
         readThread.Should().NotBeNull();
@@ -965,7 +965,7 @@ public class ThreadMessageChatTests : IAsyncLifetime
         readThread.Content.Should().NotBeNull("Thread node should have content");
         var threadJson = readThread.Content is JsonElement tje
             ? tje : JsonSerializer.SerializeToElement(readThread.Content, _options);
-        // Property name depends on serializer â€” try camelCase and PascalCase
+        // Property name depends on serializer — try camelCase and PascalCase
         var hasMsgs = threadJson.TryGetProperty("threadMessages", out var msgsEl)
                       || threadJson.TryGetProperty("Messages", out msgsEl);
         hasMsgs.Should().BeTrue("Thread content should have threadMessages/Messages property");

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserActivityCrossPartitionTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserActivityCrossPartitionTests.cs
@@ -16,7 +16,7 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 
 /// <summary>
 /// Tests that UserActivity dashboard queries return results across partitions.
-/// Covers: Latest Threads, Activity Feed, Recently Viewed â€” all of which use
+/// Covers: Latest Threads, Activity Feed, Recently Viewed — all of which use
 /// satellite tables (threads, activities, user_activities) that require
 /// per-partition fan-out instead of the cross-schema stored proc.
 /// </summary>
@@ -299,7 +299,7 @@ public class UserActivityCrossPartitionTests
         return results;
     }
 
-    // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Helpers ──────────────────────────────────────────────────────
 
     private async Task PopulateSearchableSchemasAsync(IEnumerable<string> schemas, CancellationToken ct)
     {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserNamespaceAccessTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserNamespaceAccessTests.cs
@@ -13,7 +13,7 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// <summary>
 /// Tests that access control in the User namespace works correctly with PostgreSQL:
 /// 1) User/<name> (the User node itself) is visible to any authenticated user via public-read.
-/// 2) User/<name>/<subnode> is visible ONLY to the owner (<name>) â€” not to other users.
+/// 2) User/<name>/<subnode> is visible ONLY to the owner (<name>) — not to other users.
 /// 3) When an explicit access grant is added for <subnode>, it becomes visible to others.
 /// </summary>
 [Collection("PostgreSql")]
@@ -103,12 +103,12 @@ public class UserNamespaceAccessTests
         await SeedUserNamespaceData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
 
-        // Bob queries for User/Alice/MyProject â€” should NOT be visible (no access grant)
+        // Bob queries for User/Alice/MyProject — should NOT be visible (no access grant)
         var request = MeshQueryRequest.FromQuery("path:User/Alice/MyProject", "Bob");
         var results = await Query(query, request);
 
         results.Should().BeEmpty(
-            "User/Alice/MyProject should NOT be visible to Bob â€” " +
+            "User/Alice/MyProject should NOT be visible to Bob — " +
             "subnodes under a User namespace require explicit access");
     }
 
@@ -118,7 +118,7 @@ public class UserNamespaceAccessTests
         await SeedUserNamespaceData();
         var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
 
-        // Alice queries for her own subnode â€” should be visible (she has Read on User/Alice)
+        // Alice queries for her own subnode — should be visible (she has Read on User/Alice)
         var request = MeshQueryRequest.FromQuery("path:User/Alice/MyProject", "Alice");
         var results = await Query(query, request);
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserPartitionVisibilityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserPartitionVisibilityTests.cs
@@ -92,7 +92,7 @@ public class UserPartitionVisibilityTests
         var request = MeshQueryRequest.FromQuery("path:User/Alice scope:descendants", "Bob");
         var results = await Query(query, request);
 
-        // Bob should see zero content nodes â€” subnodes require explicit access
+        // Bob should see zero content nodes — subnodes require explicit access
         results
             .Where(n => n.NodeType != "User")
             .Should().BeEmpty("Bob must not see Alice's partition content");

--- a/test/MeshWeaver.Hosting.Test/HttpMeshStorageAdapterTests.cs
+++ b/test/MeshWeaver.Hosting.Test/HttpMeshStorageAdapterTests.cs
@@ -14,7 +14,7 @@ using MeshWeaver.Fixture;
 namespace MeshWeaver.Hosting.Test;
 
 /// <summary>
-/// Tests for <see cref="HttpMeshStorageAdapter"/> â€” verifies the adapter
+/// Tests for <see cref="HttpMeshStorageAdapter"/> — verifies the adapter
 /// correctly translates each <see cref="MeshWeaver.Mesh.Services.IStorageAdapter"/>
 /// method into the right <see cref="IRemoteMeshClient"/> call(s) without ever
 /// hitting an actual HTTP endpoint. The wire-level behaviour of
@@ -135,7 +135,7 @@ public class HttpMeshStorageAdapterTests
             because: "remote-backed adapters have no notion of empty directories");
         stub.SearchCalls.Should().ContainSingle()
             .Which.Should().Be("namespace:rbuergi/Story",
-                because: "scope must be IMMEDIATE children only â€” StorageImporter recurses one level at a time");
+                because: "scope must be IMMEDIATE children only — StorageImporter recurses one level at a time");
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public class HttpMeshStorageAdapterTests
 
         await adapter.SavePartitionObjects("rbuergi", null, [new object()], JsonOptions).Should().Emit();
 
-        // The stub records every call routed through it â€” partitions are no-op,
+        // The stub records every call routed through it — partitions are no-op,
         // so nothing should have hit the remote client.
         stub.GetCalls.Should().BeEmpty();
         stub.CreateCalls.Should().BeEmpty();

--- a/test/MeshWeaver.Hosting.Test/PathRemappingStorageAdapterTests.cs
+++ b/test/MeshWeaver.Hosting.Test/PathRemappingStorageAdapterTests.cs
@@ -15,7 +15,7 @@ using MeshWeaver.Fixture;
 namespace MeshWeaver.Hosting.Test;
 
 /// <summary>
-/// Tests for <see cref="PathRemappingStorageAdapter"/> â€” the
+/// Tests for <see cref="PathRemappingStorageAdapter"/> — the
 /// <see cref="MirrorOperations"/> uses this to push <c>rbuergi/Story</c>
 /// from local to <c>Systemorph/Story</c> on a remote portal. The remapper
 /// rewrites paths on every Read/Write/Delete + adjusts the
@@ -74,7 +74,7 @@ public class PathRemappingStorageAdapterTests
         var adapter = new PathRemappingStorageAdapter(inner, "rbuergi", "Systemorph");
 
         // A satellite node has MainNode pointing at a DIFFERENT path (its parent);
-        // we must NOT blindly rewrite it â€” the parent rename, if any, comes via
+        // we must NOT blindly rewrite it — the parent rename, if any, comes via
         // a separate Write of the parent node itself.
         await adapter.Write(new MeshNode("act-1", "rbuergi/_Activity")
         {
@@ -130,7 +130,7 @@ public class PathRemappingStorageAdapterTests
         var adapter = new PathRemappingStorageAdapter(inner, "rbuergi", "Systemorph");
 
         // Read on something outside the source prefix lands at the same
-        // path on the inner â€” the remapper only relabels its scoped subtree.
+        // path on the inner — the remapper only relabels its scoped subtree.
         await adapter.Read("Doc/Architecture/GrantingAccess", JsonOptions).Should().Emit();
 
         inner.Reads.Should().ContainSingle().Which.Should().Be("Doc/Architecture/GrantingAccess");
@@ -143,7 +143,7 @@ public class PathRemappingStorageAdapterTests
         var adapter = new PathRemappingStorageAdapter(inner, "rbuergi", "Systemorph");
 
         // Reading the root of the source ("rbuergi") should turn into reading
-        // the root of the target ("Systemorph") â€” no double prefix.
+        // the root of the target ("Systemorph") — no double prefix.
         await adapter.Read("rbuergi", JsonOptions).Should().Emit();
 
         inner.Reads.Should().ContainSingle().Which.Should().Be("Systemorph");
@@ -156,7 +156,7 @@ public class PathRemappingStorageAdapterTests
         act.Should().Throw<ArgumentNullException>().WithParameterName("inner");
     }
 
-    /// <summary>Recording stub that captures every call. No-op semantics â€” returns null/empty.</summary>
+    /// <summary>Recording stub that captures every call. No-op semantics — returns null/empty.</summary>
     private sealed class RecordingStorageAdapter : IStorageAdapter
     {
         public List<string> Reads { get; } = new();

--- a/test/MeshWeaver.Layout.Test/InlineEditingTest.cs
+++ b/test/MeshWeaver.Layout.Test/InlineEditingTest.cs
@@ -368,7 +368,7 @@ public class InlineEditingTest(ITestOutputHelper output) : HubTestBase(output)
 
 /// <summary>
 /// Tests for inline editing with actual data persistence via DataChangeRequest.
-/// Verifies the complete flow: UpdatePointer â†’ auto-save â†’ DataChangeRequest â†’ GetDataRequest returns changed value.
+/// Verifies the complete flow: UpdatePointer → auto-save → DataChangeRequest → GetDataRequest returns changed value.
 /// </summary>
 [Collection("InlineEditingPersistenceTests")]
 public class InlineEditingPersistenceTest(ITestOutputHelper output) : HubTestBase(output)

--- a/test/MeshWeaver.MathDemo.Test/MatrixViewsTest.cs
+++ b/test/MeshWeaver.MathDemo.Test/MatrixViewsTest.cs
@@ -23,7 +23,7 @@ namespace MeshWeaver.MathDemo.Test;
 /// <summary>
 /// End-to-end test for the MathDemo/Matrix sample. Exercises dynamic node-type compilation
 /// with a <c>#r "nuget:MathNet.Numerics, ..."</c> directive and renders the compiled
-/// <c>Inverse</c> layout area against a real client â€” the same path the portal uses.
+/// <c>Inverse</c> layout area against a real client — the same path the portal uses.
 ///
 /// Requires network access to api.nuget.org on first run; the persistent NuGet cache makes
 /// subsequent runs instant.
@@ -80,7 +80,7 @@ public class MatrixViewsTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
         var client = GetClient();
         var address = new Address("MathDemo/Matrix/Example");
 
-        // Initialize the hub first â€” required for routing to hit the per-node hub.
+        // Initialize the hub first — required for routing to hit the per-node hub.
         await client.Observe(new PingRequest(), o => o.WithTarget(address))
             .Should().Within(TimeSpan.FromSeconds(90)).Emit();
 
@@ -89,10 +89,10 @@ public class MatrixViewsTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
 
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(address, reference);
 
-        Output.WriteLine("Waiting for Inverse view to render (cold run resolves MathNet.Numerics from NuGet)â€¦");
+        Output.WriteLine("Waiting for Inverse view to render (cold run resolves MathNet.Numerics from NuGet)…");
         await stream.Should().Within(TimeSpan.FromSeconds(90))
             .Match(value => !value.Equals(default(JsonElement)),
-                "Inverse layout area should render â€” proves #r \"nuget:MathNet.Numerics, ...\" is resolved " +
+                "Inverse layout area should render — proves #r \"nuget:MathNet.Numerics, ...\" is resolved " +
                 "and MatrixLayoutAreas.Inverse executed against the sample instance.");
 
         Output.WriteLine("Inverse view rendered.");

--- a/test/MeshWeaver.Messaging.Hub.Test/TaskSchedulerInvariantTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TaskSchedulerInvariantTest.cs
@@ -14,7 +14,7 @@ namespace MeshWeaver.Messaging.Hub.Test;
 /// <see cref="TaskScheduler.Default"/> so they're independent of whatever
 /// scheduler created them. Hubs that explicitly call
 /// <see cref="MessageHubConfiguration.WithTaskScheduler"/> use the chosen
-/// scheduler â€” that's how Orleans glue couples the root grain hub to the
+/// scheduler — that's how Orleans glue couples the root grain hub to the
 /// grain's scheduler. See <c>Doc/Architecture/OrleansTaskScheduler.md</c>.
 /// </summary>
 public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(output)
@@ -25,7 +25,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
 
     /// <summary>
     /// Default hub configuration (no <c>WithTaskScheduler</c>) dispatches on
-    /// <see cref="TaskScheduler.Default"/> â€” the thread pool. Verifies that
+    /// <see cref="TaskScheduler.Default"/> — the thread pool. Verifies that
     /// hosted hubs created from any context end up independent.
     /// </summary>
     [Fact]
@@ -46,7 +46,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
         var response = await hub.Observe(new WhereAmIRequest(), o => o.WithTarget(hub.Address)).Should().Within(10.Seconds()).Emit();
 
         response.Message.TaskSchedulerId.Should().Be(TaskScheduler.Default.Id,
-            because: "hosted hubs must default to TaskScheduler.Default â€” they are independent actors");
+            because: "hosted hubs must default to TaskScheduler.Default — they are independent actors");
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
     public async Task ConfiguredHub_DispatchesOnTheConfiguredScheduler()
     {
         // ConcurrentExclusiveSchedulerPair.ExclusiveScheduler is a known scheduler
-        // distinct from TaskScheduler.Default â€” easy to identify by Id.
+        // distinct from TaskScheduler.Default — easy to identify by Id.
         var pair = new ConcurrentExclusiveSchedulerPair();
         var customScheduler = pair.ExclusiveScheduler;
 
@@ -83,7 +83,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
 
     /// <summary>
     /// A hosted sub-hub created from inside a hub configured with a custom
-    /// scheduler MUST default to <see cref="TaskScheduler.Default"/> â€” it does
+    /// scheduler MUST default to <see cref="TaskScheduler.Default"/> — it does
     /// NOT inherit the parent's scheduler. This is the core actor-model
     /// invariant: each hub is an independent actor.
     /// </summary>
@@ -104,7 +104,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
                 .WithPostingIdentity(PostingIdentity.System) // plumbing fixture → System (see above)
                 .WithHandler<WhereAmIRequest>((h, request) =>
                 {
-                    // Create a hosted sub-hub from inside the parent's handler â€” TaskScheduler.Current
+                    // Create a hosted sub-hub from inside the parent's handler — TaskScheduler.Current
                     // is parentScheduler at this point. The sub-hub MUST NOT inherit it.
                     var subHub = h.GetHostedHub(
                         subAddress,
@@ -124,7 +124,7 @@ public class TaskSchedulerInvariantTest(ITestOutputHelper output) : HubTestBase(
                     return request.Processed();
                 }));
 
-        // Trigger parent â†’ which creates sub-hub + posts to it.
+        // Trigger parent → which creates sub-hub + posts to it.
         await parent.Observe(new WhereAmIRequest(), o => o.WithTarget(parent.Address)).Should().Within(10.Seconds()).Emit();
 
         var observed = await subDone.Should().Within(10.Seconds()).Emit();

--- a/test/MeshWeaver.NodeOperations.Test/DeletionTests.cs
+++ b/test/MeshWeaver.NodeOperations.Test/DeletionTests.cs
@@ -46,7 +46,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact]
     public async Task Delete_LeafNode_Succeeds()
     {
-        // Arrange â€” create a single leaf node under TestData
+        // Arrange — create a single leaf node under TestData
         await NodeFactory.CreateNode(
             new MeshNode("delleaf", TestPartition) { Name = "Leaf", NodeType = "Markdown" }).Should().Emit();
 
@@ -64,7 +64,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact]
     public async Task Delete_ParentWithChildren_DeletesAll()
     {
-        // Arrange â€” create a parent with two children under TestData partition
+        // Arrange — create a parent with two children under TestData partition
         await NodeFactory.CreateNode(
             new MeshNode("del2parent", TestPartition) { Name = "Parent", NodeType = "Group" }).Should().Emit();
         await NodeFactory.CreateNode(
@@ -93,7 +93,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact]
     public async Task Delete_DeeplyNested_DeletesBottomToTop()
     {
-        // Arrange â€” create a 3-level deep hierarchy under TestData
+        // Arrange — create a 3-level deep hierarchy under TestData
         await NodeFactory.CreateNode(
             new MeshNode("del3root", TestPartition) { Name = "Root", NodeType = "Group" }).Should().Emit();
         await NodeFactory.CreateNode(
@@ -123,7 +123,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact]
     public async Task Delete_NonExistentNode_Throws()
     {
-        // Act & Assert â€” deleting a non-existent node should throw
+        // Act & Assert — deleting a non-existent node should throw
         Func<Task> act = async () => await NodeFactory.DeleteNode("nonexistent/path/that/does/not/exist").FirstAsync().ToTask();
         await act.Should().ThrowAsync<System.Exception>();
     }
@@ -131,7 +131,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact]
     public async Task Delete_NodeWithSiblings_OnlyDeletesTargetSubtree()
     {
-        // Arrange â€” create two sibling subtrees under TestData partition
+        // Arrange — create two sibling subtrees under TestData partition
         await NodeFactory.CreateNode(
             new MeshNode("del4parent", TestPartition) { Name = "Parent", NodeType = "Group" }).Should().Emit();
         await NodeFactory.CreateNode(
@@ -141,10 +141,10 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
         await NodeFactory.CreateNode(
             new MeshNode("child", $"{TestPartition}/del4parent/delete") { Name = "Child", NodeType = "Markdown" }).Should().Emit();
 
-        // Act â€” only delete one subtree
+        // Act — only delete one subtree
         await NodeFactory.DeleteNode($"{TestPartition}/del4parent/delete").Should().Emit();
 
-        // Assert â€” the kept sibling should still exist
+        // Assert — the kept sibling should still exist
         var kept = await ReadNode($"{TestPartition}/del4parent/keep").Should().Emit();
         kept.Should().NotBeNull("sibling node should not be affected");
 
@@ -195,7 +195,7 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
     [Fact(Timeout = 120_000)]
     public async Task Delete_FromNodeHub_Succeeds()
     {
-        // Arrange â€” create a node and get its hub via the routing service
+        // Arrange — create a node and get its hub via the routing service
         var nodePath = $"{TestPartition}/del6target";
         await NodeFactory.CreateNode(
             new MeshNode("del6target", TestPartition) { Name = "Target", NodeType = "Markdown" }).Should().Emit();
@@ -221,10 +221,10 @@ public class DeletionTests(ITestOutputHelper output) : MonolithMeshTestBase(outp
         // Resolve IMeshService from the NODE's hub (reproducing DeleteLayoutArea pattern)
         var nodeService = nodeHub!.ServiceProvider.GetRequiredService<IMeshService>();
 
-        // Act â€” delete from the node's hub (same as DeleteLayoutArea does)
+        // Act — delete from the node's hub (same as DeleteLayoutArea does)
         await nodeService.DeleteNode(nodePath).Should().Emit();
 
-        // Assert â€” node should be deleted. Poll the authoritative per-node read.
+        // Assert — node should be deleted. Poll the authoritative per-node read.
         await Observable.Interval(TimeSpan.FromMilliseconds(50))
             .StartWith(0L)
             .SelectMany(_ => ReadNode(nodePath))

--- a/test/MeshWeaver.NodeOperations.Test/NodeOperationsTestSeedProviders.cs
+++ b/test/MeshWeaver.NodeOperations.Test/NodeOperationsTestSeedProviders.cs
@@ -44,10 +44,10 @@ internal static class NodeOperationsTypeNames
 /// to back the namespace with a read-only
 /// <see cref="MeshWeaver.Hosting.Persistence.StaticNodePartitionStore"/>
 /// instead of a writable
-/// <see cref="MeshWeaver.Hosting.Persistence.InMemoryStorageAdapter"/> â€”
+/// <see cref="MeshWeaver.Hosting.Persistence.InMemoryStorageAdapter"/> —
 /// so the test-only NodeType definition stays addressable by routing without
 /// being mutable. See
-/// <c>Doc/Architecture/PartitionedPersistence.md</c> Â§"Where Partitions Come From".
+/// <c>Doc/Architecture/PartitionedPersistence.md</c> §"Where Partitions Come From".
 /// </summary>
 internal static class NodeOperationsTypeProviderHelpers
 {
@@ -83,12 +83,12 @@ internal static class NodeOperationsTypeProviderHelpers
     /// to back the namespace with a read-only
     /// <see cref="MeshWeaver.Hosting.Persistence.StaticNodePartitionStore"/>
     /// so the type-def is reachable via <c>meshStorage.GetNodeAsync(typeName)</c>
-    /// â€” which is what
+    /// — which is what
     /// <c>NodeTypeService.GatherInputsAsync</c> does to find the
     /// <see cref="NodeTypeDefinition"/> content for compilation. Static-provider
     /// partitions are NEVER wrapped by <c>InMemoryStorageAdapter</c>; they
     /// are immutable. See
-    /// <c>Doc/Architecture/PartitionedPersistence.md</c> Â§"Where Partitions Come From".
+    /// <c>Doc/Architecture/PartitionedPersistence.md</c> §"Where Partitions Come From".
     /// </summary>
     public static MeshNode StaticPartitionFor(string typeNamespace) =>
         new(typeNamespace, "Admin/Partition")

--- a/test/MeshWeaver.PathResolution.Test/AddressResolutionTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/AddressResolutionTest.cs
@@ -261,7 +261,7 @@ public class AddressResolutionTest(ITestOutputHelper output) : MonolithMeshTestB
         };
         await NodeFactory.CreateNode(msgNode).Should().Emit();
 
-        // Resolve the ThreadMessage path â€” should return the full message path, no remainder
+        // Resolve the ThreadMessage path — should return the full message path, no remainder
         var resolution = await PathResolver.ResolvePath($"{threadPath}/msg1").Should().Emit();
 
         resolution.Should().NotBeNull("ThreadMessage node exists at {0}/msg1", threadPath);
@@ -303,7 +303,7 @@ public class AddressResolutionTest(ITestOutputHelper output) : MonolithMeshTestB
         };
         await NodeFactory.CreateNode(msgNode).Should().Emit();
 
-        // Resolve the Thread path â€” should match the Thread node exactly
+        // Resolve the Thread path — should match the Thread node exactly
         var resolution = await PathResolver.ResolvePath(threadPath).Should().Emit();
 
         resolution.Should().NotBeNull();

--- a/test/MeshWeaver.Persistence.Test/ApplicationPageResolutionTest.cs
+++ b/test/MeshWeaver.Persistence.Test/ApplicationPageResolutionTest.cs
@@ -66,7 +66,7 @@ public class ApplicationPageResolutionTest(ITestOutputHelper output) : MonolithM
         var resolution = await PathResolver.ResolvePath("FutuRe").Should().Emit();
 
         Output.WriteLine($"Resolution: {resolution?.Prefix ?? "NULL"}, Remainder: {resolution?.Remainder ?? "NULL"}");
-        resolution.Should().NotBeNull("FutuRe should resolve â€” it has an index.md in the data directory");
+        resolution.Should().NotBeNull("FutuRe should resolve — it has an index.md in the data directory");
         resolution!.Prefix.Should().Be("FutuRe");
         resolution.Remainder.Should().BeNull();
     }

--- a/test/MeshWeaver.Query.Test/CrossPartitionSatelliteQueryTests.cs
+++ b/test/MeshWeaver.Query.Test/CrossPartitionSatelliteQueryTests.cs
@@ -40,7 +40,7 @@ public class CrossPartitionSatelliteQueryTests(ITestOutputHelper output) : Monol
         return base.ConfigureClient(configuration);
     }
 
-    // â”€â”€ Thread fan-out â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Thread fan-out ──────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task NodeTypeThread_FansOutAcrossAllPartitions()
@@ -63,7 +63,7 @@ public class CrossPartitionSatelliteQueryTests(ITestOutputHelper output) : Monol
         var threadB = resp2.Message.Node!.Path!;
         Output.WriteLine($"Thread B: {threadB}");
 
-        // Act: query nodeType:Thread without namespace â€” should fan out to all _Thread tables
+        // Act: query nodeType:Thread without namespace — should fan out to all _Thread tables
         var results = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:Thread sort:LastModified-desc")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
 
         Output.WriteLine($"nodeType:Thread => {results.Count} results: [{string.Join(", ", results.Select(r => r.Path))}]");
@@ -89,7 +89,7 @@ public class CrossPartitionSatelliteQueryTests(ITestOutputHelper output) : Monol
         var resp2 = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode("NsY", "Y thread", AdminUserId)), o => o.WithTarget(new Address("NsY"))).Should().Within(TimeSpan.FromSeconds(25)).Emit();
         resp2.Message.Success.Should().BeTrue(resp2.Message.Error ?? "");
 
-        // Act: query with explicit namespace â€” should only return threads from NsX
+        // Act: query with explicit namespace — should only return threads from NsX
         var results = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("namespace:NsX nodeType:Thread sort:LastModified-desc")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
 
         Output.WriteLine($"namespace:NsX nodeType:Thread => {results.Count} results");
@@ -99,7 +99,7 @@ public class CrossPartitionSatelliteQueryTests(ITestOutputHelper output) : Monol
             "namespace-scoped query should only return threads from that namespace");
     }
 
-    // â”€â”€ Comment fan-out â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Comment fan-out ─────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task NodeTypeComment_FansOutAcrossAllPartitions()

--- a/test/MeshWeaver.Query.Test/UserActivityDashboardQueryTests.cs
+++ b/test/MeshWeaver.Query.Test/UserActivityDashboardQueryTests.cs
@@ -33,7 +33,7 @@ public class UserActivityDashboardQueryTests(ITestOutputHelper output) : Monolit
         return base.ConfigureClient(configuration);
     }
 
-    // â”€â”€ Query 1: Activity Feed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Query 1: Activity Feed ──────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task ActivityFeed_ReturnsMainNodesWithActivitySatellites()
@@ -94,7 +94,7 @@ public class UserActivityDashboardQueryTests(ITestOutputHelper output) : Monolit
         results.Should().BeEmpty();
     }
 
-    // â”€â”€ Query 2: Recently Viewed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Query 2: Recently Viewed ────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task RecentlyViewed_InMemory_ReturnsMainNodes_ExcludesSatellites()
@@ -199,7 +199,7 @@ public class UserActivityDashboardQueryTests(ITestOutputHelper output) : Monolit
         }
     }
 
-    // â”€â”€ Query 3: Latest Threads â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Query 3: Latest Threads ─────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task LatestThreads_ByNodeType_WithDescendantsScope()
@@ -216,11 +216,11 @@ public class UserActivityDashboardQueryTests(ITestOutputHelper output) : Monolit
         var threadPath = response.Message.Node!.Path!;
         Output.WriteLine($"Thread created at: {threadPath}");
 
-        // Act 1: nodeType:Thread with scope:descendants â€” should find threads
+        // Act 1: nodeType:Thread with scope:descendants — should find threads
         var byType = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:Thread scope:descendants sort:LastModified-desc")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
         Output.WriteLine($"nodeType:Thread scope:descendants => {byType.Count} results");
 
-        // Act 2: namespace query â€” direct _Thread namespace query
+        // Act 2: namespace query — direct _Thread namespace query
         var byNamespace = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{contextPath}/_Thread nodeType:Thread")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
         Output.WriteLine($"namespace:{contextPath}/_Thread nodeType:Thread => {byNamespace.Count} results");
 
@@ -235,13 +235,13 @@ public class UserActivityDashboardQueryTests(ITestOutputHelper output) : Monolit
         // namespace query should also find it
         byNamespace.Should().NotBeEmpty($"namespace:{contextPath}/_Thread should find threads");
 
-        // Dashboard query (no path) â€” InMemory: 0 results (Children scope + empty basePath)
+        // Dashboard query (no path) — InMemory: 0 results (Children scope + empty basePath)
         // PostgreSQL via RoutingMeshQueryProvider: should work (adds scope:descendants per partition)
         Output.WriteLine($"Dashboard query found {dashboardQuery.Count} threads " +
             "(0 expected in InMemory without routing; >0 expected in PostgreSQL with routing)");
     }
 
-    // â”€â”€ Query 4: My Items â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Query 4: My Items ───────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task MyItems_ReturnsOnlyMainContentNodes()

--- a/test/MeshWeaver.Query.Test/UserDashboardThreadQueryTests.cs
+++ b/test/MeshWeaver.Query.Test/UserDashboardThreadQueryTests.cs
@@ -47,7 +47,7 @@ public class UserDashboardThreadQueryTests(ITestOutputHelper output) : MonolithM
         return base.ConfigureClient(configuration);
     }
 
-    // â”€â”€ Latest Threads â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Latest Threads ─────────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task LatestThreads_FindsThreadsAcrossNamespaces_ByCreator()
@@ -102,7 +102,7 @@ public class UserDashboardThreadQueryTests(ITestOutputHelper output) : MonolithM
         var resp = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode("External", "Thread in external namespace", AdminUserId)), o => o.WithTarget(new Address("External"))).Should().Within(TimeSpan.FromSeconds(25)).Emit();
         resp.Message.Success.Should().BeTrue(resp.Message.Error ?? "");
 
-        // Act: old query (namespace:User/userId scope:descendants) â€” misses external threads
+        // Act: old query (namespace:User/userId scope:descendants) — misses external threads
         var userNs = $"User/{AdminUserId}";
         var oldQueryResults = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:Thread namespace:{userNs} scope:descendants sort:LastModified-desc")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
 
@@ -142,7 +142,7 @@ public class UserDashboardThreadQueryTests(ITestOutputHelper output) : MonolithM
             "should not show threads created by other users");
     }
 
-    // â”€â”€ Activity Feed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Activity Feed ──────────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task ActivityFeed_FindsNodesWithActivityAcrossNamespaces()
@@ -226,7 +226,7 @@ public class UserDashboardThreadQueryTests(ITestOutputHelper output) : MonolithM
         results[0].Name.Should().Be("Item A");
     }
 
-    // â”€â”€ Thread CreatedBy storage â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // ── Thread CreatedBy storage ────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
     public async Task CreateNodeRequest_Thread_StoresCreatedByInContent()

--- a/test/MeshWeaver.Security.Test/AccessControlPipelineTest.cs
+++ b/test/MeshWeaver.Security.Test/AccessControlPipelineTest.cs
@@ -64,7 +64,7 @@ public class AccessControlPipelineTest(ITestOutputHelper output) : MonolithMeshT
         // Ensure hub is started
         await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress)).Should().Emit();
 
-        // Try to subscribe â€” should be denied by AccessControlPipeline
+        // Try to subscribe — should be denied by AccessControlPipeline
         var workspace = client.GetWorkspace();
         var reference = new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea);
         var stream = workspace.GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
@@ -114,7 +114,7 @@ public class AccessControlPipelineTest(ITestOutputHelper output) : MonolithMeshT
 
 /// <summary>
 /// Tests the HubPermissionRuleSet integration with AccessControlPipeline.
-/// Uses Organization hub which has WithPublicRead() â€” this registers
+/// Uses Organization hub which has WithPublicRead() — this registers
 /// a HubPermissionRuleSet that grants Read to all authenticated users.
 /// </summary>
 public class HubPermissionRuleSetTest(ITestOutputHelper output) : MonolithMeshTestBase(output)

--- a/test/MeshWeaver.Security.Test/HubAccessControlTest.cs
+++ b/test/MeshWeaver.Security.Test/HubAccessControlTest.cs
@@ -38,7 +38,7 @@ public class HubAccessControlTest(ITestOutputHelper output) : MonolithMeshTestBa
 
     /// <summary>
     /// When a subscriber sends a SubscribeRequest to a hub whose Read validator rejects it,
-    /// the error should propagate as an exception on the stream â€” not cause a silent timeout.
+    /// the error should propagate as an exception on the stream — not cause a silent timeout.
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task SubscribeRequest_RejectedByValidator_PropagatesException()
@@ -120,14 +120,14 @@ public class HubAccessControlTest(ITestOutputHelper output) : MonolithMeshTestBa
             }
         };
 
-        // "some-user" is not in the portal namespace â€” VUserAccessRule denies
+        // "some-user" is not in the portal namespace — VUserAccessRule denies
         Func<Task> act = () => nodeFactory.CreateNode(vUserNode).FirstAsync().ToTask();
         await act.Should().ThrowAsync<Exception>();
     }
 
     /// <summary>
     /// A portal hub posts CreateNodeRequest directly with ImpersonateAsHub().
-    /// The hub's address becomes the identity via the post pipeline â€” no IMeshService needed.
+    /// The hub's address becomes the identity via the post pipeline — no IMeshService needed.
     /// This mirrors how VirtualUserMiddleware creates VUser nodes.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -149,7 +149,7 @@ public class HubAccessControlTest(ITestOutputHelper output) : MonolithMeshTestBa
             }
         };
 
-        // Post CreateNodeRequest directly with ImpersonateAsHub() â€” bypasses IMeshService.
+        // Post CreateNodeRequest directly with ImpersonateAsHub() — bypasses IMeshService.
         // Target the mesh hub where CreateNodeRequest handler is registered.
         var response = await portalHub.Observe(new CreateNodeRequest(vUserNode), o => o.WithTarget(Mesh.Address).ImpersonateAsHub())
             .Should().Emit();
@@ -183,7 +183,7 @@ public class HubAccessControlTest(ITestOutputHelper output) : MonolithMeshTestBa
             }
         };
 
-        // Post CreateNodeRequest with ImpersonateAsHub() â€” non-portal identity should be denied.
+        // Post CreateNodeRequest with ImpersonateAsHub() — non-portal identity should be denied.
         // Target the mesh hub where CreateNodeRequest handler is registered.
         var response = await analyticsHub.Observe(new CreateNodeRequest(vUserNode), o => o.WithTarget(Mesh.Address).ImpersonateAsHub())
             .Should().Emit();

--- a/test/MeshWeaver.Security.Test/HubDataSourceSecurityTest.cs
+++ b/test/MeshWeaver.Security.Test/HubDataSourceSecurityTest.cs
@@ -37,7 +37,7 @@ public class HubDataSourceSecurityTest(ITestOutputHelper output) : MonolithMeshT
     }
 
     /// <summary>
-    /// Link 1: HubDataSource with denied access â†’ workspace stream errors.
+    /// Link 1: HubDataSource with denied access → workspace stream errors.
     /// Verifies: data source stream's OnError propagates through workspace stream to subscriber.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -63,7 +63,7 @@ public class HubDataSourceSecurityTest(ITestOutputHelper output) : MonolithMeshT
     }
 
     /// <summary>
-    /// Link 2: PartitionedHubDataSource â†’ combined stream errors.
+    /// Link 2: PartitionedHubDataSource → combined stream errors.
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task PartitionedHubDataSource_WithoutAccess_ShouldErrorStream()
@@ -159,7 +159,7 @@ public class HubDataSourceSecurityTest(ITestOutputHelper output) : MonolithMeshT
     }
 
     /// <summary>
-    /// Link 5: DataContext failure state â€” when initialization fails, DataContext stores the error.
+    /// Link 5: DataContext failure state — when initialization fails, DataContext stores the error.
     /// Subsequent SubscribeRequests get immediate DeliveryFailure with a meaningful message.
     /// </summary>
     [Fact(Timeout = 20000)]
@@ -183,7 +183,7 @@ public class HubDataSourceSecurityTest(ITestOutputHelper output) : MonolithMeshT
         Output.WriteLine($"Internal stream errored: {internalEx.GetType().Name}: {internalEx.Message}");
         internalEx.Should().NotBeOfType<TimeoutException>();
 
-        // Now a second client subscribes â€” should get immediate error, not timeout.
+        // Now a second client subscribes — should get immediate error, not timeout.
         // This also gives time for DataContext.OpenInitializationGate's ContinueWith to run.
         var client2 = GetClient(c => c.AddData(d => d));
         var remoteStream2 = client2.GetWorkspace().GetRemoteStream<EntityStore>(

--- a/test/MeshWeaver.Security.Test/HubSubscriptionSecurityTest.cs
+++ b/test/MeshWeaver.Security.Test/HubSubscriptionSecurityTest.cs
@@ -44,7 +44,7 @@ public class HubSubscriptionSecurityTest(ITestOutputHelper output) : MonolithMes
         => base.ConfigureClient(configuration).AddData(d => d);
 
     /// <summary>
-    /// Skip PublicAdminAccess â€” security tests need granular permissions.
+    /// Skip PublicAdminAccess — security tests need granular permissions.
     /// </summary>
     protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
 

--- a/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
+++ b/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
@@ -235,7 +235,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
 
         // Assert - Should fail due to insufficient permissions. Phase 2 of the delete
         // orchestrator now returns Unauthorized for this case; Phase 3 (RLS INodeValidator)
-        // would surface the same refusal as ValidationFailed â€” accept either.
+        // would surface the same refusal as ValidationFailed — accept either.
         deleteResponse.Message.Success.Should().BeFalse();
         deleteResponse.Message.RejectionReason.Should().BeOneOf(
             NodeDeletionRejectionReason.Unauthorized,
@@ -616,13 +616,13 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
             Name = "Anonymous Create",
             NodeType = "Markdown"
         };
-        // CreatedBy is null â€” anonymous request
+        // CreatedBy is null — anonymous request
         var request = new CreateNodeRequest(node);
 
         // Act
         var response = await client.Observe(request, o => o.WithTarget(Mesh.Address)).Should().Emit();
 
-        // Assert â€” must be rejected
+        // Assert — must be rejected
         response.Message.Success.Should().BeFalse("Anonymous user must not be able to create nodes");
         response.Message.RejectionReason.Should().Be(NodeCreationRejectionReason.ValidationFailed);
     }
@@ -649,13 +649,13 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
         // Clear AccessContext to simulate anonymous user
         SetAnonymous(accessService);
 
-        // Act â€” anonymous delete (no DeletedBy)
+        // Act — anonymous delete (no DeletedBy)
         var deleteResponse = await client.Observe(new DeleteNodeRequest("rls/anon_delete/ToDeleteAnon"), o => o.WithTarget(Mesh.Address)).Should().Emit();
 
-        // Assert â€” must be rejected. Acceptable reasons:
-        //   Unauthorized       â€” Phase 2 permission check denied (the new preferred shape)
-        //   ValidationFailed   â€” INodeValidator (RLS) denied during Phase 3
-        //   NodeNotFound       â€” anonymous can't even see the node
+        // Assert — must be rejected. Acceptable reasons:
+        //   Unauthorized       — Phase 2 permission check denied (the new preferred shape)
+        //   ValidationFailed   — INodeValidator (RLS) denied during Phase 3
+        //   NodeNotFound       — anonymous can't even see the node
         deleteResponse.Message.Success.Should().BeFalse("Anonymous user must not be able to delete nodes");
         deleteResponse.Message.RejectionReason.Should().BeOneOf(
             NodeDeletionRejectionReason.Unauthorized,
@@ -683,7 +683,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
     [Fact]
     public async Task AnonymousUser_WithAnonymousViewerRole_CannotCreate()
     {
-        // Arrange â€” grant Anonymous user Viewer role (Read only), clear admin context
+        // Arrange — grant Anonymous user Viewer role (Read only), clear admin context
         var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
         SetAnonymous(accessService);
         var client = GetClient();
@@ -696,7 +696,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
             .Should().Match(p => p == (Permission.Read | Permission.Execute | Permission.Api));
         permissions.Should().Be(Permission.Read | Permission.Execute | Permission.Api, "Anonymous Viewer should only have Read + Execute + Api");
 
-        // Act â€” anonymous Create (CreatedBy = empty, will resolve to Anonymous user)
+        // Act — anonymous Create (CreatedBy = empty, will resolve to Anonymous user)
         var node = new MeshNode("PublicCreate", parentPath)
         {
             Name = "Public Create",
@@ -730,7 +730,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
         // Act - editor tries to delete
         var deleteResponse = await client.Observe(new DeleteNodeRequest("rls/nodel/Protected") { DeletedBy = editorId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
 
-        // Assert â€” Phase 2 (permission) or Phase 3 (RLS validator) both valid denial shapes.
+        // Assert — Phase 2 (permission) or Phase 3 (RLS validator) both valid denial shapes.
         deleteResponse.Message.Success.Should().BeFalse("Editor lacks Delete permission");
         deleteResponse.Message.RejectionReason.Should().BeOneOf(
             NodeDeletionRejectionReason.Unauthorized,

--- a/test/MeshWeaver.Security.Test/ThreadStreamingIdentityTest.cs
+++ b/test/MeshWeaver.Security.Test/ThreadStreamingIdentityTest.cs
@@ -27,7 +27,7 @@ namespace MeshWeaver.Security.Test;
 
 /// <summary>
 /// Tests that thread chat streaming works end-to-end with RLS enabled.
-/// Verifies the identity chain: CreateThread â†’ SubmitMessage â†’ AI streaming â†’ response node update.
+/// Verifies the identity chain: CreateThread → SubmitMessage → AI streaming → response node update.
 /// This is the monolith equivalent of OrleansChatTest but with access control restrictions.
 /// The streaming response should complete even though the _Exec sub-hub runs asynchronously.
 /// </summary>
@@ -121,7 +121,7 @@ public class ThreadStreamingIdentityTest(ITestOutputHelper output) : MonolithMes
             .Should().Within(25.Seconds()).Match(tm => tm is not null);
 
         responseMessage.Should().NotBeNull(
-            "AI streaming should produce a response message â€” " +
+            "AI streaming should produce a response message — " +
             "if this fails, the identity chain is broken during async _Exec sub-hub execution");
         responseMessage!.Text.Should().NotBeNullOrEmpty();
         Output.WriteLine($"Response: '{responseMessage.Text}'");
@@ -170,7 +170,7 @@ public class ThreadStreamingIdentityTest(ITestOutputHelper output) : MonolithMes
             "Stream incrementally please",
             contextPath: UserPath);
 
-        // Wait reactively for first partial response â€” should arrive within 5 seconds,
+        // Wait reactively for first partial response — should arrive within 5 seconds,
         // NOT after full streaming completes (which would take longer).
         var meshQuery = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
         await AccumulateDescendants(meshQuery, threadPath)
@@ -186,7 +186,7 @@ public class ThreadStreamingIdentityTest(ITestOutputHelper output) : MonolithMes
         // The first partial response should arrive within 5 seconds.
         // If updates are blocked (old bug), they'd all arrive at once after streaming completes.
         latency.Should().BeLessThan(5000,
-            "first streaming update should arrive within 5s â€” if it takes longer, " +
+            "first streaming update should arrive within 5s — if it takes longer, " +
             "updates are blocked in the _Exec hub's message buffer (the bug we fixed)");
     }
 
@@ -300,7 +300,7 @@ public class ThreadStreamingIdentityTest(ITestOutputHelper output) : MonolithMes
 }
 
 /// <summary>
-/// Fake chat client for testing â€” returns a simple response.
+/// Fake chat client for testing — returns a simple response.
 /// </summary>
 internal class TestChatClientFactory : IChatClientFactory
 {

--- a/test/MeshWeaver.Threading.Test/AgentMarkdownParsingTest.cs
+++ b/test/MeshWeaver.Threading.Test/AgentMarkdownParsingTest.cs
@@ -90,7 +90,7 @@ public class AgentMarkdownParsingTest(ITestOutputHelper output) : MonolithMeshTe
         }
 
         violations.Should().BeEmpty(
-            "agent instructions must not contain literal '@path' â€” " +
+            "agent instructions must not contain literal '@path' — " +
             "the AI agent will try to use it as an actual address. " +
             "Use a real example node path instead.");
     }
@@ -142,10 +142,10 @@ public class AgentMarkdownParsingTest(ITestOutputHelper output) : MonolithMeshTe
                         // Try reading via per-node stream
                         var found = await ReadNode(refPath).Should().Emit();
                         if (found == null)
-                            missingRefs.Add($"{node.Path}: @@{refPath} â€” node not found");
+                            missingRefs.Add($"{node.Path}: @@{refPath} — node not found");
                     }
                     // Content references (e.g., Doc/AI/content:inline-example.md) are harder
-                    // to validate statically â€” skip for now
+                    // to validate statically — skip for now
                 }
             }
         }

--- a/test/MeshWeaver.Threading.Test/AutoExecuteFlowTest.cs
+++ b/test/MeshWeaver.Threading.Test/AutoExecuteFlowTest.cs
@@ -26,7 +26,7 @@ namespace MeshWeaver.Threading.Test;
 ///   <item><see cref="ThreadSubmission.CreateThreadAndSubmit"/> creates the thread
 ///     with the first user message pre-seeded; the server watcher dispatches.</item>
 ///   <item>State is observed via <c>client.GetWorkspace().GetMeshNodeStream(path)</c>
-///     â€” same reactive handle the Blazor view holds.</item>
+///     — same reactive handle the Blazor view holds.</item>
 /// </list>
 /// </summary>
 public class AutoExecuteFlowTest(ITestOutputHelper output) : MonolithMeshTestBase(output)

--- a/test/MeshWeaver.Threading.Test/CancelThreadExecutionTest.cs
+++ b/test/MeshWeaver.Threading.Test/CancelThreadExecutionTest.cs
@@ -24,7 +24,7 @@ namespace MeshWeaver.Threading.Test;
 /// <summary>
 /// Cancellation through the canonical path: <see cref="ThreadSubmission.Submit"/>
 /// dispatches the round; the cancel trigger is a stream.Update on the thread's
-/// own MeshNode (flipping <c>RequestedCancellationAt</c>) â€” same pattern the
+/// own MeshNode (flipping <c>RequestedCancellationAt</c>) — same pattern the
 /// Stop button uses in the GUI. State is observed via
 /// <c>client.GetWorkspace().GetMeshNodeStream(path)</c>.
 /// </summary>
@@ -61,7 +61,7 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
         var threadPath = createResp.Message.Node!.Path!;
 
         // Warm up the remote stream subscription BEFORE submit so the
-        // IsExecuting=trueâ†’false transition is captured. Same pattern
+        // IsExecuting=true→false transition is captured. Same pattern
         // IsExecutingLifecycleTest uses. Without this warm-up, the test races
         // the first cache.GetStream call (opened by _Exec's round watcher)
         // against the submission watcher's claim emission, and the chain
@@ -71,7 +71,7 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
             .Should().Within(10.Seconds()).Match(t => t != null);
         baselineThread!.IsExecuting.Should().BeFalse("thread should not be executing yet");
 
-        // Submit via GUI handler â€” server generates message ids.
+        // Submit via GUI handler — server generates message ids.
         client.SubmitMessage(
             threadPath,
             "Tell me a long story",
@@ -83,16 +83,16 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
             .Should().Within(15.Seconds()).Match(t => t is { IsExecuting: true, ActiveMessageId: { Length: > 0 } });
         var responseMsgId = executing!.ActiveMessageId!;
 
-        // Wait until the response cell shows "Generating response..." â€” the
+        // Wait until the response cell shows "Generating response..." — the
         // deterministic "streaming-loop-is-armed" signal: ExecuteMessageAsync
         // emits this AFTER setting the CTS and immediately before starting the
-        // streaming task. Cancelling earlier finds a null CTS â†’ no-op.
+        // streaming task. Cancelling earlier finds a null CTS → no-op.
         //
         // The server-flow path creates the response cell asynchronously after
         // flipping IsExecuting=true, so a fresh subscribe may race against the
         // CreateNode and hit a routing NotFound. RetryWhen with a short delay
         // covers that gap (same pattern the per-node hub's UpdateRemote uses
-        // internally â€” wait for the cell to materialise).
+        // internally — wait for the cell to materialise).
         await Observable.Defer(() => workspace.GetMeshNodeStream($"{threadPath}/{responseMsgId}"))
             .Select(n => (n.Content as ThreadMessage)?.Text ?? "")
             .Where(t => t.StartsWith("Generating response", StringComparison.Ordinal))
@@ -105,7 +105,7 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
         var responseStream = workspace.GetMeshNodeStream($"{threadPath}/{responseMsgId}");
         Output.WriteLine("Streaming confirmed armed (response cell shows 'Generating response...')");
 
-        // Cancel via stream.Update â€” same path the Stop button uses (see
+        // Cancel via stream.Update — same path the Stop button uses (see
         // RequestViaStreamUpdate.md). Set RequestedStatus = Cancelled; the
         // owning hub's cancel watcher reacts. Awaiting the post-update emission
         // asserts the write actually landed on the per-thread hub.
@@ -131,7 +131,7 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
         // by now. The monotonic-text guard in PushToResponseMessage can keep
         // the placeholder when cancel happens before ~500ms of streaming
         // (snapshot lengths stay below the placeholder's 22 chars), so we
-        // tolerate missing partial text â€” the core cancel guarantee is the
+        // tolerate missing partial text — the core cancel guarantee is the
         // Settled check above. If we DO see partial text, confirm it didn't
         // emit the FULL Long response (cancel must have stopped streaming).
         var partial = await responseStream
@@ -155,7 +155,7 @@ public class CancelThreadExecutionTest(ITestOutputHelper output) : MonolithMeshT
         }
         else
         {
-            Output.WriteLine("Response cell stayed on placeholder â€” cancel preempted streaming before " +
+            Output.WriteLine("Response cell stayed on placeholder — cancel preempted streaming before " +
                              "snapshot length exceeded the monotonic guard threshold. Cancel still worked " +
                              "(Settled=true above).");
         }

--- a/test/MeshWeaver.Threading.Test/ChatHistoryTest.cs
+++ b/test/MeshWeaver.Threading.Test/ChatHistoryTest.cs
@@ -58,7 +58,7 @@ public class ChatHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
         var responseMsgId = await ThreadFlow.SubmitAndWait(client, threadPath, text,
             contextPath: ContextPath, timeout: 60.Seconds()).Should().Within(60.Seconds()).Emit();
 
-        // CompletedAt is the deterministic "streaming finished" signal â€” only set
+        // CompletedAt is the deterministic "streaming finished" signal — only set
         // by the terminal PushToResponseMessage call in ExecuteMessageAsync. Beats
         // text-pattern matching against in-flight placeholders.
         var finalMessage = await ThreadFlow.ReadMessage(client, threadPath, responseMsgId,
@@ -103,7 +103,7 @@ public class ChatHistoryTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
             "second call: system + 2 history (user+assistant) + 1 new user = 4 total");
     }
 
-    #region Echo LLM â€” responds with message count to verify history is passed
+    #region Echo LLM — responds with message count to verify history is passed
 
     private class EchoChatClient : IChatClient
     {

--- a/test/MeshWeaver.Threading.Test/DelegationExecutionTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationExecutionTest.cs
@@ -89,7 +89,7 @@ public class DelegationExecutionTest(ITestOutputHelper output) : MonolithMeshTes
         }).Should().Emit();
         Output.WriteLine($"Sub-thread created: {subThreadPath}");
 
-        // Submit via GUI handler â€” server generates message ids on the sub-thread.
+        // Submit via GUI handler — server generates message ids on the sub-thread.
         var subResponseMsgId = await ThreadFlow.SubmitAndWait(client, subThreadPath,
             "Find documents about reinsurance pricing models", contextPath: ContextPath).Should().Within(30.Seconds()).Emit();
         Output.WriteLine($"Sub-thread response: {subResponseMsgId}");
@@ -118,7 +118,7 @@ public class DelegationExecutionTest(ITestOutputHelper output) : MonolithMeshTes
         subRespContent.Text.Should().NotBeNullOrEmpty();
 
         Output.WriteLine($"Sub-thread response: '{subRespContent.Text}'");
-        Output.WriteLine("Full hierarchy verified: parent â†’ message â†’ sub-thread â†’ sub-messages");
+        Output.WriteLine("Full hierarchy verified: parent → message → sub-thread → sub-messages");
     }
 
     #region Fake LLM

--- a/test/MeshWeaver.Threading.Test/DelegationFailureTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationFailureTest.cs
@@ -24,7 +24,7 @@ namespace MeshWeaver.Threading.Test;
 /// Verifies that a delegation that cannot complete (broken target) doesn't
 /// trap the parent thread when the user cancels. Submission goes through
 /// <see cref="ThreadSubmission.Submit"/>; cancel flips
-/// <c>RequestedCancellationAt</c> via the thread's MeshNode stream â€” same
+/// <c>RequestedCancellationAt</c> via the thread's MeshNode stream — same
 /// pattern the GUI's Stop button uses.
 /// </summary>
 public class DelegationFailureTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
@@ -64,7 +64,7 @@ public class DelegationFailureTest(ITestOutputHelper output) : MonolithMeshTestB
             "Do something that delegates",
             contextPath: ContextPath);
 
-        // Wait until the thread actually starts executing before cancelling â€”
+        // Wait until the thread actually starts executing before cancelling —
         // replaces a fixed Task.Delay(1000); cancelling before the CTS is armed
         // would be a no-op.
         await workspace.GetMeshNodeStream(threadPath)

--- a/test/MeshWeaver.Threading.Test/DelegationSubThreadTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationSubThreadTest.cs
@@ -185,7 +185,7 @@ public class DelegationSubThreadTest(ITestOutputHelper output) : MonolithMeshTes
             }
         }).Should().Emit();
 
-        // Navigate the hierarchy: thread Ã¢â€ â€™ message Ã¢â€ â€™ sub-thread Ã¢â€ â€™ sub-messages
+        // Navigate the hierarchy: thread → message → sub-thread → sub-messages
 
         // 1. Find sub-threads under the response message
         var subThreads = (await MeshQuery

--- a/test/MeshWeaver.Threading.Test/DelegationWriteCountTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationWriteCountTest.cs
@@ -34,7 +34,7 @@ namespace MeshWeaver.Threading.Test;
 /// the parent bubble's embedded sub-thread Streaming area.
 ///
 /// <para>This test catches a regression that would silently re-introduce
-/// the per-tick projection write â€” that pattern always risks duplicates
+/// the per-tick projection write — that pattern always risks duplicates
 /// because the FCC append and the projection write race on
 /// <c>DelegationPath</c>-by-lookup.</para>
 /// </summary>
@@ -44,11 +44,11 @@ public class DelegationWriteCountTest(ITestOutputHelper output) : MonolithMeshTe
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
-            // ðŸš¨ The test waits for cell.Status terminal; subsequent
+            // 🚨 The test waits for cell.Status terminal; subsequent
             // completion writes (thread.Status=Idle, parent NotifyParentCompletion,
             // EmitCompletionNotification) are fire-and-forget and land AFTER
             // the test exits. The default 500 ms quiesce budget is too tight
-            // for streaming-heavy rounds â€” observed 9 in-flight DataChangeRequests
+            // for streaming-heavy rounds — observed 9 in-flight DataChangeRequests
             // at dispose ("X pending callback(s) after 0.50s" failure mode).
             // 5 s wasn't enough on CI (run 26376715753 still leaked); bump to 15 s.
             // We still fail hard if writes don't drain within the longer window.
@@ -131,24 +131,24 @@ public class DelegationWriteCountTest(ITestOutputHelper output) : MonolithMeshTe
 
         // 4) Verify the entry's terminal state is well-formed: Status non-Streaming.
         //    Result population depends on whether the underlying chat client emits
-        //    FunctionResultContent in its stream output (SDK-specific â€” Claude does,
+        //    FunctionResultContent in its stream output (SDK-specific — Claude does,
         //    test agents typically don't) OR on UpdateDelegationStatus stamping
         //    a Result via my mirror. The structural invariant we enforce here is
         //    "no duplicate entries per DelegationPath + Status reaches a terminal
-        //    value", not "Result is always populated" â€” that's a separate concern
+        //    value", not "Result is always populated" — that's a separate concern
         //    that depends on the chat client and is exercised by Orleans tests.
         var entry = delegationCalls[0];
         entry.Status.Should().NotBe(ToolCallStatus.Streaming,
             "delegation entry should be at a terminal status by the time the parent response is Completed");
     }
 
-    #region Fake agents â€” parent delegates once, sub completes quickly
+    #region Fake agents — parent delegates once, sub completes quickly
 
     private sealed class DelegatingParentClient : IChatClient
     {
         // FCC iterates: turn 1 should emit one FunctionCallContent, turn 2+ should
         // emit only text. Detecting via FunctionResultContent in `messages` is
-        // unreliable (different chat-client wrappers shape that differently â€”
+        // unreliable (different chat-client wrappers shape that differently —
         // FRC may or may not be propagated back to the model). Track it
         // explicitly with a counter so the test is fully deterministic.
         private int _streamingCallCount;

--- a/test/MeshWeaver.Threading.Test/ExecuteThreadMessageTest.cs
+++ b/test/MeshWeaver.Threading.Test/ExecuteThreadMessageTest.cs
@@ -27,11 +27,11 @@ namespace MeshWeaver.Threading.Test;
 /// Every test here exercises the GUI submission path:
 /// <list type="number">
 ///   <item><see cref="ThreadSubmission.CreateThreadAndSubmit"/> creates the thread node
-///     with the first user message pre-seeded in <c>PendingUserMessages</c> â€” the
+///     with the first user message pre-seeded in <c>PendingUserMessages</c> — the
 ///     server-side watcher generates the response cell id and dispatches the round.</item>
 ///   <item><see cref="ThreadSubmission.Submit"/> posts <see cref="SubmitMessageRequest"/>
 ///     for subsequent messages on an existing thread.</item>
-///   <item>State is observed via <c>client.GetWorkspace().GetMeshNodeStream(path)</c> â€”
+///   <item>State is observed via <c>client.GetWorkspace().GetMeshNodeStream(path)</c> —
 ///     the remote-stream-cache-backed reactive handle, never <c>GetDataRequest</c>
 ///     polling or ad-hoc remote streams.</item>
 /// </list>
@@ -171,7 +171,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
     /// <summary>
     /// Pins the prod 2026-05-21 thread-loading invariant: a thread's chat
     /// execution must complete under the user's <see cref="AccessContext"/>
-    /// â€” every message MeshNode the chat flow creates must carry the user's
+    /// — every message MeshNode the chat flow creates must carry the user's
     /// identity in <c>CreatedBy</c>, NOT a hub-self-impersonated address
     /// (<c>sync/...</c>, <c>activity/...</c>, <c>node/...</c>). Pin against the
     /// cross-cutting <see cref="MeshWeaver.Messaging.AccessContextCaptureExtensions.CarryAccessContext"/>
@@ -179,9 +179,9 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
     ///
     /// <para>Without the wrap, the per-message-cell <c>CreateNode</c> in
     /// <c>ChatClientAgentFactory.ExecuteAsync</c>'s Subscribe callbacks would
-    /// run on a thread where AsyncLocal AccessContext is wiped â†’ PostPipeline
+    /// run on a thread where AsyncLocal AccessContext is wiped → PostPipeline
     /// (after the 2026-05-21 hub-self-impersonation deletion) would fail closed
-    /// â†’ the chat flow would deadlock at the first persisted write. This test
+    /// → the chat flow would deadlock at the first persisted write. This test
     /// is the canonical pin against that regression.</para>
     /// </summary>
     [Fact]
@@ -199,7 +199,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
             "user input + assistant response must both land");
 
         // Drill into the underlying MeshNode rows via the same cache that the
-        // GUI uses â€” the .CreatedBy stamping is what AccessControl would have
+        // GUI uses — the .CreatedBy stamping is what AccessControl would have
         // seen at the moment of write.
         var workspace = client.GetWorkspace();
         foreach (var msgId in thread.Messages)
@@ -210,7 +210,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
             // The critical assertion. Pre-2026-05-21, message nodes were stamped
             // with the chat-execution hub's own address (something starting with
             // "node/", "activity/", or "sync/"). Post-fix, every CreateNode runs
-            // under the actual user's AccessContext â€” Roland (the canonical
+            // under the actual user's AccessContext — Roland (the canonical
             // test-base user from AddSampleUsers).
             node.CreatedBy.Should().NotStartWith("node/",
                 $"message {msgPath} must not be written as a per-node hub identity");
@@ -224,7 +224,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     /// <summary>
-    /// DataChangeRequest is a CLIENT primitive â€” not the canonical thread mutation
+    /// DataChangeRequest is a CLIENT primitive — not the canonical thread mutation
     /// path (the GUI uses <c>workspace.GetMeshNodeStream(path).Update(...)</c>) but
     /// it must still apply correctly when used directly. The thread is observed
     /// through the same remote-stream-cache reactive handle the GUI uses.
@@ -296,7 +296,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
         var threadPath = await CreateEmptyThread(client, "End-to-end test");
         Output.WriteLine($"Thread created: {threadPath}");
 
-        // Open the layout area â€” same subscription the Blazor ThreadChatView holds.
+        // Open the layout area — same subscription the Blazor ThreadChatView holds.
         var layoutStream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(threadPath),
             new LayoutAreaReference(ThreadNodeType.ThreadArea));
@@ -347,7 +347,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
 
     /// <summary>
     /// <c>workspace.GetMeshNodeStream(path)</c> from a client workspace is the
-    /// canonical "live single-MeshNode" read â€” replaces the old
+    /// canonical "live single-MeshNode" read — replaces the old
     /// <c>GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c> ad-hoc pattern.
     /// </summary>
     [Fact]
@@ -366,7 +366,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
 
     /// <summary>
     /// <c>workspace.GetMeshNodeStream(path).Update(...)</c> from a client routes
-    /// the patch through the remote stream cache to the owning per-node hub â€”
+    /// the patch through the remote stream cache to the owning per-node hub —
     /// same primitive <see cref="ThreadInput.AppendUserInput"/> uses.
     /// </summary>
     [Fact]
@@ -393,7 +393,7 @@ public class ExecuteThreadMessageTest(ITestOutputHelper output) : MonolithMeshTe
 
     /// <summary>
     /// Same as <see cref="UpdateMeshNode_Local_UpdatesMessages"/> but the update
-    /// is composed off the latest snapshot â€” verifies <c>.Update(current =&gt; ...)</c>
+    /// is composed off the latest snapshot — verifies <c>.Update(current =&gt; ...)</c>
     /// observes the live node when the lambda runs.
     /// </summary>
     [Fact]

--- a/test/MeshWeaver.Threading.Test/IsExecutingLifecycleTest.cs
+++ b/test/MeshWeaver.Threading.Test/IsExecutingLifecycleTest.cs
@@ -21,11 +21,11 @@ using MeshThread = MeshWeaver.AI.Thread;
 namespace MeshWeaver.Threading.Test;
 
 /// <summary>
-/// ðŸš¨ Repro for "chat stuck on Generating response..." â€” a single end-to-end
+/// 🚨 Repro for "chat stuck on Generating response..." — a single end-to-end
 /// chat round that reactively asserts the full IsExecuting lifecycle.
 ///
 /// Drives the GUI handler (<see cref="ThreadSubmission.Submit"/>) and observes
-/// via <c>client.GetWorkspace().GetMeshNodeStream(path)</c> â€” the same reactive
+/// via <c>client.GetWorkspace().GetMeshNodeStream(path)</c> — the same reactive
 /// handle the Blazor view holds; if the streaming pipeline hangs, the
 /// IsExecuting=false wait times out and the test fails loud.
 /// </summary>
@@ -62,7 +62,7 @@ public class IsExecutingLifecycleTest(ITestOutputHelper output) : MonolithMeshTe
         var threadPath = createDelivery.Message.Node!.Path!;
 
         // Warm up the remote stream subscription BEFORE submit so the
-        // IsExecuting=trueâ†’false transition is captured. Same pattern
+        // IsExecuting=true→false transition is captured. Same pattern
         // ThreadFlow.SubmitAndWait uses.
         var baselineThread = await workspace.GetMeshNodeStream(threadPath)
             .Select(n => n.Content as MeshThread)
@@ -75,11 +75,11 @@ public class IsExecutingLifecycleTest(ITestOutputHelper output) : MonolithMeshTe
             contextPath: ContextPath);
 
         // 1) IsExecuting must flip to true within ~10s. Wait for the committed
-        // `Executing` state â€” NOT just any non-Idle state â€” because
+        // `Executing` state — NOT just any non-Idle state — because
         // `IsExecuting` is true during the transient `StartingExecution`
         // claim window where `ActiveMessageId` is still null (the responseMsgId
         // is generated downstream by DispatchAfterClaim's commit, which flips
-        // Status â†’ Executing AND stamps ActiveMessageId in one update).
+        // Status → Executing AND stamps ActiveMessageId in one update).
         var executingState = await workspace.GetMeshNodeStream(threadPath)
             .Select(n => n.Content as MeshThread)
             .Should().Within(10.Seconds()).Match(t => t is { Status: ThreadExecutionStatus.Executing });
@@ -102,7 +102,7 @@ public class IsExecutingLifecycleTest(ITestOutputHelper output) : MonolithMeshTe
             timeout: 15.Seconds()).Should().Within(15.Seconds()).Emit();
 
         finalMessage.Text.Should().Contain("I received",
-            "the Echo agent's streaming reply must reach the response cell â€” "
+            "the Echo agent's streaming reply must reach the response cell — "
             + "if this fails with the placeholder, the streaming Task.Run hung "
             + "but the parent flipped IsExecuting=false anyway, masking a real bug.");
 

--- a/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
+++ b/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
@@ -25,10 +25,10 @@ namespace MeshWeaver.Threading.Test;
 /// Behaviour tests for <c>ThreadExecution.LoadFullConversationHistoryFromMesh</c>.
 /// Three cases pinned by the loader's contract:
 /// <list type="number">
-///   <item>All cells have text â†’ loader returns the full ordered list.</item>
-///   <item>Some cells time out / are unreadable â†’ loader logs a warning and
+///   <item>All cells have text → loader returns the full ordered list.</item>
+///   <item>Some cells time out / are unreadable → loader logs a warning and
 ///     returns the partial list (the agent gets best-effort context).</item>
-///   <item>Every expected cell fails â†’ loader throws <see cref="TimeoutException"/>
+///   <item>Every expected cell fails → loader throws <see cref="TimeoutException"/>
 ///     instead of returning an empty list (refuses to submit a corrupt context).</item>
 /// </list>
 /// </summary>
@@ -70,7 +70,7 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
         // Wait for the response cell to reach a TERMINAL status. Earlier we
         // gated on `!IsNullOrEmpty(m.Text)`, but ThreadExecution stamps the
         // placeholder "Generating response..." onto the cell text very early
-        // in the streaming loop â€” that text passes the non-empty check while
+        // in the streaming loop — that text passes the non-empty check while
         // the real response is still mid-stream, so the history assertion
         // later read the placeholder instead of the FakeResponse.
         await ThreadFlow.ReadMessage(client, threadPath, responseMsgId,
@@ -80,7 +80,7 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
     }
 
     // 60s timeout: two real ThreadFlow.SubmitAndWait calls + ReadThread predicate
-    // waits â€” local runs ~3s, CI cold-start runs ~30s. Default 30s methodTimeout
+    // waits — local runs ~3s, CI cold-start runs ~30s. Default 30s methodTimeout
     // tripped on CI (31.85s in run 26376715753).
     [Fact]
     public async Task AllCells_HaveText_ReturnsFullHistory()
@@ -99,7 +99,7 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
             .Should().Within(60.Seconds()).Emit();
         thread.Messages.Should().HaveCount(4);
 
-        // The thread hub is the per-node hub for threadPath â€” that's the workspace
+        // The thread hub is the per-node hub for threadPath — that's the workspace
         // the loader queries via IMeshNodeStreamCache.
         var history = await ThreadExecution.LoadFullConversationHistoryFromMesh(
                 Mesh, threadPath,
@@ -121,14 +121,14 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
         var client = GetClient();
         var threadPath = await CreateThread(client, "Loader partial-history test");
 
-        // Round 1: real submit â†’ user+assistant cell, both with text.
+        // Round 1: real submit → user+assistant cell, both with text.
         await SubmitAndWaitForResponse(client, threadPath, "real question");
         var threadAfterRound1 = await ThreadFlow.ReadThread(client, threadPath,
             t => t is { IsExecuting: false } && t.Messages.Count >= 2)
             .Should().Within(60.Seconds()).Emit();
         threadAfterRound1.Messages.Should().HaveCount(2);
 
-        // Append a phantom cell ID to Messages â€” no per-node hub will ever emit
+        // Append a phantom cell ID to Messages — no per-node hub will ever emit
         // content at threadPath/{phantom-id}, so the per-cell Timeout fires and
         // the cell is omitted from the result with a warning.
         var phantomCellId = "phantom-" + Guid.NewGuid().ToString("N")[..8];
@@ -155,7 +155,7 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
         var client = GetClient();
         // This test stays async (verifies the loader observable errors with a
         // specific TimeoutException via ThrowAsync), so it must NOT use blocking
-        // reactive .Should() assertions â€” inline the thread create with await.
+        // reactive .Should() assertions — inline the thread create with await.
         var createResp = await client.Observe(
             new CreateNodeRequest(ThreadNodeType.BuildThreadNode(ContextPath, "Loader all-fail test", "TestUser")),
             o => o.WithTarget(Mesh.Address)).Should().Within(60.Seconds()).Emit();
@@ -163,13 +163,13 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
         var threadPath = createResp.Message.Node!.Path!;
 
         // Warm the cache with a request/response read so Content arrives as a
-        // typed MeshThread (not JsonElement) â€” otherwise the workspace.Update
+        // typed MeshThread (not JsonElement) — otherwise the workspace.Update
         // lambda below treats `node.Content is not MeshThread` as true and
         // short-circuits to a no-op, leaving Messages empty.
         await ThreadFlow.ReadThread(client, threadPath, _ => true)
             .Should().Within(60.Seconds()).Emit();
 
-        // Stamp two phantom cell IDs into Messages â€” no per-node hub will ever
+        // Stamp two phantom cell IDs into Messages — no per-node hub will ever
         // emit content at those paths, so every per-cell read times out and the
         // loader's guard must refuse to return empty history.
         await Mesh.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
@@ -179,7 +179,7 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
         }).Should().Within(60.Seconds()).Emit();
 
         // Confirm the thread's Messages list actually carries the phantoms before
-        // we kick off the loader â€” otherwise a stale cache snapshot would let the
+        // we kick off the loader — otherwise a stale cache snapshot would let the
         // loader sail through "cellIds.Count == 0" and miss the guard entirely.
         var settled = await ThreadFlow.ReadThread(client, threadPath,
             t => t.Messages.Contains("phantom-1") && t.Messages.Contains("phantom-2"))

--- a/test/MeshWeaver.Threading.Test/PlanStorageTest.cs
+++ b/test/MeshWeaver.Threading.Test/PlanStorageTest.cs
@@ -56,9 +56,9 @@ public class PlanStorageTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
         var planContent = @"## Plan: Set up project structure
 
 ### Steps
-1. Create Engineering department Ã¢â‚¬â€ `Create` Ã¢â‚¬â€ node under PlanTestOrg
-2. Create Marketing department Ã¢â‚¬â€ `Create` Ã¢â‚¬â€ node under PlanTestOrg
-3. Create README pages Ã¢â‚¬â€ `Create` Ã¢â‚¬â€ one per department
+1. Create Engineering department — `Create` — node under PlanTestOrg
+2. Create Marketing department — `Create` — node under PlanTestOrg
+3. Create README pages — `Create` — one per department
 
 ### Notes
 - All nodes use Markdown type

--- a/test/MeshWeaver.Threading.Test/StreamingAreaTest.cs
+++ b/test/MeshWeaver.Threading.Test/StreamingAreaTest.cs
@@ -64,7 +64,7 @@ public class StreamingAreaTest(ITestOutputHelper output) : MonolithMeshTestBase(
         var first = await streamingArea.Should().Within(5.Seconds()).Emit();
 
         Output.WriteLine($"StreamingArea emission: ChangeType={first.ChangeType}");
-        // The area returns null when idle â€” the LayoutAreaView renders nothing
+        // The area returns null when idle — the LayoutAreaView renders nothing
     }
 
     [Fact]

--- a/test/MeshWeaver.Threading.Test/StreamingRecursionTest.cs
+++ b/test/MeshWeaver.Threading.Test/StreamingRecursionTest.cs
@@ -29,7 +29,7 @@ public class StreamingRecursionTest
                     Name = "delegate_to_agent",
                     DisplayName = "Delegating to Executor",
                     DelegationPath = "Org/_Thread/parent/msg1/sub-thread",
-                    Result = null // In-progress â€” this was the trigger for recursive embed
+                    Result = null // In-progress — this was the trigger for recursive embed
                 },
                 new ToolCallEntry
                 {
@@ -56,7 +56,7 @@ public class StreamingRecursionTest
 
         // Verify the fix: in-progress delegations should be rendered as static links,
         // NOT as LayoutAreaControl(delegationPath, "Streaming")
-        // This is a design constraint test â€” the actual rendering is in StreamingCompact
+        // This is a design constraint test — the actual rendering is in StreamingCompact
         // but we verify the data model doesn't force recursion
         inProgress[0].DelegationPath.Should().NotBeNull();
         inProgress[0].Result.Should().BeNull("in-progress delegation has no result yet");

--- a/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
+++ b/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
@@ -24,33 +24,33 @@ namespace MeshWeaver.Threading.Test;
 /// <c>Systemorph/_Thread/add-markus-kleiner-as-admin-to-systemorp-c578/8721bdff/create-a-new-accessassignment-node-to-gr-a618</c>
 /// on 2026-05-20.
 ///
-/// Shape: parent agent delegates â†’ sub-thread is created with <c>IsExecuting=true</c>
-/// + a pending user message â†’ sub-thread's hub activates and starts executing â†’
-/// the sub-thread's <see cref="IChatClient"/> hangs (no streaming, no completion) â†’
+/// Shape: parent agent delegates → sub-thread is created with <c>IsExecuting=true</c>
+/// + a pending user message → sub-thread's hub activates and starts executing →
+/// the sub-thread's <see cref="IChatClient"/> hangs (no streaming, no completion) →
 /// the parent's 5-minute watchdog in
 /// <see cref="ChatClientAgentFactory"/>'s delegation drain eventually closes the
 /// PARENT's <c>IAsyncEnumerable</c>, but the <b>sub-thread itself</b> has no
-/// self-cancellation and no propagated cancel â€” so its <c>IsExecuting</c> flag
+/// self-cancellation and no propagated cancel — so its <c>IsExecuting</c> flag
 /// stays <c>true</c> forever. The user sees a perpetually-"executing" sub-thread.
 ///
 /// The existing cancel path (<see cref="MeshThread.RequestedCancellationAt"/> on the
-/// parent â†’ propagated to every active sub-thread via
+/// parent → propagated to every active sub-thread via
 /// <c>ThreadExecution</c>'s cancel watcher) only fires when the user clicks Stop.
 /// Without that intervention, the sub-thread hangs.
 ///
 /// <para>This test pins both shapes:</para>
 /// <list type="number">
-///   <item><c>HungSubThread_WithoutUserCancel_StaysExecuting</c> â€” documents the BUG:
+///   <item><c>HungSubThread_WithoutUserCancel_StaysExecuting</c> — documents the BUG:
 ///   after the sub-thread starts and its agent stalls, <c>IsExecuting</c> never
 ///   flips back to false on its own within a reasonable window.</item>
-///   <item><c>HungSubThread_UserCancelOnParent_PropagatesAndStopsSubThread</c> â€”
+///   <item><c>HungSubThread_UserCancelOnParent_PropagatesAndStopsSubThread</c> —
 ///   confirms the EXISTING fallback works: user-initiated cancel on the parent
 ///   does propagate and unwind the hung sub-thread.</item>
 /// </list>
 ///
 /// <para>Fix shape (when applied): the parent's delegation drain
 /// (<see cref="ChatClientAgentFactory"/>'s <c>ExecuteDelegationAsync</c>) must,
-/// on watchdog/cancel, flip <c>RequestedCancellationAt</c> on the sub-thread â€”
+/// on watchdog/cancel, flip <c>RequestedCancellationAt</c> on the sub-thread —
 /// the same write the user's Stop button performs. After the fix, the first
 /// test becomes a real assertion (sub-thread settles even without user cancel)
 /// and the second remains a regression guard for the manual-cancel path.</para>
@@ -63,7 +63,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         => base.ConfigureMesh(builder)
             // The hanging sub-thread leaves DataChangeRequests pending on the
             // sub-thread hub (it's hung in IChatClient, can't process writes).
-            // JsonSynchronizationStream's per-emission DataChangeRequest â†’
+            // JsonSynchronizationStream's per-emission DataChangeRequest →
             // Observe chain doesn't dispose until the framework's 60s
             // RequestTimeout fires. Without bumping QuiesceTimeout, the test
             // base's 500ms leak-detection trips on these expected-pending
@@ -101,13 +101,13 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
     /// client hangs forever. We wait until <c>IsExecuting=true</c> is observed
     /// on the sub-thread (i.e. it started), then wait
     /// <see cref="ObservationWindow"/> seconds and assert <c>IsExecuting</c> is
-    /// STILL true â€” the bug shape: sub-thread has no self-recovery, no parent
+    /// STILL true — the bug shape: sub-thread has no self-recovery, no parent
     /// watchdog propagation. In prod this stays true for hours.
     ///
     /// <para>When the fix lands (parent watchdog flips
     /// <c>RequestedCancellationAt</c> on the sub-thread, or sub-thread gets its
     /// own no-progress watchdog), invert this assertion to
-    /// <c>Should().BeFalse</c> with a generous window â€” that's the regression
+    /// <c>Should().BeFalse</c> with a generous window — that's the regression
     /// guard.</para>
     /// </summary>
     [Fact]
@@ -119,7 +119,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         var parentPath = await CreateThread(client, "Delegate to a worker that hangs");
         Output.WriteLine($"Parent thread: {parentPath}");
 
-        // Warm up the parent thread stream BEFORE submit â€” see CancelStream
+        // Warm up the parent thread stream BEFORE submit — see CancelStream
         // test for why this matters (submission watcher races first
         // cache.GetStream and can stall the chain at Status=StartingExecution).
         await workspace.GetMeshNodeStream(parentPath)
@@ -137,14 +137,14 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         var subThreadPath = await WaitForDelegationPath(client, parentPath);
         Output.WriteLine($"Sub-thread: {subThreadPath}");
 
-        // Wait for the sub-thread to reach IsExecuting=true â€” proves the
+        // Wait for the sub-thread to reach IsExecuting=true — proves the
         // sub-thread hub activated and its WatchForExecution started the
         // agent. The hanging IChatClient takes over from here.
         //
-        // ðŸš¨ Race: WaitForDelegationPath returns as soon as the parent's
+        // 🚨 Race: WaitForDelegationPath returns as soon as the parent's
         // tool call has DelegationPath stamped (synchronous), but
         // ExecuteDelegationAsync's meshService.CreateNode(subThreadNode) is
-        // fire-and-forget â€” the per-node hub may not have activated yet.
+        // fire-and-forget — the per-node hub may not have activated yet.
         // GetMeshNodeStream surfaces "missing satellite" as OnError
         // (DeliveryFailureException) almost immediately (post-2026-05-24
         // cache change f103be08a). .Catch+Defer retries with backoff so
@@ -166,7 +166,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         // ChatClientAgentFactory.ExecuteDelegationAsync has a 30s safety
         // timeout (CancellationTokenSource at line 544). When it fires, the
         // exit path at line ~634 writes RequestedCancellationAt to the
-        // sub-thread MeshNode â€” same primitive the GUI Stop button uses â€”
+        // sub-thread MeshNode — same primitive the GUI Stop button uses —
         // which propagates through the sub-thread's cancel watcher and
         // tears down its CTS, causing HangingSubAgentChatClient's
         // Task.Delay to throw OperationCanceled. Sub-thread settles
@@ -176,8 +176,8 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         // and the user sees a perpetually-"executing" bubble.
         //
         // The wait window: 30s watchdog + 15s slack for propagation through
-        // parent stream emission â†’ sub-thread cancel watcher â†’ CTS cancel â†’
-        // streaming loop exit â†’ terminal Status flip. 45s total.
+        // parent stream emission → sub-thread cancel watcher → CTS cancel →
+        // streaming loop exit → terminal Status flip. 45s total.
         var settled = await Observable.Defer(() =>
                 workspace.GetMeshNodeStream(subThreadPath)
                     .Select(n => n.Content as MeshThread)
@@ -194,23 +194,23 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             "timeout fires on a never-completing sub-thread, writes " +
             "RequestedCancellationAt to the sub-thread MeshNode (same write " +
             "the GUI Stop button performs), and the sub-thread's cancel " +
-            "watcher unwinds its CTS â€” HangingSubAgentChatClient's Task.Delay " +
+            "watcher unwinds its CTS — HangingSubAgentChatClient's Task.Delay " +
             "throws OperationCanceled and the streaming loop exits clean.");
-        Output.WriteLine($"Sub-thread settled at {DateTime.UtcNow:O} (no user cancel â€” watchdog did it)");
+        Output.WriteLine($"Sub-thread settled at {DateTime.UtcNow:O} (no user cancel — watchdog did it)");
     }
 
     /// <summary>
     /// Regression guard for the cancel-propagation fix (commit "fix(thread-exec):
     /// cancel watcher unions DelegationPaths"). User flips
-    /// <c>RequestedCancellationAt</c> on the parent â€” same primitive the GUI
-    /// Stop button uses â€” and the sub-thread's <c>IsExecuting</c> must flip
+    /// <c>RequestedCancellationAt</c> on the parent — same primitive the GUI
+    /// Stop button uses — and the sub-thread's <c>IsExecuting</c> must flip
     /// false within <see cref="CancelObservationWindow"/>.
     ///
     /// <para>Before the fix, this test failed: the parent's cancel watcher
     /// only walked <c>thread.StreamingToolCalls</c>, which stays stale while
     /// the streaming loop is blocked inside the in-flight delegation tool.
     /// The fix unions <c>StreamingToolCalls</c> with the live
-    /// <c>AgentChatClient.DelegationPaths</c> registry â€” that's written
+    /// <c>AgentChatClient.DelegationPaths</c> registry — that's written
     /// synchronously by <c>ExecuteDelegationAsync</c> the moment the
     /// sub-thread is dispatched, so the union is never stale.</para>
     /// </summary>
@@ -245,7 +245,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             .Should().Within(15.Seconds()).Match(t => t is { IsExecuting: true });
         Output.WriteLine("Sub-thread reached IsExecuting=true.");
 
-        // Set RequestedStatus = Cancelled on the PARENT â€” same write the GUI
+        // Set RequestedStatus = Cancelled on the PARENT — same write the GUI
         // Stop button performs (see RequestViaStreamUpdate.md). The parent
         // hub's cancel watcher unions StreamingToolCalls with the live
         // AgentChatClient.DelegationPaths registry and propagates the request
@@ -267,7 +267,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             "FIX: user cancel on the parent must propagate to the hung " +
             "sub-thread via the cancel watcher's union of StreamingToolCalls " +
             "+ AgentChatClient.DelegationPaths. The live DelegationPaths " +
-            "registry is the load-bearing source â€” the throttle-persisted " +
+            "registry is the load-bearing source — the throttle-persisted " +
             "StreamingToolCalls is stale while the streaming loop is blocked " +
             "inside the tool call.");
         Output.WriteLine($"Sub-thread cancelled successfully at {DateTime.UtcNow:O}");
@@ -279,7 +279,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
     // unwind the hanging IChatClient.
     private static readonly TimeSpan CancelObservationWindow = TimeSpan.FromSeconds(20);
 
-    // 10s for CI; 12min (720s) for a watchdog-debug run â€” parent
+    // 10s for CI; 12min (720s) for a watchdog-debug run — parent
     // ExecuteDelegationAsync has a 5-min CancellationTokenSource that SHOULD
     // propagate RequestedCancellationAt to the sub-thread (see
     // ChatClientAgentFactory.cs:634-643). If the sub-thread still hasn't
@@ -319,7 +319,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         var respPath = $"{parentPath}/{respMsgId}";
 
         // The sub-thread path lives on the response message's tool calls.
-        // 30s budget â€” 15s tripped on slow CI runners (run 26376715753).
+        // 30s budget — 15s tripped on slow CI runners (run 26376715753).
         var responseMsg = await workspace.GetMeshNodeStream(respPath)
             .Select(n => n.Content as ThreadMessage)
             .Should().Within(30.Seconds()).Match(m => m?.ToolCalls != null && m.ToolCalls.Count > 0
@@ -335,7 +335,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
     /// no FunctionResultContent is in the conversation yet). Sub-agent: never
     /// returns.
     ///
-    /// Target agent is <c>Worker</c> â€” one of the built-in agents registered
+    /// Target agent is <c>Worker</c> — one of the built-in agents registered
     /// by <c>.AddAI()</c>. The framework's hierarchy enumeration includes it
     /// in <c>allAgents</c>, so <c>ExecuteDelegationAsync</c> proceeds with the
     /// sub-thread create instead of short-circuiting with
@@ -355,11 +355,11 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             // Has FCC already invoked the delegation tool? If yes, this is a
-            // follow-up turn â€” emit plain text to satisfy FCC's "continue
+            // follow-up turn — emit plain text to satisfy FCC's "continue
             // until no function call" loop. If we re-emit the function call,
             // FCC infinite-loops.
             //
-            // Qualified Enumerable.SelectMany â€” the reactive Observable.SelectMany
+            // Qualified Enumerable.SelectMany — the reactive Observable.SelectMany
             // is in scope via the file's `using System.Reactive.Linq` and the
             // unqualified call would prefer it on an IEnumerable<ChatMessage>.
             var hasToolResult = false;
@@ -390,7 +390,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             }
 
             yield return new ChatResponseUpdate(ChatRole.Assistant,
-                "Delegation tool returned â€” parent finishing turn.");
+                "Delegation tool returned — parent finishing turn.");
             await Task.Yield();
         }
 
@@ -401,7 +401,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
 
     /// <summary>
     /// Sub-agent that hangs forever. Models the prod symptom: agent allocation
-    /// or the first LLM call never returns. Respects cancellation â€” the user
+    /// or the first LLM call never returns. Respects cancellation — the user
     /// cancel path uses this to settle the sub-thread.
     /// </summary>
     private sealed class HangingSubAgentChatClient : IChatClient
@@ -419,7 +419,7 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             IEnumerable<ChatMessage> messages, ChatOptions? options = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            // Block forever â€” never yields, never completes. Respects the token
+            // Block forever — never yields, never completes. Respects the token
             // so the user-cancel test can drive settlement.
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             yield break; // unreachable

--- a/test/MeshWeaver.Threading.Test/ThreadCreationTest.cs
+++ b/test/MeshWeaver.Threading.Test/ThreadCreationTest.cs
@@ -45,7 +45,7 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
     public async Task CreateThread_ViaCreateNodeRequest_UsesThreadPartitionAndSpeakingId()
     {
 
-        // Arrange Ã¢â‚¬â€ create context node so the node hub exists
+        // Arrange — create context node so the node hub exists
         // Organization ⇒ Space: a top-level context node is a partition root. Only User/Space
         // own a partition, so it must be a Space (PartitionWriteGuardValidator rejects top-level
         // Markdown). Creating a Space is the sanctioned explicit partition-creation path.
@@ -53,11 +53,11 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
         await NodeFactory.CreateNode(
             new MeshNode(contextPath) { Name = "ACME Corp", NodeType = "Space" }).Should().Emit();
 
-        // Act Ã¢â‚¬â€ send CreateNodeRequest to the context node's hub (production path)
+        // Act — send CreateNodeRequest to the context node's hub (production path)
         var client = GetClient();
         var response = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode(contextPath, "Hello, can you help me with this project?")), o => o.WithTarget(new Address(contextPath))).Should().Within(15.Seconds()).Emit();
 
-        // Assert Ã¢â‚¬â€ response
+        // Assert — response
         response.Message.Success.Should().BeTrue(response.Message.Error ?? "");
         response.Message.Node?.Path.Should().NotBeNullOrEmpty();
         response.Message.Node?.Name.Should().NotBeNullOrEmpty();
@@ -65,18 +65,18 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
         var threadPath = response.Message.Node?.Path!;
         Output.WriteLine($"Created thread at: {threadPath}");
 
-        // Assert Ã¢â‚¬â€ path uses _Thread partition
+        // Assert — path uses _Thread partition
         threadPath.Should().Contain($"/{ThreadNodeType.ThreadPartition}/",
             "thread path must use _Thread partition: {namespace}/_Thread/{speakingId}");
         threadPath.Should().StartWith($"{contextPath}/",
             "thread path must start with the context node path");
 
-        // Assert Ã¢â‚¬â€ speaking ID is human-readable (derived from message text)
+        // Assert — speaking ID is human-readable (derived from message text)
         var speakingId = threadPath.Split('/').Last();
         speakingId.Should().Contain("hello",
             "speaking ID should be derived from the message text");
 
-        // Assert Ã¢â‚¬â€ retrieve node and verify MainNode (satellite auto-set, stream read)
+        // Assert — retrieve node and verify MainNode (satellite auto-set, stream read)
         var node = await ReadNode(threadPath).Should().Emit();
         node.Should().NotBeNull("thread node should be retrievable");
         node!.NodeType.Should().Be(ThreadNodeType.NodeType);
@@ -85,7 +85,7 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
         node.MainNode.Should().NotBe(node.Path,
             "satellite MainNode must NOT be self-referencing");
 
-        // Assert Ã¢â‚¬â€ content is a MeshThread, and MainNode points to context
+        // Assert — content is a MeshThread, and MainNode points to context
         node.Content.Should().BeOfType<MeshThread>();
         node.MainNode.Should().Be(contextPath);
     }
@@ -94,13 +94,13 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
     public async Task CreateThread_ViaCreateNodeRequest_OnDifferentContextNode()
     {
 
-        // Arrange Ã¢â‚¬â€ create a different context node
+        // Arrange — create a different context node
         // Organization ⇒ Space (top-level context node = partition root; only User/Space own one).
         var contextPath = "TestProject";
         await NodeFactory.CreateNode(
             new MeshNode(contextPath) { Name = "Test Project", NodeType = "Space" }).Should().Emit();
 
-        // Act Ã¢â‚¬â€ send to the context node's hub
+        // Act — send to the context node's hub
         var client = GetClient();
         var response = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode(contextPath, "A thread on TestProject")), o => o.WithTarget(new Address(contextPath))).Should().Within(15.Seconds()).Emit();
 
@@ -252,7 +252,7 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
     public async Task GetDataRequest_ToNonExistentNode_ReturnsErrorNotEndlessMessages()
     {
         // A malformed path that mimics the bug. Posted through the CLIENT hub
-        // (same path the GUI takes) â€” the routing layer must resolve within the
+        // (same path the GUI takes) — the routing layer must resolve within the
         // timeout (response OR DeliveryFailure), not spin forever. Folding the
         // error into an emission via Catch lets the reactive assertion accept
         // both terminal outcomes while still failing if routing hangs.
@@ -272,7 +272,7 @@ public class ThreadCreationTest(ITestOutputHelper output) : MonolithMeshTestBase
     public async Task GetDataRequest_ToNonExistentThread_ReturnsErrorNotEndlessMessages()
     {
         // Thread path that looks valid but doesn't exist. Posted through the CLIENT
-        // â€” routing must resolve (response or DeliveryFailure) within the timeout.
+        // — routing must resolve (response or DeliveryFailure) within the timeout.
         var nonExistentPath = "User/TestUser/nonexistent123";
         var client = GetClient();
 
@@ -526,7 +526,7 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
-        // No PublicAdminAccess Ã¢â‚¬â€ permissions are enforced
+        // No PublicAdminAccess — permissions are enforced
         return ConfigureMeshBase(builder)
             .AddAI();
     }
@@ -538,7 +538,7 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
     }
 
     // Framework setup hook: must keep the base's `Task` signature (the base
-    // awaits it during fixture init). Not a test body â€” no deadlock risk â€” so
+    // awaits it during fixture init). Not a test body — no deadlock risk — so
     // blocking .Should().Emit() on the CreateNode streams is the right shape here.
     protected override async Task SetupAccessRightsAsync()
     {
@@ -561,7 +561,7 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
         // SecurityService loads assignments via SyncedQuery which is eventually
         // consistent. On cold-start CI, the first HasPermissionAsync call can
         // return false before the synced query catches up. Stream-poll until
-        // admin has Create permission â€” replaces a hand-rolled while +
+        // admin has Create permission — replaces a hand-rolled while +
         // Task.Delay(100) loop.
         await Mesh.GetEffectivePermissions("SecureProject", AdminUserId)
             .Should().Within(10.Seconds()).Match(p => p.HasFlag(Permission.Create));
@@ -570,7 +570,7 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
         await NodeFactory.CreateNode(
             new MeshNode("SecureProject") { Name = "Secure Project", NodeType = "Space" }).Should().Emit();
 
-        // Act Ã¢â‚¬â€ admin creates thread (has Update permission)
+        // Act — admin creates thread (has Update permission)
         var client = GetClient();
         var response = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode("SecureProject", "Admin creating a thread")), o => o.WithTarget(new Address("SecureProject"))).Should().Within(15.Seconds()).Emit();
 
@@ -668,7 +668,7 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
         TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = AdminUserId, Name = "Admin" });
 
         // Wait for the admin AccessAssignment from SetupAccessRightsAsync to land
-        // through SyncedQuery â€” same eventually-consistent race as the sibling
+        // through SyncedQuery — same eventually-consistent race as the sibling
         // test. Stream-poll until admin has Create permission.
         await Mesh.GetEffectivePermissions("SecureProject", AdminUserId)
             .Should().Within(10.Seconds()).Match(p => p.HasFlag(Permission.Create));
@@ -679,11 +679,11 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
         // Switch to viewer (Read+Execute only, no Update)
         TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = ViewerUserId, Name = "Viewer" });
 
-        // Act Ã¢â‚¬â€ viewer tries to create thread (lacks Thread permission)
+        // Act — viewer tries to create thread (lacks Thread permission)
         var client = GetClient();
         Func<Task> act = () => client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode("SecureProject", "Viewer trying to create a thread")), o => o.WithTarget(new Address("SecureProject"))).Should().Within(15.Seconds()).Emit();
 
-        // Assert Ã¢â‚¬â€ should be denied (thrown as DeliveryFailureException)
+        // Assert — should be denied (thrown as DeliveryFailureException)
         var ex = await act.Should().ThrowAsync<Exception>();
         ex.Which.Message.Should().Contain("Access denied");
         Output.WriteLine($"Denial message: {ex.Which.Message}");

--- a/test/MeshWeaver.Threading.Test/ThreadVisibilityTest.cs
+++ b/test/MeshWeaver.Threading.Test/ThreadVisibilityTest.cs
@@ -44,7 +44,7 @@ public class ThreadVisibilityTest(ITestOutputHelper output) : MonolithMeshTestBa
             Content = new MeshThread()
         }).Should().Emit();
 
-        // Query by path â€” should find it
+        // Query by path — should find it
         var result = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(
             $"path:User/{RolandId}/_Thread/test-thread-1"))
             .Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items.FirstOrDefault();
@@ -65,7 +65,7 @@ public class ThreadVisibilityTest(ITestOutputHelper output) : MonolithMeshTestBa
             Content = new MeshThread()
         }).Should().Emit();
 
-        // Query as Roland â€” scope:descendants matches the real portal fan-out behavior.
+        // Query as Roland — scope:descendants matches the real portal fan-out behavior.
         // Accumulate live deltas so a node arriving in a post-Initial Added emission
         // still satisfies the assertion (eventual-consistency safe).
         var threads = await AccumulateQuery("nodeType:Thread scope:descendants",
@@ -78,7 +78,7 @@ public class ThreadVisibilityTest(ITestOutputHelper output) : MonolithMeshTestBa
     [Fact]
     public async Task QueryThreads_SamuelCannotSeeRolandsThread()
     {
-        // Create thread under Roland (as admin â€” self-access allows creation under own scope)
+        // Create thread under Roland (as admin — self-access allows creation under own scope)
         await NodeFactory.CreateNode(new MeshNode("private-thread", $"User/{RolandId}/_Thread")
         {
             Name = "Roland private thread",
@@ -87,7 +87,7 @@ public class ThreadVisibilityTest(ITestOutputHelper output) : MonolithMeshTestBa
             Content = new MeshThread()
         }).Should().Emit();
 
-        // Switch to Samuel â€” RLS self-access only grants User/Samuel/... scope,
+        // Switch to Samuel — RLS self-access only grants User/Samuel/... scope,
         // not User/Roland/... scope. PublicAdminAccess gives broad admin
         // so in this test we just verify the thread path is under Roland's scope.
         // Full RLS isolation requires ConfigureMeshBase (no PublicAdminAccess).

--- a/test/MeshWeaver.Threading.Test/ToolCallsVisibilityTest.cs
+++ b/test/MeshWeaver.Threading.Test/ToolCallsVisibilityTest.cs
@@ -19,7 +19,7 @@ namespace MeshWeaver.Threading.Test;
 
 /// <summary>
 /// Verifies tool calls on response messages are visible via the canonical
-/// <c>client.GetWorkspace().GetMeshNodeStream(path)</c> reactive handle â€”
+/// <c>client.GetWorkspace().GetMeshNodeStream(path)</c> reactive handle —
 /// the same primitive the Blazor view consumes. Updates also go through
 /// the same handle (no ad-hoc <c>GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c>).
 /// </summary>
@@ -235,7 +235,7 @@ public class ToolCallsVisibilityTest(ITestOutputHelper output) : MonolithMeshTes
             .Should().Within(10.Seconds()).Match(d => d?.Count > 0);
         delegations.Should().HaveCount(1);
         delegations![0].DelegationPath.Should().Be(subThreadPath);
-        Output.WriteLine($"Phase 2: delegation appeared â€” {delegations[0].DisplayName}");
+        Output.WriteLine($"Phase 2: delegation appeared — {delegations[0].DisplayName}");
 
         var threadStream = workspace.GetMeshNodeStream(threadPath);
         await threadStream.Update(current =>
@@ -293,7 +293,7 @@ public class ToolCallsVisibilityTest(ITestOutputHelper output) : MonolithMeshTes
         var client = GetClient();
         var workspace = client.GetWorkspace();
 
-        // Open the layout area â€” activates ThreadMessageLayoutAreas.Overview
+        // Open the layout area — activates ThreadMessageLayoutAreas.Overview
         // subscriptions (text + toolCalls + isExecuting).
         var layoutStream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(responsePath),
@@ -306,7 +306,7 @@ public class ToolCallsVisibilityTest(ITestOutputHelper output) : MonolithMeshTes
 
         var responseStream = workspace.GetMeshNodeStream(responsePath);
 
-        // Record version BEFORE the update â€” we read it off the underlying
+        // Record version BEFORE the update — we read it off the underlying
         // sync stream, the same one the Update writes through.
         var emissionCount = 0;
         using var emissionCounter = responseStream.Subscribe(
@@ -345,7 +345,7 @@ public class ToolCallsVisibilityTest(ITestOutputHelper output) : MonolithMeshTes
         var emissionDelta = countAfter - countBefore;
         emissionDelta.Should().BeLessThan(20,
             "a single tool call update should not cause runaway re-emissions. " +
-            $"Delta was {emissionDelta} â€” indicates a feedback loop in layout area subscriptions");
+            $"Delta was {emissionDelta} — indicates a feedback loop in layout area subscriptions");
         Output.WriteLine($"Version delta: {emissionDelta} (no feedback loop)");
 
         await responseStream.Update(current =>

--- a/test/MeshWeaver.Threading.Test/ToolStatusFormatterTest.cs
+++ b/test/MeshWeaver.Threading.Test/ToolStatusFormatterTest.cs
@@ -56,7 +56,7 @@ public class ToolStatusFormatterTest
     public void DelegateToAgent_FormatsWithAgentName()
     {
         // delegate_to_agent uses FormatDelegation which prepends the task summary
-        // when present â€” "task summary (Agent)". Falls back to "Delegating to
+        // when present — "task summary (Agent)". Falls back to "Delegating to
         // Agent..." only when no task arg is supplied (see
         // DelegateToAgent_NoTask_FallsBackToBareForm below).
         var call = MakeCall("delegate_to_agent", new() { ["agentName"] = "Researcher", ["task"] = "find info" });
@@ -165,7 +165,7 @@ public class ToolStatusFormatterTest
         var method = typeof(MeshWeaver.AI.ThreadMessageLayoutAreas)
             .GetMethod("ConvertReferencesToLinks", BindingFlags.NonPublic | BindingFlags.Static);
 
-        // @/path is absolute â€” LinkUrlCleanupExtension will strip @ and see /path = absolute
+        // @/path is absolute — LinkUrlCleanupExtension will strip @ and see /path = absolute
         var result = (string)method!.Invoke(null, ["See @/User/rbuergi/doc for info"])!;
         result.Should().Contain("@/User/rbuergi/doc");
     }


### PR DESCRIPTION
139 files carried double-encoded text — bytes that are a UTF-8 encoding of an already-UTF-8-decoded-as-cp1252 string. The files are valid UTF-8, so nothing failed to compile and nothing flagged it; it renders as `â€"` in IDE tooltips and generated docs. Review had begun flagging it on unrelated PRs, on lines those PRs did not author. One mechanical change, or permanent noise.

## The rule

Per **run**, never per file. A run is a maximal sequence of adjacent non-ASCII cp1252-encodable characters, rewritten **only if** `run.encode('cp1252').decode('utf-8')` succeeds; a run that fails either step is left exactly as it is.

That is what keeps an en dash an en dash. A blanket replace of the mojibake sequence with `—` would silently flatten it — the lossy "fix" that looks complete.

## Two things the naive form gets wrong, both present here

- **cp1252 leaves five byte positions undefined** (`0x81/0x8D/0x8F/0x90/0x9D`) and Python's codec refuses them — but the mangling that produced the corruption passed them through as raw bytes. Without matching that, the **triple-encoded em dash**, whose middle byte is `0x9D`, splits into fragments that cannot round-trip and survives the sweep looking like a different, unfixable class.
- **The corruption is not uniformly single.** 31 runs were double-encoded and 7 quadruple, so the sweep runs to a **fixpoint** (4 passes), not once.

## The one hand edit, called out

Eleven separator comments in `FutuReAnalysisTest.cs`. Their box-drawing character had additionally **lost a byte** — its tail is a lone `0x80`, not the `E2 82 AC` a `─` needs — so it cannot round-trip and the mechanical rule correctly refuses it. They are repaired to the character their intact twin *on the same line* decodes to. Named here so the rest of the diff can still be reviewed by reading the rule rather than the 139 files.

## Scope and safety

- `src/`, `test/`, `clients/`, plus the one file under `memex/` that carried it. `git grep` for the mojibake markers is now **empty repo-wide**.
- **802 substitutions**, all inside comments, string literals and `#region` names. No reflowing, no rewording — the diff is exactly `802 insertions(+), 802 deletions(-)`.
- **No encoding/charset test fixture** is affected — every touched file is `.cs`, and none is an encoding test.
- **No i18n catalog is affected** (again: every touched file is `.cs`), so the byte-identical `clients/react/src/i18n/` drift guard is untouched.
- **No identifiers** — every changed line is a comment, a string literal, or a `#region` name.

## Verification

Full solution build with CI's flags — `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` — **162 project outputs, 0 Warning(s), 0 Error(s)**, from a fresh worktree (so a real compile, not an up-to-date no-op).

No **What's New** entry: comments and internal diagnostic strings, no user-visible effect.

Fixes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj