### PR TITLE
fix(#1557, #1569): order the route-collapse suppression, and give the token sweep a signal to wait on

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using MeshWeaver.Data;
@@ -46,6 +47,25 @@ internal class ApiTokenService(
     private const int TokenByteLength = 32;
     private const string NodeTypeApiToken = "ApiToken";
     private const string ApiTokenNamespace = "ApiToken";
+
+    /// <summary>
+    /// Fires the namespace of each expiry sweep as it FINISHES (see <see cref="CleanupExpired"/>).
+    ///
+    /// <para>The sweep is deliberately off the mint's critical path — a user with a backlog must
+    /// not pay for it at sign-in — which means <c>CreateToken</c>'s own emission says nothing about
+    /// whether the sweep has run. Without this signal there is no source to subscribe to, so an
+    /// observer can only SAMPLE and hope: that is what made
+    /// <c>CreateToken_SweepsTheUsersAlreadyExpiredTokens</c> fail under CI load (#1569) while
+    /// passing 11/11 locally — the assertion read the lagged query index before the sweep's deletes
+    /// had landed, and the test had no way to wait for the actual condition.</para>
+    ///
+    /// <para>Instance field on the mesh-scoped singleton — never static, so it dies with the mesh.
+    /// Synchronized because sweeps for different users complete on different threads.</para>
+    /// </summary>
+    public IObservable<string> ExpirySweepCompleted => expirySweepCompleted.AsObservable();
+
+    private readonly ISubject<string> expirySweepCompleted =
+        Subject.Synchronize(new Subject<string>());
 
     /// <summary>
     /// Single-flight recency memo for the LastUsedAt stamp, keyed by token hash:
@@ -260,8 +280,17 @@ internal class ApiTokenService(
                     }))))
             .Subscribe(
                 _ => { },
-                ex => logger.LogWarning(ex,
-                    "Expired API token cleanup sweep failed for {Namespace}", userTokenNamespace));
+                ex =>
+                {
+                    logger.LogWarning(ex,
+                        "Expired API token cleanup sweep failed for {Namespace}", userTokenNamespace);
+                    // Fire on the FAULT path too. An observer waiting for this sweep must be told it
+                    // is over either way — a signal that only fires on success turns a failed sweep
+                    // into an indefinite wait, which is the same "no source to subscribe to" defect
+                    // one level down.
+                    expirySweepCompleted.OnNext(userTokenNamespace);
+                },
+                () => expirySweepCompleted.OnNext(userTokenNamespace));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-no-resurrected-edits.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-no-resurrected-edits.md
@@ -1,0 +1,17 @@
+---
+Name: Deleted text stays deleted
+Category: Fix
+Description: Under load, a rapid sequence of edits could re-add text you had just deleted. It can't any more.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Deleted text stays deleted
+
+When edits arrived in quick succession, the portal could save the same change twice by two different
+internal routes. If the second one was slightly behind, the two versions were merged — and a merge
+with no common starting point keeps everything from both sides, so a word or a paragraph you had
+just deleted quietly came back.
+
+The two routes are now properly ordered rather than racing, so the duplicate save never happens and
+there is nothing to merge. Deletions stick, however fast you type.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -330,11 +330,57 @@ public static class MeshDataSourceExtensions
         var alreadyFlushed = flushed?.HighWater(node.Path) ?? 0L;
         if (node.Version <= alreadyFlushed)
         {
+            // 🚨 CONFIRMED versus CLAIMED (#1557). A confirmed mark means the row IS durable at or
+            // above this state, so dropping is right. An unresolved CLAIM means the flush has taken
+            // the version but its write is still in flight — whether it lands is not yet known, and
+            // dropping there would lose the write outright if the flush then failed or answered the
+            // "I do not own this path" sentinel. So defer instead: wait for the claim to resolve and
+            // write only if it reports that nothing was persisted.
+            //
+            // The claim is what makes the suppression ORDERED rather than timed. Before it, this
+            // handler could read a not-yet-raised mark, write a stale version over a row that had
+            // moved on, and have MonotonicWriteGuard's base-less merge keep the string SUPERSET —
+            // re-adding deleted text. ~4% of runs on the 2-vCPU runner, each one a real resurrection.
+            var pending = flushed?.PendingClaim(node.Path);
+            if (pending is null)
+            {
+                logger?.LogDebug(
+                    "[SaveMeshNode] skip {Path} at version={Version} — the post-commit flush already "
+                    + "persisted version={PersistedVersion}", node.Path, node.Version, alreadyFlushed);
+                return request.Processed();
+            }
+
             logger?.LogDebug(
-                "[SaveMeshNode] skip {Path} at version={Version} — the post-commit flush already "
-                + "persisted version={PersistedVersion}", node.Path, node.Version, alreadyFlushed);
+                "[SaveMeshNode] defer {Path} at version={Version} — the post-commit flush has CLAIMED "
+                + "version={ClaimedVersion} and its write is still in flight",
+                node.Path, node.Version, alreadyFlushed);
+            pending.Take(1).Subscribe(
+                persisted =>
+                {
+                    if (persisted)
+                        logger?.LogDebug(
+                            "[SaveMeshNode] drop deferred {Path} at version={Version} — the flush persisted it",
+                            node.Path, node.Version);
+                    else
+                        WriteSampledNode(persistence, hub, node, logger);
+                },
+                ex => logger?.LogWarning(ex,
+                    "[SaveMeshNode] deferred write for {Path} (version={Version}) could not resolve its "
+                    + "flush claim", node.Path, node.Version));
             return request.Processed();
         }
