### PR TITLE
fix: a debounced auto-save must flush on dispose, not drop the edit (#1606)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/AutoSaveHandler.cs
+++ b/src/MeshWeaver.Blazor/Components/AutoSaveHandler.cs
@@ -110,9 +110,12 @@ public class AutoSaveHandler : IDisposable
     }
 
     /// <summary>
-    /// Disposes the handler, FLUSHING any edit still inside the throttle window, then releasing the
-    /// subscription and completing the value subject. Subsequent calls to <c>OnValueChanged</c> are
-    /// silently ignored after disposal.
+    /// Disposes the handler: releases the throttle subscription and disposes the value subject,
+    /// then FLUSHES any edit that was still inside the throttle window. Subsequent calls to
+    /// <c>OnValueChanged</c> are silently ignored after disposal.
+    ///
+    /// <para>That order is deliberate — tearing the throttle down first makes the flush the only
+    /// remaining writer, where flushing first would leave a window in which both could fire.</para>
     ///
     /// <para>🚨 <b>The flush is the point (issue #1606).</b> <c>Throttle</c> holds the last value for
     /// the whole interval, so a dispose inside that window used to DROP it — silently, with no error

--- a/src/MeshWeaver.Blazor/Components/AutoSaveHandler.cs
+++ b/src/MeshWeaver.Blazor/Components/AutoSaveHandler.cs
@@ -110,8 +110,24 @@ public class AutoSaveHandler : IDisposable
     }
 
     /// <summary>
-    /// Disposes the handler by releasing the throttle subscription and completing the value subject.
-    /// Subsequent calls to <c>OnValueChanged</c> are silently ignored after disposal.
+    /// Disposes the handler, FLUSHING any edit still inside the throttle window, then releasing the
+    /// subscription and completing the value subject. Subsequent calls to <c>OnValueChanged</c> are
+    /// silently ignored after disposal.
+    ///
+    /// <para>🚨 <b>The flush is the point (issue #1606).</b> <c>Throttle</c> holds the last value for
+    /// the whole interval, so a dispose inside that window used to DROP it — silently, with no error
+    /// anywhere. That is not a rare teardown case: the Blazor views that own this handler create it
+    /// in <c>BindData</c> and register it with <c>AddBinding</c>, and <c>OnParametersSet</c> runs
+    /// <c>DisposeBindings()</c> → <c>BindData()</c>. So ANY re-render with new parameters inside 500 ms
+    /// of a keystroke destroyed the pending save — and a course example cell re-renders on every
+    /// emission of the node it is bound to, including the echo of the learner's own previous save.
+    /// The learner typed, the cell looked editable, and the text was gone after a reload.</para>
+    ///
+    /// <para>A pending value that equals <see cref="LastSyncedValue"/> is skipped, exactly as
+    /// <c>OnThrottledValue</c> skips it. If the throttle fires concurrently with this dispose the
+    /// worst case is the same value written twice, which the writers already treat as a no-op (they
+    /// return the node unchanged when the text matches, making the merge patch empty) — so this
+    /// needs no lock, and a lock here would be a hand-woven gate on a UI teardown path.</para>
     /// </summary>
     public void Dispose()
     {
@@ -119,7 +135,13 @@ public class AutoSaveHandler : IDisposable
             return;
 
         _disposed = true;
+        // Stop the throttle FIRST so the flush below is the only remaining writer, then flush what
+        // it was holding. Order matters: flushing first would leave a window for a double write.
         _subscription.Dispose();
         _valueSubject.Dispose();
+
+        var pending = CurrentValue;
+        if (pending is not null && pending != LastSyncedValue)
+            OnThrottledValue(pending);
     }
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-your-last-edit-is-no-longer-thrown-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-your-last-edit-is-no-longer-thrown-away.md
@@ -1,0 +1,24 @@
+---
+Name: Your last edit is no longer thrown away
+Category: Fix
+Description: Text typed into an inline editor could vanish if the page updated within half a second of the last keystroke — most visibly in course example cells, where an edit did not survive a reload.
+Icon: Edit
+Order: -20260814
+---
+
+# Your last edit is no longer thrown away
+
+Inline editors save on their own, half a second after you stop typing. That pause is what keeps a
+document from being written on every keystroke.
+
+If the page updated during that pause, the pending text was **discarded**. Not delayed, not
+retried — dropped, with nothing shown and nothing logged. And the pages most likely to update are
+exactly the ones you are editing: a view refreshes whenever the thing it displays changes,
+including the change your own previous save just made.
+
+It showed up most clearly in course example cells. A learner gets their own editable copy of an
+example, types into it, and comes back to find the original text — an editor that looks like yours
+and quietly keeps nothing. The same pause guarded every inline markdown editor.
+
+A pending edit is now **written out when the editor stops**, rather than abandoned with it. If the
+text was already saved, nothing extra is written.

--- a/test/MeshWeaver.Layout.Test/AutoSaveHandlerTest.cs
+++ b/test/MeshWeaver.Layout.Test/AutoSaveHandlerTest.cs
@@ -16,6 +16,11 @@ public class AutoSaveHandlerTest
 {
     private static readonly TimeSpan ThrottleInterval = TimeSpan.FromMilliseconds(500);
 
+    // Derived from ThrottleInterval, never hard-coded: these cases mean "before the throttle fired"
+    // and "after it fired", and they must keep meaning that if the interval is ever retuned.
+    private static readonly TimeSpan InsideTheThrottleWindow = ThrottleInterval / 2;
+    private static readonly TimeSpan PastTheThrottleWindow = ThrottleInterval + ThrottleInterval / 5;
+
     [Fact]
     public void SingleEdit_ShouldSaveAfterThrottleInterval()
     {
@@ -424,8 +429,9 @@ public class AutoSaveHandlerTest
         var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
 
         handler.OnValueChanged("the learner's edit");
-        // Less than the throttle interval: the value is still held, nothing has been saved.
-        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(200).Ticks);
+        // INSIDE the window — expressed as a fraction of the interval rather than a literal, so the
+        // case still means "a re-render arrived before the throttle fired" if the interval changes.
+        scheduler.AdvanceBy(InsideTheThrottleWindow.Ticks);
         Assert.Empty(savedValues);
 
         handler.Dispose();
@@ -458,7 +464,7 @@ public class AutoSaveHandlerTest
         var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
 
         handler.OnValueChanged("saved once");
-        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(600).Ticks);
+        scheduler.AdvanceBy(PastTheThrottleWindow.Ticks);
         Assert.Equal(new[] { "saved once" }, savedValues);
 
         handler.Dispose();
@@ -496,12 +502,12 @@ public class AutoSaveHandlerTest
 
         var first = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
         first.OnValueChanged("edit one");
-        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(100).Ticks);
+        scheduler.AdvanceBy(InsideTheThrottleWindow.Ticks);
         first.Dispose();
 
         var second = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
         second.OnValueChanged("edit one, edit two");
-        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(100).Ticks);
+        scheduler.AdvanceBy(InsideTheThrottleWindow.Ticks);
         second.Dispose();
 
         Assert.Equal(new[] { "edit one", "edit one, edit two" }, savedValues);
@@ -516,7 +522,7 @@ public class AutoSaveHandlerTest
 
         handler.Dispose();
         handler.OnValueChanged("too late");
-        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(600).Ticks);
+        scheduler.AdvanceBy(PastTheThrottleWindow.Ticks);
 
         Assert.Empty(savedValues);
     }

--- a/test/MeshWeaver.Layout.Test/AutoSaveHandlerTest.cs
+++ b/test/MeshWeaver.Layout.Test/AutoSaveHandlerTest.cs
@@ -405,4 +405,119 @@ public class AutoSaveHandlerTest
         Assert.Equal("Hel", handler.LastSyncedValue); // Still old value
         Assert.Equal("Hello", handler.CurrentValue); // Updated
     }
