### PR TITLE
fix(graph): plugin-typed slides and decks pass every compiled Deck/Slide gate

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-plugin-deck-slide-gates.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-plugin-deck-slide-gates.md
@@ -1,0 +1,15 @@
+---
+Name: Plugin slide decks get full deck navigation and export
+Category: Fix
+Description: Slides and decks installed by a plugin (e.g. Publish/Slide) now drive the deck navigation, the Export menu, and PDF/HTML export exactly like the built-in types.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Plugin slide decks get full deck navigation and export
+
+Slides whose type comes from a plugin — such as `Publish/Slide` — previously rendered without
+their deck context: the counter stuck at "Slide 1 / 1", Prev/Next never appeared, and a
+plugin-typed deck offered no Export menu and no PDF export. The platform now recognizes
+plugin slide and deck types everywhere the built-in `Slide` and `Deck` types are recognized:
+deck navigation, the presenter bar, the Export menu, pixel-faithful PDF export, and HTML export.

--- a/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
@@ -26,6 +26,18 @@ public static class DeckNodeType
     public const string NodeType = "Deck";
 
     /// <summary>
+    /// True when <paramref name="nodeType"/> is a deck type: the built-in <c>Deck</c> OR any
+    /// plugin-installed variant whose dynamic type identity ends in <c>/Deck</c> (a dynamic
+    /// NodeType's identity is its install path; instances carry it verbatim). Every compiled
+    /// gate that used to compare with <c>==</c> must use this instead — an equality gate makes
+    /// a plugin deck silently lose its Export menu, its pixel-export picker and its manifest
+    /// ordering, with no error anywhere. See <see cref="SlideNodeType.Matches"/>.
+    /// </summary>
+    public static bool Matches(string? nodeType) =>
+        nodeType == NodeType
+        || nodeType?.EndsWith("/" + NodeType, StringComparison.Ordinal) == true;
+
+    /// <summary>
     /// Inline deck/presentation-screen glyph (SVG data URI). Kept inline so the node
     /// type needs no static-asset round-trip; it renders directly as an <c>&lt;img src&gt;</c>.
     /// </summary>

--- a/src/MeshWeaver.Graph/Configuration/SlideNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SlideNodeType.cs
@@ -24,6 +24,19 @@ public static class SlideNodeType
     public const string NodeType = "Slide";
 
     /// <summary>
+    /// True when <paramref name="nodeType"/> is a slide type: the built-in <c>Slide</c> OR any
+    /// plugin-installed variant whose dynamic type identity ends in <c>/Slide</c> (a dynamic
+    /// NodeType's identity is its install path, e.g. <c>Publish/Slide</c> — instances carry it
+    /// verbatim). Every compiled gate that used to compare against <see cref="NodeType"/> with
+    /// <c>==</c> must use this instead: an equality gate silently excludes all plugin-typed
+    /// slides (education's 116 <c>Publish/Slide</c> nodes were invisible to the deck sibling
+    /// query). Same precedent as <c>MarkdownFileParser.IsSlideNodeType</c>.
+    /// </summary>
+    public static bool Matches(string? nodeType) =>
+        nodeType == NodeType
+        || nodeType?.EndsWith("/" + NodeType, StringComparison.Ordinal) == true;
+
+    /// <summary>
     /// Registers the built-in "Slide" MeshNode on the mesh builder.
     /// </summary>
     public static TBuilder AddSlideType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder

--- a/src/MeshWeaver.Graph/DeckLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/DeckLayoutAreas.cs
@@ -256,8 +256,10 @@ public static class DeckLayoutAreas
     /// <param name="deckNode">The deck node whose <see cref="DeckContent"/> declares the selection.</param>
     /// <param name="deckPath">The deck's mesh path, used to resolve bare-id references and the default query.</param>
     /// <param name="options">JSON options used to read <see cref="DeckContent"/> off the node.</param>
