### PR TITLE
fix(graph): self-heal watchers read the type node via ContentAs — the #1669 rebind blindness

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-instance-rebind-selfheal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-instance-rebind-selfheal.md
@@ -1,0 +1,11 @@
+---
+Name: Pages refresh themselves after plugin updates
+Category: Fix
+Description: Open pages no longer keep showing an outdated view after a plugin or platform update.
+Icon: Sparkle
+Order: -20260816
+---
+
+# Pages refresh themselves after plugin updates
+
+When a plugin or the platform updated, an already-open page could keep showing its old state — in the worst case losing its buttons and panels — until someone recycled it by hand. The self-healing watcher that should have caught the update was blind to one common message shape; it now sees every update, so affected pages rebind to the new version automatically.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1590,8 +1590,12 @@ internal static class NodeTypeEnrichmentHelpers
         // convicts; typed content short-circuits in ContentAs, so the materialized path pays
         // nothing.
         => typeStream
-            .Where(t => t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger) is { } d
-                && NodeTypeCompilationHelpers.HasUsableBuild(t, d, modulesHash)
+            // Deserialize ONCE per emission — the Subscribe below reuses the recovered definition
+            // (a second ContentAs would also duplicate its degraded-content warning logs).
+            .Select(t => (Node: t,
+                Def: t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger)))
+            .Where(x => x.Def is { } d
+                && NodeTypeCompilationHelpers.HasUsableBuild(x.Node!, d, modulesHash)
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && !string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal))
             // 🚨 Wait for the type to stop publishing — see AssemblySettleWindow. An install
@@ -1600,9 +1604,9 @@ internal static class NodeTypeEnrichmentHelpers
             .Throttle(AssemblySettleWindow, scheduler ?? Scheduler.Default)
             .Take(1)
             .Subscribe(
-                t =>
+                x =>
                 {
-                    var published = t.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger)?.LatestAssemblyPath;
+                    var published = x.Def?.LatestAssemblyPath;
                     logger?.LogInformation(
                         "Stale-assembly self-heal: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — recycling instance '{InstancePath}' so it rebinds",
                         nodeType, published, boundAssemblyPath, instanceHub.Address);

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -407,7 +407,9 @@ internal static class NodeTypeEnrichmentHelpers
         // The Where below is now strict on those fields, so the slow-path
         // Take(1) keeps waiting until the healed emission arrives.
         var healSub = typeStream
-            .Where(t => t?.Content is NodeTypeDefinition stale
+            // ContentAs, never `is NodeTypeDefinition` — the #1669 blindness on un-materialized
+            // JSON emissions; see ArmStaleAssemblySelfHeal's predicate note.
+            .Where(t => t?.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions, logger) is { } stale
                 && stale.CompilationStatus == CompilationStatus.Ok
                 && (string.IsNullOrEmpty(stale.LatestAssemblyCollection)
                     || string.IsNullOrEmpty(stale.LatestAssemblyPath))
@@ -423,7 +425,7 @@ internal static class NodeTypeEnrichmentHelpers
             .SelectMany(_ => Observable.Using(
                 () => AccessContextScope.AsSystem(enrichAccessService),
                 _2 => typeStream.Update(curr =>
-                    curr.Content is NodeTypeDefinition d
+                    curr.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions, logger) is { } d
                     && d.CompilationStatus == CompilationStatus.Ok
                     && (string.IsNullOrEmpty(d.LatestAssemblyCollection)
                         || string.IsNullOrEmpty(d.LatestAssemblyPath))
@@ -1579,8 +1581,16 @@ internal static class NodeTypeEnrichmentHelpers
         ILogger? logger,
         IScheduler? scheduler = null,
         string? modulesHash = null)
+        // 🚨 ContentAs, never `is NodeTypeDefinition` (#1669): the type node reaches this stream
+        // in UN-MATERIALIZED JSON shape whenever the publication just crossed a sync stream — the
+        // normal shape for exactly the emission this watcher exists to catch. A CLR type test is
+        // blind there, so the watcher ignored the new build and the instance served its stale
+        // (worst case zero-areas) activation until a manual recycle — the ThinkInStreams/Subscribe
+        // + post-roll Store shape. Same divergence class the settle-gate's own doc comment
+        // convicts; typed content short-circuits in ContentAs, so the materialized path pays
+        // nothing.
         => typeStream
-            .Where(t => t?.Content is NodeTypeDefinition d
+            .Where(t => t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger) is { } d
                 && NodeTypeCompilationHelpers.HasUsableBuild(t, d, modulesHash)
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && !string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal))
@@ -1592,7 +1602,7 @@ internal static class NodeTypeEnrichmentHelpers
             .Subscribe(
                 t =>
                 {
-                    var published = (t.Content as NodeTypeDefinition)?.LatestAssemblyPath;
+                    var published = t.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger)?.LatestAssemblyPath;
                     logger?.LogInformation(
                         "Stale-assembly self-heal: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — recycling instance '{InstancePath}' so it rebinds",
                         nodeType, published, boundAssemblyPath, instanceHub.Address);
@@ -1634,7 +1644,10 @@ internal static class NodeTypeEnrichmentHelpers
         IScheduler? scheduler = null,
         string? modulesHash = null)
     {
-        var usable = typeStream.Where(t => t?.Content is NodeTypeDefinition d
+        // ContentAs, never `is NodeTypeDefinition` — the #1669 blindness on un-materialized JSON
+        // emissions; see ArmStaleAssemblySelfHeal's predicate note.
+        var usable = typeStream.Where(t =>
+            t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger) is { } d
             && NodeTypeCompilationHelpers.HasUsableBuild(t, d, modulesHash));
 
         // FAST path — the version advanced past the overlay: a genuinely NEW build landed, heal now.

--- a/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
@@ -109,6 +109,37 @@ public class StaleAssemblySelfHealWatcherTest
         hub.Received(1).Post(
             Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
 
+    /// <summary>
+    /// 🚨 The #1669 regression: the publication arrives in UN-MATERIALIZED JSON shape — the normal
+    /// shape for a node that just crossed a sync stream, and exactly how the emission reached the
+    /// watcher in the ThinkInStreams/Subscribe + post-roll Store incidents. The old
+    /// <c>is NodeTypeDefinition</c> predicate was blind here, so the instance kept its stale
+    /// (worst case zero-areas) activation until a manual recycle. The watcher must recover the
+    /// definition via <c>ContentAs</c> and fire.
+    /// </summary>
+    [Fact]
+    public void UnmaterializedJsonEmission_StillRecyclesTheInstance()
+    {
+        var hub = BuildInstanceHub(out var capturedOptions);
+        var options = new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web);
+        hub.JsonSerializerOptions.Returns(options);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler);
+
+        // The same publication NewlyPublishedAssembly_… fires on — but serialized to a raw
+        // JsonElement, as the sync stream delivers it before materialization re-types it.
+        var typed = TypeNode(version: 12, assemblyPath: "TestData_StaleAssemblyType/v12-abc-222222222222.dll");
+        var json = System.Text.Json.JsonSerializer.SerializeToElement(
+            (NodeTypeDefinition)typed.Content!, options);
+        typeStream.OnNext(typed with { Content = json });
+
+        Settle(scheduler);
+        AssertDisposedExactlyOnce(hub);
+        AssertTargetsItself(capturedOptions);
+    }
+
     [Fact]
     public void NewlyPublishedAssembly_RecyclesTheInstance_ExactlyOnce()
     {


### PR DESCRIPTION
Fixes #1669. The stale-assembly + overlay self-heal watchers and the slow-path Ok+null-assembly heal predicated on `Content is NodeTypeDefinition` — blind on un-materialized JSON emissions (the normal fresh-cross-sync shape), which is EXACTLY the publication emission the watchers exist to catch. Instances then kept a stale (worst case zero-areas) activation until a manual recycle: ThinkInStreams/Subscribe's 'no renderer registered' (2026-08-16 prod), the post-roll Store family, and the education e2e's recurring 'cover must offer the install step' — the 'paywall gate-fold flake' was this bug.

Converted all four sites to `ContentAs<NodeTypeDefinition>` — the same divergence the file's own settle-gate doc comment convicts (and the reason that gate was converted earlier); typed content short-circuits in `ContentAs`, so the materialized path is unchanged. Regression pinned: `UnmaterializedJsonEmission_StillRecyclesTheInstance` serializes the publication to a raw JsonElement and demands the recycle.

Follow-up (education repo): remove the flake/allow entry for the install-step e2e once this ships — it is the acceptance test.

Verification: Graph Release -warnaserror clean; StaleAssemblySelfHealWatcherTest + OverlaySelfHealWatcherTest 13/13; full Graph.Test 1191/1191; SubscribeDuringRecycleTest green — fresh .trx each.

What's New: Category Fix — 'Pages no longer get stuck on an outdated view after a plugin update; they refresh themselves.' (entry included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)