### PR TITLE
fix: restore TrainingSimResponder — six live course pages call it in-mesh

### DIFF
--- a/src/MeshWeaver.AI/TrainingSimResponder.cs
+++ b/src/MeshWeaver.AI/TrainingSimResponder.cs
@@ -1,0 +1,192 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Layout;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// LIVE-mode adapter for <see cref="PromptCell"/>: wires the cell's
+/// <c>Responder</c> contract to a REAL agent thread. The prompt is submitted
+/// through the canonical <see cref="HubThreadExtensions.StartThread"/> surface
+/// (agent <see cref="AgentName"/> — the dedicated in-course demo agent), the
+/// reply is observed via <see cref="ThreadFlow.ObserveResponses"/> (the standard
+/// mesh-node-stream observation — no polling), and projected into the cell's
+/// <see cref="PromptCellResponse"/> shape (first fenced code block → code pane,
+/// remainder → output pane).
+/// <para>The Simulated mode needs none of this — <see cref="PromptCell.Simulated"/>
+/// lives in MeshWeaver.Layout with no AI reference. This adapter is the thin
+/// LIVE half, kept here because it needs the thread-submission surface.</para>
+/// </summary>
+public static class TrainingSimResponder
+{
+    /// <summary>The dedicated training agent (Data/Agent/TrainingSim.md).</summary>
+    public const string AgentName = "TrainingSim";
+
+    /// <summary>
+    /// Upper bound on one live round. When it trips, the failure is SURFACED to
+    /// the cell's output pane ("could not answer") — a graceful sink, never a
+    /// silent spinner.
+    /// </summary>
+    public static readonly TimeSpan RoundTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Builds a LIVE responder: each submitted prompt starts a thread under
+    /// <paramref name="namespacePath"/> with the training agent and completes
+    /// with the projected reply. Errors (thread refused, round failed, timeout)
+    /// propagate as OnError — <see cref="PromptCell"/> renders them in the
+    /// exchange pane.
+    /// </summary>
+    /// <param name="hub">The hub used to submit and observe (client-side hub).</param>
+    /// <param name="namespacePath">The exercise namespace the thread anchors under.</param>
+    /// <param name="agentName">Override for the agent (default <see cref="AgentName"/>).</param>
+    /// <param name="contextPath">Optional context node the agent reads.</param>
+    public static Func<string, IObservable<PromptCellResponse>> Live(
+        IMessageHub hub,
+        string namespacePath,
+        string? agentName = null,
+        string? contextPath = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (string.IsNullOrEmpty(namespacePath))
+            throw new ArgumentException("namespacePath is required", nameof(namespacePath));
+        var agent = string.IsNullOrEmpty(agentName) ? AgentName : agentName!;
+
+        return prompt => Observable.Create<PromptCellResponse>(observer =>
+        {
+            // 🚨 DEGRADE GRACEFULLY when no language model is configured. Submitting a doomed round
+            // would surface the raw factory error ("ApiKey is missing for model 'glm-5.2'. Configure
+            // a ModelProvider node …") inline in the training cell — hostile on a course page whose
+            // point is to DEMONSTRATE the one-prompt-in / one-cell-out shape, not to debug config.
+            // The credential resolver already answers "is any model available?" reactively from its
+            // warm catalog snapshot (ResolveDefaultModelId → null when none resolves); when there is
+            // none, emit the calm notice instead of starting a thread. NOT a fabricated model / hard-
+            // coded key — the cell just says "configure a model to run this" and stays inert.
+            if (!IsAnyModelConfigured(hub))
+            {
+                observer.OnNext(NoModelNotice());
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
+            var replySubscription = new SerialDisposable();
+            hub.StartThread(
+                namespacePath,
+                prompt,
+                agentName: agent,
+                contextPath: contextPath,
+                onCreated: node => replySubscription.Disposable =
+                    ThreadFlow.ObserveResponses(hub, node.Path)
+                        .Take(1)
+                        .Timeout(RoundTimeout)
+                        .Subscribe(
+                            reply =>
+                            {
+                                // A round that RAN but whose reply IS the model-config error (the
+                                // factory failure surfaced as the assistant's text, not as an
+                                // OnError) must also degrade to the calm notice rather than echo the
+                                // raw "ApiKey is missing" into the cell.
+                                observer.OnNext(reply.Message is null || LooksLikeMissingModel(reply.Message.Text)
+                                    ? NoModelNotice()
+                                    : Project(reply.Message));
+                                observer.OnCompleted();
+                            },
+                            error =>
+                            {
+                                // A round that ERRORED with the model-config failure degrades too;
+                                // any other error still surfaces to the cell's exchange pane.
+                                if (LooksLikeMissingModel(error.Message))
+                                {
+                                    observer.OnNext(NoModelNotice());
+                                    observer.OnCompleted();
+                                }
+                                else
+                                    observer.OnError(error);
+                            }),
+                onError: error => observer.OnError(new InvalidOperationException(error)));
+            return replySubscription;
+        });
+    }
+
+    /// <summary>
+    /// The calm inline notice a training cell shows when no usable language model is configured —
+    /// empty code pane, a friendly explanation in the output pane. Keeps the one-prompt-in /
+    /// one-result-out SHAPE (a code pane + an output pane) so the cell still reads as a demo,
+    /// without a fabricated model or a hard-coded key.
+    /// </summary>
+    public static PromptCellResponse NoModelNotice() =>
+        new(string.Empty, Controls.Markdown(
+            "▶ **Live agent demo** — configure a language model to run this. "
+            + "_(This cell shows how an agent turns your prompt into one code cell.)_"));
+
+    /// <summary>
+    /// Reactive "is any model available?" check for the LIVE responder, off the same warm catalog
+    /// snapshot the credential resolver maintains: <c>ResolveDefaultModelId()</c> returns the lowest-
+    /// Order LanguageModel whose credentials actually resolve, or <c>null</c> when none does. When the
+    /// resolver isn't registered (a hub without the AI stack), assume a model MIGHT exist and let the
+    /// round proceed — the reply-text / OnError classification below still catches a config failure.
+    /// </summary>
+    private static bool IsAnyModelConfigured(IMessageHub hub)
+    {
+        var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
+        return resolver is null || resolver.ResolveDefaultModelId() is not null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="text"/> carries the signature of a missing-model / model-creation
+    /// failure — the factory's "ApiKey is missing …" / "Configure a ModelProvider …" error, or the
+    /// agent client's "No AI model is available …" banner. Used to convert a raw config error (whether
+    /// it arrived as the reply text or as an OnError) into the calm <see cref="NoModelNotice"/> instead
+    /// of echoing it into a course cell. Deliberately narrow: only the model-config signatures, so a
+    /// genuine agent answer or a real runtime error is never masked.
+    /// </summary>
+    internal static bool LooksLikeMissingModel(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+        return text.Contains("ApiKey is missing", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("Configure a ModelProvider", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("No AI model is available", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("creating it failed via factory", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Projects an assistant reply into the cell's three-pane shape: the FIRST
+    /// fenced code block becomes the code pane; everything else renders as the
+    /// output markdown. A reply without a fence yields an empty code pane.
+    /// </summary>
+    public static PromptCellResponse Project(ThreadMessage message, string? locale = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        var text = message.Text ?? "";
+        var (code, remainder) = ExtractFirstCodeFence(text);
+        var output = string.IsNullOrWhiteSpace(remainder)
+            ? Controls.Markdown(LocalizationCatalog.Get("ui.mdNoFurtherOutput", locale))
+            : Controls.Markdown(remainder);
+        return new PromptCellResponse(code, output);
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> at its first triple-backtick fence:
+    /// returns the fence BODY (without the fence lines / language tag) and the
+    /// text with that fence removed. No fence → ("", text).
+    /// </summary>
+    internal static (string Code, string Remainder) ExtractFirstCodeFence(string text)
+    {
+        const string fence = "```";
+        var open = text.IndexOf(fence, StringComparison.Ordinal);
+        if (open < 0)
+            return ("", text);
+        var bodyStart = text.IndexOf('\n', open);
+        if (bodyStart < 0)
+            return ("", text);
+        bodyStart++; // past the "```lang" line
+        var close = text.IndexOf(fence, bodyStart, StringComparison.Ordinal);
+        if (close < 0)
+            return ("", text);
+        var code = text[bodyStart..close].TrimEnd('\n', '\r');
+        var closeEnd = close + fence.Length;
+        var remainder = (text[..open] + text[closeEnd..]).Trim();
+        return (code, remainder);
+    }
+}

--- a/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
+++ b/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
@@ -1,0 +1,142 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Coverage of the PromptCell LIVE adapter (<see cref="TrainingSimResponder"/>):
+/// <list type="number">
+///   <item><see cref="TrainingSimResponder.Project"/> splits an assistant reply
+///   into the cell's three-pane shape — first fenced code block → code pane,
+///   remainder → output markdown.</item>
+///   <item>Subscribing the LIVE responder submits the prompt through the
+///   canonical <c>hub.StartThread</c> surface: a thread node is created under
+///   the exercise namespace with <c>Composer.AgentName = TrainingSim</c> and
+///   the prompt queued as its first message. Model-less environment — the
+///   REPLY leg (a real agent round) is e2e-stack territory; this pins the
+///   submission side effect the adapter owes the cell.</item>
+/// </list>
+/// </summary>
+public class TrainingSimResponderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string OwnerId = "Roland";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddAI().AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact]
+    public void Project_Splits_First_Fence_Into_Code_And_Output()
+    {
+        var reply = new ThreadMessage
+        {
+            Role = "assistant",
+            Text = """
+                Here's the cell:
+
+                ```csharp
+                var totals = sales.GroupBy(s => s.Region);
+                Controls.DataGrid(totals)
+                ```
+
+                The grid shows one row per region.
+                """
+        };
+
+        var projected = TrainingSimResponder.Project(reply);
+
+        projected.Code.Should().Contain("GroupBy(s => s.Region)");
+        projected.Code.Should().NotContain("```", "the fence lines are stripped — the cell re-fences itself");
+        var outputMarkdown = projected.Output.Should().BeOfType<MarkdownControl>()
+            .Subject.Markdown!.ToString()!;
+        outputMarkdown.Should().Contain("one row per region");
+        outputMarkdown.Should().NotContain("GroupBy", "the code lives in the code pane, not the output");
+    }
+
+    [Fact]
+    public void Project_Without_Fence_Yields_Empty_Code_And_Full_Output()
+    {
+        var projected = TrainingSimResponder.Project(new ThreadMessage
+        {
+            Role = "assistant",
+            Text = "Just an explanation, no code."
+        });
+        projected.Code.Should().BeEmpty();
+        projected.Output.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Contain("Just an explanation");
+    }
+
+    /// <summary>
+    /// Model-less environment: the LIVE responder must DEGRADE GRACEFULLY — emit the calm
+    /// "configure a language model" notice and NOT submit a thread. This replaced the pre-guard
+    /// behavior (submit unconditionally, assert the thread node) when
+    /// <c>TrainingSimResponder.IsAnyModelConfigured</c> was introduced: with the credential
+    /// resolver registered and no model resolvable, <see cref="TrainingSimResponder.Live"/>
+    /// returns the notice BEFORE <c>hub.StartThread</c>. The old assertion (thread lands under
+    /// the owner) was therefore impossible and burned its full 60 s wait on every run — one of
+    /// the hidden AI.Test failures masked by the CI 6-minute kill. The submit-with-model leg is
+    /// e2e-stack territory (needs a real model).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Live_Responder_WithoutModel_EmitsCalmNotice()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetHostIdentity(TestUsers.Admin);
+
+        var client = GetClient();
+        await client.Observe(new PingRequest(), o => o.WithTarget(new Address(OwnerId)))
+            .Should().Within(30.Seconds()).Emit();
+
+        var prompt = $"training-live-{Guid.NewGuid():N}";
+        var responder = TrainingSimResponder.Live(client, OwnerId);
+
+        var response = await responder(prompt)
+            .Should().Within(30.Seconds()).Emit();
+
+        response!.Code.Should().BeEmpty("the notice keeps the code pane empty");
+        var markdown = response.Output.Should().BeOfType<MarkdownControl>()
+            .Subject.Markdown!.ToString()!;
+        markdown.Should().Contain("configure a language model",
+            "a model-less environment must show the calm notice, not a raw factory error");
+    }
+}
+
+/// <summary>
+/// Host-free coverage of the model-config classifier that lets a training cell DEGRADE GRACEFULLY
+/// (a calm "configure a model to run this" notice) instead of echoing the raw "ApiKey is missing …"
+/// factory error into a course page.
+/// </summary>
+public class TrainingSimResponderClassificationTest
+{
+    [Theory]
+    [InlineData("ApiKey is missing for model 'glm-5.2'. Configure a ModelProvider node (Provider 'OpenAI').")]
+    [InlineData("No AI model is available for this hub.")]
+    [InlineData("Selected agent 'Agent/TrainingSim' was found, but creating it failed via factory 'OpenAI' for model 'z-ai/glm-5.2'.")]
+    public void LooksLikeMissingModel_TrueForModelConfigSignatures(string text)
+        => TrainingSimResponder.LooksLikeMissingModel(text).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Here is a DataGrid of the five orders.")]
+    [InlineData("The order total is 1,211.25.")]
+    public void LooksLikeMissingModel_FalseForRealAnswersAndEmpty(string? text)
+        => TrainingSimResponder.LooksLikeMissingModel(text).Should().BeFalse();
+}


### PR DESCRIPTION
Hotfix for a #1600 over-deletion. `TrainingSimResponder` had no compiled caller, but SIX AgenticEngineering pages call `TrainingSimResponder.Live(host.Hub, ...)` from **in-mesh** cells to wire their PromptCell workbench — the in-mesh-callers blind spot AGENTS.md warns about, and I misread the education-repo grep hits as prose in #1600's sweep.

Evidence: the education e2e's `copies are REAL nodes` assertion reproduced 4× on images ≥ci.3783; the failure screenshot shows `AskForATable` rendering fully EXCEPT its workbench. Portals are on ci.3788, so the live PromptCell exercises are degraded until this ships.

- The class returns verbatim, homed in `src/MeshWeaver.AI` (its namespace was `MeshWeaver.AI` all along — in-mesh resolution unchanged; builds clean with no new project references).
- Its 10 tests return with it: **10/10 green**.
- The proper retirement stays as originally sequenced: migrate the six in-mesh call sites into the Edu pack first, then delete (follow-up issue).

What's New: skipped — this restores behavior users had; the breakage never reached a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)