### PR TITLE
fix(content): evaluate the ingest trigger-order claim atomically with the stream apply (#1692)

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -307,7 +307,9 @@ public class ContentCollection : IDisposable
     /// and reports whether this ingest may proceed. <c>false</c> means a LATER-triggered read of
     /// the same file already landed, so this (older) snapshot must be dropped rather than
     /// overwrite it — the article-level twin of <c>MonotonicWriteGuardStorageAdapter</c>'s
-    /// high-water mark for mesh nodes.
+    /// high-water mark for mesh nodes. 🚨 Only ever evaluated INSIDE the stream's update
+    /// transform (<see cref="MergeIngestedArticle"/>), where the sync hub serializes it — see
+    /// the atomicity note there (#1692).
     /// </summary>
     private bool ClaimIngest(string key, long sequence)
     {
@@ -386,7 +388,9 @@ public class ContentCollection : IDisposable
         // empty PrerenderedHtml forever, which is the CollectionNamedArea flake's exact
         // signature (MarkdownControl { Markdown = , Html = } as the last emission). Ordering by
         // trigger is the correct rule because every read observes the file at-or-after its own
-        // trigger: a LATER trigger can therefore never carry OLDER content.
+        // trigger: a LATER trigger can therefore never carry OLDER content. The claim is taken
+        // HERE (trigger time) but EVALUATED inside the stream's serialized update transform —
+        // see MergeIngestedArticle for why checking it any earlier reopens the hole (#1692).
         var sequence = Interlocked.Increment(ref ingestSequence);
 
         // The file read + parse is the IO leaf — pooled OFF the hub; only the parsed
@@ -404,24 +408,49 @@ public class ContentCollection : IDisposable
                 {
                     if (article is null)
                         return;
-                    var key = ArticleKey(article.Path);
-                    if (!ClaimIngest(key, sequence))
-                        return;   // a later-triggered read of this file already landed — drop this one
-                    using var _ = caller is null ? null : AccessService?.SwitchAccessContext(caller);
-                    markdownStream.Update(
-                        x => new ChangeItem<InstanceCollection>(x!.SetItem(key, article), markdownStream.StreamId, Hub.Version),
-                        ex =>
-                        {
-                            // The stream errors incoming pushes once it (or its hub) is disposing — typically a
-                            // FileSystemWatcher event racing collection teardown. Close the incoming stream at the
-                            // source so no further events flow into a disposed hub. See Doc/Architecture/HubDisposalModel.
-                            if (ex is ObjectDisposedException)
-                                monitorDisposable?.Dispose();
-                        });
+                    MergeIngestedArticle(article, ArticleKey(article.Path), sequence, caller);
                 },
                 ex => Hub.ServiceProvider.GetService<ILoggerFactory>()
                     ?.CreateLogger(typeof(ContentCollection))
                     .LogWarning(ex, "IngestContentFile failed reading {Path} in collection {Collection}", path, Collection));
+    }
+
+    /// <summary>
+    /// Merges a completed ingest read into the synchronization stream. 🚨 The trigger-order claim
+    /// (<see cref="ClaimIngest"/>) is evaluated INSIDE the update transform, which the stream's
+    /// sync hub invokes strictly serially (one <c>UpdateStreamRequest</c> at a time) — so claim
+    /// and apply are ATOMIC and apply order can never invert claim order. Checking the claim on
+    /// the (pool) read-completion thread and posting the update afterwards — what #978
+    /// shipped — left a check-then-act window: an EARLIER-triggered ingest (the watcher's Created
+    /// event, whose share-tolerant read legally observes the just-created file at 0 bytes) could
+    /// pass its claim, then be overtaken before its post enqueued by the LATER-triggered
+    /// read-your-writes ingest claiming and posting the complete article. The hub then applied
+    /// complete-then-torn, the empty article stuck, and — Linux inotify dropping events for files
+    /// written into a just-created subdirectory — no repair event ever came: the #1692 recurrence
+    /// of the exact #978 signature. A superseded ingest's transform returns <c>null</c>, which the
+    /// stream skips as a no-op. Virtual so the deterministic pin
+    /// (<c>ContentCollectionClaimApplyRaceTest</c>) can hold one ingest at this exact boundary
+    /// (post-parse, pre-post) and prove the inversion is harmless.
+    /// </summary>
+    /// <param name="article">The parsed article from the completed read.</param>
+    /// <param name="key">The article's <see cref="InstanceCollection"/> key (<see cref="ArticleKey"/>).</param>
+    /// <param name="sequence">The trigger-order sequence claimed when this ingest was triggered.</param>
+    /// <param name="caller">The originating user's context snapshot, or <c>null</c> for watcher-driven changes.</param>
+    protected virtual void MergeIngestedArticle(MarkdownElement article, string key, long sequence, AccessContext? caller)
+    {
+        using var _ = caller is null ? null : AccessService?.SwitchAccessContext(caller);
+        markdownStream.Update(
+            x => ClaimIngest(key, sequence)
+                ? new ChangeItem<InstanceCollection>(x!.SetItem(key, article), markdownStream.StreamId, Hub.Version)
+                : null,   // a later-triggered read of this file already applied — drop this one
+            ex =>
+            {
+                // The stream errors incoming pushes once it (or its hub) is disposing — typically a
+                // FileSystemWatcher event racing collection teardown. Close the incoming stream at the
+                // source so no further events flow into a disposed hub. See Doc/Architecture/HubDisposalModel.
+                if (ex is ObjectDisposedException)
+                    monitorDisposable?.Dispose();
+            });
     }
 
     private async Task<MarkdownElement?> ParseContentAsync(Stream? stream, string path, DateTime lastModified, CancellationToken ct)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-content-upload-empty-render-race.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-content-upload-empty-render-race.md
@@ -1,0 +1,17 @@
+---
+Name: Uploaded files can no longer open as an empty page
+Category: Fix
+Description: A rare race could make a just-uploaded markdown file open as an empty page until the collection reloaded — the stale snapshot can no longer win.
+Icon: Sparkle
+Order: -20260816
+---
+
+# Uploaded files can no longer open as an empty page
+
+Uploading a file into a content collection and opening it right away could — very rarely — show
+an empty page instead of the file's content, and the page stayed empty until the collection was
+reloaded. The cause was a race between the upload's own read of the file and the file-system
+watcher's read of the moment the file was created: the stale, still-empty snapshot could be
+applied after the complete one and stick. The ordering guard is now applied atomically with the
+update itself, so the complete content always wins and the freshly uploaded file renders
+immediately.

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionClaimApplyRaceTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionClaimApplyRaceTest.cs
@@ -1,0 +1,204 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// DETERMINISTIC repro of the #1692 recurrence of the CollectionNamedArea empty-render flake —
+/// the residual hole #978 left open.
+///
+/// <para><b>The defect.</b> #978 established the trigger-order rule: every ingest of a file
+/// claims a monotonic sequence at TRIGGER time, and an ingest may only merge if no
+/// later-triggered ingest of the same file has already landed (a read observes the file
+/// at-or-after its own trigger, so a later trigger can never carry older content). But the shipped
+/// code CHECKED that claim on the pool read-completion thread and then POSTED the merge to the
+/// stream's sync hub as a separate step. Claim and apply were not atomic: the watcher's
+/// <c>Created</c>-event ingest (triggered while the just-created file is still 0 bytes, so its
+/// share-tolerant read legally parses an EMPTY article) could pass its claim, then be overtaken —
+/// before its post enqueued — by SaveFile's later-triggered read-your-writes ingest claiming and
+/// posting the complete article. The hub then applied complete-then-torn: apply order inverted
+/// claim order, the empty article landed last and stuck, and (Linux inotify dropping events for
+/// files written into a just-created subdirectory) no repair event ever came. The collection
+/// served <c>MarkdownControl { Markdown = , Html = }</c> forever — the exact CI signature of
+/// runs 31972489250 (#1692) and the original #978 failure.</para>
+///
+/// <para><b>The fix.</b> <see cref="ContentCollection.MergeIngestedArticle"/> evaluates
+/// <c>ClaimIngest</c> INSIDE the update transform, which the sync hub invokes strictly serially —
+/// claim order IS apply order by construction; a superseded ingest's transform returns
+/// <c>null</c> and the stream skips it as a no-op.</para>
+///
+/// <para><b>The pin.</b> Timing is removed entirely: a collection subclass HOLDS the torn ingest
+/// at the exact boundary the defect lives on — after its read completed and parsed (so, pre-fix,
+/// after its claim had already passed), before its merge is posted. The complete article is then
+/// written and provably applied, and only afterwards is the held merge released. Pre-fix the
+/// released post applies unconditionally and the empty article overwrites the complete one
+/// (guaranteed loss); post-fix the claim — evaluated at apply time under the stream's
+/// serialization — drops it.</para>
+/// </summary>
+public class ContentCollectionClaimApplyRaceTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).AddContentCollections();
+
+    private const string RealContent = "# Hello from the collection area";
+
+    [Fact(Timeout = 60_000)]
+    public async Task TornIngestOvertakenBetweenClaimAndPost_CannotOverwriteTheLaterTriggeredArticle()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var dir = Path.Combine(AppContext.BaseDirectory, "Files", "ClaimApplyRace", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        var provider = new TornFirstReadProvider(new FileSystemStreamProvider(dir));
+        using var collection = new HoldFirstMergeCollection(
+            new ContentCollectionConfig
+            {
+                Name = "content",
+                SourceType = "FileSystem",
+                IsEditable = true,
+                BasePath = dir,
+            },
+            provider,
+            GetHost());
+        await collection.Initialize().FirstAsync().ToTask(ct);
+
+        // 1. The watcher's Created event, delivered while the file is still 0 bytes — the FIRST
+        //    ingest triggered for this path. Its (empty) read completes immediately, and the
+        //    collection subclass holds it right at the merge boundary: post-parse — and, pre-fix,
+        //    post-CLAIM — but pre-post. This is the overtaking window: a thread paused here while
+        //    a later-triggered ingest claims, posts, and applies.
+        provider.FireWatcher("sub/hello.md");
+        await collection.HeldMergeArrived.Should().Within(20.Seconds()).Emit();
+        Output.WriteLine("[torn] the Created-triggered ingest parsed the empty file and is held at the merge boundary");
+
+        // 2. The write completes and SaveFile's own read-your-writes ingest reads the COMPLETE
+        //    file — a strictly LATER trigger — and provably applies it.
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(RealContent)))
+            await collection.SaveFile("/sub", "hello.md", stream).ToTask(ct);
+
+        var complete = await collection.GetMarkdown("sub/hello.md")
+            .Should().Within(30.Seconds())
+            .Match(x => x is MarkdownElement { Content: RealContent },
+                "SaveFile's own ingest must publish the complete article");
+        Output.WriteLine($"[complete] content='{((MarkdownElement)complete!).Content}'");
+
+        // 3. Release the held torn merge — its post now enqueues AFTER the complete article
+        //    applied, even though its trigger (and, pre-fix, its claim) came FIRST. Pre-fix it
+        //    applies unconditionally and the empty article wins; post-fix the claim is evaluated
+        //    at apply time under the stream's serialization and drops it.
+        collection.ReleaseHeldMerge();
+        Output.WriteLine("[torn] released");
+
+        // 4. Negative window — give the released merge several of its own turns to do damage,
+        //    then assert the collection still serves the complete article.
+        await Observable.Timer(TimeSpan.FromSeconds(2)).Should().Within(20.Seconds()).Emit();
+
+        var after = await collection.GetMarkdown("sub/hello.md")
+            .Should().Within(20.Seconds()).Emit();
+        after.Should().BeOfType<MarkdownElement>();
+        ((MarkdownElement)after!).Content.Should().Be(RealContent,
+            "an ingest whose merge post is overtaken between its trigger-order claim and its "
+            + "enqueue must never overwrite the article of a later-triggered ingest that already "
+            + "applied — the claim must be evaluated atomically with the apply, under the "
+            + "stream's serialization");
+    }
+
+    /// <summary>
+    /// Exposes the exact boundary the #1692 defect lives on: the FIRST completed ingest (the
+    /// torn Created-event read) is captured after its parse — pre-fix, after its claim had
+    /// already passed — and before its merge posts to the stream. <see cref="ReleaseHeldMerge"/>
+    /// then issues that merge after a later-triggered ingest has provably applied, which is the
+    /// overtaking the check-then-act window allowed a preempted pool thread to suffer for real.
+    /// No thread is blocked: the hold is a capture-and-return, the release replays the base merge.
+    /// </summary>
+    private sealed class HoldFirstMergeCollection(
+        ContentCollectionConfig config, IStreamProvider provider, IMessageHub hub)
+        : ContentCollection(config, provider, hub)
+    {
+        private readonly ReplaySubject<Unit> heldArrived = new(1);
+        private (MarkdownElement Article, string Key, long Sequence, AccessContext? Caller)? held;
+        private int merges;
+
+        public IObservable<Unit> HeldMergeArrived => heldArrived.Take(1);
+
+        protected override void MergeIngestedArticle(
+            MarkdownElement article, string key, long sequence, AccessContext? caller)
+        {
+            if (Interlocked.Increment(ref merges) == 1)
+            {
+                held = (article, key, sequence, caller);
+                heldArrived.OnNext(Unit.Default);
+                return;
+            }
+            base.MergeIngestedArticle(article, key, sequence, caller);
+        }
+
+        public void ReleaseHeldMerge()
+        {
+            var (article, key, sequence, caller) = held!.Value;
+            base.MergeIngestedArticle(article, key, sequence, caller);
+        }
+    }
+
+    /// <summary>
+    /// Delegates everything to a real provider, but (a) hands the monitor callback to the test so
+    /// a <c>Created</c> event can be fired at an exact point, and (b) intercepts the FIRST
+    /// <see cref="GetStreamWithMetadataAsync"/> call to report the file as EMPTY — the torn read
+    /// of a just-created, not-yet-written file (the write is share-tolerant by design, see
+    /// <c>FileSystemStreamProvider.WriteStreamAsync</c>). Unlike
+    /// <c>ContentCollectionIngestOrderTest</c>'s provider there is no gate on the read: #1692's
+    /// hole is AFTER the read completes, so the torn read finishes immediately and the hold
+    /// happens at the collection's merge boundary instead.
+    /// </summary>
+    private sealed class TornFirstReadProvider(IStreamProvider inner) : IStreamProvider
+    {
+        private int reads;
+        private Action<string>? monitor;
+
+        public void FireWatcher(string path) => monitor?.Invoke(path);
+
+        public string ProviderType => inner.ProviderType;
+
+        public IDisposable? AttachMonitor(Action<string> onChanged)
+        {
+            monitor = onChanged;
+            return Disposable.Empty;
+        }
+
+        public Task<(Stream? Stream, string Path, DateTime LastModified)> GetStreamWithMetadataAsync(
+            string path, CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref reads) == 1)
+                // The file existed but carried no bytes yet — exactly what a read racing
+                // FileStream(FileMode.Create) ahead of CopyToAsync observes.
+                return Task.FromResult<(Stream? Stream, string Path, DateTime LastModified)>(
+                    (new MemoryStream(), path, DateTime.UtcNow));
+            return inner.GetStreamWithMetadataAsync(path, ct);
+        }
+
+        public Task<Stream?> GetStreamAsync(string reference, CancellationToken ct = default)
+            => inner.GetStreamAsync(reference, ct);
+        public Task WriteStreamAsync(string reference, Stream content, CancellationToken ct = default)
+            => inner.WriteStreamAsync(reference, content, ct);
+        public IAsyncEnumerable<(Stream? Stream, string Path, DateTime LastModified)> GetStreamsAsync(
+            Func<string, bool> filter, CancellationToken ct = default) => inner.GetStreamsAsync(filter, ct);
+        public IAsyncEnumerable<FolderItem> GetFolders(string path, CancellationToken ct = default)
+            => inner.GetFolders(path, ct);
+        public IAsyncEnumerable<FileItem> GetFiles(string path, CancellationToken ct = default)
+            => inner.GetFiles(path, ct);
+        public Task SaveFileAsync(string path, string fileName, Stream content, CancellationToken ct = default)
+            => inner.SaveFileAsync(path, fileName, content, ct);
+        public Task CreateFolderAsync(string folderPath) => inner.CreateFolderAsync(folderPath);
+        public Task DeleteFolderAsync(string folderPath) => inner.DeleteFolderAsync(folderPath);
+        public Task DeleteFileAsync(string filePath) => inner.DeleteFileAsync(filePath);
+        public Task<ImmutableDictionary<string, Author>> LoadAuthorsAsync(CancellationToken ct = default)
+            => inner.LoadAuthorsAsync(ct);
+    }
+}