+        WriteSampledNode(persistence, hub, node, logger);
+        return request.Processed();
+    }
+
+    /// <summary>
+    /// The sampler's durable write — extracted so the deferred path (a sampled state held behind an
+    /// unresolved post-commit flush claim, see <c>PostCommitFlushRegistry</c>) writes through
+    /// exactly the same code, including the <c>MonotonicWriteGuard</c> refusal contract below.
+    /// </summary>
+    private static void WriteSampledNode(
+        IStorageAdapter persistence, IMessageHub hub, MeshNode node, ILogger? logger)
+    {
         logger?.LogDebug("[SaveMeshNode] start path={Path} version={Version}",
             node.Path, node.Version);
         // Storage adapter's own Changes feed publishes the Updated event
@@ -373,7 +419,6 @@ public static class MeshDataSourceExtensions
                 },
                 ex => logger?.LogWarning(ex, "SaveMeshNode failed for {Path} (version={Version})",
                     node.Path, node.Version));
-        return request.Processed();
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -354,7 +354,21 @@ public static class MeshDataSourceExtensions
                 "[SaveMeshNode] defer {Path} at version={Version} — the post-commit flush has CLAIMED "
                 + "version={ClaimedVersion} and its write is still in flight",
                 node.Path, node.Version, alreadyFlushed);
-            pending.Take(1).Subscribe(
+            // 🚨 The deferred write goes back THROUGH THE HUB, and the subscription dies with it.
+            //
+            // The claim resolves on whatever thread the flush completes on — a storage/emission
+            // thread, not this hub's inbox. Calling the write directly from there would bypass the
+            // single-threaded action block every other handler is serialised by, and the
+            // subscription would outlive teardown: precisely the two properties the actor model
+            // exists to guarantee. Re-posting SaveMeshNodeRequest puts the retry back in the queue,
+            // where it is ordered against every other message and refused outright once the hub is
+            // shutting down.
+            //
+            // It cannot loop: a resolved claim is REMOVED from the registry, so the re-posted
+            // request reads a high-water of 0 for that version and writes. If a NEWER claim exists
+            // by then it defers once more against THAT one, which resolves in its turn.
+            var deferred = new System.Reactive.Disposables.SingleAssignmentDisposable();
+            deferred.Disposable = pending.Take(1).Subscribe(
                 persisted =>
                 {
                     if (persisted)
@@ -362,11 +376,17 @@ public static class MeshDataSourceExtensions
                             "[SaveMeshNode] drop deferred {Path} at version={Version} — the flush persisted it",
                             node.Path, node.Version);
                     else
-                        WriteSampledNode(persistence, hub, node, logger);
+                    {
+                        logger?.LogDebug(
+                            "[SaveMeshNode] re-enqueue deferred {Path} at version={Version} — the flush "
+                            + "did not persist it", node.Path, node.Version);
+                        hub.Post(new SaveMeshNodeRequest(node));
+                    }
                 },
                 ex => logger?.LogWarning(ex,
                     "[SaveMeshNode] deferred write for {Path} (version={Version}) could not resolve its "
                     + "flush claim", node.Path, node.Version));
