### PR TITLE
fix: the chat's thread lists were empty for everyone

### DIFF
--- a/src/MeshWeaver.AI/ThreadQueries.cs
+++ b/src/MeshWeaver.AI/ThreadQueries.cs
@@ -1,0 +1,68 @@
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The mesh queries every THREAD LIST binds to — the side panel's thread picker, the in-thread
+/// navigation menu, and any list of threads a user can pick from. One place, because the two rules
+/// below are invisible at the call site and every hand-written copy has got at least one of them
+/// wrong, each time producing the same symptom: a list that renders "No threads yet" forever.
+///
+/// <para>🚨 <b>Ownership is decided by the QUERY, never re-filtered in the client.</b> Threads live in
+/// the <c>_Thread</c> satellite table, and the authorship columns exist ONLY on <c>mesh_nodes</c> —
+/// a satellite read projects <c>NULL::text AS created_by</c>
+/// (<c>PostgreSqlStorageAdapter.AuthorCols</c>). So <see cref="MeshWeaver.Mesh.MeshNode.CreatedBy"/>
+/// is structurally null on EVERY thread that comes back, and a client-side <c>n.CreatedBy == me</c>
+/// pass drops every row — for every user, silently. The creator is carried in the thread's CONTENT
+/// (<see cref="Thread.CreatedBy"/>), which is where these queries filter, matching the dashboard's
+/// cross-partition thread query (<c>CrossPartitionThreadQueryTests</c>).</para>
+///
+/// <para>🚨 <b>"My threads" is not scoped to the page I am on.</b> A thread is created at
+/// <c>{contextPath}/_Thread/{id}</c> for whatever node it was started from, so scoping the list to the
+/// current page's node path answers empty everywhere except that one node. RLS already limits the
+/// snapshot to what the caller may read; the user filter does the rest.</para>
+///
+/// <para>The projection always NAMES <c>content</c>: a <c>select:</c> that omits it yields nodes whose
+/// <c>Content</c> is silently null (<c>SyncedQueryProjectionContractTest</c>), which would strip the
+/// status the lists filter on and the summary they render.</para>
+/// </summary>
+public static class ThreadQueries
+{
+    /// <summary>
+    /// The columns a thread list needs. <c>content</c> is named deliberately — see the type remarks.
+    /// </summary>
+    public const string ListProjection =
+        "select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content";
+
+    private const string NewestFirst = "sort:LastModified-desc";
+
+    /// <summary>
+    /// Every thread <paramref name="userId"/> created, across every partition, newest first —
+    /// the "Threads" picker. A null/empty user falls back to "every thread I may read".
+    /// </summary>
+    /// <param name="userId">The current user's id (<c>CircuitUser.ResolveUserId</c>).</param>
+    public static string MyThreads(string? userId) =>
+        $"nodeType:{ThreadNodeType.NodeType}{OwnedBy(userId)} {NewestFirst} {ListProjection}";
+
+    /// <summary>
+    /// <see cref="MyThreads"/> minus the ones marked done — the nav menu's "other open threads".
+    /// </summary>
+    /// <param name="userId">The current user's id.</param>
+    public static string MyOpenThreads(string? userId) =>
+        $"nodeType:{ThreadNodeType.NodeType}{OwnedBy(userId)} -content.status:{ThreadExecutionStatus.Done} " +
+        $"{NewestFirst} {ListProjection}";
+
+    /// <summary>
+    /// The threads nested under <paramref name="path"/> — a thread's delegated sub-threads. Descendants,
+    /// not immediate children: a delegation nests at <c>{threadPath}/{responseMsgId}/{subThreadId}</c>.
+    /// The node itself is included by the query and filtered out by the caller.
+    /// </summary>
+    /// <param name="path">The parent thread's path.</param>
+    public static string ThreadsUnder(string path) =>
+        $"namespace:{path} scope:descendants nodeType:{ThreadNodeType.NodeType} {NewestFirst} {ListProjection}";
+
+    /// <summary>
+    /// The ownership term, or nothing when the caller has no user id (RLS still scopes the read).
+    /// Filters where the creator actually lives — the thread's content; see the type remarks.
+    /// </summary>
+    private static string OwnedBy(string? userId) =>
+        string.IsNullOrEmpty(userId) ? string.Empty : $" content.createdBy:{userId}";
+}

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2973,17 +2973,13 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
 
     private Task SwitchToResumeModeAsync()
     {
-        var ns = NavigationService.CurrentNamespace;
-        if (string.IsNullOrEmpty(ns))
-        {
-            var accessService = Hub.ServiceProvider.GetService<AccessService>();
-            var userId = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
-            ns = userId;
-        }
-
-        var query = string.IsNullOrEmpty(ns)
-            ? "nodeType:Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content"
-            : $"nodeType:Thread namespace:{ns}/_Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content";
+        // 🚨 MY threads, every partition — NOT the page I happen to be on. This used to ask for
+        // `namespace:{NavigationService.CurrentNamespace}/_Thread`, and CurrentNamespace is the PAGE's
+        // node path (LayoutArea stamps the top area's Address), so on every page that has never hosted
+        // a thread of its own — nearly all of them — the picker queried a namespace that holds nothing
+        // and rendered "No threads yet". Ownership comes from content.createdBy; the envelope column
+        // does not exist on the satellite table threads live in (see ThreadQueries).
+        var query = ThreadQueries.MyThreads(_userHome);
 
         viewMode = ChatViewMode.ResumeThreads;
         resumeLoading = true;
@@ -2997,7 +2993,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         // Removed that dropped the just-used thread from the list until a full reload (F5). Same
         // surface + pattern the agent/model pickers use (AgentPickerProjection.ObserveSnapshot).
         resumeSubscription?.Dispose();
-        resumeSubscription = Hub.GetQuery($"resume-threads|{ns}", query)
+        resumeSubscription = Hub.GetQuery("resume-threads", query)
             .Subscribe(
                 snapshot => InvokeAsync(() =>
                 {
@@ -3068,17 +3064,18 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     private void SetupMyThreadsSubscription()
     {
         myThreadsSubscription?.Dispose();
-        var me = _userHome;
-        myThreadsSubscription = Hub.GetQuery("my-threads", "nodeType:Thread -content.status:Done sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content")
+        // 🚨 Ownership is decided by the QUERY (content.createdBy). The client pass this replaces
+        // (`n.CreatedBy == me`) could never match: threads live in the _Thread satellite table, whose
+        // reads project NULL for the authorship columns, so MeshNode.CreatedBy is null on every thread
+        // that arrives and the list came out empty for every signed-in user. See ThreadQueries.
+        myThreadsSubscription = Hub.GetQuery("my-threads", ThreadQueries.MyOpenThreads(_userHome))
             .Subscribe(
                 snapshot => InvokeAsync(() =>
                 {
                     if (_isDisposed) return;
                     var projected = snapshot
                         .Where(n => !string.IsNullOrEmpty(n.Path)
-                            && string.Equals(n.NodeType, ThreadNodeType.NodeType, StringComparison.OrdinalIgnoreCase)
-                            && (string.IsNullOrEmpty(me)
-                                || string.Equals(n.CreatedBy, me, StringComparison.OrdinalIgnoreCase)))
+                            && string.Equals(n.NodeType, ThreadNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
                         .OrderByDescending(n => n.LastModified)
                         .ToList();
                     if (!VisibleThreadListChanged(ref _myThreadsKey, projected)) return;
@@ -3140,8 +3137,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         childThreads = [];
         if (string.IsNullOrEmpty(path))
             return;
-        childThreadsSubscription = Hub.GetQuery($"child-threads|{path}",
-                $"namespace:{path} scope:descendants nodeType:Thread sort:LastModified-desc select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified,content")
+        childThreadsSubscription = Hub.GetQuery($"child-threads|{path}", ThreadQueries.ThreadsUnder(path))
             .Subscribe(
                 snapshot => InvokeAsync(() =>
                 {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -3064,8 +3064,8 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     private void SetupMyThreadsSubscription()
     {
         myThreadsSubscription?.Dispose();
-        // 🚨 Ownership is decided by the QUERY (content.createdBy). The client pass this replaces
-        // (`n.CreatedBy == me`) could never match: threads live in the _Thread satellite table, whose
+        // 🚨 Ownership is decided by the QUERY (content.createdBy). The client-side filter this
+        // replaces (`n.CreatedBy == me`) could never match: threads live in the _Thread satellite table, whose
         // reads project NULL for the authorship columns, so MeshNode.CreatedBy is null on every thread
         // that arrives and the list came out empty for every signed-in user. See ThreadQueries.
         myThreadsSubscription = Hub.GetQuery("my-threads", ThreadQueries.MyOpenThreads(_userHome))

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-your-threads-list-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-your-threads-list-again.md
@@ -1,0 +1,20 @@
+---
+Name: Your threads are listed again
+Category: Fix
+Description: The side panel's thread picker and the in-thread navigation menu list your threads instead of coming up empty.
+Icon: Chat
+Order: -20260816
+---
+
+# Your threads are listed again
+
+Opening the thread picker in the chat side panel showed "No threads yet" on almost every page, and
+the in-thread navigation menu's list of your other open threads was empty for everyone.
+
+Two separate causes, one symptom. The picker only looked for threads belonging to the page you
+happened to be viewing, so unless you had started a thread on that exact page there was nothing to
+find. The navigation menu asked for threads by their author, but a thread records its author in the
+conversation itself rather than on the node, so the filter never matched anything.
+
+Both lists now show your threads wherever you started them — the picker lists all of them, newest
+first, and the navigation menu lists the ones you have not marked done.

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadListQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadListQueryTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins <see cref="ThreadQueries"/> — the queries every THREAD LIST binds to (the side panel's
+/// thread picker, the in-thread navigation menu) — against a REAL PG-backed mesh, because both ways
+/// these lists have gone empty are invisible anywhere else.
+///
+/// <para>🚨 <b>The gap this closes.</b> <c>CrossPartitionThreadQueryTests</c> already pins
+/// <c>content.createdBy</c> for the DASHBOARD's thread query, and the chat's own lists — written as
+/// separate query strings that no test touched — each carried a different defect and rendered
+/// "No threads yet" forever:</para>
+/// <list type="number">
+///   <item>The side panel's picker scoped itself to <c>namespace:{currentPage}/_Thread</c>. A thread
+///     is created under whatever node it was started from, so on any page that never hosted one the
+///     query asked for a namespace that holds nothing.</item>
+///   <item>The nav menu filtered <c>MeshNode.CreatedBy == me</c> on the client. Threads live in the
+///     <c>threads</c> satellite table, whose reads project <c>NULL::text AS created_by</c>
+///     (<c>PostgreSqlStorageAdapter.AuthorCols</c>) — so that column is null on EVERY thread and the
+///     filter matched nothing, for every signed-in user.</item>
+/// </list>
+/// <para>Only the second reproduces on PG specifically, which is why the whole set lives here rather
+/// than on an in-memory mesh: the null is a property of satellite-table storage, not of the query.</para>
+///
+/// <para>Each test owns a UNIQUE creator id, so the deliberately unscoped (cross-partition) query
+/// these lists issue in production matches only this test's rows — a sibling test writing threads
+/// concurrently can neither page them out nor leak into the assertions (#834).</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            // Registers the Thread NodeType + satellite routing rule and the AI type-registry
+            // entries the polymorphic Thread content needs to round-trip.
+            .AddAI();
+    }
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    /// <summary>A creator id unique to one test — see the class remarks on why that IS the scoping.</summary>
+    private static string NewOwner() => $"tlq_{Guid.NewGuid():N}"[..18].ToLowerInvariant();
+
+    /// <summary>
+    /// Creates <paramref name="owner"/>'s partition root and, under <paramref name="contextPath"/>,
+    /// a thread in that node's <c>_Thread</c> satellite — the shape
+    /// <c>ThreadNodeType.BuildThreadNode</c> produces for a thread started from any page.
+    /// </summary>
+    private async Task<string> CreateThread(
+        string owner, string contextPath, string name, ThreadExecutionStatus status = ThreadExecutionStatus.Idle)
+    {
+        var id = $"t{Guid.NewGuid():N}"[..10];
+        var thread = new MeshNode(id, $"{contextPath}/{ThreadNodeType.ThreadPartition}")
+        {
+            Name = name,
+            NodeType = ThreadNodeType.NodeType,
+            MainNode = contextPath,
+            State = MeshNodeState.Active,
+            Content = new MeshThread { CreatedBy = owner, Status = status },
+        };
+        await MeshService.CreateNode(thread).Should().Within(30.Seconds()).Emit();
+        return thread.Path!;
+    }
+
+    private async Task CreatePartitionRoot(string owner)
+    {
+        await MeshService.CreateNode(new MeshNode(owner)
+        {
+            NodeType = "User",
+            Name = owner,
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+    }
+
+    private async Task CreateNode(string id, string ns)
+    {
+        await MeshService.CreateNode(new MeshNode(id, ns)
+        {
+            NodeType = "Markdown",
+            Name = id,
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>
+    /// Subscribes the query the way the chat lists do and waits for the first snapshot satisfying
+    /// <paramref name="until"/> — never a fixed delay. The cache id is per-call so no test inherits
+    /// a sibling's snapshot (GetQuery caches by id + caller identity).
+    /// </summary>
+    private Task<IEnumerable<MeshNode>> Snapshot(
+        string id, string query, Func<IEnumerable<MeshNode>, bool> until) =>
+        Mesh.GetWorkspace().GetQuery($"test:threadlist:{id}", query)
+            .Where(until)
+            .Take(1)
+            .Should().Within(30.Seconds()).Emit();
+
+    private static IEnumerable<string> Paths(IEnumerable<MeshNode> nodes) =>
+        nodes.Where(n => !string.IsNullOrEmpty(n.Path)).Select(n => n.Path!);
+
+    /// <summary>
+    /// 🚨 THE SIDE-PANEL BUG. A thread started from an ordinary content page lives under THAT page,
+    /// not under the user's home — so "my threads" must not be scoped to any one namespace. The
+    /// picker used to scope itself to the page the user happened to be looking at and therefore
+    /// listed nothing anywhere else.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task MyThreads_FindsAThreadStartedOnAnyNode()
+    {
+        var owner = NewOwner();
+        using var _ = Access.ImpersonateAsSystem();
+        await CreatePartitionRoot(owner);
+        await CreateNode("Docs", owner);
+        await CreateNode("Page", $"{owner}/Docs");
+
+        var onHome = await CreateThread(owner, owner, "Thread on my home");
+        var onPage = await CreateThread(owner, $"{owner}/Docs/Page", "Thread on a doc page");
+
+        var snapshot = await Snapshot(
+            $"any-node-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2);
+
+        Paths(snapshot).Should().Contain(onHome).And.Contain(onPage,
+            "a thread is created under the node it was started from — the list is the USER's, not the page's");
+    }
+
+    /// <summary>Someone else's thread is not mine, in any partition.</summary>
+    [Fact(Timeout = 120_000)]
+    public async Task MyThreads_ExcludesAnotherUsersThread()
+    {
+        var owner = NewOwner();
+        var other = NewOwner();
+        using var _ = Access.ImpersonateAsSystem();
+        await CreatePartitionRoot(owner);
+        await CreatePartitionRoot(other);
+
+        var mine = await CreateThread(owner, owner, "Mine");
+        var theirs = await CreateThread(other, other, "Theirs");
+
+        var snapshot = await Snapshot(
+            $"others-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine));
+
+        Paths(snapshot).Should().NotContain(theirs);
+    }
+
+    /// <summary>
+    /// The nav menu lists OPEN threads: a thread marked done drops out of
+    /// <see cref="ThreadQueries.MyOpenThreads"/> while staying in <see cref="ThreadQueries.MyThreads"/>
+    /// (the picker can still resume it). Pins the <c>-content.status:Done</c> term — including that the
+    /// status enum is matched by NAME in the stored JSON.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task MyOpenThreads_ExcludesDone_WhileMyThreadsKeepsIt()
+    {
+        var owner = NewOwner();
+        using var _ = Access.ImpersonateAsSystem();
+        await CreatePartitionRoot(owner);
+
+        var open = await CreateThread(owner, owner, "Still open");
+        var done = await CreateThread(owner, owner, "Finished", ThreadExecutionStatus.Done);
+
+        var all = await Snapshot(
+            $"all-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2);
+        Paths(all).Should().Contain(open).And.Contain(done,
+            "the picker resumes any of my threads, done or not");
+
+        var openOnly = await Snapshot(
+            $"open-{owner}", ThreadQueries.MyOpenThreads(owner), s => Paths(s).Contains(open));
+        Paths(openOnly).Should().NotContain(done);
+    }
+
+    /// <summary>
+    /// 🚨 THE NAV-MENU BUG, pinned at its root: a thread ARRIVES with no envelope authorship, so
+    /// ownership can only be decided server-side.
+    ///
+    /// <para>Authorship columns exist only on <c>mesh_nodes</c> — a satellite read projects
+    /// <c>NULL::text AS created_by</c> (<c>PostgreSqlStorageAdapter.AuthorCols</c>), so a thread's
+    /// <see cref="MeshNode.CreatedBy"/> is ALWAYS null however it was created. The nav menu asked the
+    /// server for every thread and then kept the ones where <c>n.CreatedBy == me</c>: that predicate
+    /// is false for every row, for every user, forever.</para>
+    ///
+    /// <para>The subtlety that makes this so easy to get wrong: the SERVER-side term is fine — the
+    /// query layer maps a <c>createdBy:</c> filter onto the stored content, so it does select the
+    /// right rows. It is only the projected VALUE that is null. Filter where the data is; never
+    /// re-filter a thread list in the client on an envelope field.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ThreadOwnership_ArrivesWithNoEnvelopeAuthorship_SoTheClientCannotFilterOnIt()
+    {
+        var owner = NewOwner();
+        using var _ = Access.ImpersonateAsSystem();
+        await CreatePartitionRoot(owner);
+        var mine = await CreateThread(owner, owner, "Mine");
+
+        var byContent = await Snapshot(
+            $"content-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine));
+
+        byContent.Single(n => n.Path == mine).CreatedBy.Should().BeNull(
+            "satellite reads project NULL::text AS created_by — see PostgreSqlStorageAdapter.AuthorCols");
+
+        // Exactly what the nav menu used to do to the snapshot it had just been handed.
+        byContent
+            .Where(n => string.Equals(n.CreatedBy, owner, StringComparison.OrdinalIgnoreCase))
+            .Should().BeEmpty(
+                "re-filtering a thread list on MeshNode.CreatedBy drops EVERY row — that is the bug, "
+                + "and it is invisible because the server already returned exactly the right ones");
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadListQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ThreadListQueryTests.cs
@@ -98,7 +98,15 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
         return thread.Path!;
     }
 
-    private async Task CreatePartitionRoot(string owner)
+    /// <summary>
+    /// <paramref name="owner"/>'s partition, provisioned the way a real user's is. Creating the User
+    /// root is enough: onboarding writes the <c>{owner}/_Access/{owner}_Access</c> assignment itself
+    /// (adding it here fails with "Node already exists"). That grant is what lets the reads below run
+    /// as <paramref name="owner"/> rather than as system — without it RLS hides the partition from
+    /// everyone, since a platform admin is NOT a data superuser, and every assertion would have to be
+    /// made from an identity production never uses.
+    /// </summary>
+    private async Task CreateUserPartition(string owner)
     {
         await MeshService.CreateNode(new MeshNode(owner)
         {
@@ -106,6 +114,14 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
             Name = owner,
             State = MeshNodeState.Active,
         }).Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>Runs <paramref name="read"/> as <paramref name="owner"/> — a real circuit user on the
+    /// secured, per-result RLS path, exactly as the chat calls <c>Hub.GetQuery</c>.</summary>
+    private async Task<T> AsUser<T>(string owner, Func<Task<T>> read)
+    {
+        using var _ = Access.SwitchAccessContext(new AccessContext { ObjectId = owner, Name = owner });
+        return await read();
     }
 
     private async Task CreateNode(string id, string ns)
@@ -122,6 +138,12 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
     /// Subscribes the query the way the chat lists do and waits for the first snapshot satisfying
     /// <paramref name="until"/> — never a fixed delay. The cache id is per-call so no test inherits
     /// a sibling's snapshot (GetQuery caches by id + caller identity).
+    ///
+    /// <para>🚨 Every read runs through <see cref="AsUser"/>, NOT under <c>ImpersonateAsSystem</c>.
+    /// System impersonation is scoped to SEEDING (writing into a partition before its owner exists);
+    /// the assertions then run as the owning user on the secured, per-result RLS path the chat takes.
+    /// Reading as system would let an RLS regression — a user who cannot see their own threads — pass
+    /// silently, which is the same class of failure this suite exists for.</para>
     /// </summary>
     private Task<IEnumerable<MeshNode>> Snapshot(
         string id, string query, Func<IEnumerable<MeshNode>, bool> until) =>
@@ -143,38 +165,51 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
     public async Task MyThreads_FindsAThreadStartedOnAnyNode()
     {
         var owner = NewOwner();
-        using var _ = Access.ImpersonateAsSystem();
-        await CreatePartitionRoot(owner);
-        await CreateNode("Docs", owner);
-        await CreateNode("Page", $"{owner}/Docs");
+        string onHome, onPage;
+        using (Access.ImpersonateAsSystem())
+        {
+            await CreateUserPartition(owner);
+            await CreateNode("Docs", owner);
+            await CreateNode("Page", $"{owner}/Docs");
 
-        var onHome = await CreateThread(owner, owner, "Thread on my home");
-        var onPage = await CreateThread(owner, $"{owner}/Docs/Page", "Thread on a doc page");
+            onHome = await CreateThread(owner, owner, "Thread on my home");
+            onPage = await CreateThread(owner, $"{owner}/Docs/Page", "Thread on a doc page");
+        }
 
-        var snapshot = await Snapshot(
-            $"any-node-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2);
+        var snapshot = await AsUser(owner, () => Snapshot(
+            $"any-node-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2));
 
         Paths(snapshot).Should().Contain(onHome).And.Contain(onPage,
             "a thread is created under the node it was started from — the list is the USER's, not the page's");
     }
 
-    /// <summary>Someone else's thread is not mine, in any partition.</summary>
+    /// <summary>
+    /// Someone else's thread is not mine — and the exclusion has to come from the QUERY.
+    ///
+    /// <para>🚨 Both threads deliberately live in the SAME partition, one created by each user. Put
+    /// the other user's thread in a partition of their own and RLS hides it anyway, so the assertion
+    /// would pass without the ownership term ever being evaluated — a vacuous pass dressed as
+    /// coverage.</para>
+    /// </summary>
     [Fact(Timeout = 120_000)]
     public async Task MyThreads_ExcludesAnotherUsersThread()
     {
         var owner = NewOwner();
         var other = NewOwner();
-        using var _ = Access.ImpersonateAsSystem();
-        await CreatePartitionRoot(owner);
-        await CreatePartitionRoot(other);
+        string mine, theirs;
+        using (Access.ImpersonateAsSystem())
+        {
+            await CreateUserPartition(owner);
 
-        var mine = await CreateThread(owner, owner, "Mine");
-        var theirs = await CreateThread(other, other, "Theirs");
+            mine = await CreateThread(owner, owner, "Mine");
+            theirs = await CreateThread(other, owner, "Theirs");
+        }
 
-        var snapshot = await Snapshot(
-            $"others-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine));
+        var snapshot = await AsUser(owner, () => Snapshot(
+            $"others-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine)));
 
-        Paths(snapshot).Should().NotContain(theirs);
+        Paths(snapshot).Should().NotContain(theirs,
+            "the other user's thread is readable here — only the ownership term keeps it out");
     }
 
     /// <summary>
@@ -187,19 +222,22 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
     public async Task MyOpenThreads_ExcludesDone_WhileMyThreadsKeepsIt()
     {
         var owner = NewOwner();
-        using var _ = Access.ImpersonateAsSystem();
-        await CreatePartitionRoot(owner);
+        string open, done;
+        using (Access.ImpersonateAsSystem())
+        {
+            await CreateUserPartition(owner);
 
-        var open = await CreateThread(owner, owner, "Still open");
-        var done = await CreateThread(owner, owner, "Finished", ThreadExecutionStatus.Done);
+            open = await CreateThread(owner, owner, "Still open");
+            done = await CreateThread(owner, owner, "Finished", ThreadExecutionStatus.Done);
+        }
 
-        var all = await Snapshot(
-            $"all-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2);
+        var all = await AsUser(owner, () => Snapshot(
+            $"all-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Count() >= 2));
         Paths(all).Should().Contain(open).And.Contain(done,
             "the picker resumes any of my threads, done or not");
 
-        var openOnly = await Snapshot(
-            $"open-{owner}", ThreadQueries.MyOpenThreads(owner), s => Paths(s).Contains(open));
+        var openOnly = await AsUser(owner, () => Snapshot(
+            $"open-{owner}", ThreadQueries.MyOpenThreads(owner), s => Paths(s).Contains(open)));
         Paths(openOnly).Should().NotContain(done);
     }
 
@@ -222,12 +260,15 @@ public class ThreadListQueryTests(PostgreSqlFixture fixture, ITestOutputHelper o
     public async Task ThreadOwnership_ArrivesWithNoEnvelopeAuthorship_SoTheClientCannotFilterOnIt()
     {
         var owner = NewOwner();
-        using var _ = Access.ImpersonateAsSystem();
-        await CreatePartitionRoot(owner);
-        var mine = await CreateThread(owner, owner, "Mine");
+        string mine;
+        using (Access.ImpersonateAsSystem())
+        {
+            await CreateUserPartition(owner);
+            mine = await CreateThread(owner, owner, "Mine");
+        }
 
-        var byContent = await Snapshot(
-            $"content-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine));
+        var byContent = await AsUser(owner, () => Snapshot(
+            $"content-{owner}", ThreadQueries.MyThreads(owner), s => Paths(s).Contains(mine)));
 
         byContent.Single(n => n.Path == mine).CreatedBy.Should().BeNull(
             "satellite reads project NULL::text AS created_by — see PostgreSqlStorageAdapter.AuthorCols");


### PR DESCRIPTION
## Symptom

The **Threads** picker in the chat side panel lists nothing. Same for the in-thread nav menu's "other open threads".

## Two independent defects, one symptom

**1 — the picker was scoped to the page you're standing on.** `SwitchToResumeModeAsync` queried
`namespace:{NavigationService.CurrentNamespace}/_Thread`. `CurrentNamespace` is the **page's node path** (`LayoutArea` stamps the top area's `Address`), and a thread is created under whatever node it was started from — so on any page that never hosted a thread of its own, the picker asked for a namespace that holds nothing. Verified against memex: `nodeType:Thread namespace:Doc/Architecture/AsynchronousCalls/_Thread` → **0 results**, while `nodeType:Thread content.createdBy:rbuergi` → the user's threads across every partition.

**2 — the nav menu filtered on a field that is structurally null.** `SetupMyThreadsSubscription` asked the server for every thread and then kept the ones where `n.CreatedBy == me`. Threads live in the `_Thread` **satellite table**, and the authorship columns exist only on `mesh_nodes` — a satellite read projects `NULL::text AS created_by` (`PostgreSqlStorageAdapter.AuthorCols`). So `MeshNode.CreatedBy` is null on every thread that arrives, and that predicate was false for every row, for every signed-in user. (Confirmed on live data: a thread node returns no `createdBy`; a `mesh_nodes` node does.)

The subtlety that makes #2 easy to get wrong: the **server-side** `createdBy:` term is fine — the query layer maps it onto the stored content. Only the projected *value* is null.

## The fix

One place, `MeshWeaver.AI/ThreadQueries.cs`, holding the two rules that are invisible at the call site:

- ownership is decided **by the query** (`content.createdBy`) — the same predicate the dashboard's thread query already uses and that `CrossPartitionThreadQueryTests` already pins — never re-filtered in the client;
- a thread list is **not scoped to the current page**.

`MyThreads` / `MyOpenThreads` / `ThreadsUnder` now back the picker, the nav menu and the sub-thread list.

## "Don't we have tests for it?" — we did not, and that's why it broke twice

Nothing covered these two lists. What existed: `CrossPartitionThreadQueryTests` (the **dashboard's** thread query — the same `content.createdBy` lesson, learned once and pinned for one call site only), `SyncedQueryProjectionContractTest` (the `select:` contract, added after b78cfe909 — the *previous* time this same picker silently returned nothing), and `ThreadResumeTest` (loading one thread's messages). The chat's lists were hand-written query strings that no test touched.

New `ThreadListQueryTests` (real PG-backed mesh, `workspace.GetQuery` — the production path) pins:
- a thread started on an ordinary content page is found by "my threads" (kills the page scoping);
- another user's thread is not;
- `Done` drops out of `MyOpenThreads` but stays in `MyThreads` (also pins that the status enum matches by name);
- the row arrives with **no envelope authorship at all**, so re-filtering it client-side drops everything — the trap that only reproduces on PG.

Each test owns a unique creator id, so the deliberately unscoped cross-partition query matches only its own rows (no #834-style paging flake).

## Verification

- `dotnet build -c Release -warnaserror` clean: `MeshWeaver.Blazor.Portal` (builds `MeshWeaver.AI`), `MeshWeaver.Hosting.PostgreSql.Test`.
- `ThreadListQueryTests` — 4 passed against a real Postgres container. (First run caught a wrong claim in my own test — that the server-side envelope term matches nothing — which is how the "server-side is fine, the value is null" distinction above got established.)
- Not visually confirmed in a running portal; the queries are pinned by the tests above.

## Left alone deliberately

`ChatHistorySelector.razor` carries the same `createdBy:{userId}` shape but is **referenced nowhere** — dead code. Its server-side term is in fact correct; it wants deleting rather than editing, which is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmBFaHTqhy7h742wkAaJKj