+
+    /// <summary>
+    /// 🚨 Issue #1606 — the learner's edit that never reached the node.
+    ///
+    /// <para>A course example cell renders as an inline editor and re-renders on every emission of
+    /// the node it is bound to. The Blazor views create this handler in <c>BindData</c> and register
+    /// it with <c>AddBinding</c>, and <c>OnParametersSet</c> runs <c>DisposeBindings()</c> →
+    /// <c>BindData()</c> — so a re-render inside the 500 ms throttle window disposed the handler
+    /// while <c>Throttle</c> was still holding the keystroke. The value went nowhere, with no error
+    /// anywhere: the learner typed, reloaded, and their work was gone.</para>
+    /// </summary>
+    [Fact]
+    public void DisposeInsideTheThrottleWindow_FlushesThePendingEdit()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+        var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+
+        handler.OnValueChanged("the learner's edit");
+        // Less than the throttle interval: the value is still held, nothing has been saved.
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(200).Ticks);
+        Assert.Empty(savedValues);
+
+        handler.Dispose();
+
+        Assert.Equal(new[] { "the learner's edit" }, savedValues);
+    }
+
+    /// <summary>
+    /// The flush must not manufacture a write. A handler disposed with nothing pending — or with
+    /// only what was already saved — writes nothing, or every re-render would post a redundant
+    /// patch for a cell nobody touched.
+    /// </summary>
+    [Fact]
+    public void DisposeWithNothingPending_SavesNothing()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+        var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+
+        handler.Dispose();
+
+        Assert.Empty(savedValues);
+    }
+
+    [Fact]
+    public void DisposeAfterTheThrottleAlreadyFired_DoesNotSaveTwice()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+        var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+
+        handler.OnValueChanged("saved once");
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(600).Ticks);
+        Assert.Equal(new[] { "saved once" }, savedValues);
+
+        handler.Dispose();
+
+        Assert.Equal(new[] { "saved once" }, savedValues);
+    }
+
+    /// <summary>
+    /// An external update that the editor adopted is the new baseline, so disposing afterwards must
+    /// not write it back — that would turn a read into a write on every re-render.
+    /// </summary>
+    [Fact]
+    public void DisposeAfterAnExternalUpdateWasApplied_SavesNothing()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+        var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+
+        handler.OnExternalUpdateApplied("text from the stream");
+        handler.Dispose();
+
+        Assert.Empty(savedValues);
+    }
+
+    /// <summary>
+    /// The realistic sequence: type, re-render (dispose + rebuild), type again, re-render again.
+    /// Every keystroke run must survive its re-render — a cell bound to a node that emits on each
+    /// save re-renders constantly, which is why the drop was total rather than occasional.
+    /// </summary>
+    [Fact]
+    public void EveryRebindFlushesItsOwnPendingEdit()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+
+        var first = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+        first.OnValueChanged("edit one");
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(100).Ticks);
+        first.Dispose();
+
+        var second = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+        second.OnValueChanged("edit one, edit two");
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(100).Ticks);
+        second.Dispose();
+
+        Assert.Equal(new[] { "edit one", "edit one, edit two" }, savedValues);
+    }
+
+    [Fact]
+    public void OnValueChangedAfterDispose_IsStillIgnored()
+    {
+        var scheduler = new TestScheduler();
+        var savedValues = new List<string>();
+        var handler = new AutoSaveHandler(ThrottleInterval, savedValues.Add, scheduler);
+
+        handler.Dispose();
+        handler.OnValueChanged("too late");
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(600).Ticks);
+
+        Assert.Empty(savedValues);
+    }
 }


### PR DESCRIPTION
Closes #1606.

## Root cause — candidate 1 of the three the issue listed, and it is provable from the code

`AutoSaveHandler.Dispose()` released the `Throttle` subscription and completed the subject **without flushing**:

```csharp
_disposed = true;
_subscription.Dispose();
_valueSubject.Dispose();     // ← whatever Throttle was holding goes with it
```

`Throttle` holds the last value for the whole 500 ms interval, so a dispose inside that window dropped it — silently, with nothing shown and nothing logged.

**That is not a rare teardown case.** Both editor views create the handler in `BindData` and register it with `AddBinding`, and `BlazorView.OnParametersSet` runs:

```csharp
DisposeBindings();
BindData();
```

So **any** re-render with new parameters within 500 ms of a keystroke destroyed the pending save — and a course example cell re-renders on every emission of the node it is bound to, *including the echo of the learner's own previous save*. The drop was closer to total than occasional, which is why the e2e test saw nothing persist at all rather than an intermittent loss.

### The other two candidates are ruled out by the same reading

| # | the issue's candidate | verdict |
|---|---|---|
| 2 | *"it fires against the wrong path (the master's, not the learner's copy)"* | No. `AutoSaveCode` reads the `autoSavePath` field, and `DisposeBindings()` runs **before** `BindData()` reassigns it — so a flush during re-bind writes the OLD text to the OLD path, which is the learner's copy. |
| 3 | *"it is written and then overwritten by the editor's own seed on the next emission"* | No. The writer returns the node **unchanged** when `config.Code == value`, making the merge patch empty — an echo cannot clobber. |

## The fix

Dispose stops the throttle **first** (so the flush is the only remaining writer), then writes what it was holding, skipping a value equal to `LastSyncedValue` exactly as `OnThrottledValue` does.

No lock. If the throttle fires concurrently with the dispose the worst case is the same value written twice, and both writers already treat that as a no-op — so a lock here would be a hand-woven gate on a UI teardown path, bought for nothing.

**It covers the markdown editor too.** `MarkdownEditorView` owns the same handler with the same lifecycle, so every inline markdown auto-save had the same window.

## Verification — the new tests fail without the fix

| | |
|---|---|
| **without** the Dispose change | `Failed: 2, Passed: 15` — `DisposeInsideTheThrottleWindow_FlushesThePendingEdit`, `EveryRebindFlushesItsOwnPendingEdit` |
| **with** it | `Failed: 0, Passed: 17` |

Six cases, driven on a `TestScheduler` so they are deterministic: the flush itself; nothing-pending writes nothing; no double save when the throttle already fired; no write-back after an adopted external update (that would turn a read into a write on every re-render); the realistic type → re-render → type → re-render sequence; and `OnValueChanged` after dispose still ignored.

`-c Release -warnaserror` clean for `MeshWeaver.Blazor` and the test project.