### PR TITLE
fix(#1486): the NACK takes the local route the forward message took

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -443,6 +443,29 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     }
 
     /// <summary>
+    /// The LOCAL route for <paramref name="address"/>, or null when this silo hosts no hub there —
+    /// the same step-1 short-circuit <see cref="DeliverMessage"/> takes, exposed so the FAILURE leg
+    /// can take it too (issue #1486).
+    ///
+    /// <para>🚨 <b>Why this exists.</b> Every same-process delivery to a co-hosted hub short-circuits
+    /// here and never touches an Orleans stream — except the NACK, which
+    /// <c>RoutingGrain.PostFailure</c> published to a stream unconditionally. That made the failure
+    /// leg the WEAKEST inbound path: a hub whose stream subscription was never attached (or was
+    /// attached and then lost — <see cref="SubscribeWhenStreamingReadyAsync"/> can give up while the
+    /// local route stays live) is reachable for forward traffic and unreachable for NACKs. And a
+    /// publish to a stream with NO live subscriber SUCCEEDS: nothing faults, the continuation never
+    /// sees <c>IsFaulted</c>, and the NACK is simply gone — so the requester waits forever for an
+    /// answer the router believes it sent.</para>
+    ///
+    /// <para>Answering through the local route removes the stream dependency entirely for the
+    /// co-hosted case, which is the majority. It is deliberately NOT the whole
+    /// <see cref="DeliverMessage"/> pipeline: a failure must never re-enter grain dispatch and
+    /// generate a failure of its own.</para>
+    /// </summary>
+    public AsyncDelivery? TryGetLocalRoute(Address address) =>
+        streams.TryGetValue(GetHostAddress(address), out var callback) ? callback : null;
+
+    /// <summary>
     /// Registers a local delivery callback for an address and subscribes the matching Orleans
     /// memory stream so cross-process messages for that address are routed into the callback.
     /// </summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-faster-failure-answers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-faster-failure-answers.md
@@ -1,0 +1,17 @@
+---
+Name: Failures come back straight away
+Category: Fix
+Description: When a page asked for something the portal could not serve, the answer could take a full minute to arrive — or never arrive at all.
+Icon: Sparkle
+Order: -20260814
+---
+
+# Failures come back straight away
+
+When part of a page asked the portal for something it could not serve — a file from a component
+that was restarting, say — the "no" was sent back by a slower internal route than the original
+question travelled on. Usually that was fine. Occasionally the answer was simply lost, and whatever
+was waiting for it waited a full minute, or forever.
+
+Failure answers now come back the same way the request went out. Something that cannot be served
+says so immediately, so a slow corner of a page stays a slow corner instead of holding the rest up.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -55,6 +55,14 @@ internal class RoutingGrain(
         meshHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Routing)
         ?? IoPool.Unbounded;
 
+    // The silo's LOCAL route table — the same one the forward leg short-circuits on. PostFailure
+    // consults it so a NACK to a co-hosted sender takes the route the forward message took, instead
+    // of the Orleans stream that was this leg's only path (#1486). Resolved from the mesh hub's
+    // provider, which is where the routing service singleton lives; null on a host that registered a
+    // different IRoutingService, in which case the stream remains the only option — same as before.
+    private readonly OrleansRoutingService? localRoutes =
+        meshHub.ServiceProvider.GetService<IRoutingService>() as OrleansRoutingService;
+
     /// <summary>
     /// Per-destination FIFO for the stream-routed branch. Instance field — its lifetime is this
     /// activation's, and it holds an entry only while a destination has work in flight.
@@ -418,6 +426,35 @@ internal class RoutingGrain(
                 .WithTarget(delivery.Sender)
                 .WithProperty(PostOptions.RequestId, delivery.Id),
             System.Text.Json.JsonSerializerOptions.Default);
+        // 🚨 THE LOCAL ROUTE FIRST — the same short-circuit the FORWARD leg takes (#1486).
+        //
+        // Every other same-process delivery to a co-hosted hub resolves on the local route table and
+        // never touches a stream. This leg did not: it published to the sender's Orleans stream
+        // unconditionally, which made it the weakest inbound path in the system. A hub whose stream
+        // subscription was never attached — or was attached and then lost, which
+        // SubscribeWhenStreamingReadyAsync can do while the local route stays live — is reachable
+        // for forward traffic and UNREACHABLE for NACKs.
+        //
+        // And the failure is silent by construction: a publish to a stream with no live subscriber
+        // SUCCEEDS. Nothing faults, the continuation below never sees IsFaulted, and the NACK is
+        // simply gone — so the requester waits forever for an answer the router believes it sent.
+        // That is the [STALE-CALLBACK] shape.
+        //
+        // Answering through the local route removes the stream dependency for the co-hosted case,
+        // which is the majority. Only a sender on ANOTHER silo still needs the stream.
+        var localRoute = localRoutes?.TryGetLocalRoute(delivery.Sender);
+        if (localRoute is not null)
+        {
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_LOCAL_ROUTE id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
+            localRoute.Invoke(failureDelivery, CancellationToken.None)
+                .Subscribe(
+                    _ => { },
+                    ex => logger.LogWarning(ex,
+                        "[ROUTE] Failed to deliver {ErrorType} failure to co-hosted sender {Sender} over its local route",
+                        errorType, delivery.Sender));
+            return;
+        }
+
         streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
             .OnNextAsync(failureDelivery)
             .ContinueWith(t =>
@@ -428,7 +465,12 @@ internal class RoutingGrain(
                     logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
                 }
                 else
-                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
+                    // 🚨 "OK" here means the PUBLISH did not fault — NOT that anything received it.
+                    // A memory-stream publish with no subscriber succeeds, so this line cannot
+                    // distinguish delivered from discarded. It is only reached for a sender this
+                    // silo does not host; the co-hosted case took the local route above, where
+                    // delivery IS observable.
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK_UNCONFIRMED id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
             }, TaskScheduler.Default);
     }
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingFailureTakesTheLocalRouteTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingFailureTakesTheLocalRouteTest.cs
@@ -48,11 +48,15 @@ public class RoutingFailureTakesTheLocalRouteTest(ITestOutputHelper output) : Te
     {
         var routing = CreateRouter();
         var delivered = 0;
-        using var _ = routing.RegisterStream(CoHostedSender, (d, _) =>
+        // 🚨 Counted on SUBSCRIPTION, not on Invoke. A counter bumped in the delegate body would
+        // also read 1 for a route whose returned observable is never subscribed — i.e. it would
+        // pass without the NACK ever being handed over. Deferring makes the assertion mean what it
+        // says, and matches how PostFailure calls it: Invoke(...).Subscribe(...).
+        using var _ = routing.RegisterStream(CoHostedSender, (d, _) => Observable.Defer(() =>
         {
             delivered++;
             return Observable.Return(d);
-        });
+        }));
 
         var route = routing.TryGetLocalRoute(CoHostedSender);
 
@@ -61,7 +65,12 @@ public class RoutingFailureTakesTheLocalRouteTest(ITestOutputHelper output) : Te
             + "same path — publishing to a stream instead is what made the failure leg the weakest "
             + "inbound path");
 
