### PR TITLE
feat(modules): the pgvector content-indexing pipeline becomes a module

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -27,7 +27,8 @@
       "MeshWeaver.AI.Copilot.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
-      "MeshWeaver.Blazor.GoogleMaps.dll"
+      "MeshWeaver.Blazor.GoogleMaps.dll",
+      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll"
     ]
   }
 }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -7,7 +7,6 @@ using Memex.Portal.Shared.Instances;
 using Memex.Portal.Shared.SelfUpdate;
 using Memex.Portal.Shared.Settings;
 using Memex.Portal.Shared.Social;
-using MeshWeaver.Hosting.Embeddings;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MeshWeaver.AI;
 using MeshWeaver.Mcp;
@@ -22,9 +21,6 @@ using MeshWeaver.Blazor.Portal.Chat;
 using MeshWeaver.Blazor.Portal.Components;
 using MeshWeaver.Blazor.Portal.Layout;
 using MeshWeaver.ContentCollections;
-using MeshWeaver.ContentCollections.Indexing;
-using MeshWeaver.ContentCollections.Indexing.Graph;
-using MeshWeaver.ContentCollections.Indexing.PostgreSql;
 using MeshWeaver.Documentation;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
@@ -767,37 +763,13 @@ public static class MemexConfiguration
             // editing its module list. Features:Ai flags remain only for the portal-side blocks
             // that co-host CLI processes (Connect, skills sync).
 
-            // Content → vector index (core tech). When embeddings are configured, wire the
-            // upload→Activity indexing pipeline (extract→chunk→embed→store), per-file Document nodes
-            // (extractive summary by default — swap in a chat client for AI summaries), and chunk-search
-            // @-autocomplete. The vector store lives IN THE MESH DATABASE, in each partition's OWN schema
-            // (content_chunks/content_files alongside that partition's mesh_nodes) — no separate database.
-            // Inert when there's no mesh Postgres connection (e.g. the FileSystem monolith) or embeddings
-            // aren't set: it compiles in but never activates.
-            var meshConnectionString = configuration.GetConnectionString("memex");
-            var embeddingsConfigured = !string.IsNullOrWhiteSpace(configuration["Embedding:Endpoint"])
-                && !string.IsNullOrWhiteSpace(configuration["Embedding:ApiKey"]);
-            if (!string.IsNullOrWhiteSpace(meshConnectionString) && embeddingsConfigured)
-            {
-                mb = mb
-                    .AddContentIndexingPipeline(
-                        storeFactory: sp => new PostgreSqlChunkedContentVectorStore(
-                            meshConnectionString,
-                            sp.GetService<IoPoolRegistry>(),
-                            sp.GetRequiredService<IEmbeddingProvider>().Dimensions),
-                        embedderFactory: sp => new EmbeddingProviderChunkEmbedder(
-                            sp.GetRequiredService<IEmbeddingProvider>(),
-                            sp.GetService<IoPoolRegistry>()),
-                        summarizerFactory: _ => new ExtractiveSummarizer(),
-                        // Images have no extractable text: caption them on save with the mesh's default
-                        // (multimodal) chat model so the description is embedded for search AND written
-                        // to the file's Document node. Degrades to no-text when no vision model resolves.
-                        imageDescriberFactory: sp => new ChatClientImageDescriber(
-                            () => sp.GetRequiredService<DefaultChatClientProvider>().TryCreate(),
-                            sp.GetRequiredService<IoPoolRegistry>(),
-                            sp.GetService<ILogger<ChatClientImageDescriber>>()))
-                    .AddContentSearch();
-            }
+            // Content → vector index is a MODULE now (MeshWeaver.ContentCollections.Indexing.
+            // PostgreSql in Modules:Assemblies — PostgresContentIndexingModuleAttribute). Its
+            // activation is decided at RESOLVE time on the same conditions this block used to
+            // check at compose time (mesh Postgres connection + Embedding:Endpoint/ApiKey + a
+            // registered IEmbeddingProvider); unconfigured deployments stay inert exactly as
+            // before. The image describer rides the AI package (AddAgentChatServices TryAdds the
+            // optional IImageDescriber off the default multimodal model).
 
             return (TBuilder)mb
                 .AddSelfRegistry()
@@ -955,9 +927,10 @@ public static class MemexConfiguration
                         // Code workspace tab — on-disk working-tree editor (checkout/edit/commit/push).
                         .AddWorkingTreeTab()
                         // Git history tab — read-only git browser (commit log + changes + diffs) over the same working tree.
-                        .AddGitHistoryTab()
-                        // Content Indexing tab — Space nodes, only when the indexing pipeline is active.
-                        .AddContentIndexSettingsTab();
+                        .AddGitHistoryTab();
+                    // The Content Indexing tab rides the indexing MODULE
+                    // (PostgresContentIndexingModuleAttribute's default-node-hub hook) — it
+                    // appears exactly when the deployment lists the pipeline.
                 })
                 // SignalR mesh transport — external participants (native clients) join over a WebSocket.
                 .AddSignalRHub()

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -9,7 +9,8 @@
       "MeshWeaver.AI.Copilot.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
-      "MeshWeaver.Blazor.GoogleMaps.dll"
+      "MeshWeaver.Blazor.GoogleMaps.dll",
+      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll"
     ]
   },
   // Production logging.

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -205,6 +205,18 @@ public static class AIExtensions
             services.AddTransient<IImageGenerator, ImageGenerator>();
             services.AddTransient<IDescriptionGenerator, DescriptionGenerator>();
 
+            // The content-indexing image describer: an OPTIONAL input to ContentIndexingService
+            // (sp.GetService<IImageDescriber>()), registered from the AI side because captioning
+            // needs the mesh's default multimodal chat model — the indexing module itself carries
+            // no AI dependency. Lazy per call via DefaultChatClientProvider.TryCreate, so "no
+            // vision model" degrades to indexing the image as no-text, never an error.
+            services.TryAddSingleton<DefaultChatClientProvider>();
+            services.TryAddSingleton<MeshWeaver.ContentCollections.Indexing.IImageDescriber>(sp =>
+                new MeshWeaver.ContentCollections.Indexing.Graph.ChatClientImageDescriber(
+                    () => sp.GetRequiredService<DefaultChatClientProvider>().TryCreate(),
+                    sp.GetRequiredService<MeshWeaver.Mesh.Threading.IoPoolRegistry>(),
+                    sp.GetService<Microsoft.Extensions.Logging.ILogger<MeshWeaver.ContentCollections.Indexing.Graph.ChatClientImageDescriber>>()));
+
             // Slash-skills are declarative nodeType:Skill mesh nodes (BuiltInSkillProvider, imported to
             // PG), extensible per Space/NodeType/user via namespace inheritance — there is no C# command
             // registry. See SkillNodeType / SkillAutocompleteProvider.

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -49,6 +49,7 @@
       <ProjectReference Include="..\MeshWeaver.Application.Styles\MeshWeaver.Application.Styles.csproj" />
       <ProjectReference Include="..\MeshWeaver.ContentCollections\MeshWeaver.ContentCollections.csproj" />
       <ProjectReference Include="..\MeshWeaver.ContentCollections.Indexing\MeshWeaver.ContentCollections.Indexing.csproj" />
+      <ProjectReference Include="..\MeshWeaver.ContentCollections.Indexing.Graph\MeshWeaver.ContentCollections.Indexing.Graph.csproj" />
       <ProjectReference Include="..\MeshWeaver.Data.Contract\MeshWeaver.Data.Contract.csproj" />
       <ProjectReference Include="..\MeshWeaver.Data\MeshWeaver.Data.csproj" />
       <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
@@ -38,7 +38,8 @@ public static class ContentIndexingPipelineExtensions
         Func<IServiceProvider, IChunkEmbedder> embedderFactory,
         Func<IServiceProvider, ISummarizer>? summarizerFactory = null,
         ContentIndexingOptions? options = null,
-        Func<IServiceProvider, IImageDescriber>? imageDescriberFactory = null)
+        Func<IServiceProvider, IImageDescriber>? imageDescriberFactory = null,
+        Func<IServiceProvider, bool>? enabledWhen = null)
         where TBuilder : MeshBuilder
     {
         ArgumentNullException.ThrowIfNull(storeFactory);
@@ -81,16 +82,42 @@ public static class ContentIndexingPipelineExtensions
             // single instance is the upload reactor. A plain AddSingleton (not TryAddEnumerable) because
             // the latter cannot dedupe a forwarding factory by implementation type; this extension is
             // called once per host, so idempotency isn't needed.
-            services.AddSingleton<ContentIndexingObserver>(sp => new ContentIndexingObserver(
-                sp.GetRequiredService<IMessageHub>(),
-                sp.GetRequiredService<ContentIndexingService>(),
-                sp.GetService<ILogger<ContentIndexingObserver>>()));
-            services.AddSingleton<IContentUploadObserver>(sp => sp.GetRequiredService<ContentIndexingObserver>());
+            //
+            // enabledWhen is the RESOLVE-TIME activation gate (a boot-loaded module has no
+            // IConfiguration at install time, so the "is this deployment configured for indexing?"
+            // decision cannot be made at registration). Evaluated once, at first resolution:
+            // disabled ⇒ the upload seam gets a no-op observer (uploads proceed, nothing indexes —
+            // the documented inert-when-unconfigured behavior), while resolving the CONCRETE
+            // observer (the GUI's reindex entry point) fails with an actionable message instead of
+            // a bare missing-dependency error from deep inside the store factory.
+            services.AddSingleton<ContentIndexingObserver>(sp =>
+                enabledWhen is null || enabledWhen(sp)
+                    ? new ContentIndexingObserver(
+                        sp.GetRequiredService<IMessageHub>(),
+                        sp.GetRequiredService<ContentIndexingService>(),
+                        sp.GetService<ILogger<ContentIndexingObserver>>())
+                    : throw new InvalidOperationException(
+                        "Content indexing is not active on this deployment: the pipeline's activation " +
+                        "condition is false (typically no mesh database connection string or no " +
+                        "Embedding:Endpoint/Embedding:ApiKey configuration). Configure both to index content."));
+            services.AddSingleton<IContentUploadObserver>(sp =>
+                enabledWhen is null || enabledWhen(sp)
+                    ? sp.GetRequiredService<ContentIndexingObserver>()
+                    : InertContentUploadObserver.Instance);
 
             return services;
         });
 
         return builder;
+    }
+
+    /// <summary>
+    /// The disabled-pipeline stand-in on the upload seam: uploads proceed, nothing indexes.
+    /// </summary>
+    private sealed class InertContentUploadObserver : IContentUploadObserver
+    {
+        public static readonly InertContentUploadObserver Instance = new();
+        public void OnUploaded(string collectionPath, string filePath) { }
     }
 
     /// <summary>

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentIndexingExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentIndexingExtensions.cs
@@ -100,7 +100,9 @@ public static class DocumentIndexingExtensions
     /// <c>Document</c> node. See <c>PostgreSqlSqlGenerator.GenerateVectorSearchQuery</c> /
     /// <c>GenerateCrossSchemaSelectQuery</c>.</para>
     /// </summary>
-    public static TBuilder AddContentSearch<TBuilder>(this TBuilder builder)
+    public static TBuilder AddContentSearch<TBuilder>(
+        this TBuilder builder,
+        Func<IServiceProvider, bool>? enabledWhen = null)
         where TBuilder : MeshBuilder
     {
         builder.ConfigureServices(services =>
@@ -111,14 +113,32 @@ public static class DocumentIndexingExtensions
             // registered for IAutocompleteProvider". Since AddContentSearch is called exactly once per
             // host, a plain AddScoped into the IAutocompleteProvider enumerable is correct (GetServices
             // returns it alongside the concrete-typed providers).
+            //
+            // enabledWhen mirrors AddContentIndexingPipeline's resolve-time activation gate: a
+            // boot-loaded module can't consult IConfiguration at registration, and an unconfigured
+            // deployment must degrade to "no content suggestions", never a missing-store error
+            // surfacing inside the autocomplete aggregator.
             services.AddScoped<IAutocompleteProvider>(sp =>
-                new ContentChunkAutocompleteProvider(
-                    sp.GetRequiredService<IChunkedContentVectorStore>(),
-                    sp.GetRequiredService<IChunkEmbedder>(),
-                    CollectionScopeFromContext));
+                enabledWhen is null || enabledWhen(sp)
+                    ? new ContentChunkAutocompleteProvider(
+                        sp.GetRequiredService<IChunkedContentVectorStore>(),
+                        sp.GetRequiredService<IChunkEmbedder>(),
+                        CollectionScopeFromContext)
+                    : InertAutocompleteProvider.Instance);
             return services;
         });
         return builder;
+    }
+
+    /// <summary>
+    /// The disabled-search stand-in: settles immediately on the empty snapshot (the contract
+    /// forbids <c>Observable.Empty</c>, which would stall the aggregator's CombineLatest).
+    /// </summary>
+    private sealed class InertAutocompleteProvider : IAutocompleteProvider
+    {
+        public static readonly InertAutocompleteProvider Instance = new();
+        public IObservable<IReadOnlyCollection<AutocompleteItem>> GetItems(string query, string? contextPath = null)
+            => System.Reactive.Linq.Observable.Return(AutocompleteSnapshots.Empty);
     }
 
     /// <summary>

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj
@@ -13,6 +13,7 @@
     <!-- The storage-agnostic indexing core (IChunkedContentVectorStore / ContentChunk /
          IChunkEmbedder) this adapter implements. -->
     <ProjectReference Include="..\MeshWeaver.ContentCollections.Indexing\MeshWeaver.ContentCollections.Indexing.csproj" />
+    <ProjectReference Include="..\MeshWeaver.ContentCollections.Indexing.Graph\MeshWeaver.ContentCollections.Indexing.Graph.csproj" />
     <!-- The framework PG hosting project that owns IEmbeddingProvider (the embedder this
          adapter wraps) and the NpgsqlDataSourceBuilder.UseVector() / pgvector DDL patterns
          this schema mirrors. Brings MeshWeaver.Hosting transitively (MessageHubConfiguration). -->

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentIndexingExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentIndexingExtensions.cs
@@ -1,9 +1,13 @@
 using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.ContentCollections.Indexing.Graph;
 using MeshWeaver.Hosting.Embeddings;
 using MeshWeaver.Hosting.PostgreSql;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace MeshWeaver.ContentCollections.Indexing.PostgreSql;
 
@@ -48,5 +52,51 @@ public static class PostgreSqlContentIndexingExtensions
 
             return services;
         });
+    }
+
+    /// <summary>
+    /// One-call wiring of the pgvector-backed content-indexing pipeline + chunk search against the
+    /// MESH database, gated at RESOLVE time on the deployment actually being configured for it —
+    /// the boot-pack entry point (<see cref="PostgresContentIndexingModuleAttribute"/>). The image
+    /// describer is NOT wired here: the AI package registers the optional <c>IImageDescriber</c>
+    /// when present, so this module carries no AI dependency.
+    /// </summary>
+    public static TBuilder AddPostgreSqlContentIndexing<TBuilder>(this TBuilder builder)
+        where TBuilder : MeshBuilder
+        => builder
+            .AddContentIndexingPipeline(
+                storeFactory: sp => new PostgreSqlChunkedContentVectorStore(
+                    MeshConnectionString(sp)
+                        ?? throw new InvalidOperationException(
+                            "Content indexing resolved its store without a mesh database connection — " +
+                            "the enabledWhen gate should have kept it inert."),
+                    sp.GetService<IoPoolRegistry>(),
+                    sp.GetRequiredService<IEmbeddingProvider>().Dimensions),
+                embedderFactory: sp => new EmbeddingProviderChunkEmbedder(
+                    sp.GetRequiredService<IEmbeddingProvider>(),
+                    sp.GetService<IoPoolRegistry>()),
+                // Extractive summary by default — deployments wanting AI summaries swap the
+                // summarizer; images are captioned via the AI package's optional IImageDescriber.
+                summarizerFactory: _ => new ExtractiveSummarizer(),
+                enabledWhen: IsConfigured)
+            .AddContentSearch(IsConfigured);
+
+    /// <summary>
+    /// The mesh database connection: the platform's <c>ConnectionStrings:memex</c> convention,
+    /// falling back to the registered <see cref="NpgsqlDataSource"/> — the SAME chain
+    /// <c>AddPartitionedPostgreSqlPersistence</c> resolves with, so the chunks land in the mesh
+    /// database the nodes live in.
+    /// </summary>
+    private static string? MeshConnectionString(IServiceProvider sp)
+        => sp.GetService<IConfiguration>()?.GetConnectionString("memex")
+           ?? sp.GetService<NpgsqlDataSource>()?.ConnectionString;
+
+    private static bool IsConfigured(IServiceProvider sp)
+    {
+        var configuration = sp.GetService<IConfiguration>();
+        return !string.IsNullOrWhiteSpace(MeshConnectionString(sp))
+            && !string.IsNullOrWhiteSpace(configuration?["Embedding:Endpoint"])
+            && !string.IsNullOrWhiteSpace(configuration?["Embedding:ApiKey"])
+            && sp.GetService<IEmbeddingProvider>() is not null;
     }
 }

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgresContentIndexingModuleAttribute.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgresContentIndexingModuleAttribute.cs
@@ -1,0 +1,39 @@
+using MeshWeaver.ContentCollections.Indexing.Graph;
+using MeshWeaver.Hosting.Embeddings;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+[assembly: MeshWeaver.ContentCollections.Indexing.PostgreSql.PostgresContentIndexingModule]
+
+namespace MeshWeaver.ContentCollections.Indexing.PostgreSql;
+
+/// <summary>
+/// Module registration for the pgvector content-indexing pipeline. Listing this DLL under
+/// <c>Modules:Assemblies</c> wires the full upload→extract→chunk→embed→store pipeline, the
+/// per-file <c>Document</c> nodes, and the <c>@document</c> chunk autocomplete — the vector store
+/// living in each partition's OWN schema of the mesh database.
+///
+/// <para><b>Activation is decided at RESOLVE time, not install time</b>: a module has no
+/// <c>IConfiguration</c> when its attribute folds in, so the pipeline registers with the
+/// <c>enabledWhen</c> gate — active only when the mesh database connection resolves AND
+/// <c>Embedding:Endpoint</c>/<c>Embedding:ApiKey</c> are configured AND an
+/// <see cref="IEmbeddingProvider"/> is registered. Unconfigured deployments (e.g. the FileSystem
+/// monolith) stay inert: uploads proceed unindexed and content autocomplete settles empty —
+/// never a missing-store error.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class PostgresContentIndexingModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations =>
+        [builder => builder.AddPostgreSqlContentIndexing()];
+
+    /// <summary>
+    /// The Content Indexing settings tab on every per-node hub — riding the module so the tab
+    /// appears exactly when the deployment lists the pipeline (its layout area self-gates on the
+    /// node shape; an unconfigured-but-listed deployment shows it and the reindex entry point
+    /// fails with the actionable configuration message).
+    /// </summary>
+    public override IEnumerable<Func<MessageHubConfiguration, MessageHubConfiguration>> DefaultNodeHubConfigurations =>
+        [config => config.AddContentIndexSettingsTab()];
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/IndexingBootPackTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/IndexingBootPackTest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Indexing.PostgreSql.Test;
+
+/// <summary>
+/// Pins the boot-pack contract of the pgvector content-indexing module: installing the assembly
+/// via <see cref="MeshBuilder.InstallAssemblies"/> (the <c>Modules:Assemblies</c> path) registers
+/// the pipeline with its RESOLVE-TIME activation gate — an unconfigured deployment resolves an
+/// inert upload observer (uploads proceed unindexed) instead of faulting on a missing store.
+/// </summary>
+public class IndexingBootPackTest
+{
+    private static IServiceCollection InstallModule()
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+        builder.InstallAssemblies(typeof(PostgresContentIndexingModuleAttribute).Assembly.Location);
+        return serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+    }
+
+    [Fact]
+    public void TheAttribute_CarriesTheBuilderHook()
+    {
+        var attributes = typeof(PostgresContentIndexingModuleAttribute).Assembly
+            .GetCustomAttributes<MeshNodeProviderAttribute>()
+            .ToList();
+        Assert.Contains(attributes, a => a.BuilderConfigurations.Any());
+    }
+
+    [Fact]
+    public void Unconfigured_ResolvesAnInertUploadObserver()
+    {
+        var services = InstallModule();
+        // An empty configuration — no connection string, no embeddings: the gate must hold.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        using var provider = services.BuildServiceProvider();
+
+        var observer = provider.GetRequiredService<IContentUploadObserver>();
+        // The inert stand-in: uploading indexes nothing and throws nothing.
+        observer.OnUploaded("part/content", "docs/note.txt");
+        Assert.DoesNotContain("ContentIndexingObserver", observer.GetType().Name);
+    }
+
+    [Fact]
+    public void Unconfigured_ReindexEntryPoint_FailsActionably()
+    {
+        var services = InstallModule();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        using var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => provider.GetRequiredService<Graph.ContentIndexingObserver>());
+        Assert.Contains("Embedding:Endpoint", ex.Message);
+    }
+}


