### PR TITLE
feat: accept an API token over Basic auth, so NuGet can read the content route

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
@@ -48,13 +48,60 @@ public class ApiTokenAuthenticationHandler(
     /// <summary>Retry-After (seconds) advertised on the 503 unavailable challenge.</summary>
     internal const int RetryAfterSeconds = 5;
 
+    /// <summary>
+    /// The API token from an <c>Authorization</c> header — <c>Bearer &lt;token&gt;</c>, or
+    /// <c>Basic base64(user:&lt;token&gt;)</c> — or null when it carries neither.
+    ///
+    /// <para>🚨 Basic is accepted because a <b>NuGet client cannot send Bearer</b>: nuget.config's
+    /// <c>packageSourceCredentials</c> speaks Basic, and the only alternative is shipping a
+    /// credential-provider plugin. Accepting both lets `dotnet restore` read the access-controlled
+    /// content route with the SAME personal token every other API caller uses — one credential,
+    /// one validator, and the route's existing per-node Read check stays the authorization gate.</para>
+    ///
+    /// <para>The username half is ignored (the token is the whole secret); NuGet merely requires
+    /// one to be present. The token stays in the HEADER either way — the easier
+    /// <c>?apiKey=</c> would leak it into every access log and proxy log along the route.</para>
+    ///
+    /// <para>Malformed Basic payloads yield null (→ the normal no-result path), never an
+    /// exception: an unauthenticated caller must not be able to make the handler throw. The length
+    /// cap bounds what such a caller can make us decode.</para>
+    /// </summary>
+    internal static string? ExtractToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+            return null;
+        var header = authorizationHeader.Trim();
+
+        if (header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return header["Bearer ".Length..].Trim() is { Length: > 0 } bearer ? bearer : null;
+
+        if (!header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var encoded = header["Basic ".Length..].Trim();
+        if (encoded.Length is 0 or > MaxBasicPayloadChars)
+            return null;
+
+        Span<byte> buffer = stackalloc byte[MaxBasicPayloadChars / 4 * 3];
+        if (!Convert.TryFromBase64String(encoded, buffer, out var written))
+            return null;
+
+        // UTF8.GetString uses replacement fallback, so invalid bytes become U+FFFD rather than
+        // throwing — and such a token simply fails validation downstream.
+        var decoded = System.Text.Encoding.UTF8.GetString(buffer[..written]);
+        var separator = decoded.IndexOf(':');
+        if (separator < 0)
+            return null;
+
+        return decoded[(separator + 1)..].Trim() is { Length: > 0 } password ? password : null;
+    }
+
+    /// <summary>Largest Basic payload considered; see <see cref="ExtractToken"/>.</summary>
+    private const int MaxBasicPayloadChars = 1024;
+
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        var authHeader = Request.Headers.Authorization.ToString();
-        if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return AuthenticateResult.NoResult();
-
-        var rawToken = authHeader["Bearer ".Length..].Trim();
+        var rawToken = ExtractToken(Request.Headers.Authorization.ToString());
         if (string.IsNullOrEmpty(rawToken))
             return AuthenticateResult.NoResult();
 

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -77,4 +77,9 @@
          Open Sans is Apache-2.0, already shipped with the MAUI client. -->
     <EmbeddedResource Include="Seo/OpenSans-Regular.ttf" LogicalName="Memex.Portal.Shared.Seo.OpenSans-Regular.ttf" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- ExtractToken is pinned by tests (Bearer/Basic parsing on an unauthenticated path). -->
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
+  </ItemGroup>
+
 </Project>

--- a/test/Memex.Portal.Shared.Test/ApiTokenBasicAuthTest.cs
+++ b/test/Memex.Portal.Shared.Test/ApiTokenBasicAuthTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Text;
+using Memex.Portal.Shared.Authentication;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins how an API token is read out of an <c>Authorization</c> header.
+///
+/// <para><b>Why Basic is accepted at all.</b> A NuGet client cannot send <c>Bearer</c> —
+/// nuget.config's <c>packageSourceCredentials</c> speaks Basic, and the only alternative is
+/// shipping a credential-provider plugin. Accepting both lets <c>dotnet restore</c> read the
+/// access-controlled <c>/api/content</c> route with the SAME personal token every other API caller
+/// uses, so the route's per-node Read check remains the authorization gate rather than a second
+/// scheme growing its own rules.</para>
+///
+/// <para>This runs on an UNAUTHENTICATED request path, so the parse must never throw: a malformed
+/// header is an anonymous caller, not a 500 anyone can trigger.</para>
+/// </summary>
+public class ApiTokenBasicAuthTest
+{
+    private static string Basic(string user, string password) =>
+        "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{password}"));
+
+    [Theory]
+    [InlineData("Bearer mw_abc", "mw_abc")]
+    [InlineData("bearer mw_abc", "mw_abc")]                  // scheme is case-insensitive
+    [InlineData("  Bearer   mw_abc  ", "mw_abc")]            // stray whitespace tolerated
+    public void BearerStillWorks(string header, string expected)
+        => Assert.Equal(expected, ApiTokenAuthenticationHandler.ExtractToken(header));
+
+    [Theory]
+    [InlineData("nuget")]
+    [InlineData("anything")]
+    [InlineData("")]
+    public void BasicYieldsThePasswordHalf(string username)
+        // The username is ignored — the token is the whole secret — but NuGet requires one to be
+        // present, so any value must work.
+        => Assert.Equal("mw_abc", ApiTokenAuthenticationHandler.ExtractToken(Basic(username, "mw_abc")));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("mw_abc")]                                   // no scheme
+    [InlineData("Bearer ")]
+    [InlineData("Basic ")]
+    [InlineData("Basic !!!not-base64!!!")]
+    [InlineData("Negotiate abc")]                            // unrelated scheme
+    public void MalformedHeadersYieldNoTokenAndDoNotThrow(string? header)
+        => Assert.Null(ApiTokenAuthenticationHandler.ExtractToken(header));
+
+    [Fact]
+    public void BasicWithoutAColonYieldsNoToken()
+        // No colon means no password half; reading the whole blob would accept a bare username.
+        => Assert.Null(ApiTokenAuthenticationHandler.ExtractToken(
+            "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("mw_abc"))));
+
+    [Fact]
+    public void OverlongBasicPayloadYieldsNoToken()
+        // Unauthenticated, attacker-controlled input: the reject path must not decode an unbounded
+        // blob, and must not throw doing it.
+        => Assert.Null(ApiTokenAuthenticationHandler.ExtractToken("Basic " + new string('A', 5000)));
+
+    [Fact]
+    public void ATokenContainingAColonSurvives()
+    {
+        // Only the FIRST colon separates user from password, per RFC 7617 — a token that itself
+        // contains one must come back whole, or such tokens would silently fail to authenticate.
+        var header = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("user:mw_a:b:c"));
+
+        Assert.Equal("mw_a:b:c", ApiTokenAuthenticationHandler.ExtractToken(header));
+    }
+}