-    /// <returns>The ordered explicit slide paths, or the query to run when the manifest is empty.</returns>
-    public static (ImmutableList<string> Paths, string? Query) ResolveDeckSelection(
+    /// <returns>The ordered explicit slide paths, or the query to run when the manifest is empty —
+    /// with <c>FilterSlideTypes</c> set when the consumer must additionally keep only
+    /// <see cref="SlideNodeType.Matches">slide-typed</see> results.</returns>
+    public static (ImmutableList<string> Paths, string? Query, bool FilterSlideTypes) ResolveDeckSelection(
         MeshNode? deckNode, string deckPath, JsonSerializerOptions options)
     {
         var deck = deckNode.ContentAs<DeckContent>(options);
@@ -266,13 +268,20 @@ public static class DeckLayoutAreas
             .Select(r => ResolveSlidePath(deckPath, r))
             .ToImmutableList();
         // Empty manifest → a live query: the deck's custom Query, else the DEFAULT subtree of
-        // Slide nodes (a deck can be just "a folder of slides"; only Slide nodes count).
+        // slide nodes (a deck can be just "a folder of slides"; only slide nodes count).
+        // 🚨 The default deliberately carries NO `nodeType:` term: that filter is EQUALITY, and a
+        // plugin slide type's identity is its install path (`Publish/Slide`), so `nodeType:Slide`
+        // silently dropped every plugin-typed slide from the deck. Instead FilterSlideTypes tells
+        // the consumer to keep only SlideNodeType.Matches results — suffix-aware, and applied only
+        // to the DEFAULT selection: a custom DeckContent.Query keeps full authority over what
+        // counts as a slide (it can carry its own nodeType term, or none).
+        var useDefaultQuery = paths.Count == 0 && string.IsNullOrWhiteSpace(deck?.Query);
         var query = paths.Count > 0
             ? null
-            : string.IsNullOrWhiteSpace(deck?.Query)
-                ? $"path:{deckPath} nodeType:{SlideNodeType.NodeType} scope:subtree"
+            : useDefaultQuery
+                ? $"path:{deckPath} scope:subtree"
                 : deck!.Query!.Trim();
-        return (paths, query);
+        return (paths, query, useDefaultQuery);
     }
 
     private static string LastSegment(string reference)
@@ -300,7 +309,7 @@ public static class DeckLayoutAreas
                 ? Observable.CombineLatest(x.Paths.Select(ObserveSlide(host)))
                     .Select(items => (IReadOnlyList<(string, MeshNode?)>)items.ToImmutableList())
                 // Query/subtree: the live match, ordered by MeshNode.Order (nulls last, ties by path).
-                : ObserveQuerySlides(host, x.Query!, deckPath))
+                : ObserveQuerySlides(host, x.Query!, deckPath, x.FilterSlideTypes))
             .Switch()
             .StartWith((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty);
 
@@ -313,7 +322,7 @@ public static class DeckLayoutAreas
     /// children needs no manifest, and re-ordering is just editing each slide's <c>Order</c>.
     /// </summary>
     private static IObservable<IReadOnlyList<(string Path, MeshNode? Node)>> ObserveQuerySlides(
-        LayoutAreaHost host, string query, string deckPath)
+        LayoutAreaHost host, string query, string deckPath, bool filterSlideTypes)
     {
         var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
         if (meshService is null)
@@ -335,6 +344,9 @@ public static class DeckLayoutAreas
                 return map;
             })
             .Select(map => (IReadOnlyList<(string, MeshNode?)>)map.Values
+                // The default selection keeps only slide-typed nodes (suffix-aware, so plugin
+                // types like Publish/Slide count); a custom query decides for itself.
+                .Where(n => !filterSlideTypes || SlideNodeType.Matches(n.NodeType))
                 .Where(n => !string.Equals(n.Path, deckPath, StringComparison.Ordinal)
                             && !n.Segments.Skip(1).Any(s => s.StartsWith('_')))
                 .OrderBy(n => n.Order ?? int.MaxValue)

--- a/src/MeshWeaver.Graph/DeckSlidesCache.cs
+++ b/src/MeshWeaver.Graph/DeckSlidesCache.cs
@@ -148,13 +148,19 @@ public sealed class DeckSlidesCache : IDeckSlidesCache
         //     served to another. Bypass requires BOTH UserId=System on the request
         //     AND the ImpersonateAsSystem AsyncLocal scope (defense-in-depth, see
         //     PathResolutionService).
+        // 🚨 No `nodeType:` term: the query language's nodeType filter is EQUALITY, and a
+        // plugin-installed slide type's identity is its install path (`Publish/Slide`), so a
+        // `nodeType:Slide` sibling query silently excluded every plugin-typed slide (education's
+        // 116 Publish/Slide nodes rendered "Slide 1 / 1" with no Prev/Next). Query the parent's
+        // children and apply the suffix-aware SlideNodeType.Matches in the fold instead — the
+        // candidate set is one deck's children, so the wider query costs nothing.
         var request = MeshQueryRequest.FromQuery(
-            $"namespace:{parentPath} nodeType:{SlideNodeType.NodeType}") with
+            $"namespace:{parentPath}") with
         {
             UserId = MeshWeaver.Mesh.Security.WellKnownUsers.System,
         };
 
