### PR TITLE
feat(#1508): the hub's lifecycle becomes a SOURCE, not a property to sample

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
@@ -176,6 +176,25 @@ public interface IMessageHub : IMessageHandlerRegistry, IDisposable
     MessageHubRunLevel RunLevel { get; }
 
     /// <summary>
+    /// The hub's lifecycle as a SOURCE (#1508) — every <see cref="RunLevel"/> transition, replaying
+    /// the current level to each new subscriber so a late subscription cannot miss the state it is
+    /// already in. Completes when the hub reaches <see cref="MessageHubRunLevel.Dead"/>.
+    ///
+    /// <para>🚨 <b>Why this exists.</b> <see cref="RunLevel"/> is a plain property and
+    /// <see cref="DisposalCompleted"/> fires at the very END of teardown, so anything interested in
+    /// the disposal WINDOW — the interval where the hub is <c>Quiescing</c>/<c>DisposeHostedHubs</c>
+    /// but intake is still open — had nothing to subscribe to: by the time the one available signal
+    /// fired, the window had closed. Every "wait for the hub to reach state X" therefore had to
+    /// either SAMPLE the property on an interval or contrive the ordering, and the sampling form is
+    /// a standing violation of the reactive rule. That window is exactly where the interesting bugs
+    /// live (#1470: a read serviced during teardown answered as "the node does not exist").</para>
+    ///
+    /// <para>This is an ADDITION alongside <see cref="DisposalCompleted"/>, whose contract is
+    /// unchanged — it still fires once, at the end, after the drain.</para>
+    /// </summary>
+    IObservable<MessageHubRunLevel> RunLevelChanged { get; }
+
+    /// <summary>
     /// Per-hub property bag — key is <c>(<paramref name="context"/>, typeof(T))</c>.
     /// Used to cache instance state on a hub without a separate static dictionary
     /// (e.g. <c>AgentChatClient</c>, <c>CancellationTokenSource</c>, completion

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -130,7 +130,40 @@ public sealed class MessageHub : IMessageHub
     }
 
     /// <summary>The hub's current lifecycle phase; advances through start, quiescing, and the disposal phases.</summary>
-    public MessageHubRunLevel RunLevel { get; private set; }
+    public MessageHubRunLevel RunLevel
+    {
+        get => runLevel;
+        private set
+        {
+            // Publish only on an actual TRANSITION. Several disposal arms assign the same terminal
+            // level defensively (the Dead backstop in the finally, for one), and a subscriber should
+            // see the lifecycle, not the number of times a field was written.
+            if (runLevel == value)
+                return;
+            runLevel = value;
+            runLevelChanged.OnNext(value);
+            // Dead is terminal: complete the source so `.LastAsync()`, `.ToTask()` and every other
+            // completion-shaped composition over it terminates instead of hanging on a hub that will
+            // never emit again.
+            if (value == MessageHubRunLevel.Dead)
+                runLevelChanged.OnCompleted();
+        }
+    }
+
+    private MessageHubRunLevel runLevel;
+
+    /// <summary>
+    /// Backing source for <see cref="RunLevelChanged"/>. A BehaviorSubject, so a late subscriber is
+    /// told the level the hub is ALREADY in rather than waiting for the next transition — without
+    /// that, subscribing to observe the disposal window would itself race the window (#1508).
+    /// Synchronized: the phases are posted from the action block, but disposal arms and the
+    /// watchdog can terminalize from other threads.
+    /// </summary>
+    private readonly ISubject<MessageHubRunLevel> runLevelChanged =
+        Subject.Synchronize(new BehaviorSubject<MessageHubRunLevel>(MessageHubRunLevel.Starting));
+
+    /// <inheritdoc />
+    public IObservable<MessageHubRunLevel> RunLevelChanged => runLevelChanged.AsObservable();
 
     /// <summary>
     /// Non-null once a BuildupAction faulted during init. The hub stays <see cref="MessageHubRunLevel.Started"/>

--- a/test/MeshWeaver.Hosting.Test/HubRunLevelObservableTest.cs
+++ b/test/MeshWeaver.Hosting.Test/HubRunLevelObservableTest.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Issue #1508 — the hub's lifecycle had no SOURCE.
+///
+/// <para><see cref="IMessageHub.RunLevel"/> is a plain property and
+/// <see cref="IMessageHub.DisposalCompleted"/> fires at the very END of teardown, so anything
+/// interested in the disposal WINDOW — the interval where the hub is
+/// <see cref="MessageHubRunLevel.Quiescing"/>/<c>DisposeHostedHubs</c> but intake is still open —
+/// had nothing to subscribe to: by the time the one available signal fired, the window had closed.
+/// Every "wait for the hub to reach state X" therefore had to either SAMPLE the property on an
+/// interval or contrive the ordering, and the sampling form is a standing violation of the reactive
+/// rule. That window is where the interesting bugs live (#1470: a read serviced during teardown
+/// answered as "the node does not exist").</para>
+/// </summary>
+public class HubRunLevelObservableTest
+{
+    private static IHost BuildHost(out IMessageHub mesh)
+    {
+        var hostBuilder = new HostBuilder();
+        _ = new MeshHostBuilder(hostBuilder, new Address("mesh", "runlevel-source"));
+        var host = hostBuilder.Build();
+        mesh = host.Services.GetRequiredService<IMessageHub>();
+        return host;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ALateSubscriberIsToldTheLevelTheHubIsAlreadyIn()
+    {
+        using var host = BuildHost(out var mesh);
+        await host.StartAsync();
+
+        // Subscribing AFTER the hub started must not wait for the next transition — otherwise
+        // subscribing in order to observe the disposal window would itself race the window, which
+        // is the defect one level down.
+        var current = await mesh.RunLevelChanged.FirstAsync().ToTask();
+
+        current.Should().Be(mesh.RunLevel,
+            "the source replays the current level, so a subscription is never behind the property");
+
+        await host.StopAsync();
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task TheDisposalWINDOWIsObservable_NotJustItsEnd()
+    {
+        using var host = BuildHost(out var mesh);
+        await host.StartAsync();
+
+        var seen = new List<MessageHubRunLevel>();
+        using var subscription = mesh.RunLevelChanged.Subscribe(seen.Add);
+
+        await host.StopAsync();
+
+        // The end of teardown was always observable via DisposalCompleted. What was NOT is
+        // everything before it — this is the whole point of the issue.
+        seen.Should().Contain(MessageHubRunLevel.Dead, "the terminal level is still reported");
+        seen.Should().Contain(
+            l => l is MessageHubRunLevel.Quiescing
+                   or MessageHubRunLevel.DisposeHostedHubs
+                   or MessageHubRunLevel.ShutDown,
+            "at least one INTERMEDIATE disposal phase must be observable — a source that only "
+            + "reports the terminal state is DisposalCompleted with extra steps");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task TheSourceReportsTransitions_NotRepeatedAssignments()
+    {
+        using var host = BuildHost(out var mesh);
+        await host.StartAsync();
+
+        var seen = new List<MessageHubRunLevel>();
+        using var subscription = mesh.RunLevelChanged.Subscribe(seen.Add);
+
+        await host.StopAsync();
+
+        // Several disposal arms assign the same terminal level defensively (the Dead backstop in
+        // the finally, for one). A subscriber should see the lifecycle, not how many times a field
+        // was written.
+        seen.Should().OnlyHaveUniqueItems(
+            "the source publishes TRANSITIONS; a repeated assignment of the level the hub is "
+            + "already in is not a lifecycle event");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task TheSourceCOMPLETESAtDead()
+    {
+        using var host = BuildHost(out var mesh);
+        await host.StartAsync();
+
+        var completed = false;
+        using var subscription = mesh.RunLevelChanged.Subscribe(_ => { }, () => completed = true);
+
+        await host.StopAsync();
+
+        completed.Should().BeTrue(
+            "Dead is terminal, so the source must complete — otherwise every completion-shaped "
+            + "composition over it (LastAsync, ToTask) hangs on a hub that will never emit again");
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
+++ b/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using MeshWeaver.Hosting.Persistence.Http;
 using MeshWeaver.Mesh;
 
@@ -24,6 +25,18 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
 
     /// <summary>When true, every remote call throws <see cref="HttpRequestException"/>.</summary>
     public volatile bool Unreachable;
+
+    /// <summary>
+    /// Fires after every remote call this fake records (#1508). It exists so a test can SUBSCRIBE
+    /// to the remote's activity instead of sampling it on a timer: <c>WaitForRemote</c> used an
+    /// <c>Observable.Interval</c> purely because this object had no source to observe, and a fixed
+    /// sample races CI load in both directions — too short and it flakes, too long and it wastes
+    /// wall-clock across the suite.
+    /// </summary>
+    public IObservable<Unit> Changed => changed.AsObservable();
+
+    // Synchronized: remote calls arrive from whatever thread the sync pipeline is on.
+    private readonly ISubject<Unit> changed = Subject.Synchronize(new Subject<Unit>());
 
     /// <summary>Every remote call in order: (operation, path).</summary>
     public IReadOnlyList<(string Op, string Path)> Calls => calls.ToArray();
@@ -64,13 +77,29 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
 
     private void Record(string op, string path) => calls.Enqueue((op, path));
 
+    /// <summary>
+    /// Wakes <see cref="Changed"/> subscribers. 🚨 Called at the END of an operation, never from
+    /// <see cref="Record"/>: <c>Record</c> runs BEFORE the store mutation, so a subscriber woken
+    /// there re-evaluates its predicate against the state as it was just before the effect it is
+    /// waiting for — and if no further call ever comes, it waits forever. (That is not
+    /// hypothetical: notifying from <c>Record</c> hung
+    /// <c>PushOnly_local_edit_always_overwrites_even_a_newer_remote</c> for its full 30 s.)
+    /// A notification must not arrive before the thing it is announcing.
+    /// </summary>
+    private void Notify()
+    {
+        try { changed.OnNext(Unit.Default); } catch { /* a notification must never fail a fake */ }
+    }
+
     private sealed class Client(FakeRemoteMesh owner) : IRemoteMeshClient
     {
         public IObservable<MeshNode?> Get(string path) => Observable.Defer(() =>
         {
             owner.ThrowIfUnreachable();
             owner.Record("get", path);
-            return Observable.Return(owner.store.GetValueOrDefault(path));
+            var read = owner.store.GetValueOrDefault(path);
+            owner.Notify();
+            return Observable.Return(read);
         });
 
         public IObservable<Unit> Create(MeshNode node) => Observable.Defer(() =>
@@ -84,6 +113,7 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             };
             if (!owner.store.TryAdd(node.Path, stamped))
                 throw new InvalidOperationException($"Node already exists: {node.Path}");
+            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -98,6 +128,7 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
                 Version = Interlocked.Increment(ref owner.version),
                 LastModified = DateTimeOffset.UtcNow,
             };
+            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -106,6 +137,7 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             owner.ThrowIfUnreachable();
             owner.Record("delete", path);
             owner.store.TryRemove(path, out _);
+            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -132,6 +164,7 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             var hits = matches.Take(limit)
                 .Select(n => new RemoteSearchHit(n.Path, n.NodeType, n.Version, n.LastModified))
                 .ToList();
+            owner.Notify();
             return Observable.Return(new RemoteSearchResult(hits, Truncated: matches.Count > limit));
         });
     }

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Graph;
@@ -93,9 +94,18 @@ public abstract class InstanceSyncTestBase(ITestOutputHelper output) : MonolithM
             .Timeout(timeout ?? 30.Seconds())
             .ToTask();
 
-    /// <summary>Polls the fake remote until <paramref name="predicate"/> holds.</summary>
+    /// <summary>
+    /// Waits until <paramref name="predicate"/> holds on the fake remote — SUBSCRIBED to its
+    /// activity, not sampled on a timer (#1508).
+    ///
+    /// <para>This used an <c>Observable.Interval</c> only because <see cref="FakeRemoteMesh"/> had
+    /// no source to observe. It does now, so the predicate is evaluated once immediately (the
+    /// <c>StartWith</c> — the condition may already hold) and then on each actual remote call. A
+    /// fixed sample races CI load in both directions: too short and it flakes, too long and it
+    /// wastes wall-clock across the whole suite.</para>
+    /// </summary>
     protected async Task WaitForRemote(Func<FakeRemoteMesh, bool> predicate, TimeSpan? timeout = null) =>
-        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+        await Remote.Changed.StartWith(Unit.Default)
             .Where(_ => predicate(Remote))
             .FirstAsync()
             .Timeout(timeout ?? 30.Seconds())


### PR DESCRIPTION
Every *"wait for the hub to reach state X"* in this repo had to either **sample a property** or **contrive the ordering**, because there was no observable source for hub lifecycle state.

`MessageHub.RunLevel` is a plain `{ get; private set; }` — readable, not observable — and `IMessageHub` exposed only `DisposalCompleted`, which fires at the **end** of teardown. Anything interested in the disposal **window** (the interval where the hub is `Quiescing`/`DisposeHostedHubs` but intake is still open) had nothing to subscribe to: by the time the one available signal fired, the window had closed.

That window is exactly where the interesting bugs live — #1470, a read serviced during teardown answered as *"the node does not exist"*.

## `IMessageHub.RunLevelChanged`

Reactive throughout, as AGENTS.md requires: a `Subject` the `RunLevel` setter pushes to, composed and subscribed — never a `Task`-based signal or anything requiring a poll to observe.

Three properties are the substance of it, each with its own test:

- **BehaviorSubject-backed**, so a *late* subscriber is told the level the hub is already in. Without that, subscribing in order to observe the disposal window would itself race the window — the defect one level down.
- **Publishes transitions, not assignments.** Several disposal arms assign the same terminal level defensively (the `Dead` backstop in the `finally`); a subscriber should see the lifecycle, not how many times a field was written.
- **Completes at `Dead`**, so `LastAsync`/`ToTask` and every completion-shaped composition terminates instead of hanging on a hub that will never emit again.

`DisposalCompleted`'s contract is unchanged — this is an addition alongside it.

**On the interface change:** `MessageHub` is the only implementor (a sealed class), and in-mesh source *consumes* `IMessageHub` rather than implementing it — so nothing the compiler cannot see can break on an addition.

## The second half, which the issue calls out as self-contained

`FakeRemoteMesh` gains a `Changed` source, so `InstanceSyncTestBase.WaitForRemote` **subscribes** instead of sampling on a 50 ms interval.

Worth noting: **`MeshWeaver.InstanceSync.Test` went from 48 s to 15 s.** The polling latency *was* the runtime.

### 🚨 The ordering trap I walked into while writing it

`Notify()` is called at the **end** of each operation, never from `Record()`. `Record` runs *before* the store mutation, so a subscriber woken there re-evaluates its predicate against the state just before the effect it is waiting for — and waits forever if no further call comes.

Not hypothetical: notifying from `Record` hung `PushOnly_local_edit_always_overwrites_even_a_newer_remote` for its full 30 s until I moved it. A notification must not arrive before the thing it announces. The comment at the call site says so, with that failure named.

**`WaitForConfig` keeps its interval, deliberately.** Its source is a request/response read (`Sync.ReadConfig`), which is precisely the shape AGENTS.md sanctions the interval pattern for; converting it would need a source that does not exist.

## Verification

- `MeshWeaver.Hosting.Test` — **180/180** (4 new).
- `MeshWeaver.InstanceSync.Test` — **26/26**, 48 s → 15 s.
- `-c Release -warnaserror`, 0 errors / 0 warnings: `MeshWeaver.Messaging.Hub`, `MeshWeaver.Hosting`, `MeshWeaver.Graph`, `MeshWeaver.AI`, `MeshWeaver.Hosting.Orleans`, and both test projects.

No **What's New** entry: a framework surface with no user-visible behaviour change.

Fixes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj