### PR TITLE
fix: pack the module's released version, not the authored MAJOR.MINOR

### DIFF
--- a/src/MeshWeaver.Plugin.Build/PluginManifest.cs
+++ b/src/MeshWeaver.Plugin.Build/PluginManifest.cs
@@ -36,14 +36,15 @@ public sealed record PluginManifest(
     /// Reads a plugin root's <c>index.json</c>.
     /// </summary>
     /// <param name="pluginDirectory">Directory containing <c>index.json</c>.</param>
-    /// <param name="fallbackVersion">Version to use when the manifest declares none — most do not,
-    /// so in CI this is the build-number-derived version that keeps releases monotonic.</param>
+    /// <param name="fallbackVersion">Version to use when neither <c>manifest.lock</c> nor
+    /// <c>index.json</c> declares one.</param>
     public static PluginManifest Read(string pluginDirectory, string fallbackVersion)
     {
         var name = Path.GetFileName(pluginDirectory.TrimEnd(Path.DirectorySeparatorChar));
         var indexPath = Path.Combine(pluginDirectory, "index.json");
         if (!File.Exists(indexPath))
-            return new PluginManifest(name, IdPrefix + name, fallbackVersion, name, null, []);
+            return new PluginManifest(
+                name, IdPrefix + name, LockVersion(pluginDirectory) ?? fallbackVersion, name, null, []);
 
         using var doc = JsonDocument.Parse(File.ReadAllText(indexPath));
         var root = doc.RootElement;
@@ -52,7 +53,9 @@ public sealed record PluginManifest(
         return new PluginManifest(
             name,
             IdPrefix + name,
-            Normalize(GetString(content, "version")) ?? fallbackVersion,
+            // 🚨 manifest.lock FIRST — it holds the composed release version; index.json holds only
+            // the authored MAJOR.MINOR. See LockVersion.
+            LockVersion(pluginDirectory) ?? Normalize(GetString(content, "version")) ?? fallbackVersion,
             GetString(content, "description") ?? GetString(root, "description") ?? name,
             GetString(content, "minMeshVersion"),
             content.ValueKind == JsonValueKind.Object
@@ -60,6 +63,37 @@ public sealed record PluginManifest(
             && requires.ValueKind == JsonValueKind.Array
                 ? [.. requires.EnumerateArray().Select(e => e.GetString()).Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!)]
                 : []);
+    }
+
+    /// <summary>
+    /// The module's released version from <c>manifest.lock</c> — the number the repo already
+    /// publishes and that dependents pin against.
+    ///
+    /// <para>🚨 <b>Not <c>index.json</c>'s <c>content.version</c>.</b> That field carries only the
+    /// AUTHORED <c>MAJOR.MINOR</c>; the <c>PATCH</c> is DERIVED by <c>gen-manifests.py</c> and
+    /// counts CONTENT changes — it increments when the tree's <c>moduleVersion</c> hash differs
+    /// from the last release. Reading index.json alone therefore silently drops the patch and mints
+    /// a package version the repo never released: ThreeBody reads <c>1.3</c> there while its
+    /// manifest.lock — and its <c>ThreeBody/v1.3.2</c> tag — say <c>1.3.2</c>. Publishing 1.3.0 for
+    /// a 1.3.2 tree would collide with a real earlier release and make every caret pin resolve to
+    /// the wrong content, which is precisely what that versioning exists to prevent.</para>
+    /// </summary>
+    private static string? LockVersion(string pluginDirectory)
+    {
+        var lockPath = Path.Combine(pluginDirectory, "manifest.lock");
+        if (!File.Exists(lockPath))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(lockPath));
+            return Normalize(GetString(doc.RootElement, "version"));
+        }
+        catch (JsonException)
+        {
+            // A malformed lock falls back to the authored version rather than failing the pack: the
+            // lock is machine-maintained, and a broken one is the generator's problem to report.
+            return null;
+        }
     }
 
     private static string? GetString(JsonElement element, string property) =>

--- a/test/MeshWeaver.Graph.Test/PluginManifestVersionTest.cs
+++ b/test/MeshWeaver.Graph.Test/PluginManifestVersionTest.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using MeshWeaver.Plugin.Build;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins WHICH version a plugin package carries.
+///
+/// <para>🚨 <b>Two files declare a version and they legitimately disagree.</b>
+/// <c>index.json</c>'s <c>content.version</c> is the AUTHORED <c>MAJOR.MINOR</c>;
+/// <c>manifest.lock</c>'s <c>version</c> is the composed release number, whose <c>PATCH</c> is
+/// DERIVED by <c>gen-manifests.py</c> from content changes and published as the git tag
+/// <c>&lt;Module&gt;/vX.Y.Z</c>. ThreeBody reads <c>1.3</c> in one and <c>1.3.2</c> in the other,
+/// and only the second is a release anyone can resolve.</para>
+///
+/// <para>Reading the authored field alone mints a version the repo never released — colliding with
+/// a real earlier release and making every caret pin resolve to the wrong content, which is the
+/// precise failure that versioning scheme exists to prevent. It is also invisible: the pack
+/// succeeds and the number looks plausible.</para>
+/// </summary>
+public class PluginManifestVersionTest : IDisposable
+{
+    private readonly string root = Directory.CreateTempSubdirectory("mw-plugin-version").FullName;
+
+    private string Plugin(string? authored, string? locked)
+    {
+        var dir = Path.Combine(root, "Widget");
+        Directory.CreateDirectory(dir);
+        var versionField = authored is null ? "" : ",\"version\":\"" + authored + "\"";
+        File.WriteAllText(Path.Combine(dir, "index.json"),
+            "{\"id\":\"Widget\",\"content\":{\"$type\":\"PluginContent\",\"description\":\"d\""
+            + versionField + "}}");
+        if (locked is not null)
+            File.WriteAllText(Path.Combine(dir, "manifest.lock"),
+                "{\"module\":\"Widget\",\"version\":\"" + locked + "\",\"moduleVersion\":\"abc123\"}");
+        return dir;
+    }
+
+    [Fact]
+    public void TheLockWinsOverTheAuthoredVersion()
+        // The whole point: the derived PATCH must survive into the package.
+        => Assert.Equal("1.3.2", PluginManifest.Read(Plugin(authored: "1.3", locked: "1.3.2"), "0.0.1").Version);
+
+    [Fact]
+    public void TheAuthoredVersionIsUsedWhenThereIsNoLock()
+        // A plugin whose manifest has not been generated yet still packs, widened to three parts.
+        => Assert.Equal("1.3.0", PluginManifest.Read(Plugin(authored: "1.3", locked: null), "0.0.1").Version);
+
+    [Fact]
+    public void TheFallbackIsUsedWhenNeitherDeclaresOne()
+        => Assert.Equal("0.0.1", PluginManifest.Read(Plugin(authored: null, locked: null), "0.0.1").Version);
+
+    [Fact]
+    public void AMalformedLockFallsBackRatherThanFailingThePack()
+    {
+        var dir = Plugin(authored: "2.1", locked: null);
+        File.WriteAllText(Path.Combine(dir, "manifest.lock"), "{ NOT JSON");
+
+        // The lock is machine-maintained; a broken one is the generator's problem to report, and
+        // failing the pack here would block a plugin for a defect in a different tool.
+        Assert.Equal("2.1.0", PluginManifest.Read(dir, "0.0.1").Version);
+    }
+
+    public void Dispose() => Directory.Delete(root, recursive: true);
+}


### PR DESCRIPTION
## What's New

**Category: Fix** — Plugin packages now carry the version the repo actually released.

## The bug

The packer read `content.version` from `index.json`. That field is only half the number.

Per `gen-manifests.py`, a module's version has two parts with different origins:

- **`MAJOR.MINOR`** — authored in `index.json`
- **`PATCH`** — **derived**, counting *content* changes: it increments when the tree's `moduleVersion` hash differs from the last release

The composed number lands in **`manifest.lock`** and is published as the git tag `<Module>/vX.Y.Z` — "the number dependents pin against".

So the packer minted a version the repo never released. ThreeBody reads `1.3` in `index.json`, while its `manifest.lock` and its `ThreeBody/v1.3.2` tag both say **`1.3.2`**.

## Why it matters

Publishing `1.3.0` for a `1.3.2` tree collides with a real earlier release and makes every caret pin resolve to the wrong content — precisely the failure that versioning scheme exists to prevent. `tag-modules.py` is explicit about it: *"One version, one tree — forever… Moving a published tag would silently change what every caret pin resolves to."*

And it fails invisibly: the pack succeeds, and `1.3.0` looks entirely plausible.

## The fix

`manifest.lock` wins. `index.json` remains the fallback for a tree whose manifest has not been generated yet, and a malformed lock falls back rather than failing the pack — the lock is machine-maintained, so a broken one is the generator's problem to report, not a reason to block an unrelated plugin.

## Verified

- ThreeBody packs as `MeshWeaver.Plugin.ThreeBody.1.3.2.nupkg`, matching both `manifest.lock` and the tag.
- Tests pin all four cases (lock wins, no lock, neither, malformed lock) — 13 passing alongside the caret-range tests.

The two files legitimately disagreeing is exactly what made this easy to miss, so the test fixture writes both with different values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lo5L8TgTxeANJrUcDLrdSx