-        // Candidate set: the sibling Slide nodes sharing this parent.
+        // Candidate set: the sibling slide nodes (built-in or plugin-typed) sharing this parent.
         var siblingSlides = Observable.Using(
                 () => accessService?.ImpersonateAsSystem()
                       ?? System.Reactive.Disposables.Disposable.Empty,
@@ -162,12 +168,16 @@ public sealed class DeckSlidesCache : IDeckSlidesCache
             .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
             {
                 if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
-                    return change.Items.ToImmutableDictionary(n => n.Path);
+                    return change.Items
+                        .Where(n => SlideNodeType.Matches(n.NodeType))
+                        .ToImmutableDictionary(n => n.Path);
                 foreach (var item in change.Items)
                     map = change.ChangeType switch
                     {
-                        QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
-                        QueryChangeType.Removed => map.Remove(item.Path),
+                        QueryChangeType.Added or QueryChangeType.Updated when SlideNodeType.Matches(item.NodeType)
+                            => map.SetItem(item.Path, item),
+                        // An update can RETYPE a node away from a slide type — drop it either way.
+                        QueryChangeType.Removed or QueryChangeType.Updated => map.Remove(item.Path),
                         _ => map
                     };
                 return map;
@@ -191,7 +201,7 @@ public sealed class DeckSlidesCache : IDeckSlidesCache
     private static IReadOnlyList<string>? DeckManifestPaths(
         MeshNode? parent, string parentPath, JsonSerializerOptions serializerOptions)
     {
-        if (parent is null || !string.Equals(parent.NodeType, DeckNodeType.NodeType, StringComparison.Ordinal))
+        if (parent is null || !DeckNodeType.Matches(parent.NodeType))
             return null;
         var refs = parent.ContentAs<DeckContent>(serializerOptions)?.Slides;
         if (refs is null || refs.Count == 0)

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -240,14 +240,12 @@ public partial class MarkdownFileParser : IFileFormatParser
 
     /// <summary>
     /// A slide file may carry the built-in <c>Slide</c> node type or a plugin-namespaced
-    /// variant (e.g. <c>Slides/Slide</c> from the Slides store plugin). Both must build
-    /// SlideContent and round-trip Notes/Background: matching only the bare constant let
-    /// a namespaced slide degrade to MarkdownContent on import, and the next mesh→repo
-    /// export then dropped its Notes/Background frontmatter entirely.
+    /// variant (e.g. <c>Publish/Slide</c>). Both must build SlideContent and round-trip
+    /// Notes/Background: matching only the bare constant let a namespaced slide degrade to
+    /// MarkdownContent on import, and the next mesh→repo export then dropped its
+    /// Notes/Background frontmatter entirely. Delegates to the ONE suffix-aware predicate.
     /// </summary>
-    private static bool IsSlideNodeType(string? nodeType) =>
-        nodeType == SlideNodeType.NodeType
-        || nodeType?.EndsWith("/" + SlideNodeType.NodeType, StringComparison.Ordinal) == true;
+    private static bool IsSlideNodeType(string? nodeType) => SlideNodeType.Matches(nodeType);
 
     /// <inheritdoc />
     public string Serialize(MeshNode node)

--- a/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
@@ -45,7 +45,7 @@ public class DeckExportMenuProvider : INodeMenuProvider
             host.Hub.GetEffectivePermissions(hubPath),
             (node, perms) =>
             {
-                if (node is null || node.NodeType != DeckNodeType.NodeType || !perms.HasFlag(Permission.Read))
+                if (node is null || !DeckNodeType.Matches(node.NodeType) || !perms.HasFlag(Permission.Read))
                     return (IReadOnlyCollection<NodeMenuItemDefinition>)[];
 
                 return

--- a/src/MeshWeaver.Markdown.Export/Layout/ExportDocumentLayoutArea.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/ExportDocumentLayoutArea.cs
@@ -104,7 +104,7 @@ public static class ExportDocumentLayoutArea
                         };
                         subject.OnNext(enriched);
 
-                        if (node.NodeType != DeckNodeType.NodeType)
+                        if (!DeckNodeType.Matches(node.NodeType))
                             return;
 
                         var renderer = host.Hub.ServiceProvider.GetService<IPixelPdfRenderer>();

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportHtml.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportHtml.csx
@@ -63,7 +63,7 @@ if (rootNode is null)
     throw new InvalidOperationException("Source node not found: " + sourcePath);
 
 var jsonOptions = Mesh.JsonSerializerOptions;
-var isDeck = rootNode.NodeType == DeckNodeType.NodeType;
+var isDeck = DeckNodeType.Matches(rootNode.NodeType);
 var title = explicitTitle
             ?? options.Title
             ?? (isDeck ? rootNode.ContentAs<DeckContent>(jsonOptions)?.Title : null)
@@ -81,7 +81,7 @@ if (isDeck)
     // compose an empty document. Slide selection uses the SAME resolution the live Overview /
     // Present binding uses, so the email reads in the deck's own order.
     markdown.Clear();
-    var (paths, query) = DeckLayoutAreas.ResolveDeckSelection(rootNode, sourcePath, jsonOptions);
+    var (paths, query, filterSlideTypes) = DeckLayoutAreas.ResolveDeckSelection(rootNode, sourcePath, jsonOptions);
     var slides = new List<MeshNode>();
     if (paths.Count > 0)
     {
@@ -102,7 +102,10 @@ if (isDeck)
             .Select(c => c.Items)
             .FirstAsync()
             .ToTask(Ct);
+        // The DEFAULT selection keeps only slide-typed nodes (suffix-aware, so plugin types
+        // like Publish/Slide count); a custom DeckContent.Query decides for itself.
         var matched = slideMatches
+            .Where(n => !filterSlideTypes || SlideNodeType.Matches(n.NodeType))
             .Where(n => !string.Equals(n.Path, sourcePath, StringComparison.Ordinal))
             .Where(n => !n.Segments.Skip(1).Any(s => s.StartsWith('_')));
         slides = matched

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
@@ -69,7 +69,7 @@ List<ExportChapter> chapters;
 DocumentExportOptions effectiveOptions;
 string title;
 
-if (rootNode.NodeType == DeckNodeType.NodeType)
+if (DeckNodeType.Matches(rootNode.NodeType))
 {
     // ── Deck → PDF: one chapter per slide, in the deck's own order ──────────────
     var deck = rootNode.ContentAs<DeckContent>(jsonOptions);
@@ -78,7 +78,7 @@ if (rootNode.NodeType == DeckNodeType.NodeType)
     // Resolve the deck's slide SELECTION with the SAME logic the live Overview/Present
     // binding uses — the manifest (ordered paths) or, when empty, the deck's query / the
     // default Slide subtree. One source of truth for a deck's order.
-    var (paths, query) = DeckLayoutAreas.ResolveDeckSelection(rootNode, sourcePath, jsonOptions);
+    var (paths, query, filterSlideTypes) = DeckLayoutAreas.ResolveDeckSelection(rootNode, sourcePath, jsonOptions);
 
     var slideNodes = new List<MeshNode>();
     if (paths.Count > 0)
@@ -103,7 +103,10 @@ if (rootNode.NodeType == DeckNodeType.NodeType)
             .ToTask(Ct);
         // Drop the deck root itself and any '_'-prefixed governance node — same
         // filtering the live query binding applies (see DeckLayoutAreas.ObserveQuerySlides).
+        // The DEFAULT selection additionally keeps only slide-typed nodes (suffix-aware,
+        // so plugin types like Publish/Slide count); a custom query decides for itself.
         var matched = slideMatches
+            .Where(n => !filterSlideTypes || SlideNodeType.Matches(n.NodeType))
             .Where(n => !string.Equals(n.Path, sourcePath, StringComparison.Ordinal))
             .Where(n => !n.Segments.Skip(1).Any(s => s.StartsWith('_')));
         slideNodes = matched

--- a/test/MeshWeaver.Graph.Test/DeckSlidesCacheTest.cs
+++ b/test/MeshWeaver.Graph.Test/DeckSlidesCacheTest.cs
@@ -134,4 +134,56 @@ public class DeckSlidesCacheTest
         subscriptions.Keys.Should().Contain(k => k.Contains("namespace:DeckB"));
         subscriptions.Values.Should().OnlyContain(count => count == 1);
     }
+
+    /// <summary>
+    /// The sibling pipeline is suffix-aware end to end: the query carries NO
+    /// <c>nodeType:</c> term (that filter is EQUALITY, so it silently excluded every
+    /// plugin-typed slide — education's <c>Publish/Slide</c> nodes rendered
+    /// "Slide 1 / 1" with no Prev/Next), the fold keeps built-in AND <c>*/Slide</c>
+    /// types while dropping non-slide children, and a plugin-typed parent
+    /// (<c>*/Deck</c>) still gets its manifest order applied.
+    /// </summary>
+    [Fact]
+    public void BuildOrderedSlides_PluginTypedSlidesAndDeck_AreSuffixAware()
+    {
+        MeshQueryRequest? seen = null;
+        var mesh = Substitute.For<IMeshService>();
+        mesh.Query<MeshNode>(Arg.Any<MeshQueryRequest>())
+            .Returns(call =>
+            {
+                seen = call.Arg<MeshQueryRequest>();
+                return Observable
+                    .Return(new QueryResultChange<MeshNode>
+                    {
+                        ChangeType = QueryChangeType.Initial,
+                        Items =
+                        [
+                            new MeshNode("s1", "DeckA") { NodeType = "Publish/Slide", Order = 2 },
+                            new MeshNode("s2", "DeckA") { NodeType = SlideNodeType.NodeType, Order = 1 },
+                            new MeshNode("notes", "DeckA") { NodeType = "Markdown" },
+                        ]
+                    })
+                    .Concat(Observable.Never<QueryResultChange<MeshNode>>());
+            });
+
+        var parent = new MeshNode("DeckA", "")
+        {
+            NodeType = "Publish/Deck",
+            Content = new DeckContent { Slides = ["s1", "s2"] }
+        };
+
+        var lists = new List<IReadOnlyList<MeshNode>>();
+        using var sub = DeckSlidesCache.BuildOrderedSlides(
+                mesh,
+                Observable.Return<MeshNode?>(parent),
+                "DeckA",
+                new JsonSerializerOptions(),
+                accessService: null)
+            .Subscribe(lists.Add);
+
+        seen!.Query.Should().Be("namespace:DeckA",
+            "the sibling query must not carry an equality nodeType filter");
+        lists.Should().NotBeEmpty();
+        lists[^1].Select(n => n.Path).Should().Equal("DeckA/s1", "DeckA/s2");
+    }
 }

--- a/test/MeshWeaver.Security.Test/MarkdownExportMenuTest.cs
+++ b/test/MeshWeaver.Security.Test/MarkdownExportMenuTest.cs
@@ -30,6 +30,7 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
 
     private const string MarkdownNodePath = "TestOrg/TestMarkdown";
     private const string DeckNodePath = "TestOrg/TestDeck";
+    private const string PluginDeckNodePath = "TestOrg/PluginDeck";
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
@@ -45,6 +46,16 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
                     Name = "Test Deck",
                     NodeType = DeckNodeType.NodeType,
                     Content = new DeckContent { Title = "Test Deck" }
+                },
+                // A PLUGIN-typed deck: a dynamic NodeType's identity is its install path
+                // (e.g. the Publish pack's Publish/Deck). The compiled export gates must
+                // recognize it via the suffix-aware DeckNodeType.Matches — an equality
+                // gate silently drops its whole Export menu.
+                new MeshNode("PluginDeck", "TestOrg")
+                {
+                    Name = "Plugin Deck",
+                    NodeType = "Publish/Deck",
+                    Content = new DeckContent { Title = "Plugin Deck" }
                 }
             )
             .AddMarkdownExport()
@@ -173,6 +184,23 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
         group.Area.Should().Be(MarkdownExportMenuProvider.ExportGroupArea);
         group.Children!.Select(c => c.Label).Should().Equal(
             [MarkdownExportMenuProvider.PdfLabel, SendDocumentLayoutArea.SendLabel]);
+    }
+
+    /// <summary>
+    /// A PLUGIN-typed deck (NodeType <c>Publish/Deck</c> — install-path identity) gets the
+    /// SAME Export group as the built-in Deck. This pins the suffix-aware
+    /// <see cref="DeckNodeType.Matches"/> gate through the full menu pipeline: with an
+    /// equality gate the provider contributes nothing and the menu silently loses Export.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task PluginTypedDeck_GetsTheSameExportGroup()
+    {
+        var client = GetClient();
+        var items = await FetchNodeMenuItems(client, new Address(PluginDeckNodePath));
+
+        var group = items.Should().ContainSingle(i => i.Label == MarkdownExportMenuProvider.ExportGroupLabel).Which;
+        group.Children!.Select(c => c.Label).Should().Contain(MarkdownExportMenuProvider.PdfLabel,
+            "a Publish/Deck node must offer PDF export exactly like the built-in Deck");
     }
 
     [Fact(Timeout = 30000)]


