### PR TITLE
fix: three edge conditions that failed instead of degrading (#1561, #1572, #1500)

### DIFF
--- a/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
@@ -183,7 +183,24 @@ public class WebSearchPlugin : IAgentPlugin
                     "text/html,application/xhtml+xml,application/rss+xml,application/atom+xml,application/xml,text/plain");
 
                 using var response = await httpClient.SendAsync(request, ct);
-                response.EnsureSuccessStatusCode();
+
+                // 🚨 A non-success STATUS is an answer, not a fault (#1561). EnsureSuccessStatusCode
+                // turned "that page is gone" into an HttpRequestException, which surfaced as a
+                // fail-level log and aborted the fetch — for a search result pointing at a page the
+                // remote site has removed. Nothing here malfunctioned, so nothing here should error:
+                // report the status back to the model, which can then move on to the other results.
+                //
+                // Genuine transport failures (DNS, TLS, connection reset, timeout) still throw
+                // HttpRequestException out of SendAsync and are still caught + logged below — those
+                // ARE worth a log line, and keeping the two apart is the whole point.
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogInformation(
+                        "FetchWebPage: {Url} answered {StatusCode} ({Reason}) — reporting it to the caller rather than failing",
+                        url, (int)response.StatusCode, response.ReasonPhrase);
+                    return $"The page could not be fetched: the server answered "
+                           + $"{(int)response.StatusCode} {response.ReasonPhrase ?? response.StatusCode.ToString()} for {url}.";
+                }
 
                 var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
                 var content = await response.Content.ReadAsStringAsync(ct);

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.js
@@ -94,7 +94,13 @@ export function getWindowDimensions() {
     };
 }
 
