### PR TITLE
fix: an ordinary .json file is not a node file, and not an import error

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-a-repo-sync-no-longer-fails-on-package-json.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-a-repo-sync-no-longer-fails-on-package-json.md
@@ -1,0 +1,26 @@
+---
+Name: A repo sync no longer fails over an ordinary JSON file
+Category: Fix
+Description: Syncing a source repository reported a failed import because of files like package.json, which were never meant to be content in the first place.
+Icon: DocumentBulletList
+Order: -20260814
+---
+
+# A repo sync no longer fails over an ordinary JSON file
+
+Syncing a source repository brings its files into the mesh. Some of those files describe content;
+most are just part of the project — an npm manifest, a compiler configuration, a lock file.
+
+Every JSON file was being read as though it described a piece of content. When one of them did not
+fit — an npm `package.json` records its version as `0.1.0`, where content records a version as a
+number — the sync reported the file as broken and finished as **failed**. The file was fine; it was
+simply never content. Any repository holding one showed a failed sync on every run, and the genuine
+problems that report is meant to surface were buried alongside it.
+
+The quieter case mattered more. A JSON file with nothing in common with a content file did not fail
+at all — it was imported as an **empty** entry, silently. So the two possible outcomes for an
+ordinary project file were a false alarm or an invisible piece of clutter.
+
+A sync now recognises which JSON files describe content and leaves the rest alone, exactly as it
+already does for other project files. A file that genuinely is content but is malformed is still
+reported — that report now means what it says.

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
@@ -25,15 +25,64 @@ public class JsonFileParser : IFileFormatParser
 
     /// <inheritdoc />
     /// <remarks>
-    /// A malformed document THROWS (<see cref="JsonException"/>) rather than returning null:
+    /// <para>A malformed document THROWS (<see cref="JsonException"/>) rather than returning null:
     /// <see cref="FileFormatParserRegistry.TryParse"/> catches per-parser failures and surfaces
     /// them through its <c>onError</c> callback, so an import pipeline can report the dropped
     /// file on its activity instead of silently losing the node (the old <c>catch → null</c>
-    /// here swallowed the error before the registry ever saw it).
+    /// here swallowed the error before the registry ever saw it).</para>
+    ///
+    /// <para>🚨 But a well-formed document that is simply NOT A NODE is not an error, and must not
+    /// be reported as one. A synced source repo is full of ordinary JSON — <c>package.json</c>,
+    /// <c>tsconfig.json</c>, <c>launchSettings.json</c>, lock files — and deserializing those into a
+    /// <see cref="MeshNode"/> has two bad outcomes and no good one: npm's <c>"version": "0.1.0"</c>
+    /// (a string where <see cref="MeshNode.Version"/> is numeric) THREW, so every sync of a repo
+    /// containing one reported a failed import forever; and a document that merely has no
+    /// overlapping keys deserializes "successfully" into an all-default node, which is worse — a
+    /// silent empty node in the mesh. Both were the same missing decision: whether this file is a
+    /// node at all.</para>
+    ///
+    /// <para>It is answered structurally, by <see cref="LooksLikeMeshNode"/>, and a non-node returns
+    /// <c>null</c> — the same silent "no node here" a <c>.yml</c> or <c>.py</c> already gets from
+    /// having no registered parser at all. The extension having a parser is what made a
+    /// non-node <c>.json</c> a hard error while identical content in a <c>.txt</c> was fine.</para>
     /// </remarks>
     public MeshNode? Parse(string filePath, string content, string relativePath)
     {
-        return JsonSerializer.Deserialize<MeshNode>(content, _options);
+        // ONE parse: JsonDocument answers "is this a node?" and then feeds the materialization, so
+        // a node file costs no more than before and a non-node file costs strictly less (it is no
+        // longer materialized just to be thrown away). ParseFile runs this under .Merge(8) over
+        // every file in a repo, so a second full pass would not be free.
+        using var document = JsonDocument.Parse(content);
+        return LooksLikeMeshNode(document.RootElement)
+            ? document.RootElement.Deserialize<MeshNode>(_options)
+            : null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="root"/> is shaped like an authored node file: a JSON object
+    /// carrying at least one property that only a <see cref="MeshNode"/> has —
+    /// <c>$type</c>, <c>id</c>, or <c>nodeType</c>.
+    ///
+    /// <para>🚨 The marker set is empirical, not a guess: all <b>597</b> authored node <c>.json</c>
+    /// files across <c>src/MeshWeaver.Documentation/Data</c>, <c>samples/*/Data</c> and
+    /// <c>content/</c> carry one, so nothing that parses today stops parsing. It is deliberately
+    /// checked case-insensitively — the serializer writes camelCase, but a hand-authored file may
+    /// use <c>Id</c>.</para>
+    ///
+    /// <para>Weaker markers are excluded on purpose. <c>name</c> and <c>description</c> are the two
+    /// <see cref="MeshNode"/> fields ordinary package manifests also use, so treating either as a
+    /// marker would re-admit exactly the files this exists to exclude.</para>
+    /// </summary>
+    private static bool LooksLikeMeshNode(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+            return false;
+        foreach (var property in root.EnumerateObject())
+            if (property.NameEquals("$type")
+                || string.Equals(property.Name, "id", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(property.Name, "nodeType", StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
     }
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
@@ -52,7 +52,18 @@ public class JsonFileParser : IFileFormatParser
         // a node file costs no more than before and a non-node file costs strictly less (it is no
         // longer materialized just to be thrown away). ParseFile runs this under .Merge(8) over
         // every file in a repo, so a second full pass would not be free.
-        using var document = JsonDocument.Parse(content);
+        //
+        // 🚨 The parse must be exactly as tolerant as the deserializer it replaces at the front of
+        // this method. JsonDocumentOptions defaults REJECT comments and trailing commas, so taking
+        // the default here would have made a node file that parsed yesterday — under a hub whose
+        // options skip comments — start failing today, in the name of a fix about not failing on
+        // files that were never nodes. The three tolerances are copied off the hub's own options.
+        using var document = JsonDocument.Parse(content, new JsonDocumentOptions
+        {
+            CommentHandling = _options.ReadCommentHandling,
+            AllowTrailingCommas = _options.AllowTrailingCommas,
+            MaxDepth = _options.MaxDepth,
+        });
         return LooksLikeMeshNode(document.RootElement)
             ? document.RootElement.Deserialize<MeshNode>(_options)
             : null;
@@ -65,9 +76,14 @@ public class JsonFileParser : IFileFormatParser
     ///
     /// <para>🚨 The marker set is empirical, not a guess: all <b>597</b> authored node <c>.json</c>
     /// files across <c>src/MeshWeaver.Documentation/Data</c>, <c>samples/*/Data</c> and
-    /// <c>content/</c> carry one, so nothing that parses today stops parsing. It is deliberately
-    /// checked case-insensitively — the serializer writes camelCase, but a hand-authored file may
-    /// use <c>Id</c>.</para>
+    /// <c>content/</c> carry one, so nothing that parses today stops parsing.</para>
+    ///
+    /// <para><c>id</c> and <c>nodeType</c> are matched case-INsensitively — the serializer writes
+    /// camelCase, but a hand-authored file may use <c>Id</c>. <c>$type</c> is matched EXACTLY,
+    /// deliberately: it is not a property name an author chooses but the serializer's own
+    /// discriminator, emitted verbatim, and <c>System.Text.Json</c> only ever honours it in that
+    /// exact spelling — so accepting <c>$Type</c> here would admit a file the deserializer will
+    /// then treat as untyped.</para>
     ///
     /// <para>Weaker markers are excluded on purpose. <c>name</c> and <c>description</c> are the two
     /// <see cref="MeshNode"/> fields ordinary package manifests also use, so treating either as a

--- a/test/MeshWeaver.GitSync.Test/OrdinaryJsonIsNotANodeFileTest.cs
+++ b/test/MeshWeaver.GitSync.Test/OrdinaryJsonIsNotANodeFileTest.cs
@@ -100,6 +100,31 @@ public class OrdinaryJsonIsNotANodeFileTest
     }
 
     /// <summary>
+    /// 🚨 The structural pre-check must be exactly as tolerant as the deserializer it front-runs.
+    /// <c>JsonDocumentOptions</c> defaults REJECT comments and trailing commas, so taking the
+    /// default would have made a node file that parsed yesterday — under a hub whose options skip
+    /// comments — start failing today, in the name of a fix about not failing on files that were
+    /// never nodes. Caught in review on PR #1615.
+    /// </summary>
+    [Theory]
+    [InlineData("{\n  // a hand-authored node with a comment\n  \"id\": \"Commented\"\n}")]
+    [InlineData("{ \"id\": \"TrailingComma\", \"name\": \"x\", }")]
+    public void ATolerantlyAuthoredNodeFileStillParses(string content)
+    {
+        var tolerant = new JsonFileParser(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        });
+
+        tolerant.Parse("f.json", content, "Space/f.json").Should().NotBeNull(
+            "the pre-check reads the same document the deserializer would — a file the hub's own "
+            + "options accept must not be rejected one layer earlier");
+    }
+
+    /// <summary>
     /// A JSON array or scalar is a document, never a node — and must not throw on the way to
     /// saying so.
     /// </summary>

--- a/test/MeshWeaver.GitSync.Test/OrdinaryJsonIsNotANodeFileTest.cs
+++ b/test/MeshWeaver.GitSync.Test/OrdinaryJsonIsNotANodeFileTest.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// A synced source repo is full of ordinary JSON that is not a node — <c>package.json</c>,
+/// <c>tsconfig.json</c>, <c>launchSettings.json</c>, lock files.
+///
+/// <para><b>Measured on memex-cloud, 2026-08-14 10:14:14Z</b> (pod
+/// <c>memex-portal-deployment-79867669f4-f2zzl</c>): every sync of this very repository logged
+/// <c>Failed to parse MeshWeaver/clients/grpc-web/package.json — file skipped on import</c>, with
+/// <c>The JSON value could not be converted to System.Int64. Path: $.version</c> — npm's
+/// <c>"version": "0.1.0"</c> is a string where <see cref="MeshNode.Version"/> is numeric. That
+/// throw is reported as an Error on the import activity, and <c>ActivityRunner.Finish</c> rolls it
+/// up, so the import terminates <c>Failed</c> — permanently, on every run, for a file that was
+/// never a node.</para>
+///
+/// <para>The quieter half is worse: a document with no overlapping keys deserializes
+/// "successfully" into an all-default <see cref="MeshNode"/>, so the alternative to a red import
+/// was a silent empty node. Both are the same missing decision — whether the file is a node at
+/// all — which is now made structurally, before deserializing.</para>
+/// </summary>
+public class OrdinaryJsonIsNotANodeFileTest
+{
+    private static readonly JsonFileParser Parser = new(new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    });
+
+    private static MeshNode? Parse(string content) => Parser.Parse("f.json", content, "Space/f.json");
+
+    /// <summary>The exact file, and the exact failure, from the production log.</summary>
+    [Fact]
+    public void TheNpmManifestThatFailedEveryImportIsSimplyNotANode()
+    {
+        const string packageJson = """
+            {
+              "name": "@meshweaver/grpc-web",
+              "version": "0.1.0",
+              "description": "gRPC-web transport for MeshWeaver clients",
+              "main": "dist/index.js",
+              "scripts": { "build": "tsc" }
+            }
+            """;
+
+        Parse(packageJson).Should().BeNull(
+            "an npm manifest is not a node — reporting it as a failed parse turned every sync of a "
+            + "repo containing one into a permanently red import");
+    }
+
+    /// <summary>
+    /// The quiet half: no overlapping keys, so it USED to deserialize into an all-default node.
+    /// Silence is not the right answer either — absence is.
+    /// </summary>
+    [Fact]
+    public void AConfigFileDoesNotBecomeAnEmptyNode()
+    {
+        const string tsconfig = """
+            { "compilerOptions": { "target": "ES2022", "strict": true }, "include": ["src"] }
+            """;
+
+        Parse(tsconfig).Should().BeNull(
+            "deserializing this into a MeshNode succeeds and yields an all-default node — a silent "
+            + "empty node in the mesh is worse than the loud failure, not better");
+    }
+
+    /// <summary>
+    /// 🚨 The regression guard that matters: every authored node file must still parse. The marker
+    /// set was chosen against the whole corpus (597/597 authored node .json files carry one of
+    /// these three), so these cases are representative rather than illustrative.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"id":"SampleStatistics","namespace":"Doc/Architecture","name":"Sample statistics"}""")]
+    [InlineData("""{"$type":"MeshNode","id":"Doc","path":"Doc","name":"Doc","nodeType":"Space","version":1}""")]
+    [InlineData("""{"nodeType":"Code","name":"A node whose id comes from its path"}""")]
+    [InlineData("""{"Id":"PascalCased","Name":"Hand-authored"}""")]
+    public void AnAuthoredNodeFileStillParses(string content)
+    {
+        Parse(content).Should().NotBeNull(
+            "the change may only ever REMOVE files from the node set; a node that parsed before "
+            + "must parse now, or the fix costs content");
+    }
+
+    /// <summary>
+    /// Malformed JSON still THROWS, because that genuinely is a broken node file and the import
+    /// activity is supposed to name it. Returning null here would trade a reported failure for a
+    /// silently missing node — the defect the throw was introduced to fix.
+    /// </summary>
+    [Fact]
+    public void MalformedJsonStillThrowsSoTheImportCanReportIt()
+    {
+        Action act = () => _ = Parse("""{"id":"Broken", "name": }""");
+
+        act.Should().Throw<JsonException>(
+            "a file that cannot be parsed at all is not the same as a file that is not a node");
+    }
+
+    /// <summary>
+    /// A JSON array or scalar is a document, never a node — and must not throw on the way to
+    /// saying so.
+    /// </summary>
+    [Theory]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("\"just a string\"")]
+    [InlineData("42")]
+    public void ANonObjectDocumentIsNotANode(string content) =>
+        Parse(content).Should().BeNull();
+}


