### PR TITLE
feat(modules): Speech becomes a module; OpenAI model discovery rides its provider module

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -177,6 +177,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Orleans.Core" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.2.2" />

--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -28,7 +28,8 @@
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
-      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll"
+      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
+      "MeshWeaver.Speech.dll"
     ]
   }
 }

--- a/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
@@ -47,11 +47,15 @@ public static class SpeechEndpoints
     }
 
     private static async Task<IResult> HandleTranscribe(
-        HttpContext http, ISpeechTranscriber transcriber, CancellationToken ct)
+        HttpContext http, CancellationToken ct)
     {
+        // OPTIONAL resolution: the transcriber ships as a module (MeshWeaver.Speech in
+        // Modules:Assemblies) — a deployment without it must answer the same 503 as an
+        // unconfigured one, never a missing-service 500.
+        var transcriber = http.RequestServices.GetService(typeof(ISpeechTranscriber)) as ISpeechTranscriber;
         // Off/unset => tell the caller plainly rather than 500. The mic UI also checks IsConfigured
         // (via /api/mesh base-url / config) and stays hidden, so this is a belt-and-suspenders guard.
-        if (!transcriber.IsConfigured)
+        if (transcriber is null || !transcriber.IsConfigured)
             return Results.Json(
                 new { error = "Speech transcription is not configured (no Whisper endpoint, or disabled)." },
                 statusCode: StatusCodes.Status503ServiceUnavailable);

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -10,7 +10,6 @@ using Memex.Portal.Shared.Social;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MeshWeaver.AI;
 using MeshWeaver.Mcp;
-using MeshWeaver.Speech;
 using MeshWeaver.Blazor.Graph;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Hosting.Grpc;
@@ -268,15 +267,11 @@ public static class MemexConfiguration
         // ModelProviderService backs the Models settings tab — users store
         // their own AI provider credentials as MeshNodes in their namespace.
         services.AddSingleton<Memex.Portal.Shared.Models.ModelProviderService>();
-        // ProviderModelLister fetches a provider's live model list (HTTP /models via
-        // the I/O pool) so the add-provider flow lets users pick which models to bring.
-        services.AddSingleton<Memex.Portal.Shared.Models.ProviderModelLister>();
-        // OpenAI-compatible (Ollama) auto-discovery — keeps the OpenAICompatible provider's
-        // LanguageModel catalog in sync with the models installed on its endpoint, so a locally
-        // pulled model shows up in the picker without editing OpenAICompatible:Models[]. Opt-in
-        // (OpenAICompatible:DiscoverModels=true) and inert otherwise; only when the provider is on.
-        if (features.Ai.Providers.OpenAICompatible)
-            services.AddHostedService<Memex.Portal.Shared.Models.OpenAICompatibleModelSync>();
+        // ProviderModelLister moved to MeshWeaver.AI (AddAgentChatServices registers it) — the
+        // add-provider flow and the OpenAI module's model-discovery sync both resolve it there.
+        // OpenAI-compatible (Ollama) model auto-discovery rides the MeshWeaver.AI.OpenAI MODULE
+        // now (OpenAIProvidersAttribute registers the hosted sync; it self-gates on
+        // OpenAICompatible:Endpoint + DiscoverModels=true) — nothing to register here.
 
         // GitHub sync — per-user OAuth credential (device flow) + bidirectional
         // Space ↔ GitHub sync (export = "sync back"; import = create / re-import a
@@ -453,11 +448,11 @@ public static class MemexConfiguration
         // multipart upload size cap. See MeshApiEndpoints.
         services.AddMeshApi();
 
-        // Centralized speech-to-text: registers ISpeechTranscriber (the Whisper container client)
-        // and binds the `Speech` config section (Endpoint/Language/Enabled). The client-facing
-        // POST /api/speech/transcribe endpoint (MapSpeechApi) forwards audio to the container, so
-        // the model host stays behind portal auth. See Doc/Architecture/CentralizedSpeech.
-        services.AddSpeechTranscription(builder.Configuration);
+        // Centralized speech-to-text is a MODULE now (MeshWeaver.Speech in Modules:Assemblies —
+        // SpeechModuleAttribute binds the `Speech` section via the options pipeline and registers
+        // ISpeechTranscriber). The compiled surface degrades without it: the mic UI resolves the
+        // transcriber optionally and hides, and POST /api/speech/transcribe answers 503. See
+        // Doc/Architecture/CentralizedSpeech.
     }
 
     /// <summary>

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -10,7 +10,8 @@
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
-      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll"
+      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
+      "MeshWeaver.Speech.dll"
     ]
   },
   // Production logging.

