### PR TITLE
feat(modules): all remaining flippable service modules leave the host build graph (#1644 step 2, task #66)

### DIFF
--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -65,16 +65,19 @@
          the app closure (via MeshWeaver.Blazor -> MeshWeaver.Markdown.Export.Contract). -->
     <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.AzureFoundry\MeshWeaver.AI.AzureFoundry.csproj" />
-    <!-- SHIPS-THE-BITS references: these four flow the provider-pack DLLs + their SDK closures
+    <!-- SHIPS-THE-BITS references: these flow the provider-pack DLLs + their SDK closures
          into output/publish, and nothing more — the composition root carries NO provider type
          references, and registration happens exclusively via Modules:Assemblies -> each pack's
          MeshNodeProviderAttribute (a deployment drops a provider by editing its module list).
          ReferenceOutputAssembly=false was tried and rejected: it drops the DLLs from the app
          output, so the boot loader has nothing to load. Hard decoupling (delete these refs +
          publish packs into a modules/ folder) is the follow-up once that publish step exists. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.AI.OpenAI\MeshWeaver.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.ClaudeCode\MeshWeaver.AI.ClaudeCode.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.Copilot\MeshWeaver.AI.Copilot.csproj" />
+    <!-- MeshWeaver.AI.OpenAI is deliberately NOT referenced (#1644 step 2): it ships via the
+         modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
+         Modules:Assemblies -> its MeshNodeProviderAttribute. -->
+
     <!-- Social publishing -->
     <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />
   </ItemGroup>

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -13,7 +13,9 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Radzen\MeshWeaver.Blazor.Radzen.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Analysis\MeshWeaver.Blazor.Analysis.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.GoogleMaps\MeshWeaver.Blazor.GoogleMaps.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
+    <!-- MeshWeaver.OgCard is deliberately NOT referenced (#1644 step 2): it ships via the
+         modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
+         Modules:Assemblies -> OgCardModuleAttribute. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Approvals\MeshWeaver.Approvals.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.OpenStreetMap\MeshWeaver.Blazor.OpenStreetMap.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.AppleMaps\MeshWeaver.Blazor.AppleMaps.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -64,7 +64,6 @@
          Modules:Assemblies -> MarkdownExportProviderAttribute. Only the wire contract stays in
          the app closure (via MeshWeaver.Blazor -> MeshWeaver.Markdown.Export.Contract). -->
     <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.AI.AzureFoundry\MeshWeaver.AI.AzureFoundry.csproj" />
     <!-- SHIPS-THE-BITS references: these flow the provider-pack DLLs + their SDK closures
          into output/publish, and nothing more — the composition root carries NO provider type
          references, and registration happens exclusively via Modules:Assemblies -> each pack's
@@ -74,9 +73,10 @@
          publish packs into a modules/ folder) is the follow-up once that publish step exists. -->
     <ProjectReference Include="..\..\src\MeshWeaver.AI.ClaudeCode\MeshWeaver.AI.ClaudeCode.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.Copilot\MeshWeaver.AI.Copilot.csproj" />
-    <!-- MeshWeaver.AI.OpenAI is deliberately NOT referenced (#1644 step 2): it ships via the
-         modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
-         Modules:Assemblies -> its MeshNodeProviderAttribute. -->
+    <!-- MeshWeaver.AI.OpenAI and MeshWeaver.AI.AzureFoundry are deliberately NOT referenced
+         (#1644 step 2): they ship via the modules/<Name>/ closure layout in
+         MeshModulesPublish.targets and activate via Modules:Assemblies -> each pack's
+         MeshNodeProviderAttribute. -->
 
     <!-- Social publishing -->
     <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -49,7 +49,11 @@
          + embeddings are configured (so the monolith compiles it but never activates it). -->
     <ProjectReference Include="..\..\src\MeshWeaver.ContentCollections.Indexing\MeshWeaver.ContentCollections.Indexing.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.ContentCollections.Indexing.Graph\MeshWeaver.ContentCollections.Indexing.Graph.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.ContentCollections.Indexing.PostgreSql\MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
+    <!-- MeshWeaver.ContentCollections.Indexing.PostgreSql is deliberately NOT referenced (#1644
+         step 2): it ships via the modules/<Name>/ closure layout in MeshModulesPublish.targets
+         and activates via Modules:Assemblies -> PostgresContentIndexingModuleAttribute (which
+         self-gates enabledWhen the mesh database connection resolves). -->
+
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.PostgreSql\MeshWeaver.Hosting.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Kernel.Hub\MeshWeaver.Kernel.Hub.csproj" />
     <!-- AI Services -->

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -34,7 +34,12 @@
     <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
     <!-- The package FORMAT, shared with the CI tool so the feed and a CI pack cannot disagree. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Plugin.Packaging\MeshWeaver.Plugin.Packaging.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Observability\MeshWeaver.Observability.csproj" />
+    <!-- MeshWeaver.Observability is deliberately NOT referenced (#1644 step 2): the engine ships
+         via the modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
+         Modules:Assemblies -> ObservabilityProviderAttribute. Only the wire contract stays in the
+         app closure (LogIncidentEndpoints resolves ILogIncidentIngest optionally and answers an
+         actionable 503 when the module is not listed). -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Observability.Contract\MeshWeaver.Observability.Contract.csproj" />
     <!-- Notification delivery channels module (double-ship transition state: the bits ride this
          ProjectReference; activation is the hosts' Modules:Assemblies listing). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Notifications.Channels\MeshWeaver.Notifications.Channels.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -40,9 +40,10 @@
          app closure (LogIncidentEndpoints resolves ILogIncidentIngest optionally and answers an
          actionable 503 when the module is not listed). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Observability.Contract\MeshWeaver.Observability.Contract.csproj" />
-    <!-- Notification delivery channels module (double-ship transition state: the bits ride this
-         ProjectReference; activation is the hosts' Modules:Assemblies listing). -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Notifications.Channels\MeshWeaver.Notifications.Channels.csproj" />
+    <!-- MeshWeaver.Notifications.Channels is deliberately NOT referenced (#1644 step 2): it
+         ships via the modules/<Name>/ closure layout in MeshModulesPublish.targets and activates
+         via Modules:Assemblies -> NotificationChannelsModuleAttribute (the triage watcher
+         self-skips unless Email:Enabled). -->
     <ProjectReference Include="..\..\src\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
     <!-- Content → vector index (core tech): chunk/embed/store on a separate Postgres vector DB,
          per-file Document nodes, chunk-search autocomplete. Inert unless ConnectionStrings:contentindex

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -64,18 +64,11 @@
          Modules:Assemblies -> MarkdownExportProviderAttribute. Only the wire contract stays in
          the app closure (via MeshWeaver.Blazor -> MeshWeaver.Markdown.Export.Contract). -->
     <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
-    <!-- SHIPS-THE-BITS reference: flows the provider-pack DLL + its SDK closure
-         into output/publish, and nothing more — the composition root carries NO provider type
-         references, and registration happens exclusively via Modules:Assemblies -> each pack's
-         MeshNodeProviderAttribute (a deployment drops a provider by editing its module list).
-         ReferenceOutputAssembly=false was tried and rejected: it drops the DLLs from the app
-         output, so the boot loader has nothing to load. Hard decoupling (delete these refs +
-         publish packs into a modules/ folder) is the follow-up once that publish step exists. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.AI.Copilot\MeshWeaver.AI.Copilot.csproj" />
-    <!-- MeshWeaver.AI.OpenAI, MeshWeaver.AI.AzureFoundry and MeshWeaver.AI.ClaudeCode are
+    <!-- The AI provider packs — MeshWeaver.AI.OpenAI, .AzureFoundry, .ClaudeCode, .Copilot — are
          deliberately NOT referenced (#1644 step 2): they ship via the modules/<Name>/ closure
          layout in MeshModulesPublish.targets and activate via Modules:Assemblies -> each pack's
-         MeshNodeProviderAttribute. -->
+         MeshNodeProviderAttribute (a deployment drops a provider by editing its module list).
+         The composition root carries no provider type references. -->
 
     <!-- Social publishing -->
     <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -64,18 +64,17 @@
          Modules:Assemblies -> MarkdownExportProviderAttribute. Only the wire contract stays in
          the app closure (via MeshWeaver.Blazor -> MeshWeaver.Markdown.Export.Contract). -->
     <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
-    <!-- SHIPS-THE-BITS references: these flow the provider-pack DLLs + their SDK closures
+    <!-- SHIPS-THE-BITS reference: flows the provider-pack DLL + its SDK closure
          into output/publish, and nothing more — the composition root carries NO provider type
          references, and registration happens exclusively via Modules:Assemblies -> each pack's
          MeshNodeProviderAttribute (a deployment drops a provider by editing its module list).
          ReferenceOutputAssembly=false was tried and rejected: it drops the DLLs from the app
          output, so the boot loader has nothing to load. Hard decoupling (delete these refs +
          publish packs into a modules/ folder) is the follow-up once that publish step exists. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.AI.ClaudeCode\MeshWeaver.AI.ClaudeCode.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.Copilot\MeshWeaver.AI.Copilot.csproj" />
-    <!-- MeshWeaver.AI.OpenAI and MeshWeaver.AI.AzureFoundry are deliberately NOT referenced
-         (#1644 step 2): they ship via the modules/<Name>/ closure layout in
-         MeshModulesPublish.targets and activate via Modules:Assemblies -> each pack's
+    <!-- MeshWeaver.AI.OpenAI, MeshWeaver.AI.AzureFoundry and MeshWeaver.AI.ClaudeCode are
+         deliberately NOT referenced (#1644 step 2): they ship via the modules/<Name>/ closure
+         layout in MeshModulesPublish.targets and activate via Modules:Assemblies -> each pack's
          MeshNodeProviderAttribute. -->
 
     <!-- Social publishing -->

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -47,7 +47,6 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />
@@ -55,6 +54,7 @@
     <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2). -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,6 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,6 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,6 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -47,7 +47,6 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />
 
     <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2). -->
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -45,7 +45,6 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,6 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
@@ -55,6 +54,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -48,13 +48,13 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.ContentCollections.Indexing.PostgreSql/MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Observability/MeshWeaver.Observability.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Notifications.Channels/MeshWeaver.Notifications.Channels.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />
 
-    <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2, flip #1). -->
+    <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2). -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Markdown.Export/MeshWeaver.Markdown.Export.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.OgCard/MeshWeaver.OgCard.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -15,9 +15,10 @@
          shells call — an unmapped one there answers the SPA fallback with a 200, not a 404 (#1474). -->
     <ProjectReference Include="..\..\memex\Memex.LocalMesh\Memex.LocalMesh.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
-    <!-- Direct on purpose (#1644 step 2): the export engine left Memex.Portal.Shared's closure
-         (it ships via modules/), so ModuleLaneSwitchTest anchors the real DLL itself. -->
+    <!-- Direct on purpose (#1644 step 2): these modules left Memex.Portal.Shared's closure
+         (they ship via modules/), so the module-fold tests anchor the real DLLs themselves. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Markdown.Export\MeshWeaver.Markdown.Export.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in
          `dotnet test`. It only ever ran INSIDE the migration container before, so a registry/
          DbVersion.Latest drift shipped a dead image while main stayed green (V53, 2026-08-14). -->

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Markdown.Export\MeshWeaver.Markdown.Export.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Observability\MeshWeaver.Observability.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Notifications.Channels\MeshWeaver.Notifications.Channels.csproj" />
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in
          `dotnet test`. It only ever ran INSIDE the migration container before, so a registry/
          DbVersion.Latest drift shipped a dead image while main stayed green (V53, 2026-08-14). -->

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Observability\MeshWeaver.Observability.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Notifications.Channels\MeshWeaver.Notifications.Channels.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.AI.OpenAI\MeshWeaver.AI.OpenAI.csproj" />
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in
          `dotnet test`. It only ever ran INSIDE the migration container before, so a registry/
          DbVersion.Latest drift shipped a dead image while main stayed green (V53, 2026-08-14). -->

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -19,6 +19,7 @@
          (they ship via modules/), so the module-fold tests anchor the real DLLs themselves. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Markdown.Export\MeshWeaver.Markdown.Export.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Observability\MeshWeaver.Observability.csproj" />
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in
          `dotnet test`. It only ever ran INSIDE the migration container before, so a registry/
          DbVersion.Latest drift shipped a dead image while main stayed green (V53, 2026-08-14). -->

--- a/test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj
+++ b/test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj
@@ -11,6 +11,9 @@
     <ProjectReference Include="..\..\src\MeshWeaver.AI.OpenAI\MeshWeaver.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.ClaudeCode\MeshWeaver.AI.ClaudeCode.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.AI.AzureFoundry\MeshWeaver.AI.AzureFoundry.csproj" />
+    <!-- Direct on purpose (#1644 step 2): the pack left Memex.Portal.Shared's closure (it ships
+         via modules/), so the Copilot harness/boot tests reference it themselves. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.AI.Copilot\MeshWeaver.AI.Copilot.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
     <!-- McpArgumentValidationTest drives the REAL MCP tool declarations (McpMeshPlugin +
          McpArgumentValidation). Available transitively via Memex.Portal.Shared; referenced

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -64,6 +64,9 @@
         <ProjectReference Include="..\..\src\MeshWeaver.Maps\MeshWeaver.Maps.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.OgCard\MeshWeaver.OgCard.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />
+        <!-- Direct on purpose (#1644 step 2): the provider pack left Memex.Portal.Shared's
+             closure (it ships via modules/), so AgentPickerProjectionTest references it itself. -->
+        <ProjectReference Include="..\..\src\MeshWeaver.AI.AzureFoundry\MeshWeaver.AI.AzureFoundry.csproj" />
         <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
## What

#1644 step 2, task #66: every remaining SERVICE-ONLY module whose activation already rides `Modules:Assemblies` is flipped off the host's ships-the-bits ProjectReference and onto the `modules/<Name>/` closure lane in `memex/MeshModulesPublish.targets`. One commit per module:

**Flipped (8 total on this branch)**
- `MeshWeaver.OgCard`, `MeshWeaver.Observability` (engine; contract stays), `MeshWeaver.ContentCollections.Indexing.PostgreSql` — the three flips from the first part of this sequence
- `MeshWeaver.Notifications.Channels` — host never compiled against it (comments only); triage watcher self-skips unless `Email:Enabled`
- `MeshWeaver.AI.OpenAI`, `MeshWeaver.AI.AzureFoundry`, `MeshWeaver.AI.ClaudeCode`, `MeshWeaver.AI.Copilot` — the four provider packs. Their csproj comment named exactly this hard decoupling as the follow-up "once that publish step exists"; it exists now. The composition root carries no provider type references; activation stays `Modules:Assemblies` → each pack's `MeshNodeProviderAttribute`.

Test projects that compiled against a flipped module through the host's closure now reference it directly: `Memex.Portal.Shared.Test` (+Notifications.Channels, +AI.OpenAI), `MeshWeaver.Hosting.Monolith.Test` (+AI.AzureFoundry for AgentPickerProjectionTest), `MeshWeaver.AI.Test` (+AI.Copilot).

**Not flipped — real compile-time coupling in the host, per the "do not force it" rule:**
- `MeshWeaver.Speech` — `Memex.Portal.Shared/Api/SpeechEndpoints.cs` compiles against `ISpeechTranscriber`, which lives in the module assembly; there is no `MeshWeaver.Speech.Contract`. A contract split is a separate design change, not a flip.
- `MeshWeaver.Social` — `Memex.Portal.Shared/Social/ApiCredentialNodeType.cs` compiles against `PlatformCredential`, and `SocialModuleAttribute`'s own docs say the ApiCredential node-type registration deliberately stays host-side so existing credential nodes survive module delisting.
- `MeshWeaver.Hosting.Grpc` — the host keeps the one compiled middleware line `app.UseMeshWeaverGrpcWebWhenInstalled()` (defined in the module assembly): middleware must run between `UseRouting` and the endpoint maps and cannot ride `MeshEndpointProviderAttribute` (documented in `GrpcHostingExtensions`). Middleware-order coupling — the exact not-flippable category.

View packs (Blazor.*) are out of scope — task #67.

## Verification

- `Memex.Portal.Shared`, `Memex.Portal.Monolith`, `Memex.Portal.Distributed`: `-c Release -warnaserror` clean (0 warnings, 0 errors) after every flip and at the end.
- Monolith Release build lays out `bin/Release/net10.0/modules/<Name>/<Name>.dll` for all 8 flipped modules; the app root no longer carries the flipped DLLs. Private deps landed as designed: AzureFoundry keeps `Azure.AI.Agents.Persistent`/`Microsoft.Agents.AI.AzureAI.Persistent`/`Microsoft.Extensions.AI.AzureAIInference`, ClaudeCode keeps `ClaudeAgentSdk`, Copilot keeps `GitHub.Copilot.SDK`; OpenAI keeps none (its SDK closure still rides the app via `MeshWeaver.AI`).
- Tests (Release, fresh .trx each): `Memex.Portal.Shared.Test` 367/367 passed; `MeshWeaver.AI.Test` 1150 passed / 5 skipped / 0 failed; `MeshWeaver.Hosting.Monolith.Test` filtered `AgentPickerProjectionTest` 6/6 passed.

No What's New entry: pure-internal build-graph/publish-layout change with no user-visible effect.

Refs #1644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)