### PR TITLE
feat(ws7): generic top-bar menus from data + AI menu entries as contributions

### DIFF
--- a/memex/Memex.Portal.Shared/AiMenuContributions.cs
+++ b/memex/Memex.Portal.Shared/AiMenuContributions.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using MeshWeaver.AI;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+
+namespace Memex.Portal.Shared;
+
+/// <summary>
+/// The AI (✨) menu's NAVIGATION entries as seeded <see cref="UiContribution"/> nodes (WS7
+/// slice 3, design #1645): Threads / Models / Tiers / Providers / Agents / Skills each open a
+/// catalog URL, so they are pure links — data, not behavior — and ride the same contribution lane
+/// a plugin's AI-menu entry arrives through. The one entry that stays COMPILED is "New thread"
+/// (<see cref="MemexConfiguration.AiMenuItems"/>): it is an imperative click-action sentinel whose
+/// destination is resolved from the circuit's viewer identity at click time — behavior, which the
+/// closed contribution vocabulary deliberately cannot express.
+/// </summary>
+public static class AiMenuContributions
+{
+    /// <summary>
+    /// The seeds, exposed for the pinning tests (the same single-source-of-truth contract
+    /// <see cref="MemexConfiguration.AiMenuItems"/> keeps for the imperative entry).
+    /// </summary>
+    internal static IReadOnlyList<MeshNode> Seeds { get; } =
+    [
+        Seed("AiThreads", "Threads", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiThreads",
+            Label = "Threads",
+            LabelKey = "menu.threads",
+            Icon = "/static/NodeTypeIcons/chat.svg",
+            Order = 10,
+            Href = "/search?q=nodeType%3AThread&groupBy=Namespace",
+            Tooltip = "Conversation threads across every namespace",
+            TooltipKey = "menu.threadsTooltip",
+        }),
+        Seed("AiModels", "Models", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiModels",
+            Label = "Models",
+            LabelKey = "menu.models",
+            Icon = "/static/NodeTypeIcons/sparkle.svg",
+            Order = 20,
+            Href = $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ModelsArea}",
+            Tooltip = "Language models — global, space, and user",
+            TooltipKey = "menu.modelsTooltip",
+        }),
+        // Tiers sit between Models and Providers on purpose: it is the third thing you configure
+        // when you set a deployment up — which models exist, what each one is FOR, and whose key
+        // pays.
+        Seed("AiModelTiers", "Tiers", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiModelTiers",
+            Label = "Tiers",
+            LabelKey = "menu.modelTiers",
+            Icon = "/static/NodeTypeIcons/task-list.svg",
+            Order = 22,
+            Href = $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.TiersArea}",
+            Tooltip = "Model tiers — what each model is used for",
+            TooltipKey = "menu.modelTiersTooltip",
+        }),
+        Seed("AiProviders", "Providers", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiProviders",
+            Label = "Providers",
+            LabelKey = "menu.providers",
+            Icon = "/static/NodeTypeIcons/key.svg",
+            Order = 25,
+            Href = $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ProvidersArea}",
+            Tooltip = "AI providers — endpoints + keys",
+            TooltipKey = "menu.providersTooltip",
+        }),
+        Seed("AiAgents", "Agents", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiAgents",
+            Label = "Agents",
+            LabelKey = "menu.agents",
+            Icon = "/static/NodeTypeIcons/bot.svg",
+            Order = 30,
+            Href = $"/Agent/{AiCatalogLayoutAreas.AgentsArea}",
+            Tooltip = "AI agents — global, space, and user",
+            TooltipKey = "menu.agentsTooltip",
+        }),
+        Seed("AiSkills", "Skills", new UiContribution
+        {
+            Context = NodeMenuItemsExtensions.AiMenuContext,
+            Area = "AiSkills",
+            Label = "Skills",
+            LabelKey = "menu.skills",
+            Icon = "/static/NodeTypeIcons/rocket.svg",
+            Order = 40,
+            Href = $"/{SkillNodeType.RootNamespace}/{AiCatalogLayoutAreas.SkillsArea}",
+            Tooltip = "Reusable skills — global, space, and user",
+            TooltipKey = "menu.skillsTooltip",
+        }),
+    ];
+
+    /// <summary>Seeds the AI menu's navigation entries as platform-static contribution nodes.</summary>
+    public static MeshBuilder AddAiMenuContributions(this MeshBuilder builder)
+        => builder.AddMeshNodes(Seeds);
+
+    private static MeshNode Seed(string id, string name, UiContribution content)
+        => new(id, "Admin/UiContribution")
+        {
+            NodeType = UiContributionNodeType.NodeType,
+            Name = name,
+            Content = content,
+        };
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -499,10 +499,12 @@ public static class MemexConfiguration
     }
 
     /// <summary>