--- a/src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj
+++ b/src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
   </ItemGroup>

--- a/src/MeshWeaver.AI.OpenAI/OpenAICompatibleModelSync.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenAICompatibleModelSync.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Memex.Portal.Shared.Models;
+namespace MeshWeaver.AI.OpenAI;
 
 /// <summary>
 /// Keeps the <c>OpenAICompatible</c> provider's <c>LanguageModel</c> catalog in sync with the models
@@ -36,7 +36,7 @@ namespace Memex.Portal.Shared.Models;
 ///     system identity — mirrors <c>EventSubscriptionRunner</c>.</item>
 ///   <item>Writes go through <see cref="IMeshService.CreateOrUpdateNode"/> (idempotent upsert — race-free
 ///     re-runs) and <see cref="IMeshService.DeleteNode"/>. The child nodes match the platform shape
-///     <see cref="ModelProviderService"/> emits (<c>ProviderRef</c> → the parent provider node, no key on
+///     <c>ModelProviderService</c> emits (<c>ProviderRef</c> → the parent provider node, no key on
 ///     the child), so the chat-client factory resolves credentials the same way.</item>
 /// </list>
 /// </para>

--- a/src/MeshWeaver.AI.OpenAI/OpenAIProvidersAttribute.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenAIProvidersAttribute.cs
@@ -37,6 +37,12 @@ public sealed class OpenAIProvidersAttribute : MeshNodeProviderAttribute
             services.AddOptions<OpenAIConfiguration>().BindConfiguration("OpenAI");
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IChatClientFactory, OpenAIChatClientAgentFactory>());
+            // Endpoint model discovery for the OpenAI-compatible provider (GET /v1/models →
+            // ModelDefinition nodes). Formerly a flag-gated portal registration
+            // (Features:Ai:Providers:OpenAICompatible) — riding the module now: it self-gates on
+            // OpenAICompatible:Endpoint + the opt-in DiscoverModels flag, so listing the module
+            // without that config keeps it inert.
+            services.AddHostedService<OpenAICompatibleModelSync>();
             return services.AddAzureOpenAI().AddOpenAICompatible().AddOpenRouter();
         }),
     ];

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -205,6 +205,11 @@ public static class AIExtensions
             services.AddTransient<IImageGenerator, ImageGenerator>();
             services.AddTransient<IDescriptionGenerator, DescriptionGenerator>();
 
+            // Live provider model listing (HTTP /models via the I/O pool) — the add-provider
+            // flow and the OpenAI module's model-discovery sync both resolve it. Formerly a
+            // portal-local registration.
+            services.TryAddSingleton<ProviderModelLister>();
+
             // The content-indexing image describer: an OPTIONAL input to ContentIndexingService
             // (sp.GetService<IImageDescriber>()), registered from the AI side because captioning
             // needs the mesh's default multimodal chat model — the indexing module itself carries

--- a/src/MeshWeaver.AI/ProviderModelLister.cs
+++ b/src/MeshWeaver.AI/ProviderModelLister.cs
@@ -6,7 +6,7 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Memex.Portal.Shared.Models;
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Fetches the <b>live model list</b> from a provider's HTTP API so the

--- a/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
+++ b/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />

--- a/src/MeshWeaver.Speech/SpeechModuleAttribute.cs
+++ b/src/MeshWeaver.Speech/SpeechModuleAttribute.cs
@@ -1,0 +1,30 @@
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: MeshWeaver.Speech.SpeechModule]
+
+namespace MeshWeaver.Speech;
+
+/// <summary>
+/// Module registration for centralized speech-to-text. Listing this DLL under
+/// <c>Modules:Assemblies</c> registers the Whisper-container <see cref="ISpeechTranscriber"/>,
+/// binding <see cref="SpeechConfiguration"/> from the host's <c>Speech</c> section through the
+/// options pipeline. Unconfigured deployments stay inert (<see cref="ISpeechTranscriber.IsConfigured"/>
+/// false ⇒ the mic UI hides and <c>POST /api/speech/transcribe</c> answers 503); a deployment
+/// WITHOUT the module behaves identically — the endpoint and the chat view both resolve the
+/// transcriber optionally.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class SpeechModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.Speech")
+        {
+            Name = "Speech transcription",
+            NodeType = "ModuleDefinition",
+        }
+        .WithGlobalServiceRegistry(services => services.AddSpeechTranscriptionFromConfiguration()),
+    ];
+}