### PR DESCRIPTION
## What's New

**Category: Feature** — API tokens now work over Basic auth, which is what a NuGet client sends.

## Why

A NuGet client **cannot send `Bearer`**. `nuget.config`'s `packageSourceCredentials` speaks Basic, and the only alternative is shipping a credential-provider plugin. So a machine caller could not authenticate to `/api/content` at all.

That matters because **that route is already most of a package feed**: it resolves a mesh path, and it gates the read with a per-node `Read` check decided by the real `PermissionEvaluator` before a single byte is read.

Accepting Basic lets `dotnet restore` use the **same personal token every other API caller uses**, so that existing check stays the authorization gate rather than a second scheme growing its own rules.

## What it unblocks

Hosting the plugin feed **inside memex**: packages live under Releases — where they need to be kept anyway — served by the content route, gated by node permissions.

No GitHub Packages billing (currently refusing publishes with `Account has reached its billing limit`), no new storage account, and entitlement comes from the access model that already exists rather than a bolted-on one.

## Safety

- **The token stays in the header.** The easier `?apiKey=` would leak it into every access log and proxy log along the route.
- **Malformed payloads yield no token, never an exception.** This runs on an unauthenticated path, so a bad header must be an anonymous caller — not a 500 any unauthenticated caller can trigger. A length cap bounds what such a caller can make the handler decode.
- **Only the first colon separates user from password** (RFC 7617), so a token containing one survives intact — pinned by test, because silently truncating such a token would fail authentication for no visible reason.
- Bearer behaviour is unchanged: every header that authenticated before still does.

## Verified

`Memex.Portal.Shared.Test` — 17 passing, covering Bearer (including case-insensitivity and whitespace), Basic with any username, no-colon, overlong payload, non-base64, unrelated schemes, and the colon-in-token case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lo5L8TgTxeANJrUcDLrdSx