### PR TITLE
feat(modules): complete the lane switch — Markdown.Export + Observability activate via Modules:Assemblies

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -29,7 +29,9 @@
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
       "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
-      "MeshWeaver.Speech.dll"
+      "MeshWeaver.Speech.dll",
+      "MeshWeaver.Markdown.Export.dll",
+      "MeshWeaver.Observability.dll"
     ]
   }
 }

--- a/memex/Memex.Portal.Shared/Api/LogIncidentEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/LogIncidentEndpoints.cs
@@ -51,12 +51,22 @@ public static class LogIncidentEndpoints
 
         // AllowAnonymous at the ASP.NET auth layer: the caller is a cluster service, not a
         // signed-in user, so the user auth schemes do not apply. The shared secret below IS the gate.
+        // The ingest seam resolves OPTIONALLY: the engine rides the MeshWeaver.Observability
+        // module, so "token configured but module not listed" must answer an actionable 503,
+        // never a missing-service 500.
         endpoints.MapPost(Route, (
                     HttpContext http,
                     LogIncidentReport report,
-                    ILogIncidentIngest ingest,
                     CancellationToken ct) =>
-                Ingest(http, report, ingest, expected, logger, ct))
+                {
+                    var ingest = http.RequestServices.GetService(typeof(ILogIncidentIngest)) as ILogIncidentIngest;
+                    if (ingest is null)
+                        return Task.FromResult(Results.Json(
+                            new { error = "Red-log ingest is not active: LogWatch:IngestToken is configured but the " +
+                                          "MeshWeaver.Observability module is not listed under Modules:Assemblies." },
+                            statusCode: StatusCodes.Status503ServiceUnavailable));
+                    return Ingest(http, report, ingest, expected, logger, ct);
+                })
             .AllowAnonymous();
 
         logger?.LogInformation("Red-log ingest mapped at {Route}.", Route);

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -24,11 +24,9 @@ using MeshWeaver.Documentation;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
-using MeshWeaver.Observability;
 using MeshWeaver.PluginCatalog;
 using MeshWeaver.InstanceSync;
 using MeshWeaver.Graph.Configuration;
-using MeshWeaver.Markdown.Export.Configuration;
 using MeshWeaver.Hosting.AzureBlob;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Blazor;
@@ -693,11 +691,12 @@ public static class MemexConfiguration
                 // admin tab installs from PluginCatalog:RegistryUrl. The options carry the consumer's
                 // registry URL/ref (empty RegistryUrl -> the tab shows a "not configured" note).
                 .AddPluginCatalog()
-                // Red-log ticketing: the LogIncident node type plus the ingest/triage/file control
-                // plane. The DETECTOR is not here — it is a separate service in the cluster's
-                // monitoring namespace that polls Loki and POSTs to /api/log-incidents, so it keeps
-                // working when the portal is the thing throwing errors (Doc/Architecture/LogWatchTriage.md).
-                .AddLogWatch(configuration)
+                // Red-log ticketing rides the MeshWeaver.Observability MODULE
+                // (ObservabilityProviderAttribute → AddLogWatch(); LogWatchOptions binds through
+                // the options pipeline). The DETECTOR is not here either way — it is a separate
+                // service in the cluster's monitoring namespace that polls Loki and POSTs to
+                // /api/log-incidents (Doc/Architecture/LogWatchTriage.md); the compiled endpoint
+                // resolves the ILogIncidentIngest Contract seam optionally.
                 // Bind the whole section so the multi-registry list (PluginCatalog:Registries:N:*)
                 // binds alongside the legacy single RegistryUrl/RegistryRef pair.
                 .ConfigureServices(pcs => pcs.AddSingleton(
@@ -778,7 +777,9 @@ public static class MemexConfiguration
                 // types); off the thread pool so it never blocks startup.
                 .ConfigureServices(services =>
                     services.AddHostedService<ShippedReleaseSeedHostedService>())
-                .AddMarkdownExport()
+                // Markdown export (PDF/DOCX/HTML + share-by-email) rides the
+                // MeshWeaver.Markdown.Export MODULE (MarkdownExportProviderAttribute →
+                // AddMarkdownExport(); node seeding is IfAbsent so the lane switch is idempotent).
                 // Register Azure Blob support for content collections.
                 .ConfigureServices(services => services.AddAzureBlob())
                 // Shared NodeType assembly cache (versioned, cross-replica consistent).

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -11,7 +11,9 @@
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
       "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
-      "MeshWeaver.Speech.dll"
+      "MeshWeaver.Speech.dll",
+      "MeshWeaver.Markdown.Export.dll",
+      "MeshWeaver.Observability.dll"
     ]
   },
   // Production logging.

--- a/test/Memex.Portal.Shared.Test/ModuleLaneSwitchTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleLaneSwitchTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Markdown.Export;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Observability;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the completed lane switch for Markdown.Export + Observability: the portal no longer makes
+/// the compiled <c>AddMarkdownExport()</c>/<c>AddLogWatch()</c> calls — listing the DLLs under
+/// <c>Modules:Assemblies</c> is the complete activation, folding the SAME registrations through
+/// each assembly's <see cref="MeshNodeProviderAttribute"/>.
+/// </summary>
+public class ModuleLaneSwitchTest
+{
+    private static IServiceCollection Install(params Type[] anchors)
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+        builder.InstallAssemblies(anchors.Select(t => t.Assembly.Location).Distinct().ToArray());
+        return serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+    }
+
+    [Fact]
+    public void MarkdownExportModule_FoldsTheEngineRegistrations()
+    {
+        var services = Install(typeof(MarkdownExportTemplates));
+        Assert.Contains(services, d => d.ServiceType == typeof(MarkdownExportConfig));
+        // Both kernel-script assembly registrations (engine + contract) ride the fold.
+        var scriptAssemblies = services
+            .Where(d => d.ServiceType == typeof(MeshWeaver.Kernel.Hub.KernelScriptAssembly))
+            .Select(d => ((MeshWeaver.Kernel.Hub.KernelScriptAssembly)d.ImplementationInstance!).Assembly)
+            .ToList();
+        Assert.Contains(typeof(MarkdownExportTemplates).Assembly, scriptAssemblies);
+        Assert.Contains(typeof(MeshWeaver.Markdown.Export.Messaging.RenderedDocument).Assembly, scriptAssemblies);
+    }
+
+    [Fact]
+    public void ObservabilityModule_FoldsTheIngestSeam()
+    {
+        var services = Install(typeof(LogIncidentIngestService));
+        Assert.Contains(services, d => d.ServiceType == typeof(LogIncidentIngestService));
+        Assert.Contains(services, d => d.ServiceType == typeof(ILogIncidentIngest));
+        Assert.Contains(services, d => d.ServiceType == typeof(LogIncidentControlPlane));
+    }
+}


### PR DESCRIPTION
Wave-4 #1 — closes the half-done state from #1631 (attributes shipped, compiled calls remained):

- Portal drops `.AddMarkdownExport()` + `.AddLogWatch(configuration)`; both hosts list `MeshWeaver.Markdown.Export.dll` + `MeshWeaver.Observability.dll` — the attributes fold the SAME registrations (one code path).
- `MapLogIncidents` hardens to the Speech pattern: optional `ILogIncidentIngest` resolve ⇒ actionable 503 for token-set-but-module-missing, never a 500.
- `ModuleLaneSwitchTest` 2/2 pins both install folds.

No What's New: no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)