### PR DESCRIPTION
## What

Step 2 of the Deck/Slide consolidation (after Plugins#482 healed the `Publish/Slide` fork): every compiled gate that compared a node type against the built-in `Slide`/`Deck` constants with **equality** now uses one suffix-aware predicate per type — `SlideNodeType.Matches` / `DeckNodeType.Matches` (`X` or `*/X`, ordinal; same semantics `MarkdownFileParser.IsSlideNodeType` already had, which now delegates).

Fixed gates and their user-visible failures:

| Gate | Failure for a plugin-typed (`Publish/*`) deck/slide |
|---|---|
| `DeckSlidesCache` sibling query (`nodeType:Slide` — query equality) | counter stuck at "Slide 1 / 1", no Prev/Next (education's 116 `Publish/Slide` slides) |
| `DeckLayoutAreas` default deck selection (`nodeType:Slide scope:subtree`) | manifest-less decks found no slides |
| `DeckExportMenuProvider` (`== Deck`) | Export menu silently absent |
| `ExportDocumentLayoutArea` (`== Deck`) | no pixel-fidelity picker |
| `ExportPdf.csx` / `ExportHtml.csx` (`== Deck`) | deck exported as an empty document |

The sibling/subtree queries drop their equality `nodeType:` term and filter results through the predicate instead. `ResolveDeckSelection` now returns `FilterSlideTypes` so only the **default** selection is filtered — a custom `DeckContent.Query` keeps full authority over what counts as a slide.

## Bridge, not architecture

These gates are transitional: the declaration-driven export design (#1576) lets node types carry their export composers in their own configuration lambdas, after which the compiled gates are deleted. They are also the prerequisite for moving `Deck` into the Publish pack (step 3).

## Verification

- `dotnet build` Release `-warnaserror` green for Graph.Test, Security.Test, Hosting.Monolith.Test (+ their src dependencies)
- Targeted tests all green: DeckSlidesCacheTest 4/4 (incl. new suffix-aware pipeline test pinning the widened query, the `*/Slide` fold and a `Publish/Deck` manifest), MarkdownExportMenuTest 7/7 (incl. new `Publish/Deck` Export-menu test), Deck/Slide layout-area tests 12/12, export relay + pixel-fidelity tests 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)