### PR TITLE
feat(modules): bundle build + Store funnel + auto-update — #1664 Slices B+C

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -119,18 +119,48 @@ public static class PluginBundleEndpoints
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
 
         return InstalledPackages(rootHub, ct)
-            .Select(packages => Results.Json(new
-            {
-                frameworkMvid = FrameworkMvid,
-                bundles = packages.Select(p => new
+            .SelectMany(packages => ServableModules(rootHub, packages)
+                .Select(modules => Results.Json(new
                 {
-                    plugin = p.PluginId,
-                    version = p.Version,
-                    url = $"{baseUrl}/{Uri.EscapeDataString(p.PluginId)}/{Uri.EscapeDataString(p.Version)}",
-                }).ToArray(),
-            }))
+                    frameworkMvid = FrameworkMvid,
+                    bundles = packages.Select(p => new
+                    {
+                        plugin = p.PluginId,
+                        version = p.Version,
+                        url = $"{baseUrl}/{Uri.EscapeDataString(p.PluginId)}/{Uri.EscapeDataString(p.Version)}",
+                        // The compiled module this bundle carries (#1664) — stamped ONLY when this
+                        // instance can actually serve its bytes, so a consumer never downloads for
+                        // a module section that will not be there. Additive: an older client's
+                        // BundleRef simply ignores it.
+                        module = modules.TryGetValue(p.PluginId, out var moduleName) ? moduleName : null,
+                    }).ToArray(),
+                })))
             .FirstAsync()
             .ToTask(ct);
+    }
+
+    /// <summary>
+    /// Which of the installed packages' declared modules this instance can serve right now:
+    /// plugin id → module assembly name, for exactly the entries whose bytes exist under
+    /// <c>modules/&lt;name&gt;/</c> and pass the framework gate (<see cref="ModuleBundleSource"/>).
+    /// One activation-sidecar read for the whole index.
+    /// </summary>
+    private static IObservable<IReadOnlyDictionary<string, string>> ServableModules(
+        IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
+    {
+        var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
+        var declaring = packages.Where(p => !string.IsNullOrWhiteSpace(p.Module)).ToArray();
+        if (landing is null || declaring.Length == 0)
+            return Observable.Return<IReadOnlyDictionary<string, string>>(
+                new Dictionary<string, string>());
+
+        return landing.GetActivation().Take(1)
+            .Select(activation => (IReadOnlyDictionary<string, string>)declaring
+                .Where(p => ModuleBundleSource.Collect(
+                        landing.BaseDirectory, p.Module!, activation,
+                        PrebuiltAssemblySeeder.DeclineReason)
+                    .DeclineReason is null)
+                .ToDictionary(p => p.PluginId, p => p.Module!, StringComparer.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -199,7 +229,39 @@ public static class PluginBundleEndpoints
                     ? Observable.Return(Array.Empty<(string NodePath, string? Path)>())
                     : lookups.CombineLatest().Select(x => x.ToArray());
 
-                return assemblies.Select(found => BuildResult(package, found));
+                return assemblies.SelectMany(found => ModuleFiles(rootHub, package)
+                    .Select(moduleFiles => BuildResult(package, found, moduleFiles)));
+            });
+    }
+
+    /// <summary>
+    /// The MODULE closure files this bundle carries (#1664) — the instance's own
+    /// <c>modules/&lt;name&gt;/</c> bytes, resolved through <see cref="ModuleBundleSource"/> (which
+    /// refuses uninstalled and framework-stale landings). Empty for a package that declares no
+    /// module or whose bytes this instance cannot serve — the bundle then simply has no module
+    /// section, which a consumer reads as "nothing to land".
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> ModuleFiles(
+        IMessageHub rootHub, BundleEntry package)
+    {
+        var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
+        if (landing is null || string.IsNullOrWhiteSpace(package.Module))
+            return Observable.Return<IReadOnlyList<string>>([]);
+
+        var logger = rootHub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(PluginBundleEndpoints));
+
+        return landing.GetActivation().Take(1)
+            .Select(activation =>
+            {
+                var (files, decline) = ModuleBundleSource.Collect(
+                    landing.BaseDirectory, package.Module!, activation,
+                    PrebuiltAssemblySeeder.DeclineReason);
+                if (decline is not null)
+                    logger?.LogInformation(
+                        "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",
+                        package.PluginId, package.Module, decline);
+                return files;
             });
     }
 
@@ -225,7 +287,8 @@ public static class PluginBundleEndpoints
     /// </summary>
     private static IResult BuildResult(
         BundleEntry package,
-        IReadOnlyList<(string NodePath, string? Path)> assemblies)
+        IReadOnlyList<(string NodePath, string? Path)> assemblies,
+        IReadOnlyList<string> moduleFiles)
     {
         var entries = new List<NuGetPackageWriter.Entry>();
         var assemblyRecords = new List<object>();
@@ -241,6 +304,17 @@ public static class PluginBundleEndpoints
             assemblyRecords.Add(new { nodePath, assembly = $"{nodePath}.dll" });
         }
 
+        // The module closure, under its own folder (#1664): these bytes land beside the consumer's
+        // app via ModuleLandingService, a different lane than the assembly store above — the two
+        // must never mix (a module DLL seeded as a NodeType assembly fails only at activation).
+        foreach (var moduleFile in moduleFiles)
+        {
+            var local = moduleFile;
+            entries.Add(new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleEntryPathFor(Path.GetFileName(local)),
+                () => File.OpenRead(local)));
+        }
+
         var manifest = new PackagingManifest(
             package.PluginId, package.PackageId, package.Version, package.PluginId, null, []);
 
@@ -249,12 +323,26 @@ public static class PluginBundleEndpoints
             {
                 plugin = package.PluginId,
                 version = package.Version,
-                // The framework this instance RUNS — these assemblies came out of its bake, so that
-                // is the only framework they are known good against.
+                // The framework this instance RUNS — these assemblies came out of its bake (and its
+                // own modules/ tree), so that is the only framework they are known good against.
                 frameworkMvid = FrameworkMvid,
                 assemblies = assemblyRecords,
+                // The module section — the manifest names every closure file; a consumer reads
+                // this list, never the folder (BundleReader.ReadModule). Null (omitted) when the
+                // bundle carries no module.
+                module = moduleFiles.Count == 0
+                    ? null
+                    : new
+                    {
+                        assemblyName = package.Module,
+                        assemblies = moduleFiles.Select(Path.GetFileName).ToArray(),
+                    },
             },
-            new JsonSerializerOptions { WriteIndented = true });
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            });
 
         var buffer = new MemoryStream();
         NuGetPackageWriter.Write(buffer, manifest, "3.0.0", entries, manifestJson);
@@ -285,10 +373,12 @@ public static class PluginBundleEndpoints
                     rootHub.JsonSerializerOptions))
                 .Where(m => m is not null && !string.IsNullOrWhiteSpace(m.ReleasedVersion))
                 .Select(m => new BundleEntry(
-                    PackagingManifest.IdPrefix + m!.Id, m.ReleasedVersion!, m.Id))
+                    PackagingManifest.IdPrefix + m!.Id, m.ReleasedVersion!, m.Id, m.Module))
                 .OrderBy(e => e.PluginId, StringComparer.OrdinalIgnoreCase)
                 .ToArray());
 
-    /// <summary>One servable bundle: its package id, its released version, and the plugin it is.</summary>
-    private sealed record BundleEntry(string PackageId, string Version, string PluginId);
+    /// <summary>One servable bundle: its package id, its released version, the plugin it is, and
+    /// the compiled module the plugin's install record declares (null for content-only plugins).</summary>
+    private sealed record BundleEntry(
+        string PackageId, string Version, string PluginId, string? Module = null);
 }

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -133,6 +133,10 @@ public static class PluginBundleEndpoints
                         // a module section that will not be there. Additive: an older client's
                         // BundleRef simply ignores it.
                         module = modules.TryGetValue(p.PluginId, out var moduleName) ? moduleName : null,
+                        // The module's declared platform FLOOR — the consumer's gate (a semver
+                        // floor, never MVID equality; the index-level frameworkMvid above stays
+                        // the NodeType lane's strict gate and, for modules, diagnostics).
+                        minMeshVersion = modules.ContainsKey(p.PluginId) ? p.MinMeshVersion : null,
                     }).ToArray(),
                 })))
             .FirstAsync()
@@ -142,8 +146,9 @@ public static class PluginBundleEndpoints
     /// <summary>
     /// Which of the installed packages' declared modules this instance can serve right now:
     /// plugin id → module assembly name, for exactly the entries whose bytes exist under
-    /// <c>modules/&lt;name&gt;/</c> and pass the framework gate (<see cref="ModuleBundleSource"/>).
-    /// One activation-sidecar read for the whole index.
+    /// <c>modules/&lt;name&gt;/</c> and pass the platform-floor gate (<see cref="ModuleBundleSource"/>
+    /// — the same <see cref="ModulePlatformFloor"/> check boot applies, so a registry never serves
+    /// a landing its own boot skips). One activation-sidecar read for the whole index.
     /// </summary>
     private static IObservable<IReadOnlyDictionary<string, string>> ServableModules(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
@@ -158,7 +163,7 @@ public static class PluginBundleEndpoints
             .Select(activation => (IReadOnlyDictionary<string, string>)declaring
                 .Where(p => ModuleBundleSource.Collect(
                         landing.BaseDirectory, p.Module!, activation,
-                        PrebuiltAssemblySeeder.DeclineReason)
+                        ModulePlatformFloor.DeclineReason)
                     .DeclineReason is null)
                 .ToDictionary(p => p.PluginId, p => p.Module!, StringComparer.OrdinalIgnoreCase));
     }
@@ -256,7 +261,7 @@ public static class PluginBundleEndpoints
             {
                 var (files, decline) = ModuleBundleSource.Collect(
                     landing.BaseDirectory, package.Module!, activation,
-                    PrebuiltAssemblySeeder.DeclineReason);
+                    ModulePlatformFloor.DeclineReason);
                 if (decline is not null)
                     logger?.LogInformation(
                         "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",
@@ -329,13 +334,16 @@ public static class PluginBundleEndpoints
                 assemblies = assemblyRecords,
                 // The module section — the manifest names every closure file; a consumer reads
                 // this list, never the folder (BundleReader.ReadModule). Null (omitted) when the
-                // bundle carries no module.
+                // bundle carries no module. minMeshVersion is the consumer's landing gate (a
+                // semver floor — MVID equality is the NodeType lane's gate, and the frameworkMvid
+                // above is, for the module, diagnostics).
                 module = moduleFiles.Count == 0
                     ? null
                     : new
                     {
                         assemblyName = package.Module,
                         assemblies = moduleFiles.Select(Path.GetFileName).ToArray(),
+                        minMeshVersion = package.MinMeshVersion,
                     },
             },
             new JsonSerializerOptions
@@ -373,12 +381,15 @@ public static class PluginBundleEndpoints
                     rootHub.JsonSerializerOptions))
                 .Where(m => m is not null && !string.IsNullOrWhiteSpace(m.ReleasedVersion))
                 .Select(m => new BundleEntry(
-                    PackagingManifest.IdPrefix + m!.Id, m.ReleasedVersion!, m.Id, m.Module))
+                    PackagingManifest.IdPrefix + m!.Id, m.ReleasedVersion!, m.Id, m.Module,
+                    m.MinMeshVersion))
                 .OrderBy(e => e.PluginId, StringComparer.OrdinalIgnoreCase)
                 .ToArray());
 
-    /// <summary>One servable bundle: its package id, its released version, the plugin it is, and
-    /// the compiled module the plugin's install record declares (null for content-only plugins).</summary>
+    /// <summary>One servable bundle: its package id, its released version, the plugin it is, the
+    /// compiled module the plugin's install record declares (null for content-only plugins), and
+    /// that module's declared platform floor.</summary>
     private sealed record BundleEntry(
-        string PackageId, string Version, string PluginId, string? Module = null);
+        string PackageId, string Version, string PluginId, string? Module = null,
+        string? MinMeshVersion = null);
 }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -527,20 +527,23 @@ public static class MemexConfiguration
             //
             // #1664 step 9 — the effective set is the appsettings baseline ∪ the ENABLED entries
             // of the modules/activation.json sidecar (store-installed modules landed by
