### PR TITLE
docs(social): mark the Social module's relocation to MeshWeaver.SocialMedia (task #63) — double-ship, platform copy is master until the flip

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -59,7 +59,9 @@
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
          (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
-         compiles against PlatformCredential; registration deliberately host-side), Hosting.Grpc
+         compiles against PlatformCredential; registration deliberately host-side; RELOCATING to
+         MeshWeaver.SocialMedia per task #63 — double-ship, this copy is the master until the flip:
+         see src/MeshWeaver.Social/README.md), Hosting.Grpc
          (UseMeshWeaverGrpcWebWhenInstalled is middleware-order-coupled, cannot ride the endpoint hook). -->
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -60,7 +60,8 @@
     <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
          (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
          compiles against PlatformCredential; registration deliberately host-side; RELOCATING to
-         MeshWeaver.SocialMedia per task #63 — double-ship, this copy is the master until the flip:
+         MeshWeaver.SocialMedia per the modularization program's task 63 (a program-plan task, not
+         a GitHub issue) — double-ship, this copy is the master until the flip:
          see src/MeshWeaver.Social/README.md), Hosting.Grpc
          (UseMeshWeaverGrpcWebWhenInstalled is middleware-order-coupled, cannot ride the endpoint hook). -->
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />

--- a/src/MeshWeaver.Social/README.md
+++ b/src/MeshWeaver.Social/README.md
@@ -6,7 +6,9 @@ families (riding `MeshEndpointProviderAttribute`, design #1655/#1667), and the L
 node-menu providers. Ships as a mesh MODULE: `Modules:Assemblies` + the thin module lane
 (`memex/MeshModulesPublish.targets`).
 
-## 🚨 Relocating to Systemorph/MeshWeaver.SocialMedia (task #63) — this copy is the MASTER until the flip
+## 🚨 Relocating to Systemorph/MeshWeaver.SocialMedia — this copy is the MASTER until the flip
+
+(Task 63 of the 2026-08 modularization program — a program-plan task, not a GitHub issue number.)
 
 This module's sources ALSO live in
 [MeshWeaver.SocialMedia `src/MeshWeaver.Social`](https://github.com/Systemorph/MeshWeaver.SocialMedia/tree/main/src/MeshWeaver.Social),
@@ -27,7 +29,8 @@ During the double-ship transition:
      and NodeType compilation references only TRUSTED_PLATFORM_ASSEMBLIES, so a modules/-only
      assembly is invisible to it (the #1683/#1685 `AddApprovals` breakage class). Re-sweep
      `content/ samples/*/Data`, node JSON, AND the live meshes before deleting any symbol.
-  3. Task #74's satellite-bundle rollout, so consumers land the SocialMedia-built bundle
+  3. The modularization program's satellite-bundle rollout (program-plan task 74, not a GitHub
+     issue), so consumers land the SocialMedia-built bundle
      automatically (until then the registry's thin-lane `modules/MeshWeaver.Social/` is empty by
      construction and serves nothing).
   When it flips: remove this project + the `Memex.Portal.Shared` reference + the `@(MeshModule)`

--- a/src/MeshWeaver.Social/README.md
+++ b/src/MeshWeaver.Social/README.md
@@ -1,17 +1,50 @@
 # MeshWeaver.Social
 
-Social publishing on the MeshWeaver mesh. Turns mesh content into platform posts through an
-approval-gated pipeline, with LinkedIn as the first platform integration.
+Social publishing for the MeshWeaver mesh: the platform-publisher abstraction with a LinkedIn
+implementation, the LinkedIn connect / company-Page sync / member publish+engagement endpoint
+families (riding `MeshEndpointProviderAttribute`, design #1655/#1667), and the LinkedIn/social
+node-menu providers. Ships as a mesh MODULE: `Modules:Assemblies` + the thin module lane
+(`memex/MeshModulesPublish.targets`).
+
+## 🚨 Relocating to Systemorph/MeshWeaver.SocialMedia (task #63) — this copy is the MASTER until the flip
+
+This module's sources ALSO live in
+[MeshWeaver.SocialMedia `src/MeshWeaver.Social`](https://github.com/Systemorph/MeshWeaver.SocialMedia/tree/main/src/MeshWeaver.Social),
+where the SocialMedia package is the first MIXED package (node content + compiled module:
+`SocialMedia/index.json` declares `content.module` and its CI builds + module-packs the bundle).
+During the double-ship transition:
+
+- **Change the module here first, then mirror the `.cs` files to the satellite verbatim** (they are
+  kept byte-identical; the satellite's csproj differs — it project-references a platform checkout).
+- **Do NOT delete this project yet.** The flip is blocked by, and its PR must resolve, ALL of:
+  1. `Memex.Portal.Shared` compiles against `PlatformCredential`
+     (`Social/ApiCredentialNodeType.cs` — deliberately host-side so existing credential nodes keep
+     deserializing) and holds the ships-the-bits `ProjectReference` (PR #1681's "not flippable"
+     verdict; also `AddLinkedInAuthentication` stays platform — auth schemes configure before the
+     host builds).
+  2. In-mesh sources call `SocialExtensions.AddSocial` — at least
+     `samples/Graph/Data/Doc/DataMesh/SocialMedia/{Post,Profile}.json` configuration lambdas —
+     and NodeType compilation references only TRUSTED_PLATFORM_ASSEMBLIES, so a modules/-only
+     assembly is invisible to it (the #1683/#1685 `AddApprovals` breakage class). Re-sweep
+     `content/ samples/*/Data`, node JSON, AND the live meshes before deleting any symbol.
+  3. Task #74's satellite-bundle rollout, so consumers land the SocialMedia-built bundle
+     automatically (until then the registry's thin-lane `modules/MeshWeaver.Social/` is empty by
+     construction and serves nothing).
+  When it flips: remove this project + the `Memex.Portal.Shared` reference + the `@(MeshModule)`
+  entry in `memex/MeshModulesPublish.targets`; the `Modules:Assemblies` entries STAY (the runtime
+  then loads the landed module from `modules/`).
 
 ## Features
 
-- `IPlatformPublisher` / `IPublishQueue` — the platform-agnostic publishing pipeline
-- `ApprovalToPublishHandler` — publishing gated on mesh `Approval` nodes
-- `LinkedInPublisher` / `LinkedInPublishService` / `LinkedInPostsApi` — publish, list, and manage LinkedIn posts
-- `LinkedInAnalytics` + `PastPostIngestJob` — per-post analytics and history import
-- `PlatformCredential` — per-user platform credentials as mesh data
+- `SocialMeshModuleAttribute` / `SocialModuleAttribute` — the module's two activation halves
+  (DI + menu providers; endpoint contributions via `MapMeshModuleEndpoints`)
+- `IPlatformPublisher` — the platform-agnostic publishing abstraction
+- `LinkedInPublisher` / `LinkedInPublishService` / `LinkedInPostsApi` — publish, list, and manage
+  LinkedIn posts
+- `LinkedInAnalytics` — per-post analytics
+- `PlatformCredential` — per-user platform credentials as mesh data (registered host-side)
 
 ## Links
 
-- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [MeshWeaver.SocialMedia repository](https://github.com/Systemorph/MeshWeaver.SocialMedia)
 - [Documentation](https://memex.meshweaver.cloud/Doc)


### PR DESCRIPTION
Task #63 (modularization program): the Social module relocated to **Systemorph/MeshWeaver.SocialMedia** ([PR #31](https://github.com/Systemorph/MeshWeaver.SocialMedia/pull/31)) — the SocialMedia package is now the first MIXED package (node content + compiled module), with the satellite's CI building the module Release `-warnaserror` against a pinned platform ref and packing the bundle via the reusable `module-pack` lane (#1664 Slice B / #1673), bundle closure + manifest asserted in CI.

This platform PR is deliberately **NOT the source delete** — it is the double-ship marker that keeps the two copies from diverging:

- `src/MeshWeaver.Social/README.md` — records the relocation state, the "platform copy is the MASTER until the flip; mirror `.cs` verbatim" rule, and the exact flip blockers a future delete-PR must resolve:
  1. `Memex.Portal.Shared` compiles against `PlatformCredential` (`ApiCredentialNodeType` stays host-side by design) + the ships-the-bits ProjectReference — PR #1681's "not flippable" verdict;
  2. in-mesh callers of `SocialExtensions.AddSocial` (at least `samples/Graph/Data/Doc/DataMesh/SocialMedia/{Post,Profile}.json` config lambdas; NodeType compilation sees only TPA — the #1683/#1685 `AddApprovals` breakage class); a fresh `content/ samples/*/Data` + node-JSON + live-mesh sweep is mandatory before any symbol is deleted;
  3. task #74's satellite-bundle rollout (until then the registry's thin-lane `modules/MeshWeaver.Social/` is empty by construction and serves nothing).
  It also records what the flip changes (project + `Memex.Portal.Shared` reference + `@(MeshModule)` entry removed) and what STAYS (`Modules:Assemblies` entries — the runtime then loads the landed module from `modules/`).
- `memex/MeshModulesPublish.targets` — one comment pointing the "Social not flippable" note at the relocation state.

**What's New: skipped** — docs-only marker, no user-visible change (pure relocation; the module keeps shipping identically via the thin lane).

Verification: sources in the satellite are byte-identical to this repo's copies (`cmp` over all 13 `.cs`); `dotnet build src/MeshWeaver.Social -c Release -warnaserror` → 0 errors; targets file XML-validated; branch rebased on current main (post-#1687).

🤖 Generated with [Claude Code](https://claude.com/claude-code)