### PR TITLE
feat(#1660 WS3): commit-deterministic framework identity — the CI bake seeds at boot

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# publish-bake-bundles.sh <bake-dir> <source-name>
+#
+# Publishes a CI NodeType bake (the directory mw-plugin-test's --bake-output wrote: one
+# <package>.zip per package + framework-mvid.txt) to the shared storage the portals read at boot
+# (#1660 WS3). The portal side is ShippedPrebuiltBundles.SeedPublishedRoot: each pod seeds
+# <PreWarm:PrebuiltBundleRoot>/<its-own-framework-identity>/**/*.zip, so the key layout here is
+#
+#     <base>/prebuilt-bundles/<framework-identity>/<source-name>/<bundle>.zip
+#
+# where <framework-identity> comes from the bake's framework-mvid.txt (for CI builds: the commit
+# identity g<sha>, identical for every CI build of the same commit — that determinism is what
+# makes this publication findable by the images built from the same commit). <source-name> is the
+# producing repo's segment (e.g. meshweaver-content, plugins, education) so multiple independent
+# producers publish without clobbering; the bundle manifests inside carry the exact source SHA.
+#
+# ENVIRONMENT
+#   BAKE_PUBLISH_TARGETS   whitespace-separated targets, each  <storage-account>/<file-share>
+#                          (optionally <storage-account>/<file-share>/<base-path>). These are the
+#                          Azure Files shares the portals mount (on AKS: the share behind the
+#                          memex-data PVC, mounted at /data — so the portal reads
+#                          /data/prebuilt-bundles/... when PreWarm__PrebuiltBundleRoot is
+#                          /data/prebuilt-bundles).
+#
+# AUTH: `az login` must already have happened (the CD jobs use OIDC). Data-plane access uses
+# --auth-mode login with --backup-intent, which requires the identity to hold the
+# "Storage File Data Privileged Contributor" role on the target storage accounts.
+#
+# Loud by design: a missing/empty target list, identity file, or bundle set FAILS — a publish
+# step that silently ships nothing is exactly the regression (#1347 → #1660) this lane fixes.
+set -euo pipefail
+
+BAKE_DIR="${1:?usage: publish-bake-bundles.sh <bake-dir> <source-name>}"
+SOURCE="${2:?usage: publish-bake-bundles.sh <bake-dir> <source-name>}"
+
+if [ -z "${BAKE_PUBLISH_TARGETS:-}" ]; then
+  echo "::error::BAKE_PUBLISH_TARGETS is not set — provision the repo variable with the portals' storage targets (<account>/<share>[/<base-path>], whitespace-separated). The CI bake cannot reach any portal without it."
+  exit 1
+fi
+
+IDENTITY_FILE="$BAKE_DIR/framework-mvid.txt"
+if [ ! -s "$IDENTITY_FILE" ]; then
+  echo "::error::$IDENTITY_FILE is missing or empty — the bake carries no framework identity, so nothing can adopt it."
+  exit 1
+fi
+IDENTITY="$(tr -d '[:space:]' < "$IDENTITY_FILE")"
+
+shopt -s nullglob
+BUNDLES=("$BAKE_DIR"/*.zip)
+if [ "${#BUNDLES[@]}" -eq 0 ]; then
+  echo "::error::no bundle zips under $BAKE_DIR — a bake that produced nothing must not reach the publish step."
+  exit 1
+fi
+
+publish_one_target() { # <account> <share> <dest-dir>
+  local account="$1" share="$2" dest="$3" path="" part
+  # az storage directory create is not recursive and errors on an existing directory on some CLI
+  # versions — create each level only when absent.
+  local IFS='/'
+  for part in $dest; do
+    path="${path:+$path/}$part"
+    local exists
+    exists=$(az storage directory exists --account-name "$account" --share-name "$share" \
+      --name "$path" --auth-mode login --backup-intent --query exists -o tsv --only-show-errors)
+    if [ "$exists" != "true" ]; then
+      az storage directory create --account-name "$account" --share-name "$share" \
+        --name "$path" --auth-mode login --backup-intent --only-show-errors > /dev/null
+    fi
+  done
+  local zip
+  for zip in "${BUNDLES[@]}"; do
+    az storage file upload --account-name "$account" --share-name "$share" \
+      --path "$dest/$(basename "$zip")" --source "$zip" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null
+    echo "published: $account/$share/$dest/$(basename "$zip")"
+  done
+}
+
+for target in $BAKE_PUBLISH_TARGETS; do
+  ACCOUNT="${target%%/*}"
+  REST="${target#*/}"
+  SHARE="${REST%%/*}"
+  BASE=""
+  case "$REST" in */*) BASE="${REST#*/}";; esac
+  if [ -z "$ACCOUNT" ] || [ -z "$SHARE" ] || [ "$ACCOUNT" = "$target" ]; then
+    echo "::error::malformed BAKE_PUBLISH_TARGETS entry '$target' — expected <account>/<share>[/<base-path>]"
+    exit 1
+  fi
+  DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+  echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s))"
+  publish_one_target "$ACCOUNT" "$SHARE" "$DEST"
+done
+
+echo "bake published: identity=$IDENTITY source=$SOURCE bundles=${#BUNDLES[@]}"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1306,13 +1306,14 @@ jobs:
         tar -I 'zstd --long=27' -xf build-output-0.tar.zst
         rm -f build-output-0.tar.zst
     # 🚨 Since #1660 WS1 this job is not verdict-only: the SAME tester run that proves the content
-    # compiles also PERSISTS the compiled assemblies (--bake-output) as MVID-keyed prebuilt
-    # bundles, uploaded below as `baked-assemblies-<mvid>`. Consumers inside THIS run (test lanes,
-    # a future thin containerize step) can adopt them because every job reuses the ONE solution
-    # build — same Graph.dll, same MVID. A consumer built ANYWHERE else (today's main-cd legs
-    # recompile with their own run number as a version input) has a different MVID and correctly
-    # declines the whole set — that is the seeder's ABI gate, not a bug; #1660 WS3 (framework-
-    # identity determinism) is what will make cross-workflow adoption possible.
+    # compiles also PERSISTS the compiled assemblies (--bake-output) as identity-keyed prebuilt
+    # bundles, uploaded below as `baked-assemblies-<identity>`. Since #1660 WS3 the framework
+    # identity is COMMIT-DETERMINISTIC (for CI builds: g<sha>, stamped by Directory.Build.props —
+    # no run number or ticks reach any compiled attribute), so consumers are no longer limited to
+    # this run: main-cd's publish-bake job copies these bundles to the portals' shared storage,
+    # where every pod built from the SAME COMMIT seeds them at boot
+    # (ShippedPrebuiltBundles.SeedPublishedRoot) instead of recompiling. The seeder's identity
+    # gate still declines anything from another commit — that is the ABI gate, not a bug.
     - name: "Compile + run the Doc content against this PR"
       id: gate
       run: |

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -92,6 +92,9 @@ permissions:
   # packages: write — the mw-plugin-test image is ALSO published to GHCR so the
   # MeshWeaver.Plugins CI can pull it with a GitHub token instead of ACR credentials.
   packages: write
+  # actions: read — publish-bake downloads the Build-and-Test run's baked-assemblies-* artifact
+  # (the CI NodeType bake this CD publishes to the portals' storage, #1660 WS3).
+  actions: read
 
 # Every green main merge ships its OWN image increment — CD runs never supersede each
 # other. The previous shared `main-cd` group dated from when this workflow also ROLLED
@@ -882,6 +885,141 @@ jobs:
             echo "- memex-portal-next \`$V_NEXT\`, \`$SHA\`, \`main\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # ────────────────── PUBLISH THE CI NODETYPE BAKE TO PORTAL STORAGE ──────────────────
+  # #1660 WS3 — "bake on CI": the Build-and-Test run of this same commit already compiled every
+  # shipped NodeType (its doc-gate runs mw-plugin-test with --bake-output and uploads the result
+  # as `baked-assemblies-<framework-identity>`). CI builds are commit-deterministic, so that
+  # artifact's framework identity EQUALS the identity of the images promote just armed — this job
+  # copies the bundles into the storage the portals mount, laid out
+  # `prebuilt-bundles/<identity>/<source>/`, and each booting pod seeds its own identity's
+  # directory (ShippedPrebuiltBundles.SeedPublishedRoot) before its NodeType sweep: pending drops
+  # to the user-content remainder, with zero Roslyn for shipped content on the pod.
+  #
+  # 🚨 The CONFIG is preflighted RED, not skipped: BAKE_PUBLISH_TARGETS missing means no portal
+  # can ever receive a bake, which is exactly the silent regression (#1347) this lane fixes — a
+  # grey skip here would hide it forever (AGENTS.md: a gate never tests its own inputs).
+  # A missing ARTIFACT, by contrast, is a legitimate per-run state (a reuse-green run skips the
+  # doc-gate, so THAT run baked nothing; the pods then compile as before) and only warns.
+  publish-bake:
+    name: "Publish CI bake to portal storage"
+    needs: [gate, promote]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
+      - name: "Preflight: the publish targets must be provisioned"
+        run: |
+          set -euo pipefail
+          if [ -z "${{ vars.BAKE_PUBLISH_TARGETS }}" ]; then
+            echo "::error::Repo variable BAKE_PUBLISH_TARGETS is not provisioned — the CI bake can reach no portal. Set it to the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>] (on AKS: the account/share behind each portal's memex-data PVC — resolve with 'kubectl get pv -o jsonpath' on the claim; the CD identity needs the 'Storage File Data Privileged Contributor' role on those accounts)."
+            exit 1
+          fi
+      - name: "Locate the Build-and-Test run for this commit"
+        id: bt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.gate.outputs.sha }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/dotnet-test.yml/runs?head_sha=$SHA&status=success&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "Build-and-Test run for $SHA: ${run_id:-<none>}"
+      - name: "Download the bake artifact"
+        id: dl
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "${{ steps.bt.outputs.run_id }}" ]; then
+            echo "::warning::No successful Build-and-Test run found for this commit — nothing to publish; pods bake locally."
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/bake-dl"
+          if ! gh run download "${{ steps.bt.outputs.run_id }}" --repo "$GITHUB_REPOSITORY" \
+               --pattern 'baked-assemblies-*' --dir "$RUNNER_TEMP/bake-dl"; then
+            # Legitimate on a reuse-green run (the doc-gate — the bake producer — was skipped
+            # because an identical tree was already proven green): that run baked nothing, and an
+            # earlier commit's bake carries a DIFFERENT identity anyway. Pods compile as before.
+            echo "::warning::Build-and-Test run ${{ steps.bt.outputs.run_id }} carries no baked-assemblies-* artifact (reuse-green run, or expired) — nothing to publish; pods bake locally."
+            echo "### ⚠️ No CI bake artifact for this commit — pods bake locally" >> "$GITHUB_STEP_SUMMARY"
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          bake_dir=$(find "$RUNNER_TEMP/bake-dl" -maxdepth 1 -type d -name 'baked-assemblies-*' | head -1)
+          if [ -z "$bake_dir" ] || [ ! -s "$bake_dir/framework-mvid.txt" ]; then
+            echo "::error::baked-assemblies artifact downloaded but carries no framework-mvid.txt — the bake artifact contract regressed."
+            exit 1
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "bake_dir=$bake_dir" >> "$GITHUB_OUTPUT"
+      - name: Ensure Azure CLI
+        if: steps.dl.outputs.found == 'true'
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        if: steps.dl.outputs.found == 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: "Publish bundles to every portal target"
+        if: steps.dl.outputs.found == 'true'
+        env:
+          BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
+        run: |
+          set -euo pipefail
+          .github/scripts/publish-bake-bundles.sh "${{ steps.dl.outputs.bake_dir }}" meshweaver-content
+          {
+            echo "### 📦 CI bake published"
+            echo "- identity: \`$(cat "${{ steps.dl.outputs.bake_dir }}/framework-mvid.txt")\`"
+            echo "- source: \`meshweaver-content\`  targets: \`${BAKE_PUBLISH_TARGETS}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ────────────────── NOTIFY DEPENDENT REPOS (repository_dispatch) ──────────────────
+  # "Subscribe to new releases of any dependency and rebuild": dependency bumps INSIDE a repo are
+  # already covered by the commit-scoped framework identity (a Dependabot merge is a commit ⇒ a
+  # new identity ⇒ a fresh CI bake). The cross-REPO edge — this platform releasing while the node
+  # repos (Plugins, Education, Reinsurance, SocialMedia) sit unchanged — is closed here: one
+  # repository_dispatch per subscriber, which their CI receives with
+  #   on: repository_dispatch: { types: [meshweaver-framework-released] }
+  # and answers by re-running its gate + bake + publish against the new framework identity.
+  # REPORTER-CLASS like notify-platform-update: a lost dispatch costs one delayed rebake wave
+  # (the next release re-notifies) and can never hide a defect — unconfigured stays a loud
+  # NOTICE, never a red.
+  notify-dependents:
+    name: "Notify dependent repos"
+    needs: [gate, portal-image, promote]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: "Dispatch meshweaver-framework-released"
+        env:
+          TOKEN: ${{ secrets.DEPENDENT_DISPATCH_TOKEN }}
+          REPOS: ${{ vars.BAKE_SUBSCRIBER_REPOS }}
+          SHA: ${{ needs.gate.outputs.sha }}
+          VERSION: ${{ needs.portal-image.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ] || [ -z "${REPOS:-}" ]; then
+            echo "::notice::Dependent-repo dispatch NOT CONFIGURED — set repo var BAKE_SUBSCRIBER_REPOS (owner/repo, whitespace-separated) and secret DEPENDENT_DISPATCH_TOKEN (a token with repo scope on the subscribers) so node repos rebake on every framework release."
+            echo "### ⚠️ Dependent-repo dispatch not configured (BAKE_SUBSCRIBER_REPOS / DEPENDENT_DISPATCH_TOKEN)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          for repo in $REPOS; do
+            echo "→ $repo"
+            curl -sS -o /tmp/resp -w '%{http_code}\n' -X POST \
+              -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$repo/dispatches" \
+              -d "{\"event_type\":\"meshweaver-framework-released\",\"client_payload\":{\"sha\":\"$SHA\",\"identity\":\"g$SHA\",\"version\":\"$VERSION\"}}" \
+              | grep -q '^2' \
+              || echo "::warning::dispatch to $repo failed ($(cat /tmp/resp)) — its next own push (or the next release) re-bakes it."
+          done
+          echo "### 📣 Framework release dispatched to: $REPOS" >> "$GITHUB_STEP_SUMMARY"
+
   # ────────────────── NOTIFY THE PLATFORM-UPDATE AGENT (optional) ──────────────────
   # After the release is ARMED (promote's last PUT), tell the registry instance's mesh that a new
   # platform build exists: one signed POST to the WebhookInbox target the Hosting plugin watches
@@ -1005,7 +1143,7 @@ jobs:
   #   writes its attempt ledger to the same issue, so the whole story is in one place.
   alert-on-failure:
     name: "Alert: CD failed on main"
-    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images]
+    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images, publish-bake, notify-dependents]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,8 +45,9 @@
     <FLUENTASSERTIONS_SUPPRESS_WARNING>true</FLUENTASSERTIONS_SUPPRESS_WARNING>
     <!-- Maintained platform version — the ONE number, set centrally here. Override at
          build time (Docker image / CI) with -p:PlatformVersion=3.0.1 (the next patch) or
-         3.1.0-rc1 (to start the next pre-release line). Clean release; the per-build
-         +build.<ticks> suffix below keeps every build distinct (NodeType cache invalidation).
+         3.1.0-rc1 (to start the next pre-release line). Clean release; CI builds are
+         COMMIT-DETERMINISTIC (issue #1660 WS3 — see the InformationalVersion note below), and
+         NodeType cache invalidation keys on the commit identity, not on a per-build stamp.
          It is also the content-version for static-repo / GitHub data-sync
          (Doc/Architecture/DataSyncSetup.md §3): a release tagged v$(PlatformVersion) is what
          a deployed binary syncs from.
@@ -168,19 +169,21 @@
        • CONTINUOUS (default — CI pipeline and local dev): append a build number, e.g.
          3.0.0-rc1.ci.21901, so continuous packages are DISTINGUISHABLE from the release and a
          local-deploy build always carries a build number.
-       Under CIRun — released or continuous alike — InformationalVersion carries +build.<ticks> so
-       NodeTypeCompilationHelpers.FrameworkVersion is distinct every build (NodeType cache
-       invalidation); local builds keep it stable to preserve incremental. See the 🚨 note on the
-       InformationalVersion property below before touching that stamp. A direct -p:Version=… still
-       overrides everything (escape hatch). -->
+       🚨 $(Version) — the run-numbered string — feeds NuGet package versions and Docker image
+       tags ONLY. It must NOT reach any COMPILED attribute: under CIRun every compiled input is
+       COMMIT-DETERMINISTIC (issue #1660 WS3), so two CI builds of the same commit — the
+       Build-and-Test run that bakes NodeType assemblies and the main-cd run that builds the
+       image — produce ABI-identical assemblies and share one framework identity
+       (NodeTypeCompilationHelpers.FrameworkVersion; see the 🚨 note on InformationalVersion
+       below). The runtime still shows the run-numbered version: the container publish injects
+       $(Version) as the MESHWEAVER_PLATFORM_VERSION environment variable (see
+       Memex.Portal.Distributed.csproj), which rides the image CONFIG, not the assemblies.
+       A direct -p:Version=… still overrides everything (escape hatch). -->
   <PropertyGroup Condition="'$(Version)' == ''">
-    <!-- Build number. CI (CIRun=true): seconds-since-midnight / 2 (~2s granularity) so continuous
-         packages are distinguishable. LOCAL DEV: a STABLE 0 — a per-build number re-stamps
-         AssemblyVersion/FileVersion/InformationalVersion every build, regenerating AssemblyInfo.cs
-         and DESTROYING incremental builds (full rebuild every time → hot machine). NodeType ABI
-         invalidation no longer depends on the version string (it uses the Graph assembly MVID —
-         NodeTypeCompilationHelpers.FrameworkVersion), so a stable local version is correct; CI does
-         clean builds so incremental doesn't apply there anyway. -->
+    <!-- Fallback build number for the .ci.N suffix when CIRun is set OFF GitHub Actions (no
+         $(GITHUB_RUN_NUMBER)): seconds-since-midnight / 2 (~2s granularity) so such packages are
+         still distinguishable. LOCAL DEV: a STABLE 0. Feeds ONLY _CiBuildNumber → $(Version) —
+         never a compiled attribute (FileVersion is pinned below; see the channel note above). -->
     <_SecondsToday>$([System.DateTime]::UtcNow.TimeOfDay.TotalSeconds.ToString("F0"))</_SecondsToday>
     <_BuildNumber Condition="'$(CIRun)' == 'true'">$([MSBuild]::Divide($(_SecondsToday), 2).ToString("F0"))</_BuildNumber>
     <_BuildNumber Condition="'$(CIRun)' != 'true'">0</_BuildNumber>
@@ -205,32 +208,35 @@
     <_CiSep Condition="'$(_VersionDash)' != '-1'">.</_CiSep>
     <Version Condition="'$(PublicRelease)' == 'true'">$(PlatformVersion)</Version>
     <Version Condition="'$(PublicRelease)' != 'true'">$(PlatformVersion)$(_CiSep)ci.$(_CiBuildNumber)</Version>
-    <!-- CI appends +build.<ticks> so each continuous build's InformationalVersion is unique; LOCAL
-         keeps it stable (= $(Version)) so AssemblyInfo isn't regenerated every build (a per-build
-         stamp regenerates AssemblyInfo.cs and destroys incremental builds — see _BuildNumber above).
+    <!-- 🚨 CIRun compiles NOTHING per-build into InformationalVersion — commit-determinism IS the
+         point (issue #1660 WS3, the fix the memex-bake retirement #1347 demanded). The property is
+         the bare $(PlatformVersion); the SDK's AddSourceRevisionToInformationalVersion target then
+         appends +<SourceRevisionId> (the CHECKED-OUT commit — identical in every CI job that
+         builds the same commit), so the compiled attribute is e.g. `3.0.0-rc3+<sha>`: the same
+         bytes whether the Build-and-Test run or the main-cd image build compiled them. That is
+         what lets the CI NodeType bake (mw-plugin-test's bake-output stage) produce assemblies
+         the deployed portal ADOPTS instead of recompiling — the bake artifact and the image agree on
+         NodeTypeCompilationHelpers.FrameworkVersion.
 
-         🚨 THIS TICKS STAMP IS LOAD-BEARING ABI SAFETY, NOT COSMETICS. It is easy to read the MVID
-         switch as "the version string no longer affects ABI identity" and delete the stamp. It does
-         affect it: this attribute is compiled INTO every assembly, MeshWeaver.Graph included, so
-         under CIRun the ticks are exactly what makes Graph's MVID — and therefore
-         NodeTypeCompilationHelpers.FrameworkVersion — differ on every CI build. That is what forces
-         a full NodeType recompile on every deployed build.
-
-         Removing the stamp would make the MVID content-stable, and a content-stable MVID is NOT a
-         sufficient staleness signal, for two independent reasons:
-           • A NodeType's compile reference set is AppContext's TRUSTED_PLATFORM_ASSEMBLIES — EVERY
-             assembly in the image (MeshNodeCompilationService.GetDefaultReferences), not just
-             Graph's dependency closure. A breaking change in an assembly Graph never references is
-             still inside that reference set, and a stable Graph MVID would declare the stale
-             NodeType assemblies valid and LOAD them across it.
-           • AssemblyVersion is pinned at 3.0.0.0 (issue #143, below), so runtime assembly binding
-             will not catch the mismatch either — nothing else stands between a stale NodeType
-             assembly and being loaded.
-         So: anyone removing the ticks stamp MUST, in the SAME change, widen FrameworkVersion to
-         cover the WHOLE reference set (e.g. a hash over the TPA closure). Do not remove one without
-         the other. Cost/benefit of the current scheme: deploy/CHANGE-PROPAGATION.md#the-bake-tax
-         (a full bake is ~10 min on the largest mesh — measured, not the hours once assumed). -->
-    <InformationalVersion Condition="'$(CIRun)' == 'true'">$(Version)+build.$([System.DateTime]::UtcNow.Ticks)</InformationalVersion>
+         🚨 HISTORY — this line used to be `$(Version)+build.<UtcNow.Ticks>` (a fresh stamp per
+         build), and that stamp was load-bearing then: FrameworkVersion was Graph's MVID alone,
+         Graph's MVID only covers Graph's own compile inputs, and a NodeType's compile reference
+         set is the WHOLE TPA (MeshNodeCompilationService.GetDefaultReferences) — so per-build
+         uniqueness was the only thing forcing stale NodeType builds out after a deploy that
+         changed an assembly Graph never references. The pairing that replaced it:
+           • Under CIRun, FrameworkVersion is now the COMMIT identity (the
+             `MeshWeaverFrameworkIdentity` assembly metadata stamped by AddCommitHashMetadata
+             below — `g<sha>`). A commit names the ENTIRE tree — every source file and every
+             package pin — so ANY reference-assembly change still flips the identity (a superset
+             of the old guarantee), while two builds of the SAME commit now share it.
+           • Local (non-CIRun) builds carry no identity stamp and keep the Graph-MVID scheme —
+             content-correct for a dirty working tree, incremental-friendly.
+           • AssemblyVersion stays pinned (issue #143, below), so runtime binding still catches
+             nothing — the identity gate remains the ONLY thing between a stale NodeType assembly
+             and being loaded. Do not weaken it.
+         Cost/benefit: deploy/CHANGE-PROPAGATION.md#the-bake-tax — with the commit identity the
+         full bake runs ONCE per commit, on CI; pods adopt. -->
+    <InformationalVersion Condition="'$(CIRun)' == 'true'">$(PlatformVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(CIRun)' != 'true'">$(Version)</InformationalVersion>
     <!-- 🔴 AssemblyVersion is STABLE (3.0.0.0) — it is the RUNTIME ASSEMBLY-BINDING identity, so it
          MUST be identical across every assembly in a coherent build. `_BuildNumber` is
@@ -240,12 +246,16 @@
          Version=3.0.0.280` while the packaged DLL had a different `3.0.0.<other>` → FileNotFoundException
          at startup → the migration CrashLoopBackOff'd, the schema stuck at v39, and Space creation
          failed (issue #143). Binding identity must not depend on wall-clock time.
-         FileVersion KEEPS the per-build number — that (plus build timestamps) drives MSBuild's
-         CopyToOutputDirectory heuristic so test bins don't hold stale framework DLLs; it does NOT
-         participate in assembly binding, so it can vary freely. NodeType ABI identity uses the Graph
-         MVID and the self-updater keys on the image tag (ci.N) — neither uses AssemblyVersion. -->
+         FileVersion is pinned for the same commit-determinism reason as InformationalVersion
+         above: it is a COMPILED attribute, so a per-build number would fork the MVIDs of two CI
+         builds of the same commit and break the bake identity. (It used to carry $(_BuildNumber)
+         to nudge MSBuild's CopyToOutputDirectory heuristic on incremental test builds — but local
+         builds always had 0 there anyway, and CI builds from clean, so the heuristic never
+         actually relied on it.) NodeType ABI identity is FrameworkVersion (commit under CIRun,
+         Graph MVID locally) and the self-updater keys on the image tag (ci.N) — neither uses
+         AssemblyVersion or FileVersion. -->
     <AssemblyVersion>$(_VersionNumeric).0</AssemblyVersion>
-    <FileVersion>$(_VersionNumeric).$(_BuildNumber)</FileVersion>
+    <FileVersion>$(_VersionNumeric).0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
@@ -265,15 +275,32 @@
        declare an HTML parser and two crypto packages and pushed a High advisory onto every
        downstream consumer. Prefer fixing the source package over adding one. -->
   <!-- Bake the git commit SHA into every assembly as AssemblyMetadata("CommitHash") so the About
-       page can show EXACTLY which build is running and link to the GitHub commit. This is kept
-       SEPARATE from InformationalVersion on purpose: CI overrides InformationalVersion to
-       $(Version)+build.<ticks> (above), which drops the SDK's default +<sha> suffix — so the SHA
-       has to ride on its own metadata attribute to survive a CI build.
+       page can show EXACTLY which build is running and link to the GitHub commit — a stable,
+       explicit carrier independent of whatever shape InformationalVersion has.
        SHA source, in order: the SDK's source-control $(SourceRevisionId) (populated locally and in
        any git checkout by InitializeSourceControlInformation), else $(GITHUB_SHA) — MSBuild imports
        environment variables as properties, so the GitHub Actions commit SHA is available with NO
        workflow change. When neither is set (a git-less source drop) the attribute is simply omitted
-       and the About page falls back to the version string. -->
+       and the About page falls back to the version string.
+
+       🚨 Under CIRun the SAME resolved SHA is ALSO stamped as
+       AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>") — THE framework build identity
+       (issue #1660 WS3). NodeTypeCompilationHelpers.FrameworkVersion reads this attribute off
+       MeshWeaver.Graph and uses it VERBATIM as the ABI-staleness key for every dynamic NodeType
+       (assembly-store filename tag, CompiledFrameworkVersion stamps, the CI bake artifact key,
+       PrebuiltAssemblySeeder's adoption gate). Two CI builds of the same commit therefore share
+       one identity — which is what lets the CI-baked NodeType assemblies seed at portal boot —
+       while ANY code or package-pin change mints a new one (a commit names the entire tree, a
+       strict superset of the old per-build-ticks guarantee's scope; see the InformationalVersion
+       note above). Stamped ONLY for CIRun builds ON GitHub Actions (GITHUB_ACTIONS=true), ON
+       PURPOSE: a CI checkout is always CLEAN at the named commit, while a local working tree can
+       be DIRTY at it — and AGENTS.md has developers reproduce CI locally with -p:CIRun=true, so
+       a CIRun-alone condition would give two different local builds (same commit, different
+       edits) one identity and let a stale NodeType assembly be adopted across them. Local builds
+       (CIRun or not) therefore carry no stamp and fall back to the Graph MVID (content-exact).
+       SourceRevisionId is preferred over GITHUB_SHA because it names the CHECKED-OUT commit; on
+       a workflow_run-triggered CD job GITHUB_SHA can be the branch tip rather than the commit
+       being built, which would fork the identity. -->
   <Target Name="AddCommitHashMetadata"
           BeforeTargets="CoreGenerateAssemblyInfo"
           DependsOnTargets="InitializeSourceControlInformation"
@@ -286,6 +313,12 @@
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>CommitHash</_Parameter1>
         <_Parameter2>$(_CommitHash)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+    <ItemGroup Condition="'$(_CommitHash)' != '' and '$(CIRun)' == 'true' and '$(GITHUB_ACTIONS)' == 'true'">
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>MeshWeaverFrameworkIdentity</_Parameter1>
+        <_Parameter2>g$(_CommitHash)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/deploy/CHANGE-PROPAGATION.md
+++ b/deploy/CHANGE-PROPAGATION.md
@@ -49,40 +49,39 @@ older code would mint a higher `-ci.<n>` and roll installs backwards.
 
 > **The `memex-bake` leg is RETIRED (#1347).** It took **12m23s** of that 28m38s
 > *(measured 2026-07-28)* — a full portal-sized dependency closure, because reference fidelity
-> required it to reference `Memex.Portal.Shared` — and it could never have contributed a single
-> usable assembly. A separately-published image cannot share the portal image's framework identity:
-> `InformationalVersion` carries `+build.<UtcNow.Ticks>` under `CIRun`
-> (`Directory.Build.props`), stamped independently by **each** `dotnet publish`, so the bake
-> image's `MeshWeaver.Graph` and the portal image's differ in MVID even when built from the same
-> commit in the same CD run. The bake therefore wrote assemblies under a framework tag no portal
-> would ever look up — and, worse, its compile write-back flipped live NodeType records, which is
-> what stopped the one AKS attempt (memex-cloud, 2026-07-30). The pod-side sweep has the right
-> fingerprint *by construction* (it IS the serving process) and measures 76 s for 280 types.
+> required it to reference `Memex.Portal.Shared` — and, at the time, it could never have
+> contributed a single usable assembly: `InformationalVersion` then carried
+> `+build.<UtcNow.Ticks>` under `CIRun`, stamped independently by **each** `dotnet publish`, so
+> the bake image's `MeshWeaver.Graph` and the portal image's differed in MVID even when built from
+> the same commit in the same CD run. The bake therefore wrote assemblies under a framework tag no
+> portal would ever look up — and, worse, its compile write-back flipped live NodeType records,
+> which is what stopped the one AKS attempt (memex-cloud, 2026-07-30). #1660 WS3 removed the ticks
+> stamp and made the framework identity **commit-scoped** (`g<sha>`, see below) — the CI bake now
+> rides the Build-and-Test run's `mw-plugin-test --bake-output` artifact, which `main-cd`'s
+> `publish-bake` job copies to the portals' storage; the pod-side sweep then adopts it at boot
+> (`ShippedPrebuiltBundles.SeedPublishedRoot`) and compiles only what CI did not bake.
 
-### Every core release invalidates the compile cache — plan for the bake on all of them
+### Every core release still invalidates the compile cache — but CI pre-pays the bake
 
-This page used to claim the opposite: that a release touching only, say, `MeshWeaver.Blazor.Portal`
-leaves Graph's bytes identical, so "every cached assembly stays valid and there is no bake at all".
-**That is false, and it is false twice over.** Do not plan a release around it.
+The compile cache keys on the **framework identity** (`NodeTypeCompilationHelpers.FrameworkVersion`).
+Since #1660 WS3 that identity is **the commit** for CI builds (`g<sha>`, stamped as
+`AssemblyMetadata("MeshWeaverFrameworkIdentity")` by `Directory.Build.props`; local builds keep
+Graph's MVID). Two consequences, replacing the per-build-ticks scheme this section used to
+describe:
 
-The compile cache keys on **Graph's MVID** (`NodeTypeCompilationHelpers.FrameworkVersion` — the
-`MeshWeaver.Graph` module's content hash). Both halves of the old claim break down:
-
-1. **The MVID is not content-stable in CI.** `Directory.Build.props` stamps the
-   `InformationalVersion` property with `$([System.DateTime]::UtcNow.Ticks)` under `CIRun`, and that
-   attribute is compiled *into* every assembly — Graph included. So **Graph's MVID changes on every
-   CI build regardless of which source files the release touched**, and every cached assembly is
-   invalidated on every core release. That stamp is deliberate and load-bearing (see point 2); the
-   mistake was reasoning about the MVID as if it were a pure content hash of Graph's *source*.
-2. **Graph's dependency closure is not the ABI boundary anyway.** A NodeType compiles against
+1. **Every core release is still a full invalidation** — a release is a new commit, so the
+   identity changes even when the release touches only, say, `MeshWeaver.Blazor.Portal`. That
+   breadth is deliberate: a NodeType compiles against
    `AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")` — **every assembly in the image**, not just
-   what Graph references (`MeshNodeCompilationService.GetDefaultReferences`). So a breaking change
-   in an assembly Graph never references is still inside a NodeType's reference set, and a
-   content-stable Graph MVID would happily declare those stale assemblies valid and load them.
-
-Together: the ticks stamp is what keeps invalidation *conservative* over that wider reference set.
-**Budget every core release as a full bake** — which, at the real measured cost below, is minutes,
-not the hours this page used to imply.
+   Graph's dependency closure (`MeshNodeCompilationService.GetDefaultReferences`) — and a commit
+   names the entire tree, so any reference-assembly change flips the identity. (Graph's bare MVID
+   would not: it only covers Graph's own compile inputs.)
+2. **The invalidation no longer implies pod-side Roslyn.** CI compile inputs are
+   commit-deterministic (no run number or timestamp reaches any compiled attribute), so the
+   Build-and-Test bake, the CD-built images, and the booting pods all agree on the identity for a
+   given commit — the pods adopt the CI-baked assemblies instead of recompiling. The bake tax
+   below is still the truth for anything CI did not bake (user-partition NodeTypes, a reuse-green
+   run that skipped the bake job, a deployment without `PreWarm__PrebuiltBundleRoot`).
 
 ---
 
@@ -131,9 +130,12 @@ Cost is dominated by that repo's own CI, not by the mesh. Only if the change tou
 
 ## The bake tax
 
-When the framework MVID *does* change, every dynamic NodeType must be recompiled against the new
-framework — by design, for ABI safety (assemblies built against the old framework may reference
-members whose signatures moved).
+When the framework identity *does* change, every dynamic NodeType must be recompiled against the
+new framework — by design, for ABI safety (assemblies built against the old framework may reference
+members whose signatures moved). Since #1660 WS3 the CI bake pre-pays this for shipped content
+(the pod adopts the published bundles at boot); the figures below are what any REMAINING compile
+costs — user-partition types, and the whole fleet wherever the published-bundle lane is not
+provisioned.
 
 **This cost is not new and the bake does not add it.** Without the bake it is paid *lazily*:
 unordered, on user requests, on a pod already serving, ~2.4 s at a time in front of whoever arrives

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -301,21 +301,25 @@ the outage happens anyway.
 Both are rendered correctly by the chart — a `helm upgrade` restores them. A per-env `portal-patch.json`
 or a hand `kubectl patch` can still override them, which is how the drift happened.
 
-🪦 **There is no pre-run bake Job any more, and there never can be one (#1347).** The separate
-`memex-bake` image was removed after two weeks of running in zero namespaces. On its only AKS run
-(memex-cloud, 2026-07-30) `memex-bake:3.0.0-ci.1565` computed a **different framework fingerprint**
-than the running `portal-ai:3.0.0-ci.1565` — same version, same commit, separately published — so
-its framework-stale kickoff started flipping CURRENT NodeType records to `Pending` and rebuilding
-them for a framework nothing serves. That was not a bug to tune: `InformationalVersion` carries
-`+build.<UtcNow.Ticks>` under `CIRun` (`Directory.Build.props`, and the stamp is load-bearing ABI
-safety), so **every** `dotnet publish` mints a fresh `MeshWeaver.Graph` MVID and no second image can
-ever agree with the portal's framework identity.
+🪦 **There is no pre-run bake Job any more (#1347) — the CI bake replaced it (#1660 WS3).** The
+separate `memex-bake` image was removed after two weeks of running in zero namespaces. On its only
+AKS run (memex-cloud, 2026-07-30) `memex-bake:3.0.0-ci.1565` computed a **different framework
+fingerprint** than the running `portal-ai:3.0.0-ci.1565` — same version, same commit, separately
+published — so its framework-stale kickoff started flipping CURRENT NodeType records to `Pending`
+and rebuilding them for a framework nothing serves. The cause was the per-build
+`+build.<UtcNow.Ticks>` stamp `InformationalVersion` then carried under `CIRun`: every
+`dotnet publish` minted a fresh `MeshWeaver.Graph` MVID. #1660 WS3 removed that stamp and made CI
+builds **commit-deterministic** — the framework identity is now the commit (`g<sha>`), identical
+across every CI build of it — so the Build-and-Test run's bake artifact IS adoptable: `main-cd`'s
+`publish-bake` job copies it onto the portals' `/data` share
+(`prebuilt-bundles/<identity>/<source>/`), and each booting pod seeds its own identity's bundles
+(`PreWarm__PrebuiltBundleRoot`) before its sweep.
 
-**The pod-side sweep is the bake.** It runs in the serving process, so its fingerprint is right by
-construction, and it is fast — 76 s for 280 types (memex-cloud, batch direct-compile). The "fail
-before prod" contract the Job was meant to give is given, and given better, by
-`PreWarm__GateReadiness` + `maxSurge:1` / `maxUnavailable:0`: the new pod refuses readiness until
-its OWN bake is green while the old image keeps serving.
+**The pod-side sweep remains the enforcement.** It runs in the serving process, adopts whatever CI
+published, and compiles the remainder — 76 s for 280 types cold (memex-cloud, batch
+direct-compile), seconds when the CI bake covered the shipped content. The "fail before prod"
+contract is given by `PreWarm__GateReadiness` + `maxSurge:1` / `maxUnavailable:0`: the new pod
+refuses readiness until its OWN bake is green while the old image keeps serving.
 
 **Verify after every roll** — the bake completing is the deploy signal, not HTTP 200:
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -182,6 +182,16 @@ config:
     # environment that cannot answer the enumeration, accepting lazy compilation; it can never
     # waive a real regression, and /health keeps reporting the bake as unproven.
     PreWarm__AllowUnprovenBake: "false"
+    # ---- CI-published bake bundles (#1660 WS3) -----------------------------
+    # main-cd's publish-bake job copies the Build-and-Test run's baked NodeType assemblies onto
+    # this portal's /data share as prebuilt-bundles/<framework-identity>/<source>/*.zip; the pod
+    # seeds its OWN identity's directory before the sweep (ShippedPrebuiltBundles.
+    # SeedPublishedRoot), so shipped content boots with zero Roslyn. CI builds are
+    # commit-deterministic, so the identity CI baked under equals this image's. Inert while CI
+    # has published nothing (the directory is simply absent and the sweep compiles as before).
+    # Producer side: repo variable BAKE_PUBLISH_TARGETS must name this share
+    # (.github/scripts/publish-bake-bundles.sh).
+    PreWarm__PrebuiltBundleRoot: "/data/prebuilt-bundles"
     # ---- Assembly-cache retention ------------------------------------------
     # Every roll above writes a WHOLE NEW GENERATION of NodeType assemblies into
     # /data/assembly-cache (the framework MVID changes per image, by design), and

--- a/memex/Memex.Client/Services/UpdateNotificationService.cs
+++ b/memex/Memex.Client/Services/UpdateNotificationService.cs
@@ -65,11 +65,35 @@ public sealed partial class UpdateNotificationService(ILogger<UpdateNotification
 
     /// <summary>True if <paramref name="remote"/> is a strictly newer platform version than
     /// <paramref name="local"/> (SemVer2). Unparseable local version → false (never nag on an
-    /// unstamped build).</summary>
-    public static bool IsNewer(string remote, string local) =>
-        NuGetVersion.TryParse(remote, out var r)
-        && NuGetVersion.TryParse(local, out var l)
-        && r > l;
+    /// unstamped build). A local version WITHOUT a <c>.ci.N</c> run number — CI assemblies are
+    /// commit-deterministic (#1660 WS3), so the run number is injected per-deployment and a client
+    /// app carries only <c>PlatformVersion+sha</c> — is compared at RELEASE granularity (the
+    /// remote's trailing ci counter stripped): a current client must not be nagged on every
+    /// connect just because the portal's version carries a build counter.</summary>
+    public static bool IsNewer(string remote, string local)
+    {
+        if (!NuGetVersion.TryParse(remote, out var r) || !NuGetVersion.TryParse(local, out var l))
+            return false;
+        if (!HasCiCounter(l) && HasCiCounter(r))
+            r = StripCiCounter(r);
+        return r > l;
+    }
+
+    /// <summary>Whether the version carries the continuous-build <c>ci</c> release label.</summary>
+    private static bool HasCiCounter(NuGetVersion version) =>
+        version.ReleaseLabels.Any(l => string.Equals(l, "ci", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The version with its <c>ci</c> label and everything after it removed
+    /// (<c>3.0.0-rc3.ci.3961</c> → <c>3.0.0-rc3</c>).</summary>
+    private static NuGetVersion StripCiCounter(NuGetVersion version)
+    {
+        var labels = version.ReleaseLabels
+            .TakeWhile(l => !string.Equals(l, "ci", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        return new NuGetVersion(
+            version.Major, version.Minor, version.Patch,
+            labels, metadata: null);
+    }
 
     private void Notify(string meshId, string remoteVersion)
     {

--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -76,15 +76,21 @@ public static class ShippedReleaseSeed
     public const string PlatformVersionNodePath = $"{AdminPartition}/{PlatformVersionId}";
 
     /// <summary>
-    /// The installed platform version — the entry assembly's
-    /// <see cref="AssemblyInformationalVersionAttribute"/> (set centrally from the
-    /// <c>PlatformVersion</c> MSBuild property; see <c>Directory.Build.props</c>), falling back to the
-    /// numeric assembly version, then <c>"unknown"</c>.
+    /// The installed platform version. The FULL run-numbered version (<c>3.0.0-rc3.ci.N</c>) is no
+    /// longer compiled into any assembly — CI builds are commit-deterministic so the bake identity
+    /// holds across CI jobs (#1660 WS3) — so this reads the
+    /// <see cref="MeshWeaver.Mesh.PlatformBuildInfo.PlatformVersionEnvironmentVariable"/> the
+    /// container publish injects FIRST (the self-updater's version comparison against registry
+    /// tags depends on the run number), then falls back to the entry assembly's
+    /// <see cref="AssemblyInformationalVersionAttribute"/> (<c>PlatformVersion+&lt;sha&gt;</c> on a
+    /// CI build), the numeric assembly version, then <c>"unknown"</c>.
     /// </summary>
     public static string InstalledPlatformVersion
     {
         get
         {
+            if (MeshWeaver.Mesh.PlatformBuildInfo.RuntimePlatformVersion is { } injected)
+                return injected;
             var asm = Assembly.GetEntryAssembly() ?? typeof(ShippedReleaseSeed).Assembly;
             return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                 ?? asm.GetName().Version?.ToString()

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -65,6 +65,17 @@
              CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <!-- The run-numbered platform version ($(Version), e.g. 3.0.0-rc3.ci.3961) rides the container
+       IMAGE CONFIG, never a compiled attribute: CI compile inputs are commit-deterministic
+       (#1660 WS3 — the framework identity that lets CI-baked NodeType assemblies seed at boot
+       must be equal between the Build-and-Test bake and this image build), so the run number
+       cannot be baked into the assemblies. The runtime reads this variable first
+       (PlatformBuildInfo / ShippedReleaseSeed.InstalledPlatformVersion) — the self-updater's
+       tag comparison and the Admin/PlatformVersion node depend on the run number being visible. -->
+  <ItemGroup Condition="'$(CIRun)' == 'true'">
+    <ContainerEnvironmentVariable Include="MESHWEAVER_PLATFORM_VERSION" Value="$(Version)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Npgsql" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" />

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -97,10 +97,11 @@ else
     // default. (A file lease beside the assembly cache used to serialise this; it is deleted, its
     // one-builder and steal-on-stale properties carried by the claim arbiter.)
 
-    // 🚨 …and ONE WHOLE GENERATION of that cache is written per deploy, because the store keys every
-    // file by the MeshWeaver.Graph MVID and a CI build stamps a fresh InformationalVersion into
-    // every assembly. That is deliberate ABI safety; what was missing is anything that ever removes
-    // an old generation. Measured on memex 2026-08-12: 7817 DLLs across 93 generations, 3.2 GB — of
+    // 🚨 …and ONE WHOLE GENERATION of that cache is written per DEPLOYED COMMIT, because the store
+    // keys every file by the framework identity (the commit for CI builds — #1660 WS3; images of
+    // the SAME commit now share a generation, and the CI bake pre-fills it). That is deliberate
+    // ABI safety; what was missing is anything that ever removes an old generation. Measured on
+    // memex 2026-08-12 (when every BUILD was its own generation): 7817 DLLs across 93 generations, 3.2 GB — of
     // which 83 files (1%) were loadable by the running image — on the SAME 16 GiB share that holds
     // the DataProtection key ring below, so filling it takes auth-adjacent state down with it.
     //

--- a/src/MeshWeaver.Blazor.Portal/Infrastructure/AppVersionService.cs
+++ b/src/MeshWeaver.Blazor.Portal/Infrastructure/AppVersionService.cs
@@ -18,11 +18,17 @@ public class AppVersionService : IAppVersionService
     }
 
     /// <summary>
-    /// Reads the assembly's informational version, trimming any trailing build metadata to a short commit hash.
+    /// Reads the deployment's injected run-numbered platform version
+    /// (<see cref="MeshWeaver.Mesh.PlatformBuildInfo"/> — CI assemblies are commit-deterministic,
+    /// so the <c>.ci.N</c> run number rides the image config, not the compiled attribute), falling
+    /// back to the assembly's informational version with any trailing build metadata trimmed to a
+    /// short commit hash.
     /// </summary>
     /// <returns>The version string, or an empty string when no version attribute is present.</returns>
     public static string GetVersionFromAssembly()
     {
+        if (MeshWeaver.Mesh.PlatformBuildInfo.RuntimePlatformVersion is { } injected)
+            return injected;
         var strVersion = string.Empty;
         var versionAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
         if (versionAttribute != null)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -178,6 +178,42 @@ a published tag shape would break whatever is pinned today. It is documented at 
 produces it rather than silently "fixed". This is also why `check-image-set.sh` identifies the set by
 **short SHA** and not by version tag: the SHA is the one identity all four images share.
 
+## After the promote — the bake publication and the dependent-repo dispatch
+
+Two post-promote legs ride every armed release (#1660 WS3):
+
+**`publish-bake`** copies the Build-and-Test run's CI NodeType bake (the
+`baked-assemblies-<framework-identity>` artifact its doc-gate produced with
+`mw-plugin-test --bake-output`) onto the portals' shared storage, laid out
+`prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip`
+(`.github/scripts/publish-bake-bundles.sh`). CI builds are **commit-deterministic**, so the
+identity the bake was keyed under equals the identity of the images promote just armed — each
+booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
+`ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
+did not bake. Its configuration is **preflighted red, never skipped**: repo variable
+`BAKE_PUBLISH_TARGETS` names the Azure Files targets (`<account>/<share>[/<base-path>]`,
+whitespace-separated), and a missing value fails the job naming exactly that — a grey skip here
+would silently restore the every-pod-rebakes-everything regression (#1347). A missing bake
+*artifact* only warns: a reuse-green run legitimately skips the doc-gate, and that run simply has
+nothing to publish.
+
+**`notify-dependents`** sends one `repository_dispatch` (`meshweaver-framework-released`, payload:
+commit, identity, version) to each repo in `BAKE_SUBSCRIBER_REPOS`, using
+`DEPENDENT_DISPATCH_TOKEN`. A node repo subscribes with
+
+```yaml
+on:
+  repository_dispatch:
+    types: [meshweaver-framework-released]
+```
+
+on its gate workflow and answers by re-running its compile gate + bake + publish against the new
+framework identity — the cross-repo half of "a dependency released, rebuild". (The in-repo half
+needs no event at all: a dependency bump lands as a commit, and a commit IS a new framework
+identity, so the next CI run re-bakes by construction.) Reporter-class like the platform-update
+webhook: an unconfigured or lost dispatch is a loud notice, never a red — the next release
+re-notifies, and nothing downstream certifies anything on it.
+
 ## See also
 
 - [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy) — the two channels, the update policy node, and how each install applies an update.

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -365,17 +365,24 @@ assemblies change and the cached DLL may be ABI-incompatible — so a release is
 only usable while the framework version matches.
 
 `RunCompile` stamps `NodeTypeDefinition.CompiledFrameworkVersion` with
-`NodeTypeCompilationHelpers.FrameworkVersion` on every success. That value is:
+`NodeTypeCompilationHelpers.FrameworkVersion` on every success. That value is
+resolved once per process (`FrameworkBuildIdentity`,
+[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3):
 
-- **Deployed builds** — the semver baked into `AssemblyInformationalVersion` by
-  the NuGet pack process (e.g. `3.0.0-preview2`). It is identical on every server
-  running the same deployed build — a file write-time would differ per machine and
-  is therefore *not* used.
-- **Un-packed dev builds** — the version stays the frozen default (`1.0.0`) across
-  every local `dotnet build`, so the `MeshWeaver.Graph` assembly's last-write time
-  is folded in (`1.0.0+{timestamp}`). On the single dev machine that is
-  "frozen per build" — stable within a run, changes on rebuild — exactly the
-  dev-iteration signal we want.
+- **CI builds** — the **commit identity** `g<sha>`, stamped into every assembly as
+  `AssemblyMetadata("MeshWeaverFrameworkIdentity")` by `Directory.Build.props`.
+  CI compile inputs are commit-deterministic (no run number or timestamp reaches
+  any compiled attribute), so every CI build of the same commit — the
+  Build-and-Test run that bakes NodeType assemblies and the main-cd run that
+  builds the image — shares one identity; that is what lets the CI bake seed at
+  portal boot instead of recompiling. Any code or package-pin change is a new
+  commit and therefore a new identity — a commit names the whole tree, covering
+  the full TPA reference set a NodeType compiles against, not just Graph's own
+  dependency closure.
+- **Local builds** — the `MeshWeaver.Graph` assembly's **MVID** (a content hash
+  of the compiled module; no stamp is present). Content-exact for a dirty
+  working tree — stable across rebuilds that don't change Graph's bytes,
+  changed whenever they do.
 
 On a framework-version mismatch the NodeType recompiles and **mints a new release**
 for the new framework. The old release is left intact as history so instances still

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -90,35 +90,42 @@ environment, is narrower, and reintroduces the `CS0616` above.
 
 ---
 
-## 🚨 The framework identity is an MVID, not a version string
+## 🚨 The framework identity is a build fact, not a version string
 
 `HasUsableBuild` skips a compile only when `CompiledFrameworkVersion` equals the live
-`NodeTypeCompilationHelpers.FrameworkVersion` — and that value is the **Module Version Id of the
-MeshWeaver.Graph assembly**, not a semver.
+`NodeTypeCompilationHelpers.FrameworkVersion` — never a semver. Since
+[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 that value has two shapes, one
+resolution (`FrameworkBuildIdentity`): for a **CI-built framework** it is the **commit identity**
+`g<sha>` (stamped as `AssemblyMetadata("MeshWeaverFrameworkIdentity")`; CI builds are
+commit-deterministic, so every CI build of a commit shares it — including the separate workflow
+runs that bake content and build the image); for a **local build** it is the **Module Version Id
+of the MeshWeaver.Graph assembly** — a content identity.
 
-It is a *content* identity on purpose. Deriving it from `AssemblyInformationalVersion` forced
-`Directory.Build.props` to stamp a fresh version into every build, which regenerated `AssemblyInfo`
-every time and destroyed incremental compilation. The MVID decouples the two: the version string can
-stay stable across local rebuilds while ABI invalidation stays correct. For a deployed build it is
-fixed in the shipped DLL and changes only when framework content actually changes — so it recompiles
-*less* than a per-build-version scheme, not more.
+Neither is derived from `AssemblyInformationalVersion`, on purpose. Deriving identity from the
+version string once forced `Directory.Build.props` to stamp a fresh version into every build,
+which regenerated `AssemblyInfo` every time and destroyed incremental compilation. The identity
+decouples the two: the version string serves packages and image tags while ABI invalidation stays
+correct — and a commit-scoped CI identity recompiles *less* than the per-build scheme did (two
+builds of one commit now agree), never more.
 
 Three things follow.
 
-**A package must record the MVID.** `3.0.0-rc2` is not something the runtime ever compares. Two
-builds can share a version string and differ in content; the MVID is what says whether the bytes are
-ABI-compatible with the running process.
+**A package must record the identity.** `3.0.0-rc2` is not something the runtime ever compares.
+Two builds can share a version string and differ in content; the identity is what says whether the
+bytes are ABI-compatible with the running process. Producers read it with
+`FrameworkIdentity.ReadIdentity` (metadata-only PE read: the stamp when present, the MVID
+otherwise) — exactly what the consuming gate resolves in-process.
 
-**An installer that cannot establish the MVID must compile, never seed.** A wrong seed is worse than
-no seed: the assembly-store key carries the live framework tag
+**An installer that cannot establish the identity must compile, never seed.** A wrong seed is
+worse than no seed: the assembly-store key carries the live framework tag
 (`v{version}-{FrameworkTag}-{hash}.dll`, `FrameworkTag = FrameworkVersion[..8]`), so seeding
 foreign bytes under it suppresses the rebuild that was needed and the mismatch surfaces as a
 `TypeLoadException` inside an ALC at activation — no overlay, no diagnostic, nothing to grep.
 
-**Relaxing the check to a compatible semver range is the wrong trade.** It replaces a content fact
+**Relaxing the check to a compatible semver range is the wrong trade.** It replaces a build fact
 with a declared claim, and is only as good as whatever enforces the claim. The alternative needs no
-weakening at all: build plugin packages against the framework build that ships in the image, and the
-MVIDs match by construction.
+weakening at all: bake against the same commit the image is built from, and the identities match
+by construction.
 
 ## Why pre-filling the store works
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -69,20 +69,24 @@ The `PublicRelease` flag picks the channel (think **CI** vs **CD**):
   Version=3.0.0.280` while the packaged DLL carried another number →
   `FileNotFoundException` at startup → the migration CrashLoopBackOff'd and Space
   creation failed. **Do not reintroduce a per-build `AssemblyVersion`.**
-- **`FileVersion` keeps the per-build number** (`3.0.0.<build>`). It does not
-  participate in binding, and changing every build is what drives MSBuild's
-  `CopyToOutputDirectory` heuristic so test bins don't hold a stale framework DLL.
-  Both are numeric — the `-rc1` pre-release label is illegal in either.
-- **`<build>` is not one number.** The `.ci.N` suffix uses `$(GITHUB_RUN_NUMBER)` when
-  present (**monotonic** — the self-updater picks the newest version, and the
-  seconds-since-midnight value resets at midnight); `FileVersion` uses that
-  seconds-since-midnight value; **locally both are a stable `0`**, so a dev rebuild
-  doesn't regenerate `AssemblyInfo.cs` and destroy incremental builds.
-- **`InformationalVersion`** carries `+build.<ticks>` **only under `CIRun=true`**;
-  locally it equals `$(Version)`. NodeType ABI identity no longer depends on it —
-  `NodeTypeCompilationHelpers.FrameworkVersion` is the **`MeshWeaver.Graph` assembly's
-  MVID** (a content hash of the compiled module), so it is stable across rebuilds that
-  don't change Graph's bytes and changes whenever they do.
+- **`FileVersion` is pinned** (`3.0.0.0`) for the same reason `AssemblyVersion` is:
+  it is a *compiled* attribute, and CI compile inputs are **commit-deterministic**
+  ([#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3) so two CI builds
+  of the same commit produce ABI-identical assemblies — that is what lets the CI
+  NodeType bake seed at portal boot. Both are numeric — the `-rc1` pre-release label
+  is illegal in either.
+- **The `.ci.N` suffix** uses `$(GITHUB_RUN_NUMBER)` when present (**monotonic** —
+  the self-updater picks the newest version, and the seconds-since-midnight fallback
+  resets at midnight); **locally it is a stable `0`**. It reaches ONLY `$(Version)` —
+  NuGet package versions and image tags — never a compiled attribute. The runtime
+  still sees it: the container publish injects `$(Version)` as the
+  `MESHWEAVER_PLATFORM_VERSION` environment variable (image config, not bytes).
+- **`InformationalVersion`** is `$(PlatformVersion)` under `CIRun=true` (the SDK
+  appends `+<commit-sha>`); locally it equals `$(Version)`. NodeType ABI identity is
+  `NodeTypeCompilationHelpers.FrameworkVersion`: for CI builds the **stamped commit
+  identity** (`g<sha>`, `AssemblyMetadata("MeshWeaverFrameworkIdentity")`), locally
+  the **`MeshWeaver.Graph` assembly's MVID** (a content hash of the compiled module,
+  stable across rebuilds that don't change Graph's bytes).
 - **`-p:Version=…`** still overrides everything (escape hatch) — and it is what the
   tag-driven release workflows actually pass.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
@@ -117,14 +117,16 @@ generation; bake = pre-compiling every dynamic NodeType for the NEW framework fi
    generation early. Everything else transitions smoothly: activity-pinned on the old silo until
    idle, re-placed on the new one on its next activation.
 
-**Where reality stands against this (2026-08-12):** the roll is a single-Deployment rolling update
+**Where reality stands against this (2026-08-16):** the roll is a single-Deployment rolling update
 — the old pod is torn down grains-and-all (rule 1 violated: every active hub dies with its pod);
-there is no pre-run image bake at all, and there structurally cannot be one
-([#1347](https://github.com/Systemorph/MeshWeaver/issues/1347) — every `dotnet publish` mints a
-fresh Graph MVID via the `+build.<ticks>` stamp, so a separately-published bake image can never
-share the portal's framework identity; the separate image has been retired), so the new pod boots
-cold and its own 76-second prewarm sweep races the first visitors (rules 2–4 approximated only by
-the readiness gate). The sweep no longer warms the most user-visible types last — the
+the pre-run bake IMAGE stays retired
+([#1347](https://github.com/Systemorph/MeshWeaver/issues/1347)), but since
+[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 the framework identity is
+commit-scoped (`g<sha>` — CI builds are commit-deterministic, so the old "every `dotnet publish`
+mints a fresh Graph MVID" barrier is gone) and the Build-and-Test run's NodeType bake is published
+to the portals' storage, where the booting pod adopts it before its sweep — the sweep compiles
+only what CI did not bake, instead of racing the first visitors with a cold 76-second full bake
+(rules 2–4 approximated only by the readiness gate). The sweep no longer warms the most user-visible types last — the
 `Store/Coupon → Store/Order → Store/Plugin` cycle trio and the store chain behind it are now warmed
 FIRST (#1347) — but "warmed first" is still not "warmed before anyone can ask". The policy above is
 the target the pod-side bake, the readiness gate, and a two-generation silo topology are building

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-ci-bake-seeds-at-boot.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-ci-bake-seeds-at-boot.md
@@ -1,0 +1,19 @@
+---
+Name: Deployments start faster — content is compiled once on CI and reused
+Category: Feature
+Description: Framework builds are now commit-deterministic, so the NodeType assemblies CI compiles are adopted by every portal at boot instead of being recompiled on each pod.
+Icon: Sparkle
+Order: -20260816
+---
+
+# Deployments start faster — content is compiled once on CI and reused
+
+Every deployed build used to recompile all of its dynamic content on startup, because each CI
+build carried a unique timestamp that made its compiled assemblies unrecognizable to any other
+build — even of the exact same code. Builds are now deterministic per commit: CI compiles the
+shipped content once, publishes the result, and every portal built from that commit picks it up
+at boot instead of doing the work again.
+
+What you notice: after a platform update, pages backed by dynamic content are warm right away —
+the new pod no longer spends its startup re-baking hundreds of node types, and the first visitor
+no longer pays for a compile.

--- a/src/MeshWeaver.Graph/Configuration/AssemblyCacheRetention.cs
+++ b/src/MeshWeaver.Graph/Configuration/AssemblyCacheRetention.cs
@@ -231,11 +231,20 @@ public static class AssemblyCacheGenerations
         // `v1-ab-cd.dll` be attributed to a generation — and attribution is what makes a file
         // deletable. Matching exactly what the writer emits is what keeps "only files this store
         // wrote are ever deleted" literally true.
-        return parts[1].Length == FrameworkTagLength && IsHex(parts[1])
+        return IsGenerationTag(parts[1])
                && parts[2].Length == ContentHashLength && IsHex(parts[2])
             ? parts[1].ToLowerInvariant()
             : null;
     }
+
+    // The two tag shapes the store has ever written (FrameworkVersion[..8], see
+    // FileSystemAssemblyStore.FrameworkTag): 8 hex chars for an MVID identity (local builds, and
+    // every build before #1660 WS3), or 'g' + 7 hex chars for a commit identity (CI builds since
+    // #1660 WS3 — FrameworkVersion is g<sha> there). Anything else stays unattributed and
+    // therefore undeletable.
+    private static bool IsGenerationTag(string s) =>
+        s.Length == FrameworkTagLength
+        && (IsHex(s) || ((s[0] == 'g' || s[0] == 'G') && IsHex(s[1..])));
 
     private static bool IsHex(string s) =>
         s.Length > 0 && s.All(c => c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F');

--- a/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// THE framework build identity every compiled NodeType release is pinned to (issue #1660 WS3) —
+/// the value <see cref="NodeTypeCompilationHelpers.FrameworkVersion"/> resolves and every other
+/// reading (the assembly-store filename tag, <c>CompiledFrameworkVersion</c> stamps, the CI bake
+/// artifact key, <c>PrebuiltAssemblySeeder</c>'s adoption gate, the build-protocol fingerprint)
+/// flows from. One identity, one resolution — a producer and a consumer can never disagree about
+/// what "the framework" is.
+///
+/// <para><b>Two schemes, discriminated by how the build was made:</b></para>
+/// <list type="bullet">
+/// <item><description><b>CI builds (CIRun)</b> carry
+/// <c>AssemblyMetadata("MeshWeaverFrameworkIdentity", "g&lt;commit-sha&gt;")</c>, stamped by the
+/// <c>AddCommitHashMetadata</c> target in <c>Directory.Build.props</c>. The identity is the COMMIT:
+/// CI compile inputs are commit-deterministic (no per-build ticks or run numbers reach any compiled
+/// attribute), so two CI builds of the same commit — the Build-and-Test run that bakes NodeType
+/// assemblies and the main-cd run that builds the image — share the identity, and the baked
+/// assemblies seed at portal boot instead of recompiling. Any code or package-pin change is a new
+/// commit and therefore a new identity: a commit names the ENTIRE tree, so this covers the WHOLE
+/// NodeType compile reference set (the TPA — <c>MeshNodeCompilationService.GetDefaultReferences</c>),
+/// not just Graph's own dependency closure — the widening the old per-build-ticks scheme's 🚨
+/// comment demanded before that stamp could be removed.</description></item>
+/// <item><description><b>Local builds</b> carry no stamp and resolve to MeshWeaver.Graph's MVID —
+/// a content identity that is exact for a dirty working tree (a commit identity would
+/// under-invalidate there: two different local builds can sit on the same commit) and stable
+/// across incremental rebuilds that don't change Graph's bytes.</description></item>
+/// </list>
+/// </summary>
+public static class FrameworkBuildIdentity
+{
+    /// <summary>
+    /// The <see cref="AssemblyMetadataAttribute"/> key carrying the CI build identity — stamped
+    /// into every assembly by <c>Directory.Build.props</c> (target <c>AddCommitHashMetadata</c>)
+    /// when <c>CIRun=true</c> and a commit SHA is resolvable. The value shape is
+    /// <c>g&lt;full-commit-sha&gt;</c>.
+    /// </summary>
+    public const string MetadataKey = "MeshWeaverFrameworkIdentity";
+
+    /// <summary>
+    /// The pure resolution rule, unit-testable without controlling how the test assembly was
+    /// built: a non-blank stamped identity wins; otherwise the caller's content identity
+    /// (the Graph MVID) applies.
+    /// </summary>
+    /// <param name="stamped">The <see cref="MetadataKey"/> attribute value, or null when the
+    /// assembly carries none (every local build).</param>
+    /// <param name="contentIdentity">The fallback content identity (Graph's MVID, "N" format).</param>
+    public static string Resolve(string? stamped, string contentIdentity) =>
+        string.IsNullOrWhiteSpace(stamped) ? contentIdentity : stamped;
+
+    /// <summary>
+    /// Reads the stamped <see cref="MetadataKey"/> value off a LOADED assembly, or null when the
+    /// assembly carries none. (For reading the same stamp off an assembly FILE without loading it,
+    /// see <c>MeshWeaver.Plugin.Build.FrameworkIdentity.ReadIdentity</c>.)
+    /// </summary>
+    public static string? StampedIdentityOf(Assembly assembly) =>
+        assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, MetadataKey, StringComparison.Ordinal))
+            ?.Value is { Length: > 0 } value
+            ? value
+            : null;
+}

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -992,34 +992,30 @@ internal static class NodeTypeCompilationHelpers
     }
 
     /// <summary>
-    /// The live MeshWeaver framework identity a compiled NodeType release is pinned to — the
-    /// <c>MeshWeaver.Graph</c> assembly's MVID (a content hash of the compiled module). It is
-    /// identical on every server running the same build, stable across local rebuilds that don't
-    /// change Graph's bytes, and changes whenever the framework is rebuilt with different content
-    /// — so a mismatch against a NodeType's <c>CompiledFrameworkVersion</c> means "recompile".
-    /// (MVID rationale below.) Computed once per process.
+    /// The live MeshWeaver framework identity a compiled NodeType release is pinned to — see
+    /// <see cref="FrameworkBuildIdentity"/> for the scheme. CI builds resolve the stamped COMMIT
+    /// identity (<c>g&lt;sha&gt;</c> — identical for every CI build of the same commit, which is
+    /// what lets CI-baked assemblies seed at boot, #1660 WS3); local builds resolve the
+    /// <c>MeshWeaver.Graph</c> assembly's MVID (a content hash of the compiled module, exact for
+    /// a dirty working tree). A mismatch against a NodeType's <c>CompiledFrameworkVersion</c>
+    /// means "recompile". Computed once per process.
     /// </summary>
     internal static string FrameworkVersion => _frameworkVersion.Value;
 
-    // Content-based framework identity: the Graph assembly's MVID (Module Version Id). It is
-    // part of the compiled module, so it is STABLE whenever the DLL bytes are identical (an
+    // Resolution once per process. The MVID fallback rationale (local builds): the MVID is part
+    // of the compiled module, so it is STABLE whenever the DLL bytes are identical (an
     // incremental build that skips recompiling Graph, or a deterministic rebuild of unchanged
     // source) and CHANGES whenever Graph — or any dependency, which forces Graph's recompile —
-    // is rebuilt with different content. That is exactly the "did the framework ABI change?"
-    // signal a compiled NodeType release pins to.
-    //
-    // Why MVID and not AssemblyInformationalVersion: deriving this from the version STRING forced
-    // Directory.Build.props to stamp a fresh version into EVERY build (so the string changed on a
-    // local rebuild), which regenerated AssemblyInfo every build and DESTROYED incremental builds
-    // (full rebuild every time → hot machine). The MVID decouples the two — the version string can
-    // now stay stable across local rebuilds (incremental restored) while ABI invalidation stays
-    // correct. An earlier scheme appended the DLL's last-write time, but that drifted on
-    // copies/touches even when the bytes were identical; the MVID does not. For a deployed build
-    // the MVID is fixed in the shipped DLL (identical on every server) and changes only when a
-    // redeploy actually changes framework content — so it also recompiles LESS than the old
-    // per-build-version scheme, which invalidated on every deploy whether or not anything changed.
+    // is rebuilt with different content. Deriving identity from the version STRING (the scheme
+    // before the MVID) forced a fresh stamp into EVERY build and destroyed incremental builds;
+    // appending the DLL's last-write time (the scheme before that) drifted on copies/touches.
+    // The commit identity (CI) supersedes the MVID there because the MVID only covers Graph's
+    // OWN compile inputs, while a NodeType compiles against the WHOLE TPA — a commit covers the
+    // entire tree, so any reference-assembly change still invalidates (see FrameworkBuildIdentity).
     private static readonly Lazy<string> _frameworkVersion = new(() =>
-        typeof(NodeTypeCompilationHelpers).Assembly.ManifestModule.ModuleVersionId.ToString("N"));
+        FrameworkBuildIdentity.Resolve(
+            FrameworkBuildIdentity.StampedIdentityOf(typeof(NodeTypeCompilationHelpers).Assembly),
+            typeof(NodeTypeCompilationHelpers).Assembly.ManifestModule.ModuleVersionId.ToString("N")));
 
     /// <summary>
     /// True when a NodeType's persisted compile state is backed by a compiled

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -285,15 +285,22 @@ public sealed class DynamicTypePreWarmerHostedService(
 
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         // Shipped prebuilt bundles seed BEFORE the sweep decides what to build (#1660 WS1): a
-        // NodeType whose CI-baked bytes match this image's framework MVID is stamped + uploaded to
-        // the assembly store here, so the sweep's store probe reports it AlreadyBaked and never
-        // compiles it. Sequenced AFTER the static repo import for the same reason the sweep is —
-        // the nodes the bundles name must exist to be seeded. SeedAll never faults (it degrades to
-        // "compile as today", loudly), so this cannot wedge or redden the warm-up.
+        // NodeType whose CI-baked bytes match this image's framework identity is stamped +
+        // uploaded to the assembly store here, so the sweep's store probe reports it AlreadyBaked
+        // and never compiles it. Two bundle sources, same pipeline: the bundles the IMAGE itself
+        // ships (prebuilt/, DirectoryConfigKey), then the CI-PUBLISHED bundle root on shared
+        // storage (#1660 WS3, PublishedRootConfigKey — the pod seeds only its own framework
+        // identity's subdirectory, which commit-determinism makes equal to what CI baked for this
+        // commit). Sequenced AFTER the static repo import for the same reason the sweep is —
+        // the nodes the bundles name must exist to be seeded. Neither seeding faults (each
+        // degrades to "compile as today", loudly), so this cannot wedge or redden the warm-up.
         var prebuiltDirectory = services.GetService<IConfiguration>()
             ?[ShippedPrebuiltBundles.DirectoryConfigKey];
+        var publishedBundleRoot = services.GetService<IConfiguration>()
+            ?[ShippedPrebuiltBundles.PublishedRootConfigKey];
         _warmSubscription = (importSettled?.Settled ?? Observable.Return(Unit.Default))
             .SelectMany(_ => ShippedPrebuiltBundles.SeedAll(mesh, prebuiltDirectory, logger))
+            .SelectMany(_ => ShippedPrebuiltBundles.SeedPublishedRoot(mesh, publishedBundleRoot, logger))
             .SelectMany(_ => DynamicTypePreWarmer
                 .WarmDynamicTypes(mesh, logger, perTypeBudget, betweenTypes, batchBake, buildProtocol))
             .Subscribe(

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -41,6 +41,20 @@ public static class ShippedPrebuiltBundles
     /// Default: <see cref="DefaultDirectory"/>.</summary>
     public const string DirectoryConfigKey = "PreWarm:PrebuiltDirectory";
 
+    /// <summary>
+    /// Config key naming the CI-PUBLISHED bundle root (issue #1660 WS3) — a mounted storage
+    /// directory (on AKS, a path under the shared <c>/data</c> Azure Files share) that CI fills
+    /// with framework-identity-keyed bundle directories:
+    /// <c>&lt;root&gt;/&lt;frameworkIdentity&gt;/&lt;source&gt;/&lt;bundle&gt;.zip</c>
+    /// (written by <c>.github/scripts/publish-bake-bundles.sh</c> from the
+    /// <c>mw-plugin-test --bake-output</c> artifact). At boot the pod seeds ONLY its own
+    /// identity's subdirectory — CI builds are commit-deterministic, so the bake published for
+    /// commit X is found by exactly the images built from commit X. Unset (the default) the lane
+    /// is inert. Distinct from <see cref="DirectoryConfigKey"/>, which names bundles the IMAGE
+    /// itself ships.
+    /// </summary>
+    public const string PublishedRootConfigKey = "PreWarm:PrebuiltBundleRoot";
+
     /// <summary>The conventional location — <c>prebuilt/</c> beside the app binaries, which is
     /// where the publish lays <c>$(PrebuiltBakeDir)</c> bundles into the image.</summary>
     public static string DefaultDirectory => Path.Combine(AppContext.BaseDirectory, "prebuilt");
@@ -67,6 +81,50 @@ public static class ShippedPrebuiltBundles
         => Observable.Defer(() =>
         {
             var dir = string.IsNullOrWhiteSpace(directory) ? DefaultDirectory : directory;
+            return SeedDirectory(mesh, dir, SearchOption.TopDirectoryOnly, logger);
+        });
+
+    /// <summary>
+    /// Seeds the CI-published bundles for THIS process's framework identity from the configured
+    /// published root (<see cref="PublishedRootConfigKey"/>): the pod resolves its own
+    /// <c>FrameworkVersion</c> and seeds <c>&lt;root&gt;/&lt;identity&gt;/**/*.zip</c> — the
+    /// layout CI's publish step writes, one <c>&lt;source&gt;</c> subdirectory per producing repo.
+    /// Emits the number of assemblies adopted; inert (0, debug-logged) when the root is not
+    /// configured, and loud-but-degrading like <see cref="SeedAll"/> everywhere else — a missing
+    /// or partial publication only ever costs what today costs, a compile.
+    /// </summary>
+    /// <param name="mesh">The mesh hub (supplies the workspace, the I/O pool and the services).</param>
+    /// <param name="publishedRoot">The published bundle root, or null/blank when the deployment
+    /// does not consume CI bakes.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public static IObservable<int> SeedPublishedRoot(IMessageHub mesh, string? publishedRoot, ILogger? logger)
+        => Observable.Defer(() =>
+        {
+            if (string.IsNullOrWhiteSpace(publishedRoot))
+            {
+                logger?.LogDebug(
+                    "ShippedPrebuiltBundles: no published bundle root configured ({Key}) — "
+                    + "CI-published bakes are not consumed here", PublishedRootConfigKey);
+                return Observable.Return(0);
+            }
+            var identity = PrebuiltAssemblySeeder.LiveFrameworkMvid;
+            var dir = Path.Combine(publishedRoot, identity);
+            if (!Directory.Exists(dir))
+                // Info, not debug: on a deployment that HAS opted in, "CI published nothing for
+                // this identity" is the one line that explains why the sweep is compiling.
+                logger?.LogInformation(
+                    "ShippedPrebuiltBundles: no CI-published bundles for framework identity "
+                    + "{Identity} under {Root} — the sweep compiles instead",
+                    identity, publishedRoot);
+            return SeedDirectory(mesh, dir, SearchOption.AllDirectories, logger);
+        });
+
+    /// <summary>The shared seeding core: every <c>*.zip</c> under <paramref name="dir"/>
+    /// (recursively for the published-root lane), through the one bundle pipeline.</summary>
+    private static IObservable<int> SeedDirectory(
+        IMessageHub mesh, string dir, SearchOption searchOption, ILogger? logger)
+        => Observable.Defer(() =>
+        {
             if (!Directory.Exists(dir))
             {
                 logger?.LogDebug(
@@ -91,7 +149,7 @@ public static class ShippedPrebuiltBundles
                     () => AccessContextScope.AsSystem(accessService),
                     _ => pool
                         .InvokeBlocking(_ => Directory
-                            .EnumerateFiles(dir, "*.zip")
+                            .EnumerateFiles(dir, "*.zip", searchOption)
                             .OrderBy(f => f, StringComparer.Ordinal)
                             .ToList())
                         .SelectMany(bundles =>

--- a/src/MeshWeaver.Mesh.Contract/PlatformBuildInfo.cs
+++ b/src/MeshWeaver.Mesh.Contract/PlatformBuildInfo.cs
@@ -1,0 +1,31 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// How a RUNNING process learns its full, run-numbered platform version (e.g.
+/// <c>3.0.0-rc3.ci.3961</c>) now that compiled assemblies are COMMIT-DETERMINISTIC (issue #1660
+/// WS3): the run number must not be compiled in — it would fork the framework identity between the
+/// CI run that bakes NodeType assemblies and the CD run that builds the image — so the container
+/// publish injects it as an environment variable instead (image CONFIG, not assembly bytes; see
+/// the <c>ContainerEnvironmentVariable</c> item in <c>Memex.Portal.Distributed.csproj</c> and the
+/// version-channel note in <c>Directory.Build.props</c>).
+/// </summary>
+public static class PlatformBuildInfo
+{
+    /// <summary>
+    /// The environment variable carrying the deployment's run-numbered platform version. Consumers
+    /// (the self-updater's current-version, the Admin/PlatformVersion node, version displays) read
+    /// it FIRST and fall back to the entry assembly's <c>AssemblyInformationalVersion</c> —
+    /// which under CI determinism is the bare <c>PlatformVersion+&lt;sha&gt;</c>, still correct,
+    /// just without the run number.
+    /// </summary>
+    public const string PlatformVersionEnvironmentVariable = "MESHWEAVER_PLATFORM_VERSION";
+
+    /// <summary>
+    /// The injected run-numbered platform version, or null when the process runs without one
+    /// (local dev, tests — any non-container start).
+    /// </summary>
+    public static string? RuntimePlatformVersion =>
+        Environment.GetEnvironmentVariable(PlatformVersionEnvironmentVariable) is { Length: > 0 } v
+            ? v
+            : null;
+}

--- a/src/MeshWeaver.Plugin.Build/FrameworkIdentity.cs
+++ b/src/MeshWeaver.Plugin.Build/FrameworkIdentity.cs
@@ -1,21 +1,24 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using MeshWeaver.Graph.Configuration;
 
 namespace MeshWeaver.Plugin.Build;
 
 /// <summary>
 /// Resolves the framework identity a prebuilt assembly is bound to.
 ///
-/// <para>🚨 <b>The identity is the MVID, not the package version.</b> The runtime compares
-/// <c>NodeTypeDefinition.CompiledFrameworkVersion</c> against
-/// <c>NodeTypeCompilationHelpers.FrameworkVersion</c>, which is the <b>Module Version Id of the
-/// MeshWeaver.Graph assembly</b> — a content identity, chosen over
+/// <para>🚨 <b>The identity is <see cref="FrameworkBuildIdentity"/>, not the package version.</b>
+/// The runtime compares <c>NodeTypeDefinition.CompiledFrameworkVersion</c> against
+/// <c>NodeTypeCompilationHelpers.FrameworkVersion</c>: for a CI-built framework that is the stamped
+/// COMMIT identity (<c>AssemblyMetadata("MeshWeaverFrameworkIdentity", "g&lt;sha&gt;")</c> on
+/// MeshWeaver.Graph — identical for every CI build of the same commit, #1660 WS3); for a local
+/// build it is Graph's <b>MVID</b> — a content identity, chosen over
 /// <c>AssemblyInformationalVersion</c> because deriving it from the version string forced a fresh
 /// stamp into every build and destroyed incremental compilation.</para>
 ///
 /// <para>So a package recording only <c>3.0.0-rc2</c> records something the runtime never looks at:
-/// two builds can share a version string and differ in content, and the MVID is what says whether
-/// the bytes are ABI-compatible with the running process. Recording the MVID is what lets an
+/// two builds can share a version string and differ in content, and the identity is what says
+/// whether the bytes are ABI-compatible with the running process. Recording it is what lets an
 /// installer decide honestly whether a prebuilt assembly may be seeded — and seeding one under the
 /// live framework tag when it was built against different content is <b>actively harmful</b>: the
 /// store hit suppresses the rebuild that was needed, and the mismatch surfaces as a
@@ -24,12 +27,30 @@ namespace MeshWeaver.Plugin.Build;
 /// </summary>
 public static class FrameworkIdentity
 {
-    /// <summary>The assembly whose MVID IS the framework identity.</summary>
+    /// <summary>The assembly whose stamp/MVID IS the framework identity.</summary>
     public const string IdentityAssembly = "MeshWeaver.Graph";
 
     /// <summary>
-    /// Reads an assembly's MVID without loading it — metadata only, so it cannot execute a module
-    /// initializer or pin the file in an ALC.
+    /// Reads an assembly's framework identity without loading it — metadata only, so it cannot
+    /// execute a module initializer or pin the file in an ALC. Resolution mirrors
+    /// <see cref="FrameworkBuildIdentity.Resolve"/> exactly: the stamped
+    /// <c>MeshWeaverFrameworkIdentity</c> metadata attribute when present (CI builds), else the
+    /// MVID (local builds).
+    /// </summary>
+    public static string ReadIdentity(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        return FrameworkBuildIdentity.Resolve(
+            ReadStampedIdentity(metadata),
+            metadata.GetGuid(metadata.GetModuleDefinition().Mvid).ToString("N"));
+    }
+
+    /// <summary>
+    /// Reads an assembly's MVID without loading it — metadata only. Kept for callers that need the
+    /// raw content identity; adoption gates must use <see cref="ReadIdentity"/> so CI-built
+    /// frameworks resolve their stamped commit identity.
     /// </summary>
     public static string ReadMvid(string assemblyPath)
     {
@@ -41,9 +62,10 @@ public static class FrameworkIdentity
     }
 
     /// <summary>
-    /// The MVID of the <see cref="IdentityAssembly"/> a unit compiled against, or null when the
-    /// restored package cannot be located. Null is reported rather than guessed: an installer that
-    /// cannot establish the identity must fall back to compiling, never seed on faith.
+    /// The framework identity of the <see cref="IdentityAssembly"/> a unit compiled against, or
+    /// null when the restored package cannot be located. Null is reported rather than guessed: an
+    /// installer that cannot establish the identity must fall back to compiling, never seed on
+    /// faith.
     /// </summary>
     public static string? ResolveFrameworkMvid(string frameworkVersion)
     {
@@ -58,6 +80,69 @@ public static class FrameworkIdentity
             frameworkVersion,
             "lib", "net10.0", IdentityAssembly + ".dll");
 
-        return File.Exists(candidate) ? ReadMvid(candidate) : null;
+        return File.Exists(candidate) ? ReadIdentity(candidate) : null;
+    }
+
+    /// <summary>
+    /// The <c>AssemblyMetadata("MeshWeaverFrameworkIdentity", …)</c> value on the assembly
+    /// definition, or null when the assembly carries none (every local build). Decoded by hand
+    /// from the custom-attribute blob — the fixed arguments of
+    /// <see cref="System.Reflection.AssemblyMetadataAttribute"/> are two serialized strings after
+    /// the 0x0001 prolog — because <see cref="MetadataReader"/> has no reflection-free typed
+    /// decoder and this must not load the assembly.
+    /// </summary>
+    private static string? ReadStampedIdentity(MetadataReader metadata)
+    {
+        foreach (var handle in metadata.GetAssemblyDefinition().GetCustomAttributes())
+        {
+            var attribute = metadata.GetCustomAttribute(handle);
+            if (!IsAssemblyMetadataAttribute(metadata, attribute))
+                continue;
+
+            var blob = metadata.GetBlobReader(attribute.Value);
+            if (blob.Length < 2 || blob.ReadUInt16() != 0x0001)
+                continue;
+            var key = blob.ReadSerializedString();
+            var value = blob.ReadSerializedString();
+            if (string.Equals(key, FrameworkBuildIdentity.MetadataKey, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Whether a custom attribute's constructor belongs to
+    /// <c>System.Reflection.AssemblyMetadataAttribute</c>. The ctor is a
+    /// <see cref="MemberReference"/> in ordinary assemblies (the attribute type lives in the
+    /// runtime); the <see cref="MethodDefinition"/> shape is handled for completeness.
+    /// </summary>
+    private static bool IsAssemblyMetadataAttribute(MetadataReader metadata, CustomAttribute attribute)
+    {
+        string? name = null;
+        string? ns = null;
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+            {
+                var member = metadata.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                if (member.Parent.Kind != HandleKind.TypeReference)
+                    return false;
+                var type = metadata.GetTypeReference((TypeReferenceHandle)member.Parent);
+                name = metadata.GetString(type.Name);
+                ns = metadata.GetString(type.Namespace);
+                break;
+            }
+            case HandleKind.MethodDefinition:
+            {
+                var method = metadata.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                var type = metadata.GetTypeDefinition(method.GetDeclaringType());
+                name = metadata.GetString(type.Name);
+                ns = metadata.GetString(type.Namespace);
+                break;
+            }
+        }
+        return string.Equals(name, nameof(System.Reflection.AssemblyMetadataAttribute), StringComparison.Ordinal)
+               && string.Equals(ns, "System.Reflection", StringComparison.Ordinal);
     }
 }

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -177,15 +177,16 @@ public static class ModulePackCommand
             return 2;
         }
 
-        // The MVID is DIAGNOSTIC metadata (which exact platform build produced these bytes) —
-        // recorded when the restored MeshWeaver.Graph.dll is at hand, warned-and-omitted when not.
-        // It is deliberately not required and never a gate: the consumer lands on the
-        // minMeshVersion floor (API compatibility), and MVID equality stays with the NodeType
-        // bake lane.
+        // The framework identity is DIAGNOSTIC metadata (which exact platform build produced these
+        // bytes) — recorded when the restored MeshWeaver.Graph.dll is at hand, warned-and-omitted
+        // when not. It is deliberately not required and never a gate: the consumer lands on the
+        // minMeshVersion floor (API compatibility), and identity equality stays with the NodeType
+        // bake lane. ReadIdentity (not ReadMvid) so a CI-built Graph records its stamped commit
+        // identity — the value the runtime actually compares (#1660 WS3).
         graphDll ??= Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
         string? frameworkMvid = null;
         if (File.Exists(graphDll))
-            frameworkMvid = FrameworkIdentity.ReadMvid(graphDll);
+            frameworkMvid = FrameworkIdentity.ReadIdentity(graphDll);
         else
             Console.Error.WriteLine(
                 $"warning: {FrameworkIdentity.IdentityAssembly}.dll not found at {graphDll} — the "

--- a/test/MeshWeaver.Graph.Test/AssemblyCacheRetentionTest.cs
+++ b/test/MeshWeaver.Graph.Test/AssemblyCacheRetentionTest.cs
@@ -342,6 +342,11 @@ public class AssemblyCacheRetentionTest : IDisposable
     [InlineData("v7-22825f59-9f4455cd1122.dll", "22825f59")]
     [InlineData("v7-22825F59-9F4455CD1122.pdb", "22825f59")]
     [InlineData("v1234567890-2f9763d7-abcdef012345.dll", "2f9763d7")]
+    // The commit-identity tag shape (#1660 WS3): CI builds' FrameworkVersion is g<sha>, so their
+    // store tag is 'g' + 7 hex — these generations must be attributable, or CI-baked files would
+    // be unrecognised forever and the sweep could never reclaim them.
+    [InlineData("v7-g22825f5-9f4455cd1122.dll", "g22825f5")]
+    [InlineData("v7-G22825F5-9F4455CD1122.pdb", "g22825f5")]
     public void ATaggedAssembly_IsAttributedToItsGeneration(string fileName, string expected) =>
         AssemblyCacheGenerations.TagOf(fileName).Should().Be(expected);
 
@@ -352,6 +357,8 @@ public class AssemblyCacheRetentionTest : IDisposable
     [InlineData(".bake-lease-22825f59")]          // the lease
     [InlineData("vX-22825f59-9f4455cd1122.dll")]  // no version
     [InlineData("v7-zzzzzzzz-9f4455cd1122.dll")]  // tag is not hex
+    [InlineData("v7-gz2825f5-9f4455cd1122.dll")]  // g-tag whose remainder is not hex
+    [InlineData("v7-g2825f5-9f4455cd1122.dll")]   // g-tag one char short
     // 🚨 The WIDTHS are the deletion boundary, not decoration: the store always writes an 8-char
     // tag and a 12-char hash, so a foreign name that merely happens to be hex must not be
     // attributed — attribution is what makes a file deletable.

--- a/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
@@ -1,0 +1,80 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Plugin.Build;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the ONE framework build identity (#1660 WS3): the pure resolution rule, and — the pin the
+/// whole CI bake stands on — that every reader (the in-process
+/// <c>NodeTypeCompilationHelpers.FrameworkVersion</c>, the loaded-assembly reading, and
+/// <see cref="FrameworkIdentity.ReadIdentity"/>'s metadata-only PE reading a producer uses on a
+/// restored package) resolves the SAME value for the same Graph assembly. These tests run in both
+/// build flavors on purpose: locally the assembly carries no stamp (identity = MVID), on CI it
+/// carries the commit stamp (identity = g&lt;sha&gt;) — the consistency assertions must hold in
+/// BOTH, which is exactly the property that makes the bake adoptable.
+/// </summary>
+public class FrameworkBuildIdentityTest
+{
+    [Fact]
+    public void Resolve_PrefersTheStampedIdentity()
+    {
+        FrameworkBuildIdentity.Resolve("g" + new string('a', 40), "22825f59aaaaaaaaaaaaaaaaaaaaaaaa")
+            .Should().Be("g" + new string('a', 40),
+                "a CI build's commit identity covers the whole tree — it wins over the MVID");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_FallsBackToTheContentIdentity(string? stamped)
+    {
+        FrameworkBuildIdentity.Resolve(stamped, "22825f59aaaaaaaaaaaaaaaaaaaaaaaa")
+            .Should().Be("22825f59aaaaaaaaaaaaaaaaaaaaaaaa",
+                "a local build carries no stamp and keeps the content-exact MVID scheme");
+    }
+
+    [Fact]
+    public void FrameworkVersion_IsTheResolvedIdentityOfTheGraphAssembly()
+    {
+        var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+        var expected = FrameworkBuildIdentity.Resolve(
+            FrameworkBuildIdentity.StampedIdentityOf(graph),
+            graph.ManifestModule.ModuleVersionId.ToString("N"));
+
+        NodeTypeCompilationHelpers.FrameworkVersion.Should().Be(expected,
+            "there is exactly one identity resolution; every consumer flows from it");
+        PrebuiltAssemblySeeder.LiveFrameworkMvid.Should().Be(expected,
+            "the producer-facing public reading must never diverge from the gate");
+    }
+
+    [Fact]
+    public void PeRead_AgreesWithTheLoadedAssembly()
+    {
+        // The producer side (mw-plugin-test's bake, the plugin packer) reads the identity off the
+        // assembly FILE without loading it; the consumer gate reads it off the LOADED assembly.
+        // If these ever disagree, every bake declines wholesale — silently. This assertion holds
+        // in both build flavors: unstamped (both resolve the MVID) and CI-stamped (both resolve
+        // the commit identity).
+        var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+        graph.Location.Should().NotBeNullOrEmpty();
+
+        FrameworkIdentity.ReadIdentity(graph.Location)
+            .Should().Be(PrebuiltAssemblySeeder.LiveFrameworkMvid);
+    }
+
+    [Fact]
+    public void StoreTag_IsAlwaysAttributableByTheRetentionSweep()
+    {
+        // FileSystemAssemblyStore's filename tag is FrameworkVersion[..8]; the retention sweep
+        // only ever deletes files whose tag it can attribute (AssemblyCacheGenerations.TagOf).
+        // Whatever flavor built this test run, the live tag must round-trip — otherwise every
+        // generation this build writes would be unreclaimable.
+        var tag = NodeTypeCompilationHelpers.FrameworkVersion[..8];
+        AssemblyCacheGenerations.TagOf($"v7-{tag}-9f4455cd1122.dll")
+            .Should().Be(tag.ToLowerInvariant());
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
@@ -32,9 +32,11 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
     private readonly string landingRoot =
         Path.Combine(Path.GetTempPath(), "mw-funnel-" + Guid.NewGuid().ToString("N"));
 
-    /// <summary>The RUNNING framework identity — what the bundle must carry to be landable.</summary>
-    private static string LiveFrameworkMvid =>
-        typeof(PrebuiltAssemblySeeder).Assembly.ManifestModule.ModuleVersionId.ToString("N");
+    /// <summary>The RUNNING framework identity — what the bundle must carry to be landable.
+    /// Resolved through the ONE public reading (never a locally-computed MVID: a CI-built Graph
+    /// resolves its stamped commit identity, #1660 WS3, and a hand-computed MVID would diverge
+    /// from what the gate actually compares on CI).</summary>
+    private static string LiveFrameworkMvid => PrebuiltAssemblySeeder.LiveFrameworkMvid;
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -23,11 +23,12 @@ public class ModuleLandingServiceTest : IDisposable
     private readonly string baseDirectory =
         Path.Combine(Path.GetTempPath(), "mw-landing-" + Guid.NewGuid().ToString("N"));
 
-    /// <summary>The RUNNING framework identity — MeshWeaver.Graph's MVID, exactly what
-    /// <c>NodeTypeCompilationHelpers.FrameworkVersion</c> computes. Recorded on landings as
+    /// <summary>The RUNNING framework identity — exactly what
+    /// <c>NodeTypeCompilationHelpers.FrameworkVersion</c> resolves (the stamped commit identity
+    /// on a CI-built Graph, the MVID locally — #1660 WS3), read through the ONE public reading so
+    /// this test can never diverge from what the gate compares. Recorded on landings as
     /// DIAGNOSTIC metadata.</summary>
-    private static string LiveFrameworkMvid =>
-        typeof(PrebuiltAssemblySeeder).Assembly.ManifestModule.ModuleVersionId.ToString("N");
+    private static string LiveFrameworkMvid => PrebuiltAssemblySeeder.LiveFrameworkMvid;
 
     private ModuleLandingService Service => new(baseDirectory: baseDirectory);
 

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -125,6 +125,75 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
         }
     }
 
+    [Fact(Timeout = 120_000)]
+    public async Task PublishedRoot_SeedsOwnIdentitysDirectory_AndIgnoresOtherIdentities()
+    {
+        // The CI-side write → portal-side read round trip (#1660 WS3): the publish step lays
+        // bundles at <root>/<framework-identity>/<source>/<bundle>.zip
+        // (.github/scripts/publish-bake-bundles.sh), and the pod seeds ONLY its own identity's
+        // subtree. A bundle filed under ANOTHER identity — another commit's bake — must not even
+        // be read: the directory name is the first gate (the manifest MVID gate stays as belt
+        // and braces underneath).
+        var typePath = $"{TestPartition}/PublishedThing";
+        await CreateNodeType("PublishedThing");
+
+        var root = CreateBundleDirectory();
+        try
+        {
+            var mine = Path.Combine(root, PrebuiltAssemblySeeder.LiveFrameworkMvid, "meshweaver-content");
+            Directory.CreateDirectory(mine);
+            WriteBundle(
+                Path.Combine(mine, "shipped.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 9, 9, 9 })));
+
+            // Another commit's publication beside it — same node path, must be invisible.
+            var other = Path.Combine(root, "gdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "meshweaver-content");
+            Directory.CreateDirectory(other);
+            WriteBundle(
+                Path.Combine(other, "shipped.zip"),
+                "gdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 1 })));
+
+            var adopted = await ShippedPrebuiltBundles.SeedPublishedRoot(Mesh, root, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            adopted.Should().Be(1,
+                "the pod seeds its own identity's directory (recursively, one source subdir), "
+                + "and never another identity's");
+
+            var node = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+                .Where(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)
+                    ?.CompilationStatus == CompilationStatus.Ok)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+            var def = node!.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+            def.CompiledFrameworkVersion.Should().Be(PrebuiltAssemblySeeder.LiveFrameworkMvid);
+
+            var store = Mesh.ServiceProvider.GetRequiredService<IAssemblyStore>();
+            var storePath = await store
+                .TryGetAssemblyPath(typePath, def.LastCompiledVersion!.Value)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            storePath.Should().NotBeNullOrEmpty(
+                "a CI-published bake must be FOUND by the sweep's store probe — pending=0");
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task PublishedRoot_Unconfigured_IsInert()
+    {
+        var adopted = await ShippedPrebuiltBundles.SeedPublishedRoot(Mesh, null, null)
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+        adopted.Should().Be(0, "a deployment that does not consume CI bakes seeds nothing");
+    }
+
     /// <summary>A durable NodeType node nested under the base's test partition — the shape the
     /// static repo import produces for shipped content, created under the platform identity.</summary>
     private Task<MeshNode> CreateNodeType(string id)


### PR DESCRIPTION
## #1660 WS3 — commit-deterministic framework identity: the CI bake actually seeds at boot

Fixes the measured regression: every pod boot logged `DynamicTypePreWarmer: 282 of 282 dynamic
NodeType(s) need building … baked=0 pending=282 frameworkstale=269` — the CI bake existed but
seeded ZERO, because the framework identity differed between the CI run that baked and the CD run
that built the image.

### The history, precisely ("we had this")

- **PR #145 (`a6a9e4cdf`, 2026-07-02)** introduced `InformationalVersion =
  $(Version)+build.<UtcNow.Ticks>` under `CIRun` — a per-build stamp compiled into every assembly,
  minting a fresh `MeshWeaver.Graph` MVID per build.
- **`ded327556` (2026-07-28)** built the storage-publishing bake (`memex-bake`, a run-once Job like
  db-migration, writing the shared assembly cache before the portal rolled). Born broken by the
  ticks stamp: two publishes of the same commit could never share an identity.
- **#1347 (`64a9ff04f`, 2026-08-12)** retired it after it ran in zero namespaces, naming this exact
  work as the fix: *"Making it work needs FrameworkVersion widened … see Directory.Build.props"*.
- **#1660 WS1/#1674** added the CI bake artifact (`mw-plugin-test --bake-output` →
  `baked-assemblies-<identity>`), which could not be adopted cross-workflow for the same reason.

### The fix — one identity, deterministic per commit

**Compile inputs (Directory.Build.props):** under `CIRun` nothing per-build reaches any compiled
attribute: `InformationalVersion = $(PlatformVersion)` (the SDK appends `+<checked-out sha>`),
`FileVersion` pinned to `$(_VersionNumeric).0`. `$(Version)` keeps the monotonic `.ci.<run#>` for
**NuGet package versions and image tags only** — verified it reaches no compiled attribute.

**The identity (`FrameworkBuildIdentity`, one resolution):**
- CI builds (`CIRun` **and** `GITHUB_ACTIONS` — a CI checkout is clean at its commit; a local
  `-p:CIRun=true` repro can be dirty and stays on the MVID) are stamped
  `AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>")`; the identity is the **commit**. A
  commit names the whole tree — every source file and every package pin — so any
  reference-assembly change flips it: the widening over the whole TPA reference set that the old
  🚨 comment demanded (Graph's bare MVID only covers Graph's own inputs), delivered as a strict
  superset rather than a per-host TPA hash (which could never match between the bake host and the
  portal — different processes have different TPAs).
- Local builds carry no stamp → Graph MVID, content-exact for dirty trees, exactly as before.

**Every consumer moved by construction** — all flowed through
`NodeTypeCompilationHelpers.FrameworkVersion` already: `HasUsableBuild` /
`HasStaleFrameworkBuild` (staleness gate), `ApplyCompileSuccess` (`CompiledFrameworkVersion`
stamp), `FileSystemAssemblyStore.FrameworkTag` (store filename tag), `NodeTypeBakeStatus`
(probe/report), `BuildProtocolDriver` (build-claim fingerprint), `PrebuiltAssemblySeeder`
(adoption gate + `LiveFrameworkMvid`), `BakeOutput` (bake artifact identity → the
`baked-assemblies-<identity>` artifact key). The one *file-side* reader,
`Plugin.Build/FrameworkIdentity`, gained `ReadIdentity` (metadata-only PE read of the stamp,
MVID fallback) so producers record what the runtime actually compares; `ModulePackCommand` and
`ResolveFrameworkMvid` use it. `AssemblyCacheGenerations.TagOf` accepts the `g`+7-hex tag shape so
CI generations stay reclaimable.

**Delivery to storage (the restored memex-bake outcome, without the extra image):**
- `main-cd` gains `publish-bake` (needs promote): downloads the Build-and-Test run's
  `baked-assemblies-*` artifact for the same commit and publishes it via
  `.github/scripts/publish-bake-bundles.sh` to the portals' Azure Files data shares:
  `prebuilt-bundles/<identity>/<source>/<bundle>.zip`. Config is **preflighted red** (no
  skip-trapdoor): missing `BAKE_PUBLISH_TARGETS` fails naming exactly what to provision. A missing
  *artifact* only warns (a reuse-green run legitimately baked nothing).
- Portal boot: `ShippedPrebuiltBundles.SeedPublishedRoot` (new config
  `PreWarm:PrebuiltBundleRoot`, set to `/data/prebuilt-bundles` in `values.aks.yaml`) seeds ONLY
  the pod's own identity's subtree before the NodeType sweep — same seeder, same MVID gate
  underneath. Unconfigured → inert.
- The #1674 in-image `prebuilt/` lane is untouched and now redundant for this purpose (it was
  never wired into main-cd); it remains the same-build lane for the tester.

**"Subscribe to new releases of any dependency and rebuild":** in-repo dependency bumps need no
event — a Dependabot merge is a commit, a commit IS a new identity, the next CI run re-bakes. The
cross-repo edge is closed by `notify-dependents`: one `repository_dispatch`
(`meshweaver-framework-released`, payload commit/identity/version) per repo in
`BAKE_SUBSCRIBER_REPOS`; node repos subscribe with
`on: repository_dispatch: { types: [meshweaver-framework-released] }` and re-run their gate+bake.
Reporter-class (like the platform-update webhook): unconfigured is a loud notice, never red.

**Runtime version display:** the run number stays visible without being compiled in — the
container publish injects `$(Version)` as `MESHWEAVER_PLATFORM_VERSION`
(`ContainerEnvironmentVariable`, image config); `ShippedReleaseSeed.InstalledPlatformVersion`
(self-updater current-version + Admin/PlatformVersion node) and `AppVersionService` read it first.
The self-updater's target selection keys on ACR tags (unchanged, still `.ci.<run#>` monotonic);
its `IsNewer(target, current)` gate keeps its exact semantics because current keeps the run
number via the env var. `Memex.Client` (not in the solution/CI — MAUI, built separately) compares
at release granularity when its own build carries no run number, so a current client is not
nagged every connect.

### Proof (measured, not claimed)

- Two clean builds of `MeshWeaver.Graph`, `-p:CIRun=true`, `GITHUB_RUN_NUMBER=1111` vs `2222`,
  **70 s apart**: output DLLs **bit-identical** (`cmp` clean), MVID `ec8624fdd279496f87e01c70c7a7d051`
  both, identity `g5be81c02e…` both, `InformationalVersion = 3.0.0-rc3+5be81c02e…`.
- One-line source change → MVID flips to `e33b7842b5244735a69d70b9d1739c80` (identity/commit
  unchanged — which is exactly why the stamp is CI-only; see the props comment).
- Generated `AssemblyInfo.cs` carries **no run number and no ticks** (grepped both builds).
- `MeshWeaver.Graph.Test` (FrameworkBuildIdentity/AssemblyCacheRetention/PrebuiltAssemblySeeder/
  NodeTypeCompilationHelpers filters): **59/59 green**, including new pins: stamped-wins/MVID-
  fallback resolution, PE-read == loaded-assembly-read, store tag attributable by the sweep.
- `MeshWeaver.PluginCatalog.Test` (ShippedPrebuiltBundles/ModuleLandingService/ModuleFunnel):
  **21/21 green**, including the CI-writes → portal-reads round trip
  (`PublishedRoot_SeedsOwnIdentitysDirectory_AndIgnoresOtherIdentities`) asserting the published
  layout is found by the sweep's store probe (`pending=0` shape) and another identity's bundles
  are invisible.
- `DocumentationLinkIntegrityTest` green after the doc updates.
- Full solution `-c Release -warnaserror --no-incremental` green.

### Provisioned as part of this change (already live)

- Repo variable `BAKE_PUBLISH_TARGETS` = the three portals' data shares on storage account
  `f45d8e671caa74b96a6c37f` (memex `pvc-f3e4220c…`, memex-cloud `pvc-d9f747ad…`, atioz
  `pvc-9e341c82…` — resolved from the PVs behind each `memex-data` claim).
- Role `Storage File Data Privileged Contributor` for the CD OIDC principal
  (`github-actions-deploy`) on that storage account — verified assigned.

### Ops follow-ups (not in this PR)

- Live portals pick up `PreWarm__PrebuiltBundleRoot` on the next chart-managed apply (or a
  `kubectl set env`) — the values.aks.yaml change is the persistent home; prod rollout is its own
  decision.
- `BAKE_SUBSCRIBER_REPOS` + `DEPENDENT_DISPATCH_TOKEN` (cross-repo dispatch) are deliberately
  unprovisioned — needs an org token decision; the notify job says so loudly per run. Receiver
  wiring for the node repos is documented in ContinuousDeliveryContract.md (follow-up: plugins /
  education / reinsurance / social-media workflows).
- `prebuilt-bundles/` retention on the shares: bundles accumulate per commit; small, but worth a
  sweep entry later (the assembly-cache retention pattern applies).

Closes the WS3 item of #1660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
