### PR TITLE
feat(modules): dynamic activation + the runtime modules/ landing path (#1664 Slice A)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -568,7 +568,11 @@ public static class MemexConfiguration
                 // The ONE framework-identity gate (PrebuiltAssemblySeeder) — never a second
                 // notion of framework version.
                 PrebuiltAssemblySeeder.DeclineReason,
-                entry => File.Exists(MeshBuilder.ResolveModulePath(entry)),
+                // 🚨 modules/<name>/<name>.dll SPECIFICALLY — never ResolveModulePath, whose
+                // BaseDirectory fallback would let a sidecar entry with a lost modules/ folder
+                // silently bind a same-named app-closure DLL instead of being skipped. Baseline
+                // entries below keep ResolveModulePath (both locations are legitimate for them).
+                name => ModuleActivationBoot.LandedModuleDllExists(AppContext.BaseDirectory, name),
                 (module, reason) => Console.Error.WriteLine(
                     $"[ModuleActivation] SKIPPED store-installed module '{module}': {reason}"));
             if (effectiveModules.Count > 0)

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -551,13 +551,47 @@ public static class MemexConfiguration
             // per-deployment "which packs does this instance run" knob (Doc/Architecture/
             // UiExtensibility). Empty/absent = no-op; a listed path that fails to load should
             // fail loudly at startup, never silently run without the pack.
+            //
+            // #1664 step 9 — the effective set is the appsettings baseline ∪ the ENABLED entries
+            // of the modules/activation.json sidecar (store-installed modules landed by
+            // ModuleLandingService), deduped by name. Sidecar entries are guarded: a recorded
+            // framework MVID that mismatches the running framework (an image roll happened since
+            // the install) or a missing DLL SKIPS the entry with a loud stderr line — never a
+            // crash, the deployment must boot; the entry stays for the post-roll re-install.
+            // Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship to Loki regardless).
             var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
-            if (moduleAssemblies is { Length: > 0 })
+            var persistedActivation = ModuleActivationSidecar.Read(AppContext.BaseDirectory,
+                msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
+            var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                moduleAssemblies,
+                persistedActivation,
+                // The ONE framework-identity gate (PrebuiltAssemblySeeder) — never a second
+                // notion of framework version.
+                PrebuiltAssemblySeeder.DeclineReason,
+                entry => File.Exists(MeshBuilder.ResolveModulePath(entry)),
+                (module, reason) => Console.Error.WriteLine(
+                    $"[ModuleActivation] SKIPPED store-installed module '{module}': {reason}"));
+            if (effectiveModules.Count > 0)
                 // ResolveModulePath probes the modules/<name>/ publish layout first (#1644),
                 // then falls back to the classic BaseDirectory-relative location.
-                builder.InstallAssemblies(moduleAssemblies
+                builder.InstallAssemblies(effectiveModules
                     .Select(MeshBuilder.ResolveModulePath)
                     .ToArray());
+            // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
+            // consume the pending flag so the step-10 signal reads current. Best-effort: on a
+            // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.
+            if (persistedActivation.PendingRestart)
+                try
+                {
+                    ModuleActivationSidecar.Write(AppContext.BaseDirectory,
+                        persistedActivation with { PendingRestart = false });
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[ModuleActivation] could not reset PendingRestart ({ex.GetType().Name}: "
+                        + $"{ex.Message}) — the flag stays set; activation itself is unaffected.");
+                }
 
             // Read graph storage config
             var graphStorageConfig = configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -34,10 +34,47 @@ Modules that also need explicit composition (test fixtures, bespoke hosts) expos
 `Add<Name>()` extension sharing the same internal configure path as the attribute — the two lanes
 must never drift (`OgCardExtensions` is the reference shape).
 
-## Activating — `Modules:Assemblies`
+## Activating — the appsettings baseline ∪ persisted store installs
 
-The deployment's appsettings lists the DLLs to install; the list IS the on/off switch. The
-current first-party inventory and each module's configuration section:
+A deployment's active module set is the union of two lanes, computed at boot (before the DI
+container builds) and fed to `MeshBuilder.InstallAssemblies` as one list:
+
+1. **The `Modules:Assemblies` appsettings baseline** — the DLLs the image ships with; the list is
+   the operator's on/off switch for first-party packs, exactly as before. A baseline entry that
+   fails to load fails loudly at startup, never silently.
+2. **The persisted activation list** — `modules/activation.json`, a sidecar file beside the module
+   folders, written by the runtime landing service (`ModuleLandingService`) when a compiled module
+   is installed from the Store. Each entry records the module name, its source, the install
+   record's mesh path, and the framework MVID the landed assemblies were built against.
+
+The union dedupes by module name (a store install of an already-baseline module contributes
+nothing). **Activation is restart-based**: landing a module writes its assemblies into
+`modules/<name>/` and its activation entry, flags `PendingRestart` in the sidecar, and the module
+loads on the NEXT restart — nothing is loaded into the running process (a genuinely dynamic
+loader collides with the kernel snapshot). Boot consumes the `PendingRestart` flag: applying the
+list IS the restart. Uninstall is the mirror: the entry is disabled (kept, for history), the
+folder is deleted, and the change likewise takes effect at restart.
+
+**The skip rules** (persisted entries only — the deployment must always boot):
+
+- **Framework-MVID mismatch** — an image roll changed the running framework since the install, so
+  the landed bytes are ABI-stale. The entry is SKIPPED with a loud log naming both identities and
+  stays in the sidecar, waiting for a re-install against the new framework. The gate is the same
+  pure function every prebuilt lane uses (`PrebuiltAssemblySeeder.DeclineReason`) — there is one
+  notion of framework identity, never two.
+- **Missing DLL** — the entry's `modules/<name>/<name>.dll` does not resolve (lost volume, manual
+  deletion). Skipped loudly; re-install to heal.
+
+The landing service itself gates twice more, at placement: the same MVID check (declined bytes
+never reach disk), and a refusal of any module whose entry DLL name collides with an app-closure
+assembly — `ResolveModulePath` probes `modules/<name>/` first, so such a module would silently
+shadow the platform's own binary at the next boot.
+
+Why a sidecar file and not a mesh node: the list is consumed before any storage provider, hub, or
+connection string exists, and it must move with the DLLs it describes — the landing service writes
+both in one operation onto the same volume, so they cannot drift apart.
+
+The current first-party inventory and each module's configuration section:
 
 | Module DLL | Concern | Configuration |
 |---|---|---|
@@ -71,8 +108,8 @@ carries. While a module still ALSO rides a `ProjectReference` (the transition st
 prunes to empty and the loader falls back to the app folder — byte-for-byte the classic image.
 Flipping a module's reference off (one module at a time, its entry upgraded to a closure layout
 correct for that module) is what makes the folder carry real content; which modules EXIST then
-becomes a publish decision while which ACTIVATE stays `Modules:Assemblies`. Skip the whole
-target with `-p:PublishMeshModules=false`.
+becomes a publish (or Store-install) decision while which ACTIVATE stays the boot union above.
+Skip the whole target with `-p:PublishMeshModules=false`.
 
 ## Modules and the in-mesh compiler
 
@@ -85,14 +122,17 @@ NodeType source that reference it (e.g. a map control). Two boundaries stand:
 - **Kernel cells are different.** Executable `--render` cells resolve against a process-wide
   snapshot, and pack/NodeType assemblies are not reliably cell-callable — cell-callable API stays
   in compiled, startup-loaded assemblies until the pack-scripting seam lands.
-- **The bake fingerprint.** Every successful NodeType compile stamps
+- **The bake fingerprint is DECISIVE.** Every successful NodeType compile stamps
   `CompiledModulesHash` — a hash of the sorted installed-module MVIDs
-  (`InstalledModulesFingerprint`) — beside `CompiledFrameworkVersion`. While modules ride the
-  image the framework MVID already invalidates on every rebuild, so the hash is recorded but not
-  yet decisive; it joins the usable-build check when modules ship separately from the image, so a
-  module-only update invalidates baked builds that could reference it. Definitions stamped before
+  (`InstalledModulesFingerprint`) — beside `CompiledFrameworkVersion`, and the usable-build check
+  (`HasUsableBuild`) invalidates a build stamped with a DIFFERENT non-null hash than the live set,
+  while its rebuild-kickoff twin (`HasStaleFrameworkBuild`) re-drives the compile for it. That is
+  what makes a module-only update safe: a store install lands new module MVIDs without changing
+  the framework MVID, and baked builds that could reference the replaced module rebuild on the
+  next boot instead of throwing `MissingMethodException` at activation. Definitions stamped before
   the feature carry `null`, which compares as MATCH — such builds predate modules in the compile
-  surface and stay governed by the framework rule.
+  surface and stay governed by the framework rule; call sites without a mesh in scope pass no hash
+  and likewise keep the framework-only behavior.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -62,8 +62,11 @@ folder is deleted, and the change likewise takes effect at restart.
   stays in the sidecar, waiting for a re-install against the new framework. The gate is the same
   pure function every prebuilt lane uses (`PrebuiltAssemblySeeder.DeclineReason`) — there is one
   notion of framework identity, never two.
-- **Missing DLL** — the entry's `modules/<name>/<name>.dll` does not resolve (lost volume, manual
-  deletion). Skipped loudly; re-install to heal.
+- **Missing DLL** — the entry's `modules/<name>/<name>.dll` does not exist (lost volume, manual
+  deletion). Skipped loudly; re-install to heal. The check is that path SPECIFICALLY — a
+  same-named DLL in the app closure never satisfies a store-installed entry (the
+  `ResolveModulePath` base-directory fallback applies to baseline entries only, so a tampered
+  sidecar can never silently bind the platform's own binaries).
 
 The landing service itself gates twice more, at placement: the same MVID check (declined bytes
 never reach disk), and a refusal of any module whose entry DLL name collides with an app-closure

--- a/src/MeshWeaver.Graph/Configuration/InstalledModulesFingerprint.cs
+++ b/src/MeshWeaver.Graph/Configuration/InstalledModulesFingerprint.cs
@@ -10,15 +10,15 @@ namespace MeshWeaver.Graph.Configuration;
 /// set, design #1644). Stamped as <c>NodeTypeDefinition.CompiledModulesHash</c> by every
 /// successful NodeType compile, alongside <c>CompiledFrameworkVersion</c>.
 ///
-/// <para><b>Step-1 scope (deliberate):</b> the hash is RECORDED but does not yet join the
-/// usable-build decision. While modules ride the app image, a module change rebuilds the image,
-/// which changes Graph's MVID, which invalidates every build through the existing framework-match
-/// rule — the modules hash is redundant there. It becomes load-bearing exactly when modules ship
-/// SEPARATELY from the image (the <c>modules/</c> folder + bundle lane, #1644 step 2): then a
-/// module-only update must invalidate baked builds that could reference it, and this recorded
-/// hash is what the usable-build check compares. Definitions stamped before this feature carry
-/// null, which step 2 must treat as MATCH: a null-hash build was compiled when modules were in
-/// the app closure, and the framework rule already governs it.</para>
+/// <para><b>DECISIVE since #1664 Slice A:</b> the hash joins the usable-build decision —
+/// <c>NodeTypeCompilationHelpers.HasUsableBuild</c> (and its rebuild-kickoff twin
+/// <c>HasStaleFrameworkBuild</c>) invalidates a build stamped with a DIFFERENT non-null hash than
+/// the live set, so a module-only update (framework MVID unchanged — the store-install lane,
+/// where modules land in <c>modules/</c> without an image rebuild) forces the rebuild the
+/// framework rule cannot see. Definitions stamped before the feature carry null, which compares
+/// as MATCH: a null-hash build was compiled when modules were in the app closure, and the
+/// framework rule already governs it. Call sites without a mesh in scope pass null and keep the
+/// framework-only behavior.</para>
 ///
 /// <para>Registered as a mesh-scoped singleton (lifetime = the mesh, never static — test meshes
 /// with different module sets must not bleed).</para>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -80,6 +80,10 @@ internal static class NodeTypeCompilationHelpers
         // NodeType whose compile already terminally failed, so a broken type can never drive
         // the recompile storm that saturates this hub's single-threaded action block.
         var parkRegistry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>();
+        // The live installed-module fingerprint (#1664 step 11) — joins HasUsableBuild /
+        // HasStaleFrameworkBuild below so a module-only update re-drives the compile the same
+        // way a framework redeploy does. Null when the mesh registers no fingerprint (legacy).
+        var modulesHash = ModulesHashOf(hub);
 
         var installSeq = System.Threading.Interlocked.Increment(ref _watcherInstallCount);
         logger?.LogDebug(
@@ -315,7 +319,7 @@ internal static class NodeTypeCompilationHelpers
         var firstBuildKickoffSub = ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && def.CompilationStatus is null
-                && !HasUsableBuild(node, def)
+                && !HasUsableBuild(node, def, modulesHash)
                 // Same truly-static exclusion as the watcher above: the
                 // HubConfiguration delegate IS the configuration; nothing to
                 // Roslyn-compile.
@@ -442,7 +446,7 @@ internal static class NodeTypeCompilationHelpers
         var frameworkStaleKickoffSub = ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && def.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error
-                && HasStaleFrameworkBuild(def)
+                && HasStaleFrameworkBuild(def, modulesHash)
                 && !IsStaticOnlyNodeType(node, def)
                 && parkRegistry?.IsParked(hubPath) != true)
             .Take(1)
@@ -461,11 +465,23 @@ internal static class NodeTypeCompilationHelpers
             //
             // So: mismatch is the CHEAP pre-filter (a pure record read on every emission, unchanged),
             // and the store probe runs at most once per hub lifetime, here, after Take(1).
-            .SelectMany(node => ResolveAssemblyStore(hub)
-                .TryGetAssemblyPath(hubPath, DefinitionOf(hub, node)?.LastCompiledVersion ?? node.Version)
-                .Take(1)
-                .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
-                .Select(path => (Node: node, HasBytes: !string.IsNullOrEmpty(path))))
+            //
+            // 🚨 The probe answers the FRAMEWORK-mismatch case only. The store key carries the
+            // framework tag, not the modules hash — so when the staleness is a MODULES-hash
+            // mismatch on a framework-matching build (#1664 step 11), a bytes-hit for the live
+            // framework IS the very stale build we are trying to replace, and skipping on it
+            // would wedge the type forever. For that case, skip the probe and rebuild.
+            .SelectMany(node =>
+            {
+                var stampedFramework = DefinitionOf(hub, node)?.CompiledFrameworkVersion;
+                if (string.Equals(stampedFramework, FrameworkVersion, StringComparison.Ordinal))
+                    return Observable.Return((Node: node, HasBytes: false));
+                return ResolveAssemblyStore(hub)
+                    .TryGetAssemblyPath(hubPath, DefinitionOf(hub, node)?.LastCompiledVersion ?? node.Version)
+                    .Take(1)
+                    .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
+                    .Select(path => (Node: node, HasBytes: !string.IsNullOrEmpty(path)));
+            })
             .Where(probe =>
             {
                 if (!probe.HasBytes)
@@ -480,11 +496,17 @@ internal static class NodeTypeCompilationHelpers
             .Select(probe => probe.Node)
             .Subscribe(node =>
             {
-                logger?.LogInformation(
-                    "Framework-stale kickoff: NodeType {HubPath} assembly was compiled against framework {Compiled} but the live framework is {Live} — flipping CompilationStatus=Pending to rebuild",
-                    hubPath,
-                    node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions)?.CompiledFrameworkVersion ?? "(null)",
-                    FrameworkVersion);
+                // Name the ACTUAL staleness cause: on a modules-only update the stamped and live
+                // framework are EQUAL, and a framework-shaped message would read as a no-op.
+                var staleDef = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+                if (string.Equals(staleDef?.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal))
+                    logger?.LogInformation(
+                        "Stale-build kickoff: NodeType {HubPath} assembly was compiled under installed-module set {Compiled} but the live set is {Live} (framework unchanged — a module-only update) — flipping CompilationStatus=Pending to rebuild",
+                        hubPath, staleDef?.CompiledModulesHash ?? "(null)", modulesHash);
+                else
+                    logger?.LogInformation(
+                        "Framework-stale kickoff: NodeType {HubPath} assembly was compiled against framework {Compiled} but the live framework is {Live} — flipping CompilationStatus=Pending to rebuild",
+                        hubPath, staleDef?.CompiledFrameworkVersion ?? "(null)", FrameworkVersion);
                 var staleAccess = hub.ServiceProvider.GetService<AccessService>();
                 using var systemScope = staleAccess?.ImpersonateAsSystem();
                 workspace.GetMeshNodeStream().Update(curr =>
@@ -497,7 +519,7 @@ internal static class NodeTypeCompilationHelpers
                         return curr;
                     // Re-check staleness inside the lambda — a genuine rebuild may have refreshed
                     // CompiledFrameworkVersion between the outer Where and this write.
-                    if (!HasStaleFrameworkBuild(def)) return curr;
+                    if (!HasStaleFrameworkBuild(def, modulesHash)) return curr;
                     return curr with
                     {
                         Content = def with { CompilationStatus = CompilationStatus.Pending }
@@ -1026,11 +1048,37 @@ internal static class NodeTypeCompilationHelpers
     /// compile over a blocking store round-trip on every stream emission;
     /// the runtime miss is caught later when activation tries to hydrate the
     /// assembly and the store reports a miss.</para>
+    ///
+    /// <para><b>The modules fingerprint is DECISIVE (#1664 step 11).</b> When the caller passes
+    /// the mesh's live <see cref="InstalledModulesFingerprint.Hash"/> as
+    /// <paramref name="modulesHash"/>, a build stamped with a DIFFERENT non-null
+    /// <see cref="NodeTypeDefinition.CompiledModulesHash"/> is not usable — a module-only update
+    /// (framework MVID unchanged, module MVIDs changed) must invalidate baked builds that could
+    /// reference the replaced module, which the framework rule cannot see once modules ship
+    /// separately from the image. Two deliberate MATCH cases: a <c>null</c> STAMP is grandfathered
+    /// (compiled before modules joined the compile surface — the framework rule alone governs it,
+    /// per the contract on <see cref="NodeTypeDefinition.CompiledModulesHash"/>), and a
+    /// <c>null</c> CALLER (no mesh in scope to resolve the fingerprint from) keeps the legacy
+    /// framework-only behavior. The empty string is NOT null — it is the real stamped hash of a
+    /// zero-module mesh and compares like any other value.</para>
     /// </summary>
-    internal static bool HasUsableBuild(MeshNode node, NodeTypeDefinition def) =>
+    internal static bool HasUsableBuild(MeshNode node, NodeTypeDefinition def, string? modulesHash = null) =>
         !string.IsNullOrEmpty(def.LatestAssemblyCollection)
         && !string.IsNullOrEmpty(def.LatestAssemblyPath)
-        && string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal);
+        && string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal)
+        && (modulesHash is null
+            || def.CompiledModulesHash is null
+            || string.Equals(def.CompiledModulesHash, modulesHash, StringComparison.Ordinal));
+
+    /// <summary>
+    /// The mesh's live installed-module fingerprint, resolved from the hub's service tree
+    /// (<see cref="InstalledModulesFingerprint"/> is a mesh-scoped singleton registered by
+    /// <c>AddGraph</c>), or null when the mesh does not register one — the ONE resolver every
+    /// call site that threads <c>modulesHash</c> into <see cref="HasUsableBuild"/> /
+    /// <see cref="HasStaleFrameworkBuild"/> goes through, so "which hash is live" can never fork.
+    /// </summary>
+    internal static string? ModulesHashOf(IMessageHub hub) =>
+        hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash;
 
     /// <summary>
     /// True when this NodeType has a cached compiled assembly (the durable
@@ -1057,11 +1105,21 @@ internal static class NodeTypeCompilationHelpers
     private static NodeTypeDefinition? DefinitionOf(IMessageHub hub, MeshNode? node) =>
         node?.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
 
-    internal static bool HasStaleFrameworkBuild(NodeTypeDefinition def) =>
+    // The twin of HasUsableBuild's modules-hash join (#1664 step 11): a build whose stamped
+    // CompiledModulesHash differs from the live set is STALE the same way a framework mismatch
+    // is — the bytes exist but may bind a replaced module's old ABI. Without this twin the flip
+    // in HasUsableBuild would WEDGE every such type after a module-only update: HasUsableBuild
+    // says "not usable" so instances fall back to the default config, but nothing would re-drive
+    // the compile (first-build kickoff needs Status=null, recovery needs Compiling). Null stamp /
+    // null caller keep legacy behavior, exactly as in HasUsableBuild.
+    internal static bool HasStaleFrameworkBuild(NodeTypeDefinition def, string? modulesHash = null) =>
         !string.IsNullOrEmpty(def.LatestAssemblyCollection)
         && !string.IsNullOrEmpty(def.LatestAssemblyPath)
         && !string.IsNullOrEmpty(def.CompiledFrameworkVersion)
-        && !string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal);
+        && (!string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal)
+            || (modulesHash is not null
+                && def.CompiledModulesHash is not null
+                && !string.Equals(def.CompiledModulesHash, modulesHash, StringComparison.Ordinal)));
 
     /// <summary>
     /// THE terminal stamp of a SUCCESSFUL compile — the exact field set

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -418,7 +418,8 @@ internal static class NodeTypeContractHandler
                     // stuck on an undetermined state forever.
                     if (def.CompilationStatus is not null and not CompilationStatus.Unavailable)
                         return curr;
-                    if (NodeTypeCompilationHelpers.HasUsableBuild(curr, def)) return curr;
+                    if (NodeTypeCompilationHelpers.HasUsableBuild(
+                            curr, def, NodeTypeCompilationHelpers.ModulesHashOf(hub))) return curr;
                     if (NodeTypeCompilationHelpers.IsStaticOnlyNodeType(curr, def)) return curr;
                     return curr with
                     {

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -521,11 +521,14 @@ public record NodeTypeDefinition
     /// The deployment's installed-MODULE fingerprint the assembly was compiled under —
     /// <see cref="InstalledModulesFingerprint.Hash"/> (sorted module MVIDs; empty string = no
     /// modules; null = stamped before the feature, or by a mesh without the fingerprint
-    /// registered). Recorded by every successful compile (#1644 step 1); it joins the
-    /// usable-build decision when modules ship separately from the image (step 2) — a
-    /// module-only update must invalidate baked builds that could reference it, which the
-    /// framework-MVID rule cannot see. Null compares as MATCH there: a null-hash build predates
-    /// modules in the compile surface and is governed by the framework rule alone.
+    /// registered). Recorded by every successful compile (#1644 step 1) and DECISIVE since
+    /// #1664 Slice A: <c>NodeTypeCompilationHelpers.HasUsableBuild</c> invalidates a build
+    /// stamped with a different non-null hash than the live set, and
+    /// <c>HasStaleFrameworkBuild</c> re-drives the compile for it — a module-only update
+    /// (store-installed modules land in <c>modules/</c> without changing the framework MVID)
+    /// must invalidate baked builds that could reference it, which the framework rule cannot
+    /// see. Null compares as MATCH: a null-hash build predates modules in the compile surface
+    /// and is governed by the framework rule alone.
     /// </summary>
     public string? CompiledModulesHash { get; init; }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -902,7 +902,8 @@ internal static class NodeTypeEnrichmentHelpers
                 });
         }
 
-        if (NodeTypeCompilationHelpers.HasUsableBuild(typeNode, def))
+        if (NodeTypeCompilationHelpers.HasUsableBuild(
+                typeNode, def, NodeTypeCompilationHelpers.ModulesHashOf(meshHub)))
         {
             // Hot path for activating per-instance hubs: the NodeType has a
             // usable compile (LatestAssembly{Collection,Path} populated AND
@@ -1204,7 +1205,8 @@ internal static class NodeTypeEnrichmentHelpers
                     : null;
                 return WaitForCompileSettled(typeStream, typeStream
                 .Where(typeNode => IsRecompileSettled(
-                    typeNode, gate, requireUsableBuild, meshHub.JsonSerializerOptions))
+                    typeNode, gate, requireUsableBuild, meshHub.JsonSerializerOptions,
+                    NodeTypeCompilationHelpers.ModulesHashOf(meshHub)))
                 .Take(1),
                 SlowPathTimeout,
                 () => new TimeoutException(
@@ -1265,7 +1267,8 @@ internal static class NodeTypeEnrichmentHelpers
     /// </summary>
     internal static bool IsRecompileSettled(
         MeshNode typeNode, long? staleVersion, bool requireUsableBuild,
-        System.Text.Json.JsonSerializerOptions? options = null)
+        System.Text.Json.JsonSerializerOptions? options = null,
+        string? modulesHash = null)
     {
         // Read the definition through ContentAs — the same accessor ApplyStreamResult uses on
         // whatever this admits. A CLR type test is blind to an un-materialized (JsonElement /
@@ -1294,8 +1297,12 @@ internal static class NodeTypeEnrichmentHelpers
         // ride through to HasUsableBuild rather than giving up. Pinned by
         // FrameworkStaleInstanceRenderTest. If the rebuild genuinely never lands,
         // WaitForCompileSettled's no-progress deadline surfaces the overlay — never a longer hang.
+        // The modules-hash join (#1664 step 11) matters HERE specifically: on a module-only
+        // update the pre-flip stale build still passes the framework-only check, so without the
+        // hash this predicate would settle in ~0 ms on the very state the heal rejected — the
+        // exact burn-the-retry hazard the remarks above describe, in modules-stale clothing.
         if (requireUsableBuild)
-            return NodeTypeCompilationHelpers.HasUsableBuild(typeNode, d);
+            return NodeTypeCompilationHelpers.HasUsableBuild(typeNode, d, modulesHash);
 
         // The stale pre-flip re-snap (see the remarks above): not news, keep waiting.
         if (staleVersion is { } stale && typeNode.Version <= stale)
@@ -1453,7 +1460,8 @@ internal static class NodeTypeEnrichmentHelpers
                     {
                         instanceHub.RegisterForDisposal(ArmOverlaySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
-                            instanceHub, nodeType, typeVersionAtOverlay, logger));
+                            instanceHub, nodeType, typeVersionAtOverlay, logger,
+                            modulesHash: NodeTypeCompilationHelpers.ModulesHashOf(meshHub)));
                     }
                     catch (Exception ex)
                     {
@@ -1538,7 +1546,8 @@ internal static class NodeTypeEnrichmentHelpers
                     {
                         instanceHub.RegisterForDisposal(ArmStaleAssemblySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
-                            instanceHub, nodeType, boundAssemblyPath, logger));
+                            instanceHub, nodeType, boundAssemblyPath, logger,
+                            modulesHash: NodeTypeCompilationHelpers.ModulesHashOf(meshHub)));
                     }
                     catch (Exception ex)
                     {
@@ -1568,10 +1577,11 @@ internal static class NodeTypeEnrichmentHelpers
         string nodeType,
         string boundAssemblyPath,
         ILogger? logger,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        string? modulesHash = null)
         => typeStream
             .Where(t => t?.Content is NodeTypeDefinition d
-                && NodeTypeCompilationHelpers.HasUsableBuild(t, d)
+                && NodeTypeCompilationHelpers.HasUsableBuild(t, d, modulesHash)
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && !string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal))
             // 🚨 Wait for the type to stop publishing — see AssemblySettleWindow. An install
@@ -1621,10 +1631,11 @@ internal static class NodeTypeEnrichmentHelpers
         string nodeType,
         long? typeVersionAtOverlay,
         ILogger? logger,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        string? modulesHash = null)
     {
         var usable = typeStream.Where(t => t?.Content is NodeTypeDefinition d
-            && NodeTypeCompilationHelpers.HasUsableBuild(t, d));
+            && NodeTypeCompilationHelpers.HasUsableBuild(t, d, modulesHash));
 
         // FAST path — the version advanced past the overlay: a genuinely NEW build landed, heal now.
         var advanced = usable.Where(t =>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1820,6 +1820,13 @@ public static class MeshDataSourceExtensions
     /// forever) and degrade rather than fail.</para>
     ///
     /// <para>Non-NodeType nodes answer <c>true</c>, so this is safe to ask about any MeshNode.</para>
+    ///
+    /// <para>🚨 Deliberately a NULL caller of the modules-hash join (#1664 step 11): this is a
+    /// pure <see cref="MeshNode"/> predicate with no hub in scope, so it cannot resolve the mesh's
+    /// live <c>InstalledModulesFingerprint</c> and passes <c>null</c> — the framework rule alone
+    /// governs it. Acceptable because its callers (PackageInstaller's post-install waits) run on
+    /// the very mesh that just compiled the build, where the stamped hash IS the live hash; the
+    /// hash-decisive gates are the kickoff/enrichment paths, which all pass the live hash.</para>
     /// </summary>
     /// <param name="node">The NodeType MeshNode to judge.</param>
     /// <returns>False only while the node is mid-compile or is advertising an unloadable build.</returns>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -1032,7 +1032,8 @@ public static class DynamicTypePreWarmer
                         .SelectMany(baseline => stream
                             .Where(n => n?.Content is NodeTypeDefinition d
                                 && d.CompilationStatus == CompilationStatus.Ok
-                                && NodeTypeCompilationHelpers.HasUsableBuild(n, d)
+                                && NodeTypeCompilationHelpers.HasUsableBuild(
+                                    n, d, NodeTypeCompilationHelpers.ModulesHashOf(mesh))
                                 && IsFreshSuccess(d.LastCompileSucceededAt, baseline))
                             .Take(1));
                 })
@@ -1109,7 +1110,8 @@ public static class DynamicTypePreWarmer
                     // the state, so waiting out the rest of the budget for a write that
                     // is not coming only slows the sweep down.
                     .Where(n => n?.Content is NodeTypeDefinition d
-                        && (NodeTypeCompilationHelpers.HasUsableBuild(n, d)
+                        && (NodeTypeCompilationHelpers.HasUsableBuild(
+                                n, d, NodeTypeCompilationHelpers.ModulesHashOf(workspace.Hub))
                             || d.CompilationStatus is CompilationStatus.Error
                                                    or CompilationStatus.Unavailable))
                     .Take(1)

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -157,9 +157,10 @@ public static class ModuleActivationBoot
     ///     duplicates a baseline (or earlier persisted) module name — dedupe, silent, the module
     ///     is simply already activated; its recorded <see cref="ModuleActivationEntry.FrameworkMvid"/>
     ///     is refused by <paramref name="frameworkGate"/> (an image roll changed the framework —
-    ///     SKIPPED with a loud report, the entry stays for the post-roll re-install); or its DLL
-    ///     is missing per <paramref name="entryDllExists"/> (a lost volume / manual deletion —
-    ///     SKIPPED loudly). A skip is never a crash: the deployment must boot.</item>
+    ///     SKIPPED with a loud report, the entry stays for the post-roll re-install); or its
+    ///     LANDED DLL is missing per <paramref name="landedModuleDllExists"/> (a lost volume /
+    ///     manual deletion — SKIPPED loudly; a same-named app-closure DLL does not count).
+    ///     A skip is never a crash: the deployment must boot.</item>
     ///   <item>Disabled entries (uninstalled) contribute nothing and report nothing.</item>
     /// </list>
     /// </summary>
@@ -169,15 +170,21 @@ public static class ModuleActivationBoot
     /// the running framework, or null when it may — production passes
     /// <c>PrebuiltAssemblySeeder.DeclineReason</c> so there is never a second notion of framework
     /// identity.</param>
-    /// <param name="entryDllExists">Whether an entry (e.g. <c>Foo.dll</c>) resolves to an existing
-    /// file — production passes <c>File.Exists(MeshBuilder.ResolveModulePath(entry))</c>.</param>
+    /// <param name="landedModuleDllExists">Whether a persisted module's LANDED entry DLL exists —
+    /// called with the module NAME, and 🚨 it must check <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c>
+    /// SPECIFICALLY (production passes <see cref="LandedModuleDllExists"/>), never
+    /// <c>MeshBuilder.ResolveModulePath</c>: that resolver falls back to the app's base directory,
+    /// so a sidecar entry whose <c>modules/&lt;name&gt;/</c> folder is gone (tampered sidecar,
+    /// deleted folder) would silently BIND a same-named app-closure DLL instead of being skipped.
+    /// A store-installed module never legitimately lives in the app closure — a name collision
+    /// there is exactly what <see cref="ModuleLandingService"/> refuses at landing.</param>
     /// <param name="onSkipped">The loud channel: called once per skipped persisted entry with
     /// (module name, reason).</param>
     public static ImmutableList<string> ComputeEffectiveModuleEntries(
         IReadOnlyList<string>? baselineEntries,
         ModuleActivationList? persisted,
         Func<string?, string?> frameworkGate,
-        Func<string, bool> entryDllExists,
+        Func<string, bool> landedModuleDllExists,
         Action<string, string>? onSkipped = null)
     {
         var effective = ImmutableList.CreateBuilder<string>();
@@ -204,18 +211,38 @@ public static class ModuleActivationBoot
                 continue;
             }
 
-            var entry = module.Name + ".dll";
-            if (!entryDllExists(entry))
+            if (!landedModuleDllExists(module.Name))
             {
                 onSkipped?.Invoke(module.Name,
-                    $"its DLL '{entry}' does not resolve to an existing file (modules/"
-                    + $"{module.Name}/ lost or never landed) — re-install the module");
+                    $"its landed DLL 'modules/{module.Name}/{module.Name}.dll' does not exist "
+                    + "(folder lost or never landed; a same-named app-closure DLL deliberately "
+                    + "does NOT satisfy a store-installed entry) — re-install the module");
                 continue;
             }
 
-            effective.Add(entry);
+            effective.Add(module.Name + ".dll");
         }
 
         return effective.ToImmutable();
     }
+
+    /// <summary>
+    /// The landed entry-DLL path of a store-installed module:
+    /// <c>{baseDirectory}/modules/{name}/{name}.dll</c> — the ONE location the landing service
+    /// writes and the boot union checks.
+    /// </summary>
+    public static string LandedDllPath(string baseDirectory, string moduleName) =>
+        Path.Combine(baseDirectory, "modules", moduleName, moduleName + ".dll");
+
+    /// <summary>
+    /// The PRODUCTION existence check for a persisted (store-installed) entry — the landed DLL at
+    /// <see cref="LandedDllPath"/>, and nothing else. 🚨 Deliberately NOT
+    /// <c>MeshBuilder.ResolveModulePath</c>: that resolver falls back to the app's base directory,
+    /// which is correct for appsettings-baseline entries (both locations are legitimate for them)
+    /// but would let a sidecar entry whose <c>modules/&lt;name&gt;/</c> folder is gone silently
+    /// bind a same-named app-closure DLL instead of being skipped — a store-installed module never
+    /// legitimately lives in the app closure (the landing service refuses that collision).
+    /// </summary>
+    public static bool LandedModuleDllExists(string baseDirectory, string moduleName) =>
+        File.Exists(LandedDllPath(baseDirectory, moduleName));
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -1,0 +1,221 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Where a module-activation entry came from — the two lanes of #1664 step 9.
+/// </summary>
+public static class ModuleActivationSources
+{
+    /// <summary>The deployment's <c>Modules:Assemblies</c> appsettings baseline.</summary>
+    public const string AppSettings = "appsettings";
+
+    /// <summary>A Store install that landed the module via <see cref="ModuleLandingService"/>.</summary>
+    public const string Store = "store";
+}
+
+/// <summary>
+/// One activated (or deliberately deactivated) module in the persisted activation list —
+/// the durable record that replaces "edit appsettings and redeploy" for store-installed modules
+/// (#1664 step 9).
+/// </summary>
+public sealed record ModuleActivationEntry
+{
+    /// <summary>The module's DLL name WITHOUT extension (e.g. <c>MeshWeaver.Markdown.Export</c>)
+    /// — the same identity <c>MeshBuilder.ResolveModulePath</c> probes <c>modules/&lt;name&gt;/</c>
+    /// with.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>One of <see cref="ModuleActivationSources"/>. Sidecar entries are written by the
+    /// store lane; the appsettings baseline never round-trips through this file.</summary>
+    public string Source { get; init; } = ModuleActivationSources.Store;
+
+    /// <summary>The mesh path of the install record (Package node) that landed this module, when
+    /// the store lane wrote it — the back-pointer Slice C's funnel uses.</summary>
+    public string? PackagePath { get; init; }
+
+    /// <summary>The framework MVID (MeshWeaver.Graph's ModuleVersionId) the landed assemblies
+    /// were built against, as verified at landing time. Boot SKIPS the entry — loudly, never a
+    /// crash — when this does not match the running framework: after an image roll the landed
+    /// bytes are ABI-stale, and the entry waits for a re-install against the new framework.</summary>
+    public string? FrameworkMvid { get; init; }
+
+    /// <summary>False = uninstalled (the record is kept for history/idempotence; the folder is
+    /// deleted). Takes effect at the next restart, like every activation change.</summary>
+    public bool Enabled { get; init; } = true;
+}
+
+/// <summary>
+/// The persisted per-deployment module-activation list — the content of the
+/// <c>modules/activation.json</c> sidecar (see <see cref="ModuleActivationSidecar"/>).
+/// </summary>
+public sealed record ModuleActivationList
+{
+    /// <summary>The activation entries, in landing order.</summary>
+    public ImmutableList<ModuleActivationEntry> Entries { get; init; } = [];
+
+    /// <summary>True when an activation change (install/uninstall) has landed since the last
+    /// restart — the minimal #1664 step-10 "restart required" signal. Boot consumes it: applying
+    /// the list IS the restart, so <c>ConfigureMemexMesh</c> resets it to false.</summary>
+    public bool PendingRestart { get; init; }
+}
+
+/// <summary>
+/// Plain-file persistence of the module-activation list: <c>modules/activation.json</c>, beside
+/// the module folders it describes.
+///
+/// <para><b>Why a sidecar file and not a mesh node:</b> the list is consumed at BOOT, in
+/// <c>ConfigureMemexMesh</c>, BEFORE the DI container exists — before any storage provider is
+/// registered, before any hub runs, and (on PG) before a connection string has been validated.
+/// A mesh-node read at that point would need a parallel pre-DI storage bootstrap; a file beside
+/// the folders it activates needs <c>File.ReadAllText</c>. It also cannot drift from the DLLs:
+/// the landing service writes both in the same operation onto the same volume, so a
+/// restore/copy of the deployment's file tree carries both or neither.</para>
+///
+/// <para>All IO here is plain and synchronous by design — boot-time (pre-DI, pre-IoPool) callers
+/// use it directly; runtime callers go through <see cref="ModuleLandingService"/>, which runs
+/// these on its bounded IO pool.</para>
+/// </summary>
+public static class ModuleActivationSidecar
+{
+    /// <summary>The sidecar's file name inside the <c>modules/</c> folder.</summary>
+    public const string FileName = "activation.json";
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>The sidecar's full path for a deployment rooted at
+    /// <paramref name="baseDirectory"/> (normally <c>AppContext.BaseDirectory</c>).</summary>
+    public static string SidecarPath(string baseDirectory) =>
+        Path.Combine(baseDirectory, "modules", FileName);
+
+    /// <summary>
+    /// Reads the activation list. A missing file is the normal fresh-deployment state and reads
+    /// as the empty list; a CORRUPT file reads as the empty list too — the deployment must boot
+    /// (baseline modules unaffected) — but reports through <paramref name="onCorrupt"/> so the
+    /// skip is loud, never silent.
+    /// </summary>
+    public static ModuleActivationList Read(string baseDirectory, Action<string>? onCorrupt = null)
+    {
+        var path = SidecarPath(baseDirectory);
+        if (!File.Exists(path))
+            return new ModuleActivationList();
+        try
+        {
+            return JsonSerializer.Deserialize<ModuleActivationList>(File.ReadAllText(path), Json)
+                   ?? new ModuleActivationList();
+        }
+        catch (Exception ex)
+        {
+            onCorrupt?.Invoke(
+                $"Module activation sidecar '{path}' could not be read ({ex.GetType().Name}: "
+                + $"{ex.Message}) — booting with the appsettings baseline only. Store-installed "
+                + "modules will NOT load until the sidecar is repaired or the modules are "
+                + "re-installed.");
+            return new ModuleActivationList();
+        }
+    }
+
+    /// <summary>
+    /// Writes the activation list atomically: serialize to a temp file in the same directory,
+    /// then rename over the target — a crash mid-write can never leave a half-written sidecar.
+    /// </summary>
+    public static void Write(string baseDirectory, ModuleActivationList list)
+    {
+        var path = SidecarPath(baseDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        File.WriteAllText(temp, JsonSerializer.Serialize(list, Json));
+        File.Move(temp, path, overwrite: true);
+    }
+}
+
+/// <summary>
+/// The boot-time union of #1664 step 9: appsettings baseline ∪ enabled persisted store installs,
+/// deduped by module name, with the two skip rules (missing DLL, framework-MVID mismatch)
+/// applied loudly — extracted PURE so the computation is unit-testable without booting a portal.
+/// </summary>
+public static class ModuleActivationBoot
+{
+    /// <summary>
+    /// Computes the effective <c>Modules:Assemblies</c>-shaped entry list the boot loader feeds
+    /// to <c>MeshBuilder.InstallAssemblies</c> (after per-entry <c>ResolveModulePath</c>).
+    ///
+    /// <para>Rules, in order:</para>
+    /// <list type="bullet">
+    ///   <item>The appsettings <paramref name="baselineEntries"/> pass through UNCHANGED, in
+    ///     order — they are the image's own closure and keep today's contract (a baseline entry
+    ///     that fails to load fails loudly at startup; the skip rules below are for persisted
+    ///     entries only).</item>
+    ///   <item>Each ENABLED persisted entry appends as <c>&lt;Name&gt;.dll</c> unless: it
+    ///     duplicates a baseline (or earlier persisted) module name — dedupe, silent, the module
+    ///     is simply already activated; its recorded <see cref="ModuleActivationEntry.FrameworkMvid"/>
+    ///     is refused by <paramref name="frameworkGate"/> (an image roll changed the framework —
+    ///     SKIPPED with a loud report, the entry stays for the post-roll re-install); or its DLL
+    ///     is missing per <paramref name="entryDllExists"/> (a lost volume / manual deletion —
+    ///     SKIPPED loudly). A skip is never a crash: the deployment must boot.</item>
+    ///   <item>Disabled entries (uninstalled) contribute nothing and report nothing.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="baselineEntries">The raw <c>Modules:Assemblies</c> values (may be null/empty).</param>
+    /// <param name="persisted">The sidecar list (may be null).</param>
+    /// <param name="frameworkGate">Returns WHY a recorded framework identity may not load against
+    /// the running framework, or null when it may — production passes
+    /// <c>PrebuiltAssemblySeeder.DeclineReason</c> so there is never a second notion of framework
+    /// identity.</param>
+    /// <param name="entryDllExists">Whether an entry (e.g. <c>Foo.dll</c>) resolves to an existing
+    /// file — production passes <c>File.Exists(MeshBuilder.ResolveModulePath(entry))</c>.</param>
+    /// <param name="onSkipped">The loud channel: called once per skipped persisted entry with
+    /// (module name, reason).</param>
+    public static ImmutableList<string> ComputeEffectiveModuleEntries(
+        IReadOnlyList<string>? baselineEntries,
+        ModuleActivationList? persisted,
+        Func<string?, string?> frameworkGate,
+        Func<string, bool> entryDllExists,
+        Action<string, string>? onSkipped = null)
+    {
+        var effective = ImmutableList.CreateBuilder<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in baselineEntries ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+            effective.Add(entry);
+            seen.Add(Path.GetFileNameWithoutExtension(entry));
+        }
+
+        foreach (var module in persisted?.Entries ?? [])
+        {
+            if (!module.Enabled || string.IsNullOrWhiteSpace(module.Name))
+                continue;
+            if (!seen.Add(module.Name))
+                continue; // already activated (baseline or an earlier entry) — dedupe by name
+
+            if (frameworkGate(module.FrameworkMvid) is { } reason)
+            {
+                onSkipped?.Invoke(module.Name, reason);
+                continue;
+            }
+
+            var entry = module.Name + ".dll";
+            if (!entryDllExists(entry))
+            {
+                onSkipped?.Invoke(module.Name,
+                    $"its DLL '{entry}' does not resolve to an existing file (modules/"
+                    + $"{module.Name}/ lost or never landed) — re-install the module");
+                continue;
+            }
+
+            effective.Add(entry);
+        }
+
+        return effective.ToImmutable();
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -1,0 +1,230 @@
+using System.IO;
+using System.Reactive;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The runtime writer into <c>modules/</c> (#1664 step 7) — the ONE code path that lands a
+/// compiled module's assemblies beside the app at runtime and records its activation, so the next
+/// restart loads it (restart-as-activation, #1664 step 8). This is the seam Slice C's
+/// <c>PackageInstaller</c> binary branch calls after fetching a module bundle; nothing in Slice A
+/// invokes it from the install funnel yet.
+///
+/// <para><b>The MVID gate holds at placement.</b> Landing verifies the caller's declared
+/// framework identity through <see cref="PrebuiltAssemblySeeder.DeclineReason"/> — the SAME pure
+/// function the prebuilt-assembly seeder and the bundle client gate on, so there is never a
+/// second notion of framework version. A mismatch REFUSES the landing (the observable errors,
+/// naming both MVIDs); declined bytes never reach disk.</para>
+///
+/// <para><b>The same-identity trap-door is refused too.</b> <c>MeshBuilder.ResolveModulePath</c>
+/// resolves <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c> BEFORE the app folder, so landing a
+/// module named after an APP-CLOSURE assembly (e.g. <c>MeshWeaver.Graph</c>) would silently
+/// shadow the platform's own binary on the next boot. A module whose entry DLL name collides
+/// with a file in the app's base directory is refused.</para>
+///
+/// <para><b>Atomic on disk.</b> Files are written into a staging folder and renamed into
+/// <c>modules/&lt;name&gt;/</c>; a crash mid-landing leaves at worst an orphaned
+/// <c>.staging-*</c> folder, never a half-written module the next boot would load.</para>
+///
+/// <para><b>Reactive surface, pooled IO.</b> Both operations return cold
+/// <see cref="IObservable{T}"/>s whose file IO runs on this service's own cap-1
+/// <see cref="IoPool"/> — the one sanctioned bounded-IO primitive — so concurrent landings (and
+/// their sidecar read-modify-writes) serialize without a hand-rolled gate, and nothing blocks a
+/// hub scheduler. Mesh-scoped singleton: the pool dies with the mesh.</para>
+/// </summary>
+public sealed class ModuleLandingService : IDisposable
+{
+    // Cap 1 deliberately: LandModule/RemoveModule each read-modify-write the shared
+    // activation.json sidecar, and the cap IS the serialization — no lock, no semaphore
+    // outside the sealed IoPool primitive. Landing is rare and short; 1 costs nothing.
+    private readonly IoPool pool = new(1);
+    private readonly string baseDirectory;
+    private readonly ILogger<ModuleLandingService>? logger;
+
+    /// <summary>Creates the service.</summary>
+    /// <param name="logger">Diagnostics — every landing, refusal and removal is logged.</param>
+    /// <param name="baseDirectory">Seam for tests: the deployment root the <c>modules/</c>
+    /// folder lives under. Defaults to <c>AppContext.BaseDirectory</c>.</param>
+    public ModuleLandingService(
+        ILogger<ModuleLandingService>? logger = null,
+        string? baseDirectory = null)
+    {
+        this.logger = logger;
+        this.baseDirectory = baseDirectory ?? AppContext.BaseDirectory;
+    }
+
+    /// <summary>
+    /// Lands a module: verifies the framework MVID, writes the assemblies atomically into
+    /// <c>modules/&lt;name&gt;/</c>, and appends/updates the activation entry in the
+    /// <c>modules/activation.json</c> sidecar with <c>PendingRestart = true</c>. The module
+    /// LOADS on the next restart (restart-as-activation) — nothing is loaded into the running
+    /// process.
+    ///
+    /// <para>Cold: nothing happens until Subscribe. Errors (refusals) surface on the
+    /// observable.</para>
+    /// </summary>
+    /// <param name="name">The module name — its entry DLL name without extension.</param>
+    /// <param name="assemblies">The module's closure: file name + bytes per assembly. Must
+    /// contain the entry <c>&lt;name&gt;.dll</c>.</param>
+    /// <param name="frameworkMvid">The framework MVID (MeshWeaver.Graph's ModuleVersionId) the
+    /// assemblies were built against, as recorded by the producer.</param>
+    /// <param name="packagePath">The install record's mesh path, when the store lane calls.</param>
+    public IObservable<Unit> LandModule(
+        string name,
+        IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
+        string frameworkMvid,
+        string? packagePath = null)
+        => pool.InvokeBlocking(_ =>
+        {
+            LandCore(name, assemblies, frameworkMvid, packagePath);
+            return Unit.Default;
+        });
+
+    /// <summary>
+    /// Uninstalls a module landed by <see cref="LandModule"/>: disables its activation entry
+    /// (kept, for history and idempotence), deletes <c>modules/&lt;name&gt;/</c>, and sets
+    /// <c>PendingRestart = true</c>. Takes effect at the next restart. Refuses a name the
+    /// sidecar does not know — the appsettings-baseline module folders (laid out by publish)
+    /// are not this service's to delete.
+    /// </summary>
+    public IObservable<Unit> RemoveModule(string name)
+        => pool.InvokeBlocking(_ =>
+        {
+            RemoveCore(name);
+            return Unit.Default;
+        });
+
+    private void LandCore(
+        string name,
+        IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
+        string frameworkMvid,
+        string? packagePath)
+    {
+        ValidateFileName(name, "module name");
+        if (assemblies is not { Count: > 0 })
+            throw new ArgumentException($"Module '{name}': no assemblies to land.", nameof(assemblies));
+        foreach (var (fileName, bytes) in assemblies)
+        {
+            ValidateFileName(fileName, $"assembly file of module '{name}'");
+            if (bytes is not { Length: > 0 })
+                throw new ArgumentException(
+                    $"Module '{name}': assembly '{fileName}' has no bytes.", nameof(assemblies));
+        }
+        var entryDll = name + ".dll";
+        if (!assemblies.Any(a => string.Equals(a.FileName, entryDll, StringComparison.OrdinalIgnoreCase)))
+            throw new ArgumentException(
+                $"Module '{name}': the assembly list does not contain its entry '{entryDll}' — "
+                + "such a folder could never load.", nameof(assemblies));
+
+        // 🚨 THE MVID GATE, at placement — the same pure function PrebuiltAssemblySeeder and
+        // PluginBundleClient gate on. Declining is always safe; landing on faith is not: the
+        // ABI mismatch would surface only at the next boot, as a TypeLoadException with nothing
+        // connecting it to the install that caused it.
+        if (PrebuiltAssemblySeeder.DeclineReason(frameworkMvid) is { } reason)
+        {
+            logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, reason);
+            throw new InvalidOperationException($"Module '{name}' refused: {reason}");
+        }
+
+        // 🚨 The same-identity trap-door: modules/<name>/<name>.dll wins over the app folder in
+        // ResolveModulePath, so a module named after an app-closure assembly would shadow the
+        // platform's own binary on the next boot.
+        if (File.Exists(Path.Combine(baseDirectory, entryDll)))
+            throw new InvalidOperationException(
+                $"Module '{name}' refused: '{entryDll}' is part of the application closure, and "
+                + $"modules/{name}/ would SHADOW it at the next boot "
+                + "(ResolveModulePath probes the modules folder first).");
+
+        var modulesRoot = Path.Combine(baseDirectory, "modules");
+        var target = Path.Combine(modulesRoot, name);
+        var staging = Path.Combine(modulesRoot, $".staging-{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(staging);
+        try
+        {
+            foreach (var (fileName, bytes) in assemblies)
+                File.WriteAllBytes(Path.Combine(staging, fileName), bytes);
+            if (Directory.Exists(target))
+                Directory.Delete(target, recursive: true);
+            Directory.Move(staging, target);
+        }
+        catch
+        {
+            try
+            {
+                if (Directory.Exists(staging))
+                    Directory.Delete(staging, recursive: true);
+            }
+            catch
+            {
+                // Best-effort staging cleanup — the original failure is what must surface.
+            }
+            throw;
+        }
+
+        var list = ModuleActivationSidecar.Read(baseDirectory,
+            msg => logger?.LogError("{Message}", msg));
+        var entry = new ModuleActivationEntry
+        {
+            Name = name,
+            Source = ModuleActivationSources.Store,
+            PackagePath = packagePath,
+            FrameworkMvid = frameworkMvid,
+            Enabled = true,
+        };
+        ModuleActivationSidecar.Write(baseDirectory, list with
+        {
+            Entries = list.Entries
+                .RemoveAll(e => string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase))
+                .Add(entry),
+            PendingRestart = true,
+        });
+
+        logger?.LogInformation(
+            "Module '{Name}' LANDED into modules/{Name}/ ({Count} assemblies, framework "
+            + "{FrameworkMvid}) — activation recorded, RESTART REQUIRED to load it",
+            name, name, assemblies.Count, frameworkMvid);
+    }
+
+    private void RemoveCore(string name)
+    {
+        ValidateFileName(name, "module name");
+
+        var list = ModuleActivationSidecar.Read(baseDirectory,
+            msg => logger?.LogError("{Message}", msg));
+        var existing = list.Entries.FirstOrDefault(e =>
+            string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+            throw new InvalidOperationException(
+                $"Module '{name}' was not landed by the store lane (no activation entry) — "
+                + "publish-laid-out module folders are managed by the deployment, not uninstall.");
+
+        ModuleActivationSidecar.Write(baseDirectory, list with
+        {
+            Entries = list.Entries.Replace(existing, existing with { Enabled = false }),
+            PendingRestart = true,
+        });
+
+        var target = Path.Combine(baseDirectory, "modules", name);
+        if (Directory.Exists(target))
+            Directory.Delete(target, recursive: true);
+
+        logger?.LogInformation(
+            "Module '{Name}' UNINSTALLED: activation disabled, modules/{Name}/ deleted — "
+            + "takes effect at the next restart", name, name);
+    }
+
+    private static void ValidateFileName(string? value, string what)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || value is "." or ".."
+            || value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || value.Contains('/') || value.Contains('\\'))
+            throw new ArgumentException($"Invalid {what}: '{value}'.");
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => pool.Dispose();
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -103,7 +103,12 @@ public static class PluginCatalogConfigurationExtensions
                 // (Doc/Architecture/CandidateReleaseProtocol). A plain singleton, NOT a hosted
                 // service: it is a pull-on-demand READER — it starts nothing, subscribes to nothing,
                 // and writes nothing, so it costs an instance that never calls it exactly nothing.
-                .AddSingleton<InstanceComboReader>())
+                .AddSingleton<InstanceComboReader>()
+                // The runtime modules/ writer (#1664 step 7) — lands a compiled module's
+                // assemblies + activation record; restart-as-activation. Inert until called:
+                // Slice C's PackageInstaller binary branch is its caller. Mesh-scoped so its
+                // bounded IO pool dies with the mesh.
+                .AddSingleton<ModuleLandingService>())
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/MeshWeaver.Graph.Test/NodeTypeCompilationHelpersTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeCompilationHelpersTest.cs
@@ -153,4 +153,95 @@ public class NodeTypeCompilationHelpersTest
             .Should().NotBeNullOrWhiteSpace()
             .And.Be(NodeTypeCompilationHelpers.FrameworkVersion);
     }
+
+    // ---- CompiledModulesHash joins the usable-build decision (#1664 Slice A, step 11) ---------
+    //
+    // 🚨 Rule-3-adjacent: the ONLY behavior change these pins license is "a build stamped with a
+    // DIFFERENT non-null modules hash than the live installed set is not usable". Everything else
+    // — null stamps, null callers, the empty-string no-modules hash — keeps the pre-#1664 answer.
+
+    private static NodeTypeDefinition UsableDef(string? compiledModulesHash = null) => new()
+    {
+        CompilationStatus = CompilationStatus.Ok,
+        LatestAssemblyCollection = "nodetype-cache",
+        LatestAssemblyPath = "type/MyType/v1.dll",
+        CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+        CompiledModulesHash = compiledModulesHash,
+    };
+
+    [Fact]
+    public void HasUsableBuild_NullStampedModulesHash_IsGrandfatheredAsMatch()
+    {
+        // The documented contract on NodeTypeDefinition.CompiledModulesHash: a null stamp predates
+        // modules in the compile surface and stays governed by the framework rule alone.
+        var def = UsableDef(compiledModulesHash: null);
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(def), def, modulesHash: "abc123")
+            .Should().BeTrue("a null-stamped build predates the fingerprint feature — the framework rule alone governs it");
+    }
+
+    [Fact]
+    public void HasUsableBuild_EqualModulesHash_IsMatch()
+    {
+        var def = UsableDef(compiledModulesHash: "abc123");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(def), def, modulesHash: "abc123")
+            .Should().BeTrue("the build was compiled under exactly the live installed-module set");
+    }
+
+    [Fact]
+    public void HasUsableBuild_DifferentModulesHash_Invalidates()
+    {
+        // THE step-11 flip: a module-only update (framework MVID unchanged) must invalidate baked
+        // builds that could reference the replaced module.
+        var def = UsableDef(compiledModulesHash: "abc123");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(def), def, modulesHash: "def456")
+            .Should().BeFalse("a build stamped with a different non-null modules hash than the live set is not usable");
+    }
+
+    [Fact]
+    public void HasUsableBuild_EmptyStringModulesHash_IsDistinctFromNull()
+    {
+        // "" is the STAMPED hash of a mesh with zero modules (InstalledModulesFingerprint); null is
+        // "stamped before the feature". They must not collapse: a "" stamp against a live module
+        // set is a REAL mismatch, while a "" stamp against a live "" is a real match.
+        var noModulesStamp = UsableDef(compiledModulesHash: "");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(noModulesStamp), noModulesStamp, modulesHash: "")
+            .Should().BeTrue("compiled with no modules, live set has no modules — match");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(noModulesStamp), noModulesStamp, modulesHash: "abc123")
+            .Should().BeFalse("compiled with no modules but the live mesh HAS modules — the build could not reference them, but the set changed: rebuild");
+
+        var moduleStamp = UsableDef(compiledModulesHash: "abc123");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(moduleStamp), moduleStamp, modulesHash: "")
+            .Should().BeFalse("compiled against modules that are no longer installed — rebuild");
+    }
+
+    [Fact]
+    public void HasUsableBuild_NullCaller_KeepsLegacyBehavior()
+    {
+        // A call site without a mesh in scope passes null and keeps the pre-#1664 answer — the
+        // modules check simply does not join.
+        var def = UsableDef(compiledModulesHash: "abc123");
+        NodeTypeCompilationHelpers.HasUsableBuild(TypeNode(def), def)
+            .Should().BeTrue("a null modulesHash caller cannot resolve the live set and must not invalidate on it");
+    }
+
+    [Fact]
+    public void HasStaleFrameworkBuild_ModulesHashMismatch_IsStale_TwinOfHasUsableBuild()
+    {
+        // The twin: HasStaleFrameworkBuild feeds the owner-side proactive rebuild kickoff. If
+        // HasUsableBuild says "not usable" because of the modules hash while this stays false,
+        // NOTHING re-drives the compile (first-build needs Status=null, recovery needs Compiling)
+        // and every instance of the type wedges on the fallback config after a module-only update.
+        var def = UsableDef(compiledModulesHash: "abc123");
+
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(def, modulesHash: "def456")
+            .Should().BeTrue("a modules-hash mismatch is the same 'stale stamped build' shape as a framework mismatch");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(def, modulesHash: "abc123")
+            .Should().BeFalse("hash matches — nothing stale");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(def)
+            .Should().BeFalse("null caller keeps legacy behavior");
+
+        var nullStamp = UsableDef(compiledModulesHash: null);
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(nullStamp, modulesHash: "def456")
+            .Should().BeFalse("a null stamp is grandfathered as MATCH — it must not trigger rebuild storms on pre-feature definitions");
+    }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
@@ -1,0 +1,184 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The boot-time effective-set computation of #1664 Slice A, step 9 —
+/// <see cref="ModuleActivationBoot.ComputeEffectiveModuleEntries"/>, pure: appsettings baseline ∪
+/// enabled persisted store installs, deduped by name, with the two loud skip rules (framework-MVID
+/// mismatch, missing DLL) that keep an image roll or a lost volume from crashing boot. Plus the
+/// sidecar's read/write round-trip and its corrupt-file loudness.
+/// </summary>
+public class ModuleActivationBootTest
+{
+    private static readonly Func<string?, string?> AcceptAll = _ => null;
+    private static readonly Func<string, bool> AllDllsExist = _ => true;
+
+    private static ModuleActivationList List(params ModuleActivationEntry[] entries) =>
+        new() { Entries = [.. entries] };
+
+    private static ModuleActivationEntry Store(string name, bool enabled = true, string? mvid = "m1") =>
+        new() { Name = name, FrameworkMvid = mvid, Enabled = enabled };
+
+    [Fact]
+    public void EffectiveSet_IsBaselineUnionEnabledPersisted_InOrder()
+    {
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            ["MeshWeaver.OgCard.dll", "MeshWeaver.Speech.dll"],
+            List(Store("Acme.Widgets"), Store("Acme.Reports")),
+            AcceptAll, AllDllsExist);
+
+        effective.Should().Equal(
+            "MeshWeaver.OgCard.dll", "MeshWeaver.Speech.dll",
+            "Acme.Widgets.dll", "Acme.Reports.dll");
+    }
+
+    [Fact]
+    public void PersistedDuplicateOfBaseline_IsDeduplicatedByName_CaseInsensitive()
+    {
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            ["MeshWeaver.OgCard.dll"],
+            List(Store("meshweaver.ogcard"), Store("Acme.Widgets"), Store("ACME.WIDGETS")),
+            AcceptAll, AllDllsExist);
+
+        // A store install of an already-baseline module (any casing) must not double-load it.
+        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Widgets.dll");
+    }
+
+    [Fact]
+    public void DisabledPersistedEntry_ContributesNothing()
+    {
+        var skips = new List<(string Module, string Reason)>();
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            [],
+            List(Store("Acme.Widgets", enabled: false)),
+            AcceptAll, AllDllsExist,
+            (m, r) => skips.Add((m, r)));
+
+        effective.Should().BeEmpty();
+        skips.Should().BeEmpty("an uninstall is a deliberate state, not a problem to report");
+    }
+
+    [Fact]
+    public void FrameworkMvidMismatch_SkipsWithLoudReason_NeverCrashes()
+    {
+        var skips = new List<(string Module, string Reason)>();
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            ["MeshWeaver.OgCard.dll"],
+            List(Store("Acme.Widgets", mvid: "stale-mvid"), Store("Acme.Reports", mvid: "live")),
+            // The gate is injected — production passes PrebuiltAssemblySeeder.DeclineReason, so
+            // there is never a second notion of framework identity to test here, only the skip.
+            mvid => mvid == "live" ? null : $"built against framework {mvid}, live framework is live",
+            AllDllsExist,
+            (m, r) => skips.Add((m, r)));
+
+        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
+        var skip = skips.Should().ContainSingle().Subject;
+        skip.Module.Should().Be("Acme.Widgets");
+        skip.Reason.Should().Contain("stale-mvid").And.Contain("live",
+            "the skip must name both identities — the entry stays for the post-roll re-install");
+    }
+
+    [Fact]
+    public void NullRecordedMvid_IsSkipped_WhenTheGateDeclinesAbsentIdentity()
+    {
+        // Production's gate (PrebuiltAssemblySeeder.DeclineReason) declines an ABSENT identity —
+        // "cannot be shown ABI-compatible" — and the boot union inherits that: an unverifiable
+        // store entry never loads on faith.
+        var skips = new List<(string Module, string Reason)>();
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            [],
+            List(Store("Acme.Widgets", mvid: null)),
+            mvid => mvid is null ? "no recorded framework identity" : null,
+            AllDllsExist,
+            (m, r) => skips.Add((m, r)));
+
+        effective.Should().BeEmpty();
+        skips.Should().ContainSingle().Which.Module.Should().Be("Acme.Widgets");
+    }
+
+    [Fact]
+    public void MissingDll_SkipsWithLoudReason_BaselineUnaffected()
+    {
+        var skips = new List<(string Module, string Reason)>();
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            ["MeshWeaver.OgCard.dll"],
+            List(Store("Acme.Widgets"), Store("Acme.Reports")),
+            AcceptAll,
+            entry => entry != "Acme.Widgets.dll",
+            (m, r) => skips.Add((m, r)));
+
+        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
+        var skip = skips.Should().ContainSingle().Subject;
+        skip.Module.Should().Be("Acme.Widgets");
+        skip.Reason.Should().Contain("Acme.Widgets.dll");
+    }
+
+    [Fact]
+    public void NoBaseline_NoPersisted_IsEmpty()
+    {
+        ModuleActivationBoot.ComputeEffectiveModuleEntries(null, null, AcceptAll, AllDllsExist)
+            .Should().BeEmpty();
+        ModuleActivationBoot.ComputeEffectiveModuleEntries([], new ModuleActivationList(),
+                AcceptAll, AllDllsExist)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Sidecar_RoundTrips_AndReadsMissingAsEmpty()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-sidecar-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var missing = ModuleActivationSidecar.Read(dir);
+            missing.Entries.Should().BeEmpty("a fresh deployment has no sidecar");
+            missing.PendingRestart.Should().BeFalse();
+
+            var written = new ModuleActivationList
+            {
+                Entries = [Store("Acme.Widgets") with { PackagePath = "Plugins/acme" }],
+                PendingRestart = true,
+            };
+            ModuleActivationSidecar.Write(dir, written);
+            var read = ModuleActivationSidecar.Read(dir);
+            read.PendingRestart.Should().BeTrue();
+            var entry = read.Entries.Should().ContainSingle().Subject;
+            entry.Should().Be(written.Entries[0], "records round-trip value-equal through the sidecar JSON");
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Sidecar_CorruptFile_ReadsEmpty_ButReportsLoudly()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-sidecar-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir, "modules"));
+            File.WriteAllText(ModuleActivationSidecar.SidecarPath(dir), "{ not json ]");
+
+            string? reported = null;
+            var list = ModuleActivationSidecar.Read(dir, msg => reported = msg);
+
+            list.Entries.Should().BeEmpty("the deployment must boot — baseline modules unaffected");
+            reported.Should().NotBeNull("a corrupt sidecar must never be a silent skip")
+                .And.Contain(ModuleActivationSidecar.FileName);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
@@ -112,13 +112,101 @@ public class ModuleActivationBootTest
             ["MeshWeaver.OgCard.dll"],
             List(Store("Acme.Widgets"), Store("Acme.Reports")),
             AcceptAll,
-            entry => entry != "Acme.Widgets.dll",
+            name => name != "Acme.Widgets",
             (m, r) => skips.Add((m, r)));
 
         effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
         var skip = skips.Should().ContainSingle().Subject;
         skip.Module.Should().Be("Acme.Widgets");
         skip.Reason.Should().Contain("Acme.Widgets.dll");
+    }
+
+    // ---- The landed-DLL check is modules-folder-SPECIFIC (Copilot review on PR #1668) ---------
+    //
+    // ResolveModulePath falls back to AppContext.BaseDirectory, which is correct for baseline
+    // entries but would let a sidecar entry whose modules/<name>/ folder is gone silently BIND a
+    // same-named app-closure DLL instead of being skipped. These pins exercise the PRODUCTION
+    // check (LandedModuleDllExists) against real files.
+
+    [Fact]
+    public void SidecarEntry_WithLandedModulesFolderDll_IsIncluded()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-landed-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir, "modules", "Acme.Widgets"));
+            File.WriteAllBytes(
+                ModuleActivationBoot.LandedDllPath(dir, "Acme.Widgets"), [1]);
+
+            var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                [],
+                List(Store("Acme.Widgets")),
+                AcceptAll,
+                name => ModuleActivationBoot.LandedModuleDllExists(dir, name));
+
+            effective.Should().Equal("Acme.Widgets.dll");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SidecarEntry_WithOnlyASameNamedAppClosureDll_IsSkippedLoudly_NeverBindsTheFallback()
+    {
+        // THE gap: the DLL exists in the app's base directory — where ResolveModulePath would
+        // happily fall back to — but modules/Acme.Orphan/ is gone. A store-installed entry must
+        // SKIP, not bind the app-closure binary.
+        var dir = Path.Combine(Path.GetTempPath(), "mw-landed-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllBytes(Path.Combine(dir, "Acme.Orphan.dll"), [1]);
+
+            var skips = new List<(string Module, string Reason)>();
+            var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                [],
+                List(Store("Acme.Orphan")),
+                AcceptAll,
+                name => ModuleActivationBoot.LandedModuleDllExists(dir, name),
+                (m, r) => skips.Add((m, r)));
+
+            effective.Should().BeEmpty("a same-named app-closure DLL must never satisfy a store-installed entry");
+            var skip = skips.Should().ContainSingle().Subject;
+            skip.Module.Should().Be("Acme.Orphan");
+            skip.Reason.Should().Contain("modules/Acme.Orphan/Acme.Orphan.dll");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BaselineEntry_WithBaseDirectoryDll_IsIncluded_NoLandedFolderRequired()
+    {
+        // Baseline entries keep today's contract: both the modules/ layout and the classic
+        // BaseDirectory location are legitimate (ResolveModulePath handles the probing at
+        // install time), so the union includes them without a landed-folder check.
+        var dir = Path.Combine(Path.GetTempPath(), "mw-landed-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllBytes(Path.Combine(dir, "MeshWeaver.OgCard.dll"), [1]);
+
+            var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                ["MeshWeaver.OgCard.dll"],
+                new ModuleActivationList(),
+                AcceptAll,
+                name => ModuleActivationBoot.LandedModuleDllExists(dir, name));
+
+            effective.Should().Equal("MeshWeaver.OgCard.dll");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -1,0 +1,181 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The runtime <c>modules/</c> writer (#1664 Slice A, step 7): a landed module's files + its
+/// activation entry, the MVID gate at placement (the SAME
+/// <see cref="PrebuiltAssemblySeeder.DeclineReason"/> identity every other prebuilt lane gates
+/// on), the app-closure same-identity refusal, and uninstall (disable + delete,
+/// restart-as-activation).
+/// </summary>
+public class ModuleLandingServiceTest : IDisposable
+{
+    private readonly string baseDirectory =
+        Path.Combine(Path.GetTempPath(), "mw-landing-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>The RUNNING framework identity — MeshWeaver.Graph's MVID, exactly what
+    /// <c>NodeTypeCompilationHelpers.FrameworkVersion</c> computes.</summary>
+    private static string LiveFrameworkMvid =>
+        typeof(PrebuiltAssemblySeeder).Assembly.ManifestModule.ModuleVersionId.ToString("N");
+
+    private ModuleLandingService Service => new(baseDirectory: baseDirectory);
+
+    public ModuleLandingServiceTest() => Directory.CreateDirectory(baseDirectory);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(baseDirectory))
+            Directory.Delete(baseDirectory, recursive: true);
+    }
+
+    [Fact]
+    public async Task LandModule_HappyPath_LandsFilesAndActivationEntry_AndFlagsPendingRestart()
+    {
+        using var service = Service;
+        await service.LandModule(
+                "Acme.Widgets",
+                [("Acme.Widgets.dll", [1, 2, 3]), ("Acme.Widgets.Support.dll", [4, 5])],
+                LiveFrameworkMvid,
+                packagePath: "Plugins/acme-widgets")
+            .FirstAsync().ToTask();
+
+        // The files, in the exact layout ResolveModulePath probes.
+        File.ReadAllBytes(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
+            .Should().Equal([1, 2, 3]);
+        File.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.Support.dll"))
+            .Should().BeTrue();
+        // No staging leftovers.
+        Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+            .Select(Path.GetFileName)
+            .Should().NotContain(n => n!.StartsWith(".staging-"));
+
+        // The activation entry + the minimal step-10 restart-required signal.
+        var list = ModuleActivationSidecar.Read(baseDirectory);
+        var entry = list.Entries.Should().ContainSingle().Subject;
+        entry.Name.Should().Be("Acme.Widgets");
+        entry.Source.Should().Be(ModuleActivationSources.Store);
+        entry.PackagePath.Should().Be("Plugins/acme-widgets");
+        entry.FrameworkMvid.Should().Be(LiveFrameworkMvid);
+        entry.Enabled.Should().BeTrue();
+        list.PendingRestart.Should().BeTrue("landing takes effect only at the next restart");
+    }
+
+    [Fact]
+    public async Task LandModule_ReLanding_ReplacesFolderAndEntry_NeverDuplicates()
+    {
+        using var service = Service;
+        await service.LandModule("Acme.Widgets", [("Acme.Widgets.dll", [1])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+        await service.LandModule("Acme.Widgets", [("Acme.Widgets.dll", [9, 9])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+
+        File.ReadAllBytes(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
+            .Should().Equal([9, 9], "a re-landing replaces the folder atomically");
+        ModuleActivationSidecar.Read(baseDirectory).Entries
+            .Should().ContainSingle("re-landing upserts the entry, never appends a duplicate");
+    }
+
+    [Fact]
+    public async Task LandModule_FrameworkMvidMismatch_Refuses_NamingBothMvids()
+    {
+        using var service = Service;
+        var foreign = Guid.NewGuid().ToString("N");
+
+        var act = () => service
+            .LandModule("Acme.Widgets", [("Acme.Widgets.dll", [1])], foreign)
+            .FirstAsync().ToTask();
+
+        (await act.Should().ThrowAsync<InvalidOperationException>(
+                "landing ABI-stale bytes would surface only as a TypeLoadException at the next boot"))
+            .Which.Message.Should().Contain(foreign).And.Contain(LiveFrameworkMvid,
+                "the refusal must name BOTH identities so the operator can see which side is stale");
+
+        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets"))
+            .Should().BeFalse("declined bytes never reach disk");
+        ModuleActivationSidecar.Read(baseDirectory).Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LandModule_AppClosureNameCollision_Refuses()
+    {
+        // The same-identity trap-door: modules/<name>/<name>.dll WINS over the app folder in
+        // ResolveModulePath, so a module named after an app-closure assembly would shadow the
+        // platform's own binary at the next boot.
+        File.WriteAllBytes(Path.Combine(baseDirectory, "Acme.Platform.dll"), [1]);
+
+        using var service = Service;
+        var act = () => service
+            .LandModule("Acme.Platform", [("Acme.Platform.dll", [2])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("Acme.Platform.dll");
+        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Platform")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LandModule_WithoutItsEntryDll_Refuses()
+    {
+        using var service = Service;
+        var act = () => service
+            .LandModule("Acme.Widgets", [("Acme.Widgets.Support.dll", [1])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+        await act.Should().ThrowAsync<ArgumentException>(
+            "a modules/<name>/ folder without <name>.dll could never load");
+    }
+
+    [Fact]
+    public async Task RemoveModule_DisablesEntry_DeletesFolder_FlagsPendingRestart()
+    {
+        using var service = Service;
+        await service.LandModule("Acme.Widgets", [("Acme.Widgets.dll", [1])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+        // Simulate the boot that consumed the landing's restart flag, so the assert below
+        // proves REMOVAL re-raises it.
+        ModuleActivationSidecar.Write(baseDirectory,
+            ModuleActivationSidecar.Read(baseDirectory) with { PendingRestart = false });
+
+        await service.RemoveModule("Acme.Widgets").FirstAsync().ToTask();
+
+        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets"))
+            .Should().BeFalse("uninstall deletes the landed folder");
+        var list = ModuleActivationSidecar.Read(baseDirectory);
+        var entry = list.Entries.Should().ContainSingle().Subject;
+        entry.Enabled.Should().BeFalse("the entry is kept, disabled — history + idempotence");
+        list.PendingRestart.Should().BeTrue("the removal takes effect at the next restart");
+    }
+
+    [Fact]
+    public async Task RemoveModule_UnknownName_Refuses()
+    {
+        using var service = Service;
+        var act = () => service.RemoveModule("Never.Landed").FirstAsync().ToTask();
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "publish-laid-out module folders are the deployment's, not uninstall's");
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("")]
+    [InlineData("..")]
+    public async Task LandModule_InvalidModuleName_Refuses(string name)
+    {
+        using var service = Service;
+        var act = () => service
+            .LandModule(name, [(name + ".dll", [1])], LiveFrameworkMvid)
+            .FirstAsync().ToTask();
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}


### PR DESCRIPTION
Wave 7 **Slice A** of #1664: the platform half of moving first-party modules to Store packages — persisted dynamic activation (step 9), the runtime `modules/` writer (step 7), the modules fingerprint flipped decisive (step 11), and the minimal restart-required signal (step 10). No Store funnel work here — Slice C's `PackageInstaller` binary branch is the intended caller of the seam this lands.

## Step 9 — persisted activation: sidecar, not node (the design choice)

The activation list lives in **`modules/activation.json`** beside the module folders (`ModuleActivationSidecar`), not in an `Admin/Modules` mesh node. Rationale:

- The list is consumed at BOOT in `MemexConfiguration.ConfigureMemexMesh`, **before the DI container exists** — before any storage provider is registered, before a PG connection string is validated, before any hub runs. A node read there would need a parallel pre-DI storage bootstrap (there is no clean existing one; `SelfUpdateOptions`/`UpdatePolicy` nodes are all read post-boot through hubs).
- It **cannot drift from the DLLs it activates**: `ModuleLandingService` writes the assemblies and the entry in one operation onto the same volume, so a restore/copy carries both or neither.
- Boot stays dead simple: plain `File.ReadAllText`, tolerant of a missing file (fresh deployment) and loud-but-booting on a corrupt one.

Boot effective set = `Modules:Assemblies` baseline ∪ enabled sidecar entries, deduped by module name (`ModuleActivationBoot.ComputeEffectiveModuleEntries`, extracted **pure** and unit-pinned). Persisted-entry skip rules — loud stderr line, never a crash: recorded `FrameworkMvid` refused by `PrebuiltAssemblySeeder.DeclineReason` (image rolled since the install; the entry stays for re-install), or missing DLL. Baseline entries keep today's contract (fail loudly on load failure). `InstallAssemblies` itself is unchanged — it receives the union.

## Step 7 — `ModuleLandingService` (`src/MeshWeaver.PluginCatalog/`)

One reactive surface: `LandModule(name, assemblies, frameworkMvid, packagePath?) : IObservable<Unit>` + `RemoveModule(name)`. Placed in PluginCatalog by dependency direction (references Graph for the MVID gate; Slice C's installer lives beside it). Registered as a mesh-scoped singleton in `AddPluginCatalog`.

- **MVID gate at placement** — `PrebuiltAssemblySeeder.DeclineReason`, the same pure function the seeder and `PluginBundleClient` gate on (one notion of framework identity). Declined bytes never reach disk; the refusal names both MVIDs.
- **Same-identity trap-door refused** — a module whose entry DLL name collides with an app-closure assembly is rejected (`ResolveModulePath` probes `modules/<name>/` first, so it would shadow the platform's own binary at next boot).
- **Atomic** — staging dir + `Directory.Move`; re-landing replaces folder and upserts the entry.
- **Uninstall** — entry disabled (kept for history/idempotence), folder deleted, effective at restart; refuses names the sidecar doesn't know (publish-laid-out folders are the deployment's, not uninstall's).
- **IO shape** — cold observables over the service's own cap-1 `IoPool` (`PluginBundleClient`'s pattern); the cap doubles as the sidecar read-modify-write serialization, no hand-rolled gate.

## Step 10 (minimal) — restart-required signal

`PendingRestart` on the sidecar: set by land/remove, **consumed by boot** (restart-as-activation — applying the list IS the restart; best-effort reset, read-only FS tolerated). Queryable by Slice C's UI; a loud "RESTART REQUIRED" log line accompanies every landing. No UI in this slice.

## Step 11 — `CompiledModulesHash` decisive

`HasUsableBuild(node, def, string? modulesHash = null)`: a build stamped with a **different non-null** hash than the live `InstalledModulesFingerprint.Hash` is not usable. Guarantees preserved and unit-pinned FIRST (`NodeTypeCompilationHelpersTest`): null stamp grandfathered as MATCH; equal matches; different invalidates; empty-string (zero-module mesh) stays distinct from null; null CALLER keeps legacy framework-only behavior.

`HasStaleFrameworkBuild` gained the twin — without it the flip would **wedge** every modules-stale type (HasUsableBuild false, but nothing re-drives the compile: first-build needs `Status=null`, recovery needs `Compiling`). Two adjacent correctness fixes that fall out of the same flip:

- The framework-stale kickoff's **store probe is bypassed when the stamped framework matches the live one** — the store key carries the framework tag only, so for a modules-only staleness a bytes-hit IS the stale build itself and skipping on it would wedge the type forever.
- `IsRecompileSettled(requireUsableBuild)` takes the hash — otherwise the settle predicate accepts the pre-flip modules-stale state in ~0 ms and burns the single recompile retry (the exact hazard its remarks document, in modules-stale clothing).

### Fingerprint threading map

Callers that PASS the live hash (hub/mesh in scope, via the single resolver `NodeTypeCompilationHelpers.ModulesHashOf(hub)`):

| Call site | Scope source |
|---|---|
| `InstallCompileWatcher` first-build kickoff + framework-stale kickoff (`NodeTypeCompilationHelpers`) | `hub` |
| `NodeTypeContractHandler.EnsureCompileDispatched` | `hub` |
| `NodeTypeEnrichmentHelpers.ApplyStreamResult` hot path (line ~905) | `meshHub` |
| `IsRecompileSettled` via `TriggerRecompileAndRetry`'s settle wait | `meshHub` |
| `ArmOverlaySelfHeal` / `ArmStaleAssemblySelfHeal` (param threaded from the `With*` wrappers) | `meshHub` |
| `DynamicTypePreWarmer.WatchForRecovery` + `WarmOne` | `mesh` / `workspace.Hub` |

Callers that CANNOT (documented in code, keep legacy framework-only behavior):

- `MeshDataSource.HasLoadableBuild` / `AwaitLoadableBuild` — a pure `MeshNode` extension with no hub in scope; its callers (PackageInstaller post-install waits) run on the mesh that just compiled the build, where stamped == live.
- Any direct unit-test / pure-predicate invocation (`IsRecompileSettled` without the optional arg) — deliberate: the modules check only joins where a live fingerprint exists to compare against.

Both stamp paths (activation write-back and `NodeTypeBatchBake`) already recorded the hash since #1653, so on any mesh the stamped and live hashes agree until a genuine module-only update.

## Docs

`Modules.md`: activation section rewritten (baseline ∪ persisted store installs, restart-as-activation, skip rules, why-sidecar); fingerprint section now says decisive. `InstalledModulesFingerprint` / `NodeTypeDefinition.CompiledModulesHash` doc comments updated off "not yet decisive".

## Verification

- `dotnet build memex/Memex.Portal.Shared -c Release -warnaserror` (transitively Graph, Hosting, PluginCatalog): **0 warnings, 0 errors**; Graph rebuilt Release/`-warnaserror` clean after the final edit (real compile verified by DLL mtime).
- `MeshWeaver.Graph.Test` full suite: **1190/1190 passed** (re-run green on final code), incl. the new fingerprint pins and the existing stamp/settle/self-heal pins.
- `MeshWeaver.PluginCatalog.Test` full suite: **310/310 passed**, incl. 16 new tests (`ModuleLandingServiceTest`: happy path, MVID refusal naming both MVIDs, app-closure collision refusal, missing-entry refusal, re-landing upsert, uninstall, path-traversal guards; `ModuleActivationBootTest`: union/dedupe/skip pins + sidecar round-trip + corrupt-file loudness).
- `DynamicTypePreWarmerTest` (MeshWeaver.Hosting.Monolith.Test): green.
- `DocumentationLinkIntegrityTest`: green.

No What's New entry — platform-internal; Slice C's user-visible install flow carries it.

Part of #1664 (Slice A). Prereqs: #1653 (merged — `ResolveModulePath` + `InstalledModuleAssembly` verified on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