-    /// The AI (✨) menu seed. In render order (by <c>Order</c>): the imperative "New thread" entry, then
-    /// Threads / Models / Providers / Agents / Skills, each opening mesh search grouped by namespace.
-    /// This is the SINGLE SOURCE OF TRUTH, shared by the hub registration below and the unit tests, so a
-    /// regression can't quietly drop an entry (there was no coverage at all pinning "New thread" here).
+    /// The AI (✨) menu's COMPILED remainder: exactly the imperative "New thread" entry. The
+    /// navigation entries (Threads / Models / Tiers / Providers / Agents / Skills) migrated to
+    /// seeded <c>UiContribution</c> nodes (<see cref="AiMenuContributions"/>, WS7 slice 3) — they
+    /// are pure links, so they ride the same lane a plugin's AI-menu entry arrives through.
+    /// This list stays the SINGLE SOURCE OF TRUTH for the imperative entry, shared by the hub
+    /// registration below and the unit tests, so a regression can't quietly drop it.
     /// <para>
     /// 🚨 "New thread" carries NO <c>Href</c> because it CANNOT: the composer lives at
     /// <c>/User/{me}/Chat</c>, and the signed-in user is not known here — this seed is static and
@@ -525,34 +527,6 @@ public static class MemexConfiguration
             Icon: "➕", Order: 0,
             Tooltip: "Start a new conversation")
             { LabelKey = "menu.newThread", TooltipKey = "menu.newThreadTooltip" },
-        new NodeMenuItemDefinition("Threads", "AiThreads", Icon: "/static/NodeTypeIcons/chat.svg", Order: 10,
-            Href: "/search?q=nodeType%3AThread&groupBy=Namespace",
-            Tooltip: "Conversation threads across every namespace")
-            { LabelKey = "menu.threads", TooltipKey = "menu.threadsTooltip" },
-        // Scope-tabbed catalogs (This space · User · Global) with per-tab "+" create,
-        // anchored on the type roots so the catalog area resolves (AddAiCatalogLayoutAreas).
-        new NodeMenuItemDefinition("Models", "AiModels", Icon: "/static/NodeTypeIcons/sparkle.svg", Order: 20,
-            Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ModelsArea}",
-            Tooltip: "Language models — global, space, and user")
-            { LabelKey = "menu.models", TooltipKey = "menu.modelsTooltip" },
-        // Tiers sit between Models and Providers on purpose: it is the third thing you configure when
-        // you set a deployment up — which models exist, what each one is FOR, and whose key pays.
-        new NodeMenuItemDefinition("Tiers", "AiModelTiers", Icon: "/static/NodeTypeIcons/task-list.svg", Order: 22,
-            Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.TiersArea}",
-            Tooltip: "Model tiers — what each model is used for")
-            { LabelKey = "menu.modelTiers", TooltipKey = "menu.modelTiersTooltip" },
-        new NodeMenuItemDefinition("Providers", "AiProviders", Icon: "/static/NodeTypeIcons/key.svg", Order: 25,
-            Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ProvidersArea}",
-            Tooltip: "AI providers — endpoints + keys")
-            { LabelKey = "menu.providers", TooltipKey = "menu.providersTooltip" },
-        new NodeMenuItemDefinition("Agents", "AiAgents", Icon: "/static/NodeTypeIcons/bot.svg", Order: 30,
-            Href: $"/Agent/{AiCatalogLayoutAreas.AgentsArea}",
-            Tooltip: "AI agents — global, space, and user")
-            { LabelKey = "menu.agents", TooltipKey = "menu.agentsTooltip" },
-        new NodeMenuItemDefinition("Skills", "AiSkills", Icon: "/static/NodeTypeIcons/rocket.svg", Order: 40,
-            Href: $"/{SkillNodeType.RootNamespace}/{AiCatalogLayoutAreas.SkillsArea}",
-            Tooltip: "Reusable skills — global, space, and user")
-            { LabelKey = "menu.skills", TooltipKey = "menu.skillsTooltip" },
     ];
 
     extension<TBuilder>(TBuilder builder) where TBuilder : MeshBuilder
@@ -728,6 +702,11 @@ public static class MemexConfiguration
                 // What's New / About / Privacy settings-tab entries as seeded UiContribution
                 // nodes — the WS7 lane a plugin's own settings tab arrives through.
                 .AddPlatformSettingsTabContributions()
+                // The AI menu's navigation entries (Threads/Models/Tiers/Providers/Agents/Skills)
+                // as seeded UiContribution nodes — same lane a plugin's AI-menu entry (or a whole
+                // TopBar-declared menu) arrives through. Only the imperative "New thread" stays
+                // compiled (AiMenuItems).
+                .AddAiMenuContributions()
                 .AddSpaceType()
                 // Generic webhook inbox: the WebhookEvent node type behind
                 // POST /api/hooks/{target} (allowlisted via WebhookInbox:Targets).

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -114,6 +114,38 @@
                             </FluentButton>
                         }
 
+                        @* Data-declared top-bar menus (UiContribution Context="TopBar") — one dropdown per
+                           declaration, entries from the declaration's own context key. Hidden while the
+                           key has no visible entries, like the GitHub menu. *@
+                        @foreach (var contributedMenu in GetTopBarMenus())
+                        {
+                            var menuKey = contributedMenu.Area;
+                            if (string.IsNullOrEmpty(menuKey) || GetContributedMenuItems(menuKey).Count == 0)
+                                continue;
+                            var anchorId = $"contrib-menu-{menuKey}";
+                            <FluentMenu Anchor="@anchorId" Open="@IsContributedMenuOpen(menuKey)"
+                                OpenChanged="@(open => OnContributedMenuOpenChanged(menuKey, open))">
+                                <NodeMenuItemList Items="@GetContributedMenuItems(menuKey)" OnItemClick="@HandleMenuItemClick" />
+                            </FluentMenu>
+                            <FluentButton Id="@anchorId" Appearance="Appearance.Stealth" BackgroundColor="transparent"
+                                Title="@(contributedMenu.Tooltip ?? contributedMenu.Label)"
+                                aria-label="@(contributedMenu.Tooltip ?? contributedMenu.Label)"
+                                OnClick="@(() => ToggleContributedMenu(menuKey))">
+                                @if (IsEmoji(contributedMenu.Icon))
+                                {
+                                    <span class="contrib-menu-icon">@contributedMenu.Icon</span>
+                                }
+                                else if (!string.IsNullOrEmpty(contributedMenu.Icon))
+                                {
+                                    <img class="contrib-menu-icon" src="@contributedMenu.Icon" alt="" />
+                                }
+                                else
+                                {
+                                    <FluentIcon Value="@(new Icons.Regular.Size20.Apps())" Color="Color.FillInverse" />
+                                }
+                            </FluentButton>
+                        }
+
                         @* Settings — direct navigation *@
                         <FluentButton Appearance="Appearance.Stealth" BackgroundColor="transparent"
                             Title="@Access.Localize("common.settings")" aria-label="@Access.Localize("common.settings")"

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -156,6 +156,17 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     private IDisposable? _aiMenuSubscription;
     private IDisposable? _gitHubMenuSubscription;
 
+    // Data-declared top-bar menus (UiContribution Context="TopBar", design #1645). Each
+    // declaration is a NodeMenuItemDefinition whose Area names the menu's own context key; its
+    // entries arrive on that key's stream like any compiled context's. One dropdown per
+    // declaration renders after the compiled menus, hidden while it has no visible entries.
+    private const string TopBarMenuContext = "TopBar";
+    private IReadOnlyList<NodeMenuItemDefinition> _topBarMenus = [];
+    private IDisposable? _topBarMenusSubscription;
+    private readonly Dictionary<string, IReadOnlyList<NodeMenuItemDefinition>> _contributedMenuItems = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IDisposable> _contributedMenuSubscriptions = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool> _contributedMenuOpen = new(StringComparer.Ordinal);
+
 
     // Editable content collections
     /// <summary>
@@ -204,7 +215,56 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
             _gitHubMenuItems = items;
             InvokeAsync(StateHasChanged);
         });
+        _topBarMenusSubscription = MenuItemsProvider.GetMenu(TopBarMenuContext).Subscribe(menus =>
+        {
+            _topBarMenus = menus;
+            SyncContributedMenuSubscriptions(menus);
+            InvokeAsync(StateHasChanged);
+        });
     }
+
+    /// <summary>
+    /// Keeps one entry-stream subscription per declared top-bar menu key: subscribes keys that
+    /// appeared, disposes keys whose declaration went away (plugin uninstalled / gated out).
+    /// </summary>
+    private void SyncContributedMenuSubscriptions(IReadOnlyList<NodeMenuItemDefinition> menus)
+    {
+        var live = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var menu in menus)
+            if (menu.Area is { Length: > 0 } key && key != TopBarMenuContext)
+                live.Add(key);
+
+        foreach (var stale in _contributedMenuSubscriptions.Keys.Where(k => !live.Contains(k)).ToList())
+        {
+            _contributedMenuSubscriptions[stale].Dispose();
+            _contributedMenuSubscriptions.Remove(stale);
+            _contributedMenuItems.Remove(stale);
+            _contributedMenuOpen.Remove(stale);
+        }
+
+        foreach (var key in live)
+            if (!_contributedMenuSubscriptions.ContainsKey(key))
+                _contributedMenuSubscriptions[key] = MenuItemsProvider.GetMenu(key).Subscribe(items =>
+                {
+                    _contributedMenuItems[key] = items;
+                    InvokeAsync(StateHasChanged);
+                });
+    }
+
+    /// <summary>The declared top-bar menus, in declaration Order.</summary>
+    private IReadOnlyList<NodeMenuItemDefinition> GetTopBarMenus() => _topBarMenus;
+
+    private IReadOnlyList<NodeMenuItemDefinition> GetContributedMenuItems(string key)
+        => _contributedMenuItems.TryGetValue(key, out var items) ? items : [];
+
+    private bool IsContributedMenuOpen(string key)
+        => _contributedMenuOpen.TryGetValue(key, out var open) && open;
+
+    private void ToggleContributedMenu(string key)
+        => _contributedMenuOpen[key] = !IsContributedMenuOpen(key);
+
+    private void OnContributedMenuOpenChanged(string key, bool open)
+        => _contributedMenuOpen[key] = open;
 
     /// <summary>
     /// Initializes the navigation service, snapshots the authentication state, and forces the
@@ -1007,6 +1067,10 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         _meshMenuSubscription?.Dispose();
         _aiMenuSubscription?.Dispose();
         _gitHubMenuSubscription?.Dispose();
+        _topBarMenusSubscription?.Dispose();
+        foreach (var subscription in _contributedMenuSubscriptions.Values)
+            subscription.Dispose();
+        _contributedMenuSubscriptions.Clear();
         dotNetRef?.Dispose();
         jsModule?.DisposeAsync();
     }

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -550,3 +550,18 @@
     margin-left: 4px;
     color: var(--neutral-foreground-hint);
 }
+
+/* Data-declared top-bar menu buttons (UiContribution Context="TopBar"): string icons — an emoji
+   span or an svg/img URL — sized to match the FluentIcon Size20 the compiled buttons use. The
+   invert keeps a dark single-color svg legible on the dark header, mirroring Color.FillInverse. */
+::deep .contrib-menu-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 16px;
+    line-height: 20px;
+    display: inline-block;
+}
+
+::deep img.contrib-menu-icon {
+    filter: invert(1);
+}

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.cs
@@ -185,6 +185,8 @@ public partial class LayoutAreaView
     private const string MeshMenuContext = "Mesh";
     private const string AiMenuContext = "AI";
     private const string GitHubMenuContext = "GitHub";
+    // Must match UiContribution.TopBarContext (MeshWeaver.Graph) — same Blazor → Graph decoupling.
+    private const string TopBarMenuContext = "TopBar";
 
     private void BindStream()
     {
@@ -241,6 +243,7 @@ public partial class LayoutAreaView
                 // configured (the provider self-gates); the slot stays empty otherwise. (Instance
                 // sync is in the Node menu as "Synchronizations", not a separate dropdown.)
                 SubscribeMenu(GitHubMenuContext, GitHubMenuContext);
+                SubscribeContributedTopBarMenus();
             }
         }
     }
@@ -321,6 +324,31 @@ public partial class LayoutAreaView
         AreaStream!.RegisterForDisposal(AreaStream!.GetMenu(menuContext).Subscribe(
             items => MenuItemsProvider.Update(providerContext, items),
             ex => OnReducedStreamError(ex, $"{providerContext} menu")));
+    }
+
+    /// <summary>
+    /// The data-declared top-bar menus (UiContribution Context="TopBar", design #1645): pump the
+    /// declaration list itself, and subscribe each declared menu's OWN context key the first time
+    /// it appears — a contributed dropdown's entries then flow exactly like a compiled context's.
+    /// Every subscription registers on <see cref="AreaStream"/>, so teardown is the same as the
+    /// fixed menus above.
+    /// </summary>
+    private void SubscribeContributedTopBarMenus()
+    {
+        if (!IsNotPreRender)
+            return;
+        var subscribedKeys = new HashSet<string>(StringComparer.Ordinal);
+        AreaStream!.RegisterForDisposal(AreaStream!.GetMenu(TopBarMenuContext).Subscribe(
+            menus =>
+            {
+                MenuItemsProvider.Update(TopBarMenuContext, menus);
+                foreach (var menu in menus)
+                    if (menu.Area is { Length: > 0 } key
+                        && key != TopBarMenuContext
+                        && subscribedKeys.Add(key))
+                        SubscribeMenu(key, key);
+            },
+            ex => OnReducedStreamError(ex, "TopBar menu")));
     }
 
     private void OnDialogStreamChanged(JsonElement dialogData)

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -173,7 +173,7 @@ The full field surface:
 |---|---|
 | `Context` | Which menu: `Node` (default), `Mesh`, `Settings`, `AI`, `SidePanel`, `GitHub`, any registered context — or `TopBar` (below) |
 | `Area` | The layout area the entry opens (settings: embedded into the pane; menus: the link target) |
-| `Href` | Optional explicit URL overriding the derived area link — catalog-style entries (`/search?…`, type-root pages) |
+| `Href` | Optional explicit link overriding the derived area URL — **portal-internal only** (a single-slash-rooted path like `/search?…`; schemes and `//host` forms are discarded by the compiled gate and the entry falls back to its area link) |
 | `Label` / `LabelKey` | Display text; the key resolves against the shared localization catalog |
 | `Icon` | String icon — settings tabs parse it via `Icon.Parse` (Fluent name/SVG/URL/emoji); menus render emoji or image URLs |
 | `Tooltip` / `TooltipKey` | Hover text (menus and top-bar buttons) |

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -146,12 +146,61 @@ in its `TypeRegistry` or it degrades to an untyped `JsonElement` and the area re
 | A named area on a node type | `LayoutDefinition.WithView(name, generator)` | the NodeType's configuration — in-mesh or compiled |
 | Default areas on every node | `AddDefaultLayoutAreas()` composition | core only — extending it puts your area on *every node in the mesh*; prefer a NodeType-scoped area |
 | A left-rail navigation for a node family | `INodeNavigationProvider` | DI singleton (pack) — claimed by node shape at render time |
-| A settings tab | `AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(...))` | hub configuration (pack or plugin hub config) |
-| Node-menu entries / presentation | `AddNodeMenuItems(...)`; menu presentation is editable data (`MenuPresentationOverlay`) | hub configuration / mesh data |
+| A settings tab | a `UiContribution` node (`Context: Settings`) pointing at a layout area — or compiled `AddGlobalSettingsMenuItems(...)` for content that needs code | mesh data / hub configuration |
+| Node-menu entries / presentation | a `UiContribution` node (`Context: Node`/`Mesh`/`AI`/`SidePanel`/…) — or compiled `AddNodeMenuItems(...)`; presentation stays editable data (`MenuPresentationOverlay`) | mesh data / hub configuration |
+| A whole NEW top-bar menu | a `UiContribution` node (`Context: TopBar`) declaring the dropdown; entries target its key | mesh data — no code at all |
 | A home-screen tab | a `HomeTab` node | mesh data — no code at all |
 | Hub behaviour for a node type | `MeshNode.HubConfiguration` | works from in-mesh plugins at runtime |
 | Root services, nodes, hub + per-node-hub configuration, or a whole builder extension from a DLL | `MeshNodeProviderAttribute` (`Nodes` / `HubConfigurations` / `DefaultNodeHubConfigurations` / `BuilderConfigurations`) + `MeshBuilder.InstallAssemblies` | boot time only (`Modules:Assemblies`) |
 | Portal-hub config from a plugin (incl. views) | `WithPortalConfiguration(portal => …)` | the plugin's own hub configuration — at runtime |
+
+## Menus and settings tabs as data — `UiContribution` nodes
+
+The composition-first lane: a **menu entry, settings tab, or whole top-bar menu is a mesh node**
+(`nodeType: UiContribution`), so a plugin ships it as pack content and an admin edits it live —
+no build, no image, no rollout. One live query per silo (the `UiContributionCatalog`) feeds every
+per-node hub's menu aggregation; installing or updating a contribution changes every open menu
+reactively.
+
+**The security boundary.** Visibility is enforced by COMPILED code against a CLOSED vocabulary —
+a contribution can only ever NARROW its own visibility, never widen anything, and it never
+introduces a render surface: it points at a layout AREA that renders through the ordinary layout
+pipeline and its own access gates. Anything beyond the vocabulary stays in code.
+
+The full field surface:
+
+| Field | Meaning |
+|---|---|
+| `Context` | Which menu: `Node` (default), `Mesh`, `Settings`, `AI`, `SidePanel`, `GitHub`, any registered context — or `TopBar` (below) |
+| `Area` | The layout area the entry opens (settings: embedded into the pane; menus: the link target) |
+| `Href` | Optional explicit URL overriding the derived area link — catalog-style entries (`/search?…`, type-root pages) |
+| `Label` / `LabelKey` | Display text; the key resolves against the shared localization catalog |
+| `Icon` | String icon — settings tabs parse it via `Icon.Parse` (Fluent name/SVG/URL/emoji); menus render emoji or image URLs |
+| `Tooltip` / `TooltipKey` | Hover text (menus and top-bar buttons) |
+| `Order` | Sort position (default 100 — after the built-ins) |
+| `Group` / `GroupKey` / `GroupIcon` | Settings-tab grouping (entries sharing a group nest under its header) |
+| `RequiredPermission` | Checked against the viewer's LIVE effective permission on the anchoring node, floored at `Read`; anonymous sees nothing |
+| `Gates.NodeTypes` | Suffix-aware node-type filter (`"Slide"` matches `Publish/Slide`) |
+| `Gates.ExcludePartitionRoot` | Never on a protected partition root — the built-in suppression's own predicate |
+| `Gates.AdminOnly` | Platform admins only (`hub.IsGlobalAdmin()`, reactive) |
+
+**Settings tabs** (`Context: Settings`): the contributed area is embedded into the pane's styled
+stack; the tab id is the NODE id, so `/GlobalSettings/{id}` deep links stay stable when a compiled
+tab migrates to a same-named seed. The platform's own What's New / About / Privacy tabs ship this
+way (`Admin/UiContribution/*` seeds) — the reference implementation.
+
+**Whole top-bar menus** (`Context: TopBar`): the contribution declares a NEW dropdown — its `Area`
+names the menu's own context key, `Label`/`Icon`/`Order`/`Tooltip` style the button, and its
+entries are ordinary contributions targeting that key. The gates apply to the declaration itself
+(an `AdminOnly` menu disappears wholesale), and a menu with no visible entries renders nothing.
+The AI menu's catalog entries (Threads / Models / Tiers / Providers / Agents / Skills) are seeded
+contributions in the `AI` context; only imperative click-action entries (New thread, the side
+panel's new-chat/history/fullscreen) stay compiled — behavior, which the closed vocabulary
+deliberately cannot express.
+
+**Seeding**: platform-static seeds ride `MeshBuilder.AddMeshNodes(...)`
+(`AddPlatformSettingsTabContributions`, `AddAiMenuContributions`); a plugin just ships
+`UiContribution` nodes as pack content under its own namespace.
 
 ## What cannot be extended today
 

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -452,6 +452,22 @@ public static class NodeMenuItemsExtensions
             if (provider.Context is { Length: > 0 } c)
                 contexts.Add(c);
 
+        // Contexts DECLARED BY DATA (design #1645): any context a UiContribution targets, plus
+        // every top-bar menu key (a TopBar declaration's Area names a NEW context whose entries
+        // arrive as contributions targeting that key). Snapshot at render time — this renderer
+        // re-runs on every area render, so a freshly installed plugin's menu appears on the next
+        // render; its ENTRIES then flow reactively through the context's contribution stream.
+        var contributionCatalog = host.Hub.ServiceProvider.GetService<UiContributionCatalog>();
+        if (contributionCatalog is not null)
+            foreach (var (_, contribution) in contributionCatalog.Current)
+            {
+                if (contribution.Context is { Length: > 0 } declared)
+                    contexts.Add(declared);
+                if (contribution.Context == UiContribution.TopBarContext
+                    && contribution.Area is { Length: > 0 } menuKey)
+                    contexts.Add(menuKey);
+            }
+
         var result = new Dictionary<string, IObservable<IReadOnlyCollection<NodeMenuItemDefinition>>>(StringComparer.Ordinal);
         foreach (var context in contexts)
         {

--- a/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
@@ -54,6 +54,21 @@ public sealed class UiContributionCatalog : IDisposable
         }
     }
 
+    /// <summary>
+    /// Synchronous snapshot of the current set — for callers that enumerate contexts at RENDER
+    /// time (the menu renderer's context list). First access starts the shared subscription, so a
+    /// cold snapshot may be empty; the renderer re-runs on every area render, which picks up the
+    /// warmed set.
+    /// </summary>
+    public ImmutableList<(MeshNode Node, UiContribution Content)> Current
+    {
+        get
+        {
+            EnsureSubscribed();
+            return state.Value.Values.ToImmutableList();
+        }
+    }
+
     private void EnsureSubscribed()
     {
         if (subscription is not null)

--- a/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
@@ -64,6 +64,16 @@ public record UiContribution
     public const string SettingsContext = "Settings";
 
     /// <summary>
+    /// The top-bar MENU-DECLARATION context: a contribution here declares a whole NEW top-bar
+    /// dropdown. <see cref="Area"/> names the new menu's context KEY — entries target that key as
+    /// their own <see cref="Context"/> — and Label/LabelKey, Icon, Order and Tooltip style the
+    /// menu button. The closed gate vocabulary applies to the declaration like any entry (an
+    /// <c>AdminOnly</c> menu disappears wholesale for non-admins), and a menu with no visible
+    /// entries renders nothing.
+    /// </summary>
+    public const string TopBarContext = "TopBar";
+
+    /// <summary>
     /// Which menu the entry contributes to: <c>Node</c>, <c>Mesh</c>, <c>Settings</c>,
     /// <c>AiMenu</c> or <c>SidePanel</c>. Unset ⇒ <c>Node</c>.
     /// </summary>
@@ -87,6 +97,20 @@ public record UiContribution
     /// area-not-found placeholder renders if it is missing, exactly like any dangling area link.
     /// </summary>
     public string? Area { get; init; }
+
+    /// <summary>
+    /// Optional explicit navigation URL, overriding the URL derived from <see cref="Area"/> on the
+    /// anchoring node — the shape catalog-style entries use (absolute portal paths, search URLs).
+    /// Purely navigational: what the URL opens still renders through the ordinary layout pipeline
+    /// and its own access gates; the closed gate vocabulary here only NARROWS who sees the link.
+    /// </summary>
+    public string? Href { get; init; }
+
+    /// <summary>Optional hover tooltip. Prefer <see cref="TooltipKey"/> for translated text.</summary>
+    public string? Tooltip { get; init; }
+
+    /// <summary>Localization key for <see cref="Tooltip"/>.</summary>
+    public string? TooltipKey { get; init; }
 
     /// <summary>Sort order within the menu (lower = earlier). Default 100 — after the built-ins.</summary>
     public int Order { get; init; } = 100;

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -58,8 +58,13 @@ internal static class UiContributionProjection
                 contribution.Icon,
                 required,
                 contribution.Order,
-                Href: MeshNodeLayoutAreas.BuildUrl(menuPath, area))
-                { LabelKey = contribution.LabelKey });
+                // A declared Href wins (catalog-style absolute links); otherwise the entry opens
+                // its area on the anchoring node, like every built-in node-menu item.
+                Href: contribution.Href is { Length: > 0 } href
+                    ? href
+                    : MeshNodeLayoutAreas.BuildUrl(menuPath, area),
+                Tooltip: contribution.Tooltip)
+                { LabelKey = contribution.LabelKey, TooltipKey = contribution.TooltipKey });
         }
         return items ?? (IReadOnlyCollection<NodeMenuItemDefinition>)[];
     }

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -58,9 +58,13 @@ internal static class UiContributionProjection
                 contribution.Icon,
                 required,
                 contribution.Order,
-                // A declared Href wins (catalog-style absolute links); otherwise the entry opens
-                // its area on the anchoring node, like every built-in node-menu item.
-                Href: contribution.Href is { Length: > 0 } href
+                // A declared Href wins (catalog-style links) — but ONLY a portal-internal one:
+                // Href is mesh DATA reaching NavigationManager, so schemes (javascript:, https:)
+                // and protocol-relative hosts are an XSS/phishing surface the closed vocabulary
+                // must not open. Anything non-internal falls back to the derived area URL —
+                // narrowing, never widening (#1645). Otherwise the entry opens its area on the
+                // anchoring node, like every built-in node-menu item.
+                Href: contribution.Href is { Length: > 0 } href && IsPortalInternalHref(href)
                     ? href
                     : MeshNodeLayoutAreas.BuildUrl(menuPath, area),
                 Tooltip: contribution.Tooltip)
@@ -107,6 +111,16 @@ internal static class UiContributionProjection
         }
         return items;
     }
