### PR TITLE
fix: the code editor asked the CIRCUIT for a service the MESH registers (#1601)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
@@ -151,7 +151,22 @@
         var lspConfig = ViewModel.LanguageServer;
         if (lspConfig != null)
         {
-            var languageService = Services.GetService(typeof(IMeshLanguageService)) as IMeshLanguageService;
+            // 🚨 Resolve from the HUB's provider, not the circuit's (#1601). IMeshLanguageService
+            // is registered inside the MESH hub's configuration (GraphConfigurationExtensions'
+            // `services.AddSingleton<IMeshLanguageService, MeshNodeLanguageService>()`), while
+            // `Services` is the Blazor circuit's ASP.NET provider — which holds circuit-scoped things
+            // like PortalErrorSink and has no view of hub registrations. Asking the wrong provider
+            // returns null, and the `else` below then nulls BOTH callbacks, so the editor silently
+            // falls back to Monaco's built-in word-based suggestions: identifiers scraped out of the
+            // document, alphabetical, with no diagnostics either. That is exactly what #1601
+            // measured. The auto-save block above already resolves its cache from
+            // Hub.ServiceProvider for this reason; this was the one place that did not.
+            //
+            // `Services` is still tried as a fallback so a host that registers the service at the
+            // application root keeps working.
+            var languageService =
+                Hub.ServiceProvider.GetService(typeof(IMeshLanguageService)) as IMeshLanguageService
+                ?? Services.GetService(typeof(IMeshLanguageService)) as IMeshLanguageService;
             if (languageService != null)
             {
                 var nodeTypePath = lspConfig.NodeTypePath;
@@ -173,6 +188,16 @@
             }
             else
             {
+                // 🚨 LOUD, for the same reason the auto-save resolution above is: silently
+                // nulling both callbacks is indistinguishable from "the language service answered
+                // nothing", and that ambiguity is what made #1601 take a live-portal measurement to
+                // diagnose. A control that ASKED for a language server and did not get one is a
+                // misconfiguration worth naming.
+                Logger.LogWarning(
+                    "CodeEditor at {Area}: IMeshLanguageService is not registered on either the hub "
+                    + "or the circuit provider — completions and diagnostics are disabled for "
+                    + "{SourcePath}, and the editor will fall back to word-based suggestions",
+                    Area, lspConfig.SourcePath);
                 diagnosticsCallback = null;
                 diagnosticSourcePath = null;
                 codeCompletionCallback = null;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-code-help-comes-back-to-the-lesson-editor.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-14-code-help-comes-back-to-the-lesson-editor.md
@@ -1,0 +1,24 @@
+---
+Name: Code help comes back to the lesson editor
+Category: Fix
+Description: An example cell offered only alphabetical guesses scraped from its own text, and no error underlines — the editor was asking the wrong place for the compiler that answers those questions.
+Icon: Lightbulb
+Order: -20260814
+---
+
+# Code help comes back to the lesson editor
+
+An example cell in a lesson is a real code editor: it should complete what you type from the actual
+types in scope, and underline mistakes as you make them.
+
+Instead it offered a list of words scraped out of the cell's own comments and strings, in
+alphabetical order, and never underlined anything. That is the editor's own fallback for when
+nothing better is available — and nothing better was arriving, because the editor asked the wrong
+place for the service that provides it. The request went to the page's own set of services rather
+than to the mesh, where the compiler-backed one actually lives, and came back empty.
+
+Nothing reported it. Completions and error underlines are both switched off by the same empty
+answer, so the only visible sign was suggestions that felt oddly dumb.
+
+The editor now asks the mesh, and says so in the log if the service really is missing — so "no code
+help" can never again look the same as "no problems found".


### PR DESCRIPTION
Closes #1601 (candidate 1; candidate 2 addressed below).

## Candidate 1, and it is provable from the registrations

| what | where it is registered |
|---|---|
| `IMeshLanguageService` | inside the **mesh hub's** configuration — `GraphConfigurationExtensions`: `services.AddSingleton<IMeshLanguageService, MeshNodeLanguageService>()` |
| `Services` in the view | `[Inject] IServiceProvider` — the Blazor **circuit's** ASP.NET provider |

A hub provider chains **to** the application root, not the other way round, so a circuit-scoped lookup cannot see a hub registration. It returned null, and the `else` branch nulls **both** `diagnosticsCallback` and `codeCompletionCallback` — precisely the pair of symptoms the issue measured on the live portal: no suggest widget at all, zero `.squiggly-*` elements, and no browser console error (the JS provider only logs when the interop call *throws*, and nothing was ever called).

**The tell is inside the same method.** The auto-save block twenty lines above resolves its `IMeshNodeStreamCache` from `Hub.ServiceProvider`, with a comment about the *"LOUD resolution failure"* a silent one would cause. The LSP block was the only place in all of `MeshWeaver.Blazor` reaching for a hub-registered service through `Services` — the one other `Services.GetService` in the project is `PortalErrorSink`, which genuinely is circuit-scoped (`AddScoped` in `BlazorHostingExtensions`).

It now resolves from `Hub.ServiceProvider`, keeping `Services` as a fallback so a host that registers the service at the application root still works.

## …and it no longer fails silently

A control that **asked** for a language server and did not get one now logs a Warning naming the area and the source path.

Nulling both callbacks quietly is what made this need a live-portal measurement to diagnose: *"the service is absent"* and *"the service answered nothing"* produced identical UI, and the issue had to rule the second out by hand.

## Candidate 2 is deliberately not touched

> `MonacoEditorView.GetCodeCompletions` bounds the call at **5 s**, while `MeshNodeLanguageService.ResolveNode` alone allows **15 s** … A cold or cross-partition owner lookup that takes >5 s yields an empty list every time, silently.

That is a real mismatch, and changing a bound on a guess is how a real cause gets buried — so it stays as it is here. It is now **diagnosable** rather than silent: #1592 makes the language service log the read OUTCOME when it cannot build a workspace, so a 15-second `Unavailable` says so by name instead of arriving as an empty list.

If the symptom survives this fix, that log is the next piece of evidence and it will be waiting.

## Verification

`-c Release -warnaserror` clean for `MeshWeaver.Blazor`.

🚨 What this PR does **not** claim: the end-to-end symptom is measured in a browser against a live portal (the issue's own repro), and there is no unit test that can observe a Blazor circuit's provider resolving a mesh-hub singleton. What is established here is the registration mismatch and that the code now asks where the service is. The e2e in education#161's neighbourhood is what confirms the user-visible half.