### PR TITLE
feat: let a plugin configure the portal hub, so it can ship Blazor views

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/PortalApplication.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/PortalApplication.cs
@@ -103,11 +103,17 @@ public class PortalApplication : IDisposable
         // locale and rendered English for a viewer whose profile says otherwise.
         Func<AccessContext?> circuitUser = () => circuitContextAccessor.UserContext;
 
+        // Static contributions first, then the runtime ones. Statically-referenced view packs are
+        // the platform baseline; a plugin registering the same mapping is the more specific choice
+        // and must therefore win, which with last-writer-wins semantics means it applies later.
+        var layoutConfiguration = hub.ServiceProvider.GetRequiredService<ILayoutClient>().Configuration;
+        var contributed = hub.ServiceProvider.GetService<PortalConfigurationRegistry>()?.Current ?? [];
+
         Hub = hub.GetHostedHub(AddressExtensions.CreatePortalAddress(portalId),
             c =>
-                hub.ServiceProvider.GetRequiredService<ILayoutClient>()
-                    .Configuration
+                layoutConfiguration
                     .PortalConfiguration
+                    .AddRange(contributed.Select(contribution => contribution.Configure))
                     .Aggregate(DefaultPortalConfig(c, routingService, navigationService, circuitUser, errorSink),
                         (cc, ccc) => ccc.Invoke(cc)))!;
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -94,6 +94,43 @@ composition roughly **every three days**, and one built-in node type was added a
 favour of its plugin within nine days. When in doubt, lanes 1 and 2 are reversible; lane 3 is a
 permanent tax on the composition root.
 
+### Lane 2b — a plugin contributing views at runtime
+
+A view pack is compiled into the image. A **plugin** is not: its assembly is compiled and loaded at
+NodeType activation, long after the layout client was configured. `WithPortalConfiguration` is how it
+reaches the portal hub anyway.
+
+The portal hub is a different hub from the plugin's own — one per browser circuit — so returning a
+modified config cannot reach it. The delegate is routed instead:
+
+```csharp
+// A NodeType's `configuration` lambda. It configures THIS node's hub; the portal is elsewhere.
+config => config
+    .WithType(typeof(HeatmapControl))
+    .WithPortalConfiguration(portal => portal
+        .WithType(typeof(HeatmapControl))
+        .AddViews(layout => layout.WithView<HeatmapControl, HeatmapView>()))
+```
+
+`HeatmapControl` and `HeatmapView` come from the plugin's own assembly, delivered by its bundle
+(see [PluginPackaging](../PluginPackaging)). From the portal's side nothing is special — it is the same
+`WithView` seam `MeshWeaver.Blazor.Radzen` uses.
+
+Three properties worth knowing, because each is invisible when it bites:
+
+- **Re-registration replaces.** The contribution is keyed by the plugin hub's address, so a
+  recompile — which mints a new collectible `AssemblyLoadContext` — replaces the previous delegate
+  instead of stacking one. Stacking would pin the old ALC against unload *and* put two CLR
+  identities of the same view type into one portal.
+- **It applies to the NEXT portal hub.** A portal hub is configured once, at circuit creation, so a
+  plugin installed mid-session takes effect on the viewer's next page load.
+- **A dropped contribution is logged.** On a headless host (the sidecar, a test mesh with no layout
+  client) there is no portal to configure and the contribution is discarded — with a warning naming
+  the address, because otherwise it presents as a view that simply never renders.
+
+Note the type registration on **both** sides: the control travels between hubs, so each end needs it
+in its `TypeRegistry` or it degrades to an untyped `JsonElement` and the area renders empty.
+
 ## The seams, in one table
 
 | You want to contribute… | Seam | Registered on |
@@ -107,6 +144,7 @@ permanent tax on the composition root.
 | A home-screen tab | a `HomeTab` node | mesh data — no code at all |
 | Hub behaviour for a node type | `MeshNode.HubConfiguration` | works from in-mesh plugins at runtime |
 | Root services + nodes from a DLL | `MeshNodeProviderAttribute` + `MeshBuilder.InstallAssemblies` | boot time only |