### PR DESCRIPTION
Wave-3 #2 — the one Wave-2 boot-pack verdict that was never executed, now on the module lane:

- **`PostgresContentIndexingModuleAttribute`**: `BuilderConfigurations` → `AddPostgreSqlContentIndexing()` (pipeline + chunk search); `DefaultNodeHubConfigurations` → the Content Indexing settings tab — the whole feature arrives and leaves with one `Modules:Assemblies` line.
- **Compose-time gate → resolve-time `enabledWhen`** on `AddContentIndexingPipeline`/`AddContentSearch` (a module has no IConfiguration at install). Unconfigured deployments stay inert exactly as before: inert upload observer, empty-snapshot autocomplete (the aggregator contract forbids `Observable.Empty`), actionable error on the reindex entry point. Connection resolution mirrors `AddPartitionedPostgreSqlPersistence`'s own `ConnectionStrings:memex ?? NpgsqlDataSource` chain.
- **AI decoupling**: `AddAgentChatServices` TryAdds the optional `IImageDescriber` off the default multimodal model — `ContentIndexingService` already treated it as optional — so the indexing module carries no AI dependency and image captioning pairs with AI presence, same as the old inline wiring.
- Portal's inline block + usings removed; ProjectReferences stay (publish output); both hosts list the module.

Verified: all four src projects + both test projects `-c Release -warnaserror` clean; `Indexing.PostgreSql.Test` 8/8 (new `IndexingBootPackTest`: install fold, inert-when-unconfigured, actionable reindex failure); `Indexing.Graph.Test` 32/32.

No What's New entry: no user-visible change — configured deployments index exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)