+
+    /// <summary>
+    /// The Href gate: a contributed link must be PORTAL-INTERNAL — a single-slash-rooted path
+    /// (<c>/search?…</c>, <c>/Agent/AiAgents</c>). A leading scheme (<c>javascript:</c>,
+    /// <c>https:</c>) or a protocol-relative <c>//host</c> cannot pass, because a rooted path can
+    /// contain neither. External links stay a COMPILED concern until an explicit allowlist
+    /// vocabulary exists.
+    /// </summary>
+    internal static bool IsPortalInternalHref(string href) =>
+        href.Length > 1 && href[0] == '/' && href[1] != '/';
 
     /// <summary>Suffix-aware node-type gate — the platform's <c>Matches</c> semantics.</summary>
     internal static bool NodeTypeGateMatches(string? nodeType, string gate) =>

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -26,11 +26,14 @@ public class AiMenuNewThreadTest
 
         // Order 0 → it sorts ahead of every other AI entry (Threads 10, Models 20, …). The menu
         // aggregator inserts into an ImmutableSortedSet keyed on Order, so this IS the positioning
-        // contract — there is no post-hoc OrderBy to fall back on.
+        // contract — there is no post-hoc OrderBy to fall back on. The navigation entries live in
+        // AiMenuContributions.Seeds now (WS7 slice 3), so the ordering contract spans both lists.
         Assert.Equal(0, newThread.Order);
         Assert.All(
-            items.Where(i => i.Area != PortalLayoutBase.AiNewThreadAction),
-            i => Assert.True(i.Order > 0, $"'{i.Label}' must sort after New thread"));
+            AiMenuContributions.Seeds,
+            seed => Assert.True(
+                Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(seed.Content).Order > 0,
+                $"'{seed.Name}' must sort after New thread"));
     }
 
     [Fact]
@@ -73,19 +76,35 @@ public class AiMenuNewThreadTest
     [Fact]
     public void Every_Other_AiMenu_Entry_Navigates_By_Href()
     {
-        // The inverse of the sentinel contract: everything that is NOT the imperative entry must be a
-        // plain navigation, so it works identically from any page and needs no client state.
-        Assert.All(
-            MemexConfiguration.AiMenuItems.Where(i => i.Area != PortalLayoutBase.AiNewThreadAction),
-            i => Assert.False(string.IsNullOrEmpty(i.Href), $"'{i.Label}' must navigate by Href"));
+        // The inverse of the sentinel contract: everything that is NOT the imperative entry must be
+        // a plain navigation, so it works identically from any page and needs no client state.
+        // Those entries are seeded UiContribution nodes (WS7 slice 3) — data, because they carry no
+        // behavior; only the imperative "New thread" stays in the compiled list.
+        Assert.Single(MemexConfiguration.AiMenuItems);
+        Assert.NotEmpty(AiMenuContributions.Seeds);
+        Assert.All(AiMenuContributions.Seeds, seed =>
+        {
+            var contribution = Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(seed.Content);
+            Assert.Equal("AI", contribution.Context);
+            Assert.False(string.IsNullOrEmpty(contribution.Href), $"'{seed.Name}' must navigate by Href");
+            Assert.False(string.IsNullOrEmpty(contribution.LabelKey), $"'{seed.Name}' must localize its label");
+        });
     }
 
     [Fact]
     public void AiMenu_Entries_Are_Uniquely_Keyed()
     {
         // The aggregator dedupes on (Order, Label, Area) via ImmutableSortedSet — two entries
-        // colliding on all three would silently drop one from the rendered menu.
-        var keys = MemexConfiguration.AiMenuItems.Select(i => (i.Order, i.Label, i.Area)).ToList();
+        // colliding on all three would silently drop one from the rendered menu. Spans the compiled
+        // imperative entry AND the seeded navigation contributions.
+        var keys = MemexConfiguration.AiMenuItems
+            .Select(i => (i.Order, Label: (string?)i.Label, Area: (string?)i.Area))
+            .Concat(AiMenuContributions.Seeds.Select(s =>
+            {
+                var c = Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(s.Content);
+                return (c.Order, Label: c.Label, Area: c.Area);
+            }))
+            .ToList();
         Assert.Equal(keys.Count, keys.Distinct().Count());
     }
 }

--- a/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
@@ -116,6 +116,49 @@ public class UiContributionProjectionTest
     }
 
     [Fact]
+    public void DeclaredHref_Overrides_TheDerivedAreaUrl_AndTooltipsCarryThrough()
+    {
+        var item = Assert.Single(Project(new UiContribution
+        {
+            Context = "AI",
+            Area = "AiThreads",
+            Href = "/search?q=nodeType%3AThread&groupBy=Namespace",
+            Tooltip = "Conversation threads",
+            TooltipKey = "menu.threadsTooltip",
+        }, context: "AI"));
+        Assert.Equal("/search?q=nodeType%3AThread&groupBy=Namespace", item.Href);
+        Assert.Equal("Conversation threads", item.Tooltip);
+        Assert.Equal("menu.threadsTooltip", item.TooltipKey);
+
+        // Without a declared Href the entry opens its area on the anchoring node, as before.
+        var derived = Assert.Single(Project(new UiContribution { Area = "MyArea" }));
+        Assert.Contains("MyArea", derived.Href);
+    }
+
+    [Fact]
+    public void TopBarDeclaration_ProjectsAsAMenuButton_InTheTopBarContextOnly()
+    {
+        // A whole NEW top-bar menu is itself a contribution in the TopBar context: Area names the
+        // menu's context key, Label/Icon/Order style the button, and the closed gate vocabulary
+        // applies (an AdminOnly menu disappears wholesale for non-admins).
+        var declaration = new UiContribution
+        {
+            Context = UiContribution.TopBarContext,
+            Area = "Reinsurance",
+            Label = "Reinsurance",
+            Icon = "📊",
+            Order = 60,
+            Gates = new UiContributionGates { AdminOnly = true },
+        };
+
+        Assert.Empty(Project(declaration));                                     // not in the Node menu
+        Assert.Empty(Project(declaration, context: UiContribution.TopBarContext)); // non-admin: hidden
+        var button = Assert.Single(Project(declaration, context: UiContribution.TopBarContext, isAdmin: true));
+        Assert.Equal("Reinsurance", button.Area);
+        Assert.Equal(60, button.Order);
+    }
+
+    [Fact]
     public void SettingsTabs_GateOnAdminOnly_AndCarryTheContributedArea()
     {
         var contributions = new[]

--- a/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
@@ -135,6 +135,20 @@ public class UiContributionProjectionTest
         Assert.Contains("MyArea", derived.Href);
     }
 
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("https://evil.example/phish")]
+    [InlineData("//evil.example/phish")]
+    [InlineData("data:text/html,x")]
+    public void NonInternalHref_IsDiscarded_AndTheEntryFallsBackToItsAreaUrl(string href)
+    {
+        // Href is mesh DATA reaching navigation — schemes and protocol-relative hosts must never
+        // pass the compiled gate (XSS/phishing surface). The entry degrades to its area link.
+        var item = Assert.Single(Project(new UiContribution { Area = "MyArea", Href = href }));
+        Assert.DoesNotContain(href, item.Href);
+        Assert.Contains("MyArea", item.Href);
+    }
+
     [Fact]
     public void TopBarDeclaration_ProjectsAsAMenuButton_InTheTopBarContextOnly()
     {


### PR DESCRIPTION
Slice 3 of #1645, generalized per the maintainer's direction: **any top-bar menu can be injected as data**, not just entries into the compiled menus.

## The generic mechanism
- `UiContribution` gains `Href` (overrides the derived area URL — catalog-style absolute links), `Tooltip`/`TooltipKey`, and a reserved **`TopBar` context**: a contribution there declares a whole NEW top-bar dropdown. Its `Area` names the menu's own context key; `Label`/`Icon`/`Order`/`Tooltip` style the button; its entries are ordinary contributions targeting that key. The closed gate vocabulary applies to the declaration itself — an `AdminOnly` menu disappears wholesale for non-admins, and a menu with no visible entries renders nothing.
- The menu renderer's context list unions the contexts declared by data (render-time snapshot via `UiContributionCatalog.Current`), so `$Menu:{key}` slots exist for data-declared menus. `LayoutAreaView` pumps the TopBar stream and subscribes each declared key the first time it appears (registered on the area stream, same teardown as the fixed menus). `PortalLayoutBase` renders one dropdown per declaration after the compiled menus, hidden while empty (the GitHub-menu pattern), with string icons (emoji/svg) sized to match the Fluent buttons.
- No new wire shape anywhere: a menu declaration IS a projected menu item; entries ride the existing per-context aggregation, which was already contribution-aware.

## The AI menu migration
The six navigation entries (Threads / Models / Tiers / Providers / Agents / Skills) become seeded `UiContribution` nodes (`AiMenuContributions`, `Admin/UiContribution/*`) — pure links, so they ride the same lane a plugin's AI-menu entry arrives through. Only the imperative **New thread** click-action sentinel stays compiled (`AiMenuItems`): its destination resolves from the circuit's viewer identity at click time — behavior, which the closed vocabulary deliberately cannot express. The side panel's three entries (new-chat/history/fullscreen) are likewise behavior sentinels and stay compiled; plugins can already contribute `SidePanel`-context entries through the generic lane.

No visible change for users: the AI menu renders identically (labels, icons, order, tooltips, localization keys all pre-existing — no i18n catalog change, no react mirror change). Anonymous viewers never saw these menus (the block is inside `AuthorizeView`), so the contribution permission floor changes nothing.

## Verification
- `MeshWeaver.Graph`, `MeshWeaver.Blazor.Portal`, `Memex.Portal.Shared`, `Memex.Portal.Monolith` build clean `-c Release -warnaserror`.
- `MeshWeaver.Graph.Test` 1162/1162 (new pins: Href override + tooltip carry-through; TopBar declaration projects only in the TopBar context and honors AdminOnly), `Memex.Portal.Shared.Test` 361/361 (AiMenuNewThreadTest repointed: single compiled entry, seeds all Href-navigating + localized, uniqueness spans both lists).

No What's New entry: platform capability for plugin authors; the rendered UI is unchanged (same precedent as #1646/#1648).

🤖 Generated with [Claude Code](https://claude.com/claude-code)