### PR TITLE
feat(modules): retire the Approvals→Graph IVT; view packs stay thin-lane pending the static-asset provider (task #67)

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,7 +38,7 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
-    <!-- View packs (task #67): thin-lane BLOCKED on static web assets. Each pack's CSS/JS
+    <!-- View packs (#1644 step 2, final wave): thin-lane BLOCKED on static web assets. Each pack's CSS/JS
          reaches the browser only through the HOST's build-time static-web-assets graph — i.e.
          through the ProjectReference this lane exists to remove:
            - Radzen self-loads _content/Radzen.Blazor/{css/material-base.css,Radzen.Blazor.js}

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -38,9 +38,29 @@
        dev `dotnet run` has no publish step and the flipped DLL exists nowhere else.
   -->
   <ItemGroup>
+    <!-- View packs (task #67): thin-lane BLOCKED on static web assets. Each pack's CSS/JS
+         reaches the browser only through the HOST's build-time static-web-assets graph — i.e.
+         through the ProjectReference this lane exists to remove:
+           - Radzen self-loads _content/Radzen.Blazor/{css/material-base.css,Radzen.Blazor.js}
+             (RadzenViewBase.OnAfterRenderAsync) — package assets that enter the host manifest
+             only via the host's reference graph;
+           - GoogleMaps imports ./_content/MeshWeaver.Blazor.GoogleMaps/GoogleMapView.razor.js
+             (GoogleMapView.razor.cs) — a collocated-JS static web asset;
+           - Analysis/GoogleMaps scoped .razor.css bundles into the host's <App>.styles.css at
+             HOST build (App.razor links only that aggregate).
+         Nothing serves modules/<Name>/wwwroot: UseStaticFiles/MapStaticAssets read the host's
+         build-time manifests, and a standalone RCL publish lays the pack's own assets at
+         wwwroot/ ROOT, not _content/<pack>/ — the URLs its components request. Flipping needs
+         the module static-asset provider (path-convention mapping + fingerprint/precompressed
+         endpoint variants; see UiExtensibility.md "Razor assets from a runtime-loaded
+         assembly"), not just this list. -->
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
+    <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
+         (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
+         compiles against PlatformCredential; registration deliberately host-side), Hosting.Grpc
+         (UseMeshWeaverGrpcWebWhenInstalled is middleware-order-coupled, cannot ride the endpoint hook). -->
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -300,7 +300,14 @@ public static class MeshNodeLayoutAreas
                 }));
     }
 
-    internal static string GetContainerStyle(LayoutAreaHost host, NodeTypeDefinition? typeDef = null, string? maxWidthOverride = null)
+    /// <summary>
+    /// The standard node-page container style: centered, padded, constrained to the page max
+    /// width (node-type override → <see cref="PageLayoutOptions"/> → 1200px default).
+    /// Public module-facing contract: out-of-tree modules (e.g. Approvals) apply this to their
+    /// own layout-area roots so module pages share the built-in node-page geometry instead of
+    /// duplicating the style string. Changing the returned style reflows every module page.
+    /// </summary>
+    public static string GetContainerStyle(LayoutAreaHost host, NodeTypeDefinition? typeDef = null, string? maxWidthOverride = null)
     {
         var pageMaxWidth = maxWidthOverride
             ?? typeDef?.PageMaxWidth
@@ -380,8 +387,11 @@ public static class MeshNodeLayoutAreas
     /// link and the Created/LastModified/LastModifiedBy timestamps.
     /// Clicking the icon opens an icon-picker dialog; clicking the title (when the
     /// content has a Title property and the user can edit) switches it to inline edit.
+    /// Public module-facing contract: out-of-tree modules (e.g. Approvals) compose this header
+    /// atop their own layout areas so module pages carry the same icon/title/action/meta chrome
+    /// as built-in node pages — the alternative is a hand-built copy that drifts.
     /// </summary>
-    internal static UiControl BuildHeader(LayoutAreaHost host, MeshNode? node, bool canEdit = true)
+    public static UiControl BuildHeader(LayoutAreaHost host, MeshNode? node, bool canEdit = true)
     {
         // Chrome-less pages: a node excluded from the "header" context ships without the
         // icon/title/meta block — the content (a marketing hero, a landing page) starts

--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
     <InternalsVisibleTo Include="MeshWeaver.Query.Test" />
-    <!-- The Approvals module's views compose the shared node chrome (GetContainerStyle,
-         BuildHeader) — internal layout plumbing, deliberately not public API. -->
-    <InternalsVisibleTo Include="MeshWeaver.Approvals" />
+    <!-- The build/bake pipeline drives NodeType compilation (MeshNodeCompilationService,
+         NodeTypeCompilationHelpers, TryCreateReleaseNode) — a live internal coupling,
+         tracked for retirement separately from the (removed) Approvals grant. -->
     <InternalsVisibleTo Include="MeshWeaver.Hosting" />
     <InternalsVisibleTo Include="MeshWeaver.Hosting.Monolith.Test" />
     <!-- The build-time packer calls DynamicMeshNodeAttributeGenerator directly. A prebuilt


### PR DESCRIPTION
## What

Task #67 of the modularization program, two steps:

### Step 1 — the Approvals→Graph `InternalsVisibleTo` is retired ✅

Compiling `MeshWeaver.Approvals` without the grant enumerated exactly **two** internal symbols in use, both the shared node-page chrome:

- `MeshNodeLayoutAreas.GetContainerStyle` — the standard node-page container style (max-width resolution → centered/padded geometry)
- `MeshNodeLayoutAreas.BuildHeader` — the standard icon/title/action/meta header

Both are **promoted to public** with XML docs naming the contract: an out-of-tree module (Approvals is slated for the Plugins repo) composes this chrome so its pages stay visually consistent with built-in node pages — the alternative is a hand-built copy that drifts. `MeshNodeLayoutAreas` is already a public API class (25 public members); no other visibility changed. The IVT grant to `MeshWeaver.Approvals` is **deleted**; Approvals compiles against public surface only. The #1683/#1685 `GraphLegacySurface` shims are unaffected (they delegate within the Approvals assembly / to Graph public surface).

The brief's "exactly one remaining IVT consumer" was **falsified**: `MeshWeaver.Hosting` is a LIVE consumer (verified by compiling without the grant — `MeshNodeCompilationService`, `NodeTypeCompilationHelpers`, `MeshDataSourceExtensions.TryCreateReleaseNode`), and `MeshWeaver.Plugin.Build` is deliberate (documented). Both stay, now with a csproj comment naming the coupling; retiring the Hosting grant is a separate (bigger) task.

### Step 2 — view packs: **not flippable yet**, verdict documented at the list ⛔

Investigated whether the module lane can serve a view pack's static web assets on today's main. It cannot — every asset path runs through the **host's build-time static-web-assets graph**, i.e. through the very ProjectReference the flip removes:

- `src/MeshWeaver.Blazor.Radzen/RadzenViewBase.cs:66-67` self-loads `_content/Radzen.Blazor/css/material-base.css` + `_content/Radzen.Blazor/Radzen.Blazor.js` — package assets that enter the host manifest only via the host's reference graph
- `src/MeshWeaver.Blazor.GoogleMaps/GoogleMapView.razor.cs:36` imports `./_content/MeshWeaver.Blazor.GoogleMaps/GoogleMapView.razor.js` — a collocated-JS static web asset
- Analysis/GoogleMaps scoped `.razor.css` bundles into the host's aggregate at HOST build; `memex/Memex.Portal.Shared/App.razor:31` links only that aggregate
- Nothing serves `modules/<Name>/wwwroot`: `UseStaticFiles` (`MemexConfiguration.cs:1079`) + `MapStaticAssets` (`:1220`) read the host's build-time manifests; no module static-file provider exists anywhere in src/
- Measured: a standalone RCL publish lays the pack's own assets at `wwwroot/` ROOT, **not** at the `_content/<pack>/` URLs its components request — so the provider work includes a path-convention mapping plus fingerprint/precompressed endpoint variants (the collision-gate exemption in `MeshModuleEndpointExtensions.FindRouteCollisions` covers platform duplicates only)
- `UiExtensibility.md` "Razor assets from a runtime-loaded assembly" documents the same gap

Per the "do not force it" rule: **zero packs flipped**; the verdict + evidence now live as a comment block in `memex/MeshModulesPublish.targets` where the next wave will read it (alongside the #1681 reasons for Speech/Social/Grpc). A falsified brief is a licensed result.

## Verification

- Full solution `dotnet build -c Release -warnaserror --no-incremental`: **0 warnings, 0 errors** (185 project outputs, fresh artifacts verified by mtime)
- `MeshWeaver.Approvals` compiles clean against public-only Graph surface (grant deleted)
- Monolith Release build still lays out `bin/Release/net10.0/modules/<Name>/` for all 9 closure modules (targets edit is comment-only)
- Tests (Release, `--no-build`, fresh `.trx` each): `MeshWeaver.Graph.Test` filter `~Approval` **40/40 passed**; `MeshWeaver.Hosting.Monolith.Test` filter `ApprovalsLegacySurfaceCompileTest|OverviewHeaderRenderTest` **6/6 passed**

No What's New entry: pure-internal build-graph/API-visibility change with no user-visible effect.

Refs #1644. Prerequisite for the Approvals relocation to MeshWeaver.Plugins (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)