### PR TITLE
feat(ws7): What's New/About/Privacy settings tabs ride the UiContribution lane

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -725,6 +725,9 @@ public static class MemexConfiguration
                 // RLS for cross-partition operations (list Spaces, create
                 // a new Space, etc.). Empty / missing section = no-op.
                 .AddMeshNodes(Authentication.GlobalAdminSeed.Build(configuration))
+                // What's New / About / Privacy settings-tab entries as seeded UiContribution
+                // nodes — the WS7 lane a plugin's own settings tab arrives through.
+                .AddPlatformSettingsTabContributions()
                 .AddSpaceType()
                 // Generic webhook inbox: the WebhookEvent node type behind
                 // POST /api/hooks/{target} (allowlisted via WebhookInbox:Targets).
@@ -890,15 +893,13 @@ public static class MemexConfiguration
                         // Platform-admin Instances overview: live cluster query (namespaces, versions,
                         // replica health) + Grafana log links + guided create-instance plan generator.
                         .AddInstancesAdminSettingsTab()
-                        // Public privacy statement (Admin/Privacy, served anonymously at /privacy).
-                        .AddPrivacySettingsTab()
+                        // What's New / About / Privacy ride the UiContribution lane (WS7 slice 2):
+                        // content stays compiled, exposed here as layout areas; the menu entries are
+                        // seeded UiContribution nodes (AddPlatformSettingsTabContributions below).
+                        .AddPlatformSettingsTabAreas()
                         // Published to the web: every page a logged-out visitor can open, read from
                         // the SAME enumeration /sitemap.xml renders, so the two cannot drift.
                         .AddPublishedSettingsTab()
-                        // About — exact running build (version + git commit) with a GitHub link. Ungated.
-                        .AddAboutSettingsTab()
-                        // What's New — per-entry release notes shipped as Doc/WhatsNew nodes. Ungated.
-                        .AddWhatsNewSettingsTab()
                         // Token-usage analytics (per-model _Usage satellites): filter by period,
                         // group by model / person / thread, cost from ModelPricing.
                         .AddTokenUsageSettingsTab()

--- a/memex/Memex.Portal.Shared/Settings/AboutSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/AboutSettingsTab.cs
@@ -41,22 +41,8 @@ public static class AboutSettingsTab
     /// <summary>Data id the plugin grid binds to (rows published via <c>host.UpdateData</c>).</summary>
     private const string PluginsDataId = "aboutPlugins";
 
