### PR TITLE
feat(modules): the modules/ publish layout, step 1 — probing, compile surface, fingerprint (#1644)

### DIFF
--- a/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
+++ b/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
@@ -17,4 +17,6 @@
     <ProjectReference Include="..\..\samples\Northwind\MeshWeaver.Northwind.Application\MeshWeaver.Northwind.Application.csproj" />
   </ItemGroup>
 
+  <Import Project="..\MeshModulesPublish.targets" />
+
 </Project>

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -579,10 +579,10 @@ public static class MemexConfiguration
             // fail loudly at startup, never silently run without the pack.
             var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
             if (moduleAssemblies is { Length: > 0 })
+                // ResolveModulePath probes the modules/<name>/ publish layout first (#1644),
+                // then falls back to the classic BaseDirectory-relative location.
                 builder.InstallAssemblies(moduleAssemblies
-                    .Select(path => Path.IsPathRooted(path)
-                        ? path
-                        : Path.Combine(AppContext.BaseDirectory, path))
+                    .Select(MeshBuilder.ResolveModulePath)
                     .ToArray());
 
             // Read graph storage config

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -1,0 +1,80 @@
+<Project>
+  <!--
+    The modules/ publish layout — design #1644, step 1 (ADDITIVE).
+
+    Publishing a host lays every mesh MODULE out under modules/<Name>/ beside the app. Which
+    modules EXIST is this list (a publish/composition decision); which ACTIVATE stays the
+    deployment's Modules:Assemblies configuration, whose loader probes modules/<name>/<name>.dll
+    first and falls back to the app folder (MeshBuilder.ResolveModulePath).
+
+    Step-1 scope, deliberately THIN: each module contributes its OWN build outputs (dll/pdb/xml),
+    not its transitive closure. A full `Publish` per module was measured to drag ~1400
+    framework-package assemblies the app resolves from the SHARED FRAMEWORK (a class library's
+    standalone publish rolls Microsoft.Extensions.* in; the app does not carry them), and a
+    filename prune against the app folder cannot see shared-framework provision — the same-identity
+    trap-door class in its publish-time form. Closure layout is therefore per-module STEP-2 work:
+    when a module's ProjectReference flips off, its entry here upgrades to a closure publish with a
+    prune that is correct FOR THAT MODULE (most have no private deps beyond the app's closure;
+    Speech's native runtime is the known exception).
+
+    While a module ALSO rides a ProjectReference from Memex.Portal.Shared (the step-1 double-ship),
+    even its own DLL is pruned as a same-identity duplicate of the app copy — the folder stays
+    empty for it and the loader falls back to the app folder: byte-for-byte today's behaviour.
+  -->
+  <ItemGroup>
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
+  </ItemGroup>
+
+  <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">
+    <PropertyGroup>
+      <_AppPublishDir>$([System.IO.Path]::GetFullPath('$(PublishDir)', '$(MSBuildProjectDirectory)'))</_AppPublishDir>
+    </PropertyGroup>
+
+    <!-- Build each module (already built as part of the host's graph in the double-ship state —
+         this is an incremental no-op then) and collect its primary output. Serial on purpose:
+         parallel builds have wedged the shared compiler on this repo's build hosts. -->
+    <MSBuild Projects="@(MeshModule)"
+             Targets="Build"
+             BuildInParallel="false"
+             Properties="Configuration=$(Configuration)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ModuleAssemblyBuilt" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_ModuleOwnFile Include="@(_ModuleAssemblyBuilt)" ModuleName="%(Filename)" />
+      <_ModuleOwnFile Include="@(_ModuleAssemblyBuilt->'%(RootDir)%(Directory)%(Filename).pdb')"
+                      ModuleName="%(Filename)"
+                      Condition="Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
+      <_ModuleOwnFile Include="@(_ModuleAssemblyBuilt->'%(RootDir)%(Directory)%(Filename).xml')"
+                      ModuleName="%(Filename)"
+                      Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_ModuleOwnFile)"
+          DestinationFiles="@(_ModuleOwnFile->'$(_AppPublishDir)modules/%(ModuleName)/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+
+    <!-- Prune same-identity files the app output already carries (the double-ship state). -->
+    <ItemGroup>
+      <_ModuleFolderFile Include="$(_AppPublishDir)modules/**/*.*" />
+      <_ModuleDuplicate Include="@(_ModuleFolderFile)" Condition="Exists('$(_AppPublishDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ModuleDuplicate)" />
+
+    <ItemGroup>
+      <_ModuleFileKept Include="$(_AppPublishDir)modules/**/*.*" />
+    </ItemGroup>
+    <Message Importance="high"
+             Text="PublishMeshModules: @(MeshModule->Count()) module(s) laid out; pruned @(_ModuleDuplicate->Count()) app-closure duplicate(s); modules/ keeps @(_ModuleFileKept->Count()) file(s)." />
+  </Target>
+</Project>

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,9 @@
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">
     <PropertyGroup>
-      <_AppPublishDir>$([System.IO.Path]::GetFullPath('$(PublishDir)', '$(MSBuildProjectDirectory)'))</_AppPublishDir>
+      <!-- EnsureTrailingSlash: GetFullPath does not guarantee one, and every use below
+           concatenates directly (`$(_AppPublishDir)modules/…`). -->
+      <_AppPublishDir>$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(PublishDir)', '$(MSBuildProjectDirectory)'))))</_AppPublishDir>
     </PropertyGroup>
 
     <!-- Build each module (already built as part of the host's graph in the double-ship state —

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -61,4 +61,6 @@
     <PackageReference Include="Microsoft.Orleans.Sdk" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
   </ItemGroup>
+
+  <Import Project="..\..\MeshModulesPublish.targets" />
 </Project>

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -1,0 +1,103 @@
+---
+Name: Modules
+Category: Architecture
+Description: The module lane end to end — MeshNodeProviderAttribute, the Modules:Assemblies activation list, every module's configuration section, the modules/ publish layout, and the compile-surface + fingerprint story.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg>
+---
+
+A **module** is a compiled MeshWeaver assembly a deployment turns on by LISTING it — no code
+change, no recompile of the platform. This page is the operator- and author-facing reference for
+the whole lane: how a module declares itself, how a deployment activates and configures it, how
+its bits reach the image, and how the in-mesh compiler and bake fingerprint treat it.
+
+## Declaring a module — `MeshNodeProviderAttribute`
+
+A module carries one assembly-level attribute deriving from `MeshNodeProviderAttribute`
+(`MeshWeaver.Mesh.Contract`). Its five hooks are the complete boot-time surface:
+
+| Hook | What it contributes |
+|---|---|
+| `Nodes` | Mesh nodes (node types, seeds) — with `.WithGlobalServiceRegistry` for root DI services |
+| `AddressTypes` | Address types for the type registry |
+| `HubConfigurations` | The MESH hub's configuration |
+| `DefaultNodeHubConfigurations` | Configuration applied to EVERY per-node hub (layout areas, type registrations) |
+| `BuilderConfigurations` | The full-surface hook — a `MeshBuilder → MeshBuilder` fold, applied last |
+
+Module DI options bind through the options pipeline —
+`services.AddOptions<T>().BindConfiguration("Section")` — never `services.Configure(section)`:
+there is no `IConfiguration` instance at install time. A module whose activation depends on
+runtime facts guards itself with a resolve-time `enabledWhen` gate (the PostgreSQL indexing
+module registers its provider `enabledWhen` the mesh database connection resolves) instead of
+failing at boot.
+
+Modules that also need explicit composition (test fixtures, bespoke hosts) expose ONE
+`Add<Name>()` extension sharing the same internal configure path as the attribute — the two lanes
+must never drift (`OgCardExtensions` is the reference shape).
+
+## Activating — `Modules:Assemblies`
+
+The deployment's appsettings lists the DLLs to install; the list IS the on/off switch. The
+current first-party inventory and each module's configuration section:
+
+| Module DLL | Concern | Configuration |
+|---|---|---|
+| `MeshWeaver.AI.OpenAI.dll` | OpenAI-compatible model providers | `OpenAI`, `OpenAICompatible:Models` |
+| `MeshWeaver.AI.AzureFoundry.dll` | Azure Foundry + Anthropic-on-Azure providers | `AzureFoundry`, `Anthropic` |
+| `MeshWeaver.AI.ClaudeCode.dll` | Claude Code harness | `ClaudeCode` |
+| `MeshWeaver.AI.Copilot.dll` | Copilot harness | `Copilot` |
+| `MeshWeaver.Blazor.Radzen.dll` | Radzen view pack (charts etc.) | — |
+| `MeshWeaver.Blazor.Analysis.dll` | Analysis view pack | — |
+| `MeshWeaver.Blazor.GoogleMaps.dll` | Google Maps map provider | `GoogleMaps` |
+| `MeshWeaver.ContentCollections.Indexing.PostgreSql.dll` | Content indexing (PG) | gated `enabledWhen` the mesh DB resolves |
+| `MeshWeaver.Speech.dll` | Speech transcription | `Speech` |
+| `MeshWeaver.Markdown.Export.dll` | Document export (PDF/DOCX/HTML/email) | — |
+| `MeshWeaver.Observability.dll` | Red-log ticketing / log watch | `LogWatch` |
+| `MeshWeaver.OgCard.dll` | Link-preview (og-card) layout area | — |
+
+Boot packs select by OTHER configuration too: `Graph:Storage:Type` `Cosmos`/`Snowflake` requires
+the matching `MeshWeaver.Hosting.Cosmos`/`.Snowflake` DLL in this list — installation runs before
+storage selection, so ordering is safe. Delisting a UI module removes its areas mesh-wide;
+embeds of a removed area render the standard area-not-found placeholder (documented per module).
+
+Entries resolve through `MeshBuilder.ResolveModulePath`: a rooted path passes through; a bare
+DLL name probes **`modules/<name>/<name>.dll`** beside the app first (the publish layout below),
+then falls back to the app folder.
+
+## The `modules/` publish layout (#1644)
+
+Both hosts import `memex/MeshModulesPublish.targets`: publishing lays every listed module out
+under `modules/<Name>/` beside the app, pruning same-identity files the app output already
+carries. While a module still ALSO rides a `ProjectReference` (the transition state), its folder
+prunes to empty and the loader falls back to the app folder — byte-for-byte the classic image.
+Flipping a module's reference off (one module at a time, its entry upgraded to a closure layout
+correct for that module) is what makes the folder carry real content; which modules EXIST then
+becomes a publish decision while which ACTIVATE stays `Modules:Assemblies`. Skip the whole
+target with `-p:PublishMeshModules=false`.
+
+## Modules and the in-mesh compiler
+
+In-mesh source compiles against the platform's `TRUSTED_PLATFORM_ASSEMBLIES` **plus this mesh's
+installed modules**: `InstallAssemblies` records every loaded module as an
+`InstalledModuleAssembly` DI singleton, and `MeshNodeCompilationService` composes its reference
+set from both — so a module published outside the app closure stays visible to scope classes and
+NodeType source that reference it (e.g. a map control). Two boundaries stand:
+
+- **Kernel cells are different.** Executable `--render` cells resolve against a process-wide
+  snapshot, and pack/NodeType assemblies are not reliably cell-callable — cell-callable API stays
+  in compiled, startup-loaded assemblies until the pack-scripting seam lands.
+- **The bake fingerprint.** Every successful NodeType compile stamps
+  `CompiledModulesHash` — a hash of the sorted installed-module MVIDs
+  (`InstalledModulesFingerprint`) — beside `CompiledFrameworkVersion`. While modules ride the
+  image the framework MVID already invalidates on every rebuild, so the hash is recorded but not
+  yet decisive; it joins the usable-build check when modules ship separately from the image, so a
+  module-only update invalidates baked builds that could reference it. Definitions stamped before
+  the feature carry `null`, which compares as MATCH — such builds predate modules in the compile
+  surface and stay governed by the framework rule.
+
+## Related
+
+UI contributed as data (menus, settings tabs, whole top-bar menus — `UiContribution` nodes) is
+[UI Extensibility](/Doc/Architecture/UiExtensibility). Content plugins and their registry are
+[Plugins](/Doc/Architecture/Plugins) and [Plugin Packaging](/Doc/Architecture/PluginPackaging).
+Deployment surfaces: [Feature Flags](/Doc/Architecture/FeatureFlags) ·
+[Deployment](/Doc/Architecture/Deployment).

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -81,6 +81,9 @@ public static class GraphConfigurationExtensions
             // catalog the menu aggregation maps (one query subscription per silo).
             builder.AddUiContributionType();
             builder.ConfigureServices(s => s.AddSingleton<UiContributionCatalog>());
+            // The installed-module fingerprint (#1644): resolves the mesh's InstalledModuleAssembly
+            // set (empty when no modules) — stamped by compile write-backs as CompiledModulesHash.
+            builder.ConfigureServices(s => s.AddSingleton<InstalledModulesFingerprint>());
 
             // The static-repo importer runs its bulk create/upsert traffic on a DEDICATED
             // hub (import/{meshHubId}) so it never floods the root mesh hub's action block —

--- a/src/MeshWeaver.Graph/Configuration/InstalledModulesFingerprint.cs
+++ b/src/MeshWeaver.Graph/Configuration/InstalledModulesFingerprint.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The mesh-scoped fingerprint of the deployment's installed MODULES — a stable hash over the
+/// sorted MVIDs of every <see cref="InstalledModuleAssembly"/> (the <c>Modules:Assemblies</c>
+/// set, design #1644). Stamped as <c>NodeTypeDefinition.CompiledModulesHash</c> by every
+/// successful NodeType compile, alongside <c>CompiledFrameworkVersion</c>.
+///
+/// <para><b>Step-1 scope (deliberate):</b> the hash is RECORDED but does not yet join the
+/// usable-build decision. While modules ride the app image, a module change rebuilds the image,
+/// which changes Graph's MVID, which invalidates every build through the existing framework-match
+/// rule — the modules hash is redundant there. It becomes load-bearing exactly when modules ship
+/// SEPARATELY from the image (the <c>modules/</c> folder + bundle lane, #1644 step 2): then a
+/// module-only update must invalidate baked builds that could reference it, and this recorded
+/// hash is what the usable-build check compares. Definitions stamped before this feature carry
+/// null, which step 2 must treat as MATCH: a null-hash build was compiled when modules were in
+/// the app closure, and the framework rule already governs it.</para>
+///
+/// <para>Registered as a mesh-scoped singleton (lifetime = the mesh, never static — test meshes
+/// with different module sets must not bleed).</para>
+/// </summary>
+public sealed class InstalledModulesFingerprint(IEnumerable<InstalledModuleAssembly> modules)
+{
+    /// <summary>
+    /// The hash: lowercase hex SHA-256 over the ordinal-sorted module MVIDs, or the empty string
+    /// for a mesh with no installed modules (stable, distinguishable from the null of
+    /// pre-feature definitions).
+    /// </summary>
+    public string Hash { get; } = Compute(modules);
+
+    private static string Compute(IEnumerable<InstalledModuleAssembly> modules)
+    {
+        var mvids = modules
+            .Select(m => m.Mvid.ToString("N"))
+            .Distinct()
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+        if (mvids.Length == 0)
+            return string.Empty;
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(string.Join(";", mvids)));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -179,6 +179,35 @@ internal class MeshNodeCompilationService(
     private static readonly IReadOnlyList<MetadataReference> _references = GetDefaultReferences();
 
     /// <summary>
+    /// The compile reference set: the process-wide TPA baseline (<see cref="_references"/>) plus
+    /// THIS mesh's installed module assemblies (<c>Modules:Assemblies</c> →
+    /// <see cref="InstalledModuleAssembly"/>, design #1644). A module published into
+    /// <c>modules/&lt;name&gt;/</c> is not in <c>TRUSTED_PLATFORM_ASSEMBLIES</c>, so in-mesh
+    /// consumers (e.g. a scope class using a map control) would silently lose it without this.
+    /// Deduped by path — a module still riding the app closure appears in both sets. Lazy per
+    /// service instance: modules install at boot, before any compile runs.
+    /// </summary>
+    private IReadOnlyList<MetadataReference> References => meshReferences.Value;
+
+    private readonly Lazy<IReadOnlyList<MetadataReference>> meshReferences = new(() =>
+    {
+        var modules = hub.ServiceProvider.GetServices<InstalledModuleAssembly>().ToArray();
+        if (modules.Length == 0)
+            return _references;
+        var seen = new HashSet<string>(
+            _references.Select(r => r.Display ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+        var composed = new List<MetadataReference>(_references);
+        foreach (var module in modules)
+        {
+            var location = module.Assembly.Location;
+            if (!string.IsNullOrEmpty(location) && File.Exists(location) && seen.Add(location))
+                composed.Add(MetadataReference.CreateFromFile(location));
+        }
+        return composed;
+    });
+
+    /// <summary>
     /// Builds the process-wide MetadataReference list — TPA assemblies plus a few
     /// well-known additions. Uses <see cref="MetadataReference.CreateFromFile(string, MetadataReferenceProperties, DocumentationProvider)"/>
     /// (mmap, lazy read) — Roslyn typically reads only a small fraction of each
@@ -1682,10 +1711,10 @@ internal class MeshNodeCompilationService(
         IObservable<ImmutableArray<MetadataReference>> referencesObs =
             allNugetRefs.Count > 0
                 ? _ioPool.Run(ct => nugetResolver.ResolveAsync(allNugetRefs, targetFramework: null, ct))
-                    .Select(resolved => _references
+                    .Select(resolved => References
                         .Concat(resolved.AssemblyPaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)))
                         .ToImmutableArray())
-                : Observable.Return(_references.ToImmutableArray());
+                : Observable.Return(References.ToImmutableArray());
 
         return referencesObs.Select(references =>
         {
@@ -1901,12 +1930,12 @@ internal class MeshNodeCompilationService(
         var nugetRefList = extractedRefs.ToList();
         StripBuiltInScopeGeneratorRef(nugetRefList, builtInPresent: BuiltInGeneratorPaths.Count > 0);
         var nugetRefs = nugetRefList.ToArray();
-        IEnumerable<MetadataReference> references = _references;
+        IEnumerable<MetadataReference> references = References;
         IReadOnlyList<string> nugetAssemblyPaths = [];
         if (nugetRefs.Length > 0)
         {
             var resolved = await nugetResolver.ResolveAsync(nugetRefs, targetFramework: null, ct);
-            references = _references.Concat(
+            references = References.Concat(
                 resolved.AssemblyPaths.Select(p => MetadataReference.CreateFromFile(p)));
             nugetAssemblyPaths = resolved.AssemblyPaths;
             cacheService.RegisterProbingDirectories(nodeName, resolved.ProbingDirectories);

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1085,7 +1085,8 @@ internal static class NodeTypeCompilationHelpers
         NodeCompilationResult result,
         long currentNodeVersion,
         string? activityPath,
-        string? releasePath)
+        string? releasePath,
+        string? modulesHash = null)
         => def with
         {
             CompilationStatus = CompilationStatus.Ok,
@@ -1111,6 +1112,10 @@ internal static class NodeTypeCompilationHelpers
             // live FrameworkVersion so a MeshWeaver redeploy forces a recompile instead of
             // loading an ABI-stale DLL.
             CompiledFrameworkVersion = FrameworkVersion,
+            // The installed-module fingerprint (#1644 step 1 — recorded, not yet decisive; the
+            // property doc on NodeTypeDefinition carries the full story). Preserved when the
+            // caller cannot resolve a fingerprint, so a stamped hash is never erased.
+            CompiledModulesHash = modulesHash ?? def.CompiledModulesHash,
             // Clear the consumed release-requester so a later System-only recompile doesn't
             // mis-attribute its release to a stale prior user.
             RequestedReleaseBy = null
@@ -1608,7 +1613,8 @@ internal static class NodeTypeCompilationHelpers
                             return curr with
                             {
                                 Content = ApplyCompileSuccess(
-                                    def, outcome.Result, curr.Version, resolvedActivityPath, newReleasePath)
+                                    def, outcome.Result, curr.Version, resolvedActivityPath, newReleasePath,
+                                    hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                             };
                         }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -518,6 +518,18 @@ public record NodeTypeDefinition
     public string? CompiledFrameworkVersion { get; init; }
 
     /// <summary>
+    /// The deployment's installed-MODULE fingerprint the assembly was compiled under —
+    /// <see cref="InstalledModulesFingerprint.Hash"/> (sorted module MVIDs; empty string = no
+    /// modules; null = stamped before the feature, or by a mesh without the fingerprint
+    /// registered). Recorded by every successful compile (#1644 step 1); it joins the
+    /// usable-build decision when modules ship separately from the image (step 2) — a
+    /// module-only update must invalidate baked builds that could reference it, which the
+    /// framework-MVID rule cannot see. Null compares as MATCH there: a null-hash build predates
+    /// modules in the compile surface and is governed by the framework rule alone.
+    /// </summary>
+    public string? CompiledModulesHash { get; init; }
+
+    /// <summary>
     /// 🚨 Round-trip buffer for content members this compiled shape does not declare —
     /// schema evolution: a property written by a NEWER build, or one removed since the
     /// JSON was persisted. Without this, System.Text.Json silently DROPS such members on

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -689,7 +689,8 @@ internal static class NodeTypeBatchBake
                         // IAssemblyStore upload used (it uploaded the node it was handed), so
                         // LastCompiledVersion always names a store key that has bytes.
                         ? NodeTypeCompilationHelpers.ApplyCompileSuccess(
-                            def, result!, typeNode.Version, activityPath: null, releasePath)
+                            def, result!, typeNode.Version, activityPath: null, releasePath,
+                            mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                         : NodeTypeCompilationHelpers.ApplyCompileFailure(
                             def, result, error, activityPath: null))
                     // The batch driver has no Pending→Compiling flip to stamp this at, and the

--- a/src/MeshWeaver.Mesh.Contract/InstalledModuleAssembly.cs
+++ b/src/MeshWeaver.Mesh.Contract/InstalledModuleAssembly.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One boot-installed module assembly (a <c>Modules:Assemblies</c> entry loaded by
+/// <see cref="MeshBuilder.InstallAssemblies"/>), registered as an enumerable DI singleton — the
+/// mesh-scoped record of "which modules does THIS deployment run" for surfaces that must treat
+/// modules like platform (design #1644):
+/// <list type="bullet">
+/// <item>the in-mesh compile reference set — a module published into <c>modules/&lt;name&gt;/</c>
+/// leaves <c>TRUSTED_PLATFORM_ASSEMBLIES</c>, so <c>MeshNodeCompilationService</c> composes its
+/// references as the static TPA baseline PLUS these;</item>
+/// <item>the bake fingerprint — the sorted installed-module MVID hash joins the usable-build
+/// check, so a module upgrade invalidates baked node-type builds that could reference it.</item>
+/// </list>
+/// </summary>
+/// <param name="Assembly">The loaded module assembly (Default ALC, file-backed).</param>
+public sealed record InstalledModuleAssembly(Assembly Assembly)
+{
+    /// <summary>The assembly's MVID — the per-build identity the bake fingerprint hashes.</summary>
+    public Guid Mvid => Assembly.ManifestModule.ModuleVersionId;
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -31,14 +31,48 @@ public record MeshBuilder
     private List<MeshNode> MeshNodes { get; } = new();
 
     /// <summary>
+    /// Resolves one <c>Modules:Assemblies</c> entry to an assembly path. Rooted paths pass
+    /// through; relative entries probe the <c>modules/&lt;name&gt;/&lt;entry&gt;</c> publish
+    /// layout FIRST (the modules-folder lane, #1644 — a module published beside the app wins so
+    /// flipping its ProjectReference off changes nothing for the deployment), then fall back to
+    /// the classic BaseDirectory-relative location (the double-shipped transition state, and
+    /// every module that still rides the app closure).
+    /// </summary>
+    public static string ResolveModulePath(string entry)
+    {
+        if (Path.IsPathRooted(entry))
+            return entry;
+        var baseDirectory = AppContext.BaseDirectory;
+        var moduleFolderPath = Path.Combine(
+            baseDirectory, "modules", Path.GetFileNameWithoutExtension(entry), entry);
+        return File.Exists(moduleFolderPath)
+            ? moduleFolderPath
+            : Path.Combine(baseDirectory, entry);
+    }
+
+    /// <summary>
     /// Installs mesh nodes from the specified assembly locations.
     /// </summary>
     /// <param name="assemblyLocations">Paths to assemblies containing MeshNodeProviderAttribute definitions.</param>
     /// <returns>The builder for method chaining.</returns>
     public MeshBuilder InstallAssemblies(params string[] assemblyLocations)
     {
-        var attributes = assemblyLocations
+        var assemblies = assemblyLocations
             .Select(Assembly.LoadFrom)
+            .ToArray();
+        // Record every installed module for the runtime surfaces that must SEE modules the way
+        // they see the platform: the in-mesh compile reference set (a module leaving the publish
+        // closure leaves TRUSTED_PLATFORM_ASSEMBLIES, so compilation composes TPA + these) and
+        // the bake fingerprint (a module upgrade invalidates baked builds that could reference
+        // it). Registered even while a module still ALSO rides the app closure — the surfaces
+        // dedupe by identity.
+        ConfigureServices(services =>
+        {
+            foreach (var assembly in assemblies)
+                services.AddSingleton(new InstalledModuleAssembly(assembly));
+            return services;
+        });
+        var attributes = assemblies
             .SelectMany(a => a.GetCustomAttributes<MeshNodeProviderAttribute>())
             .ToArray();
         MeshNodes.AddRange(attributes.SelectMany(a => InstallServices(a.Nodes)));

--- a/test/MeshWeaver.Graph.Test/InstalledModulesTest.cs
+++ b/test/MeshWeaver.Graph.Test/InstalledModulesTest.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the modules-folder machinery of design #1644, step 1: the fingerprint the compile
+/// write-back stamps, the stamp semantics (preserve, never erase), and the module-path probing
+/// the <c>Modules:Assemblies</c> loader resolves through.
+/// </summary>
+public class InstalledModulesTest
+{
+    [Fact]
+    public void Fingerprint_IsEmptyForNoModules_AndStableOrderIndependent()
+    {
+        Assert.Equal(string.Empty, new InstalledModulesFingerprint([]).Hash);
+
+        var a = new InstalledModuleAssembly(typeof(InstalledModulesTest).Assembly);
+        var b = new InstalledModuleAssembly(typeof(MeshBuilder).Assembly);
+
+        var forward = new InstalledModulesFingerprint([a, b]).Hash;
+        var reversed = new InstalledModulesFingerprint([b, a]).Hash;
+        Assert.NotEqual(string.Empty, forward);
+        // Sorted MVIDs — registration order can never flap the fingerprint.
+        Assert.Equal(forward, reversed);
+        // Duplicate registrations (a module both referenced and listed) collapse.
+        Assert.Equal(forward, new InstalledModulesFingerprint([a, b, a]).Hash);
+        // A different module set is a different hash.
+        Assert.NotEqual(forward, new InstalledModulesFingerprint([a]).Hash);
+    }
+
+    [Fact]
+    public void ApplyCompileSuccess_StampsTheModulesHash_AndNeverErasesAStampedOne()
+    {
+        var def = new NodeTypeDefinition();
+        var result = new NodeCompilationResult("some.dll", []);
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            def, result, currentNodeVersion: 1, activityPath: null, releasePath: null,
+            modulesHash: "abc123");
+        Assert.Equal("abc123", stamped.CompiledModulesHash);
+
+        // A caller without a resolvable fingerprint (null) must PRESERVE the recorded hash —
+        // erasing it would forge "compiled without modules" onto a build that wasn't.
+        var preserved = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            stamped, result, currentNodeVersion: 2, activityPath: null, releasePath: null);
+        Assert.Equal("abc123", preserved.CompiledModulesHash);
+    }
+
+    [Fact]
+    public void ResolveModulePath_PrefersTheModulesFolder_AndFallsBackToBaseDirectory()
+    {
+        // Rooted entries pass through untouched.
+        var rooted = Path.Combine(Path.GetTempPath(), "X.dll");
+        Assert.Equal(rooted, MeshBuilder.ResolveModulePath(rooted));
+
+        // No modules/<name>/ folder → the classic BaseDirectory-relative resolution.
+        Assert.Equal(
+            Path.Combine(AppContext.BaseDirectory, "NoSuchModule.dll"),
+            MeshBuilder.ResolveModulePath("NoSuchModule.dll"));
+
+        // A modules/<name>/<name>.dll beside the app WINS — the #1644 publish layout.
+        var name = $"ProbeModule{Guid.NewGuid():N}";
+        var folder = Path.Combine(AppContext.BaseDirectory, "modules", name);
+        Directory.CreateDirectory(folder);
+        var dll = Path.Combine(folder, name + ".dll");
+        try
+        {
+            File.WriteAllBytes(dll, []);
+            Assert.Equal(dll, MeshBuilder.ResolveModulePath(name + ".dll"));
+        }
+        finally
+        {
+            File.Delete(dll);
+            Directory.Delete(folder);
+        }
+    }
+}


### PR DESCRIPTION
Step 1 of #1644 (maintainer-approved to proceed), fully ADDITIVE — modules keep their ships-the-bits ProjectReferences, so the image is byte-for-byte unchanged while all the machinery goes live.

## What lands
- **Publish layout**: both hosts import `memex/MeshModulesPublish.targets` — each listed module (the 12-module inventory) lays its own outputs under `modules/<Name>/` beside the app, pruned of same-identity files the app output already carries. Deliberately **thin**: a full per-module `Publish` was measured to drag ~1400 shared-framework package assemblies that a filename prune cannot see (the app resolves them from the shared framework; a class library's standalone publish rolls them in) — exactly the same-identity trap-door class in publish-time form. Closure layout is therefore per-module **step-2** work, done when that module's reference flips and its private deps are known. Verified on a real publish: 12 modules laid out, everything pruned in the double-ship state, `modules/` keeps 0 files, target costs ~7s. Escape hatch: `-p:PublishMeshModules=false`.
- **Probing**: `Modules:Assemblies` entries resolve through the new `MeshBuilder.ResolveModulePath` — `modules/<name>/<name>.dll` wins, the app folder is the fallback.
- **Compile surface**: `InstallAssemblies` records every loaded module as an `InstalledModuleAssembly` DI singleton; `MeshNodeCompilationService` composes its reference set as the static TPA baseline + the mesh's installed modules (deduped by path) — so a module leaving the app closure stays visible to in-mesh source (the Cornerstone `MapControl` case).
- **Fingerprint**: every successful NodeType compile stamps `CompiledModulesHash` (`InstalledModulesFingerprint` — SHA-256 over sorted installed-module MVIDs; empty string = no modules) beside `CompiledFrameworkVersion`, on both write-back paths (activation-driven `ApplyCompileSuccess` and the batch bake). **Recorded, not yet decisive** — while modules ride the image, any module change rebuilds Graph and rule 3 already invalidates everything; the hash joins the usable-build check at step 2 when module-only updates become possible, with `null` grandfathered as MATCH (a null-hash build predates modules in the compile surface and referenced none). This sequencing keeps the rule-3-adjacent change zero-risk now.
- **Docs**: new [Architecture/Modules](../blob/main/src/MeshWeaver.Documentation/Data/Architecture/Modules.md) page — the module lane end to end: the five `MeshNodeProviderAttribute` hooks, the `Modules:Assemblies` inventory **with each module's configuration section**, the publish layout, probing, compile-surface and fingerprint story (the all-waves config reference the maintainer asked for).

## Gate parity (design §5)
Unchanged in this PR by construction: the thin layout keeps every module in the image's app closure, so `fetch-refs.py`/`compile-check.py` in the Plugins repo keep seeing the exact prod surface. The `modules/` sweep lands there together with the first step-2 flip.

## Verification
`Mesh.Contract`, `Graph`, `Hosting`, `Portal.Shared`, `Portal.Monolith` build clean `-c Release -warnaserror`; `MeshWeaver.Graph.Test` 1163/1163 (new pins: fingerprint empty/stable/order-independent/deduped, stamp preserves a recorded hash, probing prefers the modules folder and falls back); `DocumentationLinkIntegrityTest` green; real `dotnet publish` of the Monolith exercised the target end to end.

No What's New entry: platform/deployment machinery, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)