### PR TITLE
feat(#1497): one MeshRest — the three shells stop hand-rolling the same four fetches

### DIFF
--- a/clients/grpc-web/src/index.ts
+++ b/clients/grpc-web/src/index.ts
@@ -21,6 +21,15 @@
 //   mesh.patch("ACME/Stories/42", { content: { done: true } });
 
 export { Mesh, type MeshOptions } from "./mesh";
+export {
+  MeshRest,
+  type MeshRestOptions,
+  type MeshNodeRow,
+  type ContentItem,
+  type ContentListing,
+  type RenderedMarkdown,
+  type MarkdownCellSubmission,
+} from "./rest";
 export { MeshWebConnection, connect, type ConnectOptions } from "./connection";
 export { type Delivery } from "./envelope";
 export { type MeshNode } from "./types";

--- a/clients/grpc-web/src/rest.test.ts
+++ b/clients/grpc-web/src/rest.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { MeshRest } from "./rest";
+
+// THE SHARED /api/mesh CLIENT'S CONTRACT (issue #1497).
+//
+// Three shells hand-rolled these four verbs and drifted in ways nobody chose — the token, the error
+// convention, and the base-URL composition. These cases pin the decisions that replaced the drift,
+// so a future change has to break a test rather than break one shell quietly.
+
+/** Records every request and replays a canned response. */
+function stub(body: string, init: { status?: number; ok?: boolean } = {}) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetchImpl = (async (url: string | URL | Request, requestInit?: RequestInit) => {
+    calls.push({ url: String(url), init: requestInit ?? {} });
+    const status = init.status ?? 200;
+    return {
+      ok: init.ok ?? status < 400,
+      status,
+      text: async () => body,
+    } as Response;
+  }) as unknown as typeof globalThis.fetch;
+  return { calls, fetchImpl };
+}
+
+const headersOf = (init: RequestInit) => (init.headers ?? {}) as Record<string, string>;
+
+describe("the Authorization header is applied in ONE place", () => {
+  it("every verb carries Bearer when a token is present", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [], items: [], html: "" }));
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "mw_tok", fetch: fetchImpl });
+
+    await rest.queryNodes("nodeType:Story");
+    await rest.renderMarkdown("# hi");
+    await rest.listContent("acme/Docs");
+    await rest.uploadContent("acme/Docs/a.txt", new Blob(["x"]), "a.txt");
+
+    expect(calls).toHaveLength(4);
+    for (const call of calls) {
+      expect(headersOf(call.init)["authorization"]).toBe("Bearer mw_tok");
+    }
+  });
+
+  // 🚨 #1474 in one assertion. RN's copies carried NO token and every REST op 401'd against a real
+  // portal — and a 401 here reads as "the file browser is empty", not as an auth error.
+  it("no verb is left without it — the defect #1474 was", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [], items: [] }));
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "mw_tok", fetch: fetchImpl });
+
+    await rest.listContent("acme/Docs");
+    await rest.uploadContent("acme/Docs/a.txt", new Blob(["x"]), "a.txt");
+
+    expect(calls.every((c) => "authorization" in headersOf(c.init))).toBe(true);
+  });
+
+  // The anonymous same-origin sidecar must receive NO header — `Bearer ` with an empty value is not
+  // the same as absent, and the sidecar rejects it.
+  it("an absent token sends NO Authorization header at all", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [], items: [] }));
+    const rest = new MeshRest({ baseUrl: "http://127.0.0.1:5055", fetch: fetchImpl });
+
+    await rest.queryNodes("nodeType:Story");
+    await rest.listContent("acme/Docs");
+
+    expect(calls.every((c) => !("authorization" in headersOf(c.init)))).toBe(true);
+  });
+
+  it("an EMPTY token is the same as absent, not `Bearer `", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [] }));
+    const rest = new MeshRest({ baseUrl: "http://127.0.0.1:5055", token: "", fetch: fetchImpl });
+
+    await rest.queryNodes("nodeType:Story");
+
+    expect(headersOf(calls[0].init)["authorization"]).toBeUndefined();
+  });
+});
+
+describe("the error convention, decided once", () => {
+  // A listing that cannot be served renders empty rather than breaking the page embedding it.
+  it("queryNodes answers [] on a non-ok response", async () => {
+    const { fetchImpl } = stub("nope", { status: 500 });
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await expect(rest.queryNodes("nodeType:Story")).resolves.toEqual([]);
+  });
+
+  it("queryNodes answers [] on the server's Error:/Not found: text sentinels", async () => {
+    for (const body of ["Error: boom", "Not found: acme"]) {
+      const { fetchImpl } = stub(body);
+      const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+      await expect(rest.queryNodes("q")).resolves.toEqual([]);
+    }
+  });
+
+  it("queryNodes answers [] when fetch itself throws", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof globalThis.fetch;
+    const rest = new MeshRest({ baseUrl: "https://portal.example", fetch: fetchImpl });
+
+    await expect(rest.queryNodes("q")).resolves.toEqual([]);
+  });
+
+  // …but a WRITE, and a render whose output the page depends on, must not fail silently.
+  it("listContent throws rather than returning an empty listing", async () => {
+    const { fetchImpl } = stub("Error: denied");
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await expect(rest.listContent("acme/Docs")).rejects.toThrow(/denied/);
+  });
+
+  it("uploadContent throws — a silent non-upload is worse than an error", async () => {
+    const { fetchImpl } = stub("Error: too large", { status: 413 });
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await expect(rest.uploadContent("acme/Docs/a.txt", new Blob(["x"]), "a.txt")).rejects.toThrow();
+  });
+
+  it("renderMarkdown throws on a non-ok response", async () => {
+    const { fetchImpl } = stub("", { status: 500 });
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await expect(rest.renderMarkdown("# hi")).rejects.toThrow(/render-markdown failed/);
+  });
+});
+
+describe("composition rules", () => {
+  it("normalises a trailing slash on the base URL exactly once", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [] }));
+    const rest = new MeshRest({ baseUrl: "https://portal.example///", token: "t", fetch: fetchImpl });
+
+    await rest.queryNodes("q");
+
+    expect(calls[0].url).toBe("https://portal.example/api/mesh/query-nodes");
+  });
+
+  // 🚨 FormData supplies its own content-type WITH the boundary; overriding it makes the server
+  // unable to parse the body at all.
+  it("multipart sets no content-type", async () => {
+    const { calls, fetchImpl } = stub("");
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await rest.uploadContent("acme/Docs/a.txt", new Blob(["x"]), "a.txt");
+
+    expect(headersOf(calls[0].init)["content-type"]).toBeUndefined();
+    expect(headersOf(calls[0].init)["authorization"]).toBe("Bearer t");
+  });
+
+  it("the JSON verbs do send content-type", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [] }));
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await rest.queryNodes("q");
+
+    expect(headersOf(calls[0].init)["content-type"]).toBe("application/json");
+  });
+
+  it("each verb posts to its own documented path", async () => {
+    const { calls, fetchImpl } = stub(JSON.stringify({ results: [], items: [], html: "" }));
+    const rest = new MeshRest({ baseUrl: "https://portal.example", token: "t", fetch: fetchImpl });
+
+    await rest.queryNodes("q");
+    await rest.renderMarkdown("# hi");
+    await rest.listContent("acme/Docs");
+    await rest.uploadContent("acme/Docs/a.txt", new Blob(["x"]), "a.txt");
+
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://portal.example/api/mesh/query-nodes",
+      "https://portal.example/api/mesh/render-markdown",
+      "https://portal.example/api/mesh/content/list",
+      "https://portal.example/api/mesh/upload",
+    ]);
+  });
+});

--- a/clients/grpc-web/src/rest.ts
+++ b/clients/grpc-web/src/rest.ts
@@ -1,0 +1,191 @@
+// THE ONE /api/mesh REST CLIENT — the shells' shared implementation of the four verbs each of them
+// used to hand-roll (issue #1497).
+//
+// Three shells carried their own copy of `query-nodes`, `render-markdown`, `content/list` and
+// `upload`: clients/portal-next/src/client/live.ts, clients/portal/src/live.ts and
+// clients/react-native/src/liveOps.ts. Duplicating a fetch does not merely repeat code — it lets the
+// copies DRIFT in ways nobody chose, and they had:
+//
+//   * THE TOKEN. RN's three verbs carried no Authorization header at all — that IS #1474, and it is
+//     exactly the failure a duplicated fetch invites: the two web shells were written with the
+//     token, the third copy was not, and a 401 there reads as "the file browser is empty", not as an
+//     auth error.
+//   * ERROR SEMANTICS. `queryNodes` returned [] on failure in the web shells but throws in
+//     `Mesh.search`. Neither convention was written down; each copy picked one.
+//   * THE BASE URL. Only RN normalised a trailing slash, so `https://host/` + `/api/mesh/...`
+//     produced a double slash in the other two.
+//
+// So the rules are decided ONCE, here:
+//
+//   1. `Authorization: Bearer` is applied in ONE place — and ONLY when a token is present. An empty
+//      token means the anonymous same-origin sidecar, which must not receive the header at all
+//      (sending `Bearer ` is not the same as sending nothing). RN had this right; the web shells
+//      did not.
+//   2. The base URL is normalised once, on construction.
+//   3. A LISTING degrades, a WRITE throws. `queryNodes` answers [] on any failure, because a query
+//      that cannot be served should render an empty list rather than break the page that embeds it;
+//      `renderMarkdown`, `listContent` and `uploadContent` throw, because silently rendering nothing
+//      or silently not uploading is worse than an error the caller can show. That is the convention,
+//      and it is now written down rather than re-decided per copy.
+//   4. Multipart sets NO content-type — `FormData` supplies it with its boundary, and overriding it
+//      makes the server unable to parse the body.
+//
+// 🚨 Verbs genuinely local to one shell stay there: portal-next's `deleteNode`, `transcribe` and
+// `autocomplete` are not part of this surface. This owns the four the shells actually shared.
+//
+// `restContract.test.ts` (in this package) already asserts that both backends serve every path a
+// client posts to; it is the natural home for this client's own tests too.
+
+/** How a shell reaches the portal's REST surface. */
+export interface MeshRestOptions {
+  /** Portal origin serving `/api/mesh/*` — trailing slashes are normalised away. */
+  baseUrl: string;
+  /** Bearer token. OMIT (or pass "") for the anonymous same-origin sidecar — see rule 1. */
+  token?: string;
+  /** Custom fetch — the React Native seam. Unary REST works with the platform fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+/** One row of a `query-nodes` result — the node fields the shells actually read. */
+export interface MeshNodeRow {
+  path?: string;
+  name?: string;
+  nodeType?: string;
+  [key: string]: unknown;
+}
+
+/** One entry in a content-collection directory. */
+export interface ContentItem {
+  kind: "folder" | "file" | "unknown";
+  name: string;
+  path: string;
+  itemCount?: number;
+  lastModified?: string;
+}
+
+/** A content-collection listing. */
+export interface ContentListing {
+  collection: string;
+  path: string;
+  editable: boolean;
+  items: ContentItem[];
+}
+
+/** Server-rendered markdown plus the executable cells the Markdig pipeline found. */
+export interface RenderedMarkdown {
+  html: string;
+  codeSubmissions: MarkdownCellSubmission[];
+}
+
+/**
+ * An executable code cell the server's markdown pipeline emitted.
+ *
+ * 🚨 Declared here rather than imported from `@meshweaver/react`: this package is the transport
+ * layer and the renderer depends on IT, never the reverse. The members are the SERVER's wire shape
+ * (Markdig's `ExecutableCodeBlockRenderer`), which is what makes it correct to own at this layer —
+ * and it must stay structurally assignable to the renderer's `MarkdownCellSubmission`, or every
+ * shell has to cast the result of `renderMarkdown`.
+ */
+export interface MarkdownCellSubmission {
+  code: string;
+  id: string;
+  language?: string;
+}
+
+export class MeshRest {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly doFetch: typeof globalThis.fetch;
+
+  constructor(options: MeshRestOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.token = options.token ?? "";
+    this.doFetch = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Full-node mesh query (`POST /api/mesh/query-nodes`) — the browser twin of `IMeshService.Query`.
+   * Answers `[]` on ANY failure (rule 3): a listing that cannot be served renders empty rather than
+   * breaking the page that embeds it.
+   */
+  async queryNodes(query: string, limit = 50): Promise<MeshNodeRow[]> {
+    try {
+      const resp = await this.doFetch(`${this.baseUrl}/api/mesh/query-nodes`, {
+        method: "POST",
+        headers: this.jsonHeaders(),
+        body: JSON.stringify({ query, limit }),
+      });
+      if (!resp.ok) return [];
+      const text = await resp.text();
+      if (text.startsWith("Error:") || text.startsWith("Not found:")) return [];
+      const parsed = JSON.parse(text) as { results?: MeshNodeRow[] };
+      return Array.isArray(parsed.results) ? parsed.results : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Server-side Markdig render (`POST /api/mesh/render-markdown`) — the ONE markdown parser. */
+  async renderMarkdown(markdown: string, nodePath?: string): Promise<RenderedMarkdown> {
+    const resp = await this.doFetch(`${this.baseUrl}/api/mesh/render-markdown`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
+    });
+    if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
+    const text = await resp.text();
+    if (text.startsWith("Error:")) throw new Error(text);
+    const parsed = JSON.parse(text) as { html?: string; codeSubmissions?: MarkdownCellSubmission[] };
+    return { html: parsed.html ?? "", codeSubmissions: parsed.codeSubmissions ?? [] };
+  }
+
+  /**
+   * Content-collection listing (`POST /api/mesh/content/list`) — the read half of the file browser.
+   * `path` is `{node}/{collection}[/{dir}]`.
+   */
+  async listContent(path: string): Promise<ContentListing> {
+    const resp = await this.doFetch(`${this.baseUrl}/api/mesh/content/list`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify({ path }),
+    });
+    const text = await resp.text();
+    if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
+    const parsed = JSON.parse(text) as Partial<ContentListing>;
+    return {
+      collection: String(parsed.collection ?? ""),
+      path: String(parsed.path ?? ""),
+      editable: !!parsed.editable,
+      items: Array.isArray(parsed.items) ? parsed.items : [],
+    };
+  }
+
+  /**
+   * Content upload (`POST /api/mesh/upload`, multipart) — `path` is `{node}/{collection}/{filePath}`.
+   * 🚨 No content-type header: FormData supplies it WITH its boundary (rule 4).
+   */
+  async uploadContent(path: string, file: File | Blob, fileName?: string): Promise<void> {
+    const form = new FormData();
+    form.append("path", path);
+    form.append("file", file as Blob, fileName ?? (file as { name?: string }).name ?? "upload");
+    const resp = await this.doFetch(`${this.baseUrl}/api/mesh/upload`, {
+      method: "POST",
+      headers: this.authHeaders(),
+      body: form,
+    });
+    const text = await resp.text();
+    if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
+  }
+
+  /**
+   * Bearer, and ONLY when there is a token (rule 1). The anonymous same-origin sidecar must receive
+   * no Authorization header at all — `Bearer ` with an empty value is not the same as absent.
+   */
+  private authHeaders(): Record<string, string> {
+    return this.token ? { authorization: `Bearer ${this.token}` } : {};
+  }
+
+  private jsonHeaders(): Record<string, string> {
+    return { "content-type": "application/json", ...this.authHeaders() };
+  }
+}

--- a/clients/portal-next/src/client/live.ts
+++ b/clients/portal-next/src/client/live.ts
@@ -20,7 +20,7 @@ import type {
   RenderedMarkdown,
   ThreadSubmitOptions,
 } from "@meshweaver/react/core";
-import { connect, Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+import { connect, Mesh, MeshRest, type MeshWebConnection } from "@meshweaver/client-web";
 
 /** A queried mesh node row — the hub-serialized MeshNode shape (camelCase, $type-tagged content). */
 export type MeshNodeRow = Record<string, unknown>;
@@ -123,16 +123,20 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
   const connection = await connect(baseUrl, { token: rawToken, address: `portal/${stableClientId()}` });
   const mesh = Mesh.from(connection);
   const userId = (nodePath ?? "").split("/")[0] ?? "";
-  const runQuery = (query: string, limit = 50) => queryNodes(baseUrl, rawToken, query, limit);
+  // The four shared /api/mesh verbs come from ONE implementation (#1497) — the copies in this file,
+  // clients/portal/src/live.ts and clients/react-native/src/liveOps.ts had drifted on the token, the
+  // error convention and the base-URL composition. Verbs genuinely local to this shell (deleteNode,
+  // transcribe, autocomplete) stay below.
+  const rest = new MeshRest({ baseUrl, token: rawToken });
+  const runQuery = (query: string, limit = 50) => rest.queryNodes(query, limit);
   const runAutocomplete = (query: string, contextPath?: string) =>
     autocomplete(connection, userId, query, contextPath);
-  const runRenderMarkdown = (markdown: string, nodePath?: string) =>
-    renderMarkdown(baseUrl, rawToken, markdown, nodePath);
+  const runRenderMarkdown = (markdown: string, nodePath?: string) => rest.renderMarkdown(markdown, nodePath);
   const runDeleteNode = (path: string) => deleteNode(baseUrl, rawToken, path);
   const runStartKernel = (cells: MarkdownCellSubmission[]) =>
     startMarkdownKernel(connection, mesh, userId, cells, runDeleteNode);
-  const runListContent = (path: string) => listContent(baseUrl, rawToken, path);
-  const runUploadContent = (path: string, file: File) => uploadContent(baseUrl, rawToken, path, file);
+  const runListContent = (path: string) => rest.listContent(path);
+  const runUploadContent = (path: string, file: File) => rest.uploadContent(path, file);
   const runTranscribe = (audio: Blob, language?: string) => transcribe(baseUrl, rawToken, audio, language);
   return {
     connection,
@@ -155,25 +159,6 @@ async function deleteNode(baseUrl: string, token: string, path: string): Promise
     body: JSON.stringify({ paths: JSON.stringify([path]) }),
   });
   if (!resp.ok) throw new Error(`delete failed (${resp.status})`);
-}
-
-/** Server-side Markdig render (`POST /api/mesh/render-markdown`) — the ONE markdown parser. */
-async function renderMarkdown(
-  baseUrl: string,
-  token: string,
-  markdown: string,
-  nodePath?: string,
-): Promise<RenderedMarkdown> {
-  const resp = await fetch(`${baseUrl}/api/mesh/render-markdown`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
-  });
-  if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
-  const text = await resp.text();
-  if (text.startsWith("Error:")) throw new Error(text);
-  const parsed = JSON.parse(text) as { html?: string; codeSubmissions?: MarkdownCellSubmission[] };
-  return { html: parsed.html ?? "", codeSubmissions: parsed.codeSubmissions ?? [] };
 }
 
 /** Speech-to-text (`POST /api/speech/transcribe`) — multipart audio → {text, language}, Bearer-auth. */
@@ -281,23 +266,6 @@ async function startMarkdownKernel(
 function newRandomId(): string {
   const g = globalThis as { crypto?: { randomUUID?: () => string } };
   return (g.crypto?.randomUUID?.() ?? `${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`).replace(/-/g, "");
-}
-
-async function queryNodes(baseUrl: string, token: string, query: string, limit: number): Promise<MeshNodeRow[]> {
-  try {
-    const resp = await fetch(`${baseUrl}/api/mesh/query-nodes`, {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-      body: JSON.stringify({ query, limit }),
-    });
-    if (!resp.ok) return [];
-    const text = await resp.text();
-    if (text.startsWith("Error:") || text.startsWith("Not found:")) return [];
-    const parsed = JSON.parse(text) as { results?: MeshNodeRow[] };
-    return Array.isArray(parsed.results) ? parsed.results : [];
-  } catch {
-    return [];
-  }
 }
 
 async function autocomplete(
@@ -429,38 +397,6 @@ function adaptOps(
     // Speech-to-text: the composer's mic records + POSTs here (→ /api/speech/transcribe → Whisper).
     transcribe: runTranscribe,
   };
-}
-
-/** Content-collection listing (`POST /api/mesh/content/list`) — `path` = {node}/{collection}[/{dir}]. */
-async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
-  const resp = await fetch(`${baseUrl}/api/mesh/content/list`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ path }),
-  });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
-  const parsed = JSON.parse(text) as ContentListing;
-  return {
-    collection: String(parsed.collection ?? ""),
-    path: String(parsed.path ?? ""),
-    editable: !!parsed.editable,
-    items: Array.isArray(parsed.items) ? parsed.items : [],
-  };
-}
-
-/** Content upload (`POST /api/mesh/upload`, multipart) — `path` = {node}/{collection}/{filePath}. */
-async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
-  const form = new FormData();
-  form.append("path", path);
-  form.append("file", file, file.name);
-  const resp = await fetch(`${baseUrl}/api/mesh/upload`, {
-    method: "POST",
-    headers: { authorization: `Bearer ${token}` },
-    body: form,
-  });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
 }
 
 /**

--- a/clients/portal/src/live.ts
+++ b/clients/portal/src/live.ts
@@ -27,7 +27,7 @@ import type {
   RenderedMarkdown,
   ThreadSubmitOptions,
 } from "@meshweaver/react/core";
-import { connect, Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+import { connect, Mesh, MeshRest, type MeshWebConnection } from "@meshweaver/client-web";
 
 /** A queried mesh node row — the hub-serialized MeshNode shape (camelCase, $type-tagged content). */
 type MeshNodeRow = Record<string, unknown>;
@@ -70,13 +70,15 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
   // through /api/mesh/query-nodes — NOT Mesh.search (the gRPC QueryRequest has no server handler,
   // so it would silently return empty). renderMarkdown / startMarkdownKernel light up interactive
   // doc pages in the SPA (previously they showed the "execution unavailable" notice).
-  const runQuery = (query: string, limit = 50) => queryNodes(baseUrl, rawToken, query, limit);
+  // The four shared /api/mesh verbs come from ONE implementation (#1497).
+  const rest = new MeshRest({ baseUrl, token: rawToken });
+  const runQuery = (query: string, limit = 50) => rest.queryNodes(query, limit);
   const runAutocomplete = (query: string, contextPath?: string) => autocomplete(connection, userId, query, contextPath);
-  const runRenderMarkdown = (markdown: string, nodePath2?: string) => renderMarkdown(baseUrl, rawToken, markdown, nodePath2);
+  const runRenderMarkdown = (markdown: string, nodePath2?: string) => rest.renderMarkdown(markdown, nodePath2);
   const runDeleteNode = (path: string) => deleteNode(baseUrl, rawToken, path);
   const runStartKernel = (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, userId, cells, runDeleteNode);
-  const runListContent = (path: string) => listContent(baseUrl, rawToken, path);
-  const runUploadContent = (path: string, file: File) => uploadContent(baseUrl, rawToken, path, file);
+  const runListContent = (path: string) => rest.listContent(path);
+  const runUploadContent = (path: string, file: File) => rest.uploadContent(path, file);
 
   return {
     connection,
@@ -84,34 +86,6 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
     userId,
     close: () => connection.close(),
   };
-}
-
-/** Content-collection listing (`POST /api/mesh/content/list`). */
-async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
-  const resp = await fetch(`${baseUrl}/api/mesh/content/list`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ path }),
-  });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
-  const parsed = JSON.parse(text) as ContentListing;
-  return {
-    collection: String(parsed.collection ?? ""),
-    path: String(parsed.path ?? ""),
-    editable: !!parsed.editable,
-    items: Array.isArray(parsed.items) ? parsed.items : [],
-  };
-}
-
-/** Content upload (`POST /api/mesh/upload`, multipart). */
-async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
-  const form = new FormData();
-  form.append("path", path);
-  form.append("file", file, file.name);
-  const resp = await fetch(`${baseUrl}/api/mesh/upload`, { method: "POST", headers: { authorization: `Bearer ${token}` }, body: form });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
 }
 
 /**
@@ -217,24 +191,6 @@ async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState
 
 // ---- REST-backed mesh ops (parity with clients/portal-next/src/client/live.ts) -------------------
 
-/** Full-node mesh query (`POST /api/mesh/query-nodes`) — the browser twin of IMeshService.Query. */
-async function queryNodes(baseUrl: string, token: string, query: string, limit: number): Promise<MeshNodeRow[]> {
-  try {
-    const resp = await fetch(`${baseUrl}/api/mesh/query-nodes`, {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-      body: JSON.stringify({ query, limit }),
-    });
-    if (!resp.ok) return [];
-    const text = await resp.text();
-    if (text.startsWith("Error:") || text.startsWith("Not found:")) return [];
-    const parsed = JSON.parse(text) as { results?: MeshNodeRow[] };
-    return Array.isArray(parsed.results) ? parsed.results : [];
-  } catch {
-    return [];
-  }
-}
-
 /** One-shot @-mention autocomplete — every data-enabled hub handles AutocompleteRequest; the
  *  user's home hub aggregates all providers. Empty on any failure (the composer just shows none). */
 async function autocomplete(
@@ -265,24 +221,6 @@ async function deleteNode(baseUrl: string, token: string, path: string): Promise
   if (!resp.ok) throw new Error(`delete failed (${resp.status})`);
 }
 
