### PR TITLE
revert: restore WaitForRemote's poll — my #1508 test-infra half reddened main

### DIFF
--- a/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
+++ b/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using MeshWeaver.Hosting.Persistence.Http;
 using MeshWeaver.Mesh;
 
@@ -25,18 +24,6 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
 
     /// <summary>When true, every remote call throws <see cref="HttpRequestException"/>.</summary>
     public volatile bool Unreachable;
-
-    /// <summary>
-    /// Fires after every remote call this fake records (#1508). It exists so a test can SUBSCRIBE
-    /// to the remote's activity instead of sampling it on a timer: <c>WaitForRemote</c> used an
-    /// <c>Observable.Interval</c> purely because this object had no source to observe, and a fixed
-    /// sample races CI load in both directions — too short and it flakes, too long and it wastes
-    /// wall-clock across the suite.
-    /// </summary>
-    public IObservable<Unit> Changed => changed.AsObservable();
-
-    // Synchronized: remote calls arrive from whatever thread the sync pipeline is on.
-    private readonly ISubject<Unit> changed = Subject.Synchronize(new Subject<Unit>());
 
     /// <summary>Every remote call in order: (operation, path).</summary>
     public IReadOnlyList<(string Op, string Path)> Calls => calls.ToArray();
@@ -77,29 +64,13 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
 
     private void Record(string op, string path) => calls.Enqueue((op, path));
 
-    /// <summary>
-    /// Wakes <see cref="Changed"/> subscribers. 🚨 Called at the END of an operation, never from
-    /// <see cref="Record"/>: <c>Record</c> runs BEFORE the store mutation, so a subscriber woken
-    /// there re-evaluates its predicate against the state as it was just before the effect it is
-    /// waiting for — and if no further call ever comes, it waits forever. (That is not
-    /// hypothetical: notifying from <c>Record</c> hung
-    /// <c>PushOnly_local_edit_always_overwrites_even_a_newer_remote</c> for its full 30 s.)
-    /// A notification must not arrive before the thing it is announcing.
-    /// </summary>
-    private void Notify()
-    {
-        try { changed.OnNext(Unit.Default); } catch { /* a notification must never fail a fake */ }
-    }
-
     private sealed class Client(FakeRemoteMesh owner) : IRemoteMeshClient
     {
         public IObservable<MeshNode?> Get(string path) => Observable.Defer(() =>
         {
             owner.ThrowIfUnreachable();
             owner.Record("get", path);
-            var read = owner.store.GetValueOrDefault(path);
-            owner.Notify();
-            return Observable.Return(read);
+            return Observable.Return(owner.store.GetValueOrDefault(path));
         });
 
         public IObservable<Unit> Create(MeshNode node) => Observable.Defer(() =>
@@ -113,7 +84,6 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             };
             if (!owner.store.TryAdd(node.Path, stamped))
                 throw new InvalidOperationException($"Node already exists: {node.Path}");
-            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -128,7 +98,6 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
                 Version = Interlocked.Increment(ref owner.version),
                 LastModified = DateTimeOffset.UtcNow,
             };
-            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -137,7 +106,6 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             owner.ThrowIfUnreachable();
             owner.Record("delete", path);
             owner.store.TryRemove(path, out _);
-            owner.Notify();
             return Observable.Return(Unit.Default);
         });
 
@@ -164,7 +132,6 @@ public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
             var hits = matches.Take(limit)
                 .Select(n => new RemoteSearchHit(n.Path, n.NodeType, n.Version, n.LastModified))
                 .ToList();
-            owner.Notify();
             return Observable.Return(new RemoteSearchResult(hits, Truncated: matches.Count > limit));
         });
     }

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
@@ -1,4 +1,3 @@
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Graph;
@@ -94,18 +93,9 @@ public abstract class InstanceSyncTestBase(ITestOutputHelper output) : MonolithM
             .Timeout(timeout ?? 30.Seconds())
             .ToTask();
 
-    /// <summary>
-    /// Waits until <paramref name="predicate"/> holds on the fake remote — SUBSCRIBED to its
-    /// activity, not sampled on a timer (#1508).
-    ///
-    /// <para>This used an <c>Observable.Interval</c> only because <see cref="FakeRemoteMesh"/> had
-    /// no source to observe. It does now, so the predicate is evaluated once immediately (the
-    /// <c>StartWith</c> — the condition may already hold) and then on each actual remote call. A
-    /// fixed sample races CI load in both directions: too short and it flakes, too long and it
-    /// wastes wall-clock across the whole suite.</para>
-    /// </summary>
+    /// <summary>Polls the fake remote until <paramref name="predicate"/> holds.</summary>
     protected async Task WaitForRemote(Func<FakeRemoteMesh, bool> predicate, TimeSpan? timeout = null) =>
-        await Remote.Changed.StartWith(Unit.Default)
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
             .Where(_ => predicate(Remote))
             .FirstAsync()
             .Timeout(timeout ?? 30.Seconds())


### PR DESCRIPTION
🚨 **`main` is red**, and it is my regression.

`InstanceSyncPushTest.A_pending_content_change_pushes_a_DELETE_when_the_local_node_is_being_deleted` times out inside `WaitForRemote` — [run 31823380161](https://github.com/Systemorph/MeshWeaver/actions/runs/31823380161) and [31824306190](https://github.com/Systemorph/MeshWeaver/actions/runs/31824306190). I rewrote that helper in #1598 to subscribe to a new `FakeRemoteMesh.Changed` source instead of polling. It goes back.

## Reverting rather than pushing a second guess

I have a plausible mechanism: `Notify()` sits at the **end** of each operation body, so a call that **records and then throws** — `Create` on an existing path, `Update` on a missing one — never notifies, and a waiter whose predicate reads `Calls`/`WriteCount` is never re-woken. A `finally` would close it.

But **it does not reproduce locally** (6/6 green on the failing test under `DOTNET_PROCESSOR_COUNT=4`; 26/26 for the suite), so I cannot show that is *the* mechanism — and a red `main` is not the place to find out. Shipping the `finally` would be a guess dressed as a fix.

**The framework half of #1508 is untouched and stays.** `IMessageHub.RunLevelChanged` and its four tests are the part the issue was actually about, and nothing implicates them — this is only the `FakeRemoteMesh` / `WaitForRemote` test-infra half.

## For whoever picks the conversion up again

The prize is real: the suite ran **48 s polling, 15 s subscribed**. So is the coupling it introduces — the fake must emit a notification for **every** state change a predicate can observe.

I already got that wrong once inside this same change: notifying from `Record()` fires **before** the store mutation, so a woken subscriber re-evaluates against the state just before the effect it is waiting for, and `PushOnly_local_edit_always_overwrites_even_a_newer_remote` hung for its full 30 s until I moved it. **Two ordering traps in one small change** — it deserves its own PR with the failing CI shape reproduced first, not a rider on a framework addition.

## Verification

`MeshWeaver.InstanceSync.Test` — 26/26. `-c Release -warnaserror` — 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj