### PR TITLE
memex-migration:main is dead on arrival — bump DbVersion.Latest to 53 (and add the test that was claimed to exist)

### DIFF
--- a/memex/aspire/Memex.Database.Migration/DbVersion.cs
+++ b/memex/aspire/Memex.Database.Migration/DbVersion.cs
@@ -13,5 +13,5 @@ namespace Memex.Database.Migration;
 /// </summary>
 public static class DbVersion
 {
-    public const int Latest = 52;
+    public const int Latest = 53;
 }

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -15,6 +15,11 @@
          shells call — an unmapped one there answers the SPA fallback with a 200, not a 404 (#1474). -->
     <ProjectReference Include="..\..\memex\Memex.LocalMesh\Memex.LocalMesh.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in
+         `dotnet test`. It only ever ran INSIDE the migration container before, so a registry/
+         DbVersion.Latest drift shipped a dead image while main stayed green (V53, 2026-08-14). -->
+    <ProjectReference Include="..\..\memex\aspire\Memex.Database.Migration\Memex.Database.Migration.csproj"
+                      Aliases="migration" />
     <!-- OAuthCodeStoreTest runs against a full monolith mesh (the store persists
          authorization codes as mesh nodes — the multi-replica safety contract). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />

--- a/test/Memex.Portal.Shared.Test/MigrationRegistryTest.cs
+++ b/test/Memex.Portal.Shared.Test/MigrationRegistryTest.cs
@@ -1,0 +1,49 @@
+// DbVersion is compiled into BOTH assemblies on purpose (Memex.Portal.Distributed links the same
+// source so the portal's gate and the runner cannot disagree), so the name is ambiguous here — the
+// alias picks the runner's copy, which is the one the registry is checked against.
+extern alias migration;
+using Xunit;
+using MigrationRegistry = migration::MigrationRegistry;
+using DbVersion = migration::Memex.Database.Migration.DbVersion;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Runs the migration runner's own start-up guard inside <c>dotnet test</c>.
+///
+/// <para>🚨 Why this exists: <c>MigrationRegistry.VerifyComplete()</c> is called from
+/// <c>Program.Main</c> — i.e. only ever INSIDE the migration container, at deploy time. So a drift
+/// it is designed to catch cannot fail a PR: it fails the published image. On 2026-08-14 exactly
+/// that happened. V53 was registered without bumping <c>DbVersion.Latest</c>, `main` stayed green,
+/// CD published <c>memex-migration:main</c>, and every disposable-mesh e2e in every repo then died
+/// at boot with <c>service "migration" didn't complete successfully: exit 139</c> — a segfault-
+/// shaped symptom four steps from the actual message, which was:</para>
+/// <code>
+/// DbVersion.Latest (52) does not match the highest registered migration (V53).
+/// </code>
+/// <para>The registry's own comment already claimed a "RegisteredMigrationsTest" pinned this. No
+/// such test existed. This is it.</para>
+/// </summary>
+public class MigrationRegistryTest
+{
+    [Fact]
+    public void RegistryIsComplete_AndDbVersionMatchesIt()
+        // Covers BOTH rules the runner enforces at start-up: every V##_ migration class in the
+        // assembly is registered (the V42 incident — present, never registered, silently skipped),
+        // and DbVersion.Latest equals the highest registered version (the V53 incident above).
+        // Calling the guard itself, rather than restating it, keeps the test honest when the guard
+        // grows a third rule.
+        => MigrationRegistry.VerifyComplete();
+
+    [Fact]
+    public void DbVersionLatest_IsTheHighestRegisteredMigration()
+    {
+        // Stated separately so the failure NAMES the two numbers — the runner's exception does, and
+        // a bare VerifyComplete() failure in a test report would not.
+        var highest = MigrationRegistry.All.Max(m => m.Version);
+        DbVersion.Latest.Should().Be(highest,
+            "the portal's DbVersionGate is compiled from DbVersion.Latest (linked source), so a " +
+            "registry that runs ahead of the constant silently loosens the startup gate — and the " +
+            "migration run refuses to start at all");
+    }
+}


### PR DESCRIPTION
## Every disposable mesh in every repo is failing to boot right now

V53 was registered (`4fdfdbf63`) without bumping `DbVersion.Latest`, so the runner's own guard —
added one commit earlier in `313d67cda`, precisely to stop this drift — refuses to start:

```
Unhandled exception. System.InvalidOperationException: DbVersion.Latest (52) does not match
the highest registered migration (V53). Bump DbVersion.Latest in lock-step with the registry.
   at MigrationRegistry.VerifyComplete()
```

CD published `memex-migration:main` with that inside at **16:50Z**. Since then every mesh boot dies
as:

```
service "migration" didn't complete successfully: exit 139
```

which names nothing — a segfault-shaped exit code four steps from the real message. It took down
education #150's five mesh jobs (blocking install + all four shards) and will take down any repo
that boots a mesh, plus any deploy that runs migrations.

## The test that should have caught it did not exist

`MigrationRegistry`'s own comment says *"RegisteredMigrationsTest pins that EVERY `V##_*` IMigration
in this assembly appears here"*. **There is no such test in the repo.** `VerifyComplete()` is called
only from `Program.Main` — i.e. only inside the migration container, at deploy time — so this class
of drift cannot fail a PR. It can only fail an image, after main is green.

`MigrationRegistryTest` now runs the guard in `dotnet test`, and states the `DbVersion` pin
separately so the failure names both numbers rather than just throwing.

## Verification

- **Control, same machine:** with `Latest = 52` both tests **fail**; with `53` both pass.
- `Memex.Portal.Shared.Test`: **324 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)