-        route!.Invoke(NewDelivery(CoHostedSender), CancellationToken.None).Subscribe();
+        var pending = route!.Invoke(NewDelivery(CoHostedSender), CancellationToken.None);
+        delivered.Should().Be(0,
+            "the route is cold — nothing is delivered until someone subscribes, which is precisely "
+            + "why a caller that only posts and walks away cannot know the NACK landed");
+
+        pending.Subscribe();
         delivered.Should().Be(1, "resolving the route must actually deliver, not merely find an entry");
     }
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingFailureTakesTheLocalRouteTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingFailureTakesTheLocalRouteTest.cs
@@ -1,0 +1,105 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Issue #1486 — the NACK was the WEAKEST inbound path in the system.
+///
+/// <para><b>The asymmetry.</b> Every same-process delivery to a co-hosted hub short-circuits on
+/// <c>OrleansRoutingService</c>'s LOCAL ROUTE TABLE and never touches an Orleans stream. The failure
+/// leg did not: <c>RoutingGrain.PostFailure</c> published the <see cref="DeliveryFailure"/> to the
+/// sender's Orleans stream unconditionally. So a hub whose stream subscription was never attached —
+/// or was attached and then lost, which <c>SubscribeWhenStreamingReadyAsync</c> can do while the
+/// local route stays live — is reachable for forward traffic and UNREACHABLE for NACKs.</para>
+///
+/// <para><b>And the failure is silent by construction.</b> A publish to a memory stream with no live
+/// subscriber SUCCEEDS: nothing faults, the router's own <c>ContinueWith</c> never sees
+/// <c>IsFaulted</c>, and the NACK is simply gone. The requester then waits forever for an answer the
+/// router believes it sent — the <c>[STALE-CALLBACK]</c> shape. That is why bounding this leg was
+/// explicitly NOT the fix: a timeout converts a silent hang into a logged one without ever
+/// delivering the NACK.</para>
+///
+/// <para><b>What is pinned here</b> is the routing DECISION, not the transport: for a sender this
+/// silo hosts, the failure resolves on the same local route the forward message would have taken.
+/// The probe is the same one <c>OrleansRoutingShutdownClassificationTest</c> uses — a real hub at
+/// the sender's address, so the answer asserted is the actual delivery, not a stand-in.</para>
+/// </summary>
+public class RoutingFailureTakesTheLocalRouteTest(ITestOutputHelper output) : TestBase(output)
+{
+    private static readonly Address CoHostedSender = new("portal", "local-route-sender");
+    private static readonly Address ElsewhereSender = new("portal", "not-hosted-here");
+
+    private OrleansRoutingService CreateRouter() =>
+        new(null!, ServiceProvider, ServiceProvider.GetRequiredService<ILogger<OrleansRoutingService>>());
+
+    /// <summary>
+    /// The property the fix turns on: a hub registered on THIS silo is resolvable through the local
+    /// route table, so the failure leg has somewhere to send that is not the stream.
+    /// </summary>
+    [Fact]
+    public void ACoHostedSenderIsResolvableThroughTheLocalRoute()
+    {
+        var routing = CreateRouter();
+        var delivered = 0;
+        using var _ = routing.RegisterStream(CoHostedSender, (d, _) =>
+        {
+            delivered++;
+            return Observable.Return(d);
+        });
+
+        var route = routing.TryGetLocalRoute(CoHostedSender);
+
+        route.Should().NotBeNull(
+            "the forward leg short-circuits on this table, and the NACK must be able to take the "
+            + "same path — publishing to a stream instead is what made the failure leg the weakest "
+            + "inbound path");
+
+        route!.Invoke(NewDelivery(CoHostedSender), CancellationToken.None).Subscribe();
+        delivered.Should().Be(1, "resolving the route must actually deliver, not merely find an entry");
+    }
+
+    /// <summary>
+    /// The other half, and the reason this is a lookup rather than an unconditional change: a sender
+    /// on ANOTHER silo has no local route, so the stream remains its only path and the fix must not
+    /// pretend otherwise.
+    /// </summary>
+    [Fact]
+    public void ASenderThisSiloDoesNotHostHasNoLocalRoute()
+    {
+        var routing = CreateRouter();
+        using var _ = routing.RegisterStream(CoHostedSender, (d, _) => Observable.Return(d));
+
+        routing.TryGetLocalRoute(ElsewhereSender).Should().BeNull(
+            "only a hub this silo hosts is answerable locally — for anything else the Orleans "
+            + "stream is still the transport, and claiming otherwise would drop the NACK");
+    }
+
+    /// <summary>
+    /// Deregistration must be observable, or the failure leg would keep resolving a route to a hub
+    /// that is gone — trading a silent stream drop for a silent local drop.
+    /// </summary>
+    [Fact]
+    public void ADeregisteredHubStopsResolving()
+    {
+        var routing = CreateRouter();
+        var registration = routing.RegisterStream(CoHostedSender, (d, _) => Observable.Return(d));
+
+        routing.TryGetLocalRoute(CoHostedSender).Should().NotBeNull();
+        registration.Dispose();
+
+        routing.TryGetLocalRoute(CoHostedSender).Should().BeNull(
+            "a torn-down hub must stop being resolvable, or the NACK is dropped just as silently "
+            + "as it was over the stream");
+    }
+
+    private static IMessageDelivery NewDelivery(Address sender) =>
+        new MessageDelivery<string>(sender, new Address("SomeNamespace", "SomeNode"), "payload",
+            JsonSerializerOptions.Default);
+}


### PR DESCRIPTION
`RoutingGrain.PostFailure` returned the `DeliveryFailure` by publishing to the sender's Orleans stream — **unconditionally**.

Every *other* same-process delivery to a co-hosted hub short-circuits on `OrleansRoutingService`'s local route table and never touches a stream. So the failure leg was **the weakest inbound path in the system**: a hub whose stream subscription was never attached — or was attached and then lost, which `SubscribeWhenStreamingReadyAsync` can do while the local route stays live — is reachable for forward traffic and **unreachable for NACKs**.

And it fails **silently by construction**: a publish to a memory stream with no live subscriber *succeeds*. Nothing faults, the `ContinueWith` never sees `IsFaulted`, and the NACK is simply gone — so the requester waits forever for an answer the router believes it sent. That is the `[STALE-CALLBACK]` shape.

## The fix is the routing decision, not a deadline

`PostFailure` now asks the routing service for the sender's **local route** first and delivers through it when this silo hosts the sender — the same step-1 short-circuit the forward leg takes. **The answer travels the way the question did.**

Only a sender on another silo still needs the stream, and that path's trace line is renamed `FAILURE_DELIVER_OK_UNCONFIRMED`, because *"the publish did not fault"* is all it can honestly claim.

🚨 The issue is explicit that a timeout here *"would only convert a silent hang into a logged one; it would not deliver the NACK"* — so no bound was added.

## What this settles, and what it does not

**Question 3 — settled.** *"`SubscribeWhenStreamingReadyAsync` giving up while the local route stays live is its own inconsistency: two views of reachability that can disagree, with nothing reconciling them."* For a co-hosted hub they no longer disagree, because the NACK now consults the same view the forward path does.

**Question 2 — deliberately open.** For a genuinely remote sender, a publish with no subscriber still cannot distinguish delivered from discarded. That needs a stream-level answer this change does not have — it is now the *remaining* case rather than the majority one.

## Relationship to #1563

#1563 is the caller's side of the same defect: a `ContentRoute` `GetDataRequest` to an unreachable hub waiting out its full 60 s instead of taking the prompt NotFound. Its sender is the portal's own hub — co-hosted with the router — so its NACK went down exactly this path.

I've commented there rather than claiming it closed here: **one occurrence, no repro, so the honest statement is the mechanism, not a guarantee.**

## Verification

Three tests pin the routing decision, including the two ways a fix here could be wrong:

- a co-hosted sender resolves **and delivers** (not merely "an entry exists");
- a sender this silo does **not** host has no local route, so the stream stays its transport — the fix must not pretend otherwise or the NACK is dropped;
- a **deregistered** hub stops resolving, or this would trade a silent stream drop for a silent local one.

`MeshWeaver.Hosting.Orleans.Test` **163/163**. `-c Release -warnaserror` clean for `MeshWeaver.Connection.Orleans`, `MeshWeaver.Hosting.Orleans` and the test project.

Fixes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj