### PR TITLE
fix: sub-thread icons render, and never render broken

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -345,7 +345,11 @@ else
                                     {
                                         var delHeader = GetDelegationHeader(call.DelegationPath);
                                         var title = delHeader?.Title ?? callSummary;
-                                        var icon = delHeader?.Icon ?? "/static/NodeTypeIcons/chat.svg";
+                                        @* The sub-thread's own icon is a ThreadIconGenerator identicon —
+                                           raw inline <svg>, not a URL — so it goes through NodeIcon, which
+                                           picks the right element and falls back to the standard chat glyph
+                                           for anything it cannot render. *@
+                                        var icon = delHeader?.Icon;
                                         var stateIcon = isPending
                                             ? "↗"
                                             : (call.IsSuccess ? "✓" : "✗");
@@ -360,7 +364,8 @@ else
                                            class="thread-msg-tool-delegation @stateClass"
                                            title="@title">
                                             <span class="thread-msg-tool-delegation-state">@stateIcon</span>
-                                            <img src="@icon" alt="" class="thread-msg-tool-delegation-icon" />
+                                            <NodeIcon Icon="@icon" Fallback="@ThreadNodeType.DefaultIcon" Size="14"
+                                                      Class="thread-msg-tool-delegation-icon" />
                                             <span class="thread-msg-tool-delegation-title">@title</span>
                                             <span class="thread-msg-tool-delegation-agent">@callSummary</span>
                                             @* Live elapsed while the sub-thread runs — makes "it's running"
@@ -583,13 +588,14 @@ else
                     <div class="thread-runtime-section-label">@Access.Localize("chat.runningSubThreads")</div>
                     @foreach (var (path, header) in runningSubThreads)
                     {
-                        var subIcon = header.Icon ?? "/static/NodeTypeIcons/chat.svg";
+                        var subIcon = header.Icon;
                         var subTitle = header.Title ?? path;
                         var preview = !string.IsNullOrWhiteSpace(header.StreamingText)
                             ? TruncateText(header.StreamingText.Trim(), 200)
                             : (header.ExecutionStatus ?? Access.Localize("chat.working"));
                         <a class="thread-runtime-subthread-card" href="/@path" title="@subTitle">
-                            <img src="@subIcon" alt="" class="thread-runtime-subthread-icon" />
+                            <NodeIcon Icon="@subIcon" Fallback="@ThreadNodeType.DefaultIcon" Size="24"
+                                      Class="thread-runtime-subthread-icon" />
                             <div class="thread-runtime-subthread-body">
                                 <div class="thread-runtime-subthread-title">
                                     <span class="thread-runtime-subthread-title-text">@subTitle</span>
@@ -889,9 +895,11 @@ else
                             @* Non-selectable group title (e.g. a model provider). Its models
                                render as selectable items underneath. *@
                             <div class="thread-chat-widget-group">
-                                @if (!string.IsNullOrEmpty(node.Icon) && !node.Icon.TrimStart().StartsWith("<"))
+                                @* Used to skip inline-<svg> icons outright (an <img src="<svg …>"> renders
+                                   broken); NodeIcon renders each form with the element it needs. *@
+                                @if (!string.IsNullOrEmpty(node.Icon))
                                 {
-                                    <img class="thread-chat-widget-group-icon" src="@node.Icon" alt="" />
+                                    <NodeIcon Icon="@node.Icon" Size="14" Class="thread-chat-widget-group-icon" />
                                 }
                                 <span class="thread-chat-widget-group-name">@(node.Name ?? LastSegment(node.Path))</span>
                             </div>
@@ -903,14 +911,7 @@ else
                                     @onclick="@(() => SelectFromPicker(picker, node))">
                                 @if (!string.IsNullOrEmpty(node.Icon))
                                 {
-                                    @if (node.Icon.TrimStart().StartsWith("<"))
-                                    {
-                                        <span class="thread-chat-widget-item-icon">@((MarkupString)node.Icon)</span>
-                                    }
-                                    else
-                                    {
-                                        <img class="thread-chat-widget-item-icon" src="@node.Icon" alt="" />
-                                    }
+                                    <NodeIcon Icon="@node.Icon" Size="18" Class="thread-chat-widget-item-icon" />
                                 }
                                 <span class="thread-chat-widget-item-text">
                                     <span class="thread-chat-widget-item-name">@(node.Name ?? node.Id)</span>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -703,21 +703,11 @@ button.thread-chat-status-item {
     transition: background 80ms ease, border-color 80ms ease;
 }
 
-.thread-chat-widget-item-icon {
-    flex: 0 0 auto;
-    width: 18px;
-    height: 18px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+/* The icon is rendered by <NodeIcon>, which sizes itself inline and lives in its OWN CSS-isolation
+   scope — so every rule that styles it has to be anchored on an element of THIS component and reach
+   through with ::deep. Only the decoration lives here; width/height come from NodeIcon's Size. */
+.thread-chat-widget-item ::deep .thread-chat-widget-item-icon {
     color: var(--neutral-foreground-hint);
-}
-
-.thread-chat-widget-item-icon :deep(svg),
-.thread-chat-widget-item-icon img,
-.thread-chat-widget-item-icon svg {
-    width: 18px;
-    height: 18px;
 }
 
 .thread-chat-widget-item-text {
@@ -803,10 +793,7 @@ button.thread-chat-status-item {
     border-top: 1px solid var(--neutral-stroke-divider-rest);
 }
 
-.thread-chat-widget-group-icon {
-    width: 14px;
-    height: 14px;
-    flex: 0 0 auto;
+.thread-chat-widget-group ::deep .thread-chat-widget-group-icon {
     opacity: 0.8;
 }
 
@@ -1395,10 +1382,7 @@ button.thread-chat-status-item {
     color: var(--error-foreground-rest, #d93636);
 }
 
-.thread-msg-tool-delegation-icon {
-    width: 14px;
-    height: 14px;
-    flex: 0 0 auto;
+.thread-msg-tool-delegation ::deep .thread-msg-tool-delegation-icon {
     opacity: 0.85;
 }
 
@@ -1501,12 +1485,10 @@ button.thread-chat-status-item {
     background: color-mix(in srgb, var(--accent-fill-rest) 8%, var(--neutral-layer-3));
 }
 
-.thread-runtime-subthread-icon {
-    width: 24px;
-    height: 24px;
+.thread-runtime-subthread-card ::deep .thread-runtime-subthread-icon {
     border-radius: 6px;
-    flex: 0 0 auto;
     opacity: 0.9;
+    overflow: hidden;
 }
 
 .thread-runtime-subthread-body {

--- a/src/MeshWeaver.Blazor/Components/NodeIcon.razor
+++ b/src/MeshWeaver.Blazor/Components/NodeIcon.razor
@@ -18,11 +18,11 @@
 
 @if (Resolved.Kind == IconRenderKind.InlineSvg)
 {
-    <span class="@Class" style="@SvgBoxStyle">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(Resolved.Value, Size))</span>
+    <span class="@Class" style="@SvgBoxStyle" role="@SpanRole" aria-label="@SpanLabel" aria-hidden="@SpanHidden">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(Resolved.Value, Size))</span>
 }
 else if (Resolved.Kind == IconRenderKind.Glyph)
 {
-    <span class="@Class" style="@GlyphStyle">@Resolved.Value</span>
+    <span class="@Class" style="@GlyphStyle" role="@SpanRole" aria-label="@SpanLabel" aria-hidden="@SpanHidden">@Resolved.Value</span>
 }
 else
 {
@@ -58,6 +58,18 @@ else
     public string Alt { get; set; } = "";
 
     private RenderableIcon Resolved => MeshNodeImageHelper.ResolveRenderable(Icon, Fallback);
+
+    // The <img> branch gets its semantics from alt="" (decorative) / alt="…" for free; the two <span>
+    // branches carry NO implicit role, so an emoji or an inline <svg> would otherwise be announced as
+    // stray content. Decorative (the default, Alt empty) → aria-hidden; named → role="img" + label.
+    // Blazor drops an attribute whose value is null, so each branch emits exactly one of the two.
+    private bool Decorative => string.IsNullOrEmpty(Alt);
+
+    private string? SpanRole => Decorative ? null : "img";
+
+    private string? SpanLabel => Decorative ? null : Alt;
+
+    private string? SpanHidden => Decorative ? "true" : null;
 
     private string ImageStyle => $"width: {Size}px; height: {Size}px; flex: 0 0 auto; object-fit: contain;{Style}";
 

--- a/src/MeshWeaver.Blazor/Components/NodeIcon.razor
+++ b/src/MeshWeaver.Blazor/Components/NodeIcon.razor
@@ -1,0 +1,67 @@
+@using MeshWeaver.Graph
+@* A mesh node's icon, rendered with the element the value actually needs — and NEVER broken.
+
+   A MeshNode.Icon is one string holding four different things: an image URL / data URI, raw inline
+   <svg> markup (every thread carries a ThreadIconGenerator identicon), a text glyph (emoji), or a
+   legacy Fluent icon name. `<img src="@node.Icon">` is right for exactly one of them and renders the
+   browser's broken-image glyph for the rest — which is what a delegated sub-thread's chip did.
+
+   MeshNodeImageHelper.ResolveRenderable is TOTAL: icon → Fallback → the neutral box glyph, so there
+   is always something renderable and a caller can never re-create the broken case.
+
+   This is the Blazor mirror of the React client's MeshIcon (clients/react/src/controls/MeshIcon.tsx),
+   which dispatches on the same classification — keep the two in step.
+
+   Sizing is INLINE (from Size), not from the caller's CSS class: this component's markup lives in its
+   own CSS-isolation scope, so a scoped `.my-icon { width: … }` in the parent would not reach it. The
+   class is still emitted, so a parent rule anchored with ::deep (or a global stylesheet) styles it. *@
+
+@if (Resolved.Kind == IconRenderKind.InlineSvg)
+{
+    <span class="@Class" style="@SvgBoxStyle">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(Resolved.Value, Size))</span>
+}
+else if (Resolved.Kind == IconRenderKind.Glyph)
+{
+    <span class="@Class" style="@GlyphStyle">@Resolved.Value</span>
+}
+else
+{
+    <img src="@Resolved.Value" alt="@Alt" class="@Class" style="@ImageStyle" />
+}
+
+@code {
+    /// <summary>The node's raw <c>Icon</c> value — any of the four forms, or null/empty.</summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// The standard icon to show when <see cref="Icon"/> is absent or cannot be rendered — typically
+    /// the NodeType's glyph (e.g. <c>ThreadNodeType.DefaultIcon</c>). Defaults to the neutral box.
+    /// </summary>
+    [Parameter]
+    public string? Fallback { get; set; }
+
+    /// <summary>The rendered square size in CSS pixels; applied inline. Defaults to 16.</summary>
+    [Parameter]
+    public int Size { get; set; } = 16;
+
+    /// <summary>Class emitted on the rendered element (style it from a global sheet or via <c>::deep</c>).</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>Extra inline style appended after the size rules.</summary>
+    [Parameter]
+    public string? Style { get; set; }
+
+    /// <summary>Alt text for the image form; empty (decorative) by default.</summary>
+    [Parameter]
+    public string Alt { get; set; } = "";
+
+    private RenderableIcon Resolved => MeshNodeImageHelper.ResolveRenderable(Icon, Fallback);
+
+    private string ImageStyle => $"width: {Size}px; height: {Size}px; flex: 0 0 auto; object-fit: contain;{Style}";
+
+    private string SvgBoxStyle => $"width: {Size}px; height: {Size}px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;{Style}";
+
+    private string GlyphStyle => $"font-size: {Size}px; line-height: 1; flex: 0 0 auto;{Style}";
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-subthread-icon-never-broken.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-subthread-icon-never-broken.md
@@ -1,0 +1,18 @@
+---
+Name: Sub-thread icons no longer render broken
+Category: Fix
+Description: A delegated sub-thread now shows its own avatar — or the standard chat icon — instead of a broken-image placeholder.
+Icon: Chat
+Order: -20260816
+---
+
+# Sub-thread icons no longer render broken
+
+Every thread gets its own generated avatar, and in the chat that avatar was being shown the wrong
+way: the sub-thread chip inside a message and the "Running sub-threads" card below the conversation
+both drew the browser's broken-image placeholder instead of the picture.
+
+They now show the thread's real avatar, and any icon the portal cannot draw — an unknown icon name,
+an empty one — falls back to the standard chat icon rather than a broken image. The same fix applies
+to the model and agent pickers in the chat composer, where icons of that kind used to be dropped
+silently.

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -1,8 +1,35 @@
 using System.Collections.Immutable;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Mesh;
+using DomainIcon = MeshWeaver.Domain.Icon;
 
 namespace MeshWeaver.Graph;
+
+/// <summary>
+/// How an icon value has to be put on the page. A node's <c>Icon</c> is a single string that can
+/// legitimately hold three mutually-incompatible things, and rendering one through the other's
+/// element is what produces a BROKEN icon — an <c>&lt;img src="&lt;svg …"&gt;</c> (the identicon every
+/// thread gets from <c>ThreadIconGenerator</c>) or an <c>&lt;img src="Document"&gt;</c> (a Fluent name).
+/// </summary>
+public enum IconRenderKind
+{
+    /// <summary>An image URL or <c>data:</c> URI — render as <c>&lt;img src="…"&gt;</c>.</summary>
+    Image,
+
+    /// <summary>Raw inline <c>&lt;svg&gt;</c> markup — render verbatim, NEVER as an img source.</summary>
+    InlineSvg,
+
+    /// <summary>A text glyph (emoji) — render as text.</summary>
+    Glyph,
+}
+
+/// <summary>
+/// An icon value together with the element it has to be rendered with. Produced by
+/// <see cref="MeshNodeImageHelper.ResolveRenderable"/>, which guarantees the pair is renderable.
+/// </summary>
+/// <param name="Kind">The element the value has to be rendered with.</param>
+/// <param name="Value">The icon value — a URL, inline svg markup, or a text glyph, per <paramref name="Kind"/>.</param>
+public readonly record struct RenderableIcon(IconRenderKind Kind, string Value);
 
 /// <summary>
 /// Helper for resolving and classifying a mesh node's icon for rendering. Resolves
@@ -43,7 +70,7 @@ public static class MeshNodeImageHelper
             : ResolveContentPath(node.Icon, node.Path)
               ?? ShippedIconFor(node.Icon)
               ?? DefaultIconForNodeType(node.NodeType)
-              ?? $"/static/NodeTypeIcons/{NeutralNodeIcon}.svg";
+              ?? NeutralIconUrl;
 
     /// <summary>
     /// The shipped glyph matching a FLUENT ICON NAME, or null when none is shipped under that name.
@@ -80,6 +107,51 @@ public static class MeshNodeImageHelper
 
     /// <summary>The neutral glyph used when a node has no own icon and its NodeType has no mapping.</summary>
     private const string NeutralNodeIcon = "box";
+
+    /// <summary>
+    /// The URL of <see cref="NeutralNodeIcon"/> — the last-resort glyph that makes
+    /// <see cref="ResolveRenderable"/> total. A constant, not a cache: written once, never at runtime.
+    /// </summary>
+    public static readonly string NeutralIconUrl = $"/static/NodeTypeIcons/{NeutralNodeIcon}.svg";
+
+    /// <summary>
+    /// The first of <paramref name="icon"/> → <paramref name="fallback"/> → <see cref="NeutralIconUrl"/>
+    /// that can ACTUALLY be rendered, paired with the element to render it with. Total: it always
+    /// returns something renderable, so no caller can produce a broken icon.
+    ///
+    /// <para>🚨 This exists because a <c>MeshNode.Icon</c> is ONE string holding four different things
+    /// (<see cref="DomainIcon.Parse"/>), and the obvious <c>&lt;img src="@node.Icon"&gt;</c> is correct for
+    /// exactly one of them. Every thread carries a <c>ThreadIconGenerator</c> identicon — raw inline
+    /// <c>&lt;svg&gt;</c> — so a sub-thread chip built that way rendered the browser's broken-image glyph,
+    /// and the picker "fixed" it by dropping the icon entirely. A legacy Fluent NAME breaks the same
+    /// way; it resolves here only when this assembly ships a glyph of that name
+    /// (<see cref="ShippedIconFor"/>), otherwise the fallback wins rather than a broken image.</para>
+    /// </summary>
+    /// <param name="icon">The node's own icon value (any of the four forms; null/empty is fine).</param>
+    /// <param name="fallback">The icon to use when <paramref name="icon"/> is absent or unrenderable —
+    /// typically the NodeType's standard glyph (e.g. <c>/static/NodeTypeIcons/chat.svg</c> for a thread).</param>
+    public static RenderableIcon ResolveRenderable(string? icon, string? fallback = null)
+        => TryClassify(icon)
+           ?? TryClassify(fallback)
+           ?? new RenderableIcon(IconRenderKind.Image, NeutralIconUrl);
+
+    /// <summary>
+    /// Classifies one candidate, or null when it cannot be rendered at all (empty, or a Fluent icon
+    /// name this assembly ships no glyph for) and the next candidate should be tried.
+    /// </summary>
+    private static RenderableIcon? TryClassify(string? value)
+    {
+        var parsed = DomainIcon.Parse(value);
+        return parsed?.Provider switch
+        {
+            DomainIcon.InlineSvgProvider => new RenderableIcon(IconRenderKind.InlineSvg, parsed.Id),
+            DomainIcon.UrlProvider => new RenderableIcon(IconRenderKind.Image, parsed.Id),
+            DomainIcon.TextProvider => new RenderableIcon(IconRenderKind.Glyph, parsed.Id),
+            DomainIcon.FluentProvider when ShippedIconFor(parsed.Id) is { } url
+                => new RenderableIcon(IconRenderKind.Image, url),
+            _ => null,
+        };
+    }
 
     /// <summary>
     /// A default icon for a node that carries none of its own, keyed by its NodeType (the type node's

--- a/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
@@ -165,4 +165,77 @@ public class MeshNodeImageHelperTest
             .Should().Contain(resource,
                 "a skill already points at /static/NodeTypeIcons/{0}.svg — without the asset it is a broken image", name);
     }
+
+    // ── ResolveRenderable: every icon form gets the element it needs, never a broken <img> ────
+
+    /// <summary>The standard glyph a thread surface passes as the fallback.</summary>
+    private const string ThreadIcon = "/static/NodeTypeIcons/chat.svg";
+
+    /// <summary>
+    /// 🚨 THE BUG THIS FIXES. Every thread node carries a <c>ThreadIconGenerator</c> identicon —
+    /// raw inline <c>&lt;svg&gt;</c>, not a URL — and the delegated-sub-thread chip put it straight
+    /// into <c>&lt;img src="…"&gt;</c>, so the browser drew its broken-image glyph. Inline SVG must
+    /// classify as markup, and the value must survive verbatim.
+    /// </summary>
+    [Fact]
+    public void AnInlineSvgIcon_RendersAsMarkup_NeverAsAnImageSource()
+    {
+        const string identicon =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 80 80\"><rect width=\"80\" height=\"80\" rx=\"16\" fill=\"#eae5f5\"/></svg>";
+
+        var resolved = MeshNodeImageHelper.ResolveRenderable(identicon, ThreadIcon);
+
+        resolved.Kind.Should().Be(IconRenderKind.InlineSvg);
+        resolved.Value.Should().Be(identicon);
+    }
+
+    [Theory]
+    [InlineData("/static/NodeTypeIcons/bot.svg")]
+    [InlineData("https://example.com/avatar.png")]
+    [InlineData("data:image/png;base64,abc")]
+    public void AUrlIcon_RendersAsAnImage(string icon)
+        => MeshNodeImageHelper.ResolveRenderable(icon, ThreadIcon)
+            .Should().Be(new RenderableIcon(IconRenderKind.Image, icon));
+
+    [Theory]
+    [InlineData("🎯")]
+    [InlineData("➕")]
+    public void AnEmojiIcon_RendersAsText(string icon)
+        => MeshNodeImageHelper.ResolveRenderable(icon, ThreadIcon)
+            .Should().Be(new RenderableIcon(IconRenderKind.Glyph, icon));
+
+    /// <summary>A legacy Fluent NAME is renderable only where a glyph of that name is shipped.</summary>
+    [Fact]
+    public void AFluentName_RendersAsItsShippedGlyph()
+        => MeshNodeImageHelper.ResolveRenderable("Sparkle", ThreadIcon)
+            .Should().Be(new RenderableIcon(IconRenderKind.Image, "/static/NodeTypeIcons/sparkle.svg"));
+
+    /// <summary>
+    /// The other half of the bug: a Fluent name with no shipped glyph used to become
+    /// <c>&lt;img src="DocumentPdf"&gt;</c>. It has to yield the caller's standard icon instead.
+    /// </summary>
+    [Fact]
+    public void AFluentName_WithNoShippedGlyph_FallsBackToTheStandardIcon()
+        => MeshNodeImageHelper.ResolveRenderable("NoSuchIconNameAtAll", ThreadIcon)
+            .Should().Be(new RenderableIcon(IconRenderKind.Image, ThreadIcon));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoIcon_FallsBackToTheStandardIcon(string? icon)
+        => MeshNodeImageHelper.ResolveRenderable(icon, ThreadIcon)
+            .Should().Be(new RenderableIcon(IconRenderKind.Image, ThreadIcon));
+
+    /// <summary>
+    /// Total, so no caller can produce a broken icon: with neither a usable icon NOR a usable
+    /// fallback, the neutral box glyph still comes out.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("NoSuchIconNameAtAll", "AlsoNotAnIcon")]
+    public void NeitherIconNorFallback_StillYieldsTheNeutralGlyph(string? icon, string? fallback)
+        => MeshNodeImageHelper.ResolveRenderable(icon, fallback)
+            .Should().Be(new RenderableIcon(IconRenderKind.Image, "/static/NodeTypeIcons/box.svg"));
 }


### PR DESCRIPTION
## The bug

Felice's thread has a sub-thread whose icon renders as the browser's **broken-image placeholder**.

Every thread node carries a `ThreadIconGenerator` identicon — **raw inline `<svg>` markup**, not a URL (verified on a live sub-thread node in memex). Two chat surfaces put it straight into an `<img src>`:

- `ThreadChatView.razor:363` — the delegation chip inside a message bubble
- `ThreadChatView.razor:592` — the "Running sub-threads" runtime card

`<img src="<svg …>">` is a broken image, always. The chat composer's node picker had the same defect and worked around it by **dropping** inline-svg icons outright (`!node.Icon.TrimStart().StartsWith("<")`). A legacy Fluent icon NAME (`<img src="Document">`) breaks the same way at all four sites.

## The fix

A `MeshNode.Icon` is one string holding four different things (`Domain.Icon.Parse`): image URL / data URI, inline `<svg>`, emoji, or a Fluent name. `<img src="@node.Icon">` is correct for exactly one of them.

- **`MeshNodeImageHelper.ResolveRenderable(icon, fallback)`** — a **total** classification: first of `icon` → `fallback` → the neutral box glyph that can *actually* be rendered, paired with the element it needs (`Image` / `InlineSvg` / `Glyph`). A Fluent name resolves only where a glyph of that name is shipped (`ShippedIconFor`); otherwise the caller's standard icon wins rather than a broken image. There is no input for which it returns something unrenderable.
- **`NodeIcon.razor`** (`MeshWeaver.Blazor/Components`) renders that pair, so no call site can re-create the broken case. It is the Blazor mirror of the React client's `MeshIcon` (`clients/react/src/controls/MeshIcon.tsx`), which already dispatches on the same classification.
- Both sub-thread sites now pass `Fallback="@ThreadNodeType.DefaultIcon"` (the standard chat glyph) — that is the "standard icon if it's broken" the user asked for.
- The picker no longer drops inline-svg icons.

The icon element now lives in `NodeIcon`'s own CSS-isolation scope, so sizing moved inline (from `Size`) and the decorative rules in `ThreadChatView.razor.css` are anchored with `::deep`.

## Verification

- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph`, `MeshWeaver.Blazor.Portal` (which builds `MeshWeaver.Blazor`), `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test`.
- `MeshNodeImageHelperTest` — 64 passed, incl. 8 new cases pinning the identicon (inline svg ⇒ markup, never an img source), URL/emoji/shipped-Fluent forms, unknown Fluent name ⇒ fallback, and no-icon-no-fallback ⇒ neutral glyph.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` — 2 passed.
- Not visually verified in a running portal: the render change is the three-branch `NodeIcon` component; the classification it dispatches on is what the unit tests pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj