### PR TITLE
fix: migrate four client packages to TypeScript 7 (Clients workflow)

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -100,7 +100,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # 22, not 20: jsdom 30 declares engines ^22.22.2 || ^24.15.0 || >=26.0.0 (jsdom 29 still
+          # allowed 20). On Node 20 its undici dependency hits
+          # `webidl.util.markAsUncloneable is not a function` — markAsUncloneable landed in Node 22 —
+          # and EVERY jsdom worker fails to start, so vitest collects ZERO tests and exits 1.
+          # "no tests" is not a pass, which is why this must be the node version and not a fallback.
+          # (Node 20 also went end-of-life 2026-04-30; portal-next has been on 22 all along.)
+          node-version: 22
       - run: npm ci --no-audit --no-fund
       - run: npm run typecheck
       - run: npm test # vitest: renderer core, control gallery, ThreadChat (live thread-node stream), Blazor-parity ratchet

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -131,9 +131,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # 22, not 20: the worker's runtime type-stripper (amaro — see package.json's _amaro_note)
+          # declares engines node>=22, and Node 20 went end-of-life 2026-04-30.
+          node-version: 22
       - run: npm ci --no-audit --no-fund
       - run: npm run typecheck
+      - run: npm test # node --test: the js/ts Code-node execution core (type stripping → vm → REPL value)
 
   grpc-web:
     name: "@meshweaver/client-web (typecheck + test)"

--- a/clients/grpc-web/tsconfig.json
+++ b/clients/grpc-web/tsconfig.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // TypeScript 7 no longer auto-includes every package under node_modules/@types the way 5.x did,
+    // so @types/node has to be named explicitly or the contract tests that read the C# sources off
+    // disk (wireContract, restContract) lose `node:fs`, `node:path` and `process` (TS2591) — and
+    // with readFileSync untyped, their callbacks then degrade to implicit `any` (TS7006).
+    "types": ["node"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "declaration": true,

--- a/clients/portal/tsconfig.json
+++ b/clients/portal/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "baseUrl": ".",
+    // No "baseUrl": TypeScript 7 removed it (TS5102). The "paths" entries below are already
+    // relative to this tsconfig, which is exactly what baseUrl "." resolved them against.
     "paths": {
       "@meshweaver/react/core": ["../react/src/core.ts"],
       "@meshweaver/react": ["../react/src/index.tsx"],

--- a/clients/react/tsconfig.json
+++ b/clients/react/tsconfig.json
@@ -3,6 +3,12 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // TypeScript 7 no longer auto-includes every package under node_modules/@types the way 5.x did,
+    // so @types/node has to be named explicitly or the test files that read the server catalogs off
+    // disk (i18n/localize, render/parity, ciTrigger) lose `node:fs`, `node:path` and `process`
+    // (TS2591). This is the fix the compiler's own diagnostic prescribes, not a suppression — the
+    // files are still fully checked, and listing it is stricter than 5.x's include-everything.
+    "types": ["node"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -10,13 +10,17 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.8.1",
-        "typescript": "^7.0.2"
+        "amaro": "^1.1.11"
       },
       "bin": {
         "meshweaver-node-worker": "dist/worker.js"
       },
       "devDependencies": {
-        "@types/node": "^26.2.0"
+        "@types/node": "^26.2.0",
+        "typescript": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -133,6 +137,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -149,6 +154,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -165,6 +171,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -181,6 +188,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -197,6 +205,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -213,6 +222,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -229,6 +239,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -245,6 +256,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -261,6 +273,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -277,6 +290,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -293,6 +307,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -309,6 +324,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -325,6 +341,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -341,6 +358,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -357,6 +375,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -373,6 +392,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -389,6 +409,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -405,6 +426,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -421,6 +443,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -437,6 +460,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -444,6 +468,15 @@
       ],
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/amaro": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/amaro/-/amaro-1.1.11.tgz",
+      "integrity": "sha512-Tg8KzTpeCUQ23RNSuA2GeVRxHhkHyq8U9jNpKRjiMQKY2C9iJ7pLlGw2iRy4nNMYtB+tkLghk3swCo13O68zDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/ansi-regex": {
@@ -609,6 +642,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -21,12 +21,29 @@
     "test": "tsc && node --test test/*.test.mjs",
     "demo": "tsc && node dist/worker.js --demo"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.8.1",
-    "typescript": "^7.0.2"
+    "amaro": "^1.1.11"
   },
   "devDependencies": {
-    "@types/node": "^26.2.0"
-  }
+    "@types/node": "^26.2.0",
+    "typescript": "^7.0.2"
+  },
+  "_amaro_note": [
+    "amaro replaces `typescript` as the RUNTIME type-stripper for javascript/typescript Code nodes.",
+    "TypeScript 7 removed `ts.transpileModule`: the package's \".\" export is now lib/version.cjs (a",
+    "version string) and the API moved to typescript/unstable/*, which is Project/Program/Checker",
+    "shaped with no single-string transform at all. amaro is the SWC-based stripper Node itself",
+    "bundles for --experimental-strip-types, and its `mode: \"transform\"` keeps the constructs that",
+    "carry runtime semantics (enum, namespace, parameter properties) working — Node's built-in",
+    "module.stripTypeScriptTypes is strip-only and REJECTS those, which would have been a silent",
+    "capability regression for Code nodes that use them.",
+    "amaro declares engines node>=22, hence the engines field and the workflow's node 22 (Node 20",
+    "went end-of-life 2026-04-30). typescript stays, as a devDependency — it is only `tsc` now, so",
+    "the published worker no longer ships the whole compiler."
+  ]
 }

