### PR TITLE
feat(ws7): UiContribution — menu entries as plugin content, gated in compiled code

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/GlobalSettingsMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GlobalSettingsMenuItemsExtensions.cs
@@ -1,8 +1,10 @@
 using System.Reactive.Linq;
 using MeshWeaver.Application.Styles;
+using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -55,12 +57,22 @@ public static class GlobalSettingsMenuItemsExtensions
             RenderingContext ctx)
     {
         var collection = config.Get<GlobalSettingsMenuProviderCollection>();
-        if (collection == null || collection.Providers.Count == 0)
-            return Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>([]);
+        var providerDelegates = collection?.Providers
+            ?? (IReadOnlyList<GlobalSettingsMenuItemProvider>)[];
 
-        var streams = collection.Providers.Select(provider =>
+        var streams = providerDelegates.Select(provider =>
             // Skip failing providers so one broken tab can't crash all settings.
             provider(host, ctx).Catch<IReadOnlyList<GlobalSettingsMenuItemDefinition>, Exception>(
+                _ => Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>([])))
+            .ToList();
+
+        // Data-contributed tabs (UiContribution nodes with Context = Settings, design #1645): the
+        // tab's content is the contributed layout area, embedded generically; gating happens HERE
+        // in compiled code — an authenticated viewer always, plus the reactive IsGlobalAdmin
+        // stream when the contribution declares AdminOnly. Node-level RequiredPermission has no
+        // node to bind to on the global settings surface and is deliberately ignored here.
+        streams.Add(ContributedSettingsTabs(host)
+            .Catch<IReadOnlyList<GlobalSettingsMenuItemDefinition>, Exception>(
                 _ => Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>([])));
 
         return Observable.CombineLatest(streams)
@@ -70,6 +82,32 @@ public static class GlobalSettingsMenuItemsExtensions
                 items.Sort((a, b) => a.Order.CompareTo(b.Order));
                 return (IReadOnlyList<GlobalSettingsMenuItemDefinition>)items;
             });
+    }
+
+    /// <summary>
+    /// The DATA-contributed settings tabs: every <see cref="UiContribution"/> in the shared
+    /// mesh-scoped catalog declaring <see cref="UiContribution.SettingsContext"/>, gated in
+    /// compiled code — an authenticated, non-virtual viewer always (the settings surface fails
+    /// closed for anonymous), plus the live <c>IsGlobalAdmin</c> stream for
+    /// <see cref="UiContributionGates.AdminOnly"/>. The tab's content is the contributed layout
+    /// area embedded generically, so contributions never introduce a render surface (#1645).
+    /// </summary>
+    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>>
+        ContributedSettingsTabs(LayoutAreaHost host)
+    {
+        var catalog = host.Hub.ServiceProvider.GetService<UiContributionCatalog>();
+        if (catalog is null)
+            return Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>([]);
+
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var viewer = accessService?.Context ?? accessService?.CircuitContext;
+        var isAuthenticated = !string.IsNullOrEmpty(viewer?.ObjectId) && viewer?.IsVirtual != true;
+        if (!isAuthenticated)
+            return Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>([]);
+
+        return catalog.Contributions
+            .CombineLatest(host.Hub.IsGlobalAdmin().StartWith(false),
+                UiContributionProjection.ProjectSettingsTabs);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -77,6 +77,11 @@ public static class GraphConfigurationExtensions
                 .AddPartitionType()
                 .AddGlobalSettingsType();
 
+            // Data-contributed menu entries (UiContribution nodes, #1645) + the mesh-scoped live
+            // catalog the menu aggregation maps (one query subscription per silo).
+            builder.AddUiContributionType();
+            builder.ConfigureServices(s => s.AddSingleton<UiContributionCatalog>());
+
             // The static-repo importer runs its bulk create/upsert traffic on a DEDICATED
             // hub (import/{meshHubId}) so it never floods the root mesh hub's action block —
             // the router must stay free (prod 2026-06-11 wedge). Declare its address-type as

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -469,9 +469,38 @@ public static class NodeMenuItemsExtensions
                 if ((provider.Context ?? "") == context)
                     providerStreams.Add(SafeProvider(provider.GetItems(host, ctx), host, context));
 
+            // Data-contributed entries (UiContribution nodes, design #1645) — the plugin-content
+            // lane. Gated HERE, in compiled code, against the viewer's live permission stream and
+            // the closed node-shape vocabulary; a contribution can only narrow its visibility.
+            providerStreams.Add(SafeProvider(ContributionStream(host, context), host, context));
+
             result[context] = CombineProviderStreams(providerStreams);
         }
         return result;
+    }
+
+    /// <summary>
+    /// The DATA-contributed slice of one menu context: every <see cref="UiContribution"/> node in
+    /// the shared mesh-scoped catalog whose declared context matches, projected through the CLOSED
+    /// gate vocabulary — the viewer's live effective permission (floored at Read; anonymous is
+    /// already forced to <see cref="Permission.None"/> by <see cref="GetMenuContext"/>, so the
+    /// whole slice fails closed), <c>AdminOnly</c> against the reactive
+    /// <c>IsGlobalAdmin</c> stream, <c>ExcludePartitionRoot</c> against the same predicate the
+    /// built-in suppression uses, and suffix-aware <c>NodeTypes</c> matching. Enforcement lives
+    /// HERE, in compiled code — a contribution can only ever narrow its own visibility (#1645).
+    /// </summary>
+    private static IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> ContributionStream(
+        LayoutAreaHost host, string context)
+    {
+        var catalog = host.Hub.ServiceProvider.GetService<UiContributionCatalog>();
+        if (catalog is null)
+            return Observable.Return(EmptyItems);
+
+        var adminStream = host.Hub.IsGlobalAdmin().StartWith(false);
+        return catalog.Contributions
+            .CombineLatest(GetMenuContext(host), adminStream,
+                (contributions, menuCtx, isAdmin) => UiContributionProjection.ProjectMenu(
+                    contributions, context, menuCtx.menuPath, menuCtx.menuNode, menuCtx.perms, isAdmin));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
@@ -1,0 +1,136 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The mesh-scoped live catalog of <see cref="UiContribution"/> nodes — ONE query subscription per
+/// silo, shared by every per-node hub's menu aggregation (the <c>DeckSlidesCache</c> pattern:
+/// per-hub consumers map a shared replayed stream instead of each holding its own query).
+///
+/// <para>Fully REACTIVE: the query stream's Initial/Reset carry the complete set and
+/// Added/Updated/Removed fold as deltas, so a plugin installing or updating contributions changes
+/// every open menu without any generation counter, hub recycle or watchdog (the design's
+/// snapshot+bump alternative in #1645 is superseded by this — simpler and it can't go stale).
+/// Read under the SYSTEM identity: contributions are platform UI data readable by construction;
+/// per-VIEWER gating (permission + admin) happens in the aggregator against the viewer's own
+/// streams, never here.</para>
+///
+/// <para>Fault-tolerant: a query error logs and degrades to the LAST known set (or empty), then
+/// the subscription retries on the next subscriber epoch — the menu keeps rendering its compiled
+/// items no matter what this catalog does.</para>
+/// </summary>
+public sealed class UiContributionCatalog : IDisposable
+{
+    private readonly IMessageHub hub;
+    private readonly ILogger<UiContributionCatalog>? logger;
+    private readonly BehaviorSubject<ImmutableDictionary<string, (MeshNode Node, UiContribution Content)>> state =
+        new(ImmutableDictionary<string, (MeshNode, UiContribution)>.Empty);
+    private readonly object gate = new();
+    private IDisposable? subscription;
+
+    /// <summary>Creates the catalog; the query subscription starts lazily on first read.</summary>
+    public UiContributionCatalog(IMessageHub hub, ILogger<UiContributionCatalog>? logger = null)
+    {
+        this.hub = hub;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// The live contribution set, replayed to every subscriber. First access starts the shared
+    /// query subscription.
+    /// </summary>
+    public IObservable<ImmutableList<(MeshNode Node, UiContribution Content)>> Contributions
+    {
+        get
+        {
+            EnsureSubscribed();
+            return state.Select(s => s.Values.ToImmutableList());
+        }
+    }
+
+    private void EnsureSubscribed()
+    {
+        if (subscription is not null)
+            return;
+        lock (gate)
+        {
+            if (subscription is not null)
+                return;
+            var meshService = hub.ServiceProvider.GetService(typeof(IMeshService)) as IMeshService;
+            var accessService = hub.ServiceProvider.GetService(typeof(AccessService)) as AccessService;
+            if (meshService is null)
+            {
+                // A mesh without the query surface (minimal fixtures) — the catalog stays empty
+                // and the menu renders its compiled items only.
+                subscription = System.Reactive.Disposables.Disposable.Empty;
+                return;
+            }
+
+            IDisposable Subscribe()
+            {
+                using (accessService?.ImpersonateAsSystem())
+                {
+                    return meshService
+                        .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{UiContributionNodeType.NodeType}"))
+                        .Subscribe(OnChange, ex =>
+                        {
+                            // Degrade to the last known set; the compiled menu is unaffected.
+                            logger?.LogWarning(ex, "UiContribution catalog query faulted; menu contributions frozen at the last known set");
+                        });
+                }
+            }
+
+            subscription = Subscribe();
+        }
+    }
+
+    private void OnChange(QueryResultChange<MeshNode> change)
+    {
+        var current = state.Value;
+        switch (change.ChangeType)
+        {
+            case QueryChangeType.Initial:
+            case QueryChangeType.Reset:
+                current = ImmutableDictionary<string, (MeshNode, UiContribution)>.Empty;
+                foreach (var node in change.Items ?? [])
+                    current = Fold(current, node);
+                break;
+            case QueryChangeType.Added:
+            case QueryChangeType.Updated:
+                foreach (var node in change.Items ?? [])
+                    current = Fold(current, node);
+                break;
+            case QueryChangeType.Removed:
+                foreach (var node in change.Items ?? [])
+                    if (node?.Path is { Length: > 0 } removed)
+                        current = current.Remove(removed);
+                break;
+        }
+        state.OnNext(current);
+    }
+
+    private ImmutableDictionary<string, (MeshNode, UiContribution)> Fold(
+        ImmutableDictionary<string, (MeshNode, UiContribution)> current, MeshNode? node)
+    {
+        if (node?.Path is not { Length: > 0 } path)
+            return current;
+        // ContentAs is the bad-data-tolerant read; an unreadable contribution logs and is skipped —
+        // one broken node never takes the catalog down.
+        var content = node.ContentAs<UiContribution>(hub.JsonSerializerOptions, logger);
+        return content is null ? current.Remove(path) : current.SetItem(path, (node, content));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        subscription?.Dispose();
+        state.OnCompleted();
+        state.Dispose();
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The <c>UiContribution</c> node type — a MENU ENTRY contributed as mesh DATA (design #1645, the
+/// WS7 composition-first lane). A contribution adds an entry to one of the shell's menu contexts
+/// (<c>Node</c>, <c>Mesh</c>, <c>Settings</c>, <c>AiMenu</c>, <c>SidePanel</c>) pointing at a
+/// layout AREA the contributing plugin already ships — rendering stays the existing layout
+/// pipeline; contributions never introduce a render surface.
+///
+/// <para><b>The security boundary</b> (the reason <c>MenuPresentationOverlay</c> is cosmetic-only
+/// does NOT apply here): visibility is enforced by the COMPILED aggregator against a CLOSED gate
+/// vocabulary — <see cref="UiContribution.RequiredPermission"/> is checked against the viewer's
+/// LIVE effective permissions, and <see cref="UiContributionGates"/> against the node's shape. A
+/// contribution can only ever NARROW its own visibility; it cannot widen anything, and any
+/// visibility rule beyond the vocabulary stays in code (a per-NodeType in-mesh delegate or a
+/// compiled provider).</para>
+/// </summary>
+public static class UiContributionNodeType
+{
+    /// <summary>The NodeType value identifying UI-contribution nodes.</summary>
+    public const string NodeType = "UiContribution";
+
+    /// <summary>
+    /// True for the built-in type OR a plugin-installed variant whose dynamic identity ends in
+    /// <c>/UiContribution</c> — the platform's suffix-aware convention (see
+    /// <c>SlideNodeType.Matches</c>).
+    /// </summary>
+    public static bool Matches(string? nodeType) =>
+        nodeType == NodeType
+        || nodeType?.EndsWith("/" + NodeType, StringComparison.Ordinal) == true;
+
+    /// <summary>Registers the built-in <c>UiContribution</c> node type on the mesh builder.</summary>
+    public static TBuilder AddUiContributionType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(new MeshNode(NodeType)
+        {
+            Name = "UI Contribution",
+            HubConfiguration = config => config
+                .AddMeshDataSource(s => s.WithContentType<UiContribution>()),
+        });
+        // Platform plumbing, not pickable content — never offered in UCR autocomplete.
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.WithMeshType(typeof(UiContribution), nameof(UiContribution));
+        return builder;
+    }
+}
+
+/// <summary>
+/// The content of a <c>UiContribution</c> node — one contributed menu entry. Immutable; every
+/// mutation goes through <c>workspace.GetMeshNodeStream(path).Update(...)</c>.
+/// </summary>
+public record UiContribution
+{
+    /// <summary>The <c>Node</c> menu context — per-node operations (the ✏️/🗑️ dropdown).</summary>
+    public const string NodeContext = "Node";
+    /// <summary>The <c>Mesh</c> menu context — mesh-level operations (Create/Import/Export).</summary>
+    public const string MeshContext = "Mesh";
+    /// <summary>The global settings tabs context.</summary>
+    public const string SettingsContext = "Settings";
+
+    /// <summary>
+    /// Which menu the entry contributes to: <c>Node</c>, <c>Mesh</c>, <c>Settings</c>,
+    /// <c>AiMenu</c> or <c>SidePanel</c>. Unset ⇒ <c>Node</c>.
+    /// </summary>
+    public string? Context { get; init; }
+
+    /// <summary>Display text. Prefer <see cref="LabelKey"/> for entries needing translation.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Localization key for <see cref="Label"/> (resolved against the shared catalog at
+    /// aggregation, like every compiled item's <c>LabelKey</c>). One localization story — never a
+    /// second mechanism.
+    /// </summary>
+    public string? LabelKey { get; init; }
+
+    /// <summary>Optional icon — emoji string or SVG URL.</summary>
+    public string? Icon { get; init; }
+
+    /// <summary>
+    /// The layout AREA the entry opens — an area the contributing plugin ships. The standard
+    /// area-not-found placeholder renders if it is missing, exactly like any dangling area link.
+    /// </summary>
+    public string? Area { get; init; }
+
+    /// <summary>Sort order within the menu (lower = earlier). Default 100 — after the built-ins.</summary>
+    public int Order { get; init; } = 100;
+
+    /// <summary>
+    /// The permission the VIEWER must hold on the node for the entry to appear — enforced by the
+    /// compiled aggregator against the live effective-permission stream (never trusted from
+    /// data alone). Unset ⇒ <see cref="Permission.Read"/>; contributions can never demand less
+    /// than Read.
+    /// </summary>
+    public Permission RequiredPermission { get; init; } = Permission.Read;
+
+    /// <summary>Node-shape gates further narrowing where the entry appears.</summary>
+    public UiContributionGates? Gates { get; init; }
+}
+
+/// <summary>
+/// The CLOSED node-shape gate vocabulary for <see cref="UiContribution"/> — every gate can only
+/// NARROW visibility. Rules beyond this vocabulary belong in code.
+/// </summary>
+public record UiContributionGates
+{
+    /// <summary>
+    /// Restrict to nodes whose NodeType matches one of these — suffix-aware (<c>"Slide"</c>
+    /// matches <c>Publish/Slide</c>), the platform's <c>Matches</c> semantics. Empty/null = every
+    /// node type.
+    /// </summary>
+    public ImmutableList<string>? NodeTypes { get; init; }
+
+    /// <summary>Never on a protected partition root (a user's home) — the same predicate the
+    /// built-in Edit/Move/Copy/Delete suppression uses.</summary>
+    public bool ExcludePartitionRoot { get; init; }
+
+    /// <summary>Only for platform admins (<c>hub.IsGlobalAdmin()</c> — the ONE admin predicate).</summary>
+    public bool AdminOnly { get; init; }
+}

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -1,0 +1,101 @@
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The PURE projection of <see cref="UiContribution"/> data into menu entries — the compiled
+/// enforcement point of the closed gate vocabulary (#1645). Kept side-effect-free (no hub, no
+/// streams) so the security-relevant logic is unit-testable the way
+/// <c>MenuPresentationOverlay</c> is: the reactive aggregators only COMPOSE the live inputs
+/// (viewer permissions, admin stream, node stream) and hand them here.
+/// </summary>
+internal static class UiContributionProjection
+{
+    /// <summary>
+    /// Projects the catalog into one node/mesh-menu context's entries. Gates, all enforced here:
+    /// context match, a non-empty Area, the viewer's effective permission (floored at
+    /// <see cref="Permission.Read"/> — an anonymous viewer arrives with
+    /// <see cref="Permission.None"/> and gets nothing), <c>AdminOnly</c>, and the node-shape
+    /// vocabulary (<c>ExcludePartitionRoot</c>, suffix-aware <c>NodeTypes</c>).
+    /// </summary>
+    public static IReadOnlyCollection<NodeMenuItemDefinition> ProjectMenu(
+        IReadOnlyList<(MeshNode Node, UiContribution Content)> contributions,
+        string context,
+        string menuPath,
+        MeshNode? menuNode,
+        Permission perms,
+        bool isAdmin)
+    {
+        List<NodeMenuItemDefinition>? items = null;
+        foreach (var (_, contribution) in contributions)
+        {
+            if ((contribution.Context ?? UiContribution.NodeContext) != context)
+                continue;
+            if (contribution.Area is not { Length: > 0 } area)
+                continue;
+            var required = contribution.RequiredPermission == Permission.None
+                ? Permission.Read
+                : contribution.RequiredPermission;
+            if (!perms.HasFlag(required))
+                continue;
+            var gates = contribution.Gates;
+            if (gates?.AdminOnly == true && !isAdmin)
+                continue;
+            if (gates?.ExcludePartitionRoot == true
+                && PartitionRootDeletionGuard.IsUserPartitionRoot(menuNode))
+                continue;
+            if (gates?.NodeTypes is { Count: > 0 } nodeTypes
+                && !nodeTypes.Any(t => NodeTypeGateMatches(menuNode?.NodeType, t)))
+                continue;
+
+            (items ??= []).Add(new NodeMenuItemDefinition(
+                contribution.Label ?? area,
+                area,
+                contribution.Icon,
+                required,
+                contribution.Order,
+                Href: MeshNodeLayoutAreas.BuildUrl(menuPath, area))
+                { LabelKey = contribution.LabelKey });
+        }
+        return items ?? (IReadOnlyCollection<NodeMenuItemDefinition>)[];
+    }
+
+    /// <summary>
+    /// Projects the catalog into the global settings tabs. The settings surface has no node to
+    /// bind <see cref="UiContribution.RequiredPermission"/> to; the gates here are "authenticated
+    /// viewer" (enforced by the CALLER, which returns an empty stream for anonymous) and
+    /// <c>AdminOnly</c>. The tab's content is the contributed layout AREA embedded generically —
+    /// contributions never introduce a render surface.
+    /// </summary>
+    public static IReadOnlyList<GlobalSettingsMenuItemDefinition> ProjectSettingsTabs(
+        IReadOnlyList<(MeshNode Node, UiContribution Content)> contributions,
+        bool isAdmin)
+    {
+        var items = new List<GlobalSettingsMenuItemDefinition>();
+        foreach (var (node, contribution) in contributions)
+        {
+            if (contribution.Context != UiContribution.SettingsContext)
+                continue;
+            if (contribution.Area is not { Length: > 0 } area)
+                continue;
+            if (contribution.Gates?.AdminOnly == true && !isAdmin)
+                continue;
+            items.Add(new GlobalSettingsMenuItemDefinition(
+                Id: $"contrib:{node.Path}",
+                Label: contribution.Label ?? area,
+                ContentBuilder: (h, _) => Controls.LayoutArea(h.Hub.Address, area),
+                Icon: contribution.Icon,
+                Order: contribution.Order)
+                { LabelKey = contribution.LabelKey });
+        }
+        return items;
+    }
+
+    /// <summary>Suffix-aware node-type gate — the platform's <c>Matches</c> semantics.</summary>
+    internal static bool NodeTypeGateMatches(string? nodeType, string gate) =>
+        nodeType == gate
+        || nodeType?.EndsWith("/" + gate, StringComparison.Ordinal) == true;
+}

--- a/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The compiled enforcement point of the data-contributed menu lane (#1645). These tests pin the
+/// SECURITY properties the design rests on: a contribution can only ever NARROW its own
+/// visibility — the permission gate is floored at Read and enforced against the viewer's
+/// effective permission, an anonymous viewer (arriving as <see cref="Permission.None"/>) gets
+/// nothing, and every node-shape gate in the closed vocabulary subtracts.
+/// </summary>
+public class UiContributionProjectionTest
+{
+    private static (MeshNode, UiContribution) Contribution(UiContribution content) =>
+        (new MeshNode("c1", "Plugins/Contribs") { Name = "c1", NodeType = UiContributionNodeType.NodeType },
+         content);
+
+    private static readonly MeshNode SomeNode =
+        new("Doc", "Org") { Name = "Doc", NodeType = "Markdown" };
+
+    private static IReadOnlyCollection<NodeMenuItemDefinition> Project(
+        UiContribution content,
+        string context = UiContribution.NodeContext,
+        MeshNode? node = null,
+        Permission perms = Permission.Read,
+        bool isAdmin = false)
+        => UiContributionProjection.ProjectMenu(
+            [Contribution(content)], context, "Org/Doc", node ?? SomeNode, perms, isAdmin);
+
+    [Fact]
+    public void AnonymousViewer_PermissionNone_GetsNothing_EvenWhenTheContributionDemandsNothing()
+    {
+        // The aggregator forces Permission.None for anonymous; the floor (Read) must filter.
+        Assert.Empty(Project(new UiContribution { Area = "MyArea" }, perms: Permission.None));
+    }
+
+    [Fact]
+    public void PermissionFloor_IsRead_AndReadViewerSeesTheEntry()
+    {
+        var item = Assert.Single(Project(new UiContribution { Area = "MyArea", Label = "Mine" }));
+        Assert.Equal("Mine", item.Label);
+        Assert.Equal(Permission.Read, item.RequiredPermission);
+        Assert.Equal("MyArea", item.Area);
+    }
+
+    [Fact]
+    public void DeclaredPermission_IsEnforced_AgainstTheViewersEffectivePermission()
+    {
+        var demandsUpdate = new UiContribution { Area = "MyArea", RequiredPermission = Permission.Update };
+        Assert.Empty(Project(demandsUpdate, perms: Permission.Read));
+        Assert.Single(Project(demandsUpdate, perms: Permission.Read | Permission.Update));
+    }
+
+    [Fact]
+    public void AdminOnly_Subtracts_ForNonAdmins()
+    {
+        var adminEntry = new UiContribution
+        {
+            Area = "AdminArea",
+            Gates = new UiContributionGates { AdminOnly = true },
+        };
+        Assert.Empty(Project(adminEntry, isAdmin: false));
+        Assert.Single(Project(adminEntry, isAdmin: true));
+    }
+
+    [Fact]
+    public void ExcludePartitionRoot_UsesTheSharedProtectedRootPredicate()
+    {
+        var userRoot = new MeshNode("alice", "") { Name = "alice", NodeType = "User" };
+        var gated = new UiContribution
+        {
+            Area = "MyArea",
+            Gates = new UiContributionGates { ExcludePartitionRoot = true },
+        };
+        Assert.Empty(Project(gated, node: userRoot));
+        Assert.Single(Project(gated, node: SomeNode));
+    }
+
+    [Fact]
+    public void NodeTypeGate_IsSuffixAware_LikeEveryPlatformMatches()
+    {
+        var slideOnly = new UiContribution
+        {
+            Area = "MyArea",
+            Gates = new UiContributionGates { NodeTypes = ImmutableList.Create("Slide") },
+        };
+        var pluginSlide = new MeshNode("S1", "Org") { Name = "S1", NodeType = "Publish/Slide" };
+        var bareSlide = new MeshNode("S2", "Org") { Name = "S2", NodeType = "Slide" };
+
+        Assert.Single(Project(slideOnly, node: pluginSlide));
+        Assert.Single(Project(slideOnly, node: bareSlide));
+        Assert.Empty(Project(slideOnly, node: SomeNode));
+    }
+
+    [Fact]
+    public void ContextRouting_IsExact_AndSettingsContributionsNeverLeakIntoTheNodeMenu()
+    {
+        var settingsTab = new UiContribution { Area = "TabArea", Context = UiContribution.SettingsContext };
+        Assert.Empty(Project(settingsTab, context: UiContribution.NodeContext));
+
+        var nodeEntry = new UiContribution { Area = "MyArea" };   // Context unset ⇒ Node
+        Assert.Empty(Project(nodeEntry, context: UiContribution.MeshContext));
+        Assert.Single(Project(nodeEntry, context: UiContribution.NodeContext));
+    }
+
+    [Fact]
+    public void MissingArea_ContributesNothing()
+    {
+        Assert.Empty(Project(new UiContribution { Label = "No target" }));
+    }
+
+    [Fact]
+    public void SettingsTabs_GateOnAdminOnly_AndCarryTheContributedArea()
+    {
+        var contributions = new[]
+        {
+            Contribution(new UiContribution
+            {
+                Context = UiContribution.SettingsContext, Area = "TabArea", Label = "My Tab", Order = 7,
+            }),
+            Contribution(new UiContribution
+            {
+                Context = UiContribution.SettingsContext, Area = "AdminTab",
+                Gates = new UiContributionGates { AdminOnly = true },
+            }),
+        };
+
+        var forUser = UiContributionProjection.ProjectSettingsTabs(contributions, isAdmin: false);
+        var tab = Assert.Single(forUser);
+        Assert.Equal("My Tab", tab.Label);
+        Assert.Equal(7, tab.Order);
+
+        Assert.Equal(2, UiContributionProjection.ProjectSettingsTabs(contributions, isAdmin: true).Count);
+    }
+}


### PR DESCRIPTION
Slice 1 of #1645 (the WS7 composition-first lane — "factor out menus"):

- **`UiContribution` node type**: a menu entry as mesh data — `Context` (Node/Mesh/AI/SidePanel/Settings), `Label`/`LabelKey` (the ONE localization story), `Icon`, `Area`, `Order`, `RequiredPermission`, `Gates`. Excluded from autocomplete; registered mesh-wide for serialization.
- **The security boundary holds**: enforcement moved into the compiled aggregators with a CLOSED vocabulary, evaluated in the pure `UiContributionProjection` — permission floored at Read against the viewer's LIVE effective permission (anonymous ⇒ nothing), reactive `AdminOnly`, the shared partition-root predicate, suffix-aware `NodeTypes`. A contribution can only narrow its own visibility. (`SyncedOnly` dropped — no honest node-level predicate; noted on #1645.)
- **`UiContributionCatalog`**: ONE live query per silo, delta-folded and replayed to every hub's menu aggregation — plugin installs/updates change open menus reactively; no generation bump, no recycle machinery (supersedes that part of the design, noted on #1645). Fault-tolerant: bad nodes skip, a faulted query freezes the slice, the compiled menu is untouched.
- **Settings tabs**: contributed tabs render their layout area through a generic embed — no new render surface.

Verified: builds clean under CI flags; `UiContributionProjectionTest` 9/9 security pins; regressions green (MenuAccessControl 9/9, VersionViews 4/4, MenuPresentationOverlay 14/14).

Next slices per #1645: the PlatformUI pack carrying the standard settings tabs, then AI menu/side panel, then the node/mesh defaults with the minimal compiled fallback.

No What's New: a plugin-author capability; no default-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)