--- a/src/MeshWeaver.Speech/SpeechServiceExtensions.cs
+++ b/src/MeshWeaver.Speech/SpeechServiceExtensions.cs
@@ -10,6 +10,19 @@ namespace MeshWeaver.Speech;
 public static class SpeechServiceExtensions
 {
     /// <summary>
+    /// The module-lane registration: binds <see cref="SpeechConfiguration"/> from the host's
+    /// <c>Speech</c> section through the OPTIONS pipeline (no <see cref="IConfiguration"/> is in
+    /// reach at module-install time) and registers the transcriber. Unconfigured deployments stay
+    /// inert: <see cref="ISpeechTranscriber.IsConfigured"/> is false, the mic UI hides, and the
+    /// transcribe endpoint answers 503.
+    /// </summary>
+    public static IServiceCollection AddSpeechTranscriptionFromConfiguration(this IServiceCollection services)
+    {
+        services.AddOptions<SpeechConfiguration>().BindConfiguration(SpeechConfiguration.SectionName);
+        return services.AddSpeechTranscription();
+    }
+
+    /// <summary>
     /// Binds <see cref="SpeechConfiguration"/> from the <c>Speech</c> section and registers a singleton
     /// <see cref="ISpeechTranscriber"/> backed by the Whisper container. Config is read live via
     /// <see cref="IOptionsMonitor{T}"/>, so a portal edit (reloaded config) takes effect without a restart.

--- a/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
+++ b/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.OpenAI;
 using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using Microsoft.Extensions.Configuration;

--- a/test/Memex.Portal.Shared.Test/SpeechModuleTest.cs
+++ b/test/Memex.Portal.Shared.Test/SpeechModuleTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Speech;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the speech + OpenAI-module residual lanes: installing the DLLs via
+/// <see cref="MeshBuilder.InstallAssemblies"/> registers the Whisper transcriber (inert when the
+/// <c>Speech</c> section is unconfigured — the mic UI hides and the endpoint 503s) and the
+/// OpenAI-compatible model-discovery hosted sync (self-gating on its endpoint config).
+/// </summary>
+public class SpeechModuleTest
+{
+    private static IServiceCollection Install(params Type[] anchors)
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+        builder.InstallAssemblies(anchors.Select(t => t.Assembly.Location).Distinct().ToArray());
+        return serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+    }
+
+    [Fact]
+    public void SpeechModule_RegistersTheTranscriber_InertWhenUnconfigured()
+    {
+        var services = Install(typeof(SpeechModuleAttribute));
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        using var provider = services.BuildServiceProvider();
+
+        var transcriber = provider.GetRequiredService<ISpeechTranscriber>();
+        Assert.False(transcriber.IsConfigured);
+    }
+
+    [Fact]
+    public void OpenAIModule_CarriesTheModelDiscoverySync()
+    {
+        var services = Install(typeof(MeshWeaver.AI.OpenAI.OpenAICompatibleModelSync));
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(IHostedService)
+            && d.ImplementationType == typeof(MeshWeaver.AI.OpenAI.OpenAICompatibleModelSync));
+    }
+}


### PR DESCRIPTION
Wave-3 #4 — the self-contained residuals onto the module lane:

- **Speech**: `SpeechModuleAttribute` binds the `Speech` section via the options pipeline and registers `ISpeechTranscriber`. Module-absent degrades identically to unconfigured: the mic UI already resolved optionally and hides; `POST /api/speech/transcribe` now resolves optionally and answers the same 503 (never a missing-service 500). Both hosts list the DLL.
- **`OpenAICompatibleModelSync`** moves into `MeshWeaver.AI.OpenAI` and registers on its existing module attribute — the last flag-gated provider bit leaves the portal (self-gates on `OpenAICompatible:Endpoint` + `DiscoverModels`). **`ProviderModelLister`** moves to `MeshWeaver.AI` (framework-only deps; `AddAgentChatServices` registers it) — the add-provider flow and the sync share it.
- **`GoogleMapsConfiguration` relocation → WONTFIX**: packs stay in-image, so a Contract project for one config record is over-engineering; the documented note in `MeshWeaver.Maps` stands.
- Also falsified this wave (recorded, not attempted): GitSync/InstanceSync as modules — their services are platform infrastructure (PluginCatalog registry sync, red-log filer) and the compiled HTTP endpoints inject concrete types; endpoints have no contribution seam.

Verified: all four projects `-c Release -warnaserror` clean · `SpeechModuleTest` 2/2 · `OpenAICompatibleModelSyncTest` 38/38 post-move.

No What's New entry: no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)