--- a/clients/typescript/src/worker.ts
+++ b/clients/typescript/src/worker.ts
@@ -33,12 +33,23 @@ function fmt(a: unknown): string {
   try { return JSON.stringify(a); } catch { return String(a); }
 }
 
-/** Strip TypeScript types → runnable JavaScript with the bundled compiler (lazy — plain-JS runs pay nothing). */
+/**
+ * Strip TypeScript types → runnable JavaScript (lazy — plain-JS runs pay nothing).
+ *
+ * This used to call `ts.transpileModule` from the `typescript` package. TypeScript 7 removed that:
+ * the package's "." export is now just `lib/version.cjs` (a version string), and the real API moved
+ * to `typescript/unstable/*` — a project/Program/Checker-shaped API with no single-string transform
+ * anywhere in it. So the snippet transform comes from `amaro`, which is the very SWC-based stripper
+ * Node bundles for its own `--experimental-strip-types`.
+ *
+ * `mode: "transform"` (not "strip") is deliberate: strip-only blanks types out and REJECTS the
+ * TS constructs that carry runtime semantics — `enum`, `namespace`, parameter properties — which
+ * `transpileModule` used to compile. Transform mode emits real JS for them, so a Code node that ran
+ * before still runs. (Node's own `module.stripTypeScriptTypes` is strip-only, hence the package.)
+ */
 async function transpileTs(code: string): Promise<string> {
-  const ts = (await import("typescript")).default;
-  return ts.transpileModule(code, {
-    compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.None },
-  }).outputText;
+  const { transformSync } = await import("amaro");
+  return transformSync(code, { mode: "transform" }).code;
 }
 
 /**


### PR DESCRIPTION
The npm-major bump in `688ce589b` (PR #1555) moved TypeScript 5.9 → 7 across the client packages and left **six** `Clients` jobs red. #1567 already fixed `Portal-next`. This fixes **four** of the remaining five. The two react-native jobs need a scope call — see the bottom.

Verified locally by running each job's own commands (`npm ci` from the committed lock, then typecheck / test / build).

## The TS 7 change behind three of them

TypeScript 7 no longer auto-includes every package under `node_modules/@types` the way 5.x did. Reproduced in a pristine project — same tsconfig, same `@types/node@26.2.0`, only the compiler version varying:

| typescript | `import { readFileSync } from "node:fs"` + `process.cwd()` |
|---|---|
| 5.9.3 | clean |
| 7.0.2 | `TS2591` on `node:fs`, `node:path`, `process` |

| job | real error | migration |
|---|---|---|
| `@meshweaver/react` | 11 × `TS2591` — the tests that read the server catalogs off disk (`i18n/localize`, `render/parity`, `ciTrigger`) lost `node:fs` / `node:path` / `process` | `"types": ["node"]` |
| `@meshweaver/client-web` | same `TS2591` in the wire/rest contract guards, **plus** `TS7006` implicit-any that follows from an untyped `readFileSync` | `"types": ["node"]` |
| `Portal example` | `TS5102: Option 'baseUrl' has been removed` | dropped `baseUrl`; the `paths` entries are already relative to the tsconfig, which is exactly what `baseUrl "."` resolved them against — the same one-liner portal-next took in #1567 |

`"types": ["node"]` is the fix the compiler's own diagnostic prescribes. **Nothing is silenced** — the files stay fully checked, and naming one package is *stricter* than 5.x's include-everything.

## `@meshweaver/client` — a real API migration

TS 7 **removed `ts.transpileModule`**. The package's `"."` export is now `lib/version.cjs` (a version string); the API moved to `typescript/unstable/*`, which is `Project`/`Program`/`Checker` shaped with **no single-string transform anywhere in it** (`grep -r transpile` over the package: zero hits). So this is not a config problem and there is no in-package replacement.

The node kernel's type-stripper now uses **`amaro`** — the SWC-based stripper Node itself bundles for `--experimental-strip-types`.

`mode: "transform"`, not `"strip"`, is deliberate: strip-only **rejects** the TS constructs that carry runtime semantics, which `transpileModule` used to compile. Node's own `module.stripTypeScriptTypes` is strip-only, which is why it is not enough. Verified through the real `executeCode`:

| snippet | result |
|---|---|
| `const answer: number = 6*7` | 42 |
| `enum Color { Red, Green } Color.Green` | 1 |
| `namespace N { export const v = 42 } N.v` | 42 |
| `class C { constructor(private readonly x: number){} … }` | 42 |

`typescript` drops to a **devDependency** (it is only `tsc` now), so the worker no longer ships the whole compiler. `amaro` declares `engines: node>=22`, hence the `engines` field and that job moving to **node 22** — Node 20 went end-of-life 2026-04-30.

That job also **gains `npm test`**: it previously ran typecheck only, so the js/ts execution core this PR changes had *no CI coverage at all*.

## Nothing was suppressed

No `ignoreBuildErrors`, no new `skipLibCheck`, no `@ts-nocheck` / `@ts-ignore` / `@ts-expect-error`, no `--legacy-peer-deps` / `--force`, no narrowed `include`, no deleted or skipped test. Net change to how much is checked: **more** (one added test step).

## Local verification

| job | result |
|---|---|
| `@meshweaver/react` | typecheck clean · **261 tests** in 35 files · lib build clean |
| `@meshweaver/client-web` | typecheck clean · **52 tests** in 6 files |
| `@meshweaver/client` | clean `npm ci` → typecheck clean · **5/5 tests** |
| `Portal example` | `npm ci` → `tsc --noEmit` clean · vite build clean |

The i18n catalog drift guard (15 tests) and the `ciTrigger` workflow guard (4 tests) both pass — the latter re-run *after* the `clients.yml` edit.

## NOT fixed here — RN connector / RN web need a scope call

Dependabot bumped **expo 52→57 and react 18→19 but pinned `react-native` at 0.76.5**, whose peers are `react: ^18.2.0` / `@types/react: ^18.2.6`. That set is genuinely unresolvable — the `npm ci` `ERESOLVE` is the drift guard working correctly, not a packaging nit.

Three candidate fixes, all rejected on evidence:

- **`--legacy-peer-deps` / an `overrides` entry** — installs a combination upstream does not support (RN 0.76.5 predates React 19), and the RN web job actually *renders* through Playwright. Cannot be proven, so it cannot be forced.
- **Pin `@types/react` back to 18 for RN** — tested: RN typechecks `../react/src`, which resolves React **19** types from `clients/react/node_modules`, so two React type identities collide → `TS2786` at every JSX call site.
- **Revert `clients/react` to React 18 as well** — would re-break `Portal-next`, which is green *on* React 19.

The coherent direction is forward: **`react-native@0.82` peers are exactly `react: ^19.1.1` / `@types/react: ^19.1.1`** — i.e. the Expo SDK 52→57 upgrade, six RN minors, which also has to deal with `expo-av`. The repo already flagged this in `clients/react-native/package.json`: *"the real fix is the Expo SDK upgrade … which is its own migration."* Tracked separately rather than half-done here.

These two jobs do **not** gate image publication: `main-cd.yml` triggers on *MeshWeaver Build and Test*, and its image legs build `grpc-web` + `portal-next` only — never `react-native`. (The #1568 stranding was the portal-next leg, fixed in #1567.)

No What's New entry: CI/build plumbing, and no workflow publishes these npm packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
