### PR TITLE
feat(grpc): the mesh gRPC link rides the module lane — second endpoint-hook consumer

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -34,7 +34,8 @@
       "MeshWeaver.Observability.dll",
       "MeshWeaver.OgCard.dll",
       "MeshWeaver.Approvals.dll",
-      "MeshWeaver.Social.dll"
+      "MeshWeaver.Social.dll",
+      "MeshWeaver.Hosting.Grpc.dll"
     ]
   }
 }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -693,11 +693,16 @@ public static class MemexConfiguration
                 .AddPortalType()
                 .AddAI(serveFromPartition);
 
-            // gRPC mesh transport (foreign participants py/*, node/*, and the React GUI's
-            // browser Connect+Deliver split). Registers the service + declares the
-            // participant address types stream-routed. Symmetric with Features:SignalR.
-            if (features.Grpc)
-                mb = mb.AddGrpcHub();
+            // The gRPC mesh transport is a MODULE (MeshWeaver.Hosting.Grpc.dll under
+            // Modules:Assemblies — GrpcMeshModuleAttribute folds AddGrpcHub over this builder:
+            // the transport services + the py/node stream-routed participant address types; its
+            // GrpcModuleAttribute maps the meshweaver.v1.Mesh endpoint via
+            // MapMeshModuleEndpoints). 🚨 DEFAULT-ON in every deployment: the endpoint is the
+            // React GUI's browser data plane (grpc-web Connect+Deliver at the origin root), not
+            // just the foreign-participant (py/*, node/*) transport — delist only where there is
+            // no React GUI and no foreign participant. The former Features:Grpc flag is gone;
+            // the module listing IS the switch. Only the pipeline-order-bound gRPC-web
+            // middleware stays compiled (UseMeshWeaverGrpcWebWhenInstalled, below).
 
             // Each AI provider self-registers everything (catalog source +
             // IOptions binding + IChatClientFactory) via one builder extension.
@@ -1036,9 +1041,11 @@ public static class MemexConfiguration
 
         // gRPC-web middleware — lets browsers / React Native reach the mesh gRPC service
         // (Connect+Deliver split) without HTTP/2 bidi. Must sit between UseRouting and the
-        // endpoint maps. Inert for non-grpc-web requests.
-        if (features.Grpc)
-            app.UseMeshWeaverGrpcWeb();
+        // endpoint maps — the one gRPC piece that CANNOT ride the module's endpoint hook — so
+        // this compiled line stays and self-gates on the MeshWeaver.Hosting.Grpc module being
+        // listed under Modules:Assemblies (the endpoint itself maps via MapMeshModuleEndpoints).
+        // Inert for non-grpc-web requests.
+        app.UseMeshWeaverGrpcWebWhenInstalled();
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseAntiforgery();
@@ -1078,10 +1085,11 @@ public static class MemexConfiguration
         if (features.SignalR)
             app.MapMeshWeaverSignalRHubs();
 
-        // gRPC mesh endpoint (meshweaver.v1.Mesh/Open, grpc-web enabled) — foreign-language
-        // workers and the React GUI connect here.
-        if (features.Grpc)
-            app.MapMeshWeaverGrpc();
+        // The gRPC mesh endpoint (meshweaver.v1.Mesh, grpc-web enabled — foreign-language
+        // workers AND the React GUI) rides MapMeshModuleEndpoints below: the
+        // MeshWeaver.Hosting.Grpc module's GrpcModuleAttribute maps it, AllowAnonymous by
+        // explicit opt-out (the transport authenticates connections itself — Bearer token in
+        // gRPC metadata / trusted loopback port).
 
         // Map MCP endpoint
         app.MapMeshMcp();

--- a/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
+++ b/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
@@ -36,12 +36,11 @@ public sealed record MemexFeatureOptions
     /// </summary>
     public bool SignalR { get; init; } = true;
 
-    /// <summary>
-    /// gRPC mesh transport (<c>meshweaver.v1.Mesh/Open</c> + gRPC-web) for foreign-language
-    /// participants (Python/Node workers) and the browser React GUI's Connect+Deliver split.
-    /// On by default, symmetric with <see cref="SignalR"/>; close with <c>Features:Grpc=false</c>.
-    /// </summary>
-    public bool Grpc { get; init; } = true;
+    // The gRPC mesh transport (meshweaver.v1.Mesh + gRPC-web — foreign-language participants
+    // AND the React GUI's browser Connect+Deliver split) is a MODULE now: the former
+    // Features:Grpc flag is gone, and listing/delisting MeshWeaver.Hosting.Grpc.dll under
+    // Modules:Assemblies is the switch (GrpcMeshModuleAttribute + GrpcModuleAttribute;
+    // no org deployment ever set the flag). See Doc/Architecture/Modules.
 
     /// <summary>
     /// True when the deployment ships at least one in-process API provider OR one

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -50,6 +50,7 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
+    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />
 
     <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2, flip #1). -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj" />

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -2,6 +2,9 @@
   "Modules": {
     // Boot-loaded provider packs: each DLL's MeshNodeProviderAttribute registers its
     // language-model providers / CLI harness. Drop a line to drop the module.
+    // 🚨 MeshWeaver.Hosting.Grpc is DEFAULT-ON everywhere: it is the React GUI's browser
+    // data plane (grpc-web Connect+Deliver) AND the py/node foreign-participant transport —
+    // delist only where a deployment has neither.
     "Assemblies": [
       "MeshWeaver.AI.OpenAI.dll",
       "MeshWeaver.AI.AzureFoundry.dll",
@@ -16,7 +19,8 @@
       "MeshWeaver.Observability.dll",
       "MeshWeaver.OgCard.dll",
       "MeshWeaver.Approvals.dll",
-      "MeshWeaver.Social.dll"
+      "MeshWeaver.Social.dll",
+      "MeshWeaver.Hosting.Grpc.dll"
     ]
   },
   // Production logging.

--- a/src/MeshWeaver.Documentation/Data/Architecture/FeatureFlags.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/FeatureFlags.md
@@ -61,9 +61,13 @@ Configuration is layered (last wins):
 | `Features:Onboarding:InvitationOnly` | bool | `false` | When `true`, only an email with a Pending invitation may onboard. See [Invitation-Only Onboarding](/Doc/Architecture/InvitationOnlyOnboarding). |
 | `Features:Orleans:Clustering` | string | `AzureTables` | Cluster-membership provider: `AzureTables`, `AdoNet` (PostgreSQL), or `Localhost` (single in-process silo; dev only). |
 | `Features:SignalR` | bool | `true` | Opens the SignalR mesh transport (`/signalr`) for external participants (native clients). `false` closes the connection surface. |
-| `Features:Grpc` | bool | `true` | Opens the gRPC mesh transport (`meshweaver.v1.Mesh/Open` + gRPC-web) for foreign-language participants and the React GUI. Symmetric with `SignalR`. |
 | `Features:StaticRepoSync:Partitions` | string[] | `[]` | Partitions whose build-time static content is **materialized into and served from the database** instead of the in-memory read-only static provider (e.g. `["Doc","Agent","Provider","Harness","Skill"]` — what the default Helm deployment sets). Empty = every partition keeps the in-memory provider. Matching is case-insensitive; `Model` is a legacy alias for `Provider`. See [Static Repo Import](/Doc/Architecture/StaticRepoImport). |
 | `Features:StaticRepoSync:Modes:{Partition}` | enum | *(source default)* | Per-partition prune policy for that import: `FullReplace` (mirror), `Additive` (keep user-added nodes), `UpsertOnly` (never prune). Unlisted partitions use their source's default — `FullReplace` for most, but the built-in AI catalogs (Skill/Agent/Provider/Harness) default to `Additive`. Distinct from the per-**node** `SyncBehavior`. |
+
+There is no `Features:Grpc` any more: the gRPC mesh transport (`meshweaver.v1.Mesh` + gRPC-web —
+foreign-language participants AND the React GUI's browser data plane) is the
+`MeshWeaver.Hosting.Grpc` **module**, switched by listing/delisting the DLL under
+`Modules:Assemblies` — default-on everywhere, see [Modules](/Doc/Architecture/Modules).
 
 A related, separate section — `Email` — configures outbound system mail (used by invitations). It
 is documented in [Invitation-Only Onboarding → Email](/Doc/Architecture/InvitationOnlyOnboarding#sending-email-microsoft-graph).

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -33,6 +33,12 @@ module removes its routes wholesale: a 404, not a compiled optional-service 503.
 `MeshWeaver.Social` is the first consumer — its LinkedIn connect/publish/page-sync routes ride
 this hook, with the two OAuth callback routes opting out via `AllowAnonymous` (LinkedIn's
 redirect must not bounce through a login challenge; the CSRF state cookie is the guard).
+`MeshWeaver.Hosting.Grpc` is the second: the whole `meshweaver.v1.Mesh` service maps through the
+hook, `AllowAnonymous` on every route because the transport authenticates each connection itself
+(Bearer API token in gRPC call metadata, or the trusted loopback port). One piece cannot ride the
+hook: the gRPC-web MIDDLEWARE must run between `UseRouting` and the endpoint maps, so the host
+keeps a single compiled `UseMeshWeaverGrpcWebWhenInstalled()` line that self-gates on the module
+being listed — the module listing stays the only switch.
 
 Module DI options bind through the options pipeline —
 `services.AddOptions<T>().BindConfiguration("Section")` — never `services.Configure(section)`:
@@ -65,6 +71,14 @@ current first-party inventory and each module's configuration section:
 | `MeshWeaver.Observability.dll` | Red-log ticketing / log watch | `LogWatch` |
 | `MeshWeaver.OgCard.dll` | Link-preview (og-card) layout area | — |
 | `MeshWeaver.Social.dll` | LinkedIn publishing: connect/publish/page-sync endpoints + node-menu actions | `Social:LinkedIn` |
+| `MeshWeaver.Hosting.Grpc.dll` | The mesh gRPC transport: `meshweaver.v1.Mesh` + gRPC-web, `py`/`node` foreign participants AND the React GUI's browser data plane | `Grpc` (`TrustedPort`) |
+
+🚨 **`MeshWeaver.Hosting.Grpc` is DEFAULT-ON in every deployment.** Its endpoint is not just the
+foreign-participant (`py/*`, `node/*`) transport — the React GUI connects over the very same
+grpc-web `Connect`+`Deliver` split at the origin root (`clients/portal-next`, `clients/portal`).
+Delist it only in a deployment with NO React GUI and NO foreign participants; anywhere else a
+delist silently breaks the React frontend's live connection. (The former `Features:Grpc` flag is
+gone — the module listing is the switch.)
 
 Boot packs select by OTHER configuration too: `Graph:Storage:Type` `Cosmos`/`Snowflake` requires
 the matching `MeshWeaver.Hosting.Cosmos`/`.Snowflake` DLL in this list — installation runs before

--- a/src/MeshWeaver.Documentation/Data/GUI/React/GettingStarted.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/GettingStarted.md
@@ -31,22 +31,22 @@ app.Use((ctx, next) =>
 });
 ```
 
-2. **The gRPC-web transport**, gated by the `Features:Grpc` flag — the browser's data plane. Three calls wire it end to end:
+2. **The gRPC-web transport** — the browser's data plane. It is the `MeshWeaver.Hosting.Grpc`
+**module** (see [Modules](/Doc/Architecture/Modules)): listing the DLL under `Modules:Assemblies`
+wires all three pieces — the mesh half (`GrpcMeshModuleAttribute` folds `AddGrpcHub()`: the gRPC
+service + the `py/*`, `node/*` foreign-participant address types declared stream-routed), the
+endpoint half (`GrpcModuleAttribute` maps `meshweaver.v1.Mesh`, grpc-web enabled, through the
+host's `MapMeshModuleEndpoints()`), and the one compiled platform line the endpoint hook cannot
+carry, the gRPC-web middleware between `UseRouting` and the endpoint maps:
 
 ```csharp
-// Mesh tier (ConfigureMemexMesh): registers the gRPC service + declares the
-// foreign-participant address types (py/*, node/*) stream-routed.
-if (features.Grpc)
-    mb = mb.AddGrpcHub();
-
-// Request pipeline (between UseRouting and the endpoint maps):
-if (features.Grpc)
-    app.UseMeshWeaverGrpcWeb();     // gRPC-web middleware — browsers can't do HTTP/2 bidi
-
-// Endpoints:
-if (features.Grpc)
-    app.MapMeshWeaverGrpc();        // meshweaver.v1.Mesh, grpc-web enabled
+// Request pipeline — self-gates on the module being listed under Modules:Assemblies:
+app.UseMeshWeaverGrpcWebWhenInstalled();   // gRPC-web middleware — browsers can't do HTTP/2 bidi
 ```
+
+🚨 The module is **default-on in every deployment**: the same endpoint serves the React GUI AND
+the foreign-language participants — delisting it silently breaks the React frontend's live
+connection.
 
 `AddGrpcHub` / `UseMeshWeaverGrpcWeb` / `MapMeshWeaverGrpc` live in `src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs`. `AddGrpcHub` declares the `py/*` and `node/*` address types as **stream-routed** foreign-participant types — so a reply addressed to one routes back down its `Connect` stream instead of being resolved (and dropped) as a mesh-node lookup. The browser connection *defaults* to a random `node/<id>`; the Next.js shell (`clients/portal-next`) overrides it with a **stable per-tab `portal/<id>`** (`portal` is a built-in stream-routed type, the same family Blazor user circuits use) so the server keeps the participant and its sync sub-hubs alive across reloads — see [Live connection & session](/Doc/GUI/React). The wire details are on [Rendering Architecture](../Rendering).
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-grpc-link-module.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-grpc-link-module.md
@@ -1,0 +1,17 @@
+---
+Name: The mesh gRPC link rides the module lane
+Category: Feature
+Description: The gRPC mesh transport — Python/Node foreign participants AND the React GUI's browser connection — is now the MeshWeaver.Hosting.Grpc module, switched by one Modules:Assemblies line. Default-on everywhere.
+Icon: Sparkle
+Order: -20260816
+---
+
+# The mesh gRPC link rides the module lane
+
+The gRPC mesh transport — the endpoint Python and Node workers connect through, and the same one
+the React frontend uses for its live browser connection — now ships as the
+`MeshWeaver.Hosting.Grpc` module instead of being hard-wired into the portal. It stays **on by
+default in every deployment**, because the React GUI depends on it; a deployment with no React
+frontend and no foreign-language workers can now switch the whole surface off with one
+`Modules:Assemblies` line. Nothing changes for users: connections, tokens, and the trusted
+co-deployed gates work exactly as before.

--- a/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
@@ -101,9 +101,22 @@ public static class GrpcHostingExtensions
         // Assembly.LoadFrom, which normally dedupes onto the compiled reference the host already
         // loaded (double-ship), but a modules/-folder copy must gate identically.
         var moduleName = typeof(GrpcHostingExtensions).Assembly.GetName().Name;
-        if (app.ApplicationServices.GetServices<InstalledModuleAssembly>()
-            .Any(m => m.Assembly.GetName().Name == moduleName))
+        var installed = app.ApplicationServices.GetServices<InstalledModuleAssembly>()
+            .Any(m => m.Assembly.GetName().Name == moduleName);
+        // LOUD either way: gRPC silently off is indistinguishable from a broken transport —
+        // every "React GUI / py client cannot connect" triage starts by grepping for this line.
+        var logger = app.ApplicationServices.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()
+            ?.CreateLogger(typeof(GrpcHostingExtensions).FullName!);
+        if (installed)
+        {
+            if (logger is not null)
+                Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(logger,
+                    "gRPC transport ENABLED: {Module} is installed — gRPC-web middleware active, mesh gRPC endpoints map via the module hook", moduleName);
             app.UseMeshWeaverGrpcWeb();
+        }
+        else if (logger is not null)
+            Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(logger,
+                "gRPC transport OFF: {Module} is NOT in this deployment's module set (Modules:Assemblies) — the React GUI and py/node participants cannot connect. List the DLL to enable.", moduleName);
         return app;
     }
 }

--- a/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
@@ -60,7 +60,16 @@ public static class GrpcHostingExtensions
     /// <returns>The same <paramref name="endpoints"/> for chaining.</returns>
     public static IEndpointRouteBuilder MapMeshWeaverGrpc(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGrpcService<MeshGrpcService>().EnableGrpcWeb();
+        // AllowAnonymous is today's semantics made EXPLICIT, not a widening: the transport
+        // authenticates every connection ITSELF — MeshGrpcService validates the Bearer API token
+        // carried in gRPC call metadata (registry.Authenticate), a call on the loopback
+        // GrpcOptions.TrustedPort authenticates by reachability, and a definitively invalid token
+        // still connects as Anonymous whose writes are cleanly RLS-denied. ASP.NET-level
+        // authorization here would break both non-cookie callers (foreign py/node gates present
+        // mw_ API tokens no host auth scheme accepts) and the credential-less trusted-port path.
+        // The explicit opt-out matters because the module lane (GrpcModuleAttribute) maps this
+        // inside MapMeshModuleEndpoints' authenticated-by-default group.
+        endpoints.MapGrpcService<MeshGrpcService>().EnableGrpcWeb().AllowAnonymous();
         return endpoints;
     }
 
@@ -72,6 +81,29 @@ public static class GrpcHostingExtensions
     public static IApplicationBuilder UseMeshWeaverGrpcWeb(this IApplicationBuilder app)
     {
         app.UseGrpcWeb();
+        return app;
+    }
+
+    /// <summary>
+    /// The module-lane form of <see cref="UseMeshWeaverGrpcWeb"/>: applies the gRPC-web middleware
+    /// only when this assembly is INSTALLED as a module (<c>Modules:Assemblies</c> →
+    /// <see cref="InstalledModuleAssembly"/>). Middleware cannot ride
+    /// <c>MeshEndpointProviderAttribute</c> — it must run in the pipeline between
+    /// <c>UseRouting</c> and the endpoint maps — so the host keeps this ONE compiled line and the
+    /// module listing stays the single on/off switch: delist the module and both the routes
+    /// (via <c>MapMeshModuleEndpoints</c>) and this middleware drop out together.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The same <paramref name="app"/> for chaining.</returns>
+    public static IApplicationBuilder UseMeshWeaverGrpcWebWhenInstalled(this IApplicationBuilder app)
+    {
+        // Match by assembly NAME, not instance: the module list resolves through
+        // Assembly.LoadFrom, which normally dedupes onto the compiled reference the host already
+        // loaded (double-ship), but a modules/-folder copy must gate identically.
+        var moduleName = typeof(GrpcHostingExtensions).Assembly.GetName().Name;
+        if (app.ApplicationServices.GetServices<InstalledModuleAssembly>()
+            .Any(m => m.Assembly.GetName().Name == moduleName))
+            app.UseMeshWeaverGrpcWeb();
         return app;
     }
 }

--- a/src/MeshWeaver.Hosting.Grpc/GrpcModuleAttribute.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcModuleAttribute.cs
@@ -1,0 +1,55 @@
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Routing;
+
+[assembly: MeshWeaver.Hosting.Grpc.GrpcMeshModule]
+[assembly: MeshWeaver.Hosting.Grpc.GrpcModule]
+
+namespace MeshWeaver.Hosting.Grpc;
+
+/// <summary>
+/// The mesh half of the gRPC transport module: listing <c>MeshWeaver.Hosting.Grpc.dll</c> under
+/// <c>Modules:Assemblies</c> folds <see cref="GrpcHostingExtensions.AddGrpcHub(MeshBuilder)"/>
+/// over the builder — the gRPC mesh-transport services (<see cref="GrpcConnectionRegistry"/>,
+/// <c>IParticipantPresence</c>, <see cref="GrpcOptions"/> off <c>Grpc:*</c>) plus the
+/// <c>py</c>/<c>node</c> foreign-participant address types declared stream-routed. The same
+/// extension a fixture or bespoke host (e.g. <c>Memex.LocalMesh</c>) calls explicitly — the two
+/// lanes must never drift.
+///
+/// <para>🚨 <b>This module is DEFAULT-ON in every deployment.</b> The endpoint it registers is
+/// not only the foreign-participant (<c>py/*</c>, <c>node/*</c>) transport — the React GUI's
+/// browser data plane rides the SAME <c>meshweaver.v1.Mesh</c> service (the gRPC-web
+/// <c>Connect</c>+<c>Deliver</c> split at the origin root; <c>clients/portal-next</c> +
+/// <c>clients/portal</c>). Delisting it is only for deployments with NO React GUI and NO foreign
+/// participants; everywhere else a delist silently breaks the React frontend's live connection.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class GrpcMeshModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations =>
+        [GrpcHostingExtensions.AddGrpcHub];
+}
+
+/// <summary>
+/// The endpoint half of the gRPC transport module (the second consumer of the
+/// endpoint-contribution hook, after <c>MeshWeaver.Social</c> — design #1655): the
+/// <c>meshweaver.v1.Mesh</c> service maps through the host's <c>app.MapMeshModuleEndpoints()</c>,
+/// grpc-web enabled and — deliberately — <c>AllowAnonymous</c>: the transport authenticates each
+/// connection itself (see the why-comment on
+/// <see cref="GrpcHostingExtensions.MapMeshWeaverGrpc"/>). Delisting the module removes the
+/// routes wholesale — a 404, not a compiled optional-service 503.
+///
+/// <para>The gRPC-web MIDDLEWARE is NOT part of this attribute: middleware cannot ride the
+/// endpoint hook (it must run in the pipeline between <c>UseRouting</c> and the endpoint maps),
+/// so the host keeps one compiled line —
+/// <see cref="GrpcHostingExtensions.UseMeshWeaverGrpcWebWhenInstalled"/> — which self-gates on
+/// this assembly being listed, keeping the module listing the single on/off switch.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class GrpcModuleAttribute : MeshEndpointProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Action<IEndpointRouteBuilder>> EndpointConfigurations =>
+        [endpoints => endpoints.MapMeshWeaverGrpc()];
+}

--- a/src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj
+++ b/src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj
@@ -27,6 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- MeshEndpointProviderAttribute — the endpoint half of the module lane (GrpcModuleAttribute). -->
+    <ProjectReference Include="..\MeshWeaver.Hosting.AspNetCore\MeshWeaver.Hosting.AspNetCore.csproj" />
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
   </ItemGroup>

--- a/test/MeshWeaver.Hosting.Monolith.Test/GrpcModuleContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GrpcModuleContributionTest.cs
@@ -79,9 +79,14 @@ public class GrpcModuleContributionTest
         // (same shape as SocialModuleContributionTest).
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddAuthorization();
-        // The module's DI half in fixture form (two-lane rule): MapGrpcService requires the
-        // gRPC services the same assembly's mesh half registers.
-        builder.Services.AddGrpcHub();
+        // ONLY the gRPC marker services MapGrpcService needs — deliberately NOT AddGrpcHub():
+        // the module's DI half registers GrpcConnectionRegistry, a type-registered singleton
+        // whose ctor takes IMessageHub, and this host has no mesh. Under CI's
+        // DOTNET_ENVIRONMENT=Development, WebApplication.CreateBuilder turns on ValidateOnBuild,
+        // which eagerly validates every such descriptor and fails Build() on the unresolvable
+        // hub (a check Production/local skips — the exact false-local-green this comment pins).
+        // The DI half itself is asserted descriptor-level by InstallingTheAssembly_AppliesAddGrpcHub.
+        builder.Services.AddGrpc();
         builder.Services.AddSingleton(
             new InstalledModuleAssembly(typeof(GrpcModuleAttribute).Assembly));
         using var app = builder.Build();

--- a/test/MeshWeaver.Hosting.Monolith.Test/GrpcModuleContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GrpcModuleContributionTest.cs
@@ -1,0 +1,117 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Grpc.AspNetCore.Web;
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Hosting.Grpc;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the gRPC mesh transport's module shape — the SECOND consumer of the
+/// endpoint-contribution hook (design #1655, after <c>MeshWeaver.Social</c>): the assembly
+/// carries BOTH module attributes (mesh half + endpoint half), installing it applies the same
+/// <c>AddGrpcHub()</c> a fixture calls (the two lanes must not drift), and the
+/// <c>meshweaver.v1.Mesh</c> endpoints map through <c>MapMeshModuleEndpoints</c> with the exact
+/// auth semantics the compiled-in registration had — grpc-web enabled and ANONYMOUS by explicit
+/// opt-out, because the transport authenticates each connection itself (Bearer API token in
+/// gRPC call metadata / trusted loopback port; see <c>MeshGrpcService</c>). This module is
+/// DEFAULT-ON: the React GUI's browser data plane (Connect+Deliver split) rides the same
+/// endpoint as the py/node foreign participants.
+/// </summary>
+public class GrpcModuleContributionTest
+{
+    [Fact]
+    public void TheAssembly_CarriesBothModuleAttributes_WithNonEmptyContributions()
+    {
+        var assembly = typeof(GrpcModuleAttribute).Assembly;
+
+        // Mesh half: the Modules:Assemblies install path folds AddGrpcHub over the builder.
+        var meshHalf = Assert.Single(assembly.GetCustomAttributes<MeshNodeProviderAttribute>());
+        Assert.NotEmpty(meshHalf.BuilderConfigurations);
+
+        // Endpoint half: the host's MapMeshModuleEndpoints applies these.
+        var endpointHalf = Assert.Single(assembly.GetCustomAttributes<MeshEndpointProviderAttribute>());
+        Assert.NotEmpty(endpointHalf.EndpointConfigurations);
+    }
+
+    [Fact]
+    public void InstallingTheAssembly_AppliesAddGrpcHub()
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+
+        builder.InstallAssemblies(typeof(GrpcModuleAttribute).Assembly.Location);
+
+        var services = serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        // The connection registry, singleton, plus its IParticipantPresence face (the fail-fast
+        // presence check for foreign-language Code runs).
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(GrpcConnectionRegistry) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(IParticipantPresence) && d.Lifetime == ServiceLifetime.Singleton);
+
+        // Options ride the options pipeline (Grpc:TrustedPort — the loopback trust boundary).
+        // The py/node stream-routed address-type declarations ride the SAME AddGrpcHub code path
+        // pinned here (MeshBuilder.StreamRoutedAddressTypes is internal, so the service
+        // registrations are the observable proof the fold ran).
+        Assert.Contains(services, d => d.ServiceType == typeof(IConfigureOptions<GrpcOptions>));
+    }
+
+    [Fact]
+    public void GrpcEndpoints_MapThroughTheHook_AnonymousByExplicitOptOut()
+    {
+        // Built but never started — endpoint metadata is inspectable without Kestrel
+        // (same shape as SocialModuleContributionTest).
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddAuthorization();
+        // The module's DI half in fixture form (two-lane rule): MapGrpcService requires the
+        // gRPC services the same assembly's mesh half registers.
+        builder.Services.AddGrpcHub();
+        builder.Services.AddSingleton(
+            new InstalledModuleAssembly(typeof(GrpcModuleAttribute).Assembly));
+        using var app = builder.Build();
+        app.MapMeshModuleEndpoints();
+
+        var endpoints = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToList();
+
+        // The full service surface: the bidi stream + the grpc-web Connect/Deliver split the
+        // React GUI uses.
+        string[] expected =
+        [
+            "/" + MeshGrpcService.ServiceName + "/Open",
+            "/" + MeshGrpcService.ServiceName + "/Connect",
+            "/" + MeshGrpcService.ServiceName + "/Deliver",
+        ];
+        foreach (var pattern in expected)
+        {
+            var endpoint = Assert.Single(endpoints, e => e.RoutePattern.RawText == pattern);
+
+            // ANONYMOUS by explicit opt-out of the hook's authenticated-by-default group: the
+            // transport authenticates connections ITSELF (Bearer token in gRPC metadata /
+            // trusted loopback port) — ASP.NET-level authorization would break the foreign
+            // gates' mw_ tokens and the credential-less trusted-port path.
+            Assert.NotNull(endpoint.Metadata.GetMetadata<IAllowAnonymous>());
+
+            // grpc-web stays enabled — the browser Connect+Deliver split depends on it.
+            Assert.NotNull(endpoint.Metadata.GetMetadata<EnableGrpcWebAttribute>());
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -40,6 +40,9 @@
         <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.AzureBlob\MeshWeaver.Hosting.AzureBlob.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
+        <!-- GrpcModuleContributionTest pins the gRPC transport's module shape (mesh half +
+             endpoint half, anonymous-by-explicit-opt-out). -->
+        <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
         <!-- RouterTrafficTest pins that SignalRConnectionRegistry issues its per-connection
              ValidateTokenRequest on its own transport portal hub, never on the root mesh hub. -->
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />


### PR DESCRIPTION
## What

`MeshWeaver.Hosting.Grpc` — the gRPC mesh transport serving the **py/node foreign participants AND the React GUI's browser data plane** — becomes a `Modules:Assemblies` module: the **second consumer of the endpoint-contribution hook** (#1663, design #1655), on the `MeshWeaver.Social` precedent (#1667).

## Scoping verdicts

**1. What the portals wired (all three gated on `Features:Grpc`, default `true`, set nowhere in the org — code search: 0 hits):**
- `MemexConfiguration.cs` mesh tier: `mb.AddGrpcHub()` — gRPC services (`GrpcConnectionRegistry` + `IParticipantPresence` + `GrpcOptions` off `Grpc:TrustedPort`) + `py`/`node` declared stream-routed.
- Pipeline: `app.UseMeshWeaverGrpcWeb()` between `UseRouting` and the endpoint maps.
- Endpoints: `app.MapMeshWeaverGrpc()` → `MapGrpcService<MeshGrpcService>().EnableGrpcWeb()`.

**2. 🚨 The React GUI question: YES — same path.** `clients/portal-next/src/client/live.ts` and `clients/portal/src/live.ts` POST `{origin}/meshweaver.v1.Mesh/Connect` + `/Deliver` (grpc-web split) — the exact endpoint `MapMeshWeaverGrpc` maps; `clients/typescript` and `clients/python` speak the same service. **The module is therefore "the mesh's gRPC transport", React GUI included, and DEFAULT-ON in every deployment** — delisting is only for deployments with no React GUI and no foreign participants. Stated loudly in `Modules.md`, both hosts' appsettings, and the attribute doc comments.

**3. Middleware split (the honest partial):** the gRPC-web middleware cannot ride `MeshEndpointProviderAttribute` — it must run between `UseRouting` and the endpoint maps. The module carries the ENDPOINTS; the portals keep **one compiled line, `UseMeshWeaverGrpcWebWhenInstalled()`**, which self-gates on the module appearing in `InstalledModuleAssembly` (matched by assembly name so a `modules/`-folder copy gates identically). The module listing stays the single switch: delist → routes AND middleware drop out together.

**4. Python kernel/execution bits are OUT of scope** — `execute_script python` / `PythonPandasNode` ride Code-node execution and the kernel; the transport only carries the `py/*`/`node/*` routing. Untouched.

**Auth semantics — preserved exactly.** The endpoint was mapped with no `RequireAuthorization` and the portal has no fallback policy, so it was anonymous at the ASP.NET layer; `MeshGrpcService` authenticates each connection itself (Bearer API token in gRPC call metadata via `registry.Authenticate`, trusted loopback `Grpc:TrustedPort` by reachability, definitively-invalid token → Anonymous with RLS-denied writes). Inside the hook's authenticated-by-default group that must be explicit: `MapMeshWeaverGrpc` now carries `.AllowAnonymous()` with a why-comment — same single code path for both lanes.

## Moved / stayed

| | |
|---|---|
| **Moved to the module** | `AddGrpcHub` fold (`GrpcMeshModuleAttribute`), `meshweaver.v1.Mesh` endpoint mapping (`GrpcModuleAttribute` → `MapMeshModuleEndpoints`) |
| **Stayed compiled** | `UseMeshWeaverGrpcWebWhenInstalled()` pipeline line (order-bound middleware, self-gated); ships-the-bits `ProjectReference` in `Memex.Portal.Shared` (double-ship) |
| **Stayed explicit lane** | `Memex.LocalMesh` and the `Hosting.Grpc.Test` fixtures keep calling `AddGrpcHub()`/`MapMeshWeaverGrpc()` directly — two-lane rule, one code path |
| **Deleted** | `Features:Grpc` (`MemexFeatureOptions.Grpc` + its three gates) — set nowhere in the org; the module listing is the switch |
| **Added** | `MeshWeaver.Hosting.Grpc.dll` in both hosts' `Modules:Assemblies` + `MeshModulesPublish.targets`; `Hosting.AspNetCore` ProjectReference in `Hosting.Grpc` (no cycle — AspNetCore references only `Mesh.Contract`) |

## Tests

- **New `GrpcModuleContributionTest`** (Social pattern): both attribute halves present; `InstallAssemblies` applies the `AddGrpcHub` registrations; `/meshweaver.v1.Mesh/{Open,Connect,Deliver}` map through `MapMeshModuleEndpoints` with `IAllowAnonymous` + `EnableGrpcWebAttribute` on each.
- Fixture sweep: no test composes the portal pipeline's gRPC wiring; `clients/` CI tests are in-memory/mocked (no live host) — nothing to opt in.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, all `0 Warning(s) 0 Error(s)`: `MeshWeaver.Hosting.Grpc`, `Memex.Portal.Shared`, `Memex.Portal.Monolith`, `Memex.Portal.Distributed`, `MeshWeaver.Hosting.Monolith.Test`.
- Build-then-`--no-build` runs, fresh `.trx` each: contribution tests **Passed! 8/8** (3 new Grpc + 3 Social + 2 hook), `MeshWeaver.Hosting.Grpc.Test` **Passed! 8/8**, `DocumentationLinkIntegrityTest` **Passed! 1/1**.

## Docs

`Modules.md` (inventory row + default-on warning + second-consumer paragraph), `FeatureFlags.md` (flag-removed note), `GUI/React/GettingStarted.md` (module lane), What's New entry (Category: Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)