### PR DESCRIPTION
Found while tracing #1549's pod — it is in the same log, and it is not the same defect.

## Every sync of this repository has been finishing `Failed`

memex-cloud, 2026-08-14 10:14:14Z, pod `memex-portal-deployment-79867669f4-f2zzl`:

```
warn: MeshWeaver.GitSync.GitHubSyncService[0]
  Failed to parse MeshWeaver/clients/grpc-web/package.json — file skipped on import.
  System.Text.Json.JsonException: The JSON value could not be converted to System.Int64.
  Path: $.version | LineNumber: 2 | BytePositionInLine: 20.
```

npm writes `"version": "0.1.0"`; `MeshNode.Version` is numeric. `JsonFileParser` deserialized **every** `.json` into a `MeshNode`, so the throw reached `ParseFile`'s `onError` → recorded as an **Error on the import activity** → `ActivityRunner.Finish` rolls it up → the import terminates **Failed**. On every run. For a file that was never a node — and it buries the reports that gate actually exists for.

## The quieter half is worse

A JSON document with no overlapping keys — `tsconfig.json`, `launchSettings.json` — does **not** throw. Unknown properties are ignored, so it deserializes "successfully" into an **all-default `MeshNode`**: a silent empty node in the mesh.

So the two possible outcomes for an ordinary project file were a red import or invisible clutter, and both come from the same missing decision: *is this file a node at all?*

The tell is the asymmetry already in the code. An extension with **no** registered parser (`.yml`, `.py`) is silently not-a-node **by design** — `ParseFile`'s own comment says *"repos legitimately carry non-node files"*. Only `.json`, by having a parser, turned that same fact into a hard error.

## The fix

Decide structurally, before deserializing. A node file is a JSON **object** carrying at least one property only a `MeshNode` has — `$type`, `id`, or `nodeType`. Anything else returns `null`: the same silent "no node here" `.yml` already gets.

**Malformed JSON still throws.** That genuinely is a broken node file and the activity is supposed to name it — returning null there would trade a reported failure for a silently missing node, which is the defect the throw was introduced to fix.

### The marker set is empirical, not a guess

All **597** authored node `.json` files under `src/MeshWeaver.Documentation/Data`, `samples/*/Data` and `content/` carry one of the three. The change can therefore only ever **remove** files from the node set — nothing that parses today stops parsing.

`name` and `description` are deliberately **not** markers: they are the two `MeshNode` fields package manifests also use, so either would re-admit exactly the files this exists to exclude.

### It costs nothing

`JsonDocument` answers the question **and** feeds the materialization, so a node file is one parse as before, and a non-node file is now strictly cheaper — no longer materialized just to be thrown away. `ParseFile` runs this under `.Merge(8)` across every file in a repo, so a second pass would not have been free.

## Verification

| | |
|---|---|
| `OrdinaryJsonIsNotANodeFileTest` | **10/10** — the production `package.json` verbatim, the silent-empty-node case, four authored-node regression guards, malformed-still-throws, non-object documents |
| `MeshWeaver.GitSync.Test` | 173/173 |

`-c Release -warnaserror` clean.