### PR TITLE
feat: Cosmos and Snowflake storage backends become boot packs

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -583,7 +583,10 @@ public static class MemexConfiguration
         /// Configures the mesh with Graph domain only.
         ///
         /// Configuration is read from appsettings:
-        /// - Graph:Storage:Type - Storage type: "FileSystem", "AzureBlob", "PostgreSql", or "Cosmos"
+        /// - Graph:Storage:Type - Storage type: "FileSystem", "AzureBlob", "PostgreSql", "Cosmos"
+        ///   or "Snowflake". Cosmos and Snowflake are BOOT PACKS: their factories register only
+        ///   when the matching DLL (MeshWeaver.Hosting.Cosmos / .Snowflake) is listed under
+        ///   Modules:Assemblies — installation runs before this selection, so ordering is safe.
         /// - Graph:Storage:BasePath - Base path for FileSystem storage
         /// - Graph:Storage:ConnectionString - Connection string for AzureBlob/Cosmos
         /// - storage - Content collection configuration (Name, SourceType, BasePath)

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosStorageProviderAttribute.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosStorageProviderAttribute.cs
@@ -1,0 +1,29 @@
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: MeshWeaver.Hosting.Cosmos.CosmosStorageProvider]
+
+namespace MeshWeaver.Hosting.Cosmos;
+
+/// <summary>
+/// Boot-pack registration for the Cosmos DB storage backend. Loading this DLL via
+/// <c>Modules:Assemblies</c> registers the keyed <c>IStorageAdapterFactory</c> (name
+/// <c>Cosmos</c>) plus the native <c>CosmosMeshQuery</c> — everything a deployment needs for
+/// <c>Graph:Storage:Type = Cosmos</c> to resolve, with no compiled reference from the portal.
+/// Module installation runs BEFORE persistence selection reads <c>Graph:Storage</c>, so the
+/// factory is always registered in time.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class CosmosStorageProviderAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.Hosting.Cosmos")
+        {
+            Name = "Cosmos DB storage backend",
+            NodeType = "ModuleDefinition",
+        }
+        .WithGlobalServiceRegistry(services => services.AddCosmosStorageFactory()),
+    ];
+}

--- a/src/MeshWeaver.Hosting.Cosmos/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/PersistenceExtensions.cs
@@ -89,8 +89,10 @@ public static class PersistenceExtensions
         {
             var adapter = sp.GetRequiredService<IStorageAdapter>() as CosmosStorageAdapter
                 ?? throw new InvalidOperationException(
-                    "CosmosMeshQuery requires CosmosStorageAdapter. " +
-                    "Ensure Cosmos storage is configured.");
+                    "The Cosmos storage module is registered but the selected storage adapter is " +
+                    "not Cosmos. Either set Graph:Storage:Type to 'Cosmos' or remove " +
+                    "MeshWeaver.Hosting.Cosmos from Modules:Assemblies (and any direct " +
+                    "AddCosmosStorageFactory call).");
             var meshConfig = sp.GetService<MeshConfiguration>();
             return new CosmosMeshQuery(adapter, meshConfig);
         });

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeExtensions.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeExtensions.cs
@@ -92,7 +92,10 @@ public static class SnowflakeExtensions
         {
             var adapter = sp.GetRequiredService<IStorageAdapter>() as SnowflakeStorageAdapter
                 ?? throw new InvalidOperationException(
-                    "SnowflakeMeshQuery requires SnowflakeStorageAdapter.");
+                    "The Snowflake storage module is registered but the selected storage adapter " +
+                    "is not Snowflake. Either set Graph:Storage:Type to 'Snowflake' or remove " +
+                    "MeshWeaver.Hosting.Snowflake from Modules:Assemblies (and any direct " +
+                    "AddSnowflakeStorageFactory call).");
             return new SnowflakeMeshQuery(
                 adapter,
                 sp.GetService<AccessService>(),

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageProviderAttribute.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeStorageProviderAttribute.cs
@@ -1,0 +1,29 @@
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: MeshWeaver.Hosting.Snowflake.SnowflakeStorageProvider]
+
+namespace MeshWeaver.Hosting.Snowflake;
+
+/// <summary>
+/// Boot-pack registration for the Snowflake storage backend. Loading this DLL via
+/// <c>Modules:Assemblies</c> registers the keyed <c>IStorageAdapterFactory</c> (name
+/// <c>Snowflake</c>) plus the native <c>SnowflakeMeshQuery</c> (query + vector search) —
+/// everything a deployment needs for <c>Graph:Storage:Type = Snowflake</c> to resolve, with no
+/// compiled reference from the portal. Module installation runs BEFORE persistence selection
+/// reads <c>Graph:Storage</c>, so the factory is always registered in time.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class SnowflakeStorageProviderAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.Hosting.Snowflake")
+        {
+            Name = "Snowflake storage backend",
+            NodeType = "ModuleDefinition",
+        }
+        .WithGlobalServiceRegistry(services => services.AddSnowflakeStorageFactory()),
+    ];
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/GraphStorageConfig.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/GraphStorageConfig.cs
@@ -2,12 +2,15 @@ namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
 /// Configuration for graph storage.
-/// Supports FileSystem, AzureBlob, and Cosmos storage types.
+/// Supports FileSystem, AzureBlob, PostgreSql, Cosmos and Snowflake storage types.
 /// </summary>
 public record GraphStorageConfig
 {
     /// <summary>
-    /// Storage type: "FileSystem", "AzureBlob", or "Cosmos"
+    /// Storage type: "FileSystem", "AzureBlob", "PostgreSql", "Cosmos" or "Snowflake".
+    /// Cosmos and Snowflake resolve only when their boot pack (MeshWeaver.Hosting.Cosmos /
+    /// .Snowflake) is loaded via <c>Modules:Assemblies</c> — their assembly attribute registers
+    /// the keyed storage factory during module installation, which runs before this selection.
     /// </summary>
     public string Type { get; init; } = "FileSystem";
 

--- a/test/MeshWeaver.Hosting.Cosmos.Test/CosmosBootPackTest.cs
+++ b/test/MeshWeaver.Hosting.Cosmos.Test/CosmosBootPackTest.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Cosmos.Test;
+
+/// <summary>
+/// Pins the boot-pack contract: the Cosmos assembly carries a
+/// <see cref="MeshNodeProviderAttribute"/> whose global service configurations register the
+/// keyed storage factory — so a portal with NO compiled reference resolves
+/// <c>Graph:Storage:Type = Cosmos</c> purely from <c>Modules:Assemblies</c>.
+/// </summary>
+public class CosmosBootPackTest
+{
+    [Fact]
+    public void Assembly_CarriesTheBootAttribute_RegisteringTheKeyedFactory()
+    {
+        var attributes = typeof(CosmosStorageAdapterFactory).Assembly
+            .GetCustomAttributes<MeshNodeProviderAttribute>()
+            .ToList();
+        Assert.NotEmpty(attributes);
+
+        var services = new ServiceCollection();
+        foreach (var configure in attributes
+                     .SelectMany(a => a.Nodes)
+                     .SelectMany(n => n.GlobalServiceConfigurations))
+            configure(services);
+
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(IStorageAdapterFactory)
+            && Equals(d.ServiceKey, CosmosStorageAdapterFactory.StorageType)
+            && d.KeyedImplementationType == typeof(CosmosStorageAdapterFactory));
+    }
+}

--- a/test/MeshWeaver.Hosting.Snowflake.Test/SnowflakeBootPackTest.cs
+++ b/test/MeshWeaver.Hosting.Snowflake.Test/SnowflakeBootPackTest.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Snowflake.Test;
+
+/// <summary>
+/// Pins the boot-pack contract: the Snowflake assembly carries a
+/// <see cref="MeshNodeProviderAttribute"/> whose global service configurations register the
+/// keyed storage factory — so a portal with NO compiled reference resolves
+/// <c>Graph:Storage:Type = Snowflake</c> purely from <c>Modules:Assemblies</c>.
+/// </summary>
+public class SnowflakeBootPackTest
+{
+    [Fact]
+    public void Assembly_CarriesTheBootAttribute_RegisteringTheKeyedFactory()
+    {
+        var attributes = typeof(SnowflakeStorageAdapterFactory).Assembly
+            .GetCustomAttributes<MeshNodeProviderAttribute>()
+            .ToList();
+        Assert.NotEmpty(attributes);
+
+        var services = new ServiceCollection();
+        foreach (var configure in attributes
+                     .SelectMany(a => a.Nodes)
+                     .SelectMany(n => n.GlobalServiceConfigurations))
+            configure(services);
+
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(IStorageAdapterFactory)
+            && Equals(d.ServiceKey, SnowflakeStorageAdapterFactory.StorageType)
+            && d.KeyedImplementationType == typeof(SnowflakeStorageAdapterFactory));
+    }
+}


### PR DESCRIPTION
Wave 2, item 3. Both backends were unreachable in production (no portal ProjectReference — selecting them registered nothing). Each assembly now carries a `MeshNodeProviderAttribute` whose global service registry runs the existing `Add*StorageFactory`, so listing the DLL under `Modules:Assemblies` is all a deployment needs for `Graph:Storage:Type = Cosmos|Snowflake` to resolve. Ordering is safe by construction: `InstallAssemblies` runs before persistence selection reads `Graph:Storage`.

- Factory-mismatch throws (stray module + different storage selected) become actionable config messages naming the fix, replacing the bare 'requires XAdapter'.
- Docs updated (`GraphStorageConfig`, portal composition comment); one boot test per pack pins the attribute-carried keyed-factory registration.

Verified: Release `-warnaserror` green (both test projects + Monolith portal); boot tests 1/1 + 1/1.

No What's New entry: neither backend was reachable before; deployment-config surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)