-    /// <summary>Registers the About tab with the global settings menu (ungated).</summary>
-    public static MessageHubConfiguration AddAboutSettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetTab(
-        LayoutAreaHost host, RenderingContext ctx)
-        => Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>(new[]
-        {
-            new GlobalSettingsMenuItemDefinition(
-                Id: TabId,
-                Label: "About",
-                ContentBuilder: BuildContent,
-                Icon: FluentIcons.Info(),
-                Order: 900)
-            { LabelKey = "settings.about" }
-        });
+    // The menu entry is a seeded UiContribution node (PlatformSettingsTabAreas) — the tab's
+    // registration surface is the SettingsAbout layout area, not a compiled provider.
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
+++ b/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
@@ -1,0 +1,96 @@
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace Memex.Portal.Shared.Settings;
+
+/// <summary>
+/// The first tranche of settings tabs served as <see cref="UiContribution"/> DATA instead of
+/// compiled provider registrations (WS7 slice 2, design #1645): What's New, About and Privacy.
+/// The CONTENT stays compiled — each tab's existing <c>BuildContent</c> is exposed as a normal
+/// layout AREA — while the menu ENTRY (label, icon, order, grouping, admin gate) is a seeded
+/// <c>UiContribution</c> node the compiled aggregator projects under the closed gate vocabulary.
+/// A plugin contributes a settings tab the exact same way; these seeds prove the lane on the
+/// platform's own tabs.
+/// </summary>
+public static class PlatformSettingsTabAreas
+{
+    /// <summary>Layout area rendering <see cref="WhatsNewSettingsTab.BuildContent"/>.</summary>
+    public const string WhatsNewArea = "SettingsWhatsNew";
+
+    /// <summary>Layout area rendering <see cref="AboutSettingsTab.BuildContent"/>.</summary>
+    public const string AboutArea = "SettingsAbout";
+
+    /// <summary>Layout area rendering <see cref="PrivacySettingsTab.BuildContent"/> (admin-gated).</summary>
+    public const string PrivacyArea = "SettingsPrivacy";
+
+    /// <summary>
+    /// Registers the tranche's tab contents as layout areas on the per-node hubs. The settings
+    /// pane embeds them via the contributed entries' <c>Area</c>; the pane supplies the
+    /// padding/scroll container, so each area builds into a plain full-width stack.
+    /// </summary>
+    public static MessageHubConfiguration AddPlatformSettingsTabAreas(this MessageHubConfiguration config)
+        => config.AddLayout(layout => layout
+            .WithView(WhatsNewArea, (host, _) => WhatsNewSettingsTab.BuildContent(host, PaneStack()))
+            .WithView(AboutArea, (host, _) => AboutSettingsTab.BuildContent(host, PaneStack()))
+            // Privacy's tab content is the ADMIN EDITOR of the public statement (the statement
+            // itself is served anonymously at /privacy). The contributed entry hides the tab via
+            // Gates.AdminOnly, but an area is directly addressable by URL — so the area re-asserts
+            // the same gate instead of trusting the menu to be the only door.
+            .WithView(PrivacyArea, (host, _) => AdminMenuGate.IsPlatformAdmin(host)
+                .Select(isAdmin => isAdmin
+                    ? PrivacySettingsTab.BuildContent(host, PaneStack())
+                    : (UiControl)Controls.Markdown(host.Localize("ui.accessDeniedAdminsOnly")))));
+
+    /// <summary>
+    /// Seeds the tranche's menu entries as platform-static <c>UiContribution</c> nodes under
+    /// <c>Admin/UiContribution</c>. The node id is the former compiled tab id, keeping every
+    /// <c>/GlobalSettings/{Id}</c> deep link stable across the migration.
+    /// </summary>
+    public static MeshBuilder AddPlatformSettingsTabContributions(this MeshBuilder builder)
+        => builder.AddMeshNodes(
+            Seed(WhatsNewSettingsTab.TabId, "What's New", new UiContribution
+            {
+                Context = UiContribution.SettingsContext,
+                Area = WhatsNewArea,
+                Label = "What's New",
+                LabelKey = "settings.whatsNew",
+                Icon = "Sparkle",
+                Order = 910,
+            }),
+            Seed(AboutSettingsTab.TabId, "About", new UiContribution
+            {
+                Context = UiContribution.SettingsContext,
+                Area = AboutArea,
+                Label = "About",
+                LabelKey = "settings.about",
+                Icon = "Info",
+                Order = 900,
+            }),
+            Seed(PrivacySettingsTab.TabId, "Privacy", new UiContribution
+            {
+                Context = UiContribution.SettingsContext,
+                Area = PrivacyArea,
+                Label = "Privacy",
+                LabelKey = "settings.privacy",
+                Icon = "Shield",
+                Group = "Administration",
+                GroupKey = "settings.groupAdministration",
+                GroupIcon = "Shield",
+                Order = 330,
+                Gates = new UiContributionGates { AdminOnly = true },
+            }));
+
+    private static MeshNode Seed(string id, string name, UiContribution content)
+        => new(id, "Admin/UiContribution")
+        {
+            NodeType = UiContributionNodeType.NodeType,
+            Name = name,
+            Content = content,
+        };
+
+    private static StackControl PaneStack() => Controls.Stack.WithWidth("100%");
+}

--- a/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
+++ b/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
@@ -39,11 +39,15 @@ public static class PlatformSettingsTabAreas
             // Privacy's tab content is the ADMIN EDITOR of the public statement (the statement
             // itself is served anonymously at /privacy). The contributed entry hides the tab via
             // Gates.AdminOnly, but an area is directly addressable by URL — so the area re-asserts
-            // the same gate instead of trusting the menu to be the only door.
+            // the same gate instead of trusting the menu to be the only door. TakeLast(1) waits for
+            // the gate to RESOLVE (it opens with a synthetic false so menus render ungated tabs
+            // immediately) — a neutral pane shows meanwhile, so an admin never flashes the denial.
             .WithView(PrivacyArea, (host, _) => AdminMenuGate.IsPlatformAdmin(host)
+                .TakeLast(1)
                 .Select(isAdmin => isAdmin
                     ? PrivacySettingsTab.BuildContent(host, PaneStack())
-                    : (UiControl)Controls.Markdown(host.Localize("ui.accessDeniedAdminsOnly")))));
+                    : (UiControl)Controls.Markdown(host.Localize("ui.accessDeniedAdminsOnly")))
+                .StartWith((UiControl)PaneStack())));
 
     /// <summary>
     /// Seeds the tranche's menu entries as platform-static <c>UiContribution</c> nodes under