+            hub.RegisterForDisposal(deferred);
             return request.Processed();
         }
         WriteSampledNode(persistence, hub, node, logger);

--- a/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
@@ -79,12 +79,22 @@ internal sealed class StoragePostCommitFlush(IMessageHub hub) : IPostCommitFlush
                         resolved = true;
                         flushed?.Release(node.Path, node.Version);
                     }
-                },
-                // A fault and an empty sequence are both "nothing was persisted". Releasing tells
-                // the sampler — which is DEFERRED on the claim rather than dropped — to go ahead,
-                // so the ordering fix can never convert a duplicate write into a lost one.
-                _ => { if (!resolved) { resolved = true; flushed?.Release(node.Path, node.Version); } },
-                () => { if (!resolved) { resolved = true; flushed?.Release(node.Path, node.Version); } })
+                })
+            // 🚨 THE CLAIM MUST ALWAYS BE ANSWERED. Finally runs on completion, on error AND on
+            // UNSUBSCRIPTION — the last of which is the one an OnError/OnCompleted pair misses: if
+            // the patch pipeline's subscription is torn down mid-write (hub teardown, a cancelled
+            // round), no terminal notification ever fires, the claim is never resolved, and the
+            // sampler that deferred against it waits forever on a signal nobody will send. A
+            // deferred write must never outlive the thing it is deferring to.
+            //
+            // Releasing an unresolved claim is the FAIL-SAFE direction: the sampler goes ahead and
+            // writes. The other direction would drop a write nobody else is making.
+            .Finally(() =>
+            {
+                if (resolved) return;
+                resolved = true;
+                flushed?.Release(node.Path, node.Version);
+            })
             .Select(_ => true)
             .DefaultIfEmpty(true);
     }

--- a/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StoragePostCommitFlush.cs
@@ -47,12 +47,44 @@ internal sealed class StoragePostCommitFlush(IMessageHub hub) : IPostCommitFlush
         // null). Recording it would suppress the sampler's write for a row nobody persisted, which
         // would turn a duplicate-write bug into a lost-write one.
         var flushed = hub.ServiceProvider.GetService<PostCommitFlushRegistry>();
+
+        // 🚨 CLAIM BEFORE THE WRITE, confirm after (#1557). Recording only on the emission left the
+        // suppression TIMED rather than ordered: the sampler's queued SaveMeshNodeRequest can reach
+        // its handler while this round-trip is still in flight, read a mark that has not been raised
+        // yet, and write — landing as a version regression whose base-less merge keeps the string
+        // SUPERSET and re-adds deleted text. Measured at ~4% on the 2-vCPU runner, and each
+        // occurrence is a real resurrection, not just a red test.
+        //
+        // The claim is provisional and is RELEASED on every path that does not persist, so a route
+        // that does not write can never suppress the one that would.
+        flushed?.Claim(node.Path, node.Version);
+        var resolved = false;
+
         return storage.WriteAndPublishUpdated(node, hub.JsonSerializerOptions, changeFeed)
-            .Do(saved =>
-            {
-                if (saved is not null)
-                    flushed?.Record(node.Path, Math.Max(node.Version, saved.Version));
-            })
+            .Do(
+                saved =>
+                {
+                    if (saved is not null)
+                    {
+                        // Persisted — Record confirms the claim and raises the mark to whatever the
+                        // store reports durable (higher than ours when its version-conditional
+                        // upsert kept a newer row).
+                        resolved = true;
+                        flushed?.Record(node.Path, Math.Max(node.Version, saved.Version));
+                    }
+                    else
+                    {
+                        // The null try-then-claim sentinel — "this adapter does not own this path".
+                        // NOT a successful write, so the sampler must stay the writer of record.
+                        resolved = true;
+                        flushed?.Release(node.Path, node.Version);
+                    }
+                },
+                // A fault and an empty sequence are both "nothing was persisted". Releasing tells
+                // the sampler — which is DEFERRED on the claim rather than dropped — to go ahead,
+                // so the ordering fix can never convert a duplicate write into a lost one.
+                _ => { if (!resolved) { resolved = true; flushed?.Release(node.Path, node.Version); } },
+                () => { if (!resolved) { resolved = true; flushed?.Release(node.Path, node.Version); } })
             .Select(_ => true)
             .DefaultIfEmpty(true);
     }

--- a/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reactive.Subjects;
 using System.Threading;
 
 namespace MeshWeaver.Mesh.Services;
@@ -31,6 +32,17 @@ namespace MeshWeaver.Mesh.Services;
 /// trade-off for a GENUINE conflict; this one was manufactured by the framework against itself, on
 /// a strictly sequential writer, and it also devalued the guard's alarm into background noise.</para>
 ///
+/// <para>🚨 <b>CLAIMED versus RECORDED — the ordering half (#1557).</b> Recording only on the
+/// write's EMISSION left the suppression <b>timed</b>, not ordered: the sampler's queued
+/// <c>SaveMeshNodeRequest</c> can reach its handler while the flush's storage round-trip is still
+/// in flight, read a high-water that has not been raised yet, and write. Measured at ~4% on the
+/// 2-vCPU CI runner — and every occurrence is a real resurrection of deleted content, not merely a
+/// red test. So the flush now <see cref="Claim"/>s the version BEFORE its write and resolves the
+/// claim afterwards (<see cref="Record"/> on success, <see cref="Release"/> when nothing was
+/// persisted). A claim is <b>provisional</b>, and the sampler must not simply drop its write
+/// against one — see <see cref="PendingClaim"/>, which is what keeps the ordering fix from turning
+/// a duplicate-write bug into a lost-write one.</para>
+///
 /// <para><b>Why a mesh-scoped, path-keyed registry.</b> <c>IPostCommitFlush</c> is registered once
 /// per mesh (<c>AddMeshCatalog</c>) and routes writes by node path, while the sampler's handler runs
 /// on the per-node owner hub — the two do not share a hub-scoped service, so a per-hub stamp on
@@ -43,17 +55,15 @@ namespace MeshWeaver.Mesh.Services;
 /// <para><b>Why a VERSION, and why <c>&lt;=</c> is a safe skip predicate.</b> A reference-identity
 /// stamp cannot work here: the sampler's gate chain runs in the SAME synchronous fan-out as the
 /// flush and — having subscribed at hub init — runs FIRST, so nothing the flush stamps is visible
-/// to it. The mark is therefore read at HANDLER time, once the flush has settled. And two DISTINCT
-/// own-node states can never share a version: <c>MeshNodeTypeSource.UpdateImpl</c> re-stamps any own
-/// update arriving at (or below) its previous version with <c>MeshNode.NextVersion</c>. So a sampled
-/// state at or below the flushed version is either the very state the flush persisted or an older
-/// one — never newer content.</para>
+/// to it. The mark is therefore read at HANDLER time. And two DISTINCT own-node states can never
+/// share a version: <c>MeshNodeTypeSource.UpdateImpl</c> re-stamps any own update arriving at (or
+/// below) its previous version with <c>MeshNode.NextVersion</c>. So a sampled state at or below the
+/// flushed version is either the very state the flush persisted or an older one — never newer
+/// content.</para>
 ///
-/// <para>The mark is raised only on a write that actually EMITTED, so a failed flush leaves the
-/// sampler as the writer of record; and it is dropped on delete
-/// (<see cref="Forget"/>) so a same-id recreate at <c>Version = 1</c> is never mistaken for
-/// already-persisted state — the same rule <c>MonotonicWriteGuardStorageAdapter.Forget</c>
-/// follows.</para>
+/// <para>The mark is dropped on delete (<see cref="Forget"/>) so a same-id recreate at
+/// <c>Version = 1</c> is never mistaken for already-persisted state — the same rule
+/// <c>MonotonicWriteGuardStorageAdapter.Forget</c> follows.</para>
 ///
 /// <para>Footprint: one <c>path → (long, timestamp)</c> entry per node this process has patched,
 /// dropped on delete and TTL-bounded (same shape and the same amortised time-gated sweep as
@@ -68,11 +78,17 @@ public sealed class PostCommitFlushRegistry
     // orders of magnitude of headroom, and it matches RecentlyDeletedRegistry's TTL. Expiry is
     // fail-SAFE, never fail-wrong: an expired mark simply lets the sampler write again, and that
     // write carries the SAME version the flush already stored, which the store accepts as an
-    // equal-version rewrite. Only a write that regresses can produce a conflict, and that needs
-    // the row to advance inside the queue window — milliseconds, not seconds.
+    // equal-version rewrite.
     private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
 
-    private readonly ConcurrentDictionary<string, (long Version, DateTimeOffset At)> highWater =
+    /// <summary>
+    /// One entry per patched path. <paramref name="Pending"/> is non-null exactly while a
+    /// <see cref="Claim"/> is unresolved; it emits true when the flush persisted the version and
+    /// false when it did not, then completes.
+    /// </summary>
+    private readonly record struct Entry(long Version, DateTimeOffset At, AsyncSubject<bool>? Pending);
+
+    private readonly ConcurrentDictionary<string, Entry> highWater =
         new(StringComparer.OrdinalIgnoreCase);
 
     // UtcTicks of the last opportunistic prune sweep — gates the O(n) sweep to at most once per TTL
@@ -81,37 +97,96 @@ public sealed class PostCommitFlushRegistry
     private long lastPruneTicks;
 
     /// <summary>
+    /// Claims <paramref name="version"/> of <paramref name="path"/> for the flush route BEFORE its
+    /// durable write starts — the ordered half of the suppression (#1557). Resolve it with
+    /// <see cref="Record"/> (persisted) or <see cref="Release"/> (did not persist); an unresolved
+    /// claim makes the sampler DEFER rather than drop, so no write is lost either way.
+    /// </summary>
+    public void Claim(string? path, long version)
+    {
+        if (string.IsNullOrEmpty(path))
+            return;
+        var pending = new AsyncSubject<bool>();
+        var now = DateTimeOffset.UtcNow;
+        highWater.AddOrUpdate(path, new Entry(version, now, pending), (_, current) =>
+            // A claim never lowers the mark, and never displaces an EARLIER unresolved claim —
+            // whoever is already waiting on that one must still be answered.
+            current.Pending is not null
+                ? current
+                : new Entry(Math.Max(current.Version, version), now, pending));
+    }
+
+    /// <summary>
+    /// The unresolved claim for <paramref name="path"/>, or null when the mark is a confirmed
+    /// durable version (or there is no mark at all).
+    ///
+    /// <para>🚨 The sampler must consult this before dropping a write. Against a CONFIRMED mark the
+    /// row is already durable and the sampled state is at or below it, so dropping is right.
+    /// Against an unresolved CLAIM, whether the row will be durable is not yet known — dropping
+    /// there would lose the write outright if the flush then failed, or if the adapter answered the
+    /// null "I do not own this path" sentinel. Waiting on this observable and writing only when it
+    /// reports false is what makes the ordering fix safe in both directions.</para>
+    /// </summary>
+    public IObservable<bool>? PendingClaim(string? path) =>
+        !string.IsNullOrEmpty(path) && highWater.TryGetValue(path, out var entry) ? entry.Pending : null;
+
+    /// <summary>
     /// Monotonically (max) records that <paramref name="version"/> of <paramref name="path"/> is
-    /// durable. Called from the post-commit flush on the write's emission.
+    /// durable — confirming any claim the flush made before its write, and raising the mark when
+    /// the store reports a higher durable version than ours.
     /// </summary>
     public void Record(string? path, long version)
     {
         if (string.IsNullOrEmpty(path))
             return;
         var now = DateTimeOffset.UtcNow;
-        highWater.AddOrUpdate(path, (version, now),
-            (_, current) => (Math.Max(current.Version, version), now));
+        AsyncSubject<bool>? resolved = null;
+        highWater.AddOrUpdate(path, new Entry(version, now, null), (_, current) =>
+        {
+            resolved = current.Pending;
+            return new Entry(Math.Max(current.Version, version), now, null);
+        });
+        Resolve(resolved, persisted: true);
 
         var last = Interlocked.Read(ref lastPruneTicks);
         if (now.UtcTicks - last > Ttl.Ticks
             && Interlocked.CompareExchange(ref lastPruneTicks, now.UtcTicks, last) == last)
         {
             foreach (var kv in highWater)
-                if (now - kv.Value.At > Ttl)
+                // Never prune an entry with an unresolved claim — someone is waiting on it.
+                if (kv.Value.Pending is null && now - kv.Value.At > Ttl)
                     highWater.TryRemove(kv.Key, out _);
         }
     }
 
     /// <summary>
+    /// Resolves a <see cref="Claim"/> the flush did not make good on — a failed write, an empty
+    /// sequence, or the null try-then-claim sentinel meaning "this adapter does not own this path".
+    /// Waiters are told the row was NOT persisted, so the sampler becomes the writer of record.
+    /// Only acts while the entry still holds exactly the claimed version, so a later flush that
+    /// already recorded a HIGHER durable version is never undone by a stale release.
+    /// </summary>
+    public void Release(string? path, long version)
+    {
+        if (string.IsNullOrEmpty(path) || !highWater.TryGetValue(path, out var entry))
+            return;
+        if (entry.Pending is null || entry.Version != version)
+            return;
+        if (highWater.TryRemove(new KeyValuePair<string, Entry>(path, entry)))
+            Resolve(entry.Pending, persisted: false);
+    }
+
+    /// <summary>
     /// The highest version the post-commit flush has made durable for <paramref name="path"/> within
     /// the TTL window, or <c>0</c> when this process has not flushed it recently (in which case
-    /// nothing is suppressed). Expired entries are pruned on access.
+    /// nothing is suppressed). Expired entries are pruned on access — never one with an unresolved
+    /// claim.
     /// </summary>
     public long HighWater(string? path)
     {
         if (string.IsNullOrEmpty(path) || !highWater.TryGetValue(path, out var entry))
             return 0L;
-        if (DateTimeOffset.UtcNow - entry.At <= Ttl)
+        if (entry.Pending is not null || DateTimeOffset.UtcNow - entry.At <= Ttl)
             return entry.Version;
         highWater.TryRemove(path, out _);
         return 0L;
@@ -119,11 +194,22 @@ public sealed class PostCommitFlushRegistry
 
     /// <summary>
     /// Drops the mark for a deleted path, so a same-id recreate — which legitimately restarts at
-    /// <c>Version = 1</c> — is never read as "already persisted".
+    /// <c>Version = 1</c> — is never read as "already persisted". An unresolved claim is answered
+    /// "not persisted" rather than abandoned: a waiter must never be left hanging on a delete.
     /// </summary>
     public void Forget(string? path)
     {
-        if (!string.IsNullOrEmpty(path))
-            highWater.TryRemove(path, out _);
+        if (string.IsNullOrEmpty(path))
+            return;
+        if (highWater.TryRemove(path, out var entry))
+            Resolve(entry.Pending, persisted: false);
+    }
+
+    private static void Resolve(AsyncSubject<bool>? pending, bool persisted)
+    {
+        if (pending is null)
+            return;
+        pending.OnNext(persisted);
+        pending.OnCompleted();
     }
 }

--- a/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Security.Cryptography;
 using Memex.Portal.Shared.Authentication;
 using MeshWeaver.Graph.Configuration;
@@ -660,9 +661,13 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
             expiresAt: DateTimeOffset.UtcNow.AddHours(-1)).Should().Emit();
         var expiredIndexPath = $"ApiToken/{((ApiToken)expired.Node.Content!).TokenHash[..12]}";
 
+        var swept = SweepOf(service, "user1");
+
         // The next mint is what sweeps.
         var fresh = await service.CreateToken(
             "user1", "Test User", "test@example.com", "Fresh").Should().Emit();
+
+        await swept;
 
         (await ObserveNode(expired.Node.Path).Should().Match(n => n is null))
             .Should().BeNull("an expired token is a dead credential — nothing should keep it");
@@ -692,7 +697,11 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
             "user1", "Test User", "test@example.com", "Expired",
             expiresAt: DateTimeOffset.UtcNow.AddHours(-1)).Should().Emit();
 
+        var swept = SweepOf(service, "user1");
+
         await service.CreateToken("user1", "Test User", "test@example.com", "Fresh").Should().Emit();
+
+        await swept;
 
         // The expired one going away is the positive signal that the sweep RAN — so the two
         // assertions below are about what it chose not to touch, not about a race it might lose.
@@ -720,7 +729,11 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
             "user2", "Other User", "other@example.com", "Theirs expired",
             expiresAt: DateTimeOffset.UtcNow.AddHours(-1)).Should().Emit();
 
+        var swept = SweepOf(service, "user1");
+
         await service.CreateToken("user1", "Test User", "test@example.com", "Fresh").Should().Emit();
+
+        await swept;
 
         (await ObserveNode(mine.Node.Path).Should().Match(n => n is null)).Should().BeNull();
         (await ObserveNode(theirs.Node.Path).Should().Match(n => n is not null))
@@ -741,6 +754,24 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     /// production <c>ValidateToken</c> reads through it since the resilient-read fix.)
     /// </para>
     /// </summary>
+    /// <summary>
+    /// Arms a wait for the NEXT expiry sweep of <paramref name="userId"/>'s token namespace, and
+    /// returns it. 🚨 Call this BEFORE the mint that triggers the sweep — the subscription has to
+    /// exist first, or a fast sweep completes before anyone is listening and the wait hangs.
+    ///
+    /// <para>The sweep runs off the mint's critical path (deliberately: a user with a backlog must
+    /// not pay for it at sign-in), so <c>CreateToken</c>'s own emission says nothing about whether
+    /// it has finished. Sampling the query index right after the mint is waiting on the wrong
+    /// thing — it passed 11/11 locally and failed under real CI load (#1569).
+    /// <c>ExpirySweepCompleted</c> is the actual condition.</para>
+    /// </summary>
+    private static Task<string> SweepOf(ApiTokenService service, string userId) =>
+        service.ExpirySweepCompleted
+            .Where(ns => ns == $"{userId}/ApiToken")
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask();
+
     private IObservable<MeshNode?> ObserveNode(string path)
     {
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();

--- a/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
@@ -754,6 +754,22 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     /// production <c>ValidateToken</c> reads through it since the resilient-read fix.)
     /// </para>
     /// </summary>
+    private IObservable<MeshNode?> ObserveNode(string path)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}", WellKnownUsers.System))
+            .Scan((MeshNode?)null, (current, change) => change.ChangeType switch
+            {
+                QueryChangeType.Initial or QueryChangeType.Reset =>
+                    change.Items.FirstOrDefault(),
+                QueryChangeType.Added or QueryChangeType.Updated =>
+                    change.Items.FirstOrDefault() ?? current,
+                QueryChangeType.Removed => null,
+                _ => current,
+            });
+    }
+
     /// <summary>
     /// Arms a wait for the NEXT expiry sweep of <paramref name="userId"/>'s token namespace, and
     /// returns it. 🚨 Call this BEFORE the mint that triggers the sweep — the subscription has to
@@ -771,22 +787,6 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
             .FirstAsync()
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask();
-
-    private IObservable<MeshNode?> ObserveNode(string path)
-    {
-        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-        return meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}", WellKnownUsers.System))
-            .Scan((MeshNode?)null, (current, change) => change.ChangeType switch
-            {
-                QueryChangeType.Initial or QueryChangeType.Reset =>
-                    change.Items.FirstOrDefault(),
-                QueryChangeType.Added or QueryChangeType.Updated =>
-                    change.Items.FirstOrDefault() ?? current,
-                QueryChangeType.Removed => null,
-                _ => current,
-            });
-    }
 
     private sealed record LogEntry(LogLevel Level, string Message);
 


### PR DESCRIPTION
Two flakes, both of which were **waiting on the wrong thing**. One of them is also a live data-loss bug.

## #1557 — the route collapse is a timed window, and its guard asserts a deterministic outcome over it

#1249 collapsed the two durable-write routes for a patch-driven own-node change by having the post-commit flush record the version it made durable, so the per-node persistence sampler drops the duplicate. But the flush recorded on the write's **emission** — after the storage round-trip. The sampler's queued `SaveMeshNodeRequest` can reach its handler inside that window, read a high-water that has not been raised yet, and write.

By then the row has advanced, so `MonotonicWriteGuard` refuses the write as a version regression and resolves by merging — and a **base-less merge keeps the string SUPERSET**, silently re-adding text the newer write deleted.

> **This is not only a test problem.** ~4% of runs on the 2-vCPU runner, and each occurrence is a real resurrection of deleted content, reachable in production under load.

### The fix: claim before the write, resolve after

The flush now **`Claim`s** the version *before* its durable write and resolves the claim afterwards — `Record` on success, `Release` on a fault, an empty sequence, or the null *"this adapter does not own this path"* sentinel. Because the claim exists before the write starts, no sampled state at or below that version can slip past, whenever the handler runs. Ordered by construction, not by winning a race.

### 🚨 The part that keeps this from becoming a lost-write bug

A claim is **provisional**, so the sampler must *not* simply drop against one — that would lose the write outright the moment a flush failed. So:

- against a **confirmed** mark, the row is already durable and dropping is right;
- against an **unresolved claim**, the handler **defers**: it waits for the claim to resolve and writes only if it reports that nothing was persisted.

`Forget()` answers any outstanding waiter *"not persisted"* rather than abandoning it, and the TTL sweep never prunes an entry someone is waiting on. The handler's write is extracted to `WriteSampledNode` so the deferred path goes through exactly the same code — including the `MonotonicWriteGuard` refusal contract and `AdoptDurableTruth`.

**Nothing about the guard is relaxed.** Its alarm was always correct; its *input* was ours. `GenuineSecondWriter_StillTripsTheGuard_AndTheRowNeverRegresses` still passes — that is the point of that test.

### 🚨 Local green is not the gate here

This never reproduced locally (0/40 on an M-series Mac, both default and `DOTNET_PROCESSOR_COUNT=2`). The issue names its own gate: `flake-repro.yml` in **`rate` mode over ≥100 iterations** on the 2-vCPU runner, because at ~4% a clean short loop happens by luck. Dispatched against this branch — [run 31816216876](https://github.com/Systemorph/MeshWeaver/actions/runs/31816216876), 110 iterations. **The measured before/after is what should decide this PR**, and I will post it here; main's baseline is 7/170 ≈ 4% from the issue.

## #1569 — the sweep test had no signal to wait for

`CreateToken_SweepsTheUsersAlreadyExpiredTokens` sampled the lagged query index right after the mint. The expiry sweep runs **off** the mint's critical path (deliberately — a user with a backlog must not pay for it at sign-in), so `CreateToken`'s own emission says nothing about whether the sweep has finished. It passed 11/11 locally and failed under real CI load: a flake waiting on the wrong thing.

There was no source to subscribe to, so this adds one. `ApiTokenService.ExpirySweepCompleted` fires as each sweep finishes — **on the fault path too**, because a signal that only fires on success turns a failed sweep into an indefinite wait, which is the same defect one level down. The three sweep tests now arm the wait **before** the mint that triggers it, through a `SweepOf` helper that documents why.

## Verification

| | |
|---|---|
| `PatchWriteRouteCollapseTest` | 3/3 (incl. the genuine-second-writer guard) |
| `MeshWeaver.Auth.Test` | 146/146 |
| the three sweep tests, `DOTNET_PROCESSOR_COUNT=4` | 30/30 |
| `-c Release -warnaserror` | `Mesh.Contract`, `Graph`, `Hosting`, `Hosting.Monolith.Test` — 0 errors, 0 warnings |

Fixes #1569 (and #1557 pending the rate measurement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj