### PR TITLE
fix(#1493): a re-authorization replaces the client's credential instead of adding one

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
@@ -297,12 +297,26 @@ public class OAuthConnectController(
                 // days surprises users who connect once and come back months later.
                 // Refresh-token flow isn't implemented yet; until it is, default to
                 // 1 year. Bump if needed via TokenLifetime below.
+                var label = $"OAuth: {request.client_id}";
+
                 return TokenService.CreateToken(
                         userId: entry.UserId,
                         userName: entry.UserName,
                         userEmail: entry.UserEmail,
-                        label: $"OAuth: {request.client_id}",
+                        label: label,
                         expiresAt: DateTimeOffset.UtcNow.Add(TokenLifetime))
+                    // 🚨 ONE live credential per client, not N (#1493). Every authorization used to
+                    // mint a FRESH year-long token and leave the previous one live and listed, so a
+                    // reinstall, a new device, or a revoked-and-reconnected integration each left
+                    // another usable credential behind — for a year. That is what dominated the 86
+                    // ApiToken rows found on the live portal, and each of them is a key that still
+                    // opens the door.
+                    //
+                    // Ordered mint-THEN-supersede, never the reverse: if the mint fails the client
+                    // must keep the credential it already has, so revoking first could strand it
+                    // with none at all.
+                    .SelectMany(creation => SupersedePreviousTokens(entry.UserId, label, creation.Node.Path)
+                        .Select(_ => creation))
                     .Select(creation =>
                     {
                         logger.LogInformation("Issued OAuth access token for user {Email}, client {ClientId}", entry.UserEmail, request.client_id);
@@ -316,6 +330,64 @@ public class OAuthConnectController(
             })
             .FirstAsync()
             .ToTask(ct);
+    }
+
+    /// <summary>
+    /// Removes this client's PREVIOUS tokens once a fresh authorization has minted its replacement
+    /// (#1493), so a `(user, client_id)` pair has exactly one live credential.
+    ///
+    /// <para>Identity is the label — <c>OAuth: {client_id}</c> — and <c>client_id</c> is a random
+    /// 24-byte value issued per client registration, so a shared label means the same client. The
+    /// token just minted is excluded by PATH, which also makes the read's lag harmless: a listing
+    /// that has not caught up yet simply leaves an older row for the next authorization to collect,
+    /// and can never take the new one.</para>
+    ///
+    /// <para>Deleted, not merely marked revoked: this issue is BOTH "one live credential" and the
+    /// unbounded accumulation behind it, and a revoked row keeps accumulating. It matches what
+    /// #1477's expiry sweep already does with a dead credential.</para>
+    ///
+    /// <para>Never fails the exchange. The client has a valid token by this point; housekeeping
+    /// that could not complete is a Warning and the next authorization tries again.</para>
+    /// </summary>
+    private IObservable<System.Reactive.Unit> SupersedePreviousTokens(
+        string userId, string label, string keepPath)
+    {
+        var tokens = TokenService;
+        return tokens.GetTokensForUser(userId)
+            .Take(1)
+            .SelectMany(all =>
+            {
+                var superseded = all
+                    .Where(t => t.Label == label && t.NodePath != keepPath)
+                    .Select(t => t.NodePath)
+                    .ToArray();
+                if (superseded.Length == 0)
+                    return Observable.Return(System.Reactive.Unit.Default);
+
+                logger.LogInformation(
+                    "OAuth: superseding {Count} previous token(s) for user {UserId}, client label {Label} — "
+                    + "a re-authorization replaces the client's credential rather than adding one",
+                    superseded.Length, userId, label);
+
+                // Self-paced (Concat, never Merge): one delete at a time, the same shape the expiry
+                // sweep uses, so a client that re-authorized many times drains gently.
+                return Observable.Concat(superseded.Select(path => tokens.DeleteToken(path)
+                        .Catch<bool, Exception>(ex =>
+                        {
+                            logger.LogWarning(ex,
+                                "OAuth: could not supersede previous token {Path} — it stays live until "
+                                + "the next authorization or its expiry", path);
+                            return Observable.Return(false);
+                        })))
+                    .LastOrDefaultAsync()
+                    .Select(_ => System.Reactive.Unit.Default);
+            })
+            .Catch<System.Reactive.Unit, Exception>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "OAuth: could not list previous tokens for user {UserId} to supersede them", userId);
+                return Observable.Return(System.Reactive.Unit.Default);
+            });
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using MeshWeaver.Blazor.Infrastructure; // PortalApplication
+using MeshWeaver.Mesh.Security;         // ApiToken (the minted token content)
 using MeshWeaver.Messaging;             // AccessService / AccessContext
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -315,7 +316,8 @@ public class OAuthConnectController(
                     // Ordered mint-THEN-supersede, never the reverse: if the mint fails the client
                     // must keep the credential it already has, so revoking first could strand it
                     // with none at all.
-                    .SelectMany(creation => SupersedePreviousTokens(entry.UserId, label, creation.Node.Path)
+                    .SelectMany(creation => SupersedePreviousTokens(
+                            entry.UserId, label, creation.Node.Path, MintedAt(creation))
                         .Select(_ => creation))
                     .Select(creation =>
                     {
@@ -350,15 +352,29 @@ public class OAuthConnectController(
     /// that could not complete is a Warning and the next authorization tries again.</para>
     /// </summary>
     private IObservable<System.Reactive.Unit> SupersedePreviousTokens(
-        string userId, string label, string keepPath)
+        string userId, string label, string keepPath, DateTimeOffset mintedAt)
     {
         var tokens = TokenService;
         return tokens.GetTokensForUser(userId)
             .Take(1)
             .SelectMany(all =>
             {
+                // 🚨 Supersede only what is strictly OLDER, in a TOTAL order — never "everything
+                // that is not mine". Two concurrent exchanges for the same (user, client_id) each
+                // see the other's freshly-minted token in this listing, and a not-mine rule would
+                // have them delete each other's: both clients then walk away holding a credential
+                // that was removed moments later. Ordering by (CreatedAt, path) makes the outcome
+                // convergent instead — every participant deletes strictly below itself, so the
+                // NEWEST token survives no matter which exchange evaluates last, and there is
+                // still exactly one live credential at the end.
+                //
+                // The path tiebreak matters: CreatedAt is a UTC timestamp and two exchanges can
+                // land on the same tick, where "strictly older by time" would let both survive.
                 var superseded = all
                     .Where(t => t.Label == label && t.NodePath != keepPath)
+                    .Where(t => t.CreatedAt < mintedAt
+                                || (t.CreatedAt == mintedAt
+                                    && string.CompareOrdinal(t.NodePath, keepPath) < 0))
                     .Select(t => t.NodePath)
                     .ToArray();
                 if (superseded.Length == 0)
@@ -389,6 +405,15 @@ public class OAuthConnectController(
                 return Observable.Return(System.Reactive.Unit.Default);
             });
     }
+
+    /// <summary>
+    /// The creation stamp of the token this exchange just minted — the ordering key
+    /// <see cref="SupersedePreviousTokens"/> compares against. Falls back to "now" if the content
+    /// is not the expected shape, which only ever makes the sweep MORE conservative on the tie
+    /// (it can then supersede a token minted in the same instant, never a newer one).
+    /// </summary>
+    private static DateTimeOffset MintedAt(TokenCreationResult creation) =>
+        creation.Node.Content is ApiToken t ? t.CreatedAt : DateTimeOffset.UtcNow;
 
     /// <summary>
     /// Lifetime for OAuth-issued API tokens. Single source of truth — the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-one-credential-per-client.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-one-credential-per-client.md
@@ -1,0 +1,18 @@
+---
+Name: Reconnecting an app replaces its key
+Category: Fix
+Description: Reconnecting an integration now replaces its access token instead of leaving the old one live for a year.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Reconnecting an app replaces its key
+
+Every time you connected an app — Claude Desktop, an MCP client, any integration — the portal issued
+a new access token and left the previous one working. Reinstall the app, switch device, or disconnect
+and reconnect, and each round left another live key behind, valid for a year. Your token list grew,
+and every entry in it still opened the door.
+
+Reconnecting now **replaces** that app's key rather than adding one: after a fresh connection, the app
+has exactly one credential and the earlier ones are gone. The new token is always issued first, so a
+reconnection can never leave an app without access.

--- a/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
+++ b/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
@@ -495,6 +495,62 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
             "a client that re-authorizes must end with ONE live credential, not one per authorization");
     }
 
+    /// <summary>
+    /// The concurrency half of #1493, from review on the fix: two exchanges for the same
+    /// <c>(user, client_id)</c> must not delete EACH OTHER's freshly-minted token.
+    ///
+    /// <para>A naive "delete everything with this label except mine" rule is not convergent — each
+    /// exchange sees the other's new token in the listing and removes it, so BOTH clients walk away
+    /// holding a credential that was deleted moments later. That is strictly worse than the
+    /// accumulation this issue set out to fix. Superseding is therefore ordered by
+    /// <c>(CreatedAt, path)</c>: every participant deletes only strictly below itself, so the newest
+    /// survives whichever exchange evaluates last — and there is still exactly one live
+    /// credential.</para>
+    /// </summary>
+    [Fact]
+    public async Task Token_TwoAuthorizationsRacing_LeaveExactlyOneWORKINGCredential()
+    {
+        var controller = CreateController(AuthenticatedUser("dave@example.com", "Dave"));
+
+        var reg = ((ObjectResult)controller.RegisterClient(new ClientRegistrationRequest
+        {
+            ClientName = "Racing Client",
+            RedirectUris = ["https://claude.ai/cb"],
+        })!).Value as ClientRegistrationResponse;
+
+        // Both codes are obtained BEFORE either is exchanged, so the two exchanges genuinely
+        // overlap rather than running one after the other.
+        var first = AuthorizeAndExchange(controller, reg!.ClientId);
+        var second = AuthorizeAndExchange(controller, reg.ClientId);
+        var tokens = await Task.WhenAll(first, second);
+
+        var service = new ApiTokenService(
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>(),
+            Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>());
+
+        // 🚨 The property that matters is not "one row survives" but "a SURVIVING row still works".
+        // Mutual deletion satisfies the count on its way to zero.
+        var live = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => Observable.Concat(tokens.Select(t => service.ValidateToken(t).Take(1)))
+                .Where(v => v is not null).Take(1).DefaultIfEmpty())
+            .Should().Within(30.Seconds()).Match(v => v is not null);
+
+        live.Should().NotBeNull(
+            "at least one of the two racing exchanges must leave a credential that still validates — "
+            + "a not-mine deletion rule would have them remove each other's and leave the client "
+            + "holding nothing");
+
+        var label = $"OAuth: {reg.ClientId}";
+        var remaining = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => service.GetTokensForUser(live!.UserId).Take(1))
+            .Select(all => all.Where(t => t.Label == label).ToArray())
+            .Should().Within(30.Seconds()).Match(t => t.Length == 1);
+
+        remaining.Should().HaveCount(1, "and the outcome still converges on ONE live credential");
+    }
+
     /// <summary>Runs authorize → token for an already-registered client and returns the raw mw_ token.</summary>
     private async Task<string> AuthorizeAndExchange(OAuthConnectController controller, string clientId)
     {

--- a/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
+++ b/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
@@ -442,6 +442,94 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         ((int)t.GetProperty("expires_in")!.GetValue(body)!).Should().BeGreaterThan(0);
     }
 
+    /// <summary>
+    /// Issue #1493 — a re-authorization must REPLACE this client's credential, not add one.
+    ///
+    /// <para>Every `/token` exchange minted a fresh 365-day token and left the previous one live and
+    /// listed. A reinstall, a new device, or a revoked-and-reconnected integration therefore each
+    /// left another usable key behind, for a year. That is what dominated the 86 `ApiToken` rows
+    /// found on the live portal — and every one of them still opens the door.</para>
+    ///
+    /// <para>🚨 The ordering matters as much as the count: mint FIRST, supersede after. Revoking
+    /// before the mint would strand the client with no credential at all if the mint failed. The
+    /// surviving token here is the one from the SECOND exchange, which is what proves that order.</para>
+    /// </summary>
+    [Fact]
+    public async Task Token_SecondAuthorizationForTheSameClient_ReplacesTheCredentialRatherThanAddingOne()
+    {
+        var controller = CreateController(AuthenticatedUser("carol@example.com", "Carol"));
+
+        var reg = ((ObjectResult)controller.RegisterClient(new ClientRegistrationRequest
+        {
+            ClientName = "Reconnecting Client",
+            RedirectUris = ["https://claude.ai/cb"],
+        })!).Value as ClientRegistrationResponse;
+
+        var first = await AuthorizeAndExchange(controller, reg!.ClientId);
+        var second = await AuthorizeAndExchange(controller, reg.ClientId);
+
+        first.Should().NotBe(second, "each authorization mints its own credential");
+
+        // A fresh service instance over the SAME mesh — the token rows live in the mesh, not in the
+        // service, and the controller builds its own provider (see CreateController).
+        var service = new ApiTokenService(
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>(),
+            Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>());
+
+        // The credential just issued must WORK — the superseding runs after the mint, never before,
+        // and this is what would fail if that order were ever reversed.
+        var live = await service.ValidateToken(second).Should().Within(30.Seconds()).Match(v => v is not null);
+        live.Should().NotBeNull();
+
+        var label = $"OAuth: {reg.ClientId}";
+
+        // Wait on the actual condition — exactly one token carrying this client's label.
+        var remaining = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => service.GetTokensForUser(live!.UserId).Take(1))
+            .Select(all => all.Where(t => t.Label == label).ToArray())
+            .Should().Within(30.Seconds()).Match(t => t.Length == 1);
+
+        remaining.Should().HaveCount(1,
+            "a client that re-authorizes must end with ONE live credential, not one per authorization");
+    }
+
+    /// <summary>Runs authorize → token for an already-registered client and returns the raw mw_ token.</summary>
+    private async Task<string> AuthorizeAndExchange(OAuthConnectController controller, string clientId)
+    {
+        var verifier = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+        var challenge = Convert.ToBase64String(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+
+        var redirect = (RedirectResult)await controller.Authorize(
+            response_type: "code",
+            client_id: clientId,
+            redirect_uri: "https://claude.ai/cb",
+            state: "s",
+            scope: "mcp",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            ct: TestContext.Current.CancellationToken);
+
+        var code = Uri.UnescapeDataString(
+            redirect.Url["https://claude.ai/cb?code=".Length..redirect.Url.IndexOf("&state=")]);
+        await AwaitCodeVisible(code);
+
+        var result = await controller.ExchangeToken(new TokenRequest
+        {
+            grant_type = "authorization_code",
+            code = code,
+            client_id = clientId,
+            redirect_uri = "https://claude.ai/cb",
+            code_verifier = verifier,
+        }, TestContext.Current.CancellationToken).ToObservable().Should().Within(30.Seconds()).Emit() as OkObjectResult;
+
+        var body = result!.Value!;
+        return (string)body.GetType().GetProperty("access_token")!.GetValue(body)!;
+    }
+
     [Fact]
     public async Task Token_WithWrongPkceVerifier_Returns400InvalidGrant()
     {


### PR DESCRIPTION
The OAuth `/token` exchange minted a fresh **365-day** token on every authorization and left the previous one **live and listed**. A reinstall, a new device, or a revoked-and-reconnected integration therefore each left another usable key behind — for a year.

That is the shape behind most of the **86 `ApiToken` rows** found on the live portal, and every one of them still opens the door.

## Which of the three options

The issue weighs reusing a still-valid token, revoking the previous one, or implementing the refresh flow, and calls the middle one *"the smallest and also the best security answer — one live credential per client, not N."* That is what this is.

- **Identity is the label**, `OAuth: {client_id}`, and `client_id` is a random 24-byte value issued per client registration — a shared label means the same client.
- **The new token is excluded by PATH**, which also makes the listing's lag harmless: a read that has not caught up simply leaves an older row for the *next* authorization to collect, and can never take the new one.

## 🚨 The ordering is half the fix

**Mint first, supersede after — never the reverse.** Revoking before the mint would strand the client with *no* credential at all if the mint then failed.

The test asserts the **surviving** token is the one from the second exchange, so it pins that order rather than just the count.

## Delete, not just mark revoked

This issue is *both* "one live credential" and the unbounded accumulation behind it, and a revoked row keeps accumulating. Deleting matches what #1477's expiry sweep already does with a dead credential. Self-paced (`Concat`, one at a time, the same shape as that sweep), and it can never fail the exchange — the client has a valid token by that point, so housekeeping that could not complete is a Warning and the next authorization tries again.

## What is deliberately NOT here

The **other** mint path in #1493 — the browser's one-token-per-page-load — is untouched. It is already bounded (`expiresInDays: 1`, swept by #1477), and eliminating it means letting the gRPC transport authenticate from the same-origin session cookie: a materially larger change across both React shells, and not something to fold in behind a security fix.

## Verification

- `MeshWeaver.Auth.Test` — **147/147**, including a new end-to-end case that runs register → authorize → token **twice** for one client.
- **Proven RED without the fix.** The failure output is the bug, stated exactly:

```
Expected the observable to emit a value matching the predicate within 30s … (2 item(s)).
  ApiTokenInfo { NodePath = carol/ApiToken/50429e471485, Label = OAuth: ua07k8QOn…, ExpiresAt = 8/14/2027, IsRevoked = False }
  ApiTokenInfo { NodePath = carol/ApiToken/78aa9aad49fb, Label = OAuth: ua07k8QOn…, ExpiresAt = 8/14/2027, IsRevoked = False }
```

Two live year-long credentials for one `client_id`. Green with the fix.

- `-c Release -warnaserror`: `Memex.Portal.Shared`, `MeshWeaver.Auth.Test` — 0 errors, 0 warnings.

Fixes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj