### PR TITLE
fix(modules): collision gate false-positives on published static assets — ci.3958 boot refusal

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-endpoint-gate-published-assets.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-endpoint-gate-published-assets.md
@@ -1,0 +1,15 @@
+---
+Name: Portal startup fixed on published deployments
+Category: Fix
+Description: The endpoint safety check no longer mistakes precompressed static assets for route conflicts, which prevented the portal from starting.
+Icon: Sparkle
+Order: -20260816
+---
+
+# Portal startup fixed on published deployments
+
+A safety check that guards against modules accidentally overriding each other's web routes was
+too strict: on deployed (published) portals it also flagged the platform's own static files, which
+are legitimately served in several compressed variants, and refused to start the portal. The check
+now only triggers when a module's route is actually involved in a conflict, so deployments start
+normally while the protection against real route conflicts stays in place.

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleEndpointExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleEndpointExtensions.cs
@@ -21,9 +21,11 @@ public static class MeshModuleEndpointExtensions
     ///
     /// <para>Each module's routes map inside a group defaulting to
     /// <c>RequireAuthorization()</c>; a route is anonymous only where the module explicitly opts
-    /// out. On <c>ApplicationStarted</c> the whole endpoint table is checked for duplicate
-    /// (verb, pattern) registrations — a collision throws and takes the app down, because a
-    /// silently shadowed route is indistinguishable from a passing one (the #683 class).</para>
+    /// out. On <c>ApplicationStarted</c> the endpoint table is checked for duplicate
+    /// (verb, pattern) registrations involving a module-contributed endpoint — a collision throws
+    /// and takes the app down, because a silently shadowed route is indistinguishable from a
+    /// passing one (the #683 class). Platform-only duplicates are exempt: published static assets
+    /// legitimately register one endpoint per precompressed variant on the same route.</para>
     /// </summary>
     public static WebApplication MapMeshModuleEndpoints(this WebApplication app)
     {
@@ -36,8 +38,11 @@ public static class MeshModuleEndpointExtensions
         {
             // Authenticated-by-default: the group policy applies to every route the module maps
             // unless the route itself declares AllowAnonymous — a module cannot accidentally
-            // publish an open route.
-            var group = app.MapGroup(string.Empty).RequireAuthorization();
+            // publish an open route. The marker metadata scopes the collision refusal to groups
+            // involving a module-contributed endpoint (see MeshModuleEndpointMetadata).
+            var group = app.MapGroup(string.Empty).RequireAuthorization()
+                .WithMetadata(new MeshModuleEndpointMetadata(
+                    module.Assembly.GetName().Name ?? module.Assembly.FullName ?? "unknown"));
             foreach (var configure in attribute.EndpointConfigurations)
             {
                 configure(group);
@@ -82,8 +87,13 @@ public static class MeshModuleEndpointExtensions
     }
 
     /// <summary>
-    /// The pure collision predicate: duplicate (verb, pattern) pairs across the endpoint table,
-    /// or null when clean. Extracted so the refusal logic is unit-testable without a running host.
+    /// The pure collision predicate: duplicate (verb, pattern) pairs that involve at least one
+    /// module-contributed endpoint (<see cref="MeshModuleEndpointMetadata"/>), or null when clean.
+    /// Platform-only duplicates are NOT collisions: a published app's static-asset table
+    /// legitimately holds one endpoint per precompressed variant (identity/gzip/brotli) on the
+    /// same (verb, pattern), resolved by content negotiation — an unscoped assertion refuses
+    /// every published deployment while passing every dev run, which is how ci.3958 crash-looped
+    /// in prod. Extracted so the refusal logic is unit-testable without a running host.
     /// </summary>
     internal static string? FindRouteCollisions(IEnumerable<Endpoint> endpoints)
     {
@@ -95,11 +105,21 @@ public static class MeshModuleEndpointExtensions
                 .Select(verb => (Verb: verb, Pattern: endpoint.RoutePattern.RawText ?? "", Endpoint: endpoint)))
             .Where(e => e.Pattern.Length > 0)
             .GroupBy(e => (e.Verb, e.Pattern))
-            .Where(g => g.Count() > 1)
+            .Where(g => g.Count() > 1
+                        && g.Any(e => e.Endpoint.Metadata.GetMetadata<MeshModuleEndpointMetadata>() is not null))
             .ToList();
         return duplicates.Count == 0
             ? null
             : string.Join("; ", duplicates.Select(g =>
-                $"{g.Key.Verb} {g.Key.Pattern} ← [{string.Join(" | ", g.Select(e => e.Endpoint.DisplayName))}]"));
+                $"{g.Key.Verb} {g.Key.Pattern} ← [{string.Join(" | ", g.Select(Describe))}]"));
+    }
+
+    private static string Describe((string Verb, string Pattern, RouteEndpoint Endpoint) entry)
+    {
+        var display = string.IsNullOrWhiteSpace(entry.Endpoint.DisplayName)
+            ? entry.Endpoint.RoutePattern.RawText ?? "?"
+            : entry.Endpoint.DisplayName;
+        var module = entry.Endpoint.Metadata.GetMetadata<MeshModuleEndpointMetadata>();
+        return module is null ? display : $"{display} (module {module.ModuleName})";
     }
 }

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleEndpointMetadata.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleEndpointMetadata.cs
@@ -1,0 +1,13 @@
+namespace MeshWeaver.Hosting.AspNetCore;
+
+/// <summary>
+/// Marker metadata stamped on every endpoint a module contributes through
+/// <see cref="MeshModuleEndpointExtensions.MapMeshModuleEndpoints"/>. The collision refusal keys
+/// on it: only duplicate (verb, pattern) groups that involve at least one module-contributed
+/// endpoint are a refusal. The platform's own endpoint table legitimately carries duplicates —
+/// a published app's static-asset endpoints register one endpoint per precompressed variant
+/// (identity/gzip/brotli) on the SAME route, disambiguated by content negotiation — so a
+/// whole-table duplicate assertion refuses every published deployment while passing every dev run.
+/// </summary>
+/// <param name="ModuleName">The contributing module's assembly name, surfaced in the refusal.</param>
+public sealed record MeshModuleEndpointMetadata(string ModuleName);

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleEndpointContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleEndpointContributionTest.cs
@@ -84,32 +84,86 @@ public class ModuleEndpointContributionTest
         Assert.NotNull(open.Metadata.GetMetadata<IAllowAnonymous>());
     }
 
+    private static RouteEndpoint Endpoint(string pattern, string verb, string display, string? module = null) =>
+        new(
+            _ => System.Threading.Tasks.Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            module is null
+                ? new EndpointMetadataCollection(new HttpMethodMetadata([verb]))
+                : new EndpointMetadataCollection(
+                    new HttpMethodMetadata([verb]), new MeshModuleEndpointMetadata(module)),
+            display);
+
     [Fact]
     public void RouteCollisions_AreDetected_WithBothPartiesNamed()
     {
-        static RouteEndpoint Endpoint(string pattern, string verb, string display) =>
-            new(
-                _ => System.Threading.Tasks.Task.CompletedTask,
-                RoutePatternFactory.Parse(pattern),
-                order: 0,
-                new EndpointMetadataCollection(new HttpMethodMetadata([verb])),
-                display);
-
-        // Same pattern, same verb — collision, both display names surfaced.
+        // Module vs platform on the same (verb, pattern) — collision, both parties surfaced,
+        // the module named.
         var detail = MeshModuleEndpointExtensions.FindRouteCollisions(
         [
             Endpoint("/api/x", "GET", "platform: X"),
-            Endpoint("/api/x", "GET", "module: X"),
+            Endpoint("/api/x", "GET", "module: X", module: "My.Module"),
         ]);
         Assert.NotNull(detail);
         Assert.Contains("platform: X", detail);
         Assert.Contains("module: X", detail);
+        Assert.Contains("My.Module", detail);
+
+        // Module vs module is a collision too.
+        Assert.NotNull(MeshModuleEndpointExtensions.FindRouteCollisions(
+        [
+            Endpoint("/api/x", "GET", "module: A", module: "A"),
+            Endpoint("/api/x", "GET", "module: B", module: "B"),
+        ]));
 
         // Same pattern, DIFFERENT verb — legitimate, no collision.
         Assert.Null(MeshModuleEndpointExtensions.FindRouteCollisions(
         [
-            Endpoint("/api/x", "GET", "a"),
-            Endpoint("/api/x", "POST", "b"),
+            Endpoint("/api/x", "GET", "a", module: "A"),
+            Endpoint("/api/x", "POST", "b", module: "B"),
         ]));
+    }
+
+    /// <summary>
+    /// The ci.3958 prod refusal, pinned: a PUBLISHED app's static-asset table registers one
+    /// endpoint per precompressed variant (identity/gzip/brotli) on the SAME (verb, pattern),
+    /// disambiguated by content negotiation — platform-only duplicates with no module party.
+    /// The gate must not refuse them; dev runs never have the variants, so only this shape
+    /// catches the regression.
+    /// </summary>
+    [Fact]
+    public void PlatformOnlyDuplicates_PublishedStaticAssetVariants_AreNotCollisions()
+    {
+        Assert.Null(MeshModuleEndpointExtensions.FindRouteCollisions(
+        [
+            Endpoint("app.styles.css", "GET", ""),
+            Endpoint("app.styles.css", "GET", ""),   // gzip variant
+            Endpoint("app.styles.css", "GET", ""),   // brotli variant
+            Endpoint("app.styles.css", "HEAD", ""),
+            Endpoint("app.styles.css", "HEAD", ""),
+            Endpoint("app.styles.css", "HEAD", ""),
+        ]));
+
+        // …but the same route colliding WITH a module endpoint still refuses.
+        Assert.NotNull(MeshModuleEndpointExtensions.FindRouteCollisions(
+        [
+            Endpoint("app.styles.css", "GET", ""),
+            Endpoint("app.styles.css", "GET", "module route", module: "My.Module"),
+        ]));
+    }
+
+    [Fact]
+    public void ContributedEndpoints_CarryTheModuleMarker()
+    {
+        using var app = BuildAppWithTestModule();
+        foreach (var endpoint in ContributedEndpoints(app))
+        {
+            var marker = endpoint.Metadata.GetMetadata<MeshModuleEndpointMetadata>();
+            Assert.NotNull(marker);
+            Assert.Equal(
+                typeof(ModuleEndpointContributionTest).Assembly.GetName().Name,
+                marker.ModuleName);
+        }
     }
 }


### PR DESCRIPTION
## The incident

The first image carrying the endpoint-contribution hook (`3.0.0-rc3.ci.3958`) **crash-loops on every published deployment**: memex-cloud's new pod refused to serve with

```
crit: MeshWeaver.Hosting.AspNetCore.MeshModuleEndpointExtensions[0]
      Endpoint route collision(s) after module contributions — refusing to serve:
      GET Memex.Portal.Distributed.styles.css ← [ |  | ]; GET _content/BlazorMonaco/... ← [ |  | ]; ...
```

memex/atioz are still on ci.3909 only because their self-update poll hadn't fired yet.

## Root cause

`FindRouteCollisions` asserted the **whole** endpoint table for duplicate (verb, pattern). A **published** app's `MapStaticAssets` legitimately registers one endpoint per precompressed variant — identity/gzip/brotli — on the *same* route, disambiguated by `Accept-Encoding` content negotiation (the three anonymous parties in the `[ |  | ]` groups). Dev runs have no precompressed variants, so every local run and CI test passed while every published deployment refused.

## Fix

The gate's design scope is the #683 class — a **module** contribution shadowing (or shadowed by) another route. So:
- every module group now stamps `MeshModuleEndpointMetadata(moduleName)`
- `FindRouteCollisions` only flags duplicate groups involving ≥1 module-contributed endpoint, and names the module in the refusal
- platform-only duplicates (the published static-asset shape) are exempt

Regression pinned with the exact prod shape: 3× GET + 3× HEAD on one asset route with no module party → clean; the same route colliding *with* a module endpoint → still refuses. Plus a discovery test that contributed endpoints carry the marker.

Tests: `ModuleEndpointContributionTest` — 4/4 green locally (Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)