### PR TITLE
fix(modules): the THIN lane strips RID globals too — CD's second NETSDK1047 site

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -70,7 +70,8 @@
     <MSBuild Projects="@(MeshModule)"
              Targets="Build"
              BuildInParallel="false"
-             Properties="Configuration=$(Configuration)">
+             Properties="Configuration=$(Configuration)"
+             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed;PublishDir;PublishMeshModules;PrebuiltBakeDir">
       <Output TaskParameter="TargetOutputs" ItemName="_ModuleAssemblyBuilt" />
     </MSBuild>
 
@@ -139,7 +140,7 @@
     <Error Condition="'$(MeshModulesGuardAppRoot)' == 'true' And Exists('$(_AppDir)%(MeshModuleClosure.Filename).dll')"
            Text="LayoutMeshModuleClosures: %(MeshModuleClosure.Filename).dll is in the app publish root, but that module ships via modules/ only (#1644 step 2). Remove the re-added ProjectReference, or clean a stale publish directory." />
 
-    <!-- 🚨 RID-agnostic by design: every invocation below strips the outer publish's
+    <!-- 🚨 RID-agnostic by design: every module invocation in BOTH lanes (thin Build here included) strips the outer publish's
          RuntimeIdentifier(s), SelfContained, ContainerRuntimeIdentifier(s) and publish-mode globals (the exact RemoveProperties list below). Modules are portable IL —
          the app's shared framework provides the runtime, Assembly.LoadFrom never consults RID
          trees (the prune below deletes them), and a flipped module is OUTSIDE the host's restore


### PR DESCRIPTION
CD is still red on main: #1675 cured the closure lane, and the next run failed with the identical `NETSDK1047` one lane over — the THIN lane's `Build` invocation (AI packs, Radzen, …) also receives the per-arch `RuntimeIdentifier` global under CD's container publish. Same cure, second site: the identical RemoveProperties list on the thin-lane Build (plus `PrebuiltBakeDir`, which must not leak into module builds either); the RID-agnostic doc note now names both lanes.

**Verified with CD's exact invocation** — `dotnet publish Memex.Portal.Distributed -c Release --no-self-contained -t:PublishContainer -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"' -p:CIRun=true` to a local archive: both per-RID publishes green, module lanes laid out per RID, multi-arch image index built and archived. Plain `-r linux-arm64` publish also green; Monolith Release `-warnaserror` clean.

No What's New: CI/deployment fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)