### PR TITLE
fix(hosting): update-queue fault eviction guards the disposed cache

### DIFF
--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1665,7 +1665,20 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                         logger.LogError(ex,
                             "[UpdateQueue] queue pipeline FAULTED path={Path} — evicting dead queue",
                             path);
-                        _updateQueues.Remove(path);
+                        // DISPOSED-CACHE GUARD (fault side): this callback fires asynchronously,
+                        // so a straggling pipeline can fault AFTER Dispose() — MemoryCache.Dispose
+                        // never runs eviction callbacks, so the Concat subscription outlives the
+                        // cache and its late fault lands here. Touching the disposed MemoryCache
+                        // throws a synchronous ObjectDisposedException INSIDE OnError, which is
+                        // unobserved → AppDomain.UnhandledException → xUnit "catastrophic failure"
+                        // on an otherwise-green shard (CI: MeshWeaver.AI.Test MASKED exit=2 on
+                        // e0faf867b). Same Volatile idiom as the UpdateRaw write-side guard above;
+                        // the narrow catch covers the read-flag-then-Dispose race — inside OnError
+                        // nothing may throw, and evicting an already-disposed cache is a no-op by
+                        // definition (the fault stays visible via the LogError above).
+                        if (System.Threading.Volatile.Read(ref _disposed) == 0)
+                            try { _updateQueues.Remove(path); }
+                            catch (ObjectDisposedException) { /* teardown won the race */ }
                     });
                 return new UpdateQueueEntry(subject, sub);
             }, LazyThreadSafetyMode.ExecutionAndPublication);

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1677,8 +1677,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                         // nothing may throw, and evicting an already-disposed cache is a no-op by
                         // definition (the fault stays visible via the LogError above).
                         if (System.Threading.Volatile.Read(ref _disposed) == 0)
+                        {
                             try { _updateQueues.Remove(path); }
                             catch (ObjectDisposedException) { /* teardown won the race */ }
+                        }
                     });
                 return new UpdateQueueEntry(subject, sub);
             }, LazyThreadSafetyMode.ExecutionAndPublication);


### PR DESCRIPTION
One member of the #1384 flake population root-caused: a straggling update-queue pipeline faults AFTER `MeshNodeStreamCache` disposal (`MemoryCache.Dispose` never fires eviction callbacks, so the Concat subscription outlives the cache), and the OnError handler's `_updateQueues.Remove(path)` then throws `ObjectDisposedException` **inside OnError** — unobserved → `AppDomain.UnhandledException` → xUnit catastrophic failure on an otherwise-green shard.

Observed on #1643's head `e0faf867b`: `MeshWeaver.AI.Test (part 1/2) exit=2 MASKED (trx records 0 failing tests)` with the fatal stack running `UpdateRemote → GetOrCreateUpdateQueue OnError → MemoryCache.CheckDisposed`.

The fix mirrors the established write-side idiom (the `UpdateRaw` DISPOSED-CACHE GUARD in the same file — `Dispose()` sets `_disposed=1` before disposing the cache): read the flag, and keep a narrow `ObjectDisposedException` catch for the flag-then-dispose race, because inside OnError nothing may throw and evicting an already-disposed cache is a no-op by definition. The fault itself stays visible via the existing LogError.

No What's New entry: CI/teardown stability, no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)