-            // ModuleLandingService), deduped by name. Sidecar entries are guarded: a recorded
-            // framework MVID that mismatches the running framework (an image roll happened since
-            // the install) or a missing DLL SKIPS the entry with a loud stderr line — never a
-            // crash, the deployment must boot; the entry stays for the post-roll re-install.
-            // Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship to Loki regardless).
+            // ModuleLandingService), deduped by name. Sidecar entries are guarded: a declared
+            // minMeshVersion FLOOR the running platform no longer satisfies (a rollback below the
+            // module's requirement) or a missing DLL SKIPS the entry with a loud stderr line —
+            // never a crash, the deployment must boot; the entry stays for when the platform
+            // moves forward again. A landed module's built-against MVID is diagnostic only:
+            // modules bind by simple name across platform builds (the strict MVID gate is the
+            // NodeType bake lane's). Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship
+            // to Loki regardless).
             var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
             var persistedActivation = ModuleActivationSidecar.Read(AppContext.BaseDirectory,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
                 moduleAssemblies,
                 persistedActivation,
-                // The ONE framework-identity gate (PrebuiltAssemblySeeder) — never a second
-                // notion of framework version.
-                PrebuiltAssemblySeeder.DeclineReason,
+                // The ONE module platform gate (ModulePlatformFloor) — never a second notion of
+                // the module platform requirement.
+                ModulePlatformFloor.DeclineReason,
                 // 🚨 modules/<name>/<name>.dll SPECIFICALLY — never ResolveModulePath, whose
                 // BaseDirectory fallback would let a sidecar entry with a lost modules/ folder
                 // silently bind a same-named app-closure DLL instead of being skipped. Baseline

--- a/memex/Memex.Portal.Shared/SelfUpdate/PlatformModuleUpdatePolicy.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/PlatformModuleUpdatePolicy.cs
@@ -1,0 +1,61 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.SelfUpdate;
+
+/// <summary>
+/// Wires the module lane's unattended-landing gate (<see cref="IModuleUpdatePolicy"/>, #1664) to
+/// the platform's EXISTING update-policy surface — the admin-editable <c>Admin/UpdatePolicy</c>
+/// node that already governs the image roll. There is deliberately NO module-specific knob:
+///
+/// <list type="bullet">
+///   <item><b>Continuous</b> (the platform default, and the value an ABSENT node reads as) —
+///     unattended module landing is allowed: store-installed modules track their registry the same
+///     way the platform tracks its image.</item>
+///   <item><b>Stable</b> / <b>None</b> — declined: a deployment that pins its image takes updates
+///     deliberately, and its modules must not run ahead of that choice. The catalog card's manual
+///     Update (and any explicit install) still lands the module — the gate covers only the
+///     background reconcile.</item>
+/// </list>
+///
+/// <para>Read through the storage adapter (authoritative point read — the same primitive the
+/// package reconcile uses for install records); an unreadable policy DECLINES with the error as the
+/// reason, because "could not check the operator's choice" must fail toward not acting.</para>
+/// </summary>
+public sealed class PlatformModuleUpdatePolicy(IMessageHub hub, ILogger<PlatformModuleUpdatePolicy> logger)
+    : IModuleUpdatePolicy
+{
+    /// <inheritdoc />
+    public IObservable<string?> DeclineUnattendedLanding()
+    {
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (storage is null)
+            // No storage = no persisted policy = the platform default (Continuous): allowed.
+            return Observable.Return<string?>(null);
+
+        return storage.Read(UpdatePolicyNodeType.NodePath, hub.JsonSerializerOptions)
+            .Take(1)
+            .Select(node =>
+            {
+                var policy = UpdatePolicyNodeType.Parse(node, hub.JsonSerializerOptions).Policy;
+                return policy == UpdatePolicyKind.Continuous
+                    ? null
+                    : $"the deployment's update policy is {policy} "
+                      + $"({UpdatePolicyNodeType.NodePath}) — unattended module updates ride the "
+                      + "Continuous channel only; use the catalog's manual Update instead";
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[SelfUpdate] could not read {Path} — declining unattended module landing "
+                    + "this pass.", UpdatePolicyNodeType.NodePath);
+                return Observable.Return<string?>(
+                    $"the update policy at {UpdatePolicyNodeType.NodePath} could not be read "
+                    + $"({ex.GetType().Name})");
+            });
+    }
+}

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
@@ -18,6 +18,12 @@ public static class SelfUpdateConfiguration
         builder.AddUpdatePolicyType();
         builder.ConfigureServices(services =>
         {
+            // The module lane's unattended-landing gate (#1664) rides the SAME Admin/UpdatePolicy
+            // node this feature owns — Continuous (default) lands store-installed modules
+            // unattended, Stable/None decline. Registered here, beside the node type, so a host
+            // without self-update simply has no policy provider and the PluginCatalog default
+            // (allowed) applies. Platform-neutral (a storage read), so no browser guard.
+            services.AddSingleton<MeshWeaver.PluginCatalog.IModuleUpdatePolicy, PlatformModuleUpdatePolicy>();
             // Bind from configuration when the caller passes nothing. Without this the defaults were
             // baked into the image: PollInterval sat at 6h with NO way for an environment to change
             // it, and a SelfUpdate__PollInterval in the configmap silently did nothing — the failure

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -68,18 +68,22 @@ folder is deleted, and the change likewise takes effect at restart.
 
 **The skip rules** (persisted entries only — the deployment must always boot):
 
-- **Framework-MVID mismatch** — an image roll changed the running framework since the install, so
-  the landed bytes are ABI-stale. The entry is SKIPPED with a loud log naming both identities and
-  stays in the sidecar, waiting for a re-install against the new framework. The gate is the same
-  pure function every prebuilt lane uses (`PrebuiltAssemblySeeder.DeclineReason`) — there is one
-  notion of framework identity, never two.
+- **Unsatisfied platform floor** — the running platform no longer satisfies the module's declared
+  `minMeshVersion` (a rollback below its requirement). The entry is SKIPPED with a loud log
+  naming both versions and stays in the sidecar, waiting for the platform to move forward again.
+  The gate is `ModulePlatformFloor.DeclineReason` — the ONE notion of the module platform
+  requirement, shared with landing and serving. Deliberately a **semver floor, never MVID
+  equality**: a module is a plain assembly binding by simple name, so a landed module keeps
+  loading across ordinary platform updates; the MVID it was built with is recorded on the entry
+  as diagnostics only (MVID equality is bake semantics and belongs to the NodeType assembly
+  lane).
 - **Missing DLL** — the entry's `modules/<name>/<name>.dll` does not exist (lost volume, manual
   deletion). Skipped loudly; re-install to heal. The check is that path SPECIFICALLY — a
   same-named DLL in the app closure never satisfies a store-installed entry (the
   `ResolveModulePath` base-directory fallback applies to baseline entries only, so a tampered
   sidecar can never silently bind the platform's own binaries).
 
-The landing service itself gates twice more, at placement: the same MVID check (declined bytes
+The landing service itself gates twice more, at placement: the same floor check (declined bytes
 never reach disk), and a refusal of any module whose entry DLL name collides with an app-closure
 assembly — `ResolveModulePath` probes `modules/<name>/` first, so such a module would silently
 shadow the platform's own binary at the next boot.
@@ -140,52 +144,59 @@ or **installed from the Store as part of an ordinary package**. The second rides
 transport end to end — there is deliberately no second distribution channel:
 
 1. **Declare** — the package's root `index.json` carries `content.module` naming the module's
-   entry-assembly (`"module": "MeshWeaver.Social"`). The listing reads it onto the catalog entry
-   (`PackageManifest.Module`) and the ordinary install-record stamp carries it onto the record. A
-   package with content nodes AND a module is one Store product — card, price, install funnel,
-   pre-install eligibility all unchanged.
+   entry-assembly (`"module": "MeshWeaver.Social"`), plus the platform floor it requires in the
+   `content.minMeshVersion` field authors already write. The listing reads both onto the catalog
+   entry (`PackageManifest.Module` / `.MinMeshVersion`) and the ordinary install-record stamp
+   carries them onto the record. A package with content nodes AND a module is one Store product —
+   card, price, install funnel, pre-install eligibility all unchanged.
 2. **Build** — `MeshWeaver.Plugin.Build`'s `module-pack` mode packs a built module's closure into
-   a bundle keyed to the framework MVID it was compiled against (read from the
-   `MeshWeaver.Graph.dll` in the build output — never guessed). It is a plain dotnet invocation
-   over an output folder, so ANY node repo's CI can drive it — SocialMedia builds its own module
-   bundle the same way the platform repo does. The closure is an explicit statement (`--with`),
-   never a folder scrape: a publish output contains the whole app closure, and bundling framework
-   assemblies would shadow the platform at the consumer.
+   a bundle recording the `minMeshVersion` floor (`--min-mesh-version`) and, as diagnostics, the
+   MVID of the `MeshWeaver.Graph.dll` in the build output. It is a plain dotnet invocation over
+   an output folder, so ANY node repo's CI can drive it — SocialMedia builds its own module
+   bundle the same way the platform repo does — and because the gate is the floor, ONE bundle
+   serves every compatible platform build: nothing is rebundled per CI build. The closure is an
+   explicit statement (`--with`), never a folder scrape: a publish output contains the whole app
+   closure, and bundling framework assemblies would shadow the platform at the consumer.
 3. **Serve** — the registry portal's `/api/plugins/bundles` serves the module section inside the
    SAME bundle that carries the package's NodeType assemblies (`meshweaver/modules/` beside
    `meshweaver/assemblies/`, one manifest naming both). The registry serves a module's bytes from
    its own `modules/<name>/` tree — the very bytes it loads and runs — and refuses to serve a
-   landing its own boot would skip (uninstalled, or framework-stale after its image roll). The
-   index stamps each bundle's `module` only when the bytes are actually servable, so a consumer
-   never downloads for a section that will not be there. Same instance-key auth, fail-closed.
+   landing its own boot would skip (uninstalled, or a floor the registry's own platform no longer
+   satisfies). The index stamps each bundle's `module` (and its floor) only when the bytes are
+   actually servable, so a consumer never downloads for a section that will not be there. Same
+   instance-key auth, fail-closed.
 4. **Land** — on install (and on update), a consumer whose package declares a module fetches the
-   bundle, verifies the framework MVID (`PrebuiltAssemblySeeder.DeclineReason` — the one identity,
-   checked at the index, at the manifest, and again at placement), and lands it through
-   `ModuleLandingService` into `modules/<name>/` with its activation entry (version recorded).
-   Restart-as-activation as above: `PendingRestart` is the signal, the next restart loads it.
+   bundle, verifies the **platform floor** (`ModulePlatformFloor.DeclineReason` — the one notion
+   of the module platform requirement, checked at the index, at the manifest, and again at
+   placement), and lands it through `ModuleLandingService` into `modules/<name>/` with its
+   activation entry (version + floor recorded; the built-against MVID recorded as diagnostics).
+   Deliberately **not** MVID equality — that is bake semantics, the NodeType lane's gate: a
+   module binds by simple name, so a bundle built against an older platform installs ex post on
+   any deployment satisfying its floor. Restart-as-activation as above: `PendingRestart` is the
+   signal, the next restart loads it.
 
 ### Auto-update
 
 Store-installed modules **update themselves by default**. The boot reconcile
 (`RegistryUpdateReconciler`) runs a module pass after the content pass: for every installed
 module-declaring package it consults the registry's bundle index and applies the one pure decision
-(`ModuleUpdateDecision`) — a newer version **for the running framework MVID** lands via
+(`ModuleUpdateDecision`) — a newer version whose **floor this platform satisfies** lands via
 `ModuleLandingService` and flags `PendingRestart`; the same served version is skipped without a
-download; a bundle for a **different** framework MVID is skipped silently-with-log (it becomes
-relevant after the next image roll, when the same reconcile re-lands current bytes — that re-land
-is also how a landing orphaned by an image roll heals). Nothing is ever rolled back unattended.
+download; a bundle whose floor **exceeds** the running platform is skipped silently-with-log (it
+becomes installable once the platform has updated, and the same reconcile lands it then). Nothing
+is ever rolled back unattended — and an ordinary platform update needs no module re-land at all:
+landed modules keep loading across platform builds.
 
 The policy gate is the deployment's **existing update policy — `Admin/UpdatePolicy`**, the same
 single surface that governs the platform image roll; there is no module-specific knob.
 **Continuous — the platform default, and what an absent policy reads as — lands unattended;
 Stable and None decline the UPGRADE** (the catalog's manual Update still works there): a
 deployment that pins its image takes updates deliberately, and its modules do not run ahead of
-that choice. Two landings are deliberately policy-exempt, because gating them turns "no unattended
-updates" into "the module breaks": a **first landing** completes an install the operator's own
-surfaces already sanctioned, and the **image-roll heal** (re-landing the same version for the new
-framework MVID) keeps what was installed working after a roll the operator chose. The wiring is
-`IModuleUpdatePolicy` (`MeshWeaver.PluginCatalog`), implemented by the memex portals over the
-policy node; a host that registers no implementation gets the default (allowed).
+that choice. A **first landing** is deliberately policy-exempt: it completes an install the
+operator's own surfaces already sanctioned, and gating it would ship a package whose binary half
+never arrives. The wiring is `IModuleUpdatePolicy` (`MeshWeaver.PluginCatalog`), implemented by
+the memex portals over the policy node; a host that registers no implementation gets the default
+(allowed).
 
 ## Modules and the in-mesh compiler
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -133,6 +133,60 @@ none; the engine's package closure still rides the app via other references). Be
 DLL exists nowhere else, the closure lane also lays it into a plain build's output
 (`bin/…/modules/`), keeping `dotnet run` on a host working without a publish step.
 
+## The bundle lane — modules as Store packages (#1664)
+
+A compiled module reaches a deployment one of two ways: shipped in the image (the baseline above),
+or **installed from the Store as part of an ordinary package**. The second rides the plugin bundle
+transport end to end — there is deliberately no second distribution channel:
+
+1. **Declare** — the package's root `index.json` carries `content.module` naming the module's
+   entry-assembly (`"module": "MeshWeaver.Social"`). The listing reads it onto the catalog entry
+   (`PackageManifest.Module`) and the ordinary install-record stamp carries it onto the record. A
+   package with content nodes AND a module is one Store product — card, price, install funnel,
+   pre-install eligibility all unchanged.
+2. **Build** — `MeshWeaver.Plugin.Build`'s `module-pack` mode packs a built module's closure into
+   a bundle keyed to the framework MVID it was compiled against (read from the
+   `MeshWeaver.Graph.dll` in the build output — never guessed). It is a plain dotnet invocation
+   over an output folder, so ANY node repo's CI can drive it — SocialMedia builds its own module
+   bundle the same way the platform repo does. The closure is an explicit statement (`--with`),
+   never a folder scrape: a publish output contains the whole app closure, and bundling framework
+   assemblies would shadow the platform at the consumer.
+3. **Serve** — the registry portal's `/api/plugins/bundles` serves the module section inside the
+   SAME bundle that carries the package's NodeType assemblies (`meshweaver/modules/` beside
+   `meshweaver/assemblies/`, one manifest naming both). The registry serves a module's bytes from
+   its own `modules/<name>/` tree — the very bytes it loads and runs — and refuses to serve a
+   landing its own boot would skip (uninstalled, or framework-stale after its image roll). The
+   index stamps each bundle's `module` only when the bytes are actually servable, so a consumer
+   never downloads for a section that will not be there. Same instance-key auth, fail-closed.
+4. **Land** — on install (and on update), a consumer whose package declares a module fetches the
+   bundle, verifies the framework MVID (`PrebuiltAssemblySeeder.DeclineReason` — the one identity,
+   checked at the index, at the manifest, and again at placement), and lands it through
+   `ModuleLandingService` into `modules/<name>/` with its activation entry (version recorded).
+   Restart-as-activation as above: `PendingRestart` is the signal, the next restart loads it.
+
+### Auto-update
+
+Store-installed modules **update themselves by default**. The boot reconcile
+(`RegistryUpdateReconciler`) runs a module pass after the content pass: for every installed
+module-declaring package it consults the registry's bundle index and applies the one pure decision
+(`ModuleUpdateDecision`) — a newer version **for the running framework MVID** lands via
+`ModuleLandingService` and flags `PendingRestart`; the same served version is skipped without a
+download; a bundle for a **different** framework MVID is skipped silently-with-log (it becomes
+relevant after the next image roll, when the same reconcile re-lands current bytes — that re-land
+is also how a landing orphaned by an image roll heals). Nothing is ever rolled back unattended.
+
+The policy gate is the deployment's **existing update policy — `Admin/UpdatePolicy`**, the same
+single surface that governs the platform image roll; there is no module-specific knob.
+**Continuous — the platform default, and what an absent policy reads as — lands unattended;
+Stable and None decline the UPGRADE** (the catalog's manual Update still works there): a
+deployment that pins its image takes updates deliberately, and its modules do not run ahead of
+that choice. Two landings are deliberately policy-exempt, because gating them turns "no unattended
+updates" into "the module breaks": a **first landing** completes an install the operator's own
+surfaces already sanctioned, and the **image-roll heal** (re-landing the same version for the new
+framework MVID) keeps what was installed working after a roll the operator chose. The wiring is
+`IModuleUpdatePolicy` (`MeshWeaver.PluginCatalog`), implemented by the memex portals over the
+policy node; a host that registers no implementation gets the default (allowed).
+
 ## Modules and the in-mesh compiler
 
 In-mesh source compiles against the platform's `TRUSTED_PLATFORM_ASSEMBLIES` **plus this mesh's

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -161,7 +161,7 @@ A package that delivers a **compiled module** (its root's `content.module` names
 assembly) carries the module's closure in the SAME bundle, under its own folder:
 
 ```
-├── meshweaver/manifest.json          … + module: { assemblyName, assemblies[] }
+├── meshweaver/manifest.json          … + module: { assemblyName, assemblies[], minMeshVersion }
 ├── meshweaver/assemblies/<Unit>.dll  NodeType lane (assembly store, per-node ALC)
 └── meshweaver/modules/<File>.dll     module lane (modules/<name>/ beside the app, default ALC)
 ```
@@ -173,14 +173,23 @@ both manifest-driven, and the module side is **all-or-nothing** (a NodeType with
 simply compiles; a module missing part of its closure loads and then faults at first use, so an
 incomplete closure yields no files at all).
 
-Producing a module bundle in CI — from any node repo, keyed to the framework MVID the module was
-actually compiled against (read from the `MeshWeaver.Graph.dll` in the build output; there is no
-default and no version-string fallback):
+**The module gate is a `minMeshVersion` FLOOR, not the MVID.** The MVID-equality rule above is
+*bake* semantics: a NodeType assembly is compiled in-process against exact framework references,
+so only the identical build is known-good. A module is an ordinary assembly binding by **simple
+name**; its contract is API compatibility, which the semver floor expresses. So the consumer lands
+any bundle whose floor its platform satisfies — one bundle serves every compatible platform build
+(nothing is rebundled per CI build), and a module can be installed **ex post** onto a platform
+newer than the one it was built with. The bundle still records its built-against `frameworkMvid`
+as **diagnostic metadata** — logged at landing, surfaced in the index — never a refusal. The one
+gate is `ModulePlatformFloor.DeclineReason`, applied at the index, at the manifest, at placement,
+and again at boot.
+
+Producing a module bundle in CI — from any node repo:
 
 ```
 dotnet run --project src/MeshWeaver.Plugin.Build -- module-pack ./bin/Release/net10.0 \
     --module-name MeshWeaver.Social --plugin SocialMedia --package-version 1.2.0 \
-    --out ./artifacts/bundles
+    --min-mesh-version 3.0.0 --out ./artifacts/bundles
 ```
 
 The closure is an explicit statement: `<name>.dll` (+ `.pdb`), plus only the files named with

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -155,6 +155,40 @@ become `<dependency id="MeshWeaver.Plugin.Store" version="[1.0.0,2.0.0)" />`. No
 One reserved id prefix (`MeshWeaver.Plugin.`) is what lets `packageSourceMapping` pin every plugin to
 a private feed with a single rule — without it a typo'd id silently resolves against nuget.org.
 
+### The module variant (#1664)
+
+A package that delivers a **compiled module** (its root's `content.module` names the entry
+assembly) carries the module's closure in the SAME bundle, under its own folder:
+
+```
+├── meshweaver/manifest.json          … + module: { assemblyName, assemblies[] }
+├── meshweaver/assemblies/<Unit>.dll  NodeType lane (assembly store, per-node ALC)
+└── meshweaver/modules/<File>.dll     module lane (modules/<name>/ beside the app, default ALC)
+```
+
+The folders are deliberately separate — the two lanes have different destinations and different
+failure modes, and a module DLL seeded as a NodeType assembly fails only at activation. One reader
+(`BundleReader`) serves both: `Read` for the NodeType payloads, `ReadModule` for the module files —
+both manifest-driven, and the module side is **all-or-nothing** (a NodeType with missing bytes
+simply compiles; a module missing part of its closure loads and then faults at first use, so an
+incomplete closure yields no files at all).
+
+Producing a module bundle in CI — from any node repo, keyed to the framework MVID the module was
+actually compiled against (read from the `MeshWeaver.Graph.dll` in the build output; there is no
+default and no version-string fallback):
+
+```
+dotnet run --project src/MeshWeaver.Plugin.Build -- module-pack ./bin/Release/net10.0 \
+    --module-name MeshWeaver.Social --plugin SocialMedia --package-version 1.2.0 \
+    --out ./artifacts/bundles
+```
+
+The closure is an explicit statement: `<name>.dll` (+ `.pdb`), plus only the files named with
+`--with` — mirroring the `modules/<Name>/` rule that for most modules the DLL alone is the
+closure. The portal-served side assembles the module section from its own `modules/<name>/` tree
+(the bytes it runs), and the consuming side lands it through `ModuleLandingService`
+(restart-as-activation) — see [Modules](/Doc/Architecture/Modules) → "The bundle lane".
+
 **The assembly entry path is the node path verbatim**, not slash-replaced. Sanitising is not
 injective — `A/B/C` and `A_B/C` both become `A_B_C`, and mesh paths do contain underscores — so two
 NodeTypes would land on one archive entry and the second would silently adopt the first's bytes. Zip

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-modules-install-and-update-from-the-store.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-modules-install-and-update-from-the-store.md
@@ -13,8 +13,8 @@ one install. Installing such a package lands the module next to the portal, and 
 at the next restart (the portal tells you a restart is pending).
 
 From then on the module keeps itself current: whenever your instance checks its registry, a newer
-build of an installed module is picked up automatically — under the same update policy that
+version of an installed module is picked up automatically — under the same update policy that
 already governs platform updates (Settings → Updates). Continuous, the default, updates modules
 unattended; Stable or Manual leaves them untouched until you update from the catalog yourself. A
-module built for a different platform version than yours is never installed — it simply waits
-until your platform has rolled forward, then arrives on its own.
+module that requires a newer platform than yours is never installed early — it simply waits until
+your platform has caught up, then arrives on its own.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-modules-install-and-update-from-the-store.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-modules-install-and-update-from-the-store.md
@@ -1,0 +1,20 @@
+---
+Name: Modules install and update from the Store
+Category: Feature
+Description: A Store package can now carry a compiled module — it installs through the normal funnel, and updates itself automatically under your instance's existing update policy (Continuous by default).
+Icon: Sparkle
+Order: -20260816
+---
+
+# Modules install and update from the Store
+
+A Store package can now deliver a compiled module alongside its content — one product, one card,
+one install. Installing such a package lands the module next to the portal, and it starts working
+at the next restart (the portal tells you a restart is pending).
+
+From then on the module keeps itself current: whenever your instance checks its registry, a newer
+build of an installed module is picked up automatically — under the same update policy that
+already governs platform updates (Settings → Updates). Continuous, the default, updates modules
+unattended; Stable or Manual leaves them untouched until you update from the catalog yourself. A
+module built for a different platform version than yours is never installed — it simply waits
+until your platform has rolled forward, then arrives on its own.

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using MeshWeaver.Plugin.Packaging;
 
 namespace MeshWeaver.Plugin.Build;
@@ -36,6 +37,29 @@ public static class ModulePackCommand
 {
     /// <summary>The CLI verb.</summary>
     public const string Verb = "module-pack";
+
+    // 🚨 These values flow into FILE PATHS (the entry-DLL probe, the closure entries, the output
+    // bundle name) and into the bundle manifest, so they are validated to a safe shape before any
+    // path is composed — "../evil" as a module name must be a clear exit-2, never a probe outside
+    // the module folder or a bundle written somewhere surprising.
+
+    /// <summary>Assembly-/package-id shape: dot-separated segments of letters, digits, '_' and
+    /// '-'. No path separators, no empty segments, so no "." / ".." / traversal by construction.</summary>
+    private static readonly Regex IdentifierShape =
+        new(@"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*$", RegexOptions.Compiled);
+
+    /// <summary>SemVer-ish shape: numeric core (2–4 parts, matching what manifests carry) with
+    /// optional pre-release / build-metadata tail. Path separators are impossible here.</summary>
+    private static readonly Regex VersionShape =
+        new(@"^\d+(\.\d+){1,3}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$", RegexOptions.Compiled);
+
+    private static bool Invalid(string what, string? value, Regex shape, string constraint)
+    {
+        if (value is not null && shape.IsMatch(value))
+            return false;
+        Console.Error.WriteLine($"error: {what} '{value}' is invalid — {constraint}");
+        return true;
+    }
 
     /// <summary>Runs the command; returns the process exit code.</summary>
     public static int Run(string[] args)
@@ -130,6 +154,19 @@ public static class ModulePackCommand
                 + "its manifest.lock `version`)");
             return 2;
         }
+
+        // Validate BEFORE composing a single path from these values (see the shapes above).
+        const string identifierConstraint =
+            "dot-separated segments of letters, digits, '_' and '-' (e.g. MeshWeaver.Social); "
+            + "no path separators";
+        const string versionConstraint =
+            "a SemVer-shaped version (e.g. 1.2.0 or 1.2.0-rc1)";
+        if (Invalid("--module-name", moduleName, IdentifierShape, identifierConstraint)
+            || Invalid("--plugin", plugin, IdentifierShape, identifierConstraint)
+            || Invalid("--package-version", packageVersion, VersionShape, versionConstraint)
+            || (minMeshVersion is not null
+                && Invalid("--min-mesh-version", minMeshVersion, VersionShape, versionConstraint)))
+            return 2;
 
         var entryDll = Path.Combine(moduleDirectory, moduleName + ".dll");
         if (!File.Exists(entryDll))

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -5,7 +5,7 @@ namespace MeshWeaver.Plugin.Build;
 
 /// <summary>
 /// The <c>module-pack</c> mode (#1664 Slice B): produces a MODULE bundle from a built module
-/// project's output, keyed to the framework MVID the module was actually compiled against.
+/// project's output.
 ///
 /// <para><b>Reusable from any node repo by design.</b> The maintainer's constraint on the bundle
 /// lane is that SocialMedia (and every other satellite repo that owns a module) drives the same
@@ -14,7 +14,7 @@ namespace MeshWeaver.Plugin.Build;
 ///
 /// <code>
 /// dotnet run --project src/MeshWeaver.Plugin.Build -- module-pack ./artifacts/modules/MeshWeaver.Social \
-///     --plugin SocialMedia --package-version 1.2.0 --out ./artifacts/bundles
+///     --plugin SocialMedia --package-version 1.2.0 --min-mesh-version 3.0.0 --out ./artifacts/bundles
 /// </code>
 ///
 /// <para><b>The closure is an explicit statement, never a scrape.</b> A publish output contains the
@@ -24,10 +24,13 @@ namespace MeshWeaver.Plugin.Build;
 /// <c>.pdb</c> when present) plus ONLY the files the caller names with <c>--with</c> — mirroring
 /// the modules/&lt;Name&gt;/ layout rule that for most modules the DLL alone is the closure.</para>
 ///
-/// <para><b>The MVID is read, never assumed.</b> The framework identity is the MVID of the
-/// <c>MeshWeaver.Graph.dll</c> the module restored against (its copy rides the build output);
-/// there is no default and no version-string fallback, because a bundle keyed to the wrong MVID is
-/// declined everywhere and a bundle keyed to a GUESSED one would land and fault at the next boot.</para>
+/// <para><b>The consumer's gate is the <c>minMeshVersion</c> FLOOR, not an MVID.</b> A module is a
+/// plain assembly binding by simple name; its contract is API compatibility, so the bundle records
+/// the platform floor the module requires (absent = no constraint) and the consumer lands anything
+/// whose floor it satisfies — one bundle serves every compatible platform build, and nothing needs
+/// rebundling per CI build. The MVID of the <c>MeshWeaver.Graph.dll</c> in the build output is
+/// still recorded when found, as DIAGNOSTIC metadata naming the exact build behind the bytes;
+/// MVID equality remains the NodeType (bake) lane's gate only.</para>
 /// </summary>
 public static class ModulePackCommand
 {
@@ -52,9 +55,15 @@ public static class ModulePackCommand
                                               manifest.lock version); there is no default, because
                                               a bundle at an invented version collides with the
                                               repo's immutable release numbering
+                  --min-mesh-version <v>      the platform FLOOR the module requires — the
+                                              consumer's landing gate (API compatibility as a
+                                              semver floor). Omit for no constraint; mirror the
+                                              package's content.minMeshVersion when it declares one
                   --graph-dll <path>          the MeshWeaver.Graph.dll the module was built against
-                                              (default: <moduleOutputDir>/MeshWeaver.Graph.dll);
-                                              its MVID keys the bundle
+                                              (default: <moduleOutputDir>/MeshWeaver.Graph.dll).
+                                              Its MVID is recorded as DIAGNOSTIC metadata — the
+                                              exact build behind the bytes — never a gate; a
+                                              missing DLL warns and records none
                   --with <fileName>           an additional closure file from <moduleOutputDir>
                                               (repeatable). <name>.dll is always included, and its
                                               .pdb rides along when present.
@@ -73,6 +82,7 @@ public static class ModulePackCommand
         var moduleName = Path.GetFileName(moduleDirectory.TrimEnd(Path.DirectorySeparatorChar));
         string? plugin = null;
         string? packageVersion = null;
+        string? minMeshVersion = null;
         string? graphDll = null;
         var extras = new List<string>();
         var outputDirectory = Environment.CurrentDirectory;
@@ -89,6 +99,9 @@ public static class ModulePackCommand
                     break;
                 case "--package-version" when i + 1 < args.Length:
                     packageVersion = args[++i];
+                    break;
+                case "--min-mesh-version" when i + 1 < args.Length:
+                    minMeshVersion = args[++i];
                     break;
                 case "--graph-dll" when i + 1 < args.Length:
                     graphDll = Path.GetFullPath(args[++i]);
@@ -127,19 +140,20 @@ public static class ModulePackCommand
             return 2;
         }
 
+        // The MVID is DIAGNOSTIC metadata (which exact platform build produced these bytes) —
+        // recorded when the restored MeshWeaver.Graph.dll is at hand, warned-and-omitted when not.
+        // It is deliberately not required and never a gate: the consumer lands on the
+        // minMeshVersion floor (API compatibility), and MVID equality stays with the NodeType
+        // bake lane.
         graphDll ??= Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
-        if (!File.Exists(graphDll))
-        {
+        string? frameworkMvid = null;
+        if (File.Exists(graphDll))
+            frameworkMvid = FrameworkIdentity.ReadMvid(graphDll);
+        else
             Console.Error.WriteLine(
-                $"error: {FrameworkIdentity.IdentityAssembly}.dll not found at {graphDll} — the "
-                + "bundle is keyed to the framework MVID the module was BUILT against, and there "
-                + "is no default: a guessed identity lands bytes that fault at the next boot. "
-                + "Point --graph-dll at the restored framework assembly (it rides the module's "
-                + "build output when CopyLocal is on).");
-            return 2;
-        }
-
-        var frameworkMvid = FrameworkIdentity.ReadMvid(graphDll);
+                $"warning: {FrameworkIdentity.IdentityAssembly}.dll not found at {graphDll} — the "
+                + "bundle records no built-against framework MVID (diagnostic metadata only; the "
+                + "landing gate is --min-mesh-version).");
 
         // The closure: entry DLL (+ symbols when present) + exactly the files the caller named.
         var closure = new List<string> { moduleName + ".dll" };
@@ -173,12 +187,16 @@ public static class ModulePackCommand
             {
                 plugin,
                 version = packageVersion,
-                // 🚨 The identity a consumer verifies before landing a single byte. The runtime
-                // compares MVIDs, never version strings.
+                // Diagnostic: the exact platform build behind these bytes. The consumer's GATE is
+                // the module section's minMeshVersion floor below.
                 frameworkMvid,
-                module = new { assemblyName = moduleName, assemblies = closure },
+                module = new { assemblyName = moduleName, assemblies = closure, minMeshVersion },
             },
-            new JsonSerializerOptions { WriteIndented = true });
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            });
 
         var entries = closure
             .Select(fileName =>
@@ -199,7 +217,8 @@ public static class ModulePackCommand
 
         Console.WriteLine(
             $"packed {Path.GetFileName(bundlePath)} — module {moduleName}, "
-            + $"{closure.Count} file(s), framework MVID {frameworkMvid}");
+            + $"{closure.Count} file(s), floor {minMeshVersion ?? "(none)"}, "
+            + $"built-against MVID {frameworkMvid ?? "(unrecorded)"}");
         return 0;
     }
 }

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using MeshWeaver.Plugin.Packaging;
+
+namespace MeshWeaver.Plugin.Build;
+
+/// <summary>
+/// The <c>module-pack</c> mode (#1664 Slice B): produces a MODULE bundle from a built module
+/// project's output, keyed to the framework MVID the module was actually compiled against.
+///
+/// <para><b>Reusable from any node repo by design.</b> The maintainer's constraint on the bundle
+/// lane is that SocialMedia (and every other satellite repo that owns a module) drives the same
+/// packer the platform does — so this is a plain dotnet-tool invocation over a build output folder,
+/// with no assumption about which repo's CI is calling:</para>
+///
+/// <code>
+/// dotnet run --project src/MeshWeaver.Plugin.Build -- module-pack ./artifacts/modules/MeshWeaver.Social \
+///     --plugin SocialMedia --package-version 1.2.0 --out ./artifacts/bundles
+/// </code>
+///
+/// <para><b>The closure is an explicit statement, never a scrape.</b> A publish output contains the
+/// whole app closure — framework assemblies included — and bundling those would ship the platform
+/// inside a module (and shadow it at the consumer, which is exactly what
+/// <c>ModuleLandingService</c> refuses). So the bundle carries <c>&lt;name&gt;.dll</c> (+
+/// <c>.pdb</c> when present) plus ONLY the files the caller names with <c>--with</c> — mirroring
+/// the modules/&lt;Name&gt;/ layout rule that for most modules the DLL alone is the closure.</para>
+///
+/// <para><b>The MVID is read, never assumed.</b> The framework identity is the MVID of the
+/// <c>MeshWeaver.Graph.dll</c> the module restored against (its copy rides the build output);
+/// there is no default and no version-string fallback, because a bundle keyed to the wrong MVID is
+/// declined everywhere and a bundle keyed to a GUESSED one would land and fault at the next boot.</para>
+/// </summary>
+public static class ModulePackCommand
+{
+    /// <summary>The CLI verb.</summary>
+    public const string Verb = "module-pack";
+
+    /// <summary>Runs the command; returns the process exit code.</summary>
+    public static int Run(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help")
+        {
+            Console.WriteLine("""
+                usage: meshweaver-plugin-build module-pack <moduleOutputDir> [options]
+
+                  <moduleOutputDir>           the built module's output folder (bin/Release/net10.0,
+                                              a publish folder, or a curated modules/<Name>/ layout)
+                  --module-name <name>        the module's entry-assembly name without extension
+                                              (default: the folder name)
+                  --plugin <id>               the package id the bundle belongs to (default: the
+                                              module name) — must match the repo's plugin folder
+                  --package-version <v>       REQUIRED — the module package's released SemVer (the
+                                              manifest.lock version); there is no default, because
+                                              a bundle at an invented version collides with the
+                                              repo's immutable release numbering
+                  --graph-dll <path>          the MeshWeaver.Graph.dll the module was built against
+                                              (default: <moduleOutputDir>/MeshWeaver.Graph.dll);
+                                              its MVID keys the bundle
+                  --with <fileName>           an additional closure file from <moduleOutputDir>
+                                              (repeatable). <name>.dll is always included, and its
+                                              .pdb rides along when present.
+                  --out <dir>                 where to write the bundle (default: current directory)
+                """);
+            return 0;
+        }
+
+        var moduleDirectory = Path.GetFullPath(args[0]);
+        if (!Directory.Exists(moduleDirectory))
+        {
+            Console.Error.WriteLine($"error: module output directory not found: {moduleDirectory}");
+            return 2;
+        }
+
+        var moduleName = Path.GetFileName(moduleDirectory.TrimEnd(Path.DirectorySeparatorChar));
+        string? plugin = null;
+        string? packageVersion = null;
+        string? graphDll = null;
+        var extras = new List<string>();
+        var outputDirectory = Environment.CurrentDirectory;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--module-name" when i + 1 < args.Length:
+                    moduleName = args[++i];
+                    break;
+                case "--plugin" when i + 1 < args.Length:
+                    plugin = args[++i];
+                    break;
+                case "--package-version" when i + 1 < args.Length:
+                    packageVersion = args[++i];
+                    break;
+                case "--graph-dll" when i + 1 < args.Length:
+                    graphDll = Path.GetFullPath(args[++i]);
+                    break;
+                case "--with" when i + 1 < args.Length:
+                    extras.Add(args[++i]);
+                    break;
+                case "--out" when i + 1 < args.Length:
+                    outputDirectory = Path.GetFullPath(args[++i]);
+                    break;
+                default:
+                    Console.Error.WriteLine($"error: unrecognised argument '{args[i]}'");
+                    return 2;
+            }
+        }
+
+        plugin ??= moduleName;
+
+        // 🚨 Required, no default: the version names an immutable release (manifest.lock /
+        // <Module>/vX.Y.Z tag), and minting one here would fork the version namespace the repo's
+        // tagging exists to keep single.
+        if (string.IsNullOrWhiteSpace(packageVersion))
+        {
+            Console.Error.WriteLine(
+                "error: --package-version is required (the module package's released SemVer — "
+                + "its manifest.lock `version`)");
+            return 2;
+        }
+
+        var entryDll = Path.Combine(moduleDirectory, moduleName + ".dll");
+        if (!File.Exists(entryDll))
+        {
+            Console.Error.WriteLine(
+                $"error: entry assembly not found: {entryDll} — a module bundle without its entry "
+                + "DLL could never load; check --module-name against the build output");
+            return 2;
+        }
+
+        graphDll ??= Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
+        if (!File.Exists(graphDll))
+        {
+            Console.Error.WriteLine(
+                $"error: {FrameworkIdentity.IdentityAssembly}.dll not found at {graphDll} — the "
+                + "bundle is keyed to the framework MVID the module was BUILT against, and there "
+                + "is no default: a guessed identity lands bytes that fault at the next boot. "
+                + "Point --graph-dll at the restored framework assembly (it rides the module's "
+                + "build output when CopyLocal is on).");
+            return 2;
+        }
+
+        var frameworkMvid = FrameworkIdentity.ReadMvid(graphDll);
+
+        // The closure: entry DLL (+ symbols when present) + exactly the files the caller named.
+        var closure = new List<string> { moduleName + ".dll" };
+        var entryPdb = moduleName + ".pdb";
+        if (File.Exists(Path.Combine(moduleDirectory, entryPdb)))
+            closure.Add(entryPdb);
+        foreach (var extra in extras)
+        {
+            if (Path.GetFileName(extra) != extra)
+            {
+                Console.Error.WriteLine(
+                    $"error: --with takes a plain file name inside the module folder, got '{extra}'");
+                return 2;
+            }
+            if (!File.Exists(Path.Combine(moduleDirectory, extra)))
+            {
+                Console.Error.WriteLine(
+                    $"error: --with file not found: {Path.Combine(moduleDirectory, extra)} — "
+                    + "packing a partial closure would land a module that faults at first use");
+                return 2;
+            }
+            if (!closure.Contains(extra, StringComparer.OrdinalIgnoreCase))
+                closure.Add(extra);
+        }
+
+        var manifest = new PluginManifest(
+            plugin, PluginManifest.IdPrefix + plugin, packageVersion, plugin, null, []);
+
+        var manifestJson = JsonSerializer.Serialize(
+            new
+            {
+                plugin,
+                version = packageVersion,
+                // 🚨 The identity a consumer verifies before landing a single byte. The runtime
+                // compares MVIDs, never version strings.
+                frameworkMvid,
+                module = new { assemblyName = moduleName, assemblies = closure },
+            },
+            new JsonSerializerOptions { WriteIndented = true });
+
+        var entries = closure
+            .Select(fileName =>
+            {
+                var path = Path.Combine(moduleDirectory, fileName);
+                return new NuGetPackageWriter.Entry(
+                    NuGetPackageWriter.ModuleEntryPathFor(fileName), () => File.OpenRead(path));
+            })
+            .ToList();
+
+        Directory.CreateDirectory(outputDirectory);
+        var bundlePath = Path.Combine(
+            outputDirectory, $"{manifest.PackageId}.{packageVersion}.module.nupkg");
+        if (File.Exists(bundlePath))
+            File.Delete(bundlePath);
+        using (var output = File.Create(bundlePath))
+            NuGetPackageWriter.Write(output, manifest, packageVersion, entries, manifestJson);
+
+        Console.WriteLine(
+            $"packed {Path.GetFileName(bundlePath)} — module {moduleName}, "
+            + $"{closure.Count} file(s), framework MVID {frameworkMvid}");
+        return 0;
+    }
+}