-/** Server-side Markdig render (`POST /api/mesh/render-markdown`) — the ONE markdown parser. */
-async function renderMarkdown(
-  baseUrl: string,
-  token: string,
-  markdown: string,
-  nodePath?: string,
-): Promise<RenderedMarkdown> {
-  const resp = await fetch(`${baseUrl}/api/mesh/render-markdown`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
-  });
-  if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
-  const text = await resp.text();
-  if (text.startsWith("Error:")) throw new Error(text);
-  const parsed = JSON.parse(text) as { html?: string; codeSubmissions?: MarkdownCellSubmission[] };
-  return { html: parsed.html ?? "", codeSubmissions: parsed.codeSubmissions ?? [] };
-}
 
 /**
  * The per-view interactive-markdown kernel — the client twin of

--- a/clients/react-native/src/liveOps.ts
+++ b/clients/react-native/src/liveOps.ts
@@ -5,7 +5,7 @@
 // and (b) render-markdown goes over a plain fetch POST (non-streaming, so the RN global fetch is fine —
 // only the gRPC-web server-stream needs nativeStreamingFetch). renderMarkdown reuses the ONE server Markdig
 // parser; the Markdown leaf hydrates its HTML with the shared splitRenderedHtml — no bespoke parser.
-import { Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+import { Mesh, MeshRest, type MeshWebConnection } from "@meshweaver/client-web";
 import type {
   ContentListing,
   DocumentDownload,
@@ -17,64 +17,6 @@ import type {
   RenderedMarkdown,
   ThreadSubmitOptions,
 } from "@meshweaver/react/core";
-
-/** JSON headers + Bearer when a token is present — `/api/mesh/*` on a remote portal is
- * Bearer-only (issue #1474: RN sent no token, so every REST op 401'd against real portals;
- * the anonymous sidecar keeps working because an empty token adds no header). */
-function jsonHeaders(token: string): Record<string, string> {
-  const headers: Record<string, string> = { "content-type": "application/json" };
-  if (token) headers["authorization"] = `Bearer ${token}`;
-  return headers;
-}
-
-/** Server-side Markdig render (POST {baseUrl}/api/mesh/render-markdown) — the ONE markdown parser. */
-async function renderMarkdown(baseUrl: string, token: string, markdown: string, nodePath?: string): Promise<RenderedMarkdown> {
-  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/render-markdown`, {
-    method: "POST",
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
-  });
-  if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
-  const text = await resp.text();
-  if (text.startsWith("Error:")) throw new Error(text);
-  const parsed = JSON.parse(text) as { html?: string; codeSubmissions?: MarkdownCellSubmission[] };
-  return { html: parsed.html ?? "", codeSubmissions: parsed.codeSubmissions ?? [] };
-}
-
-/**
- * Content-collection listing (`POST {baseUrl}/api/mesh/content/list`) — the read half of the file
- * browser. `path` is `{node}/{collection}[/{dir}]`. Same endpoint and same response shaping as
- * portal-next's listContent; the sidecar is same-origin and anonymous (empty token), while a
- * remote portal needs the instance's Bearer token.
- */
-async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
-  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/content/list`, {
-    method: "POST",
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ path }),
-  });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
-  const parsed = JSON.parse(text) as ContentListing;
-  return {
-    collection: String(parsed.collection ?? ""),
-    path: String(parsed.path ?? ""),
-    editable: !!parsed.editable,
-    items: Array.isArray(parsed.items) ? parsed.items : [],
-  };
-}
-
-/** Content upload (`POST {baseUrl}/api/mesh/upload`, multipart). */
-async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
-  const form = new FormData();
-  form.append("path", path);
-  form.append("file", file as unknown as Blob, (file as { name?: string }).name ?? "upload");
-  const headers: Record<string, string> = {};
-  if (token) headers["authorization"] = `Bearer ${token}`; // multipart: FormData sets content-type
-  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/upload`, { method: "POST", headers, body: form });
-  const text = await resp.text();
-  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
-}
 
 /** Decode a byte[] wire value (base64 string, or a number array) to bytes. */
 function decodeBytes(raw: unknown): Uint8Array {
@@ -219,6 +161,12 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
   // The REST reach-back (search + the helpers below) carries the instance's Bearer token; empty
   // = the anonymous sidecar. Without it every REST op 401'd against a remote portal (#1474).
   const mesh = Mesh.from(connection, "mesh/main", { url: baseUrl, token: token || undefined });
+  // The four shared /api/mesh verbs come from ONE implementation (#1497). This shell is the reason
+  // that matters: its copies carried NO Authorization header at all, so every REST op 401'd against
+  // a real portal and the file browser looked merely EMPTY (#1474). MeshRest applies Bearer in one
+  // place — and omits it entirely for the anonymous same-origin sidecar, which is the behaviour this
+  // shell had right and the web shells did not.
+  const rest = new MeshRest({ baseUrl, token });
   return {
     watch: (path: string) => watchNode(mesh, path),
     startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
@@ -228,15 +176,15 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
     patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
     search: (query: string, basePath?: string, limit?: number) =>
       mesh.search(query, basePath, limit).catch(() => [] as Record<string, unknown>[]),
-    renderMarkdown: (markdown: string, nodePath?: string) => renderMarkdown(baseUrl, token, markdown, nodePath),
+    renderMarkdown: (markdown: string, nodePath?: string) => rest.renderMarkdown(markdown, nodePath),
     startMarkdownKernel: (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, partition, cells),
     getNode: (path: string) => mesh.get(path).then((n) => n.raw as Record<string, unknown>).catch(() => null),
     createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
     // The file-browser and document-export ops. These are plain REST / mesh-request calls with no
     // browser-only dependency, so RN wires the SAME three the web shells do — without them the
     // FileBrowser and ExportDocument leaves could only ever render their "not available" state.
-    listContent: (path: string) => listContent(baseUrl, token, path),
-    uploadContent: (path: string, file: File) => uploadContent(baseUrl, token, path, file),
+    listContent: (path: string) => rest.listContent(path),
+    uploadContent: (path: string, file: File) => rest.uploadContent(path, file),
     exportDocument: (sourcePath: string, options: DocumentExportOptions) => exportDocument(mesh, sourcePath, options),
   };
 }


### PR DESCRIPTION
`portal-next`, `portal` and `react-native` each carried their own copy of `query-nodes`, `render-markdown`, `content/list` and `upload`. Duplicating a fetch does not merely repeat code — **it lets the copies drift in ways nobody chose**, and they had:

| | the drift |
|---|---|
| **The token** | RN's three verbs carried **no `Authorization` header at all** — that *is* #1474, and it is exactly the failure a duplicated fetch invites: the two web shells were written with the token, the third copy was not, and a 401 there reads as *"the file browser is empty"*, not as an auth error. |
| **Error semantics** | `queryNodes` returned `[]` on failure in the web shells but throws in `Mesh.search`. Neither convention was written down; each copy picked one. |
| **The base URL** | Only RN normalised a trailing slash, so `https://host/` gave the other two a double slash. |

## `MeshRest` decides all three once

1. **Bearer is applied in one place — and only when a token is present.** An empty token means the anonymous same-origin sidecar, which must not receive the header at all: `Bearer ` is *not* the same as absent. RN had this right and the web shells did not, so **the correct behaviour is the one that survived**, not the majority one.
2. **The base URL is normalised on construction.**
3. **A listing degrades, a write throws.** `queryNodes` answers `[]` on any failure — a query that cannot be served should render an empty list rather than break the page embedding it. `renderMarkdown` / `listContent` / `uploadContent` throw, because silently rendering nothing or silently not uploading is worse than an error the caller can show.
4. **Multipart sets no content-type** — `FormData` supplies it *with its boundary*, and overriding it makes the server unable to parse the body.

Verbs genuinely local to one shell stay there: portal-next's `deleteNode`, `transcribe` and `autocomplete` are not part of this surface.

**On `MarkdownCellSubmission`:** declared at this layer rather than imported from `@meshweaver/react` — the transport package cannot depend on the renderer, the members *are* the server's Markdig wire shape, and it must stay structurally assignable to the renderer's copy or every shell ends up casting the result of `renderMarkdown`.

## The tests pin the decisions the drift came from

`rest.test.ts` — the header on every verb, the anonymous-sidecar case (and that an **empty** token is absent, not `Bearer `), the multipart no-content-type rule, the `[]`-not-throw split, and one case per endpoint path. It lives beside `restContract.test.ts`, which already owns the list of paths a client posts to and asserts both backends serve them — the home the issue nominated.

**Net −216 / +76 lines across the shells.**

## Verification, per CI job

| job | result |
|---|---|
| `@meshweaver/client-web` | typecheck ✅ · **77/77** (14 new) |
| `@meshweaver/react` | typecheck ✅ · 261/261 |
| `Portal example` | typecheck ✅ · build ✅ |
| `Portal-next` | typecheck ✅ · build ✅ |
| `RN connector` | typecheck ✅ · 157/157 |
| `RN web` | `expo export --platform web` ✅ |

<sub>`next build` rewrites `clients/portal-next/tsconfig.json` as a side effect (it even flips `jsx` to `react-jsx`); that artifact is reverted and not part of this diff.</sub>

Fixes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj