### PR TITLE
fix: seal an impersonation scope into the operation it was opened for (#1444)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
@@ -370,6 +370,38 @@ A `SynchronizationStream.OnNext` that unconditionally stamps `ImpersonateAsHub(H
 
 > Every `ImpersonateAsSystem` callsite is a deliberate choice to bypass all access checks. Grep for them; review each. If a narrower identity would suffice, use that instead.
 
+### 🚨 An impersonation scope must not ESCAPE the operation it was opened for
+
+`accessService.RunAsSystem(work)` — **not** a hand-written `Observable.Using(access.ImpersonateAsSystem, _ => work)` — wherever the scoped observable is **returned to a caller**.
+
+The hand-written idiom is correct for the work itself and leaks everywhere after it:
+
+```csharp
+// ❌ the scope escapes: Rx forwards OnNext to the subscriber BEFORE Using disposes its resource,
+//    so the write below is CONSTRUCTED while the impersonation is still open — and the write
+//    primitives eager-capture AccessService.Context when they are CALLED.
+Observable.Using(access.ImpersonateAsSystem, _ => ReadGatedSource())
+    .SelectMany(rows => meshService.CreateNodes(Plan(rows)));   // lands as `system-security`
+
+// ✅ the scope covers the read and stops at its boundary
+access.RunAsSystem(ReadGatedSource)
+    .SelectMany(rows => meshService.CreateNodes(Plan(rows)));   // lands as the CALLER
+```
+
+Because those primitives also **re-stamp** the captured identity around their own emissions (`CarryAccessContext` — "MessageHub sets, framework primitive preserves"), a leaked System identity is not merely inherited one hop — it is **re-acquired at every hop after it**. That is how a package install wrote its home root, five copy batches and its manifest as `system-security` while `_UserActivity` — the one write on that path posted directly from the request thread rather than composed on an emission — attributed to the real user (#1444).
+
+**It is an authorization concern, not only an audit one.** `AccessControlPipeline.HandleGetPermission` carries the scar: `SecurityService`'s bootstrap-time system scope leaked past its using-block onto the action-block thread, and trusting the ambient there returned `Permission.All` for **every** caller, anonymous included. That call site defends itself by resolving the identity explicitly; `RunAsSystem` fixes the class at the source so the next one does not have to know Rx's disposal order.
+
+| API | Use it for |
+|---|---|
+| `access.RunAsSystem(work)` | A system read/write whose result a caller composes on. Enters the scope at Subscribe (so the cold work is covered), delivers every notification under the **subscriber's** identity. |
+| `access.RunAsHub(hub, work)` | The same seal for a hub identity. |
+| `source.ContainIdentity(access)` | Sealing an **already-composed** chain — several system calls where the caller builds on the LAST one's emission. |
+
+🚨 **It never invents an identity.** What is restored is exactly what was ambient at Subscribe: a real user for a user-driven flow, `system-security` for a genuinely system-initiated one, and **nothing at all** when the subscriber had no identity — so a background worker that never had a user is not fail-closed by adopting it. The only behaviour that changes is the defect: a caller who *had* an identity, silently continuing as System.
+
+Pinned by `SystemScopeDoesNotEscapeTest` (test/MeshWeaver.Messaging.Hub.Test), whose first case asserts the raw Rx ordering every other case rests on.
+
 ### Implementation: define + grant + test
 
 For each sanctioned identity, you need all three:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-your-name-stays-on-what-you-asked-for.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-your-name-stays-on-what-you-asked-for.md
@@ -1,0 +1,33 @@
+---
+Name: Your name stays on what you asked for
+Category: Fix
+Description: Work you start is now recorded — and authorised — as you, not as the platform. An internal identity opened for one step could previously carry on into everything composed after it.
+Icon: PersonAccounts
+Order: -20260814
+---
+
+# Your name stays on what you asked for
+
+Some steps genuinely run as the platform rather than as you: reading content you are entitled to but
+cannot see directly, creating the storage a brand-new space lives in. That is by design, and it is
+scoped to the step that needs it.
+
+It was not staying scoped. The platform identity, once established for one step, carried on into
+everything built on that step's result — so an operation you started could have its **later** writes
+recorded as the platform instead of as you. A package install did exactly that: the home it created,
+every batch of content it copied and the manifest it finished with were all attributed to the
+platform, while the activity entry beside them correctly named the person who asked.
+
+Two things were wrong with that, and the second is the reason it is fixed at the root rather than in
+the log:
+
+- **The history read wrong.** "Who created this?" answered *the platform* for things a person asked
+  for. Nothing in the affected installs landed anywhere the person could not have written — but the
+  record no longer matched what happened.
+- **Permission questions were being answered for the wrong identity.** The platform identity is
+  allowed everything. Any check that ran after the leak was asking about the platform rather than
+  about you, so a step you should have been refused could have quietly succeeded.
+
+An internal identity is now sealed into the step it was opened for. What runs as the platform is
+exactly what has to; everything composed afterwards is yours again — audited as you, and checked
+against your permissions.

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -72,8 +72,7 @@ public static class GitHubActivityExtensions
         if (string.IsNullOrEmpty(userId) || caller?.IsVirtual == true)
             userId = WellKnownUsers.Anonymous;
 
-        IObservable<string> AsSystem() =>
-            Observable.Using(() => accessService.ImpersonateAsSystem(), _ => runActivity());
+        IObservable<string> AsSystem() => accessService.RunAsSystem(runActivity);
 
         if (string.Equals(userId, WellKnownUsers.System, StringComparison.Ordinal))
             return AsSystem();

--- a/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
+++ b/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
@@ -175,7 +175,5 @@ public sealed class SystemOwnedAccessRetractionHandler(
     /// <summary>Establishes the System identity on the write's own subscribe thread — mirrors
     /// <c>MeshExtensions.AsSystem</c>, so the deletes are attributed to the platform.</summary>
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> write)
-        => accessService is null
-            ? Observable.Defer(write)
-            : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => write());
+        => accessService.RunAsSystem(write);
 }

--- a/src/MeshWeaver.Graph/AccessGrantNotifier.cs
+++ b/src/MeshWeaver.Graph/AccessGrantNotifier.cs
@@ -208,7 +208,7 @@ public sealed class AccessGrantNotifier(
     }
 
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory)
-        => Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
+        => accessService.RunAsSystem(factory);
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -506,7 +506,7 @@ public sealed class EventSubscriptionRunner(
     /// identity — the runner has no ambient AccessContext, and both reads and writes capture identity
     /// at construction/subscribe. <c>Defer</c> moves construction inside the impersonation scope.</summary>
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory)
-        => Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
+        => accessService.RunAsSystem(factory);
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -1602,12 +1602,7 @@ public static class StaticRepoImporter
     /// (which the sync-stream post then carries). See Doc/Architecture/AccessContextPropagation.md.
     /// </summary>
     private static IObservable<T> AsSystem<T>(IMessageHub hub, Func<IObservable<T>> write)
-    {
-        var access = hub.ServiceProvider.GetService<AccessService>();
-        return access is null
-            ? Observable.Defer(write)
-            : Observable.Using(() => access.ImpersonateAsSystem(), _ => write());
-    }
+        => hub.ServiceProvider.GetService<AccessService>().RunAsSystem(write);
 
     /// <summary>
     /// Surfaces a boot/startup import failure LOUDLY in the GUI. The activity at

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -312,8 +312,5 @@ public sealed class InstanceSyncService(
     /// the user's own context and never go through here.
     /// </summary>
     public IObservable<T> AsSystem<T>(Func<IObservable<T>> operation)
-    {
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        return Observable.Using(() => accessService.ImpersonateAsSystem(), _ => operation());
-    }
+        => hub.ServiceProvider.GetRequiredService<AccessService>().RunAsSystem(operation);
 }

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2034,9 +2034,7 @@ public static class MeshExtensions
     /// infrastructure-write). Mirrors <c>StaticRepoImporter.AsSystem</c>.
     /// </summary>
     private static IObservable<T> AsSystem<T>(AccessService? access, Func<IObservable<T>> write)
-        => access is null
-            ? Observable.Defer(write)
-            : Observable.Using(() => access.ImpersonateAsSystem(), _ => write());
+        => access.RunAsSystem(write);
 
     /// <summary>
     /// True if the exception (or any inner) reports an "already exists" outcome — the idempotent-create

--- a/src/MeshWeaver.Messaging.Hub/AccessContextCaptureExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/AccessContextCaptureExtensions.cs
@@ -165,6 +165,22 @@ public static class AccessContextCaptureExtensions
     }
 
     /// <summary>
+    /// Subscribes <paramref name="observer"/> to <paramref name="source"/> with every notification
+    /// delivered inside a <see cref="AccessService.SwitchAccessContext"/> scope keyed to
+    /// <paramref name="captured"/> — the same per-callback restore
+    /// <see cref="CarryAccessContext{T}(System.IObservable{T},MeshWeaver.Messaging.AccessService,bool)"/> applies.
+    ///
+    /// <para>🚨 Exists so <see cref="ImpersonationScopeExtensions"/> can SEAL an impersonation scope
+    /// with these exact semantics rather than re-implement them. The difference between the two is
+    /// only WHEN the identity is decided — this helper is handed one, <c>CarryAccessContext</c>
+    /// snapshots the ambient at composition time, and <c>ContainIdentity</c> reads it at Subscribe.
+    /// Keeping one restore implementation is what stops those three drifting apart.</para>
+    /// </summary>
+    internal static IDisposable SubscribeRestoring<T>(
+        IObservable<T> source, IObserver<T> observer, AccessService access, AccessContext? captured) =>
+        source.Subscribe(new RestoringObserver<T>(observer, access, captured));
+
+    /// <summary>
     /// Wraps a cold observable so every emission to the subscriber happens
     /// inside an <see cref="AccessService.SwitchAccessContext"/> scope keyed
     /// to <paramref name="captured"/>. The scope is per-callback (entered on

--- a/src/MeshWeaver.Messaging.Hub/ImpersonationScopeExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/ImpersonationScopeExtensions.cs
@@ -1,0 +1,114 @@
+using System.Reactive.Linq;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// 🚨 THE framework's impersonation boundary: a scope that <b>cannot escape the operation it was
+/// opened for</b>.
+///
+/// <para><b>The defect this closes (issue #1444).</b> The idiomatic system read/write is
+/// <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; work)</c>, and it is correct for
+/// <i>the work itself</i>. It is not self-contained. Rx forwards <c>OnNext</c> to the subscriber
+/// <b>before</b> <c>Using</c> disposes its resource, so everything the subscriber composes on that
+/// emission — the next phase, a write, a permission check — is built while the impersonation is
+/// still OPEN. And the mesh write primitives EAGER-CAPTURE <see cref="AccessService.Context"/> when
+/// they are CALLED and re-stamp it around their own emissions
+/// (<see cref="AccessContextCaptureExtensions.CarryAccessContext{T}(System.IObservable{T},System.IServiceProvider,bool)"/>),
+/// so the System identity does not merely survive one hop — it is <b>re-acquired</b> at every hop
+/// after it.</para>
+///
+/// <para><b>This is not hypothetical, and it has already reached an authorization decision.</b>
+/// <c>AccessControlPipeline.HandleGetPermission</c> carries a comment describing exactly this shape:
+/// <c>SecurityService</c>'s bootstrap-time <c>ImpersonateAsSystem</c> leaked past its using-block
+/// onto the action-block thread, and trusting the ambient there "returned <c>Permission.All</c> for
+/// every caller — including anonymous deliveries". That call site defends itself by resolving the
+/// identity explicitly instead of reading the ambient. This type fixes the same class at the SOURCE,
+/// so the next call site does not have to know Rx's disposal order to be safe.</para>
+///
+/// <para><b>What it does NOT do: invent an identity.</b> <see cref="ContainIdentity{T}"/> restores
+/// exactly what was ambient at Subscribe — a real user for a user-driven flow, <c>system-security</c>
+/// for a genuinely system-initiated one, and <b>nothing at all</b> when the subscriber had no
+/// identity. That last case is deliberate and is what makes adopting this safe at an existing call
+/// site: a background worker with no ambient context keeps whatever the framework leaves it (the
+/// documented <c>restoreNullCapture: false</c> behaviour of read pipelines), so the only behaviour
+/// that changes is the one the defect describes — a caller who HAD an identity, silently continuing
+/// as System.</para>
+/// </summary>
+public static class ImpersonationScopeExtensions
+{
+    /// <summary>
+    /// Runs <paramref name="work"/> under the well-known System identity with the scope SEALED: the
+    /// impersonation is entered at Subscribe (so the cold reads/writes the factory yields carry the
+    /// system context — the <c>Observable.Using</c>, never <c>Defer</c>-plus-<c>using</c>, rule),
+    /// and every notification that reaches the subscriber is delivered under the subscriber's OWN
+    /// identity, so nothing composed downstream inherits System.
+    ///
+    /// <para>Prefer this over a hand-written <c>Observable.Using(access.ImpersonateAsSystem, …)</c>
+    /// at every site that RETURNS the scoped observable to a caller — returning it is precisely what
+    /// turns a scope into an inheritance.</para>
+    ///
+    /// <para>A null <paramref name="access"/> (minimal test hosts) runs the work unimpersonated —
+    /// deferred, so it stays cold.</para>
+    /// </summary>
+    /// <typeparam name="T">What the scoped operation emits.</typeparam>
+    /// <param name="access">The access service, or null on a host without one.</param>
+    /// <param name="work">The cold operation to run as System.</param>
+    public static IObservable<T> RunAsSystem<T>(this AccessService? access, Func<IObservable<T>> work) =>
+        access is null
+            ? Observable.Defer(work)
+            : Observable
+                .Using(access.ImpersonateAsSystem, _ => Observable.Defer(work))
+                .ContainIdentity(access);
+
+    /// <summary>
+    /// Runs <paramref name="work"/> as <paramref name="hub"/>'s own identity, sealed exactly as
+    /// <see cref="RunAsSystem{T}"/> is.
+    /// </summary>
+    /// <typeparam name="T">What the scoped operation emits.</typeparam>
+    /// <param name="access">The access service, or null on a host without one.</param>
+    /// <param name="hub">The hub whose address is stamped as the principal.</param>
+    /// <param name="work">The cold operation to run as the hub.</param>
+    public static IObservable<T> RunAsHub<T>(
+        this AccessService? access, IMessageHub hub, Func<IObservable<T>> work) =>
+        access is null
+            ? Observable.Defer(work)
+            : Observable
+                .Using(() => access.ImpersonateAsHub(hub), _ => Observable.Defer(work))
+                .ContainIdentity(access);
+
+    /// <summary>
+    /// Seals an ALREADY-COMPOSED <paramref name="source"/>: every notification is delivered to the
+    /// subscriber under the identity that was ambient when they subscribed, whatever identity
+    /// produced the emission.
+    ///
+    /// <para>Use this where the impersonated region is not one call — a chain of system writes whose
+    /// LAST emission is what the caller composes on. Sealing the chain's boundary is what stops the
+    /// caller inheriting it.</para>
+    ///
+    /// <para>The restore is per-notification (entered on <c>OnNext</c>/<c>OnError</c>/
+    /// <c>OnCompleted</c>, disposed as the callback returns), so nothing is left behind on the
+    /// emitting thread — the same shape <c>CarryAccessContext</c> uses, and the same code.</para>
+    /// </summary>
+    /// <typeparam name="T">What the operation emits.</typeparam>
+    /// <param name="source">The already-composed operation whose identity must not escape.</param>
+    /// <param name="access">The access service, or null on a host without one.</param>
+    public static IObservable<T> ContainIdentity<T>(this IObservable<T> source, AccessService? access) =>
+        access is null ? source : new ContainedIdentityObservable<T>(source, access);
+
+    /// <summary>
+    /// Reads the subscriber's identity at Subscribe — before any scope this pipeline opens, which is
+    /// the last moment the ambient context is reliably the subscriber's own — and restores it around
+    /// every notification. A null read passes straight through: nothing to restore, nothing invented.
+    /// </summary>
+    private sealed class ContainedIdentityObservable<T>(IObservable<T> source, AccessService access)
+        : IObservable<T>
+    {
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            var caller = access.Context;
+            return caller is null
+                ? source.Subscribe(observer)
+                : AccessContextCaptureExtensions.SubscribeRestoring(source, observer, access, caller);
+        }
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
@@ -731,10 +731,7 @@ public sealed class ModuleDiscoveryService : IHostedService, IDisposable
     /// failure this whole service exists to prevent. Failing to resolve must be a startup error, not
     /// a silent downgrade.</para></summary>
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> write)
-    {
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        return Observable.Using(() => accessService.ImpersonateAsSystem(), _ => write());
-    }
+        => hub.ServiceProvider.GetRequiredService<AccessService>().RunAsSystem(write);
 
     // ══════════════════════════════════════════════════════════════════════════
     //  Making it visible

--- a/test/MeshWeaver.Messaging.Hub.Test/SystemScopeDoesNotEscapeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/SystemScopeDoesNotEscapeTest.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Issue #1444 — an impersonation scope that ESCAPES the operation it was opened for.
+///
+/// <para><b>The mechanism.</b> <c>Observable.Using(access.ImpersonateAsSystem, _ =&gt; work)</c> reads
+/// as "run this work as System", and for the work itself it is. But Rx forwards <c>OnNext</c> to the
+/// subscriber BEFORE <c>Using</c> disposes its resource, so anything the subscriber composes on that
+/// emission is built while the impersonation is still open. The first test below pins that raw Rx
+/// behaviour, because every conclusion here rests on it and it must fail loudly if a future Rx
+/// changes it.</para>
+///
+/// <para><b>Why it does not stop at one hop.</b> The mesh write primitives eager-capture
+/// <see cref="AccessService.Context"/> when CALLED and re-stamp it around their own emissions
+/// (<c>CarryAccessContext</c>), so a leaked System identity is re-acquired at every hop after it —
+/// which is how a whole install chain landed as <c>system-security</c> in education CI run
+/// 31704948831 while <c>_UserActivity</c>, posted directly from the request thread rather than
+/// composed on an emission, attributed correctly.</para>
+///
+/// <para><b>Why it is a permission concern, not only an audit one.</b>
+/// <c>AccessControlPipeline.HandleGetPermission</c> already carries the scar: trusting the ambient
+/// context there returned <c>Permission.All</c> for every caller including anonymous, because
+/// <c>SecurityService</c>'s bootstrap-time system scope leaked past its using-block. That call site
+/// defends itself; <see cref="ImpersonationScopeExtensions"/> fixes the class at the source.</para>
+/// </summary>
+public class SystemScopeDoesNotEscapeTest
+{
+    private static readonly AccessContext Alice = new() { ObjectId = "alice", Name = "Alice" };
+
+    private const string System = "system-security";
+
+    /// <summary>
+    /// The premise, pinned. Not a test of our code — a test of the Rx ordering every other case here
+    /// depends on. If this ever goes green-by-accident (Rx disposing before it forwards), the seal
+    /// below stops being load-bearing and that is worth learning from a failure rather than from a
+    /// production log.
+    /// </summary>
+    [Fact]
+    public void TheIdiomaticSystemScopeIsStillOpenWhenTheSubscriberRuns()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        string? seenInsideCallback = null;
+        Observable
+            .Using(access.ImpersonateAsSystem, _ => Observable.Return(1))
+            .Subscribe(_ => seenInsideCallback = access.Context?.ObjectId);
+
+        seenInsideCallback.Should().Be(System,
+            "Rx forwards OnNext BEFORE Using disposes its resource — so a subscriber composing a "
+            + "write on this emission builds it under System. That is #1444's mechanism, and the "
+            + "seal exists because of it");
+        access.Context?.ObjectId.Should().Be("alice",
+            "the scope is correctly restored once the pipeline terminates — the leak is confined to "
+            + "the notification window, which is exactly where composition happens");
+    }
+
+    /// <summary>
+    /// The fix: the same work, the same System identity INSIDE, and the subscriber's own identity on
+    /// the way out.
+    /// </summary>
+    [Fact]
+    public void RunAsSystemRunsTheWorkAsSystemAndHandsBackTheCallersIdentity()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        string? seenByTheWork = null;
+        string? seenByTheSubscriber = null;
+
+        access
+            .RunAsSystem(() => Observable.Defer(() =>
+            {
+                seenByTheWork = access.Context?.ObjectId;
+                return Observable.Return(1);
+            }))
+            .Subscribe(_ => seenByTheSubscriber = access.Context?.ObjectId);
+
+        seenByTheWork.Should().Be(System,
+            "the scope must still cover the work — sealing it must not make a system read fail "
+            + "closed, which would trade one defect for another");
+        seenByTheSubscriber.Should().Be("alice",
+            "the identity was established FOR that read; it is never an inheritance");
+    }
+
+    /// <summary>
+    /// The half that matters most: the leak reaches whatever the subscriber BUILDS, because the mesh
+    /// write primitives capture the ambient when they are called. This is the shape the install path
+    /// had.
+    /// </summary>
+    [Fact]
+    public void WhatTheSubscriberCOMPOSESNoLongerCapturesSystem()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        // Stands in for a write primitive: it snapshots the ambient identity at CALL time, exactly
+        // as CreateNode/CreateNodes/Update do, and that snapshot is what would be authorised.
+        IObservable<string?> WriteCapturingCallerIdentity()
+        {
+            var capturedWhenCalled = access.Context?.ObjectId;
+            return Observable.Return(capturedWhenCalled);
+        }
+
+        var leaked = Observable
+            .Using(access.ImpersonateAsSystem, _ => Observable.Return(1))
+            .SelectMany(_ => WriteCapturingCallerIdentity())
+            .Wait();
+
+        var sealedOff = access
+            .RunAsSystem(() => Observable.Return(1))
+            .SelectMany(_ => WriteCapturingCallerIdentity())
+            .Wait();
+
+        leaked.Should().Be(System, "the unsealed idiom is what filed #1444");
+        sealedOff.Should().Be("alice",
+            "the write a user's operation composes must be authorised and attributed as the USER — "
+            + "System silently succeeding where the user might have been refused is the serious half");
+    }
+
+    /// <summary>
+    /// Terminal notifications are composed on too (<c>Catch</c>, <c>Finally</c>, a completion arm
+    /// that writes a manifest), so the seal has to cover them or it just moves the leak.
+    /// </summary>
+    [Fact]
+    public void TheSealCoversErrorAndCompletionToo()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        string? onCompleted = null;
+        access.RunAsSystem(() => Observable.Empty<int>())
+            .Subscribe(_ => { }, () => onCompleted = access.Context?.ObjectId);
+
+        string? onError = null;
+        access.RunAsSystem<int>(() => Observable.Throw<int>(new InvalidOperationException("boom")))
+            .Subscribe(_ => { }, _ => onError = access.Context?.ObjectId, () => { });
+
+        onCompleted.Should().Be("alice", "a completion arm that writes must write as the caller");
+        onError.Should().Be("alice", "so must an error arm that records the failure");
+    }
+
+    /// <summary>
+    /// 🚨 The property that makes adopting this safe at an existing call site: a subscriber with NO
+    /// identity keeps whatever the framework leaves it. Nothing is invented and nothing is clamped,
+    /// so a background flow that never had a user is not fail-closed by the seal.
+    /// </summary>
+    [Fact]
+    public void ASubscriberWithNoIdentityIsLeftExactlyAsItWas()
+    {
+        var access = new AccessService();
+        access.SetContext(null);
+
+        string? seen = null;
+        access.RunAsSystem(() => Observable.Return(1))
+            .Subscribe(_ => seen = access.Context?.ObjectId);
+
+        seen.Should().Be(System,
+            "with nothing to restore, the seal is a pass-through — clamping to null here would "
+            + "fail-close background flows that never had a user, which is not what #1444 is about");
+    }
+
+    /// <summary>
+    /// Nested scopes restore to the ENCLOSING identity, not to a null or to the process default —
+    /// the case a system-initiated install hits (System all the way down, and correctly so).
+    /// </summary>
+    [Fact]
+    public void ASystemInitiatedFlowStaysSystem()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        string? inner = null;
+        using (access.ImpersonateAsSystem())
+        {
+            access.RunAsSystem(() => Observable.Return(1))
+                .Subscribe(_ => inner = access.Context?.ObjectId);
+        }
+
+        inner.Should().Be(System,
+            "the seal restores the SUBSCRIBER's identity, which here genuinely is System — a "
+            + "system-initiated install must not be rewritten into a user's");
+        access.Context?.ObjectId.Should().Be("alice");
+    }
+
+    /// <summary>
+    /// A host without an <see cref="AccessService"/> (minimal test fixtures) must still run the work,
+    /// and must still run it COLD — the side effect belongs to Subscribe, not to composition.
+    /// </summary>
+    [Fact]
+    public void WithoutAnAccessServiceTheWorkStillRunsAndStaysCold()
+    {
+        AccessService? none = null;
+        var runs = 0;
+
+        var pipeline = none.RunAsSystem(() =>
+        {
+            runs++;
+            return Observable.Return(1);
+        });
+
+        runs.Should().Be(0, "composition must not run the work — every framework primitive is cold");
+        pipeline.Wait().Should().Be(1);
+        runs.Should().Be(1);
+    }
+
+    /// <summary>
+    /// <see cref="ImpersonationScopeExtensions.ContainIdentity{T}"/> on an already-composed chain —
+    /// the case where the impersonated region is several calls and it is the LAST one's emission the
+    /// caller builds on.
+    /// </summary>
+    [Fact]
+    public async Task ContainIdentitySealsAnAlreadyComposedChainAcrossThreads()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var source = new Subject<int>();
+        var seen = new List<string?>();
+        var done = new TaskCompletionSource<bool>();
+
+        source.ContainIdentity(access).Subscribe(_ =>
+        {
+            seen.Add(access.Context?.ObjectId);
+            done.TrySetResult(true);
+        });
+
+        // Emit from a thread that never had the AsyncLocal set AND is inside a system scope, which is
+        // what a hub action block running an impersonated write looks like from the subscriber's side.
+        await Task.Run(() =>
+        {
+            using (access.ImpersonateAsSystem())
+                source.OnNext(1);
+        }, TestContext.Current.CancellationToken);
+
+        await done.Task;
+        seen.Should().ContainSingle().Which.Should().Be("alice",
+            "the emitting side's identity is its own business — what the SUBSCRIBER observes is the "
+            + "identity it subscribed with");
+    }
+}


### PR DESCRIPTION
Closes #1444.

## What was established first

The issue asks to establish where the identity is acquired, whether it is load-bearing, and whether `_UserActivity`'s correct attribution is the anomaly or the norm — **before** changing anything. All three, in order:

**Where.** Not in an `ImpersonateAsSystem` scope anyone wrote around the writes — that observation in the issue is correct. The idiom `Observable.Using(access.ImpersonateAsSystem, _ => work)` is correct for the work itself and is **not self-contained**: Rx forwards `OnNext` to the subscriber **before** `Using` disposes its resource, so everything the subscriber composes on that emission — the next phase, a write, a permission check — is built while the impersonation is still open.

**Why it does not stop at one hop.** The mesh write primitives eager-capture `AccessService.Context` when they are CALLED and re-stamp it around their own emissions (`CarryAccessContext`). So a leaked System identity is not inherited once — it is **re-acquired at every hop after it**. That is a whole install chain, from one scope.

**`_UserActivity` is the norm, not the anomaly.** It is the one write on that path posted directly from the request thread rather than composed on an emission. It behaved as documented because nothing had leaked into it. Every other write was downstream of a system scope.

The first test in this PR pins the raw Rx ordering all of that rests on, so if a future Rx ever disposes before forwarding, that fact is learned from a red test rather than from a production log.

## Why this is fixed at the root and not in the log

The issue separates attribution from authorization and asks for the second to be established first. It is not hypothetical, and the framework already carries the scar:

> `AccessControlPipeline.HandleGetPermission` — *"That AsyncLocal at handler-entry holds `system-security` from SecurityService's bootstrap-time `ImpersonateAsSystem` scope (it leaks past the using-block because the bootstrap action-block thread captured the context at construction). Trusting it returned `Permission.All` for every caller — including anonymous deliveries."*

That call site defends **itself**, by resolving the identity explicitly instead of reading the ambient. This PR closes the class at the source so the next call site does not have to know Rx's disposal order to be safe.

## The fix

`ImpersonationScopeExtensions` — `RunAsSystem` / `RunAsHub` / `ContainIdentity`. The scope is entered at Subscribe (so the cold work is covered — the `Observable.Using`, never `Defer`+`using`, rule) and every notification reaches the subscriber under the **subscriber's own** identity.

Restore semantics are not re-implemented: it reuses `CarryAccessContext`'s per-callback `RestoringObserver`, so the three ways an identity attaches to a pipeline cannot drift apart.

```csharp
// ❌ the write is CONSTRUCTED while the scope is still open → lands as system-security
Observable.Using(access.ImpersonateAsSystem, _ => ReadGatedSource())
    .SelectMany(rows => meshService.CreateNodes(Plan(rows)));

// ✅ the scope covers the read and stops at its boundary → lands as the CALLER
access.RunAsSystem(ReadGatedSource)
    .SelectMany(rows => meshService.CreateNodes(Plan(rows)));
```

🚨 **It never invents an identity.** What is restored is exactly what was ambient at Subscribe: a real user for a user-driven flow, `system-security` for a genuinely system-initiated one, and **nothing at all** when the subscriber had no identity. That last case is what makes adoption safe at an existing call site — a background worker that never had a user is not fail-closed by it. The only behaviour that changes is the one the issue describes.

## Adopted by the eight copies of the same helper

`AsSystem` had been hand-written **eight times** across `src/` — Graph ×3, Mesh.Contract, GitSync ×2, InstanceSync, PluginCatalog — several carrying a comment saying they mirror one of the others. They now delegate to the one sealed primitive.

## What this PR deliberately does NOT claim

The reported install path lives in the **Plugins repo** and is already fixed there (`Store/Plugin/Source/SystemIdentity.cs`, which cites this issue). Its analysis settles the authorization question for that path: nothing landed anywhere the learner could not have written — every path was under their own partition root, where onboarding had just granted them Admin — so the realised damage is an audit trail saying the platform did what a learner asked for. The one permission check on that path resolved its subject from the same ambient context, and no shipped path handed it a user-chosen destination; that is a fact about Rx's disposal order rather than a defence anyone designed, which is why it is fixed anyway.

That plugin-local helper is what this framework primitive should have been all along. This PR is the framework half.

## Verification

| | |
|---|---|
| `SystemScopeDoesNotEscapeTest` | **8/8** — including `leaked == system-security` vs `sealed == alice` on the same composed write |
| `MeshWeaver.Messaging.Hub.Test` | 251/251 |
| `MeshWeaver.AccessControl.Test` | 29/29 |
| `MeshWeaver.InstanceSync.Test` | 26/26 |
| `MeshWeaver.GitSync.Test` | 163/163 |
| `MeshWeaver.Graph.Test` | 1127/1127 |

`-c Release -warnaserror` clean for all six touched projects.