### PR TITLE
feat(ws7): settings tabs tranche 2 ride the UiContribution lane

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -699,8 +699,9 @@ public static class MemexConfiguration
                 // RLS for cross-partition operations (list Spaces, create
                 // a new Space, etc.). Empty / missing section = no-op.
                 .AddMeshNodes(Authentication.GlobalAdminSeed.Build(configuration))
-                // What's New / About / Privacy settings-tab entries as seeded UiContribution
-                // nodes — the WS7 lane a plugin's own settings tab arrives through.
+                // The platform's settings-tab menu entries (What's New / About / Privacy and the
+                // admin tabs Invitations / Inbox / Updates / Published / Token Usage) as seeded
+                // UiContribution nodes — the WS7 lane a plugin's own settings tab arrives through.
                 .AddPlatformSettingsTabContributions()
                 // The AI menu's navigation entries (Threads/Models/Tiers/Providers/Agents/Skills)
                 // as seeded UiContribution nodes — same lane a plugin's AI-menu entry (or a whole
@@ -863,25 +864,18 @@ public static class MemexConfiguration
                         // where the concern is defined shows as its own section. Per-item configurable
                         // (label / icon / order / tooltip / href); register more under the same AI context.
                         .AddNodeMenuItems(NodeMenuItemsExtensions.AiMenuContext, [.. AiMenuItems])
-                        // Dedicated Admin menu (platform-wide GlobalSettings area), gated on root
-                        // Permission.All: Invitations + Inbox.
-                        .AddInvitationsSettingsTab()
-                        .AddInboxSettingsTab()
-                        // Platform auto-update strategy (Admin/UpdatePolicy) — stable/continuous/none.
-                        .AddUpdatePolicySettingsTab()
                         // Platform-admin Instances overview: live cluster query (namespaces, versions,
                         // replica health) + Grafana log links + guided create-instance plan generator.
                         .AddInstancesAdminSettingsTab()
-                        // What's New / About / Privacy ride the UiContribution lane (WS7 slice 2):
-                        // content stays compiled, exposed here as layout areas; the menu entries are
-                        // seeded UiContribution nodes (AddPlatformSettingsTabContributions below).
+                        // The platform's global settings tabs ride the UiContribution lane (WS7):
+                        // What's New / About / Privacy (slice 2) plus the Administration tabs —
+                        // Invitations + Inbox (invitation-only onboarding, non-user mail), Updates
+                        // (the Admin/UpdatePolicy auto-update strategy), Published to the web (the
+                        // /sitemap.xml enumeration, rendered) and Token Usage (per-model _Usage
+                        // analytics) — all in slice 4. Content stays compiled, exposed here as
+                        // layout areas; the menu entries are seeded UiContribution nodes
+                        // (AddPlatformSettingsTabContributions on the mesh builder above).
                         .AddPlatformSettingsTabAreas()
-                        // Published to the web: every page a logged-out visitor can open, read from
-                        // the SAME enumeration /sitemap.xml renders, so the two cannot drift.
-                        .AddPublishedSettingsTab()
-                        // Token-usage analytics (per-model _Usage satellites): filter by period,
-                        // group by model / person / thread, cost from ModelPricing.
-                        .AddTokenUsageSettingsTab()
                         // GitHub Sync tab — shows only on Space nodes (self-filtered).
                         .AddGitHubSyncSettingsTab()
                         // GitHub Issues & PRs tab — browse/act on the repo's issues + pull requests.

--- a/memex/Memex.Portal.Shared/Settings/InboxSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/InboxSettingsTab.cs
@@ -17,36 +17,16 @@ namespace Memex.Portal.Shared.Settings;
 /// <summary>
 /// Admin <b>Inbox</b> tab in the platform-wide GlobalSettings (Admin) menu — lists mail received from
 /// <i>non-users</i> (filed into <c>Admin/Inbox</c> by the inbound processor). Known-user mail is
-/// handled by an agent thread and never lands here. Gated on root <see cref="Permission.All"/>.
+/// handled by an agent thread and never lands here.
+///
+/// <para>Platform admins only: the menu entry is a seeded <c>UiContribution</c> node with
+/// <c>Gates.AdminOnly</c> (<see cref="PlatformSettingsTabAreas"/>), and the <c>SettingsInbox</c>
+/// layout area re-asserts the admin gate for direct URLs.</para>
 /// </summary>
 public static class InboxSettingsTab
 {
     public const string TabId = "Inbox";
     private const string ResultDataId = "inboxResult";
-
-    public static MessageHubConfiguration AddInboxSettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetInboxTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetInboxTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Inbox",
-            ContentBuilder: BuildInboxContent,
-            Group: "Administration",
-            Icon: FluentIcons.Mail(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 320)
-            { LabelKey = "settings.inbox", GroupKey = "settings.groupAdministration" };
-
-        // Reactive: AdminMenuGate.IsPlatformAdmin emits false first (tab hidden), then true once the
-        // platform-admin grant surfaces → the tab appears. No async/await/IAsyncEnumerable.
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
 
     internal static UiControl BuildInboxContent(LayoutAreaHost host, StackControl stack)
     {

--- a/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
@@ -22,41 +22,15 @@ namespace Memex.Portal.Shared.Settings;
 /// <see cref="Invitation"/>s and lets an admin invite an email (which creates the invitation
 /// node and sends a no-reply email via <see cref="IEmailSender"/>) or revoke one.
 ///
-/// <para>Gated exactly like the "Global Administration" tab
-/// (<c>UserNodeType.GetGlobalAdminTabAsync</c>): the provider yields the tab ONLY when the
-/// viewer is the node owner AND holds root-level <see cref="Permission.All"/>. Registered via
-/// <c>ConfigureDefaultNodeHub</c> (like <c>ModelsSettingsTab</c>), so combined with the gate it
-/// surfaces only on a platform admin's own User Settings page — not on every node.</para>
+/// <para>Platform admins only: the menu entry is a seeded <c>UiContribution</c> node with
+/// <c>Gates.AdminOnly</c> (<see cref="PlatformSettingsTabAreas"/>), and the
+/// <c>SettingsInvitations</c> layout area re-asserts the admin gate for direct URLs.</para>
 /// </summary>
 public static class InvitationsSettingsTab
 {
     public const string TabId = "Invitations";
     private const string ResultDataId = "invitationResult";
     private const string FormDataId = "invitationForm";
-
-    public static MessageHubConfiguration AddInvitationsSettingsTab(
-        this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetInvitationsTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetInvitationsTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Invitations",
-            ContentBuilder: BuildInvitationsContent,
-            Group: "Administration",
-            Icon: FluentIcons.Mail(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 310)
-            { LabelKey = "settings.invitations", GroupKey = "settings.groupAdministration" };
-
-        // Reactive: gated tab appears once the platform-admin grant surfaces. No async/await.
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
 
     internal static UiControl BuildInvitationsContent(
         LayoutAreaHost host, StackControl stack)

--- a/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
+++ b/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
@@ -8,13 +8,20 @@ using MeshWeaver.Messaging;
 namespace Memex.Portal.Shared.Settings;
 
 /// <summary>
-/// The first tranche of settings tabs served as <see cref="UiContribution"/> DATA instead of
-/// compiled provider registrations (WS7 slice 2, design #1645): What's New, About and Privacy.
-/// The CONTENT stays compiled — each tab's existing <c>BuildContent</c> is exposed as a normal
-/// layout AREA — while the menu ENTRY (label, icon, order, grouping, admin gate) is a seeded
-/// <c>UiContribution</c> node the compiled aggregator projects under the closed gate vocabulary.
-/// A plugin contributes a settings tab the exact same way; these seeds prove the lane on the
-/// platform's own tabs.
+/// The platform's settings tabs served as <see cref="UiContribution"/> DATA instead of compiled
+/// provider registrations (design #1645). The CONTENT stays compiled — each tab's existing
+/// <c>BuildContent</c> is exposed as a normal layout AREA — while the menu ENTRY (label, icon,
+/// order, grouping, admin gate) is a seeded <c>UiContribution</c> node the compiled aggregator
+/// projects under the closed gate vocabulary. A plugin contributes a settings tab the exact same
+/// way; these seeds prove the lane on the platform's own tabs.
+///
+/// <para>Tranche 1 (WS7 slice 2, #1648): What's New, About and Privacy. Tranche 2 (WS7 slice 4)
+/// adds the platform-admin Administration tabs: <b>Invitations</b> and <b>Inbox</b> (the
+/// invitation-only onboarding manager and the non-user mail inbox — the pair that used to be the
+/// dedicated Admin menu), <b>Updates</b> (the <c>Admin/UpdatePolicy</c> auto-update strategy —
+/// stable/continuous/none), <b>Published to the web</b> (every page a logged-out visitor can open,
+/// read from the SAME enumeration <c>/sitemap.xml</c> renders, so the two cannot drift) and
+/// <b>Token Usage</b> (per-model <c>_Usage</c> analytics with cost from ModelPricing).</para>
 /// </summary>
 public static class PlatformSettingsTabAreas
 {
@@ -27,8 +34,23 @@ public static class PlatformSettingsTabAreas
     /// <summary>Layout area rendering <see cref="PrivacySettingsTab.BuildContent"/> (admin-gated).</summary>
     public const string PrivacyArea = "SettingsPrivacy";
 
+    /// <summary>Layout area rendering <see cref="InvitationsSettingsTab.BuildInvitationsContent"/> (admin-gated).</summary>
+    public const string InvitationsArea = "SettingsInvitations";
+
+    /// <summary>Layout area rendering <see cref="InboxSettingsTab.BuildInboxContent"/> (admin-gated).</summary>
+    public const string InboxArea = "SettingsInbox";
+
+    /// <summary>Layout area rendering <see cref="UpdatePolicySettingsTab.BuildContent"/> (admin-gated).</summary>
+    public const string UpdatePolicyArea = "SettingsUpdatePolicy";
+
+    /// <summary>Layout area rendering <see cref="PublishedSettingsTab.BuildContent"/> (admin-gated).</summary>
+    public const string PublishedArea = "SettingsPublished";
+
+    /// <summary>Layout area rendering <see cref="TokenUsageSettingsTab.BuildContent"/> (admin-gated).</summary>
+    public const string TokenUsageArea = "SettingsTokenUsage";
+
     /// <summary>
-    /// Registers the tranche's tab contents as layout areas on the per-node hubs. The settings
+    /// Registers the tranches' tab contents as layout areas on the per-node hubs. The settings
     /// pane embeds them via the contributed entries' <c>Area</c>; the pane supplies the
     /// padding/scroll container, so each area builds into a plain full-width stack.
     /// </summary>
@@ -37,56 +59,161 @@ public static class PlatformSettingsTabAreas
             .WithView(WhatsNewArea, (host, _) => WhatsNewSettingsTab.BuildContent(host, PaneStack()))
             .WithView(AboutArea, (host, _) => AboutSettingsTab.BuildContent(host, PaneStack()))
             // Privacy's tab content is the ADMIN EDITOR of the public statement (the statement
-            // itself is served anonymously at /privacy). The contributed entry hides the tab via
-            // Gates.AdminOnly, but an area is directly addressable by URL — so the area re-asserts
-            // the same gate instead of trusting the menu to be the only door. TakeLast(1) waits for
-            // the gate to RESOLVE (it opens with a synthetic false so menus render ungated tabs
-            // immediately) — a neutral pane shows meanwhile, so an admin never flashes the denial.
-            .WithView(PrivacyArea, (host, _) => AdminMenuGate.IsPlatformAdmin(host)
-                .TakeLast(1)
-                .Select(isAdmin => isAdmin
-                    ? PrivacySettingsTab.BuildContent(host, PaneStack())
-                    : (UiControl)Controls.Markdown(host.Localize("ui.accessDeniedAdminsOnly")))
-                .StartWith((UiControl)PaneStack())));
+            // itself is served anonymously at /privacy).
+            .WithView(PrivacyArea, (host, _) => AdminGated(host,
+                () => PrivacySettingsTab.BuildContent(host, PaneStack())))
+            .WithView(InvitationsArea, (host, _) => AdminGated(host,
+                () => InvitationsSettingsTab.BuildInvitationsContent(host, PaneStack())))
+            .WithView(InboxArea, (host, _) => AdminGated(host,
+                () => InboxSettingsTab.BuildInboxContent(host, PaneStack())))
+            .WithView(UpdatePolicyArea, (host, _) => AdminGated(host,
+                () => UpdatePolicySettingsTab.BuildContent(host, PaneStack())))
+            .WithView(PublishedArea, (host, _) => AdminGated(host,
+                () => PublishedSettingsTab.BuildContent(host, PaneStack())))
+            .WithView(TokenUsageArea, (host, _) => AdminGated(host,
+                () => TokenUsageSettingsTab.BuildContent(host, PaneStack()))));
 
     /// <summary>
-    /// Seeds the tranche's menu entries as platform-static <c>UiContribution</c> nodes under
-    /// <c>Admin/UiContribution</c>. The node id is the former compiled tab id, keeping every
-    /// <c>/GlobalSettings/{Id}</c> deep link stable across the migration.
+    /// The admin-gated area body. Each admin tab's contributed entry hides the tab via
+    /// <c>Gates.AdminOnly</c>, but an area is directly addressable by URL — so the area re-asserts
+    /// the same gate instead of trusting the menu to be the only door. TakeLast(1) waits for the
+    /// gate to RESOLVE (it opens with a synthetic false so menus render ungated tabs immediately) —
+    /// a neutral pane shows meanwhile, so an admin never flashes the denial.
+    /// </summary>
+    private static IObservable<UiControl> AdminGated(LayoutAreaHost host, Func<UiControl> content)
+        => AdminMenuGate.IsPlatformAdmin(host)
+            .TakeLast(1)
+            .Select(isAdmin => isAdmin
+                ? content()
+                : (UiControl)Controls.Markdown(host.Localize("ui.accessDeniedAdminsOnly")))
+            .StartWith((UiControl)PaneStack());
+
+    /// <summary>
+    /// Every area <see cref="AddPlatformSettingsTabAreas"/> registers — MUST list exactly the
+    /// <c>WithView</c> entries above. The seed-integrity test asserts each seed's <c>Area</c>
+    /// points at one of these, so a seed can never dangle against an unregistered area.
+    /// </summary>
+    internal static IReadOnlyList<string> Areas { get; } =
+    [
+        WhatsNewArea, AboutArea, PrivacyArea, InvitationsArea, InboxArea,
+        UpdatePolicyArea, PublishedArea, TokenUsageArea,
+    ];
+
+    /// <summary>
+    /// The seeded menu entries, exposed for the pinning tests (same contract as
+    /// <see cref="AiMenuContributions.Seeds"/>). Node id = the tab's former compiled tab id,
+    /// keeping every <c>/GlobalSettings/{Id}</c> deep link stable across the migration; every
+    /// label/icon/order/group is copied EXACTLY from the former compiled definition.
+    /// </summary>
+    internal static IReadOnlyList<MeshNode> Seeds { get; } =
+    [
+        // Ungated tabs — visible to every signed-in viewer.
+        Seed(WhatsNewSettingsTab.TabId, "What's New", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = WhatsNewArea,
+            Label = "What's New",
+            LabelKey = "settings.whatsNew",
+            Icon = "Sparkle",
+            Order = 910,
+        }),
+        Seed(AboutSettingsTab.TabId, "About", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = AboutArea,
+            Label = "About",
+            LabelKey = "settings.about",
+            Icon = "Info",
+            Order = 900,
+        }),
+        // Administration group — platform admins only (Gates.AdminOnly on the entry, and the
+        // area re-asserts the gate for direct URLs). Ordered by tab Order within the group.
+        Seed(InvitationsSettingsTab.TabId, "Invitations", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = InvitationsArea,
+            Label = "Invitations",
+            LabelKey = "settings.invitations",
+            Icon = "Mail",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 310,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+        Seed(InboxSettingsTab.TabId, "Inbox", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = InboxArea,
+            Label = "Inbox",
+            LabelKey = "settings.inbox",
+            Icon = "Mail",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 320,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+        Seed(UpdatePolicySettingsTab.TabId, "Updates", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = UpdatePolicyArea,
+            Label = "Updates",
+            LabelKey = "settings.updates",
+            Icon = "ArrowSync",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 320,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+        Seed(PublishedSettingsTab.TabId, "Published to the web", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = PublishedArea,
+            Label = "Published to the web",
+            LabelKey = "settings.published",
+            Icon = "Globe",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 320,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+        Seed(TokenUsageSettingsTab.TabId, "Token Usage", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = TokenUsageArea,
+            Label = "Token Usage",
+            LabelKey = "settings.tokenUsage",
+            Icon = "Database",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 320,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+        Seed(PrivacySettingsTab.TabId, "Privacy", new UiContribution
+        {
+            Context = UiContribution.SettingsContext,
+            Area = PrivacyArea,
+            Label = "Privacy",
+            LabelKey = "settings.privacy",
+            Icon = "Shield",
+            Group = "Administration",
+            GroupKey = "settings.groupAdministration",
+            GroupIcon = "Shield",
+            Order = 330,
+            Gates = new UiContributionGates { AdminOnly = true },
+        }),
+    ];
+
+    /// <summary>
+    /// Seeds the menu entries as platform-static <c>UiContribution</c> nodes under
+    /// <c>Admin/UiContribution</c>.
     /// </summary>
     public static MeshBuilder AddPlatformSettingsTabContributions(this MeshBuilder builder)
-        => builder.AddMeshNodes(
-            Seed(WhatsNewSettingsTab.TabId, "What's New", new UiContribution
-            {
-                Context = UiContribution.SettingsContext,
-                Area = WhatsNewArea,
-                Label = "What's New",
-                LabelKey = "settings.whatsNew",
-                Icon = "Sparkle",
-                Order = 910,
-            }),
-            Seed(AboutSettingsTab.TabId, "About", new UiContribution
-            {
-                Context = UiContribution.SettingsContext,
-                Area = AboutArea,
-                Label = "About",
-                LabelKey = "settings.about",
-                Icon = "Info",
-                Order = 900,
-            }),
-            Seed(PrivacySettingsTab.TabId, "Privacy", new UiContribution
-            {
-                Context = UiContribution.SettingsContext,
-                Area = PrivacyArea,
-                Label = "Privacy",
-                LabelKey = "settings.privacy",
-                Icon = "Shield",
-                Group = "Administration",
-                GroupKey = "settings.groupAdministration",
-                GroupIcon = "Shield",
-                Order = 330,
-                Gates = new UiContributionGates { AdminOnly = true },
-            }));
+        => builder.AddMeshNodes(Seeds);
 
     private static MeshNode Seed(string id, string name, UiContribution content)
         => new(id, "Admin/UiContribution")

--- a/memex/Memex.Portal.Shared/Settings/PublishedSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/PublishedSettingsTab.cs
@@ -38,30 +38,9 @@ public static class PublishedSettingsTab
     /// <summary>The tab's stable id.</summary>
     public const string TabId = "PublishedToTheWeb";
 
-    /// <summary>Registers the "Published to the web" tab on the global settings menu.</summary>
-    public static MessageHubConfiguration AddPublishedSettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetPublishedTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetPublishedTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Published to the web",
-            ContentBuilder: BuildContent,
-            Group: "Administration",
-            Icon: FluentIcons.Globe(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 320)
-        { LabelKey = "settings.published", GroupKey = "settings.groupAdministration" };
-
-        // Reactive, gated like its sibling admin tabs: the published surface is not secret, but
-        // "what is public" is an administration question.
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
+    // The menu entry is a seeded UiContribution node with Gates.AdminOnly
+    // (PlatformSettingsTabAreas) — the published surface is not secret, but "what is public" is
+    // an administration question; the SettingsPublished layout area re-asserts the admin gate.
 
     /// <summary>One published page, as a plain row the grid binds to.</summary>
     public sealed record PublishedRow
@@ -78,7 +57,7 @@ public static class PublishedSettingsTab
         public DateTime Changed { get; init; }
     }
 
-    private static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
+    internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
         => stack
             .WithView(Controls.Markdown(host.Localize("ui.mdPublishedIntro")))
             .WithView((h, _) => LivePublishedList(h), "PublishedList");

--- a/memex/Memex.Portal.Shared/Settings/TokenUsageSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/TokenUsageSettingsTab.cs
@@ -23,8 +23,10 @@ namespace Memex.Portal.Shared.Settings;
 /// model's catalog node first, the built-in <see cref="ModelPricing.Defaults"/> table as fallback
 /// (<see cref="ModelPriceCatalog"/>) — and never stored, so a price edit re-prices history.
 ///
-/// <para>Gated like the other Administration tabs via <c>AdminMenuGate.IsPlatformAdmin</c>; the
-/// query is RLS-scoped to what the viewer can read. Rendered with framework controls
+/// <para>Platform admins only — the menu entry is a seeded <c>UiContribution</c> node with
+/// <c>Gates.AdminOnly</c> (<see cref="PlatformSettingsTabAreas"/>), and the
+/// <c>SettingsTokenUsage</c> layout area re-asserts the admin gate for direct URLs; the query is
+/// RLS-scoped to what the viewer can read. Rendered with framework controls
 /// (<see cref="DataGridControl"/> + a button toolbar) — no hand-built HTML.</para>
 /// </summary>
 public static class TokenUsageSettingsTab
@@ -39,28 +41,6 @@ public static class TokenUsageSettingsTab
         [(7, "Last 7 days"), (30, "Last 30 days"), (90, "Last 90 days"), (0, "All time")];
 
     private static FilterState Default => new("Model", 30);
-
-    public static MessageHubConfiguration AddTokenUsageSettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Token Usage",
-            ContentBuilder: BuildContent,
-            Group: "Administration",
-            Icon: FluentIcons.Database(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 320)
-            { LabelKey = "settings.tokenUsage", GroupKey = "settings.groupAdministration" };
-
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -16,38 +16,20 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Memex.Portal.Shared.Settings;
 
 /// <summary>
-/// Admin settings tab for the platform auto-update strategy (<c>Admin/UpdatePolicy</c>). Gated to
-/// platform admins (<see cref="AdminMenuGate.IsPlatformAdmin"/>). Edits the policy through the
-/// STANDARD node-content editor bound directly to the node stream (the <c>Policy</c> enum renders as
-/// a dropdown — no /data replica, no save subscription), shows the running version + the latest tag
-/// the poller has seen, and offers a manual "apply now" for installs that can self-patch.
+/// Admin settings tab for the platform auto-update strategy (<c>Admin/UpdatePolicy</c>). Edits the
+/// policy through the STANDARD node-content editor bound directly to the node stream (the
+/// <c>Policy</c> enum renders as a dropdown — no /data replica, no save subscription), shows the
+/// running version + the latest tag the poller has seen, and offers a manual "apply now" for
+/// installs that can self-patch.
+///
+/// <para>Platform admins only: the menu entry is a seeded <c>UiContribution</c> node with
+/// <c>Gates.AdminOnly</c> (<see cref="PlatformSettingsTabAreas"/>), and the
+/// <c>SettingsUpdatePolicy</c> layout area re-asserts the admin gate for direct URLs.</para>
 /// </summary>
 public static class UpdatePolicySettingsTab
 {
     public const string TabId = "UpdatePolicy";
     private const string ResultId = "updatePolicyResult";
-
-    public static MessageHubConfiguration AddUpdatePolicySettingsTab(this MessageHubConfiguration config)
-        => config.AddGlobalSettingsMenuItems(new GlobalSettingsMenuItemProvider(GetTab));
-
-    private static IObservable<IReadOnlyList<GlobalSettingsMenuItemDefinition>> GetTab(
-        LayoutAreaHost host, RenderingContext ctx)
-    {
-        var tab = new GlobalSettingsMenuItemDefinition(
-            Id: TabId,
-            Label: "Updates",
-            ContentBuilder: BuildContent,
-            Group: "Administration",
-            Icon: FluentIcons.ArrowSync(),
-            GroupIcon: FluentIcons.Shield(),
-            Order: 320)
-        { LabelKey = "settings.updates", GroupKey = "settings.groupAdministration" };
-
-        return AdminMenuGate.IsPlatformAdmin(host)
-            .Select(isAdmin => isAdmin
-                ? (IReadOnlyList<GlobalSettingsMenuItemDefinition>)new[] { tab }
-                : []);
-    }
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -186,8 +186,10 @@ The full field surface:
 
 **Settings tabs** (`Context: Settings`): the contributed area is embedded into the pane's styled
 stack; the tab id is the NODE id, so `/GlobalSettings/{id}` deep links stay stable when a compiled
-tab migrates to a same-named seed. The platform's own What's New / About / Privacy tabs ship this
-way (`Admin/UiContribution/*` seeds) — the reference implementation.
+tab migrates to a same-named seed. The platform's own global tabs ship this way — What's New /
+About / Privacy plus the admin tabs Invitations / Inbox / Updates / Published to the web / Token
+Usage (`Admin/UiContribution/*` seeds); every admin tab's AREA re-asserts the admin gate, because
+an area is directly URL-addressable and `Gates.AdminOnly` only hides the menu entry.
 
 **Whole top-bar menus** (`Context: TopBar`): the contribution declares a NEW dropdown — its `Area`
 names the menu's own context key, `Label`/`Icon`/`Order`/`Tooltip` style the button, and its

--- a/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
@@ -1,0 +1,101 @@
+using Memex.Portal.Shared.Settings;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Seed-integrity contract for the settings tabs riding the <c>UiContribution</c> lane
+/// (<see cref="PlatformSettingsTabAreas"/>, WS7 slices 2 + 4). Every seed must project into the
+/// global settings menu (Context = Settings), point at an AREA the same class actually registers
+/// (a dangling area renders the standard not-found placeholder — silently, to every user), keep
+/// its node id equal to the tab's former compiled tab id (the <c>/GlobalSettings/{Id}</c> deep-link
+/// contract), and the admin tabs must carry <c>Gates.AdminOnly</c> — dropping the gate would list
+/// an Administration tab in every signed-in user's settings menu.
+/// </summary>
+public class PlatformSettingsTabSeedTest
+{
+    /// <summary>The former compiled tab ids that must survive as node ids, exactly.</summary>
+    private static readonly string[] ExpectedIds =
+    [
+        WhatsNewSettingsTab.TabId,
+        AboutSettingsTab.TabId,
+        PrivacySettingsTab.TabId,
+        InvitationsSettingsTab.TabId,
+        InboxSettingsTab.TabId,
+        UpdatePolicySettingsTab.TabId,
+        PublishedSettingsTab.TabId,
+        TokenUsageSettingsTab.TabId,
+    ];
+
+    /// <summary>The tabs whose compiled providers gated on the platform-admin check.</summary>
+    private static readonly string[] AdminTabIds =
+    [
+        PrivacySettingsTab.TabId,
+        InvitationsSettingsTab.TabId,
+        InboxSettingsTab.TabId,
+        UpdatePolicySettingsTab.TabId,
+        PublishedSettingsTab.TabId,
+        TokenUsageSettingsTab.TabId,
+    ];
+
+    [Fact]
+    public void Every_Seed_Targets_The_Settings_Context_And_A_Registered_Area()
+    {
+        Assert.NotEmpty(PlatformSettingsTabAreas.Seeds);
+        Assert.All(PlatformSettingsTabAreas.Seeds, seed =>
+        {
+            var contribution = Assert.IsType<UiContribution>(seed.Content);
+            Assert.Equal(UiContribution.SettingsContext, contribution.Context);
+            Assert.NotNull(contribution.Area);
+            Assert.NotEqual("", contribution.Area);
+            Assert.Contains(contribution.Area, PlatformSettingsTabAreas.Areas);
+            Assert.False(string.IsNullOrEmpty(contribution.LabelKey),
+                $"'{seed.Id}' must localize its label");
+        });
+
+        // 1:1 — every registered area is claimed by exactly one seed, so neither list can grow
+        // without the other (an area without a seed is unreachable; a seed without an area dangles).
+        var claimed = PlatformSettingsTabAreas.Seeds
+            .Select(s => Assert.IsType<UiContribution>(s.Content).Area ?? "")
+            .ToList();
+        Assert.Equal(claimed.Count, claimed.Distinct().Count());
+        Assert.Equal(
+            PlatformSettingsTabAreas.Areas.OrderBy(a => a, StringComparer.Ordinal),
+            claimed.OrderBy(a => a, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Node_Ids_Are_The_Former_Compiled_Tab_Ids()
+    {
+        // The node id becomes the /GlobalSettings/{Id} route segment (ProjectSettingsTabs), so a
+        // renamed seed silently breaks every bookmarked deep link of the tab it migrated.
+        Assert.Equal(
+            ExpectedIds.OrderBy(i => i, StringComparer.Ordinal),
+            PlatformSettingsTabAreas.Seeds.Select(s => s.Id).OrderBy(i => i, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Admin_Tabs_Carry_The_AdminOnly_Gate_And_Ungated_Tabs_Do_Not()
+    {
+        Assert.All(PlatformSettingsTabAreas.Seeds, seed =>
+        {
+            var contribution = Assert.IsType<UiContribution>(seed.Content);
+            if (AdminTabIds.Contains(seed.Id))
+                Assert.True(contribution.Gates?.AdminOnly,
+                    $"'{seed.Id}' was admin-gated as a compiled provider and must stay admin-only");
+            else
+                Assert.NotEqual(true, contribution.Gates?.AdminOnly);
+        });
+    }
+
+    [Fact]
+    public void Seeds_Live_In_The_Admin_UiContribution_Namespace_As_UiContribution_Nodes()
+    {
+        Assert.All(PlatformSettingsTabAreas.Seeds, seed =>
+        {
+            Assert.Equal(UiContributionNodeType.NodeType, seed.NodeType);
+            Assert.Equal("Admin/UiContribution", seed.Namespace);
+        });
+    }
+}


### PR DESCRIPTION
Slice 4 of design #1645 (tranche 1: #1648; AI menu: #1652): the next batch of compiled **global-settings** tabs is served as `UiContribution` DATA. Tab content stays compiled, exposed as layout areas on `PlatformSettingsTabAreas`; the menu entries are seeded `UiContribution` nodes under `Admin/UiContribution` with **node id = the former compiled tab id**, keeping every `/GlobalSettings/{Id}` deep link stable.

## Migrated (all were `AddGlobalSettingsMenuItems` providers gated on `AdminMenuGate.IsPlatformAdmin` → seed carries `Gates.AdminOnly`, and the area re-asserts the gate because an area is directly URL-addressable)

| Tab | Node id | Area | Group / Order | Gate |
|---|---|---|---|---|
| Invitations | `Invitations` | `SettingsInvitations` | Administration / 310 | AdminOnly + area re-assert |
| Inbox | `Inbox` | `SettingsInbox` | Administration / 320 | AdminOnly + area re-assert |
| Updates | `UpdatePolicy` | `SettingsUpdatePolicy` | Administration / 320 | AdminOnly + area re-assert |
| Published to the web | `PublishedToTheWeb` | `SettingsPublished` | Administration / 320 | AdminOnly + area re-assert |
| Token Usage | `TokenUsage` | `SettingsTokenUsage` | Administration / 320 | AdminOnly + area re-assert |

Label/LabelKey/Icon/Order/Group/GroupKey/GroupIcon copied exactly from the compiled `GlobalSettingsMenuItemDefinition`s; no new localization keys. The five `Add*SettingsTab` provider registrations (and their `Get*Tab` providers) are deleted; `BuildContent` + `TabId` consts stay. `PublishedSettingsTab.BuildContent` went `private → internal` so the area can call it.

## Skipped — falsified against the code, not forced

The brief hypothesized ten tabs; five of them turned out **not to be global-settings tabs**. They register via `AddSettingsMenuItems` (`SettingsMenuItemDefinition`, the per-NODE settings surface at `/{nodePath}/Settings/{Id}`), and the `UiContribution` `Settings` context projects ONLY into the global settings menu (`GlobalSettingsMenuItemsExtensions.ContributedSettingsTabs` → `UiContributionProjection.ProjectSettingsTabs`). Migrating them would silently MOVE them to a different surface — a user-visible change this slice does not license:

- **ApiTokensSettingsTab** — node-settings tab (`Permission.None`, Security group, Order 230). Surface mismatch; also carries per-tab search `Keywords` the vocabulary has no field for.
- **InstancesSettingsTab** — node-settings tab (`Permission.None`, Security group, Order 235). Surface mismatch.
- **NotificationsSettingsTab** — node-settings tab (`Permission.None`, Preferences group, Order 240). Surface mismatch.
- **InstancesAdminSettingsTab** (`Instances/InstancesAdminLayoutArea.cs`) — node-settings tab AND predicate-gated: `IsEnabled(host)` reads `Instances:Enabled` config presence (control-instance only) before the `IsGlobalAdmin` check — a config-presence predicate the closed vocabulary cannot express.
- **CouponAdminSettingsTab** (`src/MeshWeaver.PluginCatalog`) — node-settings tab AND predicate-gated: `viewerId == nodeOwnerId` ("only on the admin's own settings page") before the `IsGlobalAdmin` check — a per-node predicate the closed vocabulary cannot express.

Also out of scope per the brief: `GitHubSyncSettingsTab` / `AddGitHubIssuesTab` (Space-with-repo-configured predicates), `InstanceGrantAdminSettingsTab` (not in the batch; same own-page predicate shape as Coupons).

Pre-existing note, untouched (out of scope): `InboxSettingsTab`/`InvitationsSettingsTab` `BuildContent` bodies still use `Controls.Html(...)` for some structured fragments — content was not modified in this refactor, only its registration surface.

## Tests

- New `PlatformSettingsTabSeedTest` (Memex.Portal.Shared.Test): every seed has `Context = Settings`, a non-empty `Area` that is 1:1 with the registered area consts, node id = former TabId, admin tabs carry `Gates.AdminOnly` (and ungated tabs don't), all seeds are `UiContribution` nodes in `Admin/UiContribution`.
- No existing test pinned any migrated provider — they pin the pure helpers (`RowFor`, `StatusMarkdown`, `ToRows`), which stay.
- `PlatformSettingsTabAreas` now exposes `Seeds` (the `AiMenuContributions.Seeds` pinning contract from #1652) and `Areas`.

## Verification

- `dotnet build -c Release -warnaserror` clean (0 errors): Memex.Portal.Shared, Memex.Portal.Monolith, Memex.Portal.Shared.Test, MeshWeaver.Graph.Test
- `dotnet test -c Release --no-build`: Memex.Portal.Shared.Test **Passed! 365/365** (incl. the 4 new seed tests); MeshWeaver.Graph.Test full suite **Passed! 1166/1166**
- DocumentationLinkIntegrityTest green after the `UiExtensibility.md` touch-up
- Sweep: no `.Add{Invitations,Inbox,UpdatePolicy,Published,TokenUsage}SettingsTab(` call remains anywhere (src/memex/test/samples/content); live-mesh search for the deleted symbols: 0 hits

No What's New entry: user-invisible refactor — same tabs, same gates, same deep links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