+| Portal-hub config from a plugin (incl. views) | `WithPortalConfiguration(portal => …)` | the plugin's own hub configuration — at runtime |
 
 ## What cannot be extended today
 
@@ -117,9 +155,12 @@ Honesty section — these are the known walls, so nobody burns a day rediscoveri
 - **Runtime `.razor` from mesh content.** The in-mesh compile pipeline is C#-only — there is no
   Razor engine at runtime, and collectible recompiles would fight the Blazor renderer's
   type-identity caching. Precompiled packs are the answer, not runtime Razor.
-- **Post-start pack loading.** View-map lists are consulted when a hub builds, but the *sources* of
-  those lists are frozen at startup today. The mutable pack registry that lifts this is planned;
-  until then packs load at boot.
+- **Razor assets from a runtime-loaded assembly.** A plugin can now register views after startup
+  (see below), but an assembly loaded at runtime brings no *static web assets*: an RCL's `wwwroot`
+  is served from a build-time manifest at `_content/<lib>/…`, and `.razor.css` is bundled into
+  `<project>.styles.css` at build. Neither exists for an assembly the image was not built with, so a
+  runtime-contributed view must carry no CSS/JS of its own — inline what it needs, or ship the
+  assets in a compiled pack.
 
 ## Rolling out to deployments
 

--- a/src/MeshWeaver.Documentation/Data/GUI.md
+++ b/src/MeshWeaver.Documentation/Data/GUI.md
@@ -93,4 +93,5 @@ Browse the full set of controls, layout primitives, and data-binding guides:
 | [Reactive Dialogs](ReactiveDialogs) | Modal dialogs backed by observable state |
 | [Node Menu](NodeMenu) | Context menus on mesh nodes |
 | [React Frontend](React) | The client-side React frontend — same `UiControl` contract, rendered in the browser over gRPC-web: running it, rendering, theming, chat, testing |
+| [Custom Blazor Controls](BlazorCustomControls) | Extend the Blazor portal with your own control — a `UiControl` subclass + a `BlazorView`, registered with `WithView`; ships from core, a pack, or a plugin at runtime |
 | [Custom React Controls](ReactCustomControls) | Extend the React renderer with your own control — server-side `$type` + a React registry entry |

--- a/src/MeshWeaver.Documentation/Data/GUI/BlazorCustomControls.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/BlazorCustomControls.md
@@ -1,0 +1,145 @@
+---
+Name: Custom Blazor Controls
+Category: Documentation
+Description: Extend the Blazor portal with your own control — define a UiControl subclass server-side, write a BlazorView that data-binds it, and register the pair with WithView. Ships three ways, including from a plugin at runtime.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M3 9h18"/><path d="M8 13h5"/><path d="M8 4v5"/></svg>
+---
+
+# Custom Blazor Controls
+
+The Blazor portal renders a **`UiControl` tree**: a layout area is delivered as one JSON object with an
+`areas` map (area key → control) and a `data` map (values bindings point at), updated via RFC 7396
+merge-patches. Every control carries a `$type` discriminator, and the renderer dispatches on it to a
+Blazor component.
+
+So extending the portal has exactly two halves — the same two the
+[React renderer](../ReactCustomControls) has:
+
+1. **Server side** — a `UiControl` subclass registered with the hub, so layout areas can emit it.
+2. **Blazor side** — a component registered as the view for that control type.
+
+> **Reach for this last.** A control that composes existing controls (`Controls.Stack`,
+> `DataGrid`, `Controls.Markdown`) works in **every** renderer for free. A custom Blazor view works
+> only in Blazor — the React and MAUI clients render the same tree and will not know your `$type`.
+> Write one when you genuinely need JS interop or a third-party component library; see
+> [Cross-Renderer Authoring](../CrossRendererAuthoring).
+
+## 1. Define the control server-side
+
+A control is a record. It carries data, never rendering:
+
+```csharp
+public record HeatmapControl(object Values) : UiControl<HeatmapControl>(ModuleSetup.ModuleName, ModuleSetup.ApiVersion)
+{
+    public object? ColorScale { get; init; }
+    public HeatmapControl WithColorScale(object scale) => this with { ColorScale = scale };
+}
+```
+
+Properties are `object?` rather than concrete types on purpose: a bound value arrives as a JSON
+pointer to the `data` map, not the value itself, and is resolved per render.
+
+## 2. Write the view
+
+Views derive from `BlazorView<TViewModel, TView>`, which supplies the hub, the synchronization
+stream, the area path, theme and data-context cascades, and disposal. Override `BindData` to wire
+each control property to a field:
+
+```csharp
+public partial class HeatmapView : BlazorView<HeatmapControl, HeatmapView>
+{
+    private object? Values { get; set; }
+    private object? ColorScale { get; set; }
+
+    protected override void BindData()
+    {
+        base.BindData();                       // 🚨 never skip — binds Id, Class, Style
+        DataBind(ViewModel.Values, x => x.Values);
+        DataBind(ViewModel.ColorScale, x => x.ColorScale);
+    }
+}
+```
+
+`DataBind` resolves a JSON pointer against the stream and re-renders on change; it takes an optional
+conversion for values that arrive as `JsonElement`. **Deserialize with
+`Stream.Hub.JsonSerializerOptions`**, never a fresh `JsonSerializerOptions` — the hub's instance is
+the one carrying the `$type` registry, and without it a polymorphic payload degrades to a raw
+`JsonElement` and the view renders empty.
+
+The `.razor` half is an ordinary component:
+
+```razor
+@inherits BlazorView<HeatmapControl, HeatmapView>
+
+@if (Values is not null)
+{
+    <div class="@Class" style="@Style">@* … *@</div>
+}
+```
+
+## 3. Register the pair
+
+One line, on the hub configuration:
+
+```csharp
+public static MessageHubConfiguration AddHeatmap(this MessageHubConfiguration config) =>
+    config.WithType(typeof(HeatmapControl))
+        .AddViews(layout => layout.WithView<HeatmapControl, HeatmapView>());
+```
+
+🚨 **`WithType` is not optional, and it is needed on every hub the control crosses.** The control
+travels as JSON between the hub that emits it and the hub that renders it; a hub whose `TypeRegistry`
+lacks the discriminator hands the renderer an untyped `JsonElement` instead of a `HeatmapControl`. The
+symptom is not an error — the area renders empty, or reports that it cannot be found.
+
+## 4. Ship it — three ways
+
+| Where the view lives | How it registers | When |
+|---|---|---|
+| Core (`MeshWeaver.Blazor`) | in the portal's own composition | platform controls |
+| A compiled **view pack** (a plain class library) | its `Add…Views()` entry point, called at startup | third-party component libraries — `MeshWeaver.Blazor.Radzen` is the reference |
+| A **plugin**, at runtime | `WithPortalConfiguration` from the plugin's own hub config | a module shipping its own UI |
+
+The third is the one that needs explanation. A plugin's assembly is compiled and loaded at NodeType
+activation, long after the layout client was configured — and the portal hub is a *different* hub
+(one per browser circuit), so returning a modified config cannot reach it. The delegate is routed
+instead:
+
+```csharp
+// A NodeType's `configuration` lambda — it configures THIS node's hub; the portal is elsewhere.
+config => config
+    .WithType(typeof(HeatmapControl))
+    .WithPortalConfiguration(portal => portal
+        .WithType(typeof(HeatmapControl))
+        .AddViews(layout => layout.WithView<HeatmapControl, HeatmapView>()))
+```
+
+From the portal's side nothing is special — it is the same `WithView` seam the packs use. See
+[UI Extensibility](/Doc/Architecture/UiExtensibility) for the registry behind it.
+
+## What to know before shipping a runtime view
+
+Each of these is invisible when it bites, which is why they are listed rather than left to discovery:
+
+- **A runtime-loaded assembly brings no static web assets.** An RCL's `wwwroot` is served from a
+  **build-time** manifest at `_content/<lib>/…`, and `.razor.css` is bundled into
+  `<project>.styles.css` at build. Neither exists for an assembly the image was not built with, so a
+  runtime-contributed view must carry no CSS/JS of its own — inline what it needs, or ship it as a
+  compiled pack. (A pack can self-load its script on first render and gate rendering on it, as
+  `RadzenChartView` does with `AssetsReady`.)
+- **A recompile mints a new type.** Every NodeType rebuild loads into a fresh collectible
+  `AssemblyLoadContext`, so "the same" view class is a different CLR type per build. Portal
+  contributions are keyed by owner and **replace** on re-registration for exactly this reason;
+  anything else you hold onto across a rebuild pins the old context against unload.
+- **A contribution applies to the next portal hub.** A portal hub is configured once, at circuit
+  creation, so a plugin installed mid-session takes effect on the viewer's next page load.
+- **Other renderers will not have your control.** React and MAUI dispatch on the same `$type` and
+  need their own component for it — [Custom React Controls](../ReactCustomControls) is the other half.
+
+## Related
+
+[Cross-Renderer Authoring](../CrossRendererAuthoring) ·
+[Custom React Controls](../ReactCustomControls) ·
+[Data Binding](../DataBinding) ·
+[Display Controls](../DisplayControls) ·
+[UI Extensibility](/Doc/Architecture/UiExtensibility)

--- a/src/MeshWeaver.Documentation/Data/GUI/React.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React.md
@@ -65,4 +65,5 @@ Everything — containers, forms, grids, charts, markdown, nav, dialogs, editors
 | [Theming](Theming) | Light/dark/system with the same localStorage contract as Blazor — one preference across both frontends |
 | [Thread Chat](ThreadChat) | The React chat: thread-node watching, message satellites, composer gating, `startThread` / `submitMessage` |
 | [Custom React Controls](../ReactCustomControls) | Extending the renderer with your own control — server-side `UiControl` subclass + a React component for its `$type`, runtime ESM loading |
+| [Custom Blazor Controls](../BlazorCustomControls) | The Blazor half of the same job — a `BlazorView` for the control type |
 | [Testing & Parity](Testing) | The parity ratchet, the vitest suites, and the transport round-trip test |

--- a/src/MeshWeaver.Layout/Client/PortalConfigurationExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/PortalConfigurationExtensions.cs
@@ -1,0 +1,80 @@
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Layout.Client;
+
+/// <summary>
+/// Lets a plugin configure the PORTAL hub from its own hub's configuration — the seam that makes a
+/// plugin able to ship Blazor views.
+/// </summary>
+public static class PortalConfigurationExtensions
+{
+    /// <summary>
+    /// Contributes <paramref name="portalConfiguration"/> to every portal hub built after this call.
+    ///
+    /// <para>Written from a NodeType's <c>configuration</c> lambda, which configures that node's OWN
+    /// hub — the portal hub is a different hub (one per browser circuit), so it cannot be reached by
+    /// returning a modified config. This routes the delegate to it instead:</para>
+    ///
+    /// <code>
+    /// config => config.WithPortalConfiguration(
+    ///     portal => portal.AddViews(layout => layout.WithView&lt;MyControl, MyView&gt;()))
+    /// </code>
+    ///
+    /// <para>🚨 <b>This registers a side effect; it does not modify the returned config.</b> Unlike
+    /// its neighbours it has to, because the portal hub is built elsewhere and later. The
+    /// registration is keyed by this hub's address, so calling it again for the same node — which is
+    /// what a recompile does — REPLACES the previous delegate rather than stacking another one. See
+    /// <see cref="PortalConfigurationRegistry"/> for why appending would pin the old
+    /// <c>AssemblyLoadContext</c> and mix two CLR identities of the same view type.</para>
+    ///
+    /// <para>A contribution applies to portal hubs created AFTER it, so a plugin installed
+    /// mid-session takes effect on the viewer's next page load.</para>
+    ///
+    /// <para>When no <see cref="PortalConfigurationRegistry"/> is reachable the contribution is
+    /// dropped and a warning is logged. Dropping rather than throwing is deliberate — a headless
+    /// host (the sidecar, a test mesh with no layout client) has no portal to configure and a plugin
+    /// must still load there — but it is never SILENT: a dropped contribution otherwise presents as
+    /// a view that simply does not render, with nothing anywhere to say why.</para>
+    /// </summary>
+    /// <param name="config">The plugin's own hub configuration; returned unchanged.</param>
+    /// <param name="portalConfiguration">Applied to each portal hub.</param>
+    public static MessageHubConfiguration WithPortalConfiguration(
+        this MessageHubConfiguration config,
+        Func<MessageHubConfiguration, MessageHubConfiguration> portalConfiguration)
+    {
+        ArgumentNullException.ThrowIfNull(portalConfiguration);
+
+        // The registry lives in the MESH's container, not this hub's — this hub is still being
+        // configured, so its own ServiceProvider does not exist yet.
+        var parent = config.ParentHub;
+        var registry = parent?.ServiceProvider.GetService<PortalConfigurationRegistry>();
+
+        if (registry is null)
+        {
+            parent?.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(PortalConfigurationExtensions))
+                .LogWarning(
+                    "Portal configuration from {Address} was DROPPED: this mesh has no "
+                    + "PortalConfigurationRegistry, so it renders no portal (headless host) or the "
+                    + "layout client was never added. Any view it registers will not appear.",
+                    config.Address);
+            return config;
+        }
+
+        registry.Set(config.Address.ToString(), portalConfiguration);
+        return config;
+    }
+
+    /// <summary>
+    /// Registers the registry. Called by the layout client's configuration so any mesh that renders
+    /// a portal has one, and headless hosts do not.
+    /// </summary>
+    /// <param name="services">The mesh's service collection.</param>
+    public static IServiceCollection AddPortalConfigurationRegistry(this IServiceCollection services)
+    {
+        services.AddSingleton<PortalConfigurationRegistry>();
+        return services;
+    }
+}

--- a/src/MeshWeaver.Layout/Client/PortalConfigurationRegistry.cs
+++ b/src/MeshWeaver.Layout/Client/PortalConfigurationRegistry.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Layout.Client;
+
+/// <summary>
+/// Portal-hub configuration contributed at RUNTIME, by code the image was not built with.
+///
+/// <para><see cref="LayoutClientConfiguration.PortalConfiguration"/> already carries the same shape
+/// of delegate, and <c>PortalApplication</c> folds it into every portal hub. But that list is fixed
+/// when the layout client is configured, so only statically-referenced code — the view packs
+/// compiled into the image — can add to it. A plugin's assembly is compiled and loaded much later,
+/// at NodeType activation, and has no way to participate. This registry is that way.</para>
+///
+/// <para>Together they let a plugin ship Blazor views: its <c>ConfigureHub</c> calls
+/// <see cref="PortalConfigurationExtensions.WithPortalConfiguration"/>, the delegate lands here, and
+/// the next portal hub applies it — the same seam
+/// <c>layout.WithView&lt;ChartControl, RadzenChartView&gt;()</c> uses.</para>
+///
+/// <para>Mesh-scoped singleton: registered in the mesh's container so its lifetime IS the mesh's and
+/// it dies at teardown. Never static — a process-wide registry would leak view registrations (and
+/// the assemblies behind them) across meshes and across tests.</para>
+/// </summary>
+public sealed class PortalConfigurationRegistry
+{
+    /// <summary>
+    /// 🚨 Keyed by OWNER, and a re-registration REPLACES rather than appends. This is what makes
+    /// recompiling a NodeType safe.
+    ///
+    /// <para>Every recompile mints a new collectible <c>AssemblyLoadContext</c>, so the delegate
+    /// registered by build N closes over types from build N's assembly. Appending would leave that
+    /// delegate live: every portal hub created afterwards would keep invoking it, which both pins
+    /// the old ALC against unload (an ALC leak already caused an OOM on memex-cloud) and mixes two
+    /// CLR identities of "the same" view type into one portal. Replacing by owner means the newest
+    /// build is the only one that runs, and the previous delegate becomes garbage.</para>
+    /// </summary>
+    private ImmutableDictionary<string, Func<MessageHubConfiguration, MessageHubConfiguration>> owners
+        = ImmutableDictionary<string, Func<MessageHubConfiguration, MessageHubConfiguration>>.Empty;
+
+    /// <summary>
+    /// Registers (or replaces) <paramref name="configuration"/> for <paramref name="owner"/>.
+    /// </summary>
+    /// <param name="owner">Stable identity of the contributor — the node hub's address, so a
+    /// recompile of the same NodeType reuses the key and replaces its previous delegate.</param>
+    /// <param name="configuration">Applied to every portal hub built after this call.</param>
+    public void Set(string owner, Func<MessageHubConfiguration, MessageHubConfiguration> configuration)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        ImmutableInterlocked.AddOrUpdate(ref owners, owner, configuration, (_, _) => configuration);
+    }
+
+    /// <summary>Drops <paramref name="owner"/>'s contribution, e.g. when its plugin is uninstalled.</summary>
+    /// <param name="owner">The key passed to <see cref="Set"/>.</param>
+    /// <returns>True when a contribution was present and removed.</returns>
+    public bool Remove(string owner) => ImmutableInterlocked.TryRemove(ref owners, owner, out _);
+
+    /// <summary>
+    /// The current contributions, ordered by owner.
+    ///
+    /// <para>Ordered rather than insertion-ordered on purpose: registration order depends on which
+    /// NodeType hub happened to activate first, which varies per pod and per boot. Two replicas
+    /// applying the same set of contributions in different orders would configure their portals
+    /// differently, and the last writer for any one view mapping would differ between them — a
+    /// divergence that shows up as "it renders differently on one pod" with nothing to explain
+    /// it.</para>
+    ///
+    /// <para>A snapshot: a portal hub is configured once at creation, so a contribution registered
+    /// afterwards applies to the NEXT portal hub, not to live ones. In practice that means a plugin
+    /// installed mid-session takes effect on the next page load — reconfiguring a hub that already
+    /// has subscribers is a different and much larger problem.</para>
+    /// </summary>
+    public ImmutableList<PortalContribution> Current =>
+        owners.OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .Select(entry => new PortalContribution(entry.Key, entry.Value))
+            .ToImmutableList();
+
+    /// <summary>The owners currently contributing, ordered — for diagnostics and tests.</summary>
+    public ImmutableList<string> Owners =>
+        owners.Keys.OrderBy(key => key, StringComparer.Ordinal).ToImmutableList();
+}
+
+/// <summary>
+/// One contribution and who made it.
+///
+/// <para>The owner travels WITH the delegate rather than being dropped at the boundary, for two
+/// reasons. It is what a log line needs to answer "which plugin configured this portal" — otherwise
+/// a misbehaving contribution is an anonymous lambda. And it is the key any future per-user
+/// filtering has to select on: which plugins a given viewer may see depends on what is installed and
+/// readable for them, so the consumer must be able to drop contributions by owner without the
+/// registry knowing anything about access.</para>
+/// </summary>
+/// <param name="Owner">The contributor's hub address.</param>
+/// <param name="Configure">The transform applied to a portal hub.</param>
+public sealed record PortalContribution(
+    string Owner,
+    Func<MessageHubConfiguration, MessageHubConfiguration> Configure);

--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -612,7 +612,11 @@ public static class LayoutExtensions
         return config
             .AddData()
             .AddLayoutTypes()
-            .WithServices(services => services.AddSingleton<ILayoutClient, LayoutClient>())
+            .WithServices(services => services
+                .AddSingleton<ILayoutClient, LayoutClient>()
+                // Lives beside ILayoutClient so it is reachable from exactly the meshes that render
+                // a portal, and absent from headless hosts that have none to configure.
+                .AddPortalConfigurationRegistry())
             .AddViews(configuration ?? (x => x))
             .WithSerialization(serialization =>
                 serialization.WithOptions(options =>

--- a/test/MeshWeaver.Layout.Test/PortalConfigurationRegistryTest.cs
+++ b/test/MeshWeaver.Layout.Test/PortalConfigurationRegistryTest.cs
@@ -1,0 +1,132 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// The registry that lets a runtime-loaded plugin configure the portal hub — so it can ship Blazor
+/// views the image was not built with.
+///
+/// <para>Every rule here fails SILENTLY when broken: a lost contribution is a view that does not
+/// render, a duplicated one is an ALC that never unloads, and an unstable order is two replicas
+/// rendering differently. None of them throws anywhere near the cause.</para>
+/// </summary>
+public class PortalConfigurationRegistryTest
+{
+    /// <summary>A delegate distinguishable by identity; the registry never invokes it.</summary>
+    private static Func<MessageHubConfiguration, MessageHubConfiguration> Marker() => c => c;
+
+    [Fact]
+    public void AContributionIsHandedBack()
+    {
+        var registry = new PortalConfigurationRegistry();
+        var contribution = Marker();
+
+        registry.Set("mesh/Plugins/ThreeBody", contribution);
+
+        Assert.Same(contribution, Assert.Single(registry.Current).Configure);
+    }
+
+    [Fact]
+    public void ReRegisteringAnOwnerREPLACESIt()
+    {
+        // 🚨 THE rule. A NodeType recompile mints a NEW collectible AssemblyLoadContext and
+        // re-registers, so the old delegate closes over types from the OLD assembly. Appending
+        // would keep invoking it on every portal hub built afterwards — pinning that ALC against
+        // unload (an ALC leak already caused an OOM on memex-cloud) and putting two CLR identities
+        // of the same view type into one portal.
+        var registry = new PortalConfigurationRegistry();
+        var build1 = Marker();
+        var build2 = Marker();
+
+        registry.Set("mesh/Plugins/ThreeBody", build1);
+        registry.Set("mesh/Plugins/ThreeBody", build2);
+
+        Assert.Same(build2, Assert.Single(registry.Current).Configure);
+    }
+
+    [Fact]
+    public void DifferentOwnersBothContribute()
+    {
+        var registry = new PortalConfigurationRegistry();
+
+        registry.Set("mesh/Plugins/A", Marker());
+        registry.Set("mesh/Plugins/B", Marker());
+
+        Assert.Equal(2, registry.Current.Count);
+        Assert.Equal(["mesh/Plugins/A", "mesh/Plugins/B"], registry.Owners);
+        // The owner travels with the delegate — that is what per-user filtering will select on.
+        Assert.Equal(["mesh/Plugins/A", "mesh/Plugins/B"],
+            registry.Current.Select(contribution => contribution.Owner));
+    }
+
+    [Fact]
+    public void TheOrderDoesNotDependOnRegistrationOrder()
+    {
+        // Registration order is whichever NodeType hub activated first, which varies per pod and
+        // per boot. Two replicas applying the same contributions in different orders would resolve
+        // a contested view mapping differently — "it renders differently on one pod", with nothing
+        // to explain it.
+        var first = new PortalConfigurationRegistry();
+        first.Set("mesh/Plugins/Zulu", Marker());
+        first.Set("mesh/Plugins/Alpha", Marker());
+
+        var second = new PortalConfigurationRegistry();
+        second.Set("mesh/Plugins/Alpha", Marker());
+        second.Set("mesh/Plugins/Zulu", Marker());
+
+        Assert.Equal(first.Owners, second.Owners);
+        Assert.Equal(["mesh/Plugins/Alpha", "mesh/Plugins/Zulu"], first.Owners);
+    }
+
+    [Fact]
+    public void RemovingAnOwnerDropsItsContribution()
+    {
+        var registry = new PortalConfigurationRegistry();
+        registry.Set("mesh/Plugins/Gone", Marker());
+
+        Assert.True(registry.Remove("mesh/Plugins/Gone"));
+        Assert.Empty(registry.Current);
+        Assert.False(registry.Remove("mesh/Plugins/Gone"));
+    }
+
+    [Fact]
+    public void CurrentIsASnapshot()
+    {
+        // A portal hub is configured once, at creation. Handing out a live view would let a
+        // registration that lands mid-configuration change the list being folded.
+        var registry = new PortalConfigurationRegistry();
+        registry.Set("mesh/Plugins/A", Marker());
+
+        var snapshot = registry.Current;
+        registry.Set("mesh/Plugins/B", Marker());
+
+        Assert.Single(snapshot);
+        Assert.Equal(2, registry.Current.Count);
+    }
+
+    [Fact]
+    public void ContributionsFoldInOrderOverTheBaseConfiguration()
+    {
+        // The registry stores transforms; the portal folds them. Pinned here because the fold is
+        // what makes a contribution actually reach a hub, and Aggregate's argument order is easy to
+        // invert with no compile error — the transforms would just run against the wrong seed.
+        var registry = new PortalConfigurationRegistry();
+        var applied = new List<string>();
+
+        registry.Set("mesh/Plugins/A", c => { applied.Add("A"); return c; });
+        registry.Set("mesh/Plugins/B", c => { applied.Add("B"); return c; });
+
+        var seed = new MessageHubConfiguration(null, new Address("test", "portal-config"));
+        var result = ImmutableList<Func<MessageHubConfiguration, MessageHubConfiguration>>.Empty
+            .AddRange(registry.Current.Select(contribution => contribution.Configure))
+            .Aggregate(seed, (config, transform) => transform(config));
+
+        Assert.Equal(["A", "B"], applied);
+        Assert.Same(seed, result);
+    }
+}


### PR DESCRIPTION
## What's New

Category: Feature

A plugin can now configure the **portal hub** — which means it can ship Blazor views the image was not built with.

## The gap

`LayoutClientConfiguration.PortalConfiguration` already holds exactly the right shape, and `PortalApplication` already folds it into every portal hub:

```csharp
public ImmutableList<Func<MessageHubConfiguration, MessageHubConfiguration>> PortalConfiguration { get; init; }
```

But that list is fixed when the layout client is configured, so only view packs compiled into the image (`MeshWeaver.Blazor.Radzen`, `MeshWeaver.GoogleMaps`) can add to it. A plugin's assembly is compiled and loaded at NodeType activation, long after. `UiExtensibility.md` listed this as a known wall — *"the mutable pack registry that lifts this is planned"*. This is that registry.

## Usage

From a NodeType's own `configuration` lambda. The portal hub is a *different* hub (one per browser circuit), so returning a modified config cannot reach it — the delegate is routed instead:

```csharp
config => config
    .WithType(typeof(HeatmapControl))
    .WithPortalConfiguration(portal => portal
        .WithType(typeof(HeatmapControl))
        .AddViews(layout => layout.WithView<HeatmapControl, HeatmapView>()))
```

From the portal's side nothing is special — the same `WithView` seam Radzen uses. The types come from the plugin's own assembly, delivered by its bundle (#1630).

## Three decisions, each guarding a silent failure

- **Re-registration REPLACES, keyed by the contributing hub's address.** A recompile mints a new collectible `AssemblyLoadContext`, so the old delegate closes over types from the old assembly. Appending would keep invoking it on every portal hub built afterwards — pinning that ALC against unload (an ALC leak already caused an OOM on memex-cloud) *and* putting two CLR identities of the same view type into one portal.
- **Ordered by owner, not by registration.** Registration order is whichever NodeType hub activated first, which varies per pod and per boot. Insertion order would let two replicas resolve a contested view mapping differently — "it renders differently on one pod", with nothing to explain it.
- **A dropped contribution is logged.** On a headless host (sidecar, test mesh with no layout client) there is no portal, so the contribution is discarded — with a warning naming the address. Silently dropping presents as a view that simply never renders.

`PortalContribution` carries its `Owner` alongside the delegate: that is what a log line needs to name the plugin, and the key that per-user filtering will select on (a viewer should only get views from what *they* have installed — follow-up).

## Doc

`UiExtensibility.md` gains a worked example (Lane 2b) and a seams-table row. Its "what cannot be extended" section is corrected — the post-start wall is gone, replaced by the one that actually remains: **a runtime-loaded assembly brings no static web assets.** An RCL's `wwwroot` is served from a build-time manifest at `_content/<lib>/…` and `.razor.css` is bundled into `<project>.styles.css` at build, so a runtime-contributed view must carry no CSS/JS of its own.

## Verification

- `dotnet build -c Release -warnaserror` clean on `MeshWeaver.Layout`, `MeshWeaver.Blazor`, `MeshWeaver.Layout.Test`.
- 7 new tests covering replacement-on-recompile, order stability across registration orders, snapshot semantics, removal, and the fold.
- `DocumentationLinkIntegrityTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lo5L8TgTxeANJrUcDLrdSx