--- a/src/MeshWeaver.Plugin.Build/Program.cs
+++ b/src/MeshWeaver.Plugin.Build/Program.cs
@@ -9,10 +9,17 @@ using MeshWeaver.Plugin.Build;
 // (unless --no-build) builds them. Exit code 0 only when EVERY unit built: a partial plugin is
 // worse than an unbuilt one, because a consumer resolving a mixed set gets a silent ABI mismatch.
 
+// The module-pack verb (#1664): packs a built MODULE's closure into a bundle keyed to the
+// framework MVID it was compiled against — invocable from any node repo's CI. Everything below
+// this dispatch is the classic per-NodeType plugin build.
+if (args.Length > 0 && args[0] == ModulePackCommand.Verb)
+    return ModulePackCommand.Run(args.Skip(1).ToArray());
+
 if (args.Length == 0 || args[0] is "-h" or "--help")
 {
     Console.WriteLine("""
         usage: meshweaver-plugin-build <pluginDirectory> [options]
+               meshweaver-plugin-build module-pack <moduleOutputDir> [options]   (see module-pack --help)
 
           --out <dir>                 where to write generated projects (default: ./obj/plugin-build)
           --framework-version <v>     MeshWeaver package version to compile against, or `latest`

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -39,7 +39,12 @@ public static class BundleReader
     /// <c>modules/&lt;name&gt;/</c> folders use.</param>
     /// <param name="Assemblies">File names inside <see cref="NuGetPackageWriter.ModuleFolder"/> —
     /// the module's private closure (for most modules just <c>&lt;AssemblyName&gt;.dll</c>).</param>
-    public sealed record ModuleRef(string? AssemblyName, IReadOnlyList<string>? Assemblies);
+    /// <param name="MinMeshVersion">The module's declared platform FLOOR — the consumer's landing
+    /// gate (a plain .NET assembly binding by simple name is compatible by API, expressed as a
+    /// semver floor). Null = no constraint. The manifest-level <see cref="Manifest.FrameworkMvid"/>
+    /// stays the NodeType lane's strict gate and, for the module, DIAGNOSTIC metadata only.</param>
+    public sealed record ModuleRef(
+        string? AssemblyName, IReadOnlyList<string>? Assemblies, string? MinMeshVersion = null);
 
     /// <summary>One landed-to-be module file: its name and bytes.</summary>
     /// <param name="FileName">File name as the manifest declared it.</param>

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -18,16 +18,33 @@ public static class BundleReader
     /// <param name="FrameworkMvid">MVID of the MeshWeaver.Graph assembly that compiled these bytes.
     /// Null when the producer recorded none, which a consumer must treat as "cannot adopt".</param>
     /// <param name="Assemblies">One entry per compiled NodeType.</param>
+    /// <param name="Module">The compiled MODULE this bundle carries (#1664), or null for a
+    /// NodeType-only bundle. A MIXED package (content + NodeTypes + a module) carries both
+    /// <paramref name="Assemblies"/> and this in ONE bundle — one reader, one transport.</param>
     public sealed record Manifest(
         string? Plugin,
         string? Version,
         string? FrameworkMvid,
-        IReadOnlyList<AssemblyRef>? Assemblies);
+        IReadOnlyList<AssemblyRef>? Assemblies,
+        ModuleRef? Module = null);
 
     /// <summary>One assembly and the NodeType it implements.</summary>
     /// <param name="NodePath">Mesh path of the NodeType — the key a consumer re-seeds under.</param>
     /// <param name="Assembly">File name inside <see cref="NuGetPackageWriter.AssemblyFolder"/>.</param>
     public sealed record AssemblyRef(string NodePath, string Assembly);
+
+    /// <summary>The bundle's compiled-module declaration.</summary>
+    /// <param name="AssemblyName">The module's entry-assembly name WITHOUT extension
+    /// (e.g. <c>MeshWeaver.Social</c>) — the same identity <c>Modules:Assemblies</c> entries and
+    /// <c>modules/&lt;name&gt;/</c> folders use.</param>
+    /// <param name="Assemblies">File names inside <see cref="NuGetPackageWriter.ModuleFolder"/> —
+    /// the module's private closure (for most modules just <c>&lt;AssemblyName&gt;.dll</c>).</param>
+    public sealed record ModuleRef(string? AssemblyName, IReadOnlyList<string>? Assemblies);
+
+    /// <summary>One landed-to-be module file: its name and bytes.</summary>
+    /// <param name="FileName">File name as the manifest declared it.</param>
+    /// <param name="Bytes">The file's bytes.</param>
+    public sealed record ModuleFile(string FileName, byte[] Bytes);
 
     /// <summary>An assembly's bytes, ready to seed.</summary>
     /// <param name="NodePath">Mesh path of the NodeType these bytes implement.</param>
@@ -85,6 +102,50 @@ public static class BundleReader
         }
 
         return (manifest, payloads);
+    }
+
+    /// <summary>
+    /// Extracts the manifest and the MODULE closure files it names (#1664) — the module half of the
+    /// same bundle <see cref="Read"/> serves NodeType assemblies from.
+    ///
+    /// <para>Manifest-driven like <see cref="Read"/>, for the same reason: the manifest is the
+    /// producer's statement of which files belong to the module, and enumerating
+    /// <see cref="NuGetPackageWriter.ModuleFolder"/> instead would adopt any stray entry a future
+    /// writer happens to place there. A file the manifest names but the archive lacks is FATAL here,
+    /// unlike the NodeType path: a NodeType with missing bytes simply compiles, but a module folder
+    /// missing part of its closure loads and then faults at first use — so an incomplete module
+    /// yields NO files rather than a subset that would land.</para>
+    /// </summary>
+    /// <param name="bundle">The archive bytes.</param>
+    /// <returns>The manifest (null when the archive carries none) and the module's files — empty
+    /// when the bundle declares no module or the declared closure is incomplete.</returns>
+    public static (Manifest? Manifest, IReadOnlyList<ModuleFile> Files) ReadModule(byte[] bundle)
+    {
+        using var buffer = new MemoryStream(bundle, writable: false);
+        using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+
+        var manifestEntry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
+        if (manifestEntry is null)
+            return (null, []);
+
+        Manifest? manifest;
+        using (var stream = manifestEntry.Open())
+            manifest = JsonSerializer.Deserialize<Manifest>(stream, Json);
+
+        if (manifest?.Module?.Assemblies is not { Count: > 0 } declared)
+            return (manifest, []);
+
+        var files = new List<ModuleFile>();
+        foreach (var fileName in declared)
+        {
+            var entry = archive.GetEntry(NuGetPackageWriter.ModuleEntryPathFor(fileName));
+            if (entry is null)
+                // Incomplete closure — all or nothing (see remarks).
+                return (manifest, []);
+            files.Add(new ModuleFile(fileName, ReadAll(entry)));
+        }
+
+        return (manifest, files);
     }
 
     private static byte[] ReadAll(ZipArchiveEntry entry)

--- a/src/MeshWeaver.Plugin.Packaging/NuGetPackageWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/NuGetPackageWriter.cs
@@ -27,6 +27,16 @@ public static class NuGetPackageWriter
     /// <summary>Node content, shipped verbatim so install stays a copy rather than a re-render.</summary>
     public const string ContentFolder = "meshweaver/content";
 
+    /// <summary>
+    /// A compiled MODULE's closure files (#1664). Distinct from <see cref="AssemblyFolder"/> on
+    /// purpose: NodeType assemblies are payload for the assembly store (per-node ALC, no restart),
+    /// while module files land beside the app in <c>modules/&lt;name&gt;/</c> and load into the
+    /// DEFAULT ALC at the next restart. Mixing the two folders would let a consumer seed a module
+    /// DLL as a NodeType assembly — correct bytes in the wrong lane, surfacing only as a
+    /// <c>TypeLoadException</c> at activation.
+    /// </summary>
+    public const string ModuleFolder = "meshweaver/modules";
+
     /// <summary>Where the node-path→assembly map lives inside the package.</summary>
     public const string ManifestEntry = "meshweaver/manifest.json";
 
@@ -48,6 +58,17 @@ public static class NuGetPackageWriter
     /// <param name="extension">File extension including the dot, e.g. <c>.dll</c>.</param>
     public static string EntryPathFor(string nodePath, string extension = ".dll") =>
         $"{AssemblyFolder}/{nodePath}{extension}";
+
+    /// <summary>
+    /// The archive entry path for one of a MODULE's closure files — the file name verbatim under
+    /// <see cref="ModuleFolder"/>. Module files are flat (a bundle carries at most ONE module, and
+    /// its manifest names every file), so unlike <see cref="EntryPathFor"/> there is no path
+    /// component to preserve — but the same rule holds: a consumer reads the file list from the
+    /// MANIFEST, never by enumerating the folder.
+    /// </summary>
+    /// <param name="fileName">The closure file's name, e.g. <c>MeshWeaver.Social.dll</c>.</param>
+    public static string ModuleEntryPathFor(string fileName) =>
+        $"{ModuleFolder}/{fileName}";
 
     /// <summary>One file destined for the package.</summary>
     /// <param name="PathInPackage">Full entry path, e.g. <c>meshweaver/content/index.json</c>.</param>

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -502,11 +502,28 @@ public static class CatalogLayoutAreas
         IMessageHub hub, IPackageSource source, string sourceRef, PackageManifest pkg, ILogger? logger,
         string? authorizingUserId)
     {
+        // The module branch of the install funnel (#1664 Slice C): a package that DECLARES a
+        // compiled module routes its binary payload — AFTER the content lands — to bundle-fetch →
+        // MVID gate → ModuleLandingService (restart-as-activation), never through the node parse.
+        // Riding here, on the ONE orchestrator, means every install path gets it identically: the
+        // catalog card's click, the content auto-update apply, and the boot default install. Only
+        // a registry source can serve a bundle (a git source has repo files and no bake behind
+        // it — the registry instance itself runs its modules from its own image/modules tree), and
+        // AdoptModule absorbs every failure into a logged zero, so this can never fail an install.
+        IObservable<InstallResult> WithModule(IObservable<InstallResult> install) =>
+            string.IsNullOrWhiteSpace(pkg.Module)
+            || (source as RegistryPackageSource)?.Bundles is not { } bundles
+                ? install
+                : install.SelectMany(result => bundles
+                    .AdoptModule(pkg.Id, pkg.Module!,
+                        $"{PackageInstaller.InstalledPartition}/{pkg.Id}")
+                    .Select(_ => result));
+
         IObservable<InstallResult> Full() =>
-            source.FetchPackageFiles(pkg, sourceRef)
+            WithModule(source.FetchPackageFiles(pkg, sourceRef)
                 .SelectMany(files => PackageInstaller.Install(
                     hub, pkg, files, sourceRef, logger,
-                    authorizingUserId: authorizingUserId));
+                    authorizingUserId: authorizingUserId)));
 
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         if (pkg.Kind != PackageKind.NodeRepo || string.IsNullOrEmpty(pkg.ModuleVersion) || persistence is null)
@@ -529,7 +546,7 @@ public static class CatalogLayoutAreas
                 }
                 if (record?.InstalledFiles is not { Count: > 0 })
                     return Full();
-                return IncrementalUpdate(hub, source, sourceRef, pkg, record, logger, authorizingUserId)
+                return WithModule(IncrementalUpdate(hub, source, sourceRef, pkg, record, logger, authorizingUserId))
                     .Catch<InstallResult, Exception>(ex =>
                     {
                         // A REFUSAL is not a failure to fall back from — the full install would be

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -582,15 +582,23 @@ public sealed class InstanceAutoRegistrationService(
                                 "Installing defaults from {Url} with NO instance key — only an open "
                                 + "dev/e2e registry will answer.", registry.Url);
                     })
-                    .Select(token => new ConfiguredPackageSource(
-                        new RegistryPackageSource(hub, registry.Url, token),
-                        string.IsNullOrWhiteSpace(registry.Ref) ? "HEAD" : registry.Ref,
-                        string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name)
+                    .Select(token =>
                     {
                         // Same URL and same key as the catalog read: a registry entitled to serve
                         // this instance its package files is exactly the one entitled to serve the
-                        // assemblies compiled from them.
-                        Bundles = new PluginBundleClient(hub, registry.Url, token),
+                        // assemblies compiled from them. ONE client, carried on BOTH handles: the
+                        // ConfiguredPackageSource's (the NodeType adopt after a default install)
+                        // and the RegistryPackageSource's own (the module landing inside
+                        // InstallOrUpdate, #1664) — so every lane reads the same promise-cached
+                        // bundle index.
+                        var bundles = new PluginBundleClient(hub, registry.Url, token);
+                        return new ConfiguredPackageSource(
+                            new RegistryPackageSource(hub, registry.Url, token) { Bundles = bundles },
+                            string.IsNullOrWhiteSpace(registry.Ref) ? "HEAD" : registry.Ref,
+                            string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name)
+                        {
+                            Bundles = bundles,
+                        };
                     }))
                 .ToObservable()
                 .Concat()
@@ -948,6 +956,11 @@ public sealed class InstanceAutoRegistrationService(
                     package.Id);
                 return Observable.Return(0);
             });
+        // A package's compiled MODULE (#1664) is deliberately NOT adopted here: the module branch
+        // lives inside CatalogLayoutAreas.InstallOrUpdate — the one orchestrator this lane (and the
+        // manual click, and the content auto-update) already funnels through — riding the
+        // RegistryPackageSource's own Bundles handle. A second call here would land drift the
+        // update policy is supposed to gate (the reconciler's module pass owns drift).
     }
 
     /// <summary>One package the default install should carry, and the source it came from.</summary>

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -38,10 +38,18 @@ public sealed record ModuleActivationEntry
     public string? PackagePath { get; init; }
 
     /// <summary>The framework MVID (MeshWeaver.Graph's ModuleVersionId) the landed assemblies
-    /// were built against, as verified at landing time. Boot SKIPS the entry — loudly, never a
-    /// crash — when this does not match the running framework: after an image roll the landed
-    /// bytes are ABI-stale, and the entry waits for a re-install against the new framework.</summary>
+    /// were built against, as the producer recorded it — DIAGNOSTIC metadata only: it names the
+    /// exact build behind the bytes when something needs debugging, but it is never a gate.
+    /// Modules bind by simple name and their contract is API compatibility, expressed by
+    /// <see cref="MinMeshVersion"/>; the strict MVID gate is bake semantics and belongs to the
+    /// NodeType assembly lane.</summary>
     public string? FrameworkMvid { get; init; }
+
+    /// <summary>The module's declared platform FLOOR (<c>minMeshVersion</c>) as recorded at
+    /// landing. Boot SKIPS the entry — loudly, never a crash — when the running platform no
+    /// longer satisfies it (a rollback below the floor); absent = no constraint. The one gate is
+    /// <see cref="ModulePlatformFloor.DeclineReason(string?)"/>.</summary>
+    public string? MinMeshVersion { get; init; }
 
     /// <summary>The package version the landed bundle was served at (the module package's released
     /// SemVer). What the auto-update reconcile compares against the registry's bundle index to
@@ -145,7 +153,7 @@ public static class ModuleActivationSidecar
 
 /// <summary>
 /// The boot-time union of #1664 step 9: appsettings baseline ∪ enabled persisted store installs,
-/// deduped by module name, with the two skip rules (missing DLL, framework-MVID mismatch)
+/// deduped by module name, with the two skip rules (missing DLL, unsatisfied platform floor)
 /// applied loudly — extracted PURE so the computation is unit-testable without booting a portal.
 /// </summary>
 public static class ModuleActivationBoot
@@ -162,21 +170,23 @@ public static class ModuleActivationBoot
     ///     entries only).</item>
     ///   <item>Each ENABLED persisted entry appends as <c>&lt;Name&gt;.dll</c> unless: it
     ///     duplicates a baseline (or earlier persisted) module name — dedupe, silent, the module
-    ///     is simply already activated; its recorded <see cref="ModuleActivationEntry.FrameworkMvid"/>
-    ///     is refused by <paramref name="frameworkGate"/> (an image roll changed the framework —
-    ///     SKIPPED with a loud report, the entry stays for the post-roll re-install); or its
-    ///     LANDED DLL is missing per <paramref name="landedModuleDllExists"/> (a lost volume /
-    ///     manual deletion — SKIPPED loudly; a same-named app-closure DLL does not count).
-    ///     A skip is never a crash: the deployment must boot.</item>
+    ///     is simply already activated; its recorded <see cref="ModuleActivationEntry.MinMeshVersion"/>
+    ///     floor is refused by <paramref name="platformGate"/> (the platform rolled BACK below
+    ///     the module's declared requirement — SKIPPED with a loud report, the entry stays for
+    ///     when the platform moves forward again); or its LANDED DLL is missing per
+    ///     <paramref name="landedModuleDllExists"/> (a lost volume / manual deletion — SKIPPED
+    ///     loudly; a same-named app-closure DLL does not count). A skip is never a crash: the
+    ///     deployment must boot. A landed module's MVID is deliberately NOT a skip condition —
+    ///     modules bind by simple name across platform builds; the recorded MVID is diagnostic.</item>
     ///   <item>Disabled entries (uninstalled) contribute nothing and report nothing.</item>
     /// </list>
     /// </summary>
     /// <param name="baselineEntries">The raw <c>Modules:Assemblies</c> values (may be null/empty).</param>
     /// <param name="persisted">The sidecar list (may be null).</param>
-    /// <param name="frameworkGate">Returns WHY a recorded framework identity may not load against
-    /// the running framework, or null when it may — production passes
-    /// <c>PrebuiltAssemblySeeder.DeclineReason</c> so there is never a second notion of framework
-    /// identity.</param>
+    /// <param name="platformGate">Returns WHY a recorded platform FLOOR is not satisfied by the
+    /// running platform, or null when it is (an absent floor is always satisfied) — production
+    /// passes <see cref="ModulePlatformFloor.DeclineReason(string?)"/> so there is never a second
+    /// notion of the module platform requirement.</param>
     /// <param name="landedModuleDllExists">Whether a persisted module's LANDED entry DLL exists —
     /// called with the module NAME, and 🚨 it must check <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c>
     /// SPECIFICALLY (production passes <see cref="LandedModuleDllExists"/>), never
@@ -190,7 +200,7 @@ public static class ModuleActivationBoot
     public static ImmutableList<string> ComputeEffectiveModuleEntries(
         IReadOnlyList<string>? baselineEntries,
         ModuleActivationList? persisted,
-        Func<string?, string?> frameworkGate,
+        Func<string?, string?> platformGate,
         Func<string, bool> landedModuleDllExists,
         Action<string, string>? onSkipped = null)
     {
@@ -212,7 +222,7 @@ public static class ModuleActivationBoot
             if (!seen.Add(module.Name))
                 continue; // already activated (baseline or an earlier entry) — dedupe by name
 
-            if (frameworkGate(module.FrameworkMvid) is { } reason)
+            if (platformGate(module.MinMeshVersion) is { } reason)
             {
                 onSkipped?.Invoke(module.Name, reason);
                 continue;

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -43,6 +43,13 @@ public sealed record ModuleActivationEntry
     /// bytes are ABI-stale, and the entry waits for a re-install against the new framework.</summary>
     public string? FrameworkMvid { get; init; }
 
+    /// <summary>The package version the landed bundle was served at (the module package's released
+    /// SemVer). What the auto-update reconcile compares against the registry's bundle index to
+    /// decide "already landed" without downloading a byte (<see cref="ModuleUpdateDecision"/>).
+    /// Null on an entry written before this field existed — which reads as "unknown", so the next
+    /// reconcile re-lands once and records it.</summary>
+    public string? Version { get; init; }
+
     /// <summary>False = uninstalled (the record is kept for history/idempotence; the folder is
     /// deleted). Takes effect at the next restart, like every activation change.</summary>
     public bool Enabled { get; init; } = true;

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -6,10 +6,10 @@ namespace MeshWeaver.PluginCatalog;
 /// What a REGISTRY instance can serve as a module bundle (#1664 Slice C, the serving half): the
 /// files under its own <c>modules/&lt;name&gt;/</c> — the very bytes this deployment loads and runs,
 /// which is the same philosophy the NodeType bundle lane established ("the inputs ARE the storage").
-/// A module laid out by the image's publish (`MeshModulesPublish.targets`) was compiled with the
-/// image and therefore matches the RUNNING framework MVID by construction; a module the registry
-/// itself store-landed carries its recorded MVID in the activation sidecar, and stale bytes are
-/// refused here so a registry can never fan out assemblies it could not load itself.
+/// A module is servable exactly when this deployment's own boot would load it: not uninstalled,
+/// its declared platform FLOOR satisfied here, its entry DLL present. The MVID a landing recorded
+/// is diagnostic and never withholds a serve — modules bind by simple name, and a consumer's own
+/// floor gate (against the floor this serve surfaces) is what protects IT.
 ///
 /// <para>Pure decision + one directory listing — no mesh, no HTTP — so the serve rules are
 /// pinnable with a temp directory.</para>
@@ -25,15 +25,16 @@ public static class ModuleBundleSource
     /// <param name="moduleName">The module's entry-assembly name without extension.</param>
     /// <param name="activation">The deployment's activation sidecar list (empty for a module that
     /// ships with the image — image modules have no sidecar entry).</param>
-    /// <param name="frameworkGate">Returns WHY a recorded framework identity may not load in THIS
-    /// process, or null when it may — production passes
-    /// <c>PrebuiltAssemblySeeder.DeclineReason</c>.</param>
+    /// <param name="platformGate">Returns WHY a recorded platform FLOOR is not satisfied by THIS
+    /// process, or null when it is (an absent floor is always satisfied) — production passes
+    /// <see cref="ModulePlatformFloor.DeclineReason(string?)"/>, the same gate boot applies, so a
+    /// registry never serves a landing its own boot skips.</param>
     /// <returns>Absolute file paths (entry DLL first) or the decline reason.</returns>
     public static (IReadOnlyList<string> Files, string? DeclineReason) Collect(
         string baseDirectory,
         string moduleName,
         ModuleActivationList activation,
-        Func<string?, string?> frameworkGate)
+        Func<string?, string?> platformGate)
     {
         if (string.IsNullOrWhiteSpace(moduleName)
             || moduleName is "." or ".."
@@ -45,11 +46,11 @@ public static class ModuleBundleSource
             string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
         if (entry is { Enabled: false })
             return ([], $"module '{moduleName}' is uninstalled on this instance");
-        if (entry is not null && frameworkGate(entry.FrameworkMvid) is { } stale)
-            // The landed bytes did not survive this instance's own image roll — they are exactly
-            // the ABI-stale assemblies the boot union skips, and serving them would hand a consumer
-            // bytes stamped with a framework NEITHER side runs.
-            return ([], $"module '{moduleName}' is landed for a stale framework here: {stale}");
+        if (entry is not null && platformGate(entry.MinMeshVersion) is { } unsatisfied)
+            // The landed module's declared floor is not satisfied HERE (the platform rolled back
+            // below it) — these are exactly the bytes this instance's own boot union skips, and a
+            // registry must never fan out a module it could not load itself.
+            return ([], $"module '{moduleName}' is not loadable on this instance: {unsatisfied}");
 
         var folder = Path.Combine(baseDirectory, "modules", moduleName);
         var entryDll = Path.Combine(folder, moduleName + ".dll");

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -1,0 +1,73 @@
+using System.IO;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What a REGISTRY instance can serve as a module bundle (#1664 Slice C, the serving half): the
+/// files under its own <c>modules/&lt;name&gt;/</c> — the very bytes this deployment loads and runs,
+/// which is the same philosophy the NodeType bundle lane established ("the inputs ARE the storage").
+/// A module laid out by the image's publish (`MeshModulesPublish.targets`) was compiled with the
+/// image and therefore matches the RUNNING framework MVID by construction; a module the registry
+/// itself store-landed carries its recorded MVID in the activation sidecar, and stale bytes are
+/// refused here so a registry can never fan out assemblies it could not load itself.
+///
+/// <para>Pure decision + one directory listing — no mesh, no HTTP — so the serve rules are
+/// pinnable with a temp directory.</para>
+/// </summary>
+public static class ModuleBundleSource
+{
+    /// <summary>
+    /// The module files this deployment may serve for <paramref name="moduleName"/>, or a decline
+    /// reason. Exactly one of the two is meaningful: a non-null <c>DeclineReason</c> means the
+    /// bundle carries no module section (which a consumer treats as "nothing to land").
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="moduleName">The module's entry-assembly name without extension.</param>
+    /// <param name="activation">The deployment's activation sidecar list (empty for a module that
+    /// ships with the image — image modules have no sidecar entry).</param>
+    /// <param name="frameworkGate">Returns WHY a recorded framework identity may not load in THIS
+    /// process, or null when it may — production passes
+    /// <c>PrebuiltAssemblySeeder.DeclineReason</c>.</param>
+    /// <returns>Absolute file paths (entry DLL first) or the decline reason.</returns>
+    public static (IReadOnlyList<string> Files, string? DeclineReason) Collect(
+        string baseDirectory,
+        string moduleName,
+        ModuleActivationList activation,
+        Func<string?, string?> frameworkGate)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName)
+            || moduleName is "." or ".."
+            || moduleName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || moduleName.Contains('/') || moduleName.Contains('\\'))
+            return ([], $"'{moduleName}' is not a valid module name");
+
+        var entry = activation.Entries.FirstOrDefault(e =>
+            string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
+        if (entry is { Enabled: false })
+            return ([], $"module '{moduleName}' is uninstalled on this instance");
+        if (entry is not null && frameworkGate(entry.FrameworkMvid) is { } stale)
+            // The landed bytes did not survive this instance's own image roll — they are exactly
+            // the ABI-stale assemblies the boot union skips, and serving them would hand a consumer
+            // bytes stamped with a framework NEITHER side runs.
+            return ([], $"module '{moduleName}' is landed for a stale framework here: {stale}");
+
+        var folder = Path.Combine(baseDirectory, "modules", moduleName);
+        var entryDll = Path.Combine(folder, moduleName + ".dll");
+        if (!File.Exists(entryDll))
+            // Covers the missing folder, the transitional publish state (a module still riding the
+            // app closure prunes its modules/ folder empty), and a lost volume alike: no entry DLL,
+            // no module bundle — the package still serves its content and NodeType assemblies.
+            return ([], $"modules/{moduleName}/{moduleName}.dll does not exist on this instance");
+
+        // Entry DLL first, the rest of the closure (dlls + symbols) in stable order. Top level
+        // only — the modules/<name>/ layout is flat by construction (ModuleLandingService writes
+        // file names, and the publish target lays closures out flat).
+        var files = new List<string> { entryDll };
+        files.AddRange(Directory.EnumerateFiles(folder)
+            .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".dll" or ".pdb")
+            .Where(f => !string.Equals(f, entryDll, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase));
+
+        return (files, null);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Reactive;
-using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -14,11 +13,13 @@ namespace MeshWeaver.PluginCatalog;
 /// the install orchestrator (<c>CatalogLayoutAreas.InstallOrUpdate</c>) and the boot reconcile
 /// (<see cref="RegistryUpdateReconciler"/>).
 ///
-/// <para><b>The MVID gate holds at placement.</b> Landing verifies the caller's declared
-/// framework identity through <see cref="PrebuiltAssemblySeeder.DeclineReason"/> — the SAME pure
-/// function the prebuilt-assembly seeder and the bundle client gate on, so there is never a
-/// second notion of framework version. A mismatch REFUSES the landing (the observable errors,
-/// naming both MVIDs); declined bytes never reach disk.</para>
+/// <para><b>The platform-floor gate holds at placement.</b> Landing verifies the module's
+/// declared <c>minMeshVersion</c> through <see cref="ModulePlatformFloor.DeclineReason(string?)"/>
+/// — the ONE notion of the module platform gate, shared with the serve and fetch sides. An
+/// unsatisfied floor REFUSES the landing (the observable errors, naming both versions); declined
+/// bytes never reach disk. The framework MVID the bundle was built against is recorded and logged
+/// as DIAGNOSTIC metadata only — modules bind by simple name, and their contract is API
+/// compatibility, not build identity (that strict gate belongs to the NodeType bake lane).</para>
 ///
 /// <para><b>The same-identity trap-door is refused too.</b> <c>MeshBuilder.ResolveModulePath</c>
 /// resolves <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c> BEFORE the app folder, so landing a
@@ -63,7 +64,7 @@ public sealed class ModuleLandingService : IDisposable
     public string BaseDirectory => baseDirectory;
 
     /// <summary>
-    /// Lands a module: verifies the framework MVID, writes the assemblies atomically into
+    /// Lands a module: verifies the declared platform floor, writes the assemblies atomically into
     /// <c>modules/&lt;name&gt;/</c>, and appends/updates the activation entry in the
     /// <c>modules/activation.json</c> sidecar with <c>PendingRestart = true</c>. The module
     /// LOADS on the next restart (restart-as-activation) — nothing is loaded into the running
@@ -76,20 +77,26 @@ public sealed class ModuleLandingService : IDisposable
     /// <param name="assemblies">The module's closure: file name + bytes per assembly. Must
     /// contain the entry <c>&lt;name&gt;.dll</c>.</param>
     /// <param name="frameworkMvid">The framework MVID (MeshWeaver.Graph's ModuleVersionId) the
-    /// assemblies were built against, as recorded by the producer.</param>
+    /// assemblies were built against, as recorded by the producer — DIAGNOSTIC metadata: logged
+    /// and recorded on the activation entry, never a refusal (modules bind by simple name; the
+    /// strict MVID gate belongs to the NodeType bake lane).</param>
     /// <param name="packagePath">The install record's mesh path, when the store lane calls.</param>
     /// <param name="version">The package version the bundle was served at — recorded on the
     /// activation entry so the auto-update reconcile can answer "already landed" without a
     /// download (<see cref="ModuleActivationEntry.Version"/>).</param>
+    /// <param name="minMeshVersion">The module's declared platform FLOOR — the gate: an
+    /// unsatisfied floor (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>) refuses the
+    /// landing. Null = no constraint declared.</param>
     public IObservable<Unit> LandModule(
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
-        string frameworkMvid,
+        string? frameworkMvid = null,
         string? packagePath = null,
-        string? version = null)
+        string? version = null,
+        string? minMeshVersion = null)
         => pool.InvokeBlocking(_ =>
         {
-            LandCore(name, assemblies, frameworkMvid, packagePath, version);
+            LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion);
             return Unit.Default;
         });
 
@@ -119,9 +126,10 @@ public sealed class ModuleLandingService : IDisposable
     private void LandCore(
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
-        string frameworkMvid,
+        string? frameworkMvid,
         string? packagePath,
-        string? version)
+        string? version,
+        string? minMeshVersion)
     {
         ValidateFileName(name, "module name");
         if (assemblies is not { Count: > 0 })
@@ -139,11 +147,14 @@ public sealed class ModuleLandingService : IDisposable
                 $"Module '{name}': the assembly list does not contain its entry '{entryDll}' — "
                 + "such a folder could never load.", nameof(assemblies));
 
-        // 🚨 THE MVID GATE, at placement — the same pure function PrebuiltAssemblySeeder and
-        // PluginBundleClient gate on. Declining is always safe; landing on faith is not: the
-        // ABI mismatch would surface only at the next boot, as a TypeLoadException with nothing
-        // connecting it to the install that caused it.
-        if (PrebuiltAssemblySeeder.DeclineReason(frameworkMvid) is { } reason)
+        // 🚨 THE PLATFORM-FLOOR GATE, at placement — the same pure function the serve and fetch
+        // sides gate on (ModulePlatformFloor), so there is never a second notion of the module
+        // platform requirement. Deliberately NOT MVID equality: modules bind by simple name and
+        // their contract is API compatibility — the strict MVID gate is bake semantics and stays
+        // with the NodeType lane. Declining an unsatisfied floor is always safe; landing on faith
+        // is not: the missing API would surface only at the next boot, as a
+        // MissingMethodException with nothing connecting it to the install that caused it.
+        if (ModulePlatformFloor.DeclineReason(minMeshVersion) is { } reason)
         {
             logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, reason);
             throw new InvalidOperationException($"Module '{name}' refused: {reason}");
@@ -193,6 +204,7 @@ public sealed class ModuleLandingService : IDisposable
             PackagePath = packagePath,
             FrameworkMvid = frameworkMvid,
             Version = version,
+            MinMeshVersion = minMeshVersion,
             Enabled = true,
         };
         ModuleActivationSidecar.Write(baseDirectory, list with
@@ -204,9 +216,11 @@ public sealed class ModuleLandingService : IDisposable
         });
 
         logger?.LogInformation(
-            "Module '{Name}' LANDED into modules/{Name}/ ({Count} assemblies, framework "
-            + "{FrameworkMvid}) — activation recorded, RESTART REQUIRED to load it",
-            name, name, assemblies.Count, frameworkMvid);
+            "Module '{Name}' LANDED into modules/{Name}/ ({Count} assemblies, floor "
+            + "{MinMeshVersion}, platform {Running}; built against framework MVID "
+            + "{FrameworkMvid} — diagnostic) — activation recorded, RESTART REQUIRED to load it",
+            name, name, assemblies.Count, minMeshVersion ?? "(none)",
+            ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)");
     }
 
     private void RemoveCore(string name)

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -9,9 +9,10 @@ namespace MeshWeaver.PluginCatalog;
 /// <summary>
 /// The runtime writer into <c>modules/</c> (#1664 step 7) — the ONE code path that lands a
 /// compiled module's assemblies beside the app at runtime and records its activation, so the next
-/// restart loads it (restart-as-activation, #1664 step 8). This is the seam Slice C's
-/// <c>PackageInstaller</c> binary branch calls after fetching a module bundle; nothing in Slice A
-/// invokes it from the install funnel yet.
+/// restart loads it (restart-as-activation, #1664 step 8). Slice C's install funnel calls it
+/// through <see cref="PluginBundleClient.AdoptModule"/> (bundle-fetch → MVID gate → here), from
+/// the install orchestrator (<c>CatalogLayoutAreas.InstallOrUpdate</c>) and the boot reconcile
+/// (<see cref="RegistryUpdateReconciler"/>).
 ///
 /// <para><b>The MVID gate holds at placement.</b> Landing verifies the caller's declared
 /// framework identity through <see cref="PrebuiltAssemblySeeder.DeclineReason"/> — the SAME pure
@@ -56,6 +57,11 @@ public sealed class ModuleLandingService : IDisposable
         this.baseDirectory = baseDirectory ?? AppContext.BaseDirectory;
     }
 
+    /// <summary>The deployment root the <c>modules/</c> tree lives under — exposed so the serving
+    /// side (<see cref="ModuleBundleSource"/> callers) reads the SAME tree this service writes,
+    /// tests included.</summary>
+    public string BaseDirectory => baseDirectory;
+
     /// <summary>
     /// Lands a module: verifies the framework MVID, writes the assemblies atomically into
     /// <c>modules/&lt;name&gt;/</c>, and appends/updates the activation entry in the
@@ -72,16 +78,29 @@ public sealed class ModuleLandingService : IDisposable
     /// <param name="frameworkMvid">The framework MVID (MeshWeaver.Graph's ModuleVersionId) the
     /// assemblies were built against, as recorded by the producer.</param>
     /// <param name="packagePath">The install record's mesh path, when the store lane calls.</param>
+    /// <param name="version">The package version the bundle was served at — recorded on the
+    /// activation entry so the auto-update reconcile can answer "already landed" without a
+    /// download (<see cref="ModuleActivationEntry.Version"/>).</param>
     public IObservable<Unit> LandModule(
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
         string frameworkMvid,
-        string? packagePath = null)
+        string? packagePath = null,
+        string? version = null)
         => pool.InvokeBlocking(_ =>
         {
-            LandCore(name, assemblies, frameworkMvid, packagePath);
+            LandCore(name, assemblies, frameworkMvid, packagePath, version);
             return Unit.Default;
         });
+
+    /// <summary>
+    /// Reads the current activation list on this service's IO pool — the runtime counterpart of the
+    /// boot-time <see cref="ModuleActivationSidecar.Read"/>, serialized behind the same cap-1 pool
+    /// as the writes so a read never observes a landing halfway through its read-modify-write.
+    /// </summary>
+    public IObservable<ModuleActivationList> GetActivation()
+        => pool.InvokeBlocking(_ => ModuleActivationSidecar.Read(baseDirectory,
+            msg => logger?.LogError("{Message}", msg)));
 
     /// <summary>
     /// Uninstalls a module landed by <see cref="LandModule"/>: disables its activation entry
@@ -101,7 +120,8 @@ public sealed class ModuleLandingService : IDisposable
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
         string frameworkMvid,
-        string? packagePath)
+        string? packagePath,
+        string? version)
     {
         ValidateFileName(name, "module name");
         if (assemblies is not { Count: > 0 })
@@ -172,6 +192,7 @@ public sealed class ModuleLandingService : IDisposable
             Source = ModuleActivationSources.Store,
             PackagePath = packagePath,
             FrameworkMvid = frameworkMvid,
+            Version = version,
             Enabled = true,
         };
         ModuleActivationSidecar.Write(baseDirectory, list with

--- a/src/MeshWeaver.PluginCatalog/ModulePlatformFloor.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePlatformFloor.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Plugin.Packaging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The ONE platform gate of the MODULE lane (#1664): a module bundle may land when the RUNNING
+/// platform version satisfies the module's declared <c>minMeshVersion</c> FLOOR.
+///
+/// <para><b>Deliberately NOT the MVID gate.</b> MVID equality is BAKE semantics — a NodeType
+/// assembly is compiled in-process against exact framework references, so only the identical build
+/// is known-good, and <c>PrebuiltAssemblySeeder.DeclineReason</c> rightly refuses everything else.
+/// A module is an ordinary .NET assembly binding by SIMPLE NAME; its real contract is API
+/// compatibility, which a semver floor expresses and an MVID cannot. Gating modules on MVID
+/// equality would force rebundling every module on every CI build and forbid installing a module
+/// ex post onto an older-or-newer platform — exactly the Store scenario the module lane exists
+/// for. The bundle still RECORDS the MVID it was built against, but as DIAGNOSTIC metadata
+/// (logged at landing, surfaced in the index), never a refusal.</para>
+///
+/// <para>The comparison is SemVer via <see cref="NuGetVersionComparer"/> (string order silently
+/// picks wrong across <c>ci.900</c>/<c>ci.3758</c>); an ABSENT floor is no constraint — most
+/// modules need none, and inventing one would be a claim the author never made.</para>
+/// </summary>
+public static class ModulePlatformFloor
+{
+    /// <summary>
+    /// The RUNNING platform's version: MeshWeaver.Graph's <c>AssemblyInformationalVersion</c>
+    /// (stamped centrally by <c>Directory.Build.props</c>), with the <c>+gitSha</c> build metadata
+    /// stripped (SemVer ignores it for ordering; stripping keeps log lines readable). Null when
+    /// the assembly carries no version stamp — which <see cref="DeclineReason(string?)"/> treats
+    /// as "cannot verify a declared floor".
+    /// </summary>
+    public static string? RunningVersion { get; } = Resolve();
+
+    private static string? Resolve()
+    {
+        var version = typeof(PrebuiltAssemblySeeder).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+        var plus = version.IndexOf('+');
+        return plus < 0 ? version : version[..plus];
+    }
+
+    /// <summary>
+    /// Why a module declaring <paramref name="minMeshVersion"/> may not land on THIS process, or
+    /// null when it may — the production overload every serve/fetch/land/boot call site uses, so
+    /// there is never a second notion of the platform floor.
+    /// </summary>
+    public static string? DeclineReason(string? minMeshVersion) =>
+        DeclineReason(minMeshVersion, RunningVersion);
+
+    /// <summary>
+    /// The pure decision (unit-testable without an assembly stamp): null = the floor is satisfied
+    /// (or none is declared); otherwise the reason, naming BOTH versions so an operator can see
+    /// which side is behind.
+    /// </summary>
+    /// <param name="minMeshVersion">The module's declared platform floor, or null/blank for none.</param>
+    /// <param name="runningVersion">The running platform's version, or null when unknown.</param>
+    public static string? DeclineReason(string? minMeshVersion, string? runningVersion)
+    {
+        if (string.IsNullOrWhiteSpace(minMeshVersion))
+            // No declared floor = no constraint. Modules bind by simple name; without a stated
+            // requirement there is nothing to verify, and refusing here would block every module
+            // that predates the field.
+            return null;
+
+        if (string.IsNullOrWhiteSpace(runningVersion))
+            // A DECLARED floor that cannot be checked is not waved through: landing on faith
+            // surfaces later as a MissingMethodException with nothing connecting it to the
+            // install. Unreachable on a normally-stamped build.
+            return $"the module declares minMeshVersion {minMeshVersion} but the running "
+                   + "platform's version could not be determined — not landing on faith";
+
+        return NuGetVersionComparer.Instance.Compare(runningVersion, minMeshVersion) < 0
+            ? $"the module requires platform {minMeshVersion} or newer but this deployment runs "
+              + $"{runningVersion} — it becomes installable after the platform updates"
+            : null;
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -114,21 +114,27 @@ public static class ModuleUpdateDecision
                 "the module was uninstalled on this deployment; an unattended update must not "
                 + "re-install it");
 
+        // Both version checks go through the ONE comparer, so "equal" and "older" cannot disagree
+        // about what a version string means: manifests legitimately carry two-part versions, and
+        // string equality would read a landed "1.2.0" against a served "1.2" as an update — a
+        // re-land on every reconcile, forever (Copilot catch on the ordinal-equality draft).
+        var landedComparison = landed is { Version.Length: > 0 }
+            ? NuGetVersionComparer.Instance.Compare(bundleVersion, landed.Version)
+            : (int?)null;
+
         // Already landed at the served version: nothing travels. The version alone keys this —
         // landed bytes stay loadable across platform builds (simple-name binding), so there is no
         // "re-land the same version for a new build" case.
-        if (landed is { } current
-            && string.Equals(current.Version, bundleVersion, StringComparison.OrdinalIgnoreCase))
+        if (landedComparison == 0)
             return new(ModuleUpdateAction.SkipUpToDate,
                 $"version {bundleVersion} is already landed");
 
         // Never roll BACK unattended: a registry serving an older version than what is landed is a
         // deliberate operator situation (a pinned rollback, a lagging registry), and silently
         // downgrading a running deployment is not this lane's call.
-        if (landed is { Version.Length: > 0 } newer
-            && NuGetVersionComparer.Instance.Compare(bundleVersion, newer.Version) < 0)
+        if (landedComparison < 0)
             return new(ModuleUpdateAction.SkipOlder,
-                $"the registry serves {bundleVersion} but {newer.Version} is landed — never "
+                $"the registry serves {bundleVersion} but {landed!.Version} is landed — never "
                 + "rolled back unattended");
 
         // 🚨 The policy gates UPGRADES ONLY — an existing landing moving to a different version.

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -1,0 +1,150 @@
+using MeshWeaver.Plugin.Packaging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The platform's gate on UNATTENDED module landing — the seam through which the module lane rides
+/// the EXISTING update-policy surface instead of growing a knob of its own (#1664).
+///
+/// <para>The memex portals implement this over the admin-editable <c>Admin/UpdatePolicy</c> node
+/// (Continuous / Stable / None — the same single policy that governs the platform image roll):
+/// <c>Continuous</c>, the platform default, allows unattended module landing; <c>Stable</c> and
+/// <c>None</c> decline it, because a deployment that pins its image has chosen to take updates
+/// deliberately, and its modules must not run ahead of that choice. A host that registers NO
+/// implementation is the platform default: unattended landing is ALLOWED.</para>
+///
+/// <para>The gate covers only the RECONCILER's unattended lane. An explicit install (the Store's
+/// Provision funnel, the default-install seed) lands its module regardless — the operator asked
+/// for the package, and the module is part of what they asked for.</para>
+/// </summary>
+public interface IModuleUpdatePolicy
+{
+    /// <summary>Why unattended module landing is currently declined, or null when it is allowed.
+    /// Cold; emits exactly once per subscription.</summary>
+    IObservable<string?> DeclineUnattendedLanding();
+}
+
+/// <summary>What the module-update reconcile decided for one installed module package.</summary>
+public enum ModuleUpdateAction
+{
+    /// <summary>Fetch the bundle and land it (restart-as-activation).</summary>
+    Land,
+
+    /// <summary>The landed module already matches the registry's bundle — nothing travels.</summary>
+    SkipUpToDate,
+
+    /// <summary>The registry serves bundles for a DIFFERENT framework MVID — skipped
+    /// silently-with-log; the bundle becomes relevant after the next image roll.</summary>
+    SkipForeignFramework,
+
+    /// <summary>The deployment's update policy declines unattended landing (Stable/None).</summary>
+    SkipPolicy,
+
+    /// <summary>The registry serves no bundle for this package.</summary>
+    SkipNoBundle,
+
+    /// <summary>The registry's bundle is OLDER than what is landed — never rolled back
+    /// unattended.</summary>
+    SkipOlder,
+
+    /// <summary>The module was deliberately uninstalled here (activation entry disabled) — the
+    /// reconcile must not fight the operator.</summary>
+    SkipUninstalled,
+}
+
+/// <summary>One reconcile verdict: the action and the human reason behind it.</summary>
+/// <param name="Action">What to do.</param>
+/// <param name="Reason">Why — one phrase for the log line.</param>
+public sealed record ModuleUpdateVerdict(ModuleUpdateAction Action, string? Reason = null);
+
+/// <summary>
+/// THE decision "does this installed module package's bundle land, and why not otherwise" — pure,
+/// so the reconciler's behaviour is pinnable without a registry, a filesystem, or a mesh
+/// (#1664 Slice C). Every input is a fact the caller already holds; nothing here fetches.
+/// </summary>
+public static class ModuleUpdateDecision
+{
+    /// <summary>
+    /// Decides for one module-declaring installed package.
+    ///
+    /// <para>Order matters and is deliberate: no-bundle before the framework gate (a registry that
+    /// serves nothing for this package says nothing about frameworks), the framework gate before
+    /// everything stateful (a foreign-MVID index makes every other question moot — and the skip is
+    /// silent-with-log, becoming relevant only after the next image roll), the uninstalled check
+    /// before up-to-date (a disabled entry may still carry the served version, and "up to date"
+    /// would misname the operator's choice), and the policy LAST — so a policy skip is only ever
+    /// reported when an update genuinely would have landed.</para>
+    /// </summary>
+    /// <param name="bundleVersion">The version the registry's bundle index serves for this package,
+    /// or null when it lists no bundle.</param>
+    /// <param name="registryFrameworkMvid">The framework MVID the registry's index advertises.</param>
+    /// <param name="frameworkGate">Returns WHY a framework identity may not load here, or null when
+    /// it may — production passes <c>PrebuiltAssemblySeeder.DeclineReason</c> so there is never a
+    /// second notion of framework identity.</param>
+    /// <param name="landed">This deployment's activation entry for the module, or null when it was
+    /// never landed (which includes "installed before the module lane existed" — those heal by
+    /// landing).</param>
+    /// <param name="policyDecline">Why the deployment's update policy declines unattended landing,
+    /// or null when it allows it (<see cref="IModuleUpdatePolicy"/>; null when no policy is
+    /// registered — the platform default is auto-update).</param>
+    public static ModuleUpdateVerdict Decide(
+        string? bundleVersion,
+        string? registryFrameworkMvid,
+        Func<string?, string?> frameworkGate,
+        ModuleActivationEntry? landed,
+        string? policyDecline)
+    {
+        if (string.IsNullOrWhiteSpace(bundleVersion))
+            return new(ModuleUpdateAction.SkipNoBundle,
+                "the registry lists no bundle for this package");
+
+        if (frameworkGate(registryFrameworkMvid) is { } foreign)
+            return new(ModuleUpdateAction.SkipForeignFramework, foreign);
+
+        if (landed is { Enabled: false })
+            return new(ModuleUpdateAction.SkipUninstalled,
+                "the module was uninstalled on this deployment; an unattended update must not "
+                + "re-install it");
+
+        // Already landed, still loadable against the RUNNING framework, and at the served version:
+        // nothing travels. A landed entry whose recorded MVID the gate refuses is NOT up to date —
+        // its bytes stopped loading at the last image roll, and re-landing current ones is exactly
+        // the heal this lane exists for.
+        if (landed is { } current
+            && frameworkGate(current.FrameworkMvid) is null
+            && string.Equals(current.Version, bundleVersion, StringComparison.OrdinalIgnoreCase))
+            return new(ModuleUpdateAction.SkipUpToDate,
+                $"version {bundleVersion} is already landed for the running framework");
+
+        // Never roll BACK unattended: a registry serving an older version than what is landed is a
+        // deliberate operator situation (a pinned rollback, a lagging registry), and silently
+        // downgrading a running deployment is not this lane's call. Only comparable when the landed
+        // bytes still load here — stale-MVID bytes are dead weight whatever their version says.
+        if (landed is { Version.Length: > 0 } newer
+            && frameworkGate(newer.FrameworkMvid) is null
+            && NuGetVersionComparer.Instance.Compare(bundleVersion, newer.Version) < 0)
+            return new(ModuleUpdateAction.SkipOlder,
+                $"the registry serves {bundleVersion} but {newer.Version} is landed — never "
+                + "rolled back unattended");
+
+        // 🚨 The policy gates UPGRADES ONLY — a loadable landing moving to a different version.
+        // Two landings are deliberately EXEMPT, because gating them turns "no unattended updates"
+        // into "the module breaks":
+        //   • a FIRST landing (landed == null) COMPLETES an install the operator's own surfaces
+        //     already sanctioned (a Provision click, the default-install config) — withholding it
+        //     ships a package whose binary half never arrives;
+        //   • a stale-MVID RE-LAND heals an image roll the operator chose: the old bytes stopped
+        //     loading with that roll, and refusing the heal leaves the module dead until someone
+        //     notices. Keeping what was installed WORKING is not an update.
+        if (policyDecline is not null
+            && landed is { } upgraded
+            && frameworkGate(upgraded.FrameworkMvid) is null)
+            return new(ModuleUpdateAction.SkipPolicy, policyDecline);
+
+        return new(ModuleUpdateAction.Land,
+            landed is null
+                ? $"never landed here — landing {bundleVersion}"
+                : $"landing {bundleVersion} (current: {landed.Version ?? "unknown"}"
+                  + (frameworkGate(landed.FrameworkMvid) is null ? ")" : ", framework-stale)"));
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -33,9 +33,9 @@ public enum ModuleUpdateAction
     /// <summary>The landed module already matches the registry's bundle — nothing travels.</summary>
     SkipUpToDate,
 
-    /// <summary>The registry serves bundles for a DIFFERENT framework MVID — skipped
-    /// silently-with-log; the bundle becomes relevant after the next image roll.</summary>
-    SkipForeignFramework,
+    /// <summary>The bundle's declared <c>minMeshVersion</c> FLOOR exceeds the running platform —
+    /// skipped silently-with-log; the bundle becomes installable after the platform updates.</summary>
+    SkipPlatformBelowFloor,
 
     /// <summary>The deployment's update policy declines unattended landing (Stable/None).</summary>
     SkipPolicy,
@@ -61,26 +61,34 @@ public sealed record ModuleUpdateVerdict(ModuleUpdateAction Action, string? Reas
 /// THE decision "does this installed module package's bundle land, and why not otherwise" — pure,
 /// so the reconciler's behaviour is pinnable without a registry, a filesystem, or a mesh
 /// (#1664 Slice C). Every input is a fact the caller already holds; nothing here fetches.
+///
+/// <para><b>The platform gate is a semver FLOOR, never MVID equality.</b> Modules are ordinary
+/// .NET assemblies binding by simple name — their contract is API compatibility, which
+/// <c>minMeshVersion</c> expresses. A bundle built against an OLDER platform whose floor this
+/// deployment satisfies LANDS (the ex-post Store install across platform versions the lane exists
+/// for); MVID equality is bake semantics and stays with the NodeType assembly lane.</para>
 /// </summary>
 public static class ModuleUpdateDecision
 {
     /// <summary>
     /// Decides for one module-declaring installed package.
     ///
-    /// <para>Order matters and is deliberate: no-bundle before the framework gate (a registry that
-    /// serves nothing for this package says nothing about frameworks), the framework gate before
-    /// everything stateful (a foreign-MVID index makes every other question moot — and the skip is
-    /// silent-with-log, becoming relevant only after the next image roll), the uninstalled check
-    /// before up-to-date (a disabled entry may still carry the served version, and "up to date"
-    /// would misname the operator's choice), and the policy LAST — so a policy skip is only ever
-    /// reported when an update genuinely would have landed.</para>
+    /// <para>Order matters and is deliberate: no-bundle before the floor gate (a registry that
+    /// serves nothing for this package declares no floor to check), the floor gate before
+    /// everything stateful (an uninstallable bundle makes every other question moot — and the
+    /// skip is silent-with-log, becoming relevant when the platform updates), the uninstalled
+    /// check before up-to-date (a disabled entry may still carry the served version, and "up to
+    /// date" would misname the operator's choice), and the policy LAST — so a policy skip is only
+    /// ever reported when an update genuinely would have landed.</para>
     /// </summary>
     /// <param name="bundleVersion">The version the registry's bundle index serves for this package,
     /// or null when it lists no bundle.</param>
-    /// <param name="registryFrameworkMvid">The framework MVID the registry's index advertises.</param>
-    /// <param name="frameworkGate">Returns WHY a framework identity may not load here, or null when
-    /// it may — production passes <c>PrebuiltAssemblySeeder.DeclineReason</c> so there is never a
-    /// second notion of framework identity.</param>
+    /// <param name="bundleMinMeshVersion">The bundle's declared platform floor, as the index
+    /// surfaces it. Null = no constraint.</param>
+    /// <param name="platformGate">Returns WHY a declared floor is not satisfied by the running
+    /// platform, or null when it is — production passes
+    /// <see cref="ModulePlatformFloor.DeclineReason(string?)"/> so there is never a second notion
+    /// of the module platform requirement.</param>
     /// <param name="landed">This deployment's activation entry for the module, or null when it was
     /// never landed (which includes "installed before the module lane existed" — those heal by
     /// landing).</param>
@@ -89,8 +97,8 @@ public static class ModuleUpdateDecision
     /// registered — the platform default is auto-update).</param>
     public static ModuleUpdateVerdict Decide(
         string? bundleVersion,
-        string? registryFrameworkMvid,
-        Func<string?, string?> frameworkGate,
+        string? bundleMinMeshVersion,
+        Func<string?, string?> platformGate,
         ModuleActivationEntry? landed,
         string? policyDecline)
     {
@@ -98,53 +106,41 @@ public static class ModuleUpdateDecision
             return new(ModuleUpdateAction.SkipNoBundle,
                 "the registry lists no bundle for this package");
 
-        if (frameworkGate(registryFrameworkMvid) is { } foreign)
-            return new(ModuleUpdateAction.SkipForeignFramework, foreign);
+        if (platformGate(bundleMinMeshVersion) is { } belowFloor)
+            return new(ModuleUpdateAction.SkipPlatformBelowFloor, belowFloor);
 
         if (landed is { Enabled: false })
             return new(ModuleUpdateAction.SkipUninstalled,
                 "the module was uninstalled on this deployment; an unattended update must not "
                 + "re-install it");
 
-        // Already landed, still loadable against the RUNNING framework, and at the served version:
-        // nothing travels. A landed entry whose recorded MVID the gate refuses is NOT up to date —
-        // its bytes stopped loading at the last image roll, and re-landing current ones is exactly
-        // the heal this lane exists for.
+        // Already landed at the served version: nothing travels. The version alone keys this —
+        // landed bytes stay loadable across platform builds (simple-name binding), so there is no
+        // "re-land the same version for a new build" case.
         if (landed is { } current
-            && frameworkGate(current.FrameworkMvid) is null
             && string.Equals(current.Version, bundleVersion, StringComparison.OrdinalIgnoreCase))
             return new(ModuleUpdateAction.SkipUpToDate,
-                $"version {bundleVersion} is already landed for the running framework");
+                $"version {bundleVersion} is already landed");
 
         // Never roll BACK unattended: a registry serving an older version than what is landed is a
         // deliberate operator situation (a pinned rollback, a lagging registry), and silently
-        // downgrading a running deployment is not this lane's call. Only comparable when the landed
-        // bytes still load here — stale-MVID bytes are dead weight whatever their version says.
+        // downgrading a running deployment is not this lane's call.
         if (landed is { Version.Length: > 0 } newer
-            && frameworkGate(newer.FrameworkMvid) is null
             && NuGetVersionComparer.Instance.Compare(bundleVersion, newer.Version) < 0)
             return new(ModuleUpdateAction.SkipOlder,
                 $"the registry serves {bundleVersion} but {newer.Version} is landed — never "
                 + "rolled back unattended");
 
-        // 🚨 The policy gates UPGRADES ONLY — a loadable landing moving to a different version.
-        // Two landings are deliberately EXEMPT, because gating them turns "no unattended updates"
-        // into "the module breaks":
-        //   • a FIRST landing (landed == null) COMPLETES an install the operator's own surfaces
-        //     already sanctioned (a Provision click, the default-install config) — withholding it
-        //     ships a package whose binary half never arrives;
-        //   • a stale-MVID RE-LAND heals an image roll the operator chose: the old bytes stopped
-        //     loading with that roll, and refusing the heal leaves the module dead until someone
-        //     notices. Keeping what was installed WORKING is not an update.
-        if (policyDecline is not null
-            && landed is { } upgraded
-            && frameworkGate(upgraded.FrameworkMvid) is null)
+        // 🚨 The policy gates UPGRADES ONLY — an existing landing moving to a different version.
+        // A FIRST landing (landed == null) is deliberately EXEMPT: it COMPLETES an install the
+        // operator's own surfaces already sanctioned (a Provision click, the default-install
+        // config), and gating it would ship a package whose binary half never arrives.
+        if (policyDecline is not null && landed is not null)
             return new(ModuleUpdateAction.SkipPolicy, policyDecline);
 
         return new(ModuleUpdateAction.Land,
             landed is null
                 ? $"never landed here — landing {bundleVersion}"
-                : $"landing {bundleVersion} (current: {landed.Version ?? "unknown"}"
-                  + (frameworkGate(landed.FrameworkMvid) is null ? ")" : ", framework-stale)"));
+                : $"landing {bundleVersion} (current: {landed.Version ?? "unknown"})");
     }
 }

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -156,6 +156,9 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         // The declared public surface — what the installer's access step scopes a
                         // free package's public read to.
                         PublicSegments = peeked.PublicSegments,
+                        // The compiled-module declaration (#1664) — what routes this package
+                        // through the module bundle funnel on top of its content install.
+                        Module = peeked.Module,
                     });
                 }
                 return (IReadOnlyList<PackageManifest>)manifests
@@ -185,7 +188,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
         string? NodeType, string? Name, string? Description,
         string? Category, string? Icon, decimal? Price, string? Currency, string? Poster,
         bool PreInstalled, ImmutableList<string> Requires, ImmutableList<string> PublicSegments,
-        string? License, string? ContactEmail);
+        string? License, string? ContactEmail, string? Module);
 
     // Reads the node's type/name/description — plus the storefront card fields (category/icon on
     // the node, price/currency/poster inside the content) — straight from the JSON: no MeshNode
@@ -205,6 +208,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
             var requires = ImmutableList<string>.Empty;
             string? license = null;
             var publicSegments = ImmutableList<string>.Empty;
+            string? module = null;
             if (r.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Object)
             {
                 if (content.TryGetProperty("price", out var p) && p.ValueKind == JsonValueKind.Number
@@ -247,6 +251,13 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         .Where(e => e.ValueKind == JsonValueKind.String)
                         .Select(e => e.GetString()!)
                         .ToImmutableList();
+                // The package's compiled-module declaration ("module": the entry-assembly name,
+                // #1664). Read here because the INSTALL funnel and the registry's bundle index both
+                // key on the manifest — leaving it unread would make it dead metadata, the defect
+                // class `preInstalled`/`publicSegments`/`contactEmail` each had.
+                if (content.TryGetProperty("module", out var mod) && mod.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(mod.GetString()))
+                    module = mod.GetString();
             }
             return new PeekedRoot(
                 r.TryGetProperty("nodeType", out var nt) ? nt.GetString() : null,
@@ -255,7 +266,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
                 r.TryGetProperty("category", out var cat) ? cat.GetString() : null,
                 r.TryGetProperty("icon", out var ic) ? ic.GetString() : null,
                 price, currency, poster, preInstalled, requires, publicSegments, license,
-                contactEmail);
+                contactEmail, module);
         }
         catch (JsonException ex)
         {

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -157,8 +157,10 @@ public sealed class NodeRepoPackageSource : IPackageSource
                         // free package's public read to.
                         PublicSegments = peeked.PublicSegments,
                         // The compiled-module declaration (#1664) — what routes this package
-                        // through the module bundle funnel on top of its content install.
+                        // through the module bundle funnel on top of its content install — and
+                        // its declared platform floor, the module lane's landing gate.
                         Module = peeked.Module,
+                        MinMeshVersion = peeked.MinMeshVersion,
                     });
                 }
                 return (IReadOnlyList<PackageManifest>)manifests
@@ -188,7 +190,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
         string? NodeType, string? Name, string? Description,
         string? Category, string? Icon, decimal? Price, string? Currency, string? Poster,
         bool PreInstalled, ImmutableList<string> Requires, ImmutableList<string> PublicSegments,
-        string? License, string? ContactEmail, string? Module);
+        string? License, string? ContactEmail, string? Module, string? MinMeshVersion);
 
     // Reads the node's type/name/description — plus the storefront card fields (category/icon on
     // the node, price/currency/poster inside the content) — straight from the JSON: no MeshNode
@@ -209,6 +211,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
             string? license = null;
             var publicSegments = ImmutableList<string>.Empty;
             string? module = null;
+            string? minMeshVersion = null;
             if (r.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Object)
             {
                 if (content.TryGetProperty("price", out var p) && p.ValueKind == JsonValueKind.Number
@@ -258,6 +261,12 @@ public sealed class NodeRepoPackageSource : IPackageSource
                 if (content.TryGetProperty("module", out var mod) && mod.ValueKind == JsonValueKind.String
                     && !string.IsNullOrWhiteSpace(mod.GetString()))
                     module = mod.GetString();
+                // The declared platform FLOOR ("minMeshVersion" — the field authors already
+                // write): the module lane's landing gate. Same dead-metadata rationale as above.
+                if (content.TryGetProperty("minMeshVersion", out var floor)
+                    && floor.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(floor.GetString()))
+                    minMeshVersion = floor.GetString();
             }
             return new PeekedRoot(
                 r.TryGetProperty("nodeType", out var nt) ? nt.GetString() : null,
@@ -266,7 +275,7 @@ public sealed class NodeRepoPackageSource : IPackageSource
                 r.TryGetProperty("category", out var cat) ? cat.GetString() : null,
                 r.TryGetProperty("icon", out var ic) ? ic.GetString() : null,
                 price, currency, poster, preInstalled, requires, publicSegments, license,
-                contactEmail, module);
+                contactEmail, module, minMeshVersion);
         }
         catch (JsonException ex)
         {

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -126,6 +126,28 @@ public record PackageManifest
     public ImmutableList<string> Requires { get; init; } = [];
 
     /// <summary>
+    /// The compiled MODULE this package delivers (#1664): the module's entry-assembly name WITHOUT
+    /// extension (e.g. <c>MeshWeaver.Social</c>) — the same identity <c>Modules:Assemblies</c>
+    /// entries and <c>modules/&lt;name&gt;/</c> folders use. Null (the default) = a pure content /
+    /// code package, which is every package before this field existed.
+    ///
+    /// <para>Non-null routes the package through the module funnel ON TOP of its normal content
+    /// install: after the content lands, the consumer fetches the package's bundle from the
+    /// registry's <c>/api/plugins/bundles</c>, verifies the framework MVID
+    /// (<c>PrebuiltAssemblySeeder.DeclineReason</c> — the ONE identity), and lands the module via
+    /// <c>ModuleLandingService</c> (restart-as-activation). The registry side serves the module's
+    /// bytes for any installed record carrying this field. A MIXED package — content nodes plus a
+    /// compiled module in one Store product (the MeshWeaver.SocialMedia shape) — is exactly this
+    /// field on an ordinary node-repo package.</para>
+    ///
+    /// <para>Authored on the plugin root's <c>content.module</c> (node-repo format) or a
+    /// <c>package.json</c>; read while listing (<see cref="NodeRepoPackageSource"/>) and carried
+    /// onto the install record by the ordinary record stamp, so the registry's bundle index can
+    /// offer the module without re-reading the repo.</para>
+    /// </summary>
+    public string? Module { get; init; }
+
+    /// <summary>
     /// The package is part of the platform's DEFAULT INSTALL: every instance that can see it in a
     /// catalog installs it automatically at startup (<see cref="InstanceAutoRegistrationService"/>),
     /// with public read established by the installer

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -148,6 +148,18 @@ public record PackageManifest
     public string? Module { get; init; }
 
     /// <summary>
+    /// The package's declared platform FLOOR (<c>content.minMeshVersion</c> — the field plugin
+    /// authors already write): the minimum MeshWeaver version its compiled module requires. For a
+    /// module-declaring package this is THE landing gate
+    /// (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>) — deliberately a semver floor,
+    /// never MVID equality, because a module is a plain assembly binding by simple name whose
+    /// contract is API compatibility. Null = no constraint (most modules need none). Carried onto
+    /// the install record and surfaced on the registry's bundle index so a consumer skips an
+    /// uninstallable bundle without downloading it.
+    /// </summary>
+    public string? MinMeshVersion { get; init; }
+
+    /// <summary>
     /// The package is part of the platform's DEFAULT INSTALL: every instance that can see it in a
     /// catalog installs it automatically at startup (<see cref="InstanceAutoRegistrationService"/>),
     /// with public read established by the installer

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -85,7 +85,11 @@ public sealed class PluginBundleClient
     /// <param name="Url">Absolute download URL.</param>
     /// <param name="Module">The compiled module the bundle carries (its entry-assembly name), or
     /// null for a NodeType-only bundle (#1664). Additive: an older registry simply omits it.</param>
-    public sealed record BundleRef(string Plugin, string Version, string Url, string? Module = null);
+    /// <param name="MinMeshVersion">The module's declared platform FLOOR — surfaced on the index
+    /// so a consumer can skip an uninstallable bundle without downloading it. Null = none.</param>
+    public sealed record BundleRef(
+        string Plugin, string Version, string Url, string? Module = null,
+        string? MinMeshVersion = null);
 
     /// <summary>
     /// Reads the registry's bundle index. Emits an empty index rather than throwing when the
@@ -155,9 +159,12 @@ public sealed class PluginBundleClient
     /// <see cref="Adopt"/>, riding the same index, the same download route and the same MVID gate.
     ///
     /// <para>The whole decision is <see cref="ModuleUpdateDecision.Decide"/>, taken BEFORE any
-    /// download: an up-to-date module, a foreign-framework registry, an uninstalled module and a
-    /// policy-declined unattended run each cost zero bytes. Landing goes through
-    /// <see cref="ModuleLandingService"/> (restart-as-activation — the sidecar's
+    /// download: an up-to-date module, a bundle whose platform floor this deployment does not
+    /// satisfy, an uninstalled module and a policy-declined unattended run each cost zero bytes.
+    /// The gate is the <c>minMeshVersion</c> FLOOR (<see cref="ModulePlatformFloor"/>), never MVID
+    /// equality — that strict gate is the NodeType lane's (<see cref="Adopt"/>); a module built
+    /// against a different platform build lands fine as long as its floor is satisfied. Landing
+    /// goes through <see cref="ModuleLandingService"/> (restart-as-activation — the sidecar's
     /// <c>PendingRestart</c> is the step-10 signal); the module LOADS at the next restart.</para>
     ///
     /// <para>Emits how many module files were landed — zero is a normal, non-error outcome (nothing
@@ -201,8 +208,8 @@ public sealed class PluginBundleClient
                             string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
 
                         var verdict = ModuleUpdateDecision.Decide(
-                            bundle?.Version, index.FrameworkMvid,
-                            PrebuiltAssemblySeeder.DeclineReason, entry, declined);
+                            bundle?.Version, bundle?.MinMeshVersion,
+                            ModulePlatformFloor.DeclineReason, entry, declined);
 
                         if (verdict.Action != ModuleUpdateAction.Land)
                         {
@@ -232,11 +239,12 @@ public sealed class PluginBundleClient
     }
 
     /// <summary>
-    /// Reads the downloaded bundle's module section and lands it. The MVID is verified AGAIN here,
-    /// against the manifest inside the archive — the index said what the registry runs, the
-    /// manifest says what these bytes were built with, and only the second is the gate that holds
-    /// (<see cref="ModuleLandingService"/> re-checks it a third time at placement; declining twice
-    /// is cheaper than debugging a TypeLoadException once).
+    /// Reads the downloaded bundle's module section and lands it. The platform FLOOR is verified
+    /// AGAIN here, against the manifest inside the archive — the index said what the registry
+    /// advertises, the manifest says what these bytes require, and only the second is the gate
+    /// that holds (<see cref="ModuleLandingService"/> re-checks it a third time at placement;
+    /// declining twice is cheaper than debugging a MissingMethodException once). The MVID the
+    /// bundle records is logged as DIAGNOSTIC metadata, never refused.
     /// </summary>
     // Internal for the ModuleFunnelTest pin (InternalsVisibleTo): the land half without HTTP.
     internal IObservable<int> LandFromBundle(
@@ -246,7 +254,7 @@ public sealed class PluginBundleClient
             {
                 var (manifest, files) = payload;
 
-                if (PrebuiltAssemblySeeder.DeclineReason(manifest?.FrameworkMvid) is { } reason)
+                if (ModulePlatformFloor.DeclineReason(manifest?.Module?.MinMeshVersion) is { } reason)
                 {
                     _logger?.LogInformation(
                         "Module bundle for {Plugin} DECLINED: {Reason} — nothing landed",
@@ -278,9 +286,12 @@ public sealed class PluginBundleClient
                     .LandModule(
                         moduleName,
                         files.Select(f => (f.FileName, f.Bytes)).ToArray(),
-                        manifest!.FrameworkMvid!,
+                        // Diagnostic metadata (which exact platform build produced these bytes),
+                        // recorded on the activation entry and logged at landing — never a gate.
+                        manifest!.FrameworkMvid,
                         packagePath,
-                        version)
+                        version,
+                        manifest.Module?.MinMeshVersion)
                     .Select(_ => files.Count)
                     .Do(count => _logger?.LogInformation(
                         "Module '{Module}' of {Plugin} landed ({Count} file(s), version {Version}) "

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -80,7 +80,12 @@ public sealed class PluginBundleClient
     public sealed record BundleIndex(string? FrameworkMvid, IReadOnlyList<BundleRef> Bundles);
 
     /// <summary>One servable bundle.</summary>
-    public sealed record BundleRef(string Plugin, string Version, string Url);
+    /// <param name="Plugin">The plugin/package id.</param>
+    /// <param name="Version">The served version.</param>
+    /// <param name="Url">Absolute download URL.</param>
+    /// <param name="Module">The compiled module the bundle carries (its entry-assembly name), or
+    /// null for a NodeType-only bundle (#1664). Additive: an older registry simply omits it.</param>
+    public sealed record BundleRef(string Plugin, string Version, string Url, string? Module = null);
 
     /// <summary>
     /// Reads the registry's bundle index. Emits an empty index rather than throwing when the
@@ -142,6 +147,144 @@ public sealed class PluginBundleClient
                         .SelectMany(bytes => bytes is null
                             ? Observable.Return(0)
                             : SeedAll(pluginId, bytes));
+            });
+
+    /// <summary>
+    /// Fetches <paramref name="pluginId"/>'s bundle and LANDS the compiled module it carries into
+    /// this deployment's <c>modules/</c> tree (#1664 Slice C) — the module counterpart of
+    /// <see cref="Adopt"/>, riding the same index, the same download route and the same MVID gate.
+    ///
+    /// <para>The whole decision is <see cref="ModuleUpdateDecision.Decide"/>, taken BEFORE any
+    /// download: an up-to-date module, a foreign-framework registry, an uninstalled module and a
+    /// policy-declined unattended run each cost zero bytes. Landing goes through
+    /// <see cref="ModuleLandingService"/> (restart-as-activation — the sidecar's
+    /// <c>PendingRestart</c> is the step-10 signal); the module LOADS at the next restart.</para>
+    ///
+    /// <para>Emits how many module files were landed — zero is a normal, non-error outcome (nothing
+    /// to land, or the bundle is for a framework this deployment does not run yet). Like
+    /// <see cref="Adopt"/>, nothing here may fail an install: every refusal is logged and absorbed.
+    /// Cold: nothing is fetched until Subscribe.</para>
+    /// </summary>
+    /// <param name="pluginId">The package id whose bundle carries the module.</param>
+    /// <param name="moduleName">The module's entry-assembly name (the package manifest's
+    /// <see cref="PackageManifest.Module"/> declaration).</param>
+    /// <param name="packagePath">The install record's mesh path, recorded on the activation entry.</param>
+    /// <param name="unattended">True on the reconciler's background lane — gates the landing on
+    /// <see cref="IModuleUpdatePolicy"/> (the deployment's existing update-policy surface; absent =
+    /// allowed, the platform default). An explicit install passes false: the operator asked.</param>
+    public IObservable<int> AdoptModule(
+        string pluginId, string moduleName, string? packagePath = null, bool unattended = false)
+    {
+        var landing = _hub.ServiceProvider.GetService<ModuleLandingService>();
+        if (landing is null)
+        {
+            _logger?.LogWarning(
+                "Module bundle for {Plugin}: no ModuleLandingService on this host — nothing landed",
+                pluginId);
+            return Observable.Return(0);
+        }
+
+        var policy = unattended ? _hub.ServiceProvider.GetService<IModuleUpdatePolicy>() : null;
+        var policyDecline = policy?.DeclineUnattendedLanding().Take(1)
+                            ?? Observable.Return<string?>(null);
+
+        return _index.GetOrCreate(FetchIndex)
+            .Take(1)
+            .SelectMany(index => landing.GetActivation().Take(1)
+                .SelectMany(activation => policyDecline
+                    .SelectMany(declined =>
+                    {
+                        var bundle = index.Bundles?.FirstOrDefault(b =>
+                            string.Equals(b.Plugin, pluginId, StringComparison.OrdinalIgnoreCase)
+                            && !string.IsNullOrWhiteSpace(b.Module));
+                        var entry = activation.Entries.FirstOrDefault(e =>
+                            string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
+
+                        var verdict = ModuleUpdateDecision.Decide(
+                            bundle?.Version, index.FrameworkMvid,
+                            PrebuiltAssemblySeeder.DeclineReason, entry, declined);
+
+                        if (verdict.Action != ModuleUpdateAction.Land)
+                        {
+                            _logger?.LogInformation(
+                                "Module '{Module}' of {Plugin}: {Action} — {Reason}",
+                                moduleName, pluginId, verdict.Action, verdict.Reason);
+                            return Observable.Return(0);
+                        }
+
+                        _logger?.LogInformation(
+                            "Module '{Module}' of {Plugin}: {Reason}",
+                            moduleName, pluginId, verdict.Reason);
+                        return Download(pluginId, bundle!.Version)
+                            .SelectMany(bytes => bytes is null
+                                ? Observable.Return(0)
+                                : LandFromBundle(pluginId, moduleName, packagePath, bundle.Version, bytes));
+                    })))
+            .Catch((Exception ex) =>
+            {
+                // A distribution hiccup must not fail the install/reconcile that asked — the module
+                // simply stays as it is until the next boot or a manual re-install.
+                _logger?.LogWarning(ex,
+                    "Module '{Module}' of {Plugin}: landing failed — the module is unchanged",
+                    moduleName, pluginId);
+                return Observable.Return(0);
+            });
+    }
+
+    /// <summary>
+    /// Reads the downloaded bundle's module section and lands it. The MVID is verified AGAIN here,
+    /// against the manifest inside the archive — the index said what the registry runs, the
+    /// manifest says what these bytes were built with, and only the second is the gate that holds
+    /// (<see cref="ModuleLandingService"/> re-checks it a third time at placement; declining twice
+    /// is cheaper than debugging a TypeLoadException once).
+    /// </summary>
+    // Internal for the ModuleFunnelTest pin (InternalsVisibleTo): the land half without HTTP.
+    internal IObservable<int> LandFromBundle(
+        string pluginId, string moduleName, string? packagePath, string version, byte[] bundleBytes) =>
+        _httpPool.InvokeBlocking(_ => BundleReader.ReadModule(bundleBytes))
+            .SelectMany(payload =>
+            {
+                var (manifest, files) = payload;
+
+                if (PrebuiltAssemblySeeder.DeclineReason(manifest?.FrameworkMvid) is { } reason)
+                {
+                    _logger?.LogInformation(
+                        "Module bundle for {Plugin} DECLINED: {Reason} — nothing landed",
+                        pluginId, reason);
+                    return Observable.Return(0);
+                }
+
+                if (files.Count == 0)
+                {
+                    _logger?.LogInformation(
+                        "Module bundle for {Plugin} carries no (complete) module payload — nothing landed",
+                        pluginId);
+                    return Observable.Return(0);
+                }
+
+                // The bundle must be the module the PACKAGE declared — a producer/catalog drift
+                // here would land bytes under an identity the boot union never asks for.
+                if (manifest?.Module?.AssemblyName is { Length: > 0 } declared
+                    && !string.Equals(declared, moduleName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger?.LogWarning(
+                        "Module bundle for {Plugin} declares module '{Declared}' but the package "
+                        + "declares '{Expected}' — nothing landed", pluginId, declared, moduleName);
+                    return Observable.Return(0);
+                }
+
+                var landing = _hub.ServiceProvider.GetRequiredService<ModuleLandingService>();
+                return landing
+                    .LandModule(
+                        moduleName,
+                        files.Select(f => (f.FileName, f.Bytes)).ToArray(),
+                        manifest!.FrameworkMvid!,
+                        packagePath,
+                        version)
+                    .Select(_ => files.Count)
+                    .Do(count => _logger?.LogInformation(
+                        "Module '{Module}' of {Plugin} landed ({Count} file(s), version {Version}) "
+                        + "— RESTART REQUIRED to load it", moduleName, pluginId, count, version));
             });
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -50,6 +50,16 @@ public sealed class RegistryPackageSource : IPackageSource
             ?.CreateClient(InstanceRegistrationClient.HttpClientName) ?? SharedHttp;
     }
 
+    /// <summary>
+    /// The prebuilt-bundle client for the SAME registry, same key (#1664) — set where this source
+    /// is constructed, because that is the only place the URL and this installation's instance key
+    /// are both known. Non-null is what lets the install orchestrator
+    /// (<see cref="CatalogLayoutAreas.InstallOrUpdate"/>) land a module-declaring package's
+    /// compiled module as part of the install; null (a test stub, an exotic host) simply means the
+    /// module lands on the next boot's reconcile instead.
+    /// </summary>
+    public PluginBundleClient? Bundles { get; init; }
+
     private sealed record ListResponse(IReadOnlyList<PackageManifest>? Packages);
     private sealed record FilesResponse(IReadOnlyList<PackageFile>? Files);
 

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -2,6 +2,7 @@
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -163,7 +164,11 @@ public sealed class RegistryUpdateReconciler(
                         + "registry will answer, so installed packages may not be reconciled.",
                         registry.Url);
 
-                var source = new RegistryPackageSource(hub, registry.Url, token);
+                // ONE bundle client for the pass, shared by the source (a content apply lands its
+                // module inside InstallOrUpdate) and the module pass below — so the promise-cached
+                // bundle index is read once per registry per boot.
+                var bundles = new PluginBundleClient(hub, registry.Url, token);
+                var source = new RegistryPackageSource(hub, registry.Url, token) { Bundles = bundles };
                 return source.ListPackages(gitRef)
                     // 🚨 The ONE attempt the design allots must actually get a fair chance (#1500).
                     //
@@ -197,8 +202,16 @@ public sealed class RegistryUpdateReconciler(
                             + "reconciling this installation's records against them.",
                             name, packages.Count, gitRef);
                         return PackageUpdateReconciler.ReconcileInstalled(
-                            hub, source, gitRef, packages,
-                            $"Served by registry '{name}'", logger);
+                                hub, source, gitRef, packages,
+                                $"Served by registry '{name}'", logger)
+                            // The MODULE lane of the same reconcile (#1664): for installed
+                            // packages that declare a compiled module, consult the registry's
+                            // bundle index and land what is newer FOR THE RUNNING framework.
+                            // AFTER the content reconcile, so a content update and its module
+                            // land in one pass; keyed on the bundle index, NOT the content
+                            // hash — a bundle rebuilt for a new framework MVID has unchanged
+                            // content, and this lane is what heals it after an image roll.
+                            .SelectMany(_ => ReconcileModules(bundles, name, packages));
                     });
             })
             .Catch((Exception ex) =>
@@ -213,5 +226,61 @@ public sealed class RegistryUpdateReconciler(
                     name, registry.Url, FeedReadRetries + 1);
                 return Observable.Return(Unit.Default);
             });
+    }
+
+    /// <summary>
+    /// The module half of the boot reconcile (#1664 Slice C): for each of the registry's packages
+    /// that declares a compiled module AND has an install record here, run the one module-update
+    /// decision (<see cref="ModuleUpdateDecision"/>) via <see cref="PluginBundleClient.AdoptModule"/>
+    /// — which lands a newer bundle for the RUNNING framework MVID through
+    /// <see cref="ModuleLandingService"/> and flags <c>PendingRestart</c>, skips an up-to-date one
+    /// without a download, and skips a foreign-framework registry silently-with-log (it becomes
+    /// relevant after the next image roll).
+    ///
+    /// <para><b>The policy gate is the deployment's EXISTING update policy</b>
+    /// (<see cref="IModuleUpdatePolicy"/> — the memex portals wire it to <c>Admin/UpdatePolicy</c>):
+    /// this lane passes <c>unattended: true</c>, so Continuous (the platform default, and the
+    /// default when no policy is registered) lands unattended while Stable/None decline. There is
+    /// deliberately NO module-specific knob.</para>
+    ///
+    /// <para>Sequential, and failure-tolerant per package — one unreachable bundle must not
+    /// withhold the rest, and <see cref="PluginBundleClient.AdoptModule"/> already absorbs its own
+    /// failures into a logged zero.</para>
+    /// </summary>
+    private IObservable<Unit> ReconcileModules(
+        PluginBundleClient bundles,
+        string registryName,
+        IReadOnlyList<PackageManifest> packages)
+    {
+        var declaring = packages
+            .Where(p => !string.IsNullOrWhiteSpace(p.Module))
+            .ToArray();
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (declaring.Length == 0 || storage is null)
+            return Observable.Return(Unit.Default);
+
+        return declaring
+            .Select(pkg =>
+            {
+                var recordPath = $"{PackageInstaller.InstalledPartition}/{pkg.Id}";
+                return storage.Read(recordPath, hub.JsonSerializerOptions)
+                    .Take(1)
+                    .SelectMany(record => record is null
+                        // Not installed here → somebody else's module; nothing to reconcile.
+                        ? Observable.Return(0)
+                        : bundles.AdoptModule(pkg.Id, pkg.Module!, recordPath, unattended: true))
+                    .Catch((Exception ex) =>
+                    {
+                        logger.LogWarning(ex,
+                            "[RegistryUpdate] module reconcile of {Id} against {Name} failed — "
+                            + "its landed module is unchanged.", pkg.Id, registryName);
+                        return Observable.Return(0);
+                    })
+                    .Select(_ => Unit.Default);
+            })
+            .ToObservable()
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync();
     }
 }

--- a/test/MeshWeaver.Graph.Test/BundleReaderTest.cs
+++ b/test/MeshWeaver.Graph.Test/BundleReaderTest.cs
@@ -150,6 +150,110 @@ public class BundleReaderTest
         Assert.Equal("PDB", Encoding.UTF8.GetString(only.Pdb!));
     }
 
+    // ── the MODULE variant (#1664): one bundle, one reader, a second lane ──
+
+    private static byte[] WriteModuleBundle(
+        object module, params (string FileName, byte[] Bytes)[] moduleFiles)
+    {
+        var entries = moduleFiles.Select(f => new NuGetPackageWriter.Entry(
+            NuGetPackageWriter.ModuleEntryPathFor(f.FileName),
+            () => new MemoryStream(f.Bytes))).ToArray();
+
+        var manifestJson = JsonSerializer.Serialize(new
+        {
+            plugin = "SocialMedia",
+            version = "1.2.0",
+            frameworkMvid = "33f2efb8aaaabbbbccccddddeeeeffff",
+            module,
+        });
+
+        var buffer = new MemoryStream();
+        NuGetPackageWriter.Write(buffer, Manifest, "3.0.0", entries, manifestJson);
+        return buffer.ToArray();
+    }
+
+    [Fact]
+    public void AModuleBundleRoundTrips()
+    {
+        var bundle = WriteModuleBundle(
+            new { assemblyName = "MeshWeaver.Social", assemblies = new[] { "MeshWeaver.Social.dll" } },
+            ("MeshWeaver.Social.dll", "SOCIAL"u8.ToArray()));
+
+        var (manifest, files) = BundleReader.ReadModule(bundle);
+
+        Assert.Equal("MeshWeaver.Social", manifest!.Module!.AssemblyName);
+        var only = Assert.Single(files);
+        Assert.Equal("MeshWeaver.Social.dll", only.FileName);
+        Assert.Equal("SOCIAL", Encoding.UTF8.GetString(only.Bytes));
+    }
+
+    [Fact]
+    public void AMixedBundleServesBothLanes()
+    {
+        // The MeshWeaver.SocialMedia shape: content nodes + NodeType assemblies + a compiled module
+        // in ONE Store product — so one bundle must serve both readers without either seeing the
+        // other's payload.
+        var manifestJson = JsonSerializer.Serialize(new
+        {
+            plugin = "SocialMedia",
+            version = "1.2.0",
+            frameworkMvid = "33f2efb8aaaabbbbccccddddeeeeffff",
+            assemblies = new[] { new { nodePath = "SocialMedia/Post", assembly = "SocialMedia/Post.dll" } },
+            module = new { assemblyName = "MeshWeaver.Social", assemblies = new[] { "MeshWeaver.Social.dll" } },
+        });
+
+        var buffer = new MemoryStream();
+        NuGetPackageWriter.Write(buffer, Manifest, "3.0.0",
+            [
+                new NuGetPackageWriter.Entry(
+                    NuGetPackageWriter.EntryPathFor("SocialMedia/Post"),
+                    () => new MemoryStream("NODETYPE"u8.ToArray())),
+                new NuGetPackageWriter.Entry(
+                    NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Social.dll"),
+                    () => new MemoryStream("MODULE"u8.ToArray())),
+            ],
+            manifestJson);
+        var bundle = buffer.ToArray();
+
+        var nodeTypes = Assert.Single(BundleReader.Read(bundle).Assemblies);
+        Assert.Equal("SocialMedia/Post", nodeTypes.NodePath);
+        Assert.Equal("NODETYPE", Encoding.UTF8.GetString(nodeTypes.Assembly));
+
+        var moduleFile = Assert.Single(BundleReader.ReadModule(bundle).Files);
+        Assert.Equal("MODULE", Encoding.UTF8.GetString(moduleFile.Bytes));
+    }
+
+    [Fact]
+    public void AnIncompleteModuleClosureYieldsNoFilesAtAll()
+    {
+        // All-or-nothing, deliberately UNLIKE the NodeType lane's skip: a NodeType with missing
+        // bytes simply compiles, but a module folder missing part of its closure loads and then
+        // faults at first use — a subset must never land.
+        var bundle = WriteModuleBundle(
+            new
+            {
+                assemblyName = "MeshWeaver.Social",
+                assemblies = new[] { "MeshWeaver.Social.dll", "MeshWeaver.Social.Support.dll" },
+            },
+            ("MeshWeaver.Social.dll", "SOCIAL"u8.ToArray()));
+
+        var (manifest, files) = BundleReader.ReadModule(bundle);
+
+        Assert.NotNull(manifest!.Module);
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void ANodeTypeOnlyBundleDeclaresNoModule()
+    {
+        var bundle = WriteBundle(("ThreeBody/Physics/Source", "PHYSICS"u8.ToArray()));
+
+        var (manifest, files) = BundleReader.ReadModule(bundle);
+
+        Assert.Null(manifest!.Module);
+        Assert.Empty(files);
+    }
+
     [Fact]
     public void AnArchiveWithoutAManifestYieldsNothing()
     {

--- a/test/MeshWeaver.Graph.Test/BundleReaderTest.cs
+++ b/test/MeshWeaver.Graph.Test/BundleReaderTest.cs
@@ -176,12 +176,20 @@ public class BundleReaderTest
     public void AModuleBundleRoundTrips()
     {
         var bundle = WriteModuleBundle(
-            new { assemblyName = "MeshWeaver.Social", assemblies = new[] { "MeshWeaver.Social.dll" } },
+            new
+            {
+                assemblyName = "MeshWeaver.Social",
+                assemblies = new[] { "MeshWeaver.Social.dll" },
+                minMeshVersion = "3.0.0",
+            },
             ("MeshWeaver.Social.dll", "SOCIAL"u8.ToArray()));
 
         var (manifest, files) = BundleReader.ReadModule(bundle);
 
         Assert.Equal("MeshWeaver.Social", manifest!.Module!.AssemblyName);
+        // The consumer's landing gate — a platform FLOOR, not the manifest-level frameworkMvid
+        // (which stays the NodeType lane's strict gate and, for the module, diagnostics).
+        Assert.Equal("3.0.0", manifest.Module.MinMeshVersion);
         var only = Assert.Single(files);
         Assert.Equal("MeshWeaver.Social.dll", only.FileName);
         Assert.Equal("SOCIAL", Encoding.UTF8.GetString(only.Bytes));

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -1,0 +1,100 @@
+#pragma warning disable CS1591
+
+using System.Text;
+using MeshWeaver.Plugin.Build;
+using MeshWeaver.Plugin.Packaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The <c>module-pack</c> CLI (#1664 Slice B): its inputs flow into FILE PATHS (the entry-DLL
+/// probe, the closure entries, the output bundle name), so path-injection-shaped values must be a
+/// clear exit-2 refusal — and what it packs must read back through the ONE reader
+/// (<see cref="BundleReader.ReadModule"/>) the consumers use.
+/// </summary>
+public class ModulePackCommandTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-module-pack-" + Guid.NewGuid().ToString("N"));
+
+    public ModulePackCommandTest()
+    {
+        Directory.CreateDirectory(Path.Combine(root, "closure"));
+        File.WriteAllBytes(Path.Combine(root, "closure", "Widget.dll"), "WIDGET"u8.ToArray());
+    }
+
+    public void Dispose()
+    {
+        // Best-effort temp cleanup — must run on assertion failure too, never mask the failure.
+        try
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        catch
+        {
+            // Leaked temp dirs are the OS's to reap; a cleanup error must not fail the test.
+        }
+    }
+
+    [Theory]
+    [InlineData("--module-name", "../evil")]
+    [InlineData("--module-name", "a/b")]
+    [InlineData("--plugin", "..\\..\\escape")]
+    [InlineData("--package-version", "1.0.0/../../x")]
+    public void PathInjectionShapedInputs_AreRejected_BeforeAnyPathIsComposed(
+        string option, string value)
+    {
+        // 🚨 The Copilot finding: these values reach Path.Combine (entry-DLL probe, bundle file
+        // name), so a traversal-shaped value must be a clear refusal naming it — never a probe
+        // outside the module folder or a bundle written somewhere surprising.
+        var args = new List<string>
+        {
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.0.0",
+            "--out", Path.Combine(root, "out"),
+        };
+        args[args.IndexOf(option) + 1] = value;
+
+        var exit = ModulePackCommand.Run([.. args]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(Path.Combine(root, "out")),
+            "a refused invocation must not have written anything");
+    }
+
+    [Fact]
+    public void APackedModuleBundle_RoundTripsThroughTheReader()
+    {
+        var outDir = Path.Combine(root, "out");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.2.0",
+            "--min-mesh-version", "3.0.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var bundlePath = Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.2.0.module.nupkg");
+        Assert.True(File.Exists(bundlePath));
+
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(bundlePath));
+
+        Assert.Equal("WidgetPkg", manifest!.Plugin);
+        Assert.Equal("1.2.0", manifest.Version);
+        Assert.Equal("Widget", manifest.Module!.AssemblyName);
+        Assert.Equal("3.0.0", manifest.Module.MinMeshVersion);
+        // No MeshWeaver.Graph.dll in the closure folder: the diagnostic MVID is simply
+        // unrecorded — warned, never an error, never a gate.
+        Assert.Null(manifest.FrameworkMvid);
+        var only = Assert.Single(files);
+        Assert.Equal("Widget.dll", only.FileName);
+        Assert.Equal("WIDGET", Encoding.UTF8.GetString(only.Bytes));
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
@@ -12,9 +12,9 @@ namespace MeshWeaver.PluginCatalog.Test;
 /// <summary>
 /// The boot-time effective-set computation of #1664 Slice A, step 9 —
 /// <see cref="ModuleActivationBoot.ComputeEffectiveModuleEntries"/>, pure: appsettings baseline ∪
-/// enabled persisted store installs, deduped by name, with the two loud skip rules (framework-MVID
-/// mismatch, missing DLL) that keep an image roll or a lost volume from crashing boot. Plus the
-/// sidecar's read/write round-trip and its corrupt-file loudness.
+/// enabled persisted store installs, deduped by name, with the two loud skip rules (unsatisfied
+/// platform floor, missing DLL) that keep a platform rollback or a lost volume from crashing
+/// boot. Plus the sidecar's read/write round-trip and its corrupt-file loudness.
 /// </summary>
 public class ModuleActivationBootTest
 {
@@ -24,8 +24,9 @@ public class ModuleActivationBootTest
     private static ModuleActivationList List(params ModuleActivationEntry[] entries) =>
         new() { Entries = [.. entries] };
 
-    private static ModuleActivationEntry Store(string name, bool enabled = true, string? mvid = "m1") =>
-        new() { Name = name, FrameworkMvid = mvid, Enabled = enabled };
+    private static ModuleActivationEntry Store(
+        string name, bool enabled = true, string? floor = null) =>
+        new() { Name = name, FrameworkMvid = "m1", MinMeshVersion = floor, Enabled = enabled };
 
     [Fact]
     public void EffectiveSet_IsBaselineUnionEnabledPersisted_InOrder()
@@ -67,41 +68,41 @@ public class ModuleActivationBootTest
     }
 
     [Fact]
-    public void FrameworkMvidMismatch_SkipsWithLoudReason_NeverCrashes()
+    public void UnsatisfiedPlatformFloor_SkipsWithLoudReason_NeverCrashes()
     {
+        // The PRODUCTION gate (ModulePlatformFloor.DeclineReason), bound to a fixed running
+        // version — the platform rolled BACK below one module's declared requirement. Deliberately
+        // a FLOOR and not an MVID check: modules bind by simple name, so a landed module keeps
+        // loading across ordinary platform updates; only a rollback below its floor skips it.
         var skips = new List<(string Module, string Reason)>();
         var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
             ["MeshWeaver.OgCard.dll"],
-            List(Store("Acme.Widgets", mvid: "stale-mvid"), Store("Acme.Reports", mvid: "live")),
-            // The gate is injected — production passes PrebuiltAssemblySeeder.DeclineReason, so
-            // there is never a second notion of framework identity to test here, only the skip.
-            mvid => mvid == "live" ? null : $"built against framework {mvid}, live framework is live",
+            List(Store("Acme.Widgets", floor: "9.0.0"), Store("Acme.Reports", floor: "1.0.0")),
+            floor => ModulePlatformFloor.DeclineReason(floor, "3.2.0"),
             AllDllsExist,
             (m, r) => skips.Add((m, r)));
 
         effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
         var skip = skips.Should().ContainSingle().Subject;
         skip.Module.Should().Be("Acme.Widgets");
-        skip.Reason.Should().Contain("stale-mvid").And.Contain("live",
-            "the skip must name both identities — the entry stays for the post-roll re-install");
+        skip.Reason.Should().Contain("9.0.0").And.Contain("3.2.0",
+            "the skip must name both versions — the entry stays for when the platform moves forward");
     }
 
     [Fact]
-    public void NullRecordedMvid_IsSkipped_WhenTheGateDeclinesAbsentIdentity()
+    public void NoRecordedFloor_Loads_AbsenceIsNoConstraint()
     {
-        // Production's gate (PrebuiltAssemblySeeder.DeclineReason) declines an ABSENT identity —
-        // "cannot be shown ABI-compatible" — and the boot union inherits that: an unverifiable
-        // store entry never loads on faith.
-        var skips = new List<(string Module, string Reason)>();
+        // An entry landed without a declared minMeshVersion (most modules; every entry written
+        // before the field existed) has stated no requirement — the production gate reads absence
+        // as satisfied, so such landings keep loading across platform builds. The recorded MVID
+        // is diagnostic and deliberately not consulted.
         var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
             [],
-            List(Store("Acme.Widgets", mvid: null)),
-            mvid => mvid is null ? "no recorded framework identity" : null,
-            AllDllsExist,
-            (m, r) => skips.Add((m, r)));
+            List(Store("Acme.Widgets")),
+            floor => ModulePlatformFloor.DeclineReason(floor, "3.2.0"),
+            AllDllsExist);
 
-        effective.Should().BeEmpty();
-        skips.Should().ContainSingle().Which.Module.Should().Be("Acme.Widgets");
+        effective.Should().Equal("Acme.Widgets.dll");
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
@@ -11,17 +11,17 @@ namespace MeshWeaver.PluginCatalog.Test;
 /// <summary>
 /// The registry's serve rules for module bundles (#1664 Slice C, the serving half): a registry may
 /// only fan out module bytes it could load itself — its own <c>modules/&lt;name&gt;/</c> tree,
-/// gated on the activation sidecar exactly as boot is.
+/// gated on the activation sidecar exactly as boot is (the platform FLOOR; the recorded MVID is
+/// diagnostic and never withholds a serve).
 /// </summary>
 public class ModuleBundleSourceTest : IDisposable
 {
     private readonly string baseDirectory =
         Path.Combine(Path.GetTempPath(), "mw-bundle-src-" + Guid.NewGuid().ToString("N"));
 
-    private const string LiveMvid = "aaaa0000aaaa0000aaaa0000aaaa0000";
-
-    private static string? Gate(string? mvid) =>
-        string.Equals(mvid, LiveMvid, StringComparison.Ordinal) ? null : $"stale ({mvid})";
+    /// <summary>The production gate bound to a fixed running platform version.</summary>
+    private static string? Gate(string? floor) =>
+        ModulePlatformFloor.DeclineReason(floor, "3.2.0");
 
     public ModuleBundleSourceTest() => Directory.CreateDirectory(baseDirectory);
 
@@ -62,13 +62,16 @@ public class ModuleBundleSourceTest : IDisposable
     }
 
     [Fact]
-    public void AStoreLandedModuleWithTheRunningFramework_IsServed()
+    public void AStoreLandedModuleWhoseFloorIsSatisfied_IsServed()
     {
         LayOut("MeshWeaver.Social");
 
         var (files, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
-            Activation(new ModuleActivationEntry { Name = "MeshWeaver.Social", FrameworkMvid = LiveMvid }),
+            Activation(new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Social", MinMeshVersion = "3.0.0",
+            }),
             Gate);
 
         Assert.Null(decline);
@@ -76,20 +79,46 @@ public class ModuleBundleSourceTest : IDisposable
     }
 
     [Fact]
-    public void AFrameworkStaleLanding_IsRefused()
+    public void ALandingBuiltByAnotherPlatformBuild_IsStillServed_TheMvidIsDiagnostic()
     {
-        // The registry itself rolled its image since it landed this module: the folder holds bytes
-        // the registry's OWN boot skips, and serving them would hand a consumer assemblies stamped
-        // with a framework neither side runs.
+        // The landing records which exact build produced the bytes — but modules bind by simple
+        // name, so those bytes load (and therefore serve) on every platform satisfying their
+        // floor. Under the old MVID-equality rule this landing went dark on the registry's first
+        // image roll, which is precisely the bake semantics the module lane rejects.
         LayOut("MeshWeaver.Social");
 
         var (files, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
-            Activation(new ModuleActivationEntry { Name = "MeshWeaver.Social", FrameworkMvid = "ffff" }),
+            Activation(new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Social",
+                FrameworkMvid = "ffff9999ffff9999ffff9999ffff9999",
+                MinMeshVersion = "3.0.0",
+            }),
+            Gate);
+
+        Assert.Null(decline);
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public void ALandingWhoseFloorExceedsTheRunningPlatform_IsRefused()
+    {
+        // The platform rolled BACK below the module's declared requirement: these are exactly the
+        // bytes this instance's own boot union skips, and a registry must never fan out a module
+        // it could not load itself.
+        LayOut("MeshWeaver.Social");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social",
+            Activation(new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Social", MinMeshVersion = "9.0.0",
+            }),
             Gate);
 
         Assert.Empty(files);
-        Assert.Contains("stale", decline);
+        Assert.Contains("9.0.0", decline);
     }
 
     [Fact]
@@ -101,7 +130,7 @@ public class ModuleBundleSourceTest : IDisposable
             baseDirectory, "MeshWeaver.Social",
             Activation(new ModuleActivationEntry
             {
-                Name = "MeshWeaver.Social", FrameworkMvid = LiveMvid, Enabled = false,
+                Name = "MeshWeaver.Social", Enabled = false,
             }),
             Gate);
 

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
@@ -1,0 +1,139 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The registry's serve rules for module bundles (#1664 Slice C, the serving half): a registry may
+/// only fan out module bytes it could load itself — its own <c>modules/&lt;name&gt;/</c> tree,
+/// gated on the activation sidecar exactly as boot is.
+/// </summary>
+public class ModuleBundleSourceTest : IDisposable
+{
+    private readonly string baseDirectory =
+        Path.Combine(Path.GetTempPath(), "mw-bundle-src-" + Guid.NewGuid().ToString("N"));
+
+    private const string LiveMvid = "aaaa0000aaaa0000aaaa0000aaaa0000";
+
+    private static string? Gate(string? mvid) =>
+        string.Equals(mvid, LiveMvid, StringComparison.Ordinal) ? null : $"stale ({mvid})";
+
+    public ModuleBundleSourceTest() => Directory.CreateDirectory(baseDirectory);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(baseDirectory))
+            Directory.Delete(baseDirectory, recursive: true);
+    }
+
+    private void LayOut(string name, params string[] extraFiles)
+    {
+        var folder = Path.Combine(baseDirectory, "modules", name);
+        Directory.CreateDirectory(folder);
+        File.WriteAllBytes(Path.Combine(folder, name + ".dll"), [1]);
+        foreach (var file in extraFiles)
+            File.WriteAllBytes(Path.Combine(folder, file), [2]);
+    }
+
+    private static ModuleActivationList Activation(params ModuleActivationEntry[] entries) =>
+        new() { Entries = [.. entries] };
+
+    [Fact]
+    public void AnImageLaidOutModule_IsServed_EntryDllFirst()
+    {
+        // No sidecar entry at all — the image's own publish layout. Those bytes were compiled with
+        // the image, so they match the running framework by construction.
+        LayOut("MeshWeaver.Social", "MeshWeaver.Social.pdb", "Aux.dll", "readme.txt");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social", Activation(), Gate);
+
+        Assert.Null(decline);
+        Assert.Equal("MeshWeaver.Social.dll", Path.GetFileName(files[0]));
+        Assert.Equal(
+            new[] { "Aux.dll", "MeshWeaver.Social.pdb" },
+            files.Skip(1).Select(Path.GetFileName).ToArray());
+        Assert.DoesNotContain(files, f => f.EndsWith("readme.txt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AStoreLandedModuleWithTheRunningFramework_IsServed()
+    {
+        LayOut("MeshWeaver.Social");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social",
+            Activation(new ModuleActivationEntry { Name = "MeshWeaver.Social", FrameworkMvid = LiveMvid }),
+            Gate);
+
+        Assert.Null(decline);
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public void AFrameworkStaleLanding_IsRefused()
+    {
+        // The registry itself rolled its image since it landed this module: the folder holds bytes
+        // the registry's OWN boot skips, and serving them would hand a consumer assemblies stamped
+        // with a framework neither side runs.
+        LayOut("MeshWeaver.Social");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social",
+            Activation(new ModuleActivationEntry { Name = "MeshWeaver.Social", FrameworkMvid = "ffff" }),
+            Gate);
+
+        Assert.Empty(files);
+        Assert.Contains("stale", decline);
+    }
+
+    [Fact]
+    public void AnUninstalledModule_IsRefused()
+    {
+        LayOut("MeshWeaver.Social");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social",
+            Activation(new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Social", FrameworkMvid = LiveMvid, Enabled = false,
+            }),
+            Gate);
+
+        Assert.Empty(files);
+        Assert.Contains("uninstalled", decline);
+    }
+
+    [Fact]
+    public void AModuleWithoutItsEntryDll_IsRefused()
+    {
+        // Covers the transitional publish state too: a module still riding the app closure prunes
+        // its modules/ folder empty, and an empty folder must serve nothing rather than a partial
+        // closure.
+        Directory.CreateDirectory(Path.Combine(baseDirectory, "modules", "MeshWeaver.Social"));
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social", Activation(), Gate);
+
+        Assert.Empty(files);
+        Assert.Contains("does not exist", decline);
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("a/b")]
+    [InlineData("")]
+    [InlineData("..")]
+    public void AnInvalidModuleName_IsRefused(string name)
+    {
+        var (files, decline) = ModuleBundleSource.Collect(baseDirectory, name, Activation(), Gate);
+
+        Assert.Empty(files);
+        Assert.NotNull(decline);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
@@ -46,6 +46,29 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
                 services.AddSingleton(new ModuleLandingService(baseDirectory: landingRoot)));
     }
 
+    /// <summary>
+    /// Teardown cleanup of the per-test landing tree — here, in the lifecycle hook, so it runs on
+    /// ASSERTION FAILURE too (inline deletes at the end of a test body are skipped the moment an
+    /// assert throws, leaking a temp dir per red run). The base implements
+    /// <see cref="IAsyncLifetime"/>, and xUnit v3 calls <c>DisposeAsync</c> in preference to
+    /// <c>IDisposable.Dispose</c> — so this override, not an added <c>Dispose()</c>, is the hook
+    /// that actually runs.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(landingRoot))
+                Directory.Delete(landingRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort: a cleanup hiccup (a straggling handle on a just-written DLL) must
+            // never turn a green test red — leaked temp dirs are the OS's to reap.
+        }
+    }
+
     private static byte[] ModuleBundle(string frameworkMvid, string? minMeshVersion = null)
     {
         var manifestJson = JsonSerializer.Serialize(new
@@ -109,8 +132,6 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         entry.FrameworkMvid.Should().Be(foreignBuild,
             "the built-against MVID rides along as diagnostics, never as a gate");
         list.PendingRestart.Should().BeTrue("restart-as-activation — nothing loads into the running process");
-
-        Directory.Delete(landingRoot, recursive: true);
     }
 
     /// <summary>
@@ -133,8 +154,6 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         Directory.Exists(Path.Combine(landingRoot, "modules", "MeshWeaver.Social"))
             .Should().BeFalse("declined bytes never reach disk");
         ModuleActivationSidecar.Read(landingRoot).Entries.Should().BeEmpty();
-
-        Directory.Delete(landingRoot, recursive: true);
     }
 
     /// <summary>
@@ -174,8 +193,6 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             "the record is what the registry's bundle index serves modules from");
         content.MinMeshVersion.Should().Be("3.0.0",
             "the floor rides the record so the index can surface it without re-reading the repo");
-
-        Directory.Delete(landingRoot, recursive: true);
     }
 
     /// <summary>
@@ -203,7 +220,5 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         social.MinMeshVersion.Should().Be("3.0.0", "the floor is the module lane's landing gate");
         packages.Single(p => p.Id == "Plain").Module.Should().BeNull(
             "a package that declares no module must never enter the module funnel");
-
-        Directory.Delete(landingRoot, recursive: true);
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
@@ -1,0 +1,196 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Plugin.Packaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using PackagingManifest = MeshWeaver.Plugin.Packaging.PluginManifest;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The module funnel (#1664 Slices B+C): a package that DECLARES a compiled module routes its
+/// binary payload through bundle-fetch → MVID gate → <see cref="ModuleLandingService"/> — never
+/// through the file→MeshNode parse — and the declaration itself flows listing → install record so
+/// both ends of the funnel (the consumer's adopt and the registry's serve) can key on it.
+/// </summary>
+public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly string landingRoot =
+        Path.Combine(Path.GetTempPath(), "mw-funnel-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>The RUNNING framework identity — what the bundle must carry to be landable.</summary>
+    private static string LiveFrameworkMvid =>
+        typeof(PrebuiltAssemblySeeder).Assembly.ManifestModule.ModuleVersionId.ToString("N");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(landingRoot);
+        return base.ConfigureMesh(builder).AddGraph().AddPluginCatalog()
+            // Land into a per-test temp tree, never the test host's own bin folder — the sidecar
+            // is a persistent file, and writing it beside the testhost would bleed across tests.
+            .ConfigureServices(services =>
+                services.AddSingleton(new ModuleLandingService(baseDirectory: landingRoot)));
+    }
+
+    private static byte[] ModuleBundle(string frameworkMvid)
+    {
+        var manifestJson = JsonSerializer.Serialize(new
+        {
+            plugin = "SocialMedia",
+            version = "1.2.0",
+            frameworkMvid,
+            module = new
+            {
+                assemblyName = "MeshWeaver.Social",
+                assemblies = new[] { "MeshWeaver.Social.dll" },
+            },
+        });
+
+        var buffer = new MemoryStream();
+        NuGetPackageWriter.Write(
+            buffer,
+            new PackagingManifest("SocialMedia", "MeshWeaver.Plugin.SocialMedia", "1.2.0", "SocialMedia", null, []),
+            "3.0.0",
+            [
+                new NuGetPackageWriter.Entry(
+                    NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Social.dll"),
+                    () => new MemoryStream("SOCIAL"u8.ToArray())),
+            ],
+            manifestJson);
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// The consumer's land half, without HTTP: a bundle carrying the RUNNING framework's MVID lands
+    /// into <c>modules/&lt;name&gt;/</c> with its activation entry — version recorded, restart
+    /// flagged — which is exactly what boot's activation union then loads.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ABundleForTheRunningFramework_LandsIntoTheModulesTree()
+    {
+        var client = new PluginBundleClient(Mesh, "http://registry.invalid");
+
+        var landed = await client
+            .LandFromBundle("SocialMedia", "MeshWeaver.Social", "Plugins/SocialMedia", "1.2.0",
+                ModuleBundle(LiveFrameworkMvid))
+            .FirstAsync().ToTask();
+
+        landed.Should().Be(1);
+        File.ReadAllBytes(Path.Combine(
+                landingRoot, "modules", "MeshWeaver.Social", "MeshWeaver.Social.dll"))
+            .Should().Equal("SOCIAL"u8.ToArray());
+
+        var list = ModuleActivationSidecar.Read(landingRoot);
+        var entry = list.Entries.Should().ContainSingle().Subject;
+        entry.Name.Should().Be("MeshWeaver.Social");
+        entry.Version.Should().Be("1.2.0",
+            "the recorded version is what lets the reconcile answer 'already landed' without a download");
+        entry.PackagePath.Should().Be("Plugins/SocialMedia");
+        entry.FrameworkMvid.Should().Be(LiveFrameworkMvid);
+        list.PendingRestart.Should().BeTrue("restart-as-activation — nothing loads into the running process");
+
+        Directory.Delete(landingRoot, recursive: true);
+    }
+
+    /// <summary>
+    /// 🚨 The MVID gate at the client: a bundle built against a DIFFERENT framework is refused
+    /// before a byte reaches disk — the refusal is a logged zero, never a failed install, because
+    /// the bundle becomes relevant after the next image roll and nothing is wrong today.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ABundleForAForeignFramework_IsRefused_NothingReachesDisk()
+    {
+        var client = new PluginBundleClient(Mesh, "http://registry.invalid");
+
+        var landed = await client
+            .LandFromBundle("SocialMedia", "MeshWeaver.Social", "Plugins/SocialMedia", "1.2.0",
+                ModuleBundle(Guid.NewGuid().ToString("N")))
+            .FirstAsync().ToTask();
+
+        landed.Should().Be(0);
+        Directory.Exists(Path.Combine(landingRoot, "modules", "MeshWeaver.Social"))
+            .Should().BeFalse("declined bytes never reach disk");
+        ModuleActivationSidecar.Read(landingRoot).Entries.Should().BeEmpty();
+
+        Directory.Delete(landingRoot, recursive: true);
+    }
+
+    /// <summary>
+    /// The declaration flows onto the install record: the registry's bundle index reads records,
+    /// not repos, so a record without the field could never offer the module.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AModuleDeclaringPackage_CarriesTheDeclarationOntoItsInstallRecord()
+    {
+        var manifest = new PackageManifest
+        {
+            Id = "SocialMedia",
+            Name = "Social Media",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "SocialMedia",
+            SourceFolder = "SocialMedia",
+            Version = "c1",
+            Module = "MeshWeaver.Social",
+        };
+        IReadOnlyList<PackageFile> files =
+        [
+            new("SocialMedia/index.json",
+                """{"$type":"MeshNode","id":"SocialMedia","namespace":"","path":"SocialMedia","mainNode":"SocialMedia","name":"Social Media","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Posts."}}"""),
+            new("SocialMedia/Notes.md", "# Social"),
+        ];
+
+        await PackageInstaller.Install(Mesh, manifest, files, "c1").FirstAsync().ToTask();
+
+        var record = await Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read($"{PackageInstaller.InstalledPartition}/SocialMedia", Mesh.JsonSerializerOptions)
+            .Take(1).ToTask();
+
+        record.Should().NotBeNull();
+        record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.Module
+            .Should().Be("MeshWeaver.Social",
+                "the record is what the registry's bundle index serves modules from");
+
+        Directory.Delete(landingRoot, recursive: true);
+    }
+
+    /// <summary>
+    /// The listing side of the same flow: the node-repo source reads the root's
+    /// <c>content.module</c> declaration — unread it would be dead metadata, the exact defect
+    /// class <c>preInstalled</c>/<c>publicSegments</c>/<c>contactEmail</c> each had.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheNodeRepoListing_ReadsTheModuleDeclaration()
+    {
+        var source = new NodeRepoPackageSource(
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("c1",
+            [
+                new RepoFile("SocialMedia/index.json",
+                    """{"nodeType":"Space","name":"Social Media","content":{"module":"MeshWeaver.Social"}}"""),
+                new RepoFile("Plain/index.json",
+                    """{"nodeType":"Space","name":"Plain","content":{}}"""),
+            ])),
+            "https://example.invalid/repo");
+
+        var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
+
+        packages.Single(p => p.Id == "SocialMedia").Module.Should().Be("MeshWeaver.Social");
+        packages.Single(p => p.Id == "Plain").Module.Should().BeNull(
+            "a package that declares no module must never enter the module funnel");
+
+        Directory.Delete(landingRoot, recursive: true);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
@@ -46,7 +46,7 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
                 services.AddSingleton(new ModuleLandingService(baseDirectory: landingRoot)));
     }
 
-    private static byte[] ModuleBundle(string frameworkMvid)
+    private static byte[] ModuleBundle(string frameworkMvid, string? minMeshVersion = null)
     {
         var manifestJson = JsonSerializer.Serialize(new
         {
@@ -57,6 +57,7 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             {
                 assemblyName = "MeshWeaver.Social",
                 assemblies = new[] { "MeshWeaver.Social.dll" },
+                minMeshVersion,
             },
         });
 
@@ -75,18 +76,22 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
     }
 
     /// <summary>
-    /// The consumer's land half, without HTTP: a bundle carrying the RUNNING framework's MVID lands
-    /// into <c>modules/&lt;name&gt;/</c> with its activation entry — version recorded, restart
-    /// flagged — which is exactly what boot's activation union then loads.
+    /// The consumer's land half, without HTTP — and the design decision of the lane in one pin: a
+    /// bundle built against a DIFFERENT platform build (a deliberately foreign MVID), whose
+    /// declared <c>minMeshVersion</c> floor this deployment satisfies, LANDS into
+    /// <c>modules/&lt;name&gt;/</c> with its activation entry — version + floor recorded, MVID
+    /// kept as diagnostics, restart flagged. That is the ex-post Store install across platform
+    /// versions that MVID equality (bake semantics, the NodeType lane's gate) would forbid.
     /// </summary>
     [Fact(Timeout = 120_000)]
-    public async Task ABundleForTheRunningFramework_LandsIntoTheModulesTree()
+    public async Task ABundleFromAnotherPlatformBuild_WithItsFloorSatisfied_Lands()
     {
         var client = new PluginBundleClient(Mesh, "http://registry.invalid");
+        var foreignBuild = Guid.NewGuid().ToString("N");
 
         var landed = await client
             .LandFromBundle("SocialMedia", "MeshWeaver.Social", "Plugins/SocialMedia", "1.2.0",
-                ModuleBundle(LiveFrameworkMvid))
+                ModuleBundle(foreignBuild, minMeshVersion: "0.0.1"))
             .FirstAsync().ToTask();
 
         landed.Should().Be(1);
@@ -99,26 +104,29 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         entry.Name.Should().Be("MeshWeaver.Social");
         entry.Version.Should().Be("1.2.0",
             "the recorded version is what lets the reconcile answer 'already landed' without a download");
+        entry.MinMeshVersion.Should().Be("0.0.1", "boot and the serve side re-check the floor");
         entry.PackagePath.Should().Be("Plugins/SocialMedia");
-        entry.FrameworkMvid.Should().Be(LiveFrameworkMvid);
+        entry.FrameworkMvid.Should().Be(foreignBuild,
+            "the built-against MVID rides along as diagnostics, never as a gate");
         list.PendingRestart.Should().BeTrue("restart-as-activation — nothing loads into the running process");
 
         Directory.Delete(landingRoot, recursive: true);
     }
 
     /// <summary>
-    /// 🚨 The MVID gate at the client: a bundle built against a DIFFERENT framework is refused
-    /// before a byte reaches disk — the refusal is a logged zero, never a failed install, because
-    /// the bundle becomes relevant after the next image roll and nothing is wrong today.
+    /// 🚨 The floor gate at the client: a bundle whose declared platform requirement exceeds this
+    /// deployment is refused before a byte reaches disk — the refusal is a logged zero, never a
+    /// failed install, because the bundle becomes installable after the platform updates and
+    /// nothing is wrong today.
     /// </summary>
     [Fact(Timeout = 120_000)]
-    public async Task ABundleForAForeignFramework_IsRefused_NothingReachesDisk()
+    public async Task ABundleWhoseFloorExceedsThisPlatform_IsRefused_NothingReachesDisk()
     {
         var client = new PluginBundleClient(Mesh, "http://registry.invalid");
 
         var landed = await client
             .LandFromBundle("SocialMedia", "MeshWeaver.Social", "Plugins/SocialMedia", "1.2.0",
-                ModuleBundle(Guid.NewGuid().ToString("N")))
+                ModuleBundle(LiveFrameworkMvid, minMeshVersion: "999.0.0"))
             .FirstAsync().ToTask();
 
         landed.Should().Be(0);
@@ -145,6 +153,7 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             SourceFolder = "SocialMedia",
             Version = "c1",
             Module = "MeshWeaver.Social",
+            MinMeshVersion = "3.0.0",
         };
         IReadOnlyList<PackageFile> files =
         [
@@ -160,9 +169,11 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             .Take(1).ToTask();
 
         record.Should().NotBeNull();
-        record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.Module
-            .Should().Be("MeshWeaver.Social",
-                "the record is what the registry's bundle index serves modules from");
+        var content = record!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!;
+        content.Module.Should().Be("MeshWeaver.Social",
+            "the record is what the registry's bundle index serves modules from");
+        content.MinMeshVersion.Should().Be("3.0.0",
+            "the floor rides the record so the index can surface it without re-reading the repo");
 
         Directory.Delete(landingRoot, recursive: true);
     }
@@ -179,7 +190,7 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             (_, _, _, _) => Observable.Return(new RepoSnapshot("c1",
             [
                 new RepoFile("SocialMedia/index.json",
-                    """{"nodeType":"Space","name":"Social Media","content":{"module":"MeshWeaver.Social"}}"""),
+                    """{"nodeType":"Space","name":"Social Media","content":{"module":"MeshWeaver.Social","minMeshVersion":"3.0.0"}}"""),
                 new RepoFile("Plain/index.json",
                     """{"nodeType":"Space","name":"Plain","content":{}}"""),
             ])),
@@ -187,7 +198,9 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
 
         var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
 
-        packages.Single(p => p.Id == "SocialMedia").Module.Should().Be("MeshWeaver.Social");
+        var social = packages.Single(p => p.Id == "SocialMedia");
+        social.Module.Should().Be("MeshWeaver.Social");
+        social.MinMeshVersion.Should().Be("3.0.0", "the floor is the module lane's landing gate");
         packages.Single(p => p.Id == "Plain").Module.Should().BeNull(
             "a package that declares no module must never enter the module funnel");
 

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -13,10 +13,10 @@ namespace MeshWeaver.PluginCatalog.Test;
 
 /// <summary>
 /// The runtime <c>modules/</c> writer (#1664 Slice A, step 7): a landed module's files + its
-/// activation entry, the MVID gate at placement (the SAME
-/// <see cref="PrebuiltAssemblySeeder.DeclineReason"/> identity every other prebuilt lane gates
-/// on), the app-closure same-identity refusal, and uninstall (disable + delete,
-/// restart-as-activation).
+/// activation entry, the platform-FLOOR gate at placement (the ONE
+/// <see cref="ModulePlatformFloor"/> notion every module call site shares — the built-against
+/// MVID is recorded as diagnostics, never refused), the app-closure same-identity refusal, and
+/// uninstall (disable + delete, restart-as-activation).
 /// </summary>
 public class ModuleLandingServiceTest : IDisposable
 {
@@ -24,7 +24,8 @@ public class ModuleLandingServiceTest : IDisposable
         Path.Combine(Path.GetTempPath(), "mw-landing-" + Guid.NewGuid().ToString("N"));
 
     /// <summary>The RUNNING framework identity — MeshWeaver.Graph's MVID, exactly what
-    /// <c>NodeTypeCompilationHelpers.FrameworkVersion</c> computes.</summary>
+    /// <c>NodeTypeCompilationHelpers.FrameworkVersion</c> computes. Recorded on landings as
+    /// DIAGNOSTIC metadata.</summary>
     private static string LiveFrameworkMvid =>
         typeof(PrebuiltAssemblySeeder).Assembly.ManifestModule.ModuleVersionId.ToString("N");
 
@@ -46,7 +47,9 @@ public class ModuleLandingServiceTest : IDisposable
                 "Acme.Widgets",
                 [("Acme.Widgets.dll", [1, 2, 3]), ("Acme.Widgets.Support.dll", [4, 5])],
                 LiveFrameworkMvid,
-                packagePath: "Plugins/acme-widgets")
+                packagePath: "Plugins/acme-widgets",
+                version: "1.2.0",
+                minMeshVersion: "0.0.1")
             .FirstAsync().ToTask();
 
         // The files, in the exact layout ResolveModulePath probes.
@@ -65,7 +68,9 @@ public class ModuleLandingServiceTest : IDisposable
         entry.Name.Should().Be("Acme.Widgets");
         entry.Source.Should().Be(ModuleActivationSources.Store);
         entry.PackagePath.Should().Be("Plugins/acme-widgets");
-        entry.FrameworkMvid.Should().Be(LiveFrameworkMvid);
+        entry.FrameworkMvid.Should().Be(LiveFrameworkMvid, "the built-against MVID is recorded as diagnostics");
+        entry.Version.Should().Be("1.2.0");
+        entry.MinMeshVersion.Should().Be("0.0.1", "the floor is what boot and the serve side re-check");
         entry.Enabled.Should().BeTrue();
         list.PendingRestart.Should().BeTrue("landing takes effect only at the next restart");
     }
@@ -86,23 +91,48 @@ public class ModuleLandingServiceTest : IDisposable
     }
 
     [Fact]
-    public async Task LandModule_FrameworkMvidMismatch_Refuses_NamingBothMvids()
+    public async Task LandModule_PlatformBelowDeclaredFloor_Refuses_NamingBothVersions()
     {
         using var service = Service;
-        var foreign = Guid.NewGuid().ToString("N");
 
         var act = () => service
-            .LandModule("Acme.Widgets", [("Acme.Widgets.dll", [1])], foreign)
+            .LandModule("Acme.Widgets", [("Acme.Widgets.dll", [1])],
+                LiveFrameworkMvid, minMeshVersion: "999.0.0")
             .FirstAsync().ToTask();
 
         (await act.Should().ThrowAsync<InvalidOperationException>(
-                "landing ABI-stale bytes would surface only as a TypeLoadException at the next boot"))
-            .Which.Message.Should().Contain(foreign).And.Contain(LiveFrameworkMvid,
-                "the refusal must name BOTH identities so the operator can see which side is stale");
+                "landing bytes whose required API surface does not exist here would surface only "
+                + "as a MissingMethodException at the next boot"))
+            .Which.Message.Should().Contain("999.0.0").And.Contain(
+                // Non-null on any stamped build — ModulePlatformFloorTest pins that.
+                ModulePlatformFloor.RunningVersion!,
+                "the refusal must name BOTH versions so the operator can see which side is behind");
 
         Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets"))
             .Should().BeFalse("declined bytes never reach disk");
         ModuleActivationSidecar.Read(baseDirectory).Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LandModule_ForeignBuiltAgainstMvid_Lands_TheMvidIsDiagnosticOnly()
+    {
+        // 🚨 The design decision of the module lane: modules bind by SIMPLE NAME and their
+        // contract is API compatibility (the minMeshVersion floor) — a bundle produced by a
+        // different platform build lands fine. MVID equality is bake semantics and stays with the
+        // NodeType assembly lane; gating modules on it would forbid the ex-post Store install
+        // across platform versions the lane exists for.
+        using var service = Service;
+        var foreignBuild = Guid.NewGuid().ToString("N");
+
+        await service.LandModule(
+                "Acme.Widgets", [("Acme.Widgets.dll", [1])], foreignBuild, version: "1.0.0")
+            .FirstAsync().ToTask();
+
+        File.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
+            .Should().BeTrue();
+        ModuleActivationSidecar.Read(baseDirectory).Entries.Should().ContainSingle()
+            .Which.FrameworkMvid.Should().Be(foreignBuild,
+                "the built-against MVID is kept as diagnostics naming the exact producing build");
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
@@ -74,6 +74,18 @@ public class ModuleUpdateDecisionTest
     }
 
     [Fact]
+    public void VersionEqualityIsSemVer_TwoPartAndThreePartFormsAreTheSameVersion()
+    {
+        // Manifests legitimately carry two-part versions ("1.2"; NuGet widens to "1.2.0"), so
+        // equality must go through the SAME comparer as the downgrade check — string equality
+        // would read this as an update and re-land the module on every reconcile, forever.
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate,
+            ModuleUpdateDecision.Decide("1.2", "3.0.0", Gate, Landed("1.2.0"), null).Action);
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate,
+            ModuleUpdateDecision.Decide("1.2.0", "3.0.0", Gate, Landed("1.2"), null).Action);
+    }
+
+    [Fact]
     public void ABundleWhoseFloorExceedsTheRunningPlatform_IsSkipped_ItBecomesInstallableAfterTheUpdate()
     {
         // The reconcile runs on every boot; a module that already requires a newer platform must

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
@@ -1,41 +1,65 @@
 #pragma warning disable CS1591
 
-using System;
 using Xunit;
 
 namespace MeshWeaver.PluginCatalog.Test;
 
 /// <summary>
 /// The ONE module auto-update decision (#1664 Slice C), pinned pure — no registry, no filesystem,
-/// no mesh. Production calls it with <c>PrebuiltAssemblySeeder.DeclineReason</c> as the framework
-/// gate and the deployment's <see cref="IModuleUpdatePolicy"/> verdict as the policy input; here
-/// both are stub functions so each rule is pinned in isolation.
+/// no mesh. Production calls it with <see cref="ModulePlatformFloor.DeclineReason(string?)"/> as
+/// the platform gate and the deployment's <see cref="IModuleUpdatePolicy"/> verdict as the policy
+/// input; here the gate is the same pure function bound to a fixed running version, so each rule
+/// is pinned in isolation.
+///
+/// <para>🚨 The platform gate is a <c>minMeshVersion</c> FLOOR, deliberately NOT MVID equality:
+/// modules are plain assemblies binding by simple name, and their contract is API compatibility.
+/// MVID equality is bake semantics (the NodeType lane's gate) — applied here it would force
+/// rebundling every module on every CI build and forbid the ex-post Store install across platform
+/// versions this lane exists for.</para>
 /// </summary>
 public class ModuleUpdateDecisionTest
 {
-    private const string LiveMvid = "aaaa0000aaaa0000aaaa0000aaaa0000";
-    private const string ForeignMvid = "ffff9999ffff9999ffff9999ffff9999";
+    private const string Running = "3.2.0";
 
-    /// <summary>The production gate's shape: null for the live identity, a reason otherwise.</summary>
-    private static string? Gate(string? mvid) =>
-        string.Equals(mvid, LiveMvid, StringComparison.Ordinal)
-            ? null
-            : $"built for framework {mvid ?? "(none)"}, live is {LiveMvid}";
+    /// <summary>The production gate's shape, bound to a fixed running platform version.</summary>
+    private static string? Gate(string? floor) =>
+        ModulePlatformFloor.DeclineReason(floor, Running);
 
-    private static ModuleActivationEntry Landed(
-        string? version, string mvid = LiveMvid, bool enabled = true) => new()
+    private static ModuleActivationEntry Landed(string? version, bool enabled = true) => new()
     {
         Name = "MeshWeaver.Social",
-        FrameworkMvid = mvid,
+        FrameworkMvid = "aaaa0000aaaa0000aaaa0000aaaa0000",
         Version = version,
         Enabled = enabled,
     };
 
     [Fact]
-    public void ANewerBundleForTheRunningFramework_Lands()
+    public void ANewerBundleWhoseFloorIsSatisfied_Lands()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+            "1.3.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void ABundleBuiltAgainstAnOlderPlatform_Lands_WhenItsFloorIsSatisfied()
+    {
+        // 🚨 THE point of the floor gate: a bundle produced against an older platform build (or
+        // years of CI builds ago — its recorded MVID is irrelevant and not even an input here)
+        // installs ex post as long as this platform satisfies its declared floor. Under MVID
+        // equality this exact case — "install GRPC ex post through the Store" — was impossible.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "1.0.0", Gate, landed: null, policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void ABundleWithNoDeclaredFloor_Lands_AbsenceIsNoConstraint()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", bundleMinMeshVersion: null, Gate, Landed("1.2.0"), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -44,22 +68,24 @@ public class ModuleUpdateDecisionTest
     public void TheSameLandedVersion_SkipsWithoutAnyDownloadDecision()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+            "1.2.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
     }
 
     [Fact]
-    public void ABundleForAForeignFrameworkMvid_IsSkipped_ItBecomesRelevantAfterTheImageRoll()
+    public void ABundleWhoseFloorExceedsTheRunningPlatform_IsSkipped_ItBecomesInstallableAfterTheUpdate()
     {
-        // 🚨 The reconcile runs on every boot; a registry that already rolled to a newer image must
-        // not error the pass, and must not land bytes this process cannot load — the skip is
-        // silent-with-log, and the SAME reconcile lands the bundle after this side's image roll.
+        // The reconcile runs on every boot; a module that already requires a newer platform must
+        // not error the pass and must not land bytes whose API surface does not exist here — the
+        // skip is silent-with-log, and the SAME reconcile lands the bundle once the platform has
+        // moved past the floor.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", ForeignMvid, Gate, Landed("1.2.0"), policyDecline: null);
+            "1.3.0", "9.0.0", Gate, Landed("1.2.0"), policyDecline: null);
 
-        Assert.Equal(ModuleUpdateAction.SkipForeignFramework, verdict.Action);
-        Assert.Contains(ForeignMvid, verdict.Reason!);
+        Assert.Equal(ModuleUpdateAction.SkipPlatformBelowFloor, verdict.Action);
+        Assert.Contains("9.0.0", verdict.Reason!);
+        Assert.Contains(Running, verdict.Reason!);
     }
 
     [Fact]
@@ -68,19 +94,7 @@ public class ModuleUpdateDecisionTest
         // Covers the heal path too: a package installed before the module lane existed has content
         // but no landed module — the reconcile is what brings the binary half in.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, landed: null, policyDecline: null);
-
-        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
-    }
-
-    [Fact]
-    public void ALandingWhoseRecordedMvidWentStale_ReLands_SameVersionIncluded()
-    {
-        // After an image roll the landed bytes are ABI-stale and boot skips them — the version
-        // string being "equal" is irrelevant, because equality only counts FOR THE RUNNING
-        // framework. This re-land is the module lane's whole answer to the roll.
-        var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, Landed("1.2.0", mvid: ForeignMvid), policyDecline: null);
+            "1.2.0", "3.0.0", Gate, landed: null, policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -89,7 +103,7 @@ public class ModuleUpdateDecisionTest
     public void AnOlderBundleThanWhatIsLanded_NeverRollsBackUnattended()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.1.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+            "1.1.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.SkipOlder, verdict.Action);
     }
@@ -101,19 +115,19 @@ public class ModuleUpdateDecisionTest
         // registry version as a rollback and silently never update (the exact defect class
         // NuGetVersionComparer exists for).
         var verdict = ModuleUpdateDecision.Decide(
-            "1.10.0", LiveMvid, Gate, Landed("1.9.0"), policyDecline: null);
+            "1.10.0", "3.0.0", Gate, Landed("1.9.0"), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
 
     [Fact]
-    public void ThePolicyOptOut_SkipsTheLanding_AndNamesThePolicy()
+    public void ThePolicyOptOut_SkipsTheUpgrade_AndNamesThePolicy()
     {
         // The gate is the deployment's EXISTING update policy (Admin/UpdatePolicy — Stable/None);
         // there is no module-specific knob. The default — no policy registered — is null here,
         // which every other test passes: auto-update is the DEFAULT, opting out is the choice.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", LiveMvid, Gate, Landed("1.2.0"),
+            "1.3.0", "3.0.0", Gate, Landed("1.2.0"),
             policyDecline: "the deployment's update policy is Stable");
 
         Assert.Equal(ModuleUpdateAction.SkipPolicy, verdict.Action);
@@ -126,7 +140,7 @@ public class ModuleUpdateDecisionTest
         // An up-to-date module under Stable must read as up-to-date, not as a policy skip — the
         // policy is the LAST gate, so its skips always mean "an update was withheld".
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, Landed("1.2.0"),
+            "1.2.0", "3.0.0", Gate, Landed("1.2.0"),
             policyDecline: "the deployment's update policy is Stable");
 
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
@@ -139,20 +153,7 @@ public class ModuleUpdateDecisionTest
         // the install itself was sanctioned by the operator's own surfaces (a Provision click, the
         // default-install config), and the module is part of what they asked for.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, landed: null,
-            policyDecline: "the deployment's update policy is Stable");
-
-        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
-    }
-
-    [Fact]
-    public void ThePolicyDoesNotBlockTheImageRollHeal()
-    {
-        // After a roll the OPERATOR chose, the old bytes stopped loading — refusing the re-land
-        // would leave the module dead until someone notices. Keeping what was installed working is
-        // not an update, so the heal is policy-exempt even at the same version.
-        var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, Landed("1.2.0", mvid: ForeignMvid),
+            "1.2.0", "3.0.0", Gate, landed: null,
             policyDecline: "the deployment's update policy is Stable");
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
@@ -162,7 +163,7 @@ public class ModuleUpdateDecisionTest
     public void AnUninstalledModule_IsNeverReinstalledByTheReconcile()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", LiveMvid, Gate, Landed("1.2.0", enabled: false), policyDecline: null);
+            "1.3.0", "3.0.0", Gate, Landed("1.2.0", enabled: false), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
     }
@@ -171,19 +172,67 @@ public class ModuleUpdateDecisionTest
     public void ARegistryListingNoBundle_SkipsQuietly()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            bundleVersion: null, LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+            bundleVersion: null, "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
 
         Assert.Equal(ModuleUpdateAction.SkipNoBundle, verdict.Action);
     }
+}
+
+/// <summary>
+/// The ONE platform gate of the module lane (<see cref="ModulePlatformFloor"/>), pinned pure —
+/// the semantics every serve/fetch/land/boot call site inherits.
+/// </summary>
+public class ModulePlatformFloorTest
+{
+    [Fact]
+    public void AnAbsentFloor_IsNoConstraint()
+    {
+        Assert.Null(ModulePlatformFloor.DeclineReason(null, "3.2.0"));
+        Assert.Null(ModulePlatformFloor.DeclineReason("", "3.2.0"));
+        Assert.Null(ModulePlatformFloor.DeclineReason("  ", "3.2.0"));
+    }
 
     [Fact]
-    public void ALandedEntryWithoutARecordedVersion_ReLandsOnce()
+    public void ASatisfiedFloor_Allows_EqualityIncluded()
     {
-        // Pre-versioning sidecar entries read as "unknown": not equal to the served version, not
-        // comparable as older — so they land once and the version is recorded from then on.
-        var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", LiveMvid, Gate, Landed(version: null), policyDecline: null);
+        Assert.Null(ModulePlatformFloor.DeclineReason("3.0.0", "3.2.0"));
+        Assert.Null(ModulePlatformFloor.DeclineReason("3.2.0", "3.2.0"));
+    }
 
-        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    [Fact]
+    public void AnExceededFloor_Declines_NamingBothVersions()
+    {
+        var reason = ModulePlatformFloor.DeclineReason("3.5.0", "3.2.0");
+
+        Assert.NotNull(reason);
+        Assert.Contains("3.5.0", reason);
+        Assert.Contains("3.2.0", reason);
+    }
+
+    [Fact]
+    public void PreReleaseOrderingIsSemVer()
+    {
+        // 3.0.0-rc3.ci.3758 > 3.0.0-rc3.ci.900 numerically (ci.900 sorts ABOVE as text — the
+        // NuGetVersionComparer defect class), and a clean release outranks its pre-releases.
+        Assert.Null(ModulePlatformFloor.DeclineReason("3.0.0-rc3.ci.900", "3.0.0-rc3.ci.3758"));
+        Assert.NotNull(ModulePlatformFloor.DeclineReason("3.0.0-rc3.ci.3758", "3.0.0-rc3.ci.900"));
+        Assert.Null(ModulePlatformFloor.DeclineReason("3.0.0-rc3", "3.0.0"));
+    }
+
+    [Fact]
+    public void ADeclaredFloorWithAnUnknownRunningVersion_Declines_NeverLandsOnFaith()
+    {
+        Assert.NotNull(ModulePlatformFloor.DeclineReason("3.0.0", null));
+    }
+
+    [Fact]
+    public void TheRunningVersionIsStamped_AndCarriesNoBuildMetadata()
+    {
+        // The production overload's anchor: MeshWeaver.Graph's informational version, +sha
+        // stripped. A missing stamp would silently turn every declared floor into a refusal.
+        var running = ModulePlatformFloor.RunningVersion;
+
+        Assert.False(string.IsNullOrWhiteSpace(running));
+        Assert.DoesNotContain("+", running);
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
@@ -1,0 +1,189 @@
+#pragma warning disable CS1591
+
+using System;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The ONE module auto-update decision (#1664 Slice C), pinned pure — no registry, no filesystem,
+/// no mesh. Production calls it with <c>PrebuiltAssemblySeeder.DeclineReason</c> as the framework
+/// gate and the deployment's <see cref="IModuleUpdatePolicy"/> verdict as the policy input; here
+/// both are stub functions so each rule is pinned in isolation.
+/// </summary>
+public class ModuleUpdateDecisionTest
+{
+    private const string LiveMvid = "aaaa0000aaaa0000aaaa0000aaaa0000";
+    private const string ForeignMvid = "ffff9999ffff9999ffff9999ffff9999";
+
+    /// <summary>The production gate's shape: null for the live identity, a reason otherwise.</summary>
+    private static string? Gate(string? mvid) =>
+        string.Equals(mvid, LiveMvid, StringComparison.Ordinal)
+            ? null
+            : $"built for framework {mvid ?? "(none)"}, live is {LiveMvid}";
+
+    private static ModuleActivationEntry Landed(
+        string? version, string mvid = LiveMvid, bool enabled = true) => new()
+    {
+        Name = "MeshWeaver.Social",
+        FrameworkMvid = mvid,
+        Version = version,
+        Enabled = enabled,
+    };
+
+    [Fact]
+    public void ANewerBundleForTheRunningFramework_Lands()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void TheSameLandedVersion_SkipsWithoutAnyDownloadDecision()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+    }
+
+    [Fact]
+    public void ABundleForAForeignFrameworkMvid_IsSkipped_ItBecomesRelevantAfterTheImageRoll()
+    {
+        // 🚨 The reconcile runs on every boot; a registry that already rolled to a newer image must
+        // not error the pass, and must not land bytes this process cannot load — the skip is
+        // silent-with-log, and the SAME reconcile lands the bundle after this side's image roll.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", ForeignMvid, Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipForeignFramework, verdict.Action);
+        Assert.Contains(ForeignMvid, verdict.Reason!);
+    }
+
+    [Fact]
+    public void ANeverLandedModule_Lands()
+    {
+        // Covers the heal path too: a package installed before the module lane existed has content
+        // but no landed module — the reconcile is what brings the binary half in.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, landed: null, policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void ALandingWhoseRecordedMvidWentStale_ReLands_SameVersionIncluded()
+    {
+        // After an image roll the landed bytes are ABI-stale and boot skips them — the version
+        // string being "equal" is irrelevant, because equality only counts FOR THE RUNNING
+        // framework. This re-land is the module lane's whole answer to the roll.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, Landed("1.2.0", mvid: ForeignMvid), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void AnOlderBundleThanWhatIsLanded_NeverRollsBackUnattended()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.1.0", LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipOlder, verdict.Action);
+    }
+
+    [Fact]
+    public void VersionOrderingIsSemVer_NotStringOrder()
+    {
+        // "1.10.0" > "1.9.0" numerically but < as text — string ordering would read the newer
+        // registry version as a rollback and silently never update (the exact defect class
+        // NuGetVersionComparer exists for).
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.10.0", LiveMvid, Gate, Landed("1.9.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void ThePolicyOptOut_SkipsTheLanding_AndNamesThePolicy()
+    {
+        // The gate is the deployment's EXISTING update policy (Admin/UpdatePolicy — Stable/None);
+        // there is no module-specific knob. The default — no policy registered — is null here,
+        // which every other test passes: auto-update is the DEFAULT, opting out is the choice.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", LiveMvid, Gate, Landed("1.2.0"),
+            policyDecline: "the deployment's update policy is Stable");
+
+        Assert.Equal(ModuleUpdateAction.SkipPolicy, verdict.Action);
+        Assert.Contains("Stable", verdict.Reason!);
+    }
+
+    [Fact]
+    public void ThePolicyIsOnlyConsultedWhenSomethingWouldLand()
+    {
+        // An up-to-date module under Stable must read as up-to-date, not as a policy skip — the
+        // policy is the LAST gate, so its skips always mean "an update was withheld".
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, Landed("1.2.0"),
+            policyDecline: "the deployment's update policy is Stable");
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+    }
+
+    [Fact]
+    public void ThePolicyDoesNotBlockAFirstLanding_ItCompletesAnInstall()
+    {
+        // Stable/None means "no unattended UPDATES", not "installed packages arrive half-delivered":
+        // the install itself was sanctioned by the operator's own surfaces (a Provision click, the
+        // default-install config), and the module is part of what they asked for.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, landed: null,
+            policyDecline: "the deployment's update policy is Stable");
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void ThePolicyDoesNotBlockTheImageRollHeal()
+    {
+        // After a roll the OPERATOR chose, the old bytes stopped loading — refusing the re-land
+        // would leave the module dead until someone notices. Keeping what was installed working is
+        // not an update, so the heal is policy-exempt even at the same version.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, Landed("1.2.0", mvid: ForeignMvid),
+            policyDecline: "the deployment's update policy is Stable");
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    [Fact]
+    public void AnUninstalledModule_IsNeverReinstalledByTheReconcile()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", LiveMvid, Gate, Landed("1.2.0", enabled: false), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
+    }
+
+    [Fact]
+    public void ARegistryListingNoBundle_SkipsQuietly()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            bundleVersion: null, LiveMvid, Gate, Landed("1.2.0"), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipNoBundle, verdict.Action);
+    }
+
+    [Fact]
+    public void ALandedEntryWithoutARecordedVersion_ReLandsOnce()
+    {
+        // Pre-versioning sidecar entries read as "unknown": not equal to the served version, not
+        // comparable as older — so they land once and the version is recorded from then on.
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.2.0", LiveMvid, Gate, Landed(version: null), policyDecline: null);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+}


### PR DESCRIPTION
Implements #1664 **Slice B** (module package shape + bundle build) and **Slice C** (funnel + landing + auto-update), on top of the merged Slice A landing seam (`ModuleActivation` / `ModuleLandingService`).

## Shape decisions

**One bundle, two lanes.** A package's compiled module rides **inside the same bundle** that already carries its NodeType assemblies — `meshweaver/modules/<file>` beside `meshweaver/assemblies/<nodePath>.dll`, one `meshweaver/manifest.json` naming both (`module: { assemblyName, assemblies[] }` next to `assemblies[]`). Same routes, same index, same instance-key auth — the #13 transport decision is honored by *extending* `/api/plugins/bundles`, not adding a channel. One reader serves both lanes (`BundleReader.Read` / `BundleReader.ReadModule`, both manifest-driven); the module side is deliberately **all-or-nothing** (a NodeType with missing bytes compiles; a module missing part of its closure loads and faults at first use).

**The declaration is two fields authors already know.** `PackageManifest.Module` = the module's entry-assembly name, `PackageManifest.MinMeshVersion` = its declared platform floor (both authored on the plugin root's `index.json` content, read by `NodeRepoPackageSource`, carried onto the install record by the ordinary record stamp). A mixed package — content nodes + compiled module in one Store product, the SocialMedia shape — is exactly these fields on an ordinary node-repo package; card/price/funnel/pre-install are untouched.

**🚨 The module gate is a `minMeshVersion` FLOOR — deliberately NOT MVID equality** (maintainer's dependency-analysis correction). MVID equality is *bake* semantics — a NodeType assembly compiled in-process against exact refs — and applying it to ordinary modules would force rebundling every module on every CI build and forbid ex-post Store installs across platform versions ("install GRPC ex post through the Store"). Modules are plain assemblies binding by **simple name**; their contract is API compatibility, which the semver floor expresses. The ONE gate is the new `ModulePlatformFloor.DeclineReason` (running platform = MeshWeaver.Graph's informational version, SemVer-compared via `NuGetVersionComparer`), applied at the index, the manifest, placement, and boot; an absent floor is no constraint. The bundle **keeps recording its built-against MVID as DIAGNOSTIC metadata** — logged at landing, surfaced in the index/sidecar — never a refusal. NodeType-bake bundles keep the strict MVID gate (`PrebuiltAssemblySeeder.DeclineReason`) unchanged. Consequence: landed modules keep loading across ordinary platform updates (no re-land per image roll); the only boot skip is a platform *rollback* below a module's declared floor.

**The registry serves what it runs.** Module bytes are served from the registry's own `modules/<name>/` tree (`ModuleBundleSource`) — the same philosophy as the NodeType lane ("the inputs ARE the storage") — and a landing the registry's own boot would skip (uninstalled, or a floor its platform no longer satisfies) is refused, so a registry can never fan out assemblies it could not load itself. The index stamps each bundle's `module` + `minMeshVersion` only when the bytes are actually servable.

**The build lane is a plain tool invocation.** `meshweaver-plugin-build module-pack <outputDir> --plugin <id> --package-version <v> --min-mesh-version <floor>` packs a module bundle recording the floor (the consumer's gate) and, when the restored `MeshWeaver.Graph.dll` is at hand, the built-against MVID (diagnostics — optional, warned when absent). Because the gate is the floor, ONE bundle serves every compatible platform build. The closure is an explicit statement (`<name>.dll` + `--with`), never a folder scrape, mirroring the modules/<Name>/ rule that for most modules the DLL alone is the closure. Invocable from any node repo's CI (the tool is `PackAsTool`; the platform's `plugin-publish.yml` already builds/runs it from a checkout).

## The funnel (Slice C)

- **Install/update**: the module branch lives in the ONE install orchestrator (`CatalogLayoutAreas.InstallOrUpdate`), riding a `Bundles` handle on `RegistryPackageSource` — so the catalog click, the content auto-update apply, and the boot default install all land a declared module identically: bundle-fetch → floor gate (`ModulePlatformFloor.DeclineReason`, checked at the index, at the manifest, and a third time at placement) → `ModuleLandingService.LandModule` (restart-as-activation; the existing `PendingRestart` sidecar flag is the signal). Nothing here can fail an install — every refusal is a logged zero. *Followed the code on the brief's "PackageInstaller binary branch": `PackageInstaller` never sees a source or a registry credential, so the branch belongs one caller up, in the orchestrator that has both — reported as a deliberate deviation.*
- **Auto-update**: `RegistryUpdateReconciler` gains a module pass after its content pass: for installed module-declaring packages it consults the registry's bundle index and applies one pure decision (`ModuleUpdateDecision.Decide`) — lands newer **when the bundle's floor is satisfied here**, skips same-version without a download, skips a bundle whose floor exceeds the running platform silently-with-log (it becomes installable after the platform updates, and the same pass lands it then). Never rolls back unattended. The landed version + floor are recorded on the activation entry (`ModuleActivationEntry.Version`/`.MinMeshVersion`) so "already landed" costs zero bytes.

## Policy-surface wiring (no new knob)

The unattended gate is the **existing `Admin/UpdatePolicy`** surface, bridged via `IModuleUpdatePolicy` (declared in `MeshWeaver.PluginCatalog`, implemented in `Memex.Portal.Shared.SelfUpdate.PlatformModuleUpdatePolicy`, registered by `AddSelfUpdate` beside the node type):

- **Continuous — the platform default, and what an absent node/absent provider reads as — lands unattended** (DEFAULT = AUTO-UPDATE, per the maintainer directive).
- **Stable / None decline the *upgrade*** — and only the upgrade: a **first landing** (completing an install the operator's own surfaces sanctioned) is policy-exempt, because gating it would ship a package whose binary half never arrives. (Under the floor gate there is no "re-land after an image roll" case at all — landed modules keep loading across platform builds.) An unreadable policy declines (fail toward not acting).

The plugin lane's existing `AutoUpdate`/`AutoUpdateByDefault` record flag keeps governing the *content* reconcile exactly as before; a content auto-update that applies carries its module with it through the orchestrator.

## Deferred (follow-ups, not this repo/PR)

- **MeshWeaver.Plugins repo**: the `PluginContent` record in `Store/Plugin/Source` gains the matching `module` field beside its existing `minMeshVersion` (authoring-side mirror of `content.module`); until then the field is plain JSON on the root and flows fine.
- **MeshWeaver.SocialMedia repo**: its CI invokes `module-pack` and declares `content.module: MeshWeaver.Social` on its root — the satellite-CI wiring the maintainer scoped out of this PR.
- **Registry acquisition of bundles it does not run**: today the registry serves module bytes from its own modules/ tree (image-shipped or store-landed). Once first-party modules fully relocate out of the image (Slice D), the registry acquires them the same way consumers do — by installing the package — or via a CI upload lane if one becomes necessary; that decision rides Slice D.
- **IVT consumers are the ONE build-time-coupled module class.** A module using `InternalsVisibleTo` internals binds to build identity, not public API — a semver floor cannot vouch for it. Currently that is exactly `MeshWeaver.Approvals` (→ `MeshWeaver.Graph` internals); such modules stay image-shipped until de-internalized, and only then join the bundle lane.

## Verification

- `MeshWeaver.Plugin.Packaging`, `MeshWeaver.Plugin.Build`, `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared` + all touched test projects: `-c Release -warnaserror`, 0 errors, one project per invocation.
- **Unit pins**: bundle round-trip incl. the floor field, the mixed (both-lanes) bundle and the all-or-nothing closure (`BundleReaderTest`); the pure floor gate itself incl. SemVer-not-string ordering and never-land-on-unknown-running-version (`ModulePlatformFloorTest`); floor refusal at fetch (`ModuleFunnelTest.ABundleWhoseFloorExceedsThisPlatform_IsRefused_NothingReachesDisk`) AND at land (`ModuleLandingServiceTest`); **the ex-post pin the correction demands** — a bundle from another platform build with a satisfied floor LANDS, MVID recorded as diagnostics (`ModuleFunnelTest.ABundleFromAnotherPlatformBuild_WithItsFloorSatisfied_Lands`, `ModuleLandingServiceTest.LandModule_ForeignBuiltAgainstMvid_Lands_TheMvidIsDiagnosticOnly`, `ModuleUpdateDecisionTest.ABundleBuiltAgainstAnOlderPlatform_Lands_WhenItsFloorIsSatisfied`, `ModuleBundleSourceTest.ALandingBuiltByAnotherPlatformBuild_IsStillServed_TheMvidIsDiagnostic`); reconciler lands-newer / skips-same / skips-below-floor / skips-older / policy-gates-upgrades-only / never-reinstalls-uninstalled — all pure (`ModuleUpdateDecisionTest`); boot union floor-skip + no-floor-loads (`ModuleActivationBootTest`); installer routing — declaration + floor flow listing → record, module payload routes to landing not node-parse (`ModuleFunnelTest`); registry serve rules (`ModuleBundleSourceTest`).
- **Suites green (Release)**: `MeshWeaver.PluginCatalog.Test` 347/347 · `MeshWeaver.Graph.Test` 1194/1194 · `Memex.Portal.Shared.Test` 366/366 · doc integrity (`DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest`) green after the doc edits.
- Reactive rules: all landing/reconcile IO composes `IObservable` through the sealed `IoPool`s (`ModuleLandingService`'s cap-1 pool, the HTTP pool in `PluginBundleClient`); no bare async in hub-reachable code.

Docs: `Modules.md` → "The bundle lane — modules as Store packages" + the auto-update paragraph naming the policy surface and default; `PluginPackaging.md` → "The module variant". What's New: *Modules install and update from the Store* (Feature).

Closes nothing on its own — #1664 remains open for Slice D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