-export function listenToWindowResize(dotnetHelper) {
+// Live resize listeners, keyed by the token their subscriber passed. They MUST be detachable:
+// the listener closes over a DotNetObjectReference, so one left attached keeps firing after the
+// component is disposed — invoking a method on a released .NET object (console errors on every
+// resize) and pinning that object for as long as the page lives.
+const resizeListeners = new Map();
+
+export function listenToWindowResize(dotnetHelper, token) {
     function throttle(func, timeout) {
         let currentTimeout = null;
         return function () {
@@ -109,17 +115,33 @@ export function listenToWindowResize(dotnetHelper) {
         }
     }
 
+    // Re-subscribing under the same token replaces the previous listener rather than stacking a
+    // second one on top of it.
+    stopListeningToWindowResize(token);
+
     const throttledResizeListener = throttle(() => {
         dotnetHelper.invokeMethodAsync('OnResizeAsync', { width: window.innerWidth, height: window.innerHeight });
     }, 150);
 
     window.addEventListener('load', throttledResizeListener);
     window.addEventListener('resize', throttledResizeListener);
+    resizeListeners.set(token, throttledResizeListener);
+}
+
+// The other half of listenToWindowResize — call it when the subscriber goes away.
+// A caller that passed no token (the older one-argument shape) detaches with no token either.
+export function stopListeningToWindowResize(token) {
+    const listener = resizeListeners.get(token);
+    if (!listener) return;
+    window.removeEventListener('load', listener);
+    window.removeEventListener('resize', listener);
+    resizeListeners.delete(token);
 }
 
 // Expose globally for BrowserDimensionWatcher
 window.getWindowDimensions = getWindowDimensions;
 window.listenToWindowResize = listenToWindowResize;
+window.stopListeningToWindowResize = stopListeningToWindowResize;
 
 // =============================================================================
 // Cookie Consent / Analytics

--- a/src/MeshWeaver.Blazor.Portal/Resize/BrowserDimensionWatcher.cs
+++ b/src/MeshWeaver.Blazor.Portal/Resize/BrowserDimensionWatcher.cs
@@ -48,6 +48,14 @@ public class BrowserDimensionWatcher : ComponentBase, IAsyncDisposable
     private DotNetObjectReference<BrowserDimensionWatcher>? selfReference;
 
     /// <summary>
+    /// Identifies THIS watcher's resize listener on the JS side, so <see cref="DisposeAsync"/> can
+    /// detach exactly it. Releasing <see cref="selfReference"/> alone is not enough: the listener
+    /// closes over that reference, so one left attached keeps firing on every resize and invokes a
+    /// method on a released .NET object — console errors, and the object pinned for the page's life.
+    /// </summary>
+    private readonly string resizeToken = Guid.NewGuid().ToString("N");
+
+    /// <summary>
     /// On first render, reads the initial window dimensions, publishes them, and registers
     /// the browser resize listener.
     /// </summary>
@@ -86,7 +94,7 @@ public class BrowserDimensionWatcher : ComponentBase, IAsyncDisposable
                 await ViewportInformationChanged.InvokeAsync(ViewportInformation);
 
                 selfReference ??= DotNetObjectReference.Create(this);
-                await module.InvokeVoidAsync("listenToWindowResize", selfReference);
+                await module.InvokeVoidAsync("listenToWindowResize", selfReference, resizeToken);
             }
             catch (JSDisconnectedException)
             {
@@ -98,21 +106,26 @@ public class BrowserDimensionWatcher : ComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Releases the JS module reference and the .NET object reference handed to the resize
-    /// listener. <see cref="JSDisconnectedException"/> is expected here: on a circuit that has
-    /// already gone away there is nothing left to release.
+    /// Detaches the browser resize listener, then releases the JS module reference and the .NET
+    /// object reference it closed over — in that order, because releasing the reference first
+    /// would leave a live listener calling into a released object.
+    /// <see cref="JSDisconnectedException"/> is expected here: on a circuit that has already gone
+    /// away there is nothing left to detach or release.
     /// </summary>
-    /// <returns>A task that completes once both references are released.</returns>
+    /// <returns>A task that completes once the listener is detached and both references released.</returns>
     public async ValueTask DisposeAsync()
     {
         try
         {
             if (module is not null)
+            {
+                await module.InvokeVoidAsync("stopListeningToWindowResize", resizeToken);
                 await module.DisposeAsync();
+            }
         }
         catch (JSDisconnectedException)
         {
-            // The circuit is gone; the browser-side module went with it.
+            // The circuit is gone; the browser-side module and its listeners went with it.
         }
         finally
         {

--- a/src/MeshWeaver.Blazor.Portal/Resize/BrowserDimensionWatcher.cs
+++ b/src/MeshWeaver.Blazor.Portal/Resize/BrowserDimensionWatcher.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.Blazor.Portal.Resize;
 /// listens for resize events, and publishes the resulting viewport size/classification
 /// through the shared <c>DimensionManager</c> and a two-way bound parameter.
 /// </summary>
-public class BrowserDimensionWatcher : ComponentBase
+public class BrowserDimensionWatcher : ComponentBase, IAsyncDisposable
 {
     /// <summary>
     /// The current viewport classification (desktop/mobile, ultra-low height/width). Two-way bound.
@@ -38,6 +38,16 @@ public class BrowserDimensionWatcher : ComponentBase
     public required DimensionManager DimensionManager { get; init; }
 
     /// <summary>
+    /// The JS module this component's interop goes through. See <see cref="OnAfterRenderAsync"/>
+    /// for why the module reference — not the <c>window.*</c> globals it also assigns — is what
+    /// this component may depend on.
+    /// </summary>
+    private IJSObjectReference? module;
+
+    /// <summary>Handed to JS for the resize callback; released in <see cref="DisposeAsync"/>.</summary>
+    private DotNetObjectReference<BrowserDimensionWatcher>? selfReference;
+
+    /// <summary>
     /// On first render, reads the initial window dimensions, publishes them, and registers
     /// the browser resize listener.
     /// </summary>
@@ -49,14 +59,34 @@ public class BrowserDimensionWatcher : ComponentBase
         {
             try
             {
-                var viewportSize = await JS.InvokeAsync<ViewportSize>("window.getWindowDimensions");
+                // 🚨 IMPORT THE MODULE, don't reach for the globals (#1572).
+                //
+                // `getWindowDimensions` / `listenToWindowResize` are EXPORTS of
+                // PortalLayoutBase.razor.js, which additionally assigns them onto `window` as a
+                // side effect OF BEING IMPORTED. That import is lazy and belongs to a different
+                // component (PortalLayoutBase.EnsureJsModuleAsync), while this watcher lives in
+                // Routes.razor and runs its own first render — so nothing orders the two. When
+                // this render won, `window.getWindowDimensions` was still undefined and the
+                // interop threw JSException ("The value 'window.getWindowDimensions' is not a
+                // function"), which kills the Blazor circuit for that user.
+                //
+                // Importing here removes the ordering dependency instead of tolerating it: ES
+                // module imports are idempotent and cached, so this costs nothing when the layout
+                // already pulled it in, and it is correct when it did not. The window.* aliases
+                // stay in the JS for any in-mesh caller the compiler cannot see — this component
+                // simply no longer relies on someone else having triggered them.
+                module ??= await JS.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.js");
+
+                var viewportSize = await module.InvokeAsync<ViewportSize>("getWindowDimensions");
                 DimensionManager.InvokeOnViewportSizeChanged(viewportSize);
                 ViewportInformation = ViewportInformation.GetViewportInformation(viewportSize);
                 DimensionManager.InvokeOnViewportInformationChanged(ViewportInformation);
 
                 await ViewportInformationChanged.InvokeAsync(ViewportInformation);
 
-                await JS.InvokeVoidAsync("window.listenToWindowResize", DotNetObjectReference.Create(this));
+                selfReference ??= DotNetObjectReference.Create(this);
+                await module.InvokeVoidAsync("listenToWindowResize", selfReference);
             }
             catch (JSDisconnectedException)
             {
@@ -65,6 +95,31 @@ public class BrowserDimensionWatcher : ComponentBase
         }
 
         await base.OnAfterRenderAsync(firstRender);
+    }
+
+    /// <summary>
+    /// Releases the JS module reference and the .NET object reference handed to the resize
+    /// listener. <see cref="JSDisconnectedException"/> is expected here: on a circuit that has
+    /// already gone away there is nothing left to release.
+    /// </summary>
+    /// <returns>A task that completes once both references are released.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (module is not null)
+                await module.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // The circuit is gone; the browser-side module went with it.
+        }
+        finally
+        {
+            module = null;
+            selfReference?.Dispose();
+            selfReference = null;
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-robustness-fixes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-robustness-fixes.md
@@ -1,0 +1,23 @@
+---
+Name: Steadier page loads and web search
+Category: Fix
+Description: A dead link in a web search no longer aborts the search, and a timing problem that could drop a page on load is gone.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Steadier page loads and web search
+
+Three small things that could go wrong at the edges no longer do.
+
+When an agent searched the web and one of the results pointed at a page that had since been removed,
+the whole page fetch failed. Now the missing page is simply reported as missing and the agent carries
+on with the other results.
+
+Occasionally a page load could fail outright because the browser measurement the layout depends on
+ran before the script that provides it had loaded. The measurement now brings its own script along,
+so the order no longer matters.
+
+Finally, a portal that starts up while its plugin registry is briefly unreachable now retries instead
+of giving up for the lifetime of that instance — so a momentary network hiccup no longer leaves
+installed plugins showing an old version until the next restart.

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -66,6 +66,17 @@ public sealed class RegistryUpdateReconciler(
 {
     private readonly CompositeDisposable subscriptions = new();
 
+    /// <summary>
+    /// How many times a transport-level failure of the feed read is re-attempted within the boot
+    /// reconcile (see the RetryWhen in <see cref="ReconcileOne"/>). Small on purpose: this bounds a
+    /// cold pod's startup work, and the retries exist to survive a hiccup, not to wait out an outage.
+    /// </summary>
+    private const int FeedReadRetries = 3;
+
+    /// <summary>Exponential-ish backoff between feed-read attempts: 2 s, 6 s, 18 s.</summary>
+    private static TimeSpan FeedReadBackoff(int attempt) =>
+        TimeSpan.FromSeconds(2 * Math.Pow(3, attempt));
+
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -154,6 +165,30 @@ public sealed class RegistryUpdateReconciler(
 
                 var source = new RegistryPackageSource(hub, registry.Url, token);
                 return source.ListPackages(gitRef)
+                    // 🚨 The ONE attempt the design allots must actually get a fair chance (#1500).
+                    //
+                    // This service deliberately has NO poll timer (see the type remarks): the bound
+                    // it promises is "a consumer learns on its NEXT BOOT". A single TCP hiccup on a
+                    // cold pod silently consumed that one chance — the feed read failed, the Error
+                    // was logged, and the installation then stayed unreconciled for the whole life
+                    // of the pod, because nothing here ever asks again. That is the defect: not the
+                    // timeout's length, but that the boot attempt is unrepeated.
+                    //
+                    // So this is a bounded retry INSIDE the boot attempt, not a clock. It does not
+                    // widen any bound and it adds no background load — and it deliberately does not
+                    // retry an InvalidOperationException, which is how RegistryPackageSource reports
+                    // a definite HTTP answer (401/403/404): a registry that refuses this instance's
+                    // key will refuse it again in two seconds, and burning the boot window on that
+                    // would only delay the log line that names it.
+                    .RetryWhen(faults => faults
+                        .Select((fault, attempt) => (fault, attempt))
+                        .SelectMany(f => f.fault is not InvalidOperationException && f.attempt < FeedReadRetries
+                            ? Observable.Timer(FeedReadBackoff(f.attempt)).Select(_ => Unit.Default)
+                                .Do(_ => logger.LogWarning(f.fault,
+                                    "[RegistryUpdate] reading {Url} failed (attempt {Attempt}/{Total}) — retrying; "
+                                    + "this boot is the only chance this installation gets to reconcile.",
+                                    registry.Url, f.attempt + 1, FeedReadRetries + 1))
+                            : Observable.Throw<Unit>(f.fault)))
                     .Take(1)
                     .SelectMany(packages =>
                     {
@@ -171,8 +206,11 @@ public sealed class RegistryUpdateReconciler(
                 // One unreachable registry must not withhold the others, and must never be silent:
                 // "the store is empty and nobody said why" is the exact failure this issue began as.
                 logger.LogError(ex,
-                    "[RegistryUpdate] could not read the package feed of {Name} ({Url}) — installed "
-                    + "packages from it are NOT reconciled this boot.", name, registry.Url);
+                    "[RegistryUpdate] could not read the package feed of {Name} ({Url}) after up to "
+                    + "{Attempts} attempt(s) — installed packages from it are NOT reconciled this "
+                    + "boot, and there is no poll behind this: the next chance is the next restart "
+                    + "or a human opening the catalog page.",
+                    name, registry.Url, FeedReadRetries + 1);
                 return Observable.Return(Unit.Default);
             });
     }

--- a/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
@@ -322,9 +322,30 @@ public class WebSearchPluginTest
         result.Should().NotContain("\"link\"");
     }
 
-    private static Task<string> FetchAsync(string body, string mediaType)
+    /// <summary>
+    /// A non-success STATUS is an answer, not a fault (#1561). A search result pointing at a page
+    /// the remote site has removed used to reach <c>EnsureSuccessStatusCode</c>, throw
+    /// <c>HttpRequestException</c>, and abort the fetch with a fail-level log — for a condition in
+    /// which nothing here malfunctioned. The status must come back to the caller so the model can
+    /// move on to the other results.
+    /// </summary>
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, "404")]
+    [InlineData(HttpStatusCode.Forbidden, "403")]
+    [InlineData(HttpStatusCode.InternalServerError, "500")]
+    public async Task FetchWebPage_NonSuccessStatus_IsReportedNotThrown(HttpStatusCode status, string expected)
     {
-        var httpClient = new HttpClient(new StubHttpMessageHandler(body, mediaType));
+        var result = await FetchAsync("<html>nope</html>", "text/html", status);
+
+        result.Should().Contain("could not be fetched",
+            "a removed remote page is a result the caller can act on, not an exception");
+        result.Should().Contain(expected, "the caller needs the status to decide what to do next");
+    }
+
+    private static Task<string> FetchAsync(
+        string body, string mediaType, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler(body, mediaType, status));
         var plugin = new WebSearchPlugin(
             httpClient,
             Options.Create(new WebSearchConfiguration()),
@@ -333,11 +354,12 @@ public class WebSearchPluginTest
         return plugin.FetchWebPageCore("https://feed.example.com/rss").FirstAsync().ToTask();
     }
 
-    private sealed class StubHttpMessageHandler(string body, string mediaType) : HttpMessageHandler
+    private sealed class StubHttpMessageHandler(
+        string body, string mediaType, HttpStatusCode status = HttpStatusCode.OK) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            => Task.FromResult(new HttpResponseMessage(status)
             {
                 Content = new StringContent(body, Encoding.UTF8, mediaType)
             });


### PR DESCRIPTION
Three unrelated filings, one shape: a condition that should have degraded gracefully aborted instead.

## #1561 — a removed remote page failed the whole fetch

`WebSearchPlugin.FetchWebPageCore` treated a non-success **status** as a fault. A search result pointing at a page the remote site had since removed reached `EnsureSuccessStatusCode()`, threw `HttpRequestException`, and aborted the fetch with a `fail:`-level log — for a condition in which **nothing here malfunctioned**.

The status now comes back to the caller so the model can move on to the other results. Genuine transport failures (DNS, TLS, connection reset, timeout) still throw out of `SendAsync` and are still caught and logged — keeping those two apart is the whole point.

Pinned by a new `404 / 403 / 500` theory in `WebSearchPluginTest`.

## #1572 — the viewport measurement raced the script that provides it

`BrowserDimensionWatcher` called `window.getWindowDimensions`. That global is assigned as a **side effect of `PortalLayoutBase.razor.js` being imported** — and that import is lazy and belongs to a *different* component (`PortalLayoutBase.EnsureJsModuleAsync`), while the watcher lives in `Routes.razor` and runs its own first render. Nothing orders the two. When this render won, the global was undefined, the interop threw `JSException`, and that user's Blazor circuit died.

The watcher now **imports the module and calls the export**. ES module imports are idempotent and cached, so this costs nothing when the layout already pulled it in and is correct when it did not — the ordering dependency is removed rather than tolerated.

The `window.*` aliases stay in the JS for any in-mesh caller the compiler cannot see; this component simply no longer relies on someone else having triggered them. The module reference and the `DotNetObjectReference` are now released on dispose.

## #1500 — the one chance the design allots was consumed by a hiccup

`RegistryUpdateReconciler` has **no poll timer, deliberately** (its own type remarks say so): the bound it promises is *"a consumer learns on its next boot"*. A single TCP hiccup on a cold pod silently consumed that one chance — the feed read failed, an Error was logged, and the installation then stayed unreconciled **for the whole life of the pod**, because nothing there ever asks again.

So the defect is not the timeout's length, it is that the boot attempt is **unrepeated**. The fix is a bounded retry *inside* the boot attempt (3 retries, 2 s / 6 s / 18 s): no clock, no background load, no widened bound, and no contradiction of the documented "no poll timer" design.

An `InvalidOperationException` is deliberately **not** retried — that is how `RegistryPackageSource` reports a definite HTTP answer (401/403/404), and a registry that refuses this instance's key will refuse it again in two seconds; burning the boot window on that would only delay the log line that names it.

## Not in this PR

**#1563** stays open on purpose. A `ContentRoute` read waiting its full 1-minute timeout when the target hub is unreachable is the **routing failure leg**, and belongs with #1486 (a NACK published to a subscriber-less stream succeeds silently) rather than being papered over here with a shorter bound.

## Verification

- `-c Release -warnaserror`, 0 errors / 0 warnings: `MeshWeaver.AI`, `MeshWeaver.Blazor.Portal`, `MeshWeaver.PluginCatalog`, `MeshWeaver.AI.Test`.
- `WebSearchPluginTest`: **16/16 green**, including the three new status cases.

Fixes #1561, #1572, #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj