### PR TITLE
Never executed must not say Done

### DIFF
--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -143,6 +143,24 @@ public static class CodeLayoutAreas
         return true;
     }
 
+    /// <summary>
+    /// Whether the recorded run can belong to THIS node at all — i.e. it did not happen before the
+    /// node existed.
+    /// <para>🚨 The partition rule alone is not enough, and the case it misses is the AUTHOR's own.
+    /// A master cell carries the run record of whoever last ran it while writing the course; a
+    /// learner's copy inherits that record wholesale. When author and reader are the SAME person,
+    /// the inherited pointer names their own partition, passes "is it mine", and a copy they have
+    /// never run greets them with <c>✓ Done</c>. Reported live: "when not executed, it still says
+    /// Done — should differentiate between never executed and executed and done."</para>
+    /// <para>A run that happened BEFORE this node was created cannot be a run OF this node. That is
+    /// decidable from the node itself — no extra read, no permission question — and it needs no
+    /// data migration: copies already carrying an inherited record read as unrun immediately.</para>
+    /// <para>An absent timestamp cannot prove inheritance, so it is shown: a node last executed
+    /// before this field existed must not go dark.</para>
+    /// </summary>
+    internal static bool RunPostDatesTheNode(DateTimeOffset created, DateTimeOffset? lastExecutedAt)
+        => lastExecutedAt is null || created == default || lastExecutedAt.Value >= created;
+
     /// <summary>The partition a mesh path lives in — its first segment — or null when it has none.</summary>
     private static string? PartitionOf(string? path)
     {
@@ -202,6 +220,19 @@ public static class CodeLayoutAreas
             .GetEffectivePermissions(host.Hub.Address.ToString())
             .DistinctUntilChanged();
 
+        // The run this cell may DISPLAY, or null when it must read as never-run: the recorded
+        // pointer must be showable here (ShowsRecordedRun) AND post-date the node itself
+        // (RunPostDatesTheNode — an inherited record from before the copy existed is not its run).
+        string? VisibleRunPath(MeshNode? node)
+        {
+            var config = node.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions);
+            var path = config?.LastActivityPath;
+            return ShowsRecordedRun(viewer, host.Hub.Address.Path, path)
+                   && RunPostDatesTheNode(node?.CreatedDate ?? default, config?.LastExecutedAt)
+                ? path
+                : null;
+        }
+
         // The LAST run's live ActivityLog: keyed off the node's LastActivityPath
         // and re-switched whenever a new run stamps a fresh path. Drives the cell
         // toolbar's Cancel visibility reactively — the toolbar re-renders when the
@@ -210,10 +241,10 @@ public static class CodeLayoutAreas
         // re-rendering the whole Content area (the output pane is a live
         // LayoutAreaControl embed and streams its own messages).
         var lastActivityStream = nodeStream
-            .Select(node => node.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions)?.LastActivityPath)
+            .Select(node => VisibleRunPath(node))
             .DistinctUntilChanged()
-            .Select(path => ShowsRecordedRun(viewer, host.Hub.Address.Path, path)
-                ? host.Workspace.GetMeshNodeStream(path!)
+            .Select(path => path is not null
+                ? host.Workspace.GetMeshNodeStream(path)
                     .Select(n => n.ContentAs<ActivityLog>(host.Hub.JsonSerializerOptions))
                 : Observable.Return<ActivityLog?>(null))
             .Switch()
@@ -328,7 +359,9 @@ public static class CodeLayoutAreas
         // under the accent Run button that is the answer to it. Absence says the same thing and
         // says it quieter (maintainer feedback, 2026-08-13). The moment Run is pressed the node
         // gains a LastActivityPath and the pane appears with the live log in it.
-        if (isExecutable && ShowsRecordedRun(viewer, hubAddress.Path, codeConfig?.LastActivityPath))
+        if (isExecutable
+            && ShowsRecordedRun(viewer, hubAddress.Path, codeConfig?.LastActivityPath)
+            && RunPostDatesTheNode(node?.CreatedDate ?? default, codeConfig?.LastExecutedAt))
         {
             const string outputStyle =
                 "width: 100%; box-sizing: border-box; " +

--- a/test/MeshWeaver.Graph.Test/CodeCellOwnRunTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeCellOwnRunTest.cs
@@ -83,4 +83,36 @@ public class CodeCellOwnRunTest
         CodeLayoutAreas.ShowsRecordedRun("alice", "Alice/RiskTransfer/L/Source/C", "bob/_Activity/abc")
             .Should().BeFalse("the copy is still hers when the path is cased differently");
     }
+
+    // ── never executed vs executed-and-done ────────────────────────────────────────────────
+    // "Don't put Done when it was never executed." The partition rule alone cannot see this case:
+    // the AUTHOR copies a course they themselves ran, so the inherited pointer names their OWN
+    // partition and passes every check above.
+
+    private static readonly DateTimeOffset CopyMade = new(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ARunFromBeforeTheNodeExisted_IsNotThisNodesRun()
+        => CodeLayoutAreas.RunPostDatesTheNode(CopyMade, CopyMade.AddHours(-6)).Should().BeFalse(
+            "the copy was made at noon; a run recorded at 06:00 happened on the MASTER and was " +
+            "inherited — the copy has never been executed and must not say Done");
+
+    [Fact]
+    public void ARunAfterTheNodeExists_IsShown()
+        => CodeLayoutAreas.RunPostDatesTheNode(CopyMade, CopyMade.AddMinutes(1)).Should().BeTrue(
+            "this is the learner pressing Run on their own copy — executed and done");
+
+    [Fact]
+    public void TheRunThatCreatedTheRecordAtCreationTime_Counts()
+        => CodeLayoutAreas.RunPostDatesTheNode(CopyMade, CopyMade).Should().BeTrue(
+            "equal timestamps are the boundary, not a violation");
+
+    [Fact]
+    public void NoTimestampAnywhere_StaysVisible()
+    {
+        // Absence cannot prove inheritance: a node executed before LastExecutedAt existed, or one
+        // whose CreatedDate was never stamped, must not go dark.
+        CodeLayoutAreas.RunPostDatesTheNode(CopyMade, null).Should().BeTrue();
+        CodeLayoutAreas.RunPostDatesTheNode(default, CopyMade.AddHours(-6)).Should().BeTrue();
+    }
 }


### PR DESCRIPTION
Reported verbatim, twice: *"when not executed, it still says Done — should differentiate between
never executed and executed and done."*

## Why #1596 did not cover it

That fix gated the recorded run on **whose copy** the cell is. It misses the AUTHOR's own case, which
is the maintainer's every day:

- a master cell carries the run record of whoever last ran it while writing the course — on memex
  every ThinkInStreams master carries `lastExecutedBy: rbuergi`;
- a learner's copy **inherits that record wholesale**;
- when author and reader are the same person, the inherited pointer names their **own** partition,
  passes "is it mine", and a copy they have never run shows `✓ Done`.

## The rule

**A run that happened BEFORE the node existed cannot be a run OF that node.**

Decidable from the node itself — no extra read, no permission question — and it needs **no data
migration**: every copy already carrying an inherited record reads as unrun on the next render.
Absent timestamps stay visible, because absence cannot prove inheritance.

Applied to *both* consumers — the output pane and the toolbar's live `ActivityLog` stream (status
chip + Cancel) — through one `VisibleRunPath` resolver, so the two can never disagree about whether
this cell has been run.

## Tests

`Graph.Test` **1150 passed**, four new cases: inherited-from-master / the learner's own run / the
equal-timestamp boundary / unknown timestamps. `AI.Test` CodeCell* **10 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)