### PR DESCRIPTION
Root-causes and fixes #1692 — the recurrence of the CollectionNamedArea empty-render flake (`CollectionNamedArea_RendersBrowserForFolder_AndContentForFile`, run 31972489250: last emission `MarkdownControl { Markdown = <empty>, Html = <empty> }`).

## Root cause

#978 established the trigger-order rule (a monotonic sequence claimed at trigger time; an ingest may only merge if no later-triggered ingest of the same file already landed), but it **checked the claim on the pool read-completion thread and posted the merge afterwards** — the apply happens later, serialized on the sync hub via `UpdateStreamRequest`. Claim and apply were not atomic:

1. The watcher's `Created`-event ingest triggers while the just-created file is still 0 bytes (share-tolerant reads are by design — see `FileSystemStreamProvider.WriteStreamAsync`); it parses an EMPTY article and **passes its claim** on its pool thread.
2. Before its `markdownStream.Update` post enqueues (a window fattened by `Update()`'s context-capture fallback chain — DI lookups between claim and post), SaveFile's **later-triggered** read-your-writes ingest claims and posts the complete article.
3. The hub applies complete-then-torn: **apply order inverts claim order**, the empty article lands last and sticks — and on Linux, inotify drops events for files written into a just-created subdirectory, so no repair event ever comes. The render serves the empty `MarkdownControl` forever.

Both prior fixes (#238 read-your-writes, #978 trigger-order claim) are intact and necessary — this closes the residual check-then-act window between them.

## Fix

`ClaimIngest` is now evaluated **inside the update transform**, which the sync hub invokes strictly serially — claim and apply are atomic, so apply order can never invert claim order. A superseded ingest's transform returns `null`, which `SetCurrent` skips as a no-op. The merge is extracted as the protected virtual `MergeIngestedArticle` boundary.

## Deterministic red-proven pin

`ContentCollectionClaimApplyRaceTest` removes the timing entirely: a collection subclass holds the torn ingest at exactly the defect's window (post-parse/post-claim, pre-post), lets the later-triggered complete article provably apply, then releases the held merge.

- **RED under pre-fix semantics** (claim in callback, unconditional apply — verified locally against that variant): the released empty article overwrites the complete one — assertion fails with `found ""`, the exact CI signature.
- **GREEN with the fix**: the claim, evaluated at apply time under the stream's serialization, drops it.

## Verification

- `ContentCollectionClaimApplyRaceTest`: red on pre-fix variant, green on fix (fresh .trx each)
- Full `MeshWeaver.ContentCollections.Test`: 30/30 passed (includes the originally-failing `NodeHubContentCollectionTest`)
- `dotnet build -c Release -warnaserror`: clean for `MeshWeaver.ContentCollections`, its test project, and `MeshWeaver.Documentation`
- What's New entry included (`Category: Fix`) — users historically saw "upload a file, open it, page is empty"

Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