--- a/memex/Memex.Portal.Shared/Settings/PrivacySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/PrivacySettingsTab.cs
@@ -23,27 +23,8 @@ public static class PrivacySettingsTab
 {
     public const string TabId = "Privacy";
 
-    public static MessageHubConfiguration AddPrivacySettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Privacy",
-            ContentBuilder: BuildContent,
-            Group: "Administration",
-            Icon: FluentIcons.Shield(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 330)
-            { LabelKey = "settings.privacy", GroupKey = "settings.groupAdministration" };
-
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
+    // The menu entry is a seeded UiContribution node with Gates.AdminOnly
+    // (PlatformSettingsTabAreas); the SettingsPrivacy layout area re-asserts the admin gate.
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
@@ -48,22 +48,8 @@ public static class WhatsNewSettingsTab
     /// </summary>
     public const string FixCategory = "Fix";
 
-    /// <summary>Registers the What's New tab with the global settings menu (ungated).</summary>
-    public static MessageHubConfiguration AddWhatsNewSettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetTab(
-        LayoutAreaHost host, RenderingContext ctx)
-        => Observable.Return<IReadOnlyList<GlobalSettingsMenuItemDefinition>>(new[]
-        {
-            new GlobalSettingsMenuItemDefinition(
-                Id: TabId,
-                Label: "What's New",
-                ContentBuilder: BuildContent,
-                Icon: FluentIcons.Sparkle(),
-                Order: 910)
-            { LabelKey = "settings.whatsNew" }
-        });
+    // The menu entry is a seeded UiContribution node (PlatformSettingsTabAreas) — the tab's
+    // registration surface is the SettingsWhatsNew layout area, not a compiled provider.
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
@@ -91,6 +91,15 @@ public record UiContribution
     /// <summary>Sort order within the menu (lower = earlier). Default 100 — after the built-ins.</summary>
     public int Order { get; init; } = 100;
 
+    /// <summary>Optional group header (settings tabs) — entries sharing a group nest under it.</summary>
+    public string? Group { get; init; }
+
+    /// <summary>Localization key for <see cref="Group"/>.</summary>
+    public string? GroupKey { get; init; }
+
+    /// <summary>Optional icon for the group header; the first non-null in a group wins.</summary>
+    public string? GroupIcon { get; init; }
+
     /// <summary>
     /// The permission the VIEWER must hold on the node for the entry to appear — enforced by the
     /// compiled aggregator against the live effective-permission stream (never trusted from

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Domain;
 using MeshWeaver.Graph.Security;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -84,12 +85,20 @@ internal static class UiContributionProjection
             if (contribution.Gates?.AdminOnly == true && !isAdmin)
                 continue;
             items.Add(new GlobalSettingsMenuItemDefinition(
-                Id: $"contrib:{node.Path}",
+                // The trailing path segment keeps the tab's /GlobalSettings/{Id} deep link stable
+                // when a compiled tab migrates to a contribution seeded under the same name.
+                Id: node.Path?.Split('/')[^1] is { Length: > 0 } id ? id : area,
                 Label: contribution.Label ?? area,
-                ContentBuilder: (h, _) => Controls.LayoutArea(h.Hub.Address, area),
-                Icon: contribution.Icon,
+                // Embed INTO the pane's stack so the contributed tab inherits the same
+                // padding/scroll container every compiled tab renders in.
+                ContentBuilder: (h, stack) => stack.WithView(Controls.LayoutArea(h.Hub.Address, area)),
+                Group: contribution.Group,
+                // Icon.Parse is the platform's TOTAL string→Icon conversion (Fluent name, SVG,
+                // URL, emoji→text) — the NavMenu renderer expects Icon objects here.
+                GroupIcon: Icon.Parse(contribution.GroupIcon),
+                Icon: Icon.Parse(contribution.Icon),
                 Order: contribution.Order)
-                { LabelKey = contribution.LabelKey });
+                { LabelKey = contribution.LabelKey, GroupKey = contribution.GroupKey });
         }
         return items;
     }

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -85,9 +85,9 @@ internal static class UiContributionProjection
             if (contribution.Gates?.AdminOnly == true && !isAdmin)
                 continue;
             items.Add(new GlobalSettingsMenuItemDefinition(
-                // The trailing path segment keeps the tab's /GlobalSettings/{Id} deep link stable
-                // when a compiled tab migrates to a contribution seeded under the same name.
-                Id: node.Path?.Split('/')[^1] is { Length: > 0 } id ? id : area,
+                // The node id (= the trailing path segment) keeps the tab's /GlobalSettings/{Id}
+                // deep link stable when a compiled tab migrates to a same-named seeded contribution.
+                Id: node.Id is { Length: > 0 } id ? id : area,
                 Label: contribution.Label ?? area,
                 // Embed INTO the pane's stack so the contributed tab inherits the same
                 // padding/scroll container every compiled tab renders in.

--- a/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
@@ -138,4 +138,40 @@ public class UiContributionProjectionTest
 
         Assert.Equal(2, UiContributionProjection.ProjectSettingsTabs(contributions, isAdmin: true).Count);
     }
+
+    [Fact]
+    public void SettingsTabs_CarryGroupingAndStableId_AndResolveFluentIconNames()
+    {
+        var contributions = new[]
+        {
+            (new MeshNode("Privacy", "Admin/UiContribution")
+                { Name = "Privacy", NodeType = UiContributionNodeType.NodeType },
+             new UiContribution
+             {
+                 Context = UiContribution.SettingsContext,
+                 Area = "SettingsPrivacy",
+                 Label = "Privacy",
+                 LabelKey = "settings.privacy",
+                 Icon = "Shield",
+                 Group = "Administration",
+                 GroupKey = "settings.groupAdministration",
+                 GroupIcon = "Shield",
+                 Order = 330,
+             }),
+        };
+
+        var tab = Assert.Single(UiContributionProjection.ProjectSettingsTabs(contributions, isAdmin: false));
+        // The node's trailing path segment IS the tab id — the /GlobalSettings/{Id} deep link a
+        // compiled tab had before migrating must survive the migration.
+        Assert.Equal("Privacy", tab.Id);
+        Assert.Equal("Administration", tab.Group);
+        Assert.Equal("settings.groupAdministration", tab.GroupKey);
+        Assert.Equal("settings.privacy", tab.LabelKey);
+        // Icon strings go through the platform's total Icon.Parse — a Fluent name becomes a
+        // fluent-provider Icon object (the NavMenu renderer's contract); both slots resolve alike.
+        var icon = Assert.IsType<Domain.Icon>(tab.Icon);
+        Assert.Equal(Domain.Icon.FluentProvider, icon.Provider);
+        Assert.Equal("Shield", icon.Id);
+        Assert.IsType<Domain.Icon>(tab.GroupIcon);
+    }
 }


### PR DESCRIPTION
Slice 2 of #1645 (WS7 composition-first), first tranche of the settings-tab migration.

## What
- **UiContribution** gains `Group`/`GroupKey`/`GroupIcon` so grouped settings tabs (Privacy under Administration) express their grouping as data.
- **ProjectSettingsTabs** embeds the contributed layout area INTO the pane's styled stack (same padding/scroll container every compiled tab gets), keeps `/GlobalSettings/{Id}` deep links stable (tab id = the node's trailing path segment), and resolves icon strings through the platform's total `Icon.Parse` (Fluent name → Icon object; emoji degrades to text provider).
- **What's New / About / Privacy** content is exposed as layout areas (`SettingsWhatsNew`/`SettingsAbout`/`SettingsPrivacy`) in `PlatformSettingsTabAreas`; their menu entries are seeded `UiContribution` nodes under `Admin/UiContribution` — the same lane a plugin's settings tab arrives through. The three `Add*SettingsTab` provider registrations are deleted.
- **Security**: Privacy keeps its admin gate twice — `Gates.AdminOnly` on the entry (enforced by the compiled aggregator) AND the area re-asserts `AdminMenuGate.IsPlatformAdmin` because an area is directly URL-addressable; a non-admin gets the localized admins-only notice. All localization keys pre-exist in both catalogs (no react i18n mirror change).

## Verification
- `MeshWeaver.Graph` + `Memex.Portal.Shared` + `Memex.Portal.Monolith` build clean `-c Release -warnaserror`.
- `MeshWeaver.Graph.Test` 1160/1160, `Memex.Portal.Shared.Test` 360/360; UiContributionProjectionTest extended with pins for grouping carry-through, stable tab id, and Icon.Parse resolution.

No What's New entry: user-invisible refactor — the three tabs render identically (label, icon, order, grouping, gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)