### PR TITLE
fix(approvals): the legacy surface is COMPLETE — ci.3971 still regressed on the uncovered classes

### DIFF
--- a/src/MeshWeaver.Approvals/GraphLegacySurface.cs
+++ b/src/MeshWeaver.Approvals/GraphLegacySurface.cs
@@ -1,38 +1,107 @@
+using System;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 
-// 🚨 Deliberately the GRAPH namespace. This file restores the EXACT public surface in-mesh
-// sources compiled against before the Approvals extraction (#1654): `MeshWeaver.Graph.
-// ApprovalExtensions` with `AddApprovals(this MessageHubConfiguration)`. The extraction moved
-// the class to the MeshWeaver.Approvals namespace and narrowed the public entry point to
-// MeshBuilder — deleting a public framework surface that the compiler cannot see the callers
-// of (AGENTS.md: in-mesh source is invisible to `dotnet build`). On the first image that
-// shipped the extraction, 11 NodeTypes across the SocialMedia and UWDeepfield partitions
-// regressed to CompileError (CS1061 AddApprovals / CS0103 ApprovalExtensions) and the bake
-// gate refused readiness mesh-wide — the same symbol that caused the #683-era outage.
-// Node content lives in OTHER repos and in production databases, so the platform keeps the
-// surface; content can migrate to the module registration at its own pace.
-namespace MeshWeaver.Graph;
-
-/// <summary>
-/// Legacy Approvals surface for in-mesh sources written before the Approvals module extraction
-/// (#1654). The real registration lives in <see cref="Approvals.ApprovalExtensions"/> and is
-/// applied to every per-node hub when the module is installed — so this entry point only fills
-/// the gap on hubs the module has not configured, and is a no-op everywhere else.
-/// </summary>
-public static class ApprovalExtensions
+// 🚨 Deliberately the GRAPH namespaces. This file restores the EXACT public surface in-mesh
+// sources compiled against before the Approvals extraction (#1654): the FOUR classes the
+// extraction deleted from MeshWeaver.Graph — ApprovalExtensions, ApprovalsView,
+// ApprovalLayoutAreas (namespace MeshWeaver.Graph) and ApprovalNodeType (namespace
+// MeshWeaver.Graph.Configuration) — as thin delegates to their MeshWeaver.Approvals homes.
+// The compiler cannot see the callers (AGENTS.md: in-mesh source is invisible to
+// `dotnet build`): on the first image shipping the extraction, 11 NodeTypes across the
+// SocialMedia and UWDeepfield partitions regressed to CompileError (CS1061 AddApprovals,
+// CS0103 ApprovalExtensions / ApprovalNodeType) and the bake gate refused readiness
+// mesh-wide — the same symbol family as the #683-era outage. Node content lives in OTHER
+// repos and in production databases, so the platform keeps the surface; content can migrate
+// to the module registration at its own pace. ApprovalsLegacySurfaceCompileTest is the
+// compiler for these callers.
+namespace MeshWeaver.Graph
 {
-    /// <summary>The sub-partition name where approvals are stored.</summary>
-    public const string ApprovalPartition = Approvals.ApprovalExtensions.ApprovalPartition;
+    /// <summary>
+    /// Legacy Approvals surface for in-mesh sources written before the Approvals module
+    /// extraction (#1654). The real registration lives in
+    /// <see cref="Approvals.ApprovalExtensions"/> and is applied to every per-node hub when the
+    /// module is installed — so this entry point only fills the gap on hubs the module has not
+    /// configured, and is a no-op everywhere else.
+    /// </summary>
+    public static class ApprovalExtensions
+    {
+        /// <summary>The sub-partition name where approvals are stored.</summary>
+        public const string ApprovalPartition = Approvals.ApprovalExtensions.ApprovalPartition;
+
+        /// <summary>
+        /// Adds approval support to this hub configuration. Idempotent: when the Approvals module
+        /// (or an earlier call) already configured the hub — detected via the
+        /// <see cref="ApprovalsEnabled"/> marker
+        /// (<see cref="ApprovalsMarkerExtensions.HasApprovals"/>, which remains the one
+        /// <c>HasApprovals</c> surface) — the configuration is returned unchanged.
+        /// </summary>
+        public static MessageHubConfiguration AddApprovals(this MessageHubConfiguration configuration)
+            => ApprovalsMarkerExtensions.HasApprovals(configuration)
+                ? configuration
+                : Approvals.ApprovalExtensions.ConfigureHub(configuration);
+    }
 
     /// <summary>
-    /// Adds approval support to this hub configuration. Idempotent: when the Approvals module
-    /// (or an earlier call) already configured the hub — detected via the
-    /// <see cref="ApprovalsEnabled"/> marker (<see cref="ApprovalsMarkerExtensions.HasApprovals"/>,
-    /// which remains the one <c>HasApprovals</c> surface) — the configuration is returned
-    /// unchanged.
+    /// Legacy home of the Approvals views (pre-#1654) — delegates to
+    /// <see cref="Approvals.ApprovalsView"/>.
     /// </summary>
-    public static MessageHubConfiguration AddApprovals(this MessageHubConfiguration configuration)
-        => ApprovalsMarkerExtensions.HasApprovals(configuration)
-            ? configuration
-            : Approvals.ApprovalExtensions.ConfigureHub(configuration);
+    public static class ApprovalsView
+    {
+        /// <inheritdoc cref="Approvals.ApprovalsView.RequestApproval"/>
+        public static IObservable<UiControl?> RequestApproval(LayoutAreaHost host, RenderingContext context)
+            => Approvals.ApprovalsView.RequestApproval(host, context);
+
+        /// <inheritdoc cref="Approvals.ApprovalsView.InlineApprovals"/>
+        public static IObservable<UiControl?> InlineApprovals(LayoutAreaHost host, RenderingContext context)
+            => Approvals.ApprovalsView.InlineApprovals(host, context);
+    }
+
+    /// <summary>
+    /// Legacy home of the Approvals layout areas (pre-#1654) — delegates to
+    /// <see cref="Approvals.ApprovalLayoutAreas"/>.
+    /// </summary>
+    public static class ApprovalLayoutAreas
+    {
+        /// <inheritdoc cref="Approvals.ApprovalLayoutAreas.OverviewArea"/>
+        public const string OverviewArea = Approvals.ApprovalLayoutAreas.OverviewArea;
+
+        /// <inheritdoc cref="Approvals.ApprovalLayoutAreas.ThumbnailArea"/>
+        public const string ThumbnailArea = Approvals.ApprovalLayoutAreas.ThumbnailArea;
+
+        /// <inheritdoc cref="Approvals.ApprovalLayoutAreas.AddApprovalViews"/>
+        public static MessageHubConfiguration AddApprovalViews(this MessageHubConfiguration configuration)
+            => Approvals.ApprovalLayoutAreas.AddApprovalViews(configuration);
+
+        /// <inheritdoc cref="Approvals.ApprovalLayoutAreas.Overview"/>
+        public static IObservable<UiControl?> Overview(LayoutAreaHost host, RenderingContext context)
+            => Approvals.ApprovalLayoutAreas.Overview(host, context);
+
+        /// <inheritdoc cref="Approvals.ApprovalLayoutAreas.Thumbnail"/>
+        public static UiControl Thumbnail(LayoutAreaHost host, RenderingContext context)
+            => Approvals.ApprovalLayoutAreas.Thumbnail(host, context);
+    }
+}
+
+namespace MeshWeaver.Graph.Configuration
+{
+    /// <summary>
+    /// Legacy home of the Approval node type helpers (pre-#1654) — delegates to
+    /// <see cref="MeshWeaver.Approvals.ApprovalNodeType"/>.
+    /// </summary>
+    public static class ApprovalNodeType
+    {
+        /// <inheritdoc cref="MeshWeaver.Approvals.ApprovalNodeType.NodeType"/>
+        public const string NodeType = MeshWeaver.Approvals.ApprovalNodeType.NodeType;
+
+        /// <inheritdoc cref="MeshWeaver.Approvals.ApprovalNodeType.AddApprovalType{TBuilder}"/>
+        public static TBuilder AddApprovalType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+            => MeshWeaver.Approvals.ApprovalNodeType.AddApprovalType(builder);
+
+        /// <inheritdoc cref="MeshWeaver.Approvals.ApprovalNodeType.CreateMeshNode"/>
+        public static MeshNode CreateMeshNode()
+            => MeshWeaver.Approvals.ApprovalNodeType.CreateMeshNode();
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/ApprovalsLegacySurfaceCompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ApprovalsLegacySurfaceCompileTest.cs
@@ -74,15 +74,24 @@ public class ApprovalsLegacySurfaceCompileTest(ITestOutputHelper output) : Monol
                 Configuration = "config => config"
             },
             ("wiring", """
+                using System;
                 using MeshWeaver.Graph;
+                using MeshWeaver.Graph.Configuration;
+                using MeshWeaver.Layout;
+                using MeshWeaver.Layout.Composition;
                 using MeshWeaver.Messaging;
 
                 public static class LegacyApprovalsWiring
                 {
                     public const string Partition = ApprovalExtensions.ApprovalPartition;
+                    public const string TypeName = ApprovalNodeType.NodeType;
+                    public const string Area = ApprovalLayoutAreas.OverviewArea;
 
                     public static MessageHubConfiguration Wire(MessageHubConfiguration configuration)
-                        => configuration.AddApprovals();
+                        => configuration.AddApprovals().AddApprovalViews();
+
+                    public static IObservable<UiControl?> Views(LayoutAreaHost host, RenderingContext context)
+                        => ApprovalsView.InlineApprovals(host, context);
                 }
                 """));
 


### PR DESCRIPTION
## Follow-up to #1683 — the first shim was one class of four

`ci.3971` (carrying #1683) still regressed 8 NodeTypes: the CS1061 `AddApprovals` errors were fixed, but **CS0103 `ApprovalNodeType` / `ApprovalExtensions`** remained. The #1654 extraction deleted **four** public classes from the Graph namespaces, and in-mesh callers use all of them:

- `SocialMedia/Post`'s **configuration lambda** — C# stored in the NodeType's JSON field, invisible to every `.cs`-shaped search (the exact AGENTS.md warning) — calls `.AddApprovals()`
- the aggregates reference `ApprovalNodeType` and `ApprovalExtensions` by short name

Verified empirically before writing code: a scratch NodeType compiled **on the ci.3971 image itself** (memex.localhost) resolved `ApprovalExtensions.ApprovalPartition` + `AddApprovals` (first shim works) and failed only on `ApprovalNodeType` — pinning exactly what was missing.

## Fix

`GraphLegacySurface` now restores the complete extraction surface as thin delegates, every public member mirrored 1:1:
- `MeshWeaver.Graph`: `ApprovalExtensions`, `ApprovalsView`, `ApprovalLayoutAreas`
- `MeshWeaver.Graph.Configuration`: `ApprovalNodeType`

The pin test's node source now exercises all four classes (consts, extensions, view delegates). Full solution Release `-warnaserror` `--no-incremental` green; `ApprovalModuleTest` 5/5; pin 1/1.

Note per maintainer: the Approvals tests relocate to the Plugins repo with the module in a follow-up (tracked) — this PR only closes the prod regression.

No What's New entry — #1683's entry covers the user-facing fix; this completes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)