### PR TITLE
fix(modules): the closure lane is RID-agnostic — CD multi-arch publish broke on the flip

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -140,7 +140,7 @@
            Text="LayoutMeshModuleClosures: %(MeshModuleClosure.Filename).dll is in the app publish root, but that module ships via modules/ only (#1644 step 2). Remove the re-added ProjectReference, or clean a stale publish directory." />
 
     <!-- 🚨 RID-agnostic by design: every invocation below strips the outer publish's
-         RuntimeIdentifier/Container* globals (see RemoveProperties). Modules are portable IL —
+         RuntimeIdentifier(s), SelfContained, ContainerRuntimeIdentifier(s) and publish-mode globals (the exact RemoveProperties list below). Modules are portable IL —
          the app's shared framework provides the runtime, Assembly.LoadFrom never consults RID
          trees (the prune below deletes them), and a flipped module is OUTSIDE the host's restore
          graph, so a RID flowing in from CD's per-arch container publish fails NETSDK1047 (no

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -139,7 +139,16 @@
     <Error Condition="'$(MeshModulesGuardAppRoot)' == 'true' And Exists('$(_AppDir)%(MeshModuleClosure.Filename).dll')"
            Text="LayoutMeshModuleClosures: %(MeshModuleClosure.Filename).dll is in the app publish root, but that module ships via modules/ only (#1644 step 2). Remove the re-added ProjectReference, or clean a stale publish directory." />
 
-    <!-- Restore explicitly: post-flip the module is OUTSIDE the host's project graph, so the
+    <!-- 🚨 RID-agnostic by design: every invocation below strips the outer publish's
+         RuntimeIdentifier/Container* globals (see RemoveProperties). Modules are portable IL —
+         the app's shared framework provides the runtime, Assembly.LoadFrom never consults RID
+         trees (the prune below deletes them), and a flipped module is OUTSIDE the host's restore
+         graph, so a RID flowing in from CD's per-arch container publish fails NETSDK1047 (no
+         linux-x64/arm64 target in the module's portable assets file) — the 2026-08-16 CD outage.
+         A module with genuinely RID-specific native deps (Speech) ships them via runtimes/*
+         inside its folder, which a PORTABLE publish lays out correctly.
+
+         Restore explicitly: post-flip the module is OUTSIDE the host's project graph, so the
          host's implicit restore never touches it and a clean machine has no assets file. A
          separate invocation (different global properties than the build below) also sidesteps
          MSBuild's evaluation reuse between a Restore and the build that needs its outputs. -->
@@ -147,7 +156,7 @@
              Targets="Restore"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
     <!-- Build, then Publish with NoBuild — deliberately TWO invocations, and the Build one runs
          with the module's ordinary global properties (RemoveProperties strips everything this
@@ -161,7 +170,7 @@
              Targets="Build"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
     <!-- SatelliteResourceLanguages=en: without it the closure publish lays out a culture folder
          per Roslyn localization (cs/de/es/… via Kernel.Hub), every one a same-identity duplicate
          of the app's own satellite folders. Suppressing them at the SOURCE beats deleting them
@@ -172,7 +181,7 @@
              Targets="Publish"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration);NoBuild=true;SatelliteResourceLanguages=en;PublishDir=$(_AppDir)modules/%(Filename)/"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishMeshModules" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
     <!-- Prune (0): RID trees. A module loads via Assembly.LoadFrom, which never consults the
          module's deps.json — the fallback probe is the module's FLAT folder only — so a


### PR DESCRIPTION
**CD is red on main** (run 31946190323): the portal-ai multi-arch leg fails `NETSDK1047` on `MeshWeaver.Markdown.Export` — no `net10.0/linux-x64|arm64` target in its assets file — so main `37ccc5f` has NO image set and every self-updating install is pinned on the previous image.

**Mechanism:** the per-arch container publish flows `RuntimeIdentifier` as a global property into the module-closure lane's inner MSBuild invocations. A flipped module is outside the host's restore graph (the #1666 design), so its assets file is portable — and the RID-carrying publish demands a target that doesn't exist.

**Fix at the contract level:** modules are portable IL (`Assembly.LoadFrom` never consults RID trees; the lane already prunes them), so the closure lane's Restore/Build/Publish now strip every RID/container/publish-mode global. Documented in the targets header including the Speech case (native deps ride `runtimes/*` inside the module folder, which a portable publish lays out correctly).

**Verified:** `dotnet publish Memex.Portal.Monolith -c Release -r linux-arm64 --no-self-contained` — previously the CI failure shape — completes with `modules/` laid out (14 thin + 1 closure, 4 files kept); Monolith Release `-warnaserror` clean.

After merge: CD re-runs on the merge commit and publishes the full set; the reconciler also heals HEAD on its 3-hourly schedule.

No What's New: CI/deployment fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)