### PR TITLE
feat(#1660 WS3): API-surface framework identity — rebuild only when we need to

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -52,6 +52,13 @@ if [ "${#BUNDLES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# The completeness sentinel (must match ShippedPrebuiltBundles.CompletionSentinelFileName): its
+# PRESENCE means "every bundle of this publication landed", because it is uploaded strictly LAST.
+# Its content lists the bundle set, so the reader can detect a listed-but-missing bundle too.
+SENTINEL="_complete"
+SENTINEL_LOCAL=$(mktemp)
+for zip in "${BUNDLES[@]}"; do basename "$zip"; done | sort > "$SENTINEL_LOCAL"
+
 publish_one_target() { # <account> <share> <dest-dir>
   local account="$1" share="$2" dest="$3" path="" part
   # az storage directory create is not recursive and errors on an existing directory on some CLI
@@ -74,6 +81,12 @@ publish_one_target() { # <account> <share> <dest-dir>
       --auth-mode login --backup-intent --only-show-errors > /dev/null
     echo "published: $account/$share/$dest/$(basename "$zip")"
   done
+  # LAST write — the atomic completeness marker. Anything that dies before this line leaves the
+  # directory sentinel-less: unreadable to portals, re-published wholesale by the next run.
+  az storage file upload --account-name "$account" --share-name "$share" \
+    --path "$dest/$SENTINEL" --source "$SENTINEL_LOCAL" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s))"
 }
 
 for target in $BAKE_PUBLISH_TARGETS; do
@@ -89,13 +102,19 @@ for target in $BAKE_PUBLISH_TARGETS; do
   DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
   # "Rebuild only when we need to" applies to the publish too (#1660 WS3): the identity is the
   # API-surface hash, so an internal-only merge resolves the SAME identity as the previous one —
-  # its bake is byte-for-byte what is already published. Skip with a notice instead of
-  # re-uploading; a genuinely new surface gets a new identity directory and publishes fully.
-  existing=$(az storage file list --account-name "$ACCOUNT" --share-name "$SHARE" \
-    --path "$DEST" --auth-mode login --backup-intent --query "length([?name!=null])" -o tsv \
-    --only-show-errors 2>/dev/null || echo 0)
-  if [ "${existing:-0}" -gt 0 ]; then
-    echo "::notice::$ACCOUNT/$SHARE already holds $existing file(s) under $DEST — surface unchanged, bake already published; skipping."
+  # its bake is byte-for-byte what is already published.
+  #
+  # 🚨 The skip keys on the _complete SENTINEL, never on "any file exists": the sentinel is
+  # written LAST, after every bundle uploaded, so a publish that died mid-way (cancelled run,
+  # network fault) leaves a directory WITHOUT it — and the next publish re-uploads everything
+  # (idempotent overwrites) instead of freezing the identity incomplete forever. The read side
+  # (ShippedPrebuiltBundles.SeedPublishedRoot) honours the same contract: a source directory
+  # without its sentinel is never seeded.
+  complete=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
+    --path "$DEST/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo false)
+  if [ "$complete" = "true" ]; then
+    echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST ($SENTINEL present) — surface unchanged, bake already published; skipping."
     continue
   fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s))"

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -87,6 +87,17 @@ for target in $BAKE_PUBLISH_TARGETS; do
     exit 1
   fi
   DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+  # "Rebuild only when we need to" applies to the publish too (#1660 WS3): the identity is the
+  # API-surface hash, so an internal-only merge resolves the SAME identity as the previous one —
+  # its bake is byte-for-byte what is already published. Skip with a notice instead of
+  # re-uploading; a genuinely new surface gets a new identity directory and publishes fully.
+  existing=$(az storage file list --account-name "$ACCOUNT" --share-name "$SHARE" \
+    --path "$DEST" --auth-mode login --backup-intent --query "length([?name!=null])" -o tsv \
+    --only-show-errors 2>/dev/null || echo 0)
+  if [ "${existing:-0}" -gt 0 ]; then
+    echo "::notice::$ACCOUNT/$SHARE already holds $existing file(s) under $DEST — surface unchanged, bake already published; skipping."
+    continue
+  fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s))"
   publish_one_target "$ACCOUNT" "$SHARE" "$DEST"
 done

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -929,8 +929,10 @@ jobs:
   # ────────────────── PUBLISH THE CI NODETYPE BAKE TO PORTAL STORAGE ──────────────────
   # #1660 WS3 — "bake on CI": the Build-and-Test run of this same commit already compiled every
   # shipped NodeType (its doc-gate runs mw-plugin-test with --bake-output and uploads the result
-  # as `baked-assemblies-<framework-identity>`). CI builds are commit-deterministic, so that
-  # artifact's framework identity EQUALS the identity of the images promote just armed — this job
+  # as `baked-assemblies-<framework-identity>`). The framework identity is the API-SURFACE hash
+  # (FrameworkBuildIdentity — deterministic per source+references, stable across internal-only
+  # merges), so that artifact's identity EQUALS the identity of the images promote just armed —
+  # and usually equals the PREVIOUS release's too, in which case the publish below skips — this job
   # copies the bundles into the storage the portals mount, laid out
   # `prebuilt-bundles/<identity>/<source>/`, and each booting pod seeds its own identity's
   # directory (ShippedPrebuiltBundles.SeedPublishedRoot) before its NodeType sweep: pending drops
@@ -1055,7 +1057,7 @@ jobs:
             curl -sS -o /tmp/resp -w '%{http_code}\n' -X POST \
               -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/$repo/dispatches" \
-              -d "{\"event_type\":\"meshweaver-framework-released\",\"client_payload\":{\"sha\":\"$SHA\",\"identity\":\"g$SHA\",\"version\":\"$VERSION\"}}" \
+              -d "{\"event_type\":\"meshweaver-framework-released\",\"client_payload\":{\"sha\":\"$SHA\",\"version\":\"$VERSION\"}}" \
               | grep -q '^2' \
               || echo "::warning::dispatch to $repo failed ($(cat /tmp/resp)) — its next own push (or the next release) re-bakes it."
           done

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -102,13 +102,16 @@
          assembly attributes. Keep them excluded explicitly (also covers obj/container/, nested). -->
     <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
   </PropertyGroup>
-  <!-- Ref assemblies stay OFF for the whole multi-arch publish (PR #552): with per-leg isolation they
-       no longer collide, but a from-clean CI container publish gains nothing from producing them
-       (they only skip downstream recompiles on INCREMENTAL rebuilds), so this is pure saved work.
-       Empty in normal dev / Build-and-Test CI — ref assemblies and incremental builds unaffected there. -->
-  <PropertyGroup Condition="'$(ContainerRuntimeIdentifiers)' != ''">
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-  </PropertyGroup>
+  <!-- 🚨 Ref assemblies stay ON in the multi-arch container publish — they are LOAD-BEARING now.
+       This block used to set ProduceReferenceAssembly=false for '$(ContainerRuntimeIdentifiers)'
+       != '' ("pure saved work" once the per-leg bin/obj isolation above killed the PR #552
+       CopyRefAssembly collisions). Since #1660 WS3's surface identity, the framework build
+       identity hashes each compile reference's REFERENCE-ASSEMBLY content (the
+       _MeshWeaverWriteSurfaceManifest target below reads @(ReferencePathWithRefAssemblies)) — so
+       a publish without ref assemblies would fall back to hashing implementation assemblies,
+       fork the image's identity away from the Build-and-Test bake's, and silently decline every
+       CI-baked NodeType bundle at boot. Do not re-add the disable. The per-leg isolation above
+       still prevents the collisions; the only cost of keeping them on is the ref-asm emit time. -->
   <!-- 🚨 A container leg that pushed NOTHING must fail HERE, not two tasks later as "invalid metadata".
        The SDK's CreateNewImage task is written to swallow cancellation:
 
@@ -284,15 +287,14 @@
        and the About page falls back to the version string.
 
        🚨 Under CIRun the SAME resolved SHA is ALSO stamped as
-       AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>") — THE framework build identity
-       (issue #1660 WS3). NodeTypeCompilationHelpers.FrameworkVersion reads this attribute off
-       MeshWeaver.Graph and uses it VERBATIM as the ABI-staleness key for every dynamic NodeType
-       (assembly-store filename tag, CompiledFrameworkVersion stamps, the CI bake artifact key,
-       PrebuiltAssemblySeeder's adoption gate). Two CI builds of the same commit therefore share
-       one identity — which is what lets the CI-baked NodeType assemblies seed at portal boot —
-       while ANY code or package-pin change mints a new one (a commit names the entire tree, a
-       strict superset of the old per-build-ticks guarantee's scope; see the InformationalVersion
-       note above). Stamped ONLY for CIRun builds ON GitHub Actions (GITHUB_ACTIONS=true), ON
+       AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>") — the COMMIT identity
+       (issue #1660 WS3). Since the API-surface identity (the _MeshWeaverWriteSurfaceManifest
+       target above; `s<hash>`) this stamp is the FALLBACK staleness key for CI processes without
+       a surface manifest (test hosts) and the DIAGNOSTIC PROVENANCE everywhere — logged beside
+       the surface identity so "which commit built this" is always answerable. Two CI builds of
+       the same commit share it; ANY code or package-pin change mints a new one (a commit names
+       the entire tree; see the InformationalVersion note above). Stamped ONLY for CIRun builds
+       ON GitHub Actions (GITHUB_ACTIONS=true), ON
        PURPOSE: a CI checkout is always CLEAN at the named commit, while a local working tree can
        be DIRTY at it — and AGENTS.md has developers reproduce CI locally with -p:CIRun=true, so
        a CIRun-alone condition would give two different local builds (same commit, different
@@ -301,6 +303,49 @@
        SourceRevisionId is preferred over GITHUB_SHA because it names the CHECKED-OUT commit; on
        a workflow_run-triggered CD job GITHUB_SHA can be the branch tip rather than the commit
        being built, which would fork the identity. -->
+  <!-- 🚨 The API-SURFACE manifest (issue #1660 WS3, "rebuild only when we need to"): entry apps
+       that opt in with <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest> (the portals,
+       mw-plugin-test — the processes that compile or bake dynamic NodeTypes) get a
+       meshweaver-surface.manifest beside their binaries: one `<AssemblyName>=<SHA-256>` line per
+       MeshWeaver.* COMPILE REFERENCE, hashed over the assembly the COMPILER actually saw —
+       @(ReferencePathWithRefAssemblies) substitutes each project reference's REFERENCE ASSEMBLY,
+       which is byte-stable under body-only / private-member edits and changes on any surface
+       change (the compiler's own definition of "the API surface"; for IVT'd assemblies the
+       internal surface counts too, which is correct conservatism). The runtime
+       (FrameworkBuildIdentity.ResolveProcessIdentity) hashes the manifest's canonical subset into
+       the framework build identity `s<hash>` — so a NodeType bake stays valid across
+       internal-only framework merges and is invalidated exactly by breaking changes.
+       Deterministic by construction: ref-assembly bytes are deterministic per source+references
+       (proven: byte-identical across independent from-clean, non-incremental rebuilds), so the
+       Build-and-Test bake host and the main-cd image compute the SAME identity for the same
+       surfaces — which is what lets the CI bake seed at boot without rebaking per commit. -->
+  <Target Name="_MeshWeaverWriteSurfaceManifest"
+          AfterTargets="Build"
+          Condition="'$(MeshWeaverSurfaceManifest)' == 'true'">
+    <ItemGroup>
+      <_MeshWeaverSurfaceRef Include="@(ReferencePathWithRefAssemblies)"
+                             Condition="$([System.String]::new('%(Filename)').StartsWith('MeshWeaver.'))" />
+    </ItemGroup>
+    <GetFileHash Files="@(_MeshWeaverSurfaceRef)" Algorithm="SHA256">
+      <Output TaskParameter="Items" ItemName="_MeshWeaverSurfaceRefHashed" />
+    </GetFileHash>
+    <WriteLinesToFile File="$(TargetDir)meshweaver-surface.manifest"
+                      Lines="@(_MeshWeaverSurfaceRefHashed->'%(Filename)=%(FileHash)')"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+  </Target>
+  <Target Name="_MeshWeaverAddSurfaceManifestToPublish"
+          BeforeTargets="CopyFilesToPublishDirectory"
+          DependsOnTargets="_MeshWeaverWriteSurfaceManifest"
+          Condition="'$(MeshWeaverSurfaceManifest)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(TargetDir)meshweaver-surface.manifest"
+                             Condition="Exists('$(TargetDir)meshweaver-surface.manifest')">
+        <RelativePath>meshweaver-surface.manifest</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
   <Target Name="AddCommitHashMetadata"
           BeforeTargets="CoreGenerateAssemblyInfo"
           DependsOnTargets="InitializeSourceControlInformation"

--- a/deploy/CHANGE-PROPAGATION.md
+++ b/deploy/CHANGE-PROPAGATION.md
@@ -61,27 +61,31 @@ older code would mint a higher `-ci.<n>` and roll installs backwards.
 > `publish-bake` job copies to the portals' storage; the pod-side sweep then adopts it at boot
 > (`ShippedPrebuiltBundles.SeedPublishedRoot`) and compiles only what CI did not bake.
 
-### Every core release still invalidates the compile cache — but CI pre-pays the bake
+### A core release invalidates the compile cache only when the API SURFACE changed
 
-The compile cache keys on the **framework identity** (`NodeTypeCompilationHelpers.FrameworkVersion`).
-Since #1660 WS3 that identity is **the commit** for CI builds (`g<sha>`, stamped as
-`AssemblyMetadata("MeshWeaverFrameworkIdentity")` by `Directory.Build.props`; local builds keep
-Graph's MVID). Two consequences, replacing the per-build-ticks scheme this section used to
-describe:
+The compile cache keys on the **framework identity** (`NodeTypeCompilationHelpers.FrameworkVersion`
+/ `FrameworkBuildIdentity`). Since #1660 WS3's refinement that identity is the **API-surface hash**
+(`s<hash>`) for every host that ships a `meshweaver-surface.manifest` — the portals and the CI
+bake host: per compile reference, the SHA-256 of its *reference assembly* (byte-stable under
+body-only and private-member edits; changed by any public/protected — and, for IVT'd assemblies,
+internal — surface change), hashed over the canonical content-surface set, with `MeshWeaver.Graph`
+contributing its full implementation MVID (its code shapes the *generated input* of every NodeType
+compile). Three consequences:
 
-1. **Every core release is still a full invalidation** — a release is a new commit, so the
-   identity changes even when the release touches only, say, `MeshWeaver.Blazor.Portal`. That
-   breadth is deliberate: a NodeType compiles against
-   `AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")` — **every assembly in the image**, not just
-   Graph's dependency closure (`MeshNodeCompilationService.GetDefaultReferences`) — and a commit
-   names the entire tree, so any reference-assembly change flips the identity. (Graph's bare MVID
-   would not: it only covers Graph's own compile inputs.)
-2. **The invalidation no longer implies pod-side Roslyn.** CI compile inputs are
-   commit-deterministic (no run number or timestamp reaches any compiled attribute), so the
-   Build-and-Test bake, the CD-built images, and the booting pods all agree on the identity for a
-   given commit — the pods adopt the CI-baked assemblies instead of recompiling. The bake tax
-   below is still the truth for anything CI did not bake (user-partition NodeTypes, a reuse-green
-   run that skipped the bake job, a deployment without `PreWarm__PrebuiltBundleRoot`).
+1. **An internal-only core release invalidates NOTHING.** Same surfaces ⇒ same identity ⇒ every
+   cached and CI-published build stays valid — pods boot with `pending≈0` and the publish step
+   skips ("rebuild only when we need to"). The commit identity this replaced re-baked the world on
+   every merge (measured: `pending=82` on a routine roll).
+2. **A breaking surface change — or any Graph change — is a full invalidation**, pre-paid by CI:
+   the Build-and-Test bake, the CD-built images, and the booting pods agree on the new identity
+   (reference-assembly bytes are deterministic per source+references), so pods adopt the fresh CI
+   bake instead of recompiling.
+3. **The staleness scope is the CONTENT-facing surface**, not the whole image: the canonical set
+   is the bake gate's own framework closure — content referencing anything outside it cannot pass
+   the gate, so portal-only assemblies (Blazor, Orleans, hosting) are deliberately outside the
+   key. The bake tax below is still the truth for anything CI did not bake (user-partition
+   NodeTypes, a reuse-green run that skipped the bake job, a deployment without
+   `PreWarm__PrebuiltBundleRoot`).
 
 ---
 

--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -309,8 +309,10 @@ published — so its framework-stale kickoff started flipping CURRENT NodeType r
 and rebuilding them for a framework nothing serves. The cause was the per-build
 `+build.<UtcNow.Ticks>` stamp `InformationalVersion` then carried under `CIRun`: every
 `dotnet publish` minted a fresh `MeshWeaver.Graph` MVID. #1660 WS3 removed that stamp and made CI
-builds **commit-deterministic** — the framework identity is now the commit (`g<sha>`), identical
-across every CI build of it — so the Build-and-Test run's bake artifact IS adoptable: `main-cd`'s
+builds deterministic — the framework identity is now the **API-surface hash** (`s<hash>`,
+`FrameworkBuildIdentity`; identical across CI builds AND across internal-only merges, moved only
+by breaking surface changes or Graph changes) — so the Build-and-Test run's bake artifact IS
+adoptable, and usually already published: `main-cd`'s
 `publish-bake` job copies it onto the portals' `/data` share
 (`prebuilt-bundles/<identity>/<source>/`), and each booting pod seeds its own identity's bundles
 (`PreWarm__PrebuiltBundleRoot`) before its sweep.

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -187,7 +187,8 @@ config:
     # this portal's /data share as prebuilt-bundles/<framework-identity>/<source>/*.zip; the pod
     # seeds its OWN identity's directory before the sweep (ShippedPrebuiltBundles.
     # SeedPublishedRoot), so shipped content boots with zero Roslyn. CI builds are
-    # commit-deterministic, so the identity CI baked under equals this image's. Inert while CI
+    # deterministic (API-surface identity), so the identity CI baked under equals this image's —
+    # and survives internal-only merges, so most rolls find the bundles already there. Inert while CI
     # has published nothing (the directory is simply absent and the sweep compiles as before).
     # Producer side: repo variable BAKE_PUBLISH_TARGETS must name this share
     # (.github/scripts/publish-bake-bundles.sh).

--- a/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
+++ b/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
@@ -7,6 +7,9 @@
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
     <RequiresAspNetWebAssets>true</RequiresAspNetWebAssets>
     <UserSecretsId>ca47ca53-2eec-4f25-9c24-1f03b5523cc9</UserSecretsId>
+    <!-- The API-surface manifest (#1660 WS3): the framework build identity resolves from it, so
+         local NodeType caches survive internal-only framework rebuilds (see Directory.Build.props). -->
+    <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -6,6 +6,10 @@
     <PublishProfile>DefaultContainer</PublishProfile>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
     <RequiresAspNetWebAssets>true</RequiresAspNetWebAssets>
+    <!-- The API-surface manifest (#1660 WS3): the portal's framework build identity resolves
+         from it — equal to the CI bake host's for unchanged surfaces, which is what lets the
+         published bake seed at boot across internal-only merges (see Directory.Build.props). -->
+    <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
     <!-- Multi-arch container publish: declare the RID set HERE (project-local), NOT as a global
          `-p:RuntimeIdentifiers=` on the CLI. The container publish (`-t:PublishContainer
          -p:ContainerRuntimeIdentifiers=linux-x64;linux-arm64`) requires RuntimeIdentifiers to be

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -43,25 +43,31 @@ The workflow uploads the directories as **`baked-assemblies-<mvid>`** (Doc + sam
 **`baked-plugins-<mvid>`** (vital plugin modules), and fails RED when a green gate produced no bake
 identity.
 
-## The identity rule: one compile, one MVID
+## The identity rule: adoptable when the SURFACE is unchanged
 
-Adoption is gated by `PrebuiltAssemblySeeder.DeclineReason` on the **MeshWeaver.Graph MVID** — a
-content identity of the compiled framework, not a version string. A bundle is adoptable only by a
-process whose Graph.dll came from the *same compilation* that produced the bundle.
+Adoption is gated by `PrebuiltAssemblySeeder.DeclineReason` on the **framework build identity**
+(`NodeTypeCompilationHelpers.FrameworkVersion` / `FrameworkBuildIdentity` — #1660 WS3). For the
+hosts that matter here — the bake host and the portals, which both ship a
+`meshweaver-surface.manifest` — that identity is the **API-surface hash** `s<hash>`: per compile
+reference, the SHA-256 of its *reference assembly* (the compiler's own definition of the API
+surface — byte-stable under body-only and private-member edits, changed by any surface change),
+hashed over the canonical content-surface set, with the generator-bearing exception
+(`MeshWeaver.Graph`, whose code shapes the *generated input* of every NodeType compile)
+contributing its full implementation MVID.
 
-Within one Build-and-Test run that holds everywhere by construction: the solution builds **once**,
-and every lane — test shards, doc-gate, plugin-gate — reuses that build's binaries. So the artifacts
-are immediately consumable by the run's own lanes.
+Three consequences:
 
-Across builds it does *not* hold today: the CI run number is a compile input
-(`Version` → assembly attributes), so `main-cd`'s image legs — which re-publish from source under
-their own run number — mint a *different* Graph MVID than the test workflow's artifact, and the
-seeder correctly declines the whole set. That is deliberate ABI safety, not a defect; two things
-follow from it:
+- **a bundle is adoptable across CI runs, images, and internal-only merges** — the bake for
+  commit X seeds at boot on the image of commit Y whenever nothing in the content-facing surface
+  changed between them ("rebuild only when we need to");
+- **a breaking surface change (or any Graph change) mints a new identity** — every cached and
+  published build for the old surface is stale, and the next Build-and-Test run bakes fresh;
+- **a declined bundle costs exactly what today costs — a compile.** Shipping bundles is strictly
+  safe; declines are logged with both identities.
 
-- until framework-identity determinism lands (#1660 workstream 3), an image can only ship bundles
-  **baked in its own publish job**, with the same version inputs;
-- a declined bundle costs exactly what today costs — a compile. Shipping bundles is strictly safe.
+Manifest-less CI processes (test hosts) fall back to the commit identity `g<sha>` stamped by
+`Directory.Build.props`; local builds fall back to the Graph MVID. The commit stamp doubles as
+provenance everywhere.
 
 ## The image: `prebuilt/` beside the app
 
@@ -94,15 +100,23 @@ logged and skipped, and the sweep compiles that type as it always has. Nothing c
 from this path — the bake gate keeps probing the store, which only ever holds what was actually
 adopted.
 
+## The delivery: main-cd publishes, boot seeds
+
+Since #1660 WS3, `main-cd`'s **`publish-bake`** job downloads the Build-and-Test run's
+`baked-assemblies-*` artifact for the promoted commit and copies the bundles to the portals'
+shared storage (`.github/scripts/publish-bake-bundles.sh`), laid out
+`prebuilt-bundles/<identity>/<source>/<bundle>.zip`. Each booting pod seeds ONLY its own
+identity's directory (`ShippedPrebuiltBundles.SeedPublishedRoot`, config
+`PreWarm:PrebuiltBundleRoot`) before its sweep. "Rebuild only when we need to" applies to the
+publish too: when the identity's directory already holds the bundles — an internal-only merge
+resolves the same surface identity as its predecessor — the script skips with a notice instead of
+re-uploading. See [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
+for the job's preflight discipline and the dependent-repo dispatch.
+
 ## What this step does not do yet
 
-- **`main-cd` does not consume or produce bundles yet.** The image legs recompile from source, so
-  the test workflow's artifact is not adoptable there (identity rule above). The next increment is
-  either baking inside the portal-image leg (same job, same MVID) or — after workstream 3 — the
-  thin containerize step that consumes the compile stage's publish + bake artifacts directly.
-- **DB-resident types** (user/partition content CI cannot see) stay on the runtime bake; that is
-  workstream 2's pre-roll bake Job.
-- Test lanes do not consume the artifact yet — it is named stably (`baked-assemblies-<mvid>`)
+- **DB-resident types** (user/partition content CI cannot see) stay on the runtime bake.
+- Test lanes do not consume the artifact yet — it is named stably (`baked-assemblies-<identity>`)
   precisely so they can start.
 
 See also: [Plugin Packaging](/Doc/Architecture/PluginPackaging) (the compilation-unit rules and the

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -105,12 +105,14 @@ adopted.
 Since #1660 WS3, `main-cd`'s **`publish-bake`** job downloads the Build-and-Test run's
 `baked-assemblies-*` artifact for the promoted commit and copies the bundles to the portals'
 shared storage (`.github/scripts/publish-bake-bundles.sh`), laid out
-`prebuilt-bundles/<identity>/<source>/<bundle>.zip`. Each booting pod seeds ONLY its own
-identity's directory (`ShippedPrebuiltBundles.SeedPublishedRoot`, config
-`PreWarm:PrebuiltBundleRoot`) before its sweep. "Rebuild only when we need to" applies to the
-publish too: when the identity's directory already holds the bundles — an internal-only merge
-resolves the same surface identity as its predecessor — the script skips with a notice instead of
-re-uploading. See [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
+`prebuilt-bundles/<identity>/<source>/<bundle>.zip`, sealed by a `_complete` sentinel written
+strictly LAST. Each booting pod seeds ONLY its own identity's SEALED source directories
+(`ShippedPrebuiltBundles.SeedPublishedRoot`, config `PreWarm:PrebuiltBundleRoot`) before its
+sweep — an unsealed or torn publication (a publish that died mid-way) is refused loudly and the
+sweep compiles instead. "Rebuild only when we need to" applies to the publish too: when the
+identity's directory is already sealed — an internal-only merge resolves the same surface
+identity as its predecessor — the script skips with a notice instead of re-uploading. See
+[The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
 for the job's preflight discipline and the dependent-repo dispatch.
 
 ## What this step does not do yet

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -186,9 +186,12 @@ Two post-promote legs ride every armed release (#1660 WS3):
 `baked-assemblies-<framework-identity>` artifact its doc-gate produced with
 `mw-plugin-test --bake-output`) onto the portals' shared storage, laid out
 `prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip`
-(`.github/scripts/publish-bake-bundles.sh`). CI builds are **commit-deterministic**, so the
-identity the bake was keyed under equals the identity of the images promote just armed — each
-booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
+(`.github/scripts/publish-bake-bundles.sh`). The framework identity is the **API-surface hash**
+(`FrameworkBuildIdentity` — reference-assembly hashes, deterministic per source+references), so
+the identity the bake was keyed under equals the identity of the images promote just armed — and
+stays equal across internal-only merges: when the identity's directory already holds the bundles,
+the script **skips with a notice** instead of re-uploading ("rebuild only when we need to").
+Each booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
 `ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
 did not bake. Its configuration is **preflighted red, never skipped**: repo variable
 `BAKE_PUBLISH_TARGETS` names the Azure Files targets (`<account>/<share>[/<base-path>]`,
@@ -198,7 +201,8 @@ would silently restore the every-pod-rebakes-everything regression (#1347). A mi
 nothing to publish.
 
 **`notify-dependents`** sends one `repository_dispatch` (`meshweaver-framework-released`, payload:
-commit, identity, version) to each repo in `BAKE_SUBSCRIBER_REPOS`, using
+commit, version — receivers resolve the framework identity themselves from the new image) to each
+repo in `BAKE_SUBSCRIBER_REPOS`, using
 `DEPENDENT_DISPATCH_TOKEN`. A node repo subscribes with
 
 ```yaml

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -189,8 +189,11 @@ Two post-promote legs ride every armed release (#1660 WS3):
 (`.github/scripts/publish-bake-bundles.sh`). The framework identity is the **API-surface hash**
 (`FrameworkBuildIdentity` — reference-assembly hashes, deterministic per source+references), so
 the identity the bake was keyed under equals the identity of the images promote just armed — and
-stays equal across internal-only merges: when the identity's directory already holds the bundles,
-the script **skips with a notice** instead of re-uploading ("rebuild only when we need to").
+stays equal across internal-only merges: when the identity's directory is already **sealed** (the
+`_complete` sentinel the publisher writes strictly LAST, after every bundle), the script skips
+with a notice instead of re-uploading ("rebuild only when we need to"). A publish that died
+mid-way leaves no sentinel — the next run re-publishes wholesale, and the portal reader refuses
+unsealed or torn directories, so a partial publication can neither freeze nor be seeded.
 Each booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
 `ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
 did not bake. Its configuration is **preflighted red, never skipped**: repo variable

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -369,16 +369,22 @@ only usable while the framework version matches.
 resolved once per process (`FrameworkBuildIdentity`,
 [#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3):
 
-- **CI builds** — the **commit identity** `g<sha>`, stamped into every assembly as
-  `AssemblyMetadata("MeshWeaverFrameworkIdentity")` by `Directory.Build.props`.
-  CI compile inputs are commit-deterministic (no run number or timestamp reaches
-  any compiled attribute), so every CI build of the same commit — the
-  Build-and-Test run that bakes NodeType assemblies and the main-cd run that
-  builds the image — shares one identity; that is what lets the CI bake seed at
-  portal boot instead of recompiling. Any code or package-pin change is a new
-  commit and therefore a new identity — a commit names the whole tree, covering
-  the full TPA reference set a NodeType compiles against, not just Graph's own
-  dependency closure.
+- **Hosts with a surface manifest** (the portals and the CI bake host, which
+  build with `MeshWeaverSurfaceManifest=true`) — the **API-surface identity**
+  `s<hash>`: per compile reference, the SHA-256 of its *reference assembly*
+  (the compiler's own definition of the API surface — byte-stable under
+  body-only and private-member edits, changed by any surface change), hashed
+  over the canonical content-surface set, with `MeshWeaver.Graph` contributing
+  its full implementation MVID because its code shapes the *generated input*
+  of every NodeType compile. "Rebuild only when we need to": an internal-only
+  framework release keeps the identity, so every cached and CI-published build
+  stays valid; a breaking surface change mints a new one, and the CI bake for
+  the new surface seeds at boot instead of recompiling per pod.
+- **Manifest-less CI processes** (test hosts) — the **commit identity** `g<sha>`
+  stamped as `AssemblyMetadata("MeshWeaverFrameworkIdentity")` by
+  `Directory.Build.props` (CI compile inputs are commit-deterministic — no run
+  number or timestamp reaches any compiled attribute). Kept everywhere as
+  logged PROVENANCE.
 - **Local builds** — the `MeshWeaver.Graph` assembly's **MVID** (a content hash
   of the compiled module; no stamp is present). Content-exact for a dirty
   working tree — stable across rebuilds that don't change Graph's bytes,

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -94,19 +94,21 @@ environment, is narrower, and reintroduces the `CS0616` above.
 
 `HasUsableBuild` skips a compile only when `CompiledFrameworkVersion` equals the live
 `NodeTypeCompilationHelpers.FrameworkVersion` — never a semver. Since
-[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 that value has two shapes, one
-resolution (`FrameworkBuildIdentity`): for a **CI-built framework** it is the **commit identity**
-`g<sha>` (stamped as `AssemblyMetadata("MeshWeaverFrameworkIdentity")`; CI builds are
-commit-deterministic, so every CI build of a commit shares it — including the separate workflow
-runs that bake content and build the image); for a **local build** it is the **Module Version Id
-of the MeshWeaver.Graph assembly** — a content identity.
+[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 that value has three shapes, one
+resolution (`FrameworkBuildIdentity`): hosts shipping a `meshweaver-surface.manifest` — the
+portals and the CI bake host — resolve the **API-surface identity** `s<hash>` (reference-assembly
+hashes over the canonical content-surface set, full impl MVID for the generator-bearing
+`MeshWeaver.Graph`; stable across internal-only merges, moved by breaking changes); manifest-less
+CI processes resolve the **commit identity** `g<sha>` (stamped as
+`AssemblyMetadata("MeshWeaverFrameworkIdentity")`, also everyone's logged provenance); a **local
+build** resolves the **Module Version Id of the MeshWeaver.Graph assembly** — a content identity.
 
-Neither is derived from `AssemblyInformationalVersion`, on purpose. Deriving identity from the
+None is derived from `AssemblyInformationalVersion`, on purpose. Deriving identity from the
 version string once forced `Directory.Build.props` to stamp a fresh version into every build,
 which regenerated `AssemblyInfo` every time and destroyed incremental compilation. The identity
 decouples the two: the version string serves packages and image tags while ABI invalidation stays
-correct — and a commit-scoped CI identity recompiles *less* than the per-build scheme did (two
-builds of one commit now agree), never more.
+correct — and the surface identity recompiles strictly *less* than every scheme before it (only
+breaking changes move it), never more than is safe.
 
 Three things follow.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -83,10 +83,13 @@ The `PublicRelease` flag picks the channel (think **CI** vs **CD**):
   `MESHWEAVER_PLATFORM_VERSION` environment variable (image config, not bytes).
 - **`InformationalVersion`** is `$(PlatformVersion)` under `CIRun=true` (the SDK
   appends `+<commit-sha>`); locally it equals `$(Version)`. NodeType ABI identity is
-  `NodeTypeCompilationHelpers.FrameworkVersion`: for CI builds the **stamped commit
-  identity** (`g<sha>`, `AssemblyMetadata("MeshWeaverFrameworkIdentity")`), locally
-  the **`MeshWeaver.Graph` assembly's MVID** (a content hash of the compiled module,
-  stable across rebuilds that don't change Graph's bytes).
+  `NodeTypeCompilationHelpers.FrameworkVersion` (`FrameworkBuildIdentity`): hosts that
+  ship a `meshweaver-surface.manifest` (portals, the CI bake host) resolve the
+  **API-surface hash** (`s<hash>` — stable across internal-only changes, moved by
+  breaking surface changes and by any `MeshWeaver.Graph` change); manifest-less CI
+  processes fall back to the **stamped commit identity** (`g<sha>`,
+  `AssemblyMetadata("MeshWeaverFrameworkIdentity")`, kept as provenance everywhere);
+  local builds fall back to the **Graph MVID**.
 - **`-p:Version=…`** still overrides everything (escape hatch) — and it is what the
   tag-driven release workflows actually pass.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-rebuild-only-on-breaking-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-16-rebuild-only-on-breaking-change.md
@@ -1,0 +1,18 @@
+---
+Name: Updates recompile content only when the API actually changed
+Category: Feature
+Description: The platform now keys compiled content to the framework's API surface, so routine internal updates keep every compiled node type warm instead of rebuilding them all.
+Icon: Sparkle
+Order: -20260816
+---
+
+# Updates recompile content only when the API actually changed
+
+Until now, every platform update invalidated all compiled dynamic content — even an internal-only
+fix that changed no API — so each roll re-did work whose inputs had not changed. Compiled content
+is now keyed to the framework's API surface: an update that does not change what content compiles
+against keeps every existing build valid, on the server and in the published CI bake alike.
+
+What you notice: most platform updates now roll through with content staying warm end to end —
+no re-compilation wave, no cold first visit after a routine update. When an update genuinely
+changes the API, content is rebuilt once on CI and reused everywhere, as before.

--- a/src/MeshWeaver.Graph/Configuration/AssemblyCacheRetention.cs
+++ b/src/MeshWeaver.Graph/Configuration/AssemblyCacheRetention.cs
@@ -237,14 +237,15 @@ public static class AssemblyCacheGenerations
             : null;
     }
 
-    // The two tag shapes the store has ever written (FrameworkVersion[..8], see
+    // The three tag shapes the store has ever written (FrameworkVersion[..8], see
     // FileSystemAssemblyStore.FrameworkTag): 8 hex chars for an MVID identity (local builds, and
-    // every build before #1660 WS3), or 'g' + 7 hex chars for a commit identity (CI builds since
-    // #1660 WS3 — FrameworkVersion is g<sha> there). Anything else stays unattributed and
-    // therefore undeletable.
+    // every build before #1660 WS3), 'g' + 7 hex chars for a commit identity (manifest-less CI
+    // processes since #1660 WS3), or 's' + 7 hex chars for the API-surface identity (hosts that
+    // ship a surface manifest — the portals and the bake host). Anything else stays unattributed
+    // and therefore undeletable.
     private static bool IsGenerationTag(string s) =>
         s.Length == FrameworkTagLength
-        && (IsHex(s) || ((s[0] == 'g' || s[0] == 'G') && IsHex(s[1..])));
+        && (IsHex(s) || ((s[0] is 'g' or 'G' or 's' or 'S') && IsHex(s[1..])));
 
     private static bool IsHex(string s) =>
         s.Length > 0 && s.All(c => c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F');

--- a/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
@@ -1,4 +1,8 @@
+using System.Collections.Immutable;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -10,39 +14,185 @@ namespace MeshWeaver.Graph.Configuration;
 /// flows from. One identity, one resolution — a producer and a consumer can never disagree about
 /// what "the framework" is.
 ///
-/// <para><b>Two schemes, discriminated by how the build was made:</b></para>
-/// <list type="bullet">
-/// <item><description><b>CI builds (CIRun)</b> carry
-/// <c>AssemblyMetadata("MeshWeaverFrameworkIdentity", "g&lt;commit-sha&gt;")</c>, stamped by the
-/// <c>AddCommitHashMetadata</c> target in <c>Directory.Build.props</c>. The identity is the COMMIT:
-/// CI compile inputs are commit-deterministic (no per-build ticks or run numbers reach any compiled
-/// attribute), so two CI builds of the same commit — the Build-and-Test run that bakes NodeType
-/// assemblies and the main-cd run that builds the image — share the identity, and the baked
-/// assemblies seed at portal boot instead of recompiling. Any code or package-pin change is a new
-/// commit and therefore a new identity: a commit names the ENTIRE tree, so this covers the WHOLE
-/// NodeType compile reference set (the TPA — <c>MeshNodeCompilationService.GetDefaultReferences</c>),
-/// not just Graph's own dependency closure — the widening the old per-build-ticks scheme's 🚨
-/// comment demanded before that stamp could be removed.</description></item>
-/// <item><description><b>Local builds</b> carry no stamp and resolve to MeshWeaver.Graph's MVID —
-/// a content identity that is exact for a dirty working tree (a commit identity would
-/// under-invalidate there: two different local builds can sit on the same commit) and stable
-/// across incremental rebuilds that don't change Graph's bytes.</description></item>
+/// <para><b>Three schemes, in resolution order:</b></para>
+/// <list type="number">
+/// <item><description><b>The API-SURFACE identity (<c>s&lt;hash&gt;</c>)</b> — the default for
+/// every host that ships a <c>meshweaver-surface.manifest</c> (the portals and the CI bake host;
+/// written at build time by the <c>_MeshWeaverWriteSurfaceManifest</c> target in
+/// <c>Directory.Build.props</c>, opt-in via <c>$(MeshWeaverSurfaceManifest)</c>). "Rebuild only
+/// when we need to": a NodeType's bytes go stale only when the API SURFACE they compiled against
+/// changed — a breaking change — not on internal-only framework commits. The manifest records,
+/// per compile reference, the SHA-256 of its REFERENCE ASSEMBLY (the compiler's own definition of
+/// an assembly's surface: byte-stable under body-only and private-member edits, changed by any
+/// public/protected — and, for IVT'd assemblies, internal — surface change; proven empirically,
+/// see the test + the props target comment). The identity hashes the sorted
+/// <c>(name, surface-id)</c> pairs of the CANONICAL content-surface set
+/// (<see cref="ContentSurfaceAssemblies"/>), with the generator-bearing exceptions
+/// (<see cref="FullMvidAssemblies"/>) contributing their FULL implementation MVID instead — their
+/// code shapes the GENERATED INPUT of every NodeType compile, so a body-only change there changes
+/// what gets compiled without any API change.</description></item>
+/// <item><description><b>The commit identity (<c>g&lt;sha&gt;</c>)</b> — the
+/// <c>AssemblyMetadata("MeshWeaverFrameworkIdentity")</c> stamp CI bakes into every assembly
+/// (clean checkout at a named commit). The fallback for CI-built processes WITHOUT a surface
+/// manifest (test hosts on CI), and retained everywhere as DIAGNOSTIC PROVENANCE — logged beside
+/// the surface identity so an operator can always answer "which commit built this".</description></item>
+/// <item><description><b>The Graph MVID</b> — local builds with neither: a content identity,
+/// exact for a dirty working tree.</description></item>
 /// </list>
+///
+/// <para><b>Why a canonical LIST and not the ambient TPA:</b> the bake host (mw-plugin-test) and
+/// the portal are different apps with different closures (the portal adds Blazor/Orleans/hosting
+/// assemblies the tester never loads — 26 of them as of 2026-08), so any host-derived set would
+/// give the two DIFFERENT identities and every bake would decline. The list is the tester's
+/// framework closure minus its host assemblies — exactly the surface shipped content can compile
+/// against, enforced by the CI gate itself (content referencing anything outside it fails the
+/// bake gate). Portal-only assemblies are deliberately outside the staleness key: shipped content
+/// provably does not reference them, and the gate keeps it that way.</para>
 /// </summary>
 public static class FrameworkBuildIdentity
 {
     /// <summary>
-    /// The <see cref="AssemblyMetadataAttribute"/> key carrying the CI build identity — stamped
+    /// The <see cref="AssemblyMetadataAttribute"/> key carrying the CI commit identity — stamped
     /// into every assembly by <c>Directory.Build.props</c> (target <c>AddCommitHashMetadata</c>)
-    /// when <c>CIRun=true</c> and a commit SHA is resolvable. The value shape is
-    /// <c>g&lt;full-commit-sha&gt;</c>.
+    /// when <c>CIRun=true</c> on GitHub Actions. The value shape is <c>g&lt;full-commit-sha&gt;</c>.
+    /// Since the surface identity landed this is the FALLBACK key (manifest-less CI processes) and
+    /// the provenance everyone logs.
     /// </summary>
     public const string MetadataKey = "MeshWeaverFrameworkIdentity";
 
     /// <summary>
-    /// The pure resolution rule, unit-testable without controlling how the test assembly was
-    /// built: a non-blank stamped identity wins; otherwise the caller's content identity
-    /// (the Graph MVID) applies.
+    /// The surface manifest's file name, resolved beside the entry assembly
+    /// (<see cref="AppContext.BaseDirectory"/>). One line per compile reference:
+    /// <c>&lt;AssemblySimpleName&gt;=&lt;SHA-256 of its reference assembly&gt;</c>.
+    /// </summary>
+    public const string SurfaceManifestFileName = "meshweaver-surface.manifest";
+
+    /// <summary>
+    /// 🚨 The CANONICAL content-surface assembly set — the ONE list both the CI bake host and
+    /// every portal hash over, ordinal-sorted. It is the transitive MeshWeaver.* closure of
+    /// <c>tools/MeshWeaver.PluginTester</c> (the content gate — the process that PROVES shipped
+    /// content compiles) minus the tester's two host assemblies (<c>MeshWeaver.PluginTester</c>,
+    /// <c>MeshWeaver.Hosting.Monolith</c>). Content that references anything outside this set
+    /// cannot pass the gate, so nothing outside it can be part of shipped content's compile
+    /// surface. <c>FrameworkBuildIdentityTest.CanonicalList_MatchesTheTesterClosure</c> recomputes
+    /// the closure from the csproj graph and fails naming the drift when the tester's references
+    /// change without this list following.
+    /// </summary>
+    public static readonly ImmutableArray<string> ContentSurfaceAssemblies =
+    [
+        "MeshWeaver.AI",
+        "MeshWeaver.Application.Styles",
+        "MeshWeaver.Approvals",
+        "MeshWeaver.ContentCollections",
+        "MeshWeaver.ContentCollections.Indexing",
+        "MeshWeaver.ContentCollections.Indexing.Graph",
+        "MeshWeaver.Data",
+        "MeshWeaver.Data.Contract",
+        "MeshWeaver.DataSetReader",
+        "MeshWeaver.DataSetReader.Csv",
+        "MeshWeaver.DataSetReader.Excel",
+        "MeshWeaver.DataSetReader.Excel.BinaryFormat",
+        "MeshWeaver.DataSetReader.Excel.OpenXmlFormat",
+        "MeshWeaver.DataSetReader.Excel.Utils",
+        "MeshWeaver.DataStructures",
+        "MeshWeaver.Domain",
+        "MeshWeaver.GitSync",
+        "MeshWeaver.Graph",
+        "MeshWeaver.Hosting",
+        "MeshWeaver.Import",
+        "MeshWeaver.Kernel",
+        "MeshWeaver.Kernel.Hub",
+        "MeshWeaver.Layout",
+        "MeshWeaver.Maps",
+        "MeshWeaver.Markdown",
+        "MeshWeaver.Markdown.Collaboration",
+        "MeshWeaver.Mesh.Contract",
+        "MeshWeaver.Messaging.Contract",
+        "MeshWeaver.Messaging.Hub",
+        "MeshWeaver.NuGet",
+        "MeshWeaver.Plugin.Packaging",
+        "MeshWeaver.PluginCatalog",
+        "MeshWeaver.Reflection",
+        "MeshWeaver.ServiceProvider",
+        "MeshWeaver.ShortGuid",
+        "MeshWeaver.Utils",
+    ];
+
+    /// <summary>
+    /// 🚨 Assemblies whose FULL implementation MVID joins the surface hash instead of their
+    /// reference-assembly hash, because their CODE contributes to the GENERATED INPUT of a
+    /// NodeType compile — a body-only change there alters what Roslyn is fed without any API
+    /// change, so the surface hash alone would under-invalidate. Each entry names why:
+    /// <list type="bullet">
+    /// <item><description><c>MeshWeaver.Graph</c> — carries the NodeType compile pipeline's
+    /// emitters and source shaping: <c>DynamicMeshNodeAttributeGenerator</c> (the generated
+    /// attribute/skeleton source injected into every dynamic NodeType compilation),
+    /// <c>MeshNodeCompilationService</c> (source aggregation, <c>@@</c> include resolution and
+    /// rebasing, <c>#r</c>/NuGet directive handling), and <c>CodeQueryResolver</c> (which source
+    /// files a compile consumes). Swept 2026-08-16: the other generator in the repo
+    /// (<c>SkeletonGenerator</c> in MeshWeaver.Plugin.Build) is plugin BUILD tooling — not loaded
+    /// by the portal's compile path and not in the canonical set.</description></item>
+    /// </list>
+    /// </summary>
+    public static readonly ImmutableArray<string> FullMvidAssemblies = ["MeshWeaver.Graph"];
+
+    /// <summary>Marker recorded for a canonical assembly absent from the manifest/process — the
+    /// absence itself is part of the identity (two hosts with different presence sets must never
+    /// share one).</summary>
+    public const string AbsentMarker = "absent";
+
+    /// <summary>
+    /// The pure surface-identity computation — unit-testable without controlling how this test
+    /// host was built. Hashes, ordinal-sorted over <see cref="ContentSurfaceAssemblies"/>, one
+    /// <c>name=id</c> line per entry where <c>id</c> is the implementation MVID for
+    /// <see cref="FullMvidAssemblies"/> members, the manifest's reference-assembly hash otherwise,
+    /// and <see cref="AbsentMarker"/> when neither resolves.
+    /// </summary>
+    /// <param name="surfaceByName">Manifest pairs: assembly simple name → reference-assembly
+    /// hash.</param>
+    /// <param name="implMvidOf">Resolves an assembly's implementation MVID ("N" format), or null
+    /// when the assembly is not present in this process.</param>
+    public static string ComputeSurfaceIdentity(
+        IReadOnlyDictionary<string, string> surfaceByName,
+        Func<string, string?> implMvidOf)
+    {
+        var text = new StringBuilder();
+        foreach (var name in ContentSurfaceAssemblies)
+        {
+            string id;
+            if (FullMvidAssemblies.Contains(name))
+                id = implMvidOf(name)
+                     ?? (surfaceByName.TryGetValue(name, out var surface) ? surface : AbsentMarker);
+            else
+                id = surfaceByName.TryGetValue(name, out var s) ? s : AbsentMarker;
+            text.Append(name).Append('=').Append(id).Append('\n');
+        }
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(text.ToString()));
+        return "s" + Convert.ToHexStringLower(hash)[..32];
+    }
+
+    /// <summary>
+    /// Parses a surface manifest's text (<c>name=hash</c> lines; blank lines and malformed lines
+    /// are ignored — an unreadable line degrades that assembly to <see cref="AbsentMarker"/> or
+    /// the MVID fallback rather than faulting identity resolution).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ParseSurfaceManifest(string manifestText)
+    {
+        var pairs = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in manifestText.Split('\n'))
+        {
+            var line = raw.Trim();
+            var eq = line.IndexOf('=');
+            if (eq <= 0 || eq == line.Length - 1)
+                continue;
+            pairs[line[..eq]] = line[(eq + 1)..];
+        }
+        return pairs;
+    }
+
+    /// <summary>
+    /// The pure resolution rule for the FALLBACK layer (no surface manifest): a non-blank stamped
+    /// commit identity wins; otherwise the caller's content identity (the Graph MVID) applies.
     /// </summary>
     /// <param name="stamped">The <see cref="MetadataKey"/> attribute value, or null when the
     /// assembly carries none (every local build).</param>
@@ -53,7 +203,9 @@ public static class FrameworkBuildIdentity
     /// <summary>
     /// Reads the stamped <see cref="MetadataKey"/> value off a LOADED assembly, or null when the
     /// assembly carries none. (For reading the same stamp off an assembly FILE without loading it,
-    /// see <c>MeshWeaver.Plugin.Build.FrameworkIdentity.ReadIdentity</c>.)
+    /// see <c>MeshWeaver.Plugin.Build.FrameworkIdentity.ReadIdentity</c>.) Since the surface
+    /// identity landed this is the PROVENANCE reading — log it, never key on it when a manifest
+    /// is present.
     /// </summary>
     public static string? StampedIdentityOf(Assembly assembly) =>
         assembly
@@ -62,4 +214,56 @@ public static class FrameworkBuildIdentity
             ?.Value is { Length: > 0 } value
             ? value
             : null;
+
+    /// <summary>
+    /// The full resolution the process identity uses, in order: surface manifest beside the app
+    /// (<c>s&lt;hash&gt;</c>) → stamped commit identity (<c>g&lt;sha&gt;</c>) → Graph MVID.
+    /// Wrapped here (not in the Lazy at the call site) so the whole chain is one testable seam.
+    /// </summary>
+    /// <param name="baseDirectory">Where to look for <see cref="SurfaceManifestFileName"/> —
+    /// the app base directory in production.</param>
+    /// <param name="graphAssembly">The MeshWeaver.Graph assembly (identity anchor).</param>
+    public static string ResolveProcessIdentity(string baseDirectory, Assembly graphAssembly)
+    {
+        var manifestPath = Path.Combine(baseDirectory, SurfaceManifestFileName);
+        if (File.Exists(manifestPath))
+        {
+            var pairs = ParseSurfaceManifest(File.ReadAllText(manifestPath));
+            if (pairs.Count > 0)
+                return ComputeSurfaceIdentity(pairs, name => ImplMvidOf(name, graphAssembly));
+        }
+        return Resolve(
+            StampedIdentityOf(graphAssembly),
+            graphAssembly.ManifestModule.ModuleVersionId.ToString("N"));
+    }
+
+    /// <summary>
+    /// An assembly's implementation MVID by simple name: the loaded assembly when present (Graph —
+    /// the only current <see cref="FullMvidAssemblies"/> member — is always loaded, since this
+    /// code IS Graph), else a metadata-only read of the DLL beside the entry assembly, else null.
+    /// </summary>
+    private static string? ImplMvidOf(string simpleName, Assembly graphAssembly)
+    {
+        if (string.Equals(graphAssembly.GetName().Name, simpleName, StringComparison.Ordinal))
+            return graphAssembly.ManifestModule.ModuleVersionId.ToString("N");
+        var loaded = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, simpleName, StringComparison.Ordinal)
+                                 && !a.IsDynamic);
+        if (loaded is not null)
+            return loaded.ManifestModule.ModuleVersionId.ToString("N");
+        var candidate = Path.Combine(AppContext.BaseDirectory, simpleName + ".dll");
+        if (!File.Exists(candidate))
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(candidate);
+            using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
+            var md = pe.GetMetadataReader();
+            return md.GetGuid(md.GetModuleDefinition().Mvid).ToString("N");
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Graph/Configuration/FrameworkBuildIdentity.cs
@@ -218,23 +218,54 @@ public static class FrameworkBuildIdentity
     /// <summary>
     /// The full resolution the process identity uses, in order: surface manifest beside the app
     /// (<c>s&lt;hash&gt;</c>) → stamped commit identity (<c>g&lt;sha&gt;</c>) → Graph MVID.
-    /// Wrapped here (not in the Lazy at the call site) so the whole chain is one testable seam.
+    /// See <see cref="ResolveProcessIdentityWithDiagnostics"/> — this is its identity-only
+    /// convenience reading.
     /// </summary>
     /// <param name="baseDirectory">Where to look for <see cref="SurfaceManifestFileName"/> —
     /// the app base directory in production.</param>
     /// <param name="graphAssembly">The MeshWeaver.Graph assembly (identity anchor).</param>
     public static string ResolveProcessIdentity(string baseDirectory, Assembly graphAssembly)
+        => ResolveProcessIdentityWithDiagnostics(baseDirectory, graphAssembly).Identity;
+
+    /// <summary>
+    /// The full resolution chain as one PURE, testable seam, returning the identity plus the
+    /// degradation warning when the surface-manifest layer could not be used (unreadable/torn
+    /// manifest, no usable pairs) — 🚨 never a throw: this runs on the boot path (the process
+    /// identity Lazy), and a torn file must cost a conservative fallback identity, never the
+    /// process. The caller that caches the identity for the process lifetime caches the warning
+    /// with it (see <c>NodeTypeCompilationHelpers</c>); the pre-warmer logs it beside the
+    /// identity it announces.
+    /// </summary>
+    /// <param name="baseDirectory">Where to look for <see cref="SurfaceManifestFileName"/> —
+    /// the app base directory in production.</param>
+    /// <param name="graphAssembly">The MeshWeaver.Graph assembly (identity anchor).</param>
+    public static (string Identity, string? Warning) ResolveProcessIdentityWithDiagnostics(
+        string baseDirectory, Assembly graphAssembly)
     {
         var manifestPath = Path.Combine(baseDirectory, SurfaceManifestFileName);
-        if (File.Exists(manifestPath))
+        string? warning = null;
+        try
         {
-            var pairs = ParseSurfaceManifest(File.ReadAllText(manifestPath));
-            if (pairs.Count > 0)
-                return ComputeSurfaceIdentity(pairs, name => ImplMvidOf(name, graphAssembly));
+            if (File.Exists(manifestPath))
+            {
+                var pairs = ParseSurfaceManifest(File.ReadAllText(manifestPath));
+                if (pairs.Count > 0)
+                    return (ComputeSurfaceIdentity(pairs, name => ImplMvidOf(name, graphAssembly)), null);
+                warning =
+                    $"surface manifest at {manifestPath} held no usable pairs — "
+                    + "resolved the stamp/MVID fallback identity instead";
+            }
         }
-        return Resolve(
+        catch (Exception ex)
+        {
+            warning =
+                $"surface manifest at {manifestPath} could not be read "
+                + $"({ex.GetType().Name}: {ex.Message}) — resolved the stamp/MVID fallback "
+                + "identity instead";
+        }
+        return (Resolve(
             StampedIdentityOf(graphAssembly),
-            graphAssembly.ManifestModule.ModuleVersionId.ToString("N"));
+            graphAssembly.ManifestModule.ModuleVersionId.ToString("N")), warning);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -993,29 +993,32 @@ internal static class NodeTypeCompilationHelpers
 
     /// <summary>
     /// The live MeshWeaver framework identity a compiled NodeType release is pinned to — see
-    /// <see cref="FrameworkBuildIdentity"/> for the scheme. CI builds resolve the stamped COMMIT
-    /// identity (<c>g&lt;sha&gt;</c> — identical for every CI build of the same commit, which is
-    /// what lets CI-baked assemblies seed at boot, #1660 WS3); local builds resolve the
-    /// <c>MeshWeaver.Graph</c> assembly's MVID (a content hash of the compiled module, exact for
-    /// a dirty working tree). A mismatch against a NodeType's <c>CompiledFrameworkVersion</c>
-    /// means "recompile". Computed once per process.
+    /// <see cref="FrameworkBuildIdentity"/> for the scheme. Hosts that ship a surface manifest
+    /// (the portals, the CI bake host) resolve the API-SURFACE identity (<c>s&lt;hash&gt;</c> —
+    /// stable across internal-only framework changes, so content rebakes ONLY on a breaking
+    /// surface change, #1660 WS3 refinement "rebuild only when we need to"); manifest-less CI
+    /// processes fall back to the stamped COMMIT identity (<c>g&lt;sha&gt;</c>, kept as logged
+    /// provenance everywhere); local builds fall back to the <c>MeshWeaver.Graph</c> assembly's
+    /// MVID (content-exact for a dirty working tree). A mismatch against a NodeType's
+    /// <c>CompiledFrameworkVersion</c> means "recompile". Computed once per process.
     /// </summary>
     internal static string FrameworkVersion => _frameworkVersion.Value;
 
-    // Resolution once per process. The MVID fallback rationale (local builds): the MVID is part
-    // of the compiled module, so it is STABLE whenever the DLL bytes are identical (an
-    // incremental build that skips recompiling Graph, or a deterministic rebuild of unchanged
-    // source) and CHANGES whenever Graph — or any dependency, which forces Graph's recompile —
-    // is rebuilt with different content. Deriving identity from the version STRING (the scheme
-    // before the MVID) forced a fresh stamp into EVERY build and destroyed incremental builds;
-    // appending the DLL's last-write time (the scheme before that) drifted on copies/touches.
-    // The commit identity (CI) supersedes the MVID there because the MVID only covers Graph's
-    // OWN compile inputs, while a NodeType compiles against the WHOLE TPA — a commit covers the
-    // entire tree, so any reference-assembly change still invalidates (see FrameworkBuildIdentity).
+    // Resolution once per process, through the ONE chain (FrameworkBuildIdentity
+    // .ResolveProcessIdentity): surface manifest → commit stamp → Graph MVID. The MVID fallback
+    // rationale (local builds): the MVID is part of the compiled module, so it is STABLE whenever
+    // the DLL bytes are identical and CHANGES whenever Graph is rebuilt with different content.
+    // The surface identity supersedes both where a manifest ships because the commit key
+    // OVER-invalidated (every merge — internal-only included — rebaked all content; measured
+    // pending=82 on the ci.3979 roll) while the Graph MVID alone UNDER-invalidates (it only
+    // covers Graph's own compile inputs, not the content-facing surface of the rest of the
+    // framework). The ref-assembly-based surface hash sits exactly between: it moves when — and
+    // only when — the API surface content compiles against changes (plus the Graph-impl
+    // exception for the compile pipeline's own emitters).
     private static readonly Lazy<string> _frameworkVersion = new(() =>
-        FrameworkBuildIdentity.Resolve(
-            FrameworkBuildIdentity.StampedIdentityOf(typeof(NodeTypeCompilationHelpers).Assembly),
-            typeof(NodeTypeCompilationHelpers).Assembly.ManifestModule.ModuleVersionId.ToString("N")));
+        FrameworkBuildIdentity.ResolveProcessIdentity(
+            AppContext.BaseDirectory,
+            typeof(NodeTypeCompilationHelpers).Assembly));
 
     /// <summary>
     /// True when a NodeType's persisted compile state is backed by a compiled

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1002,10 +1002,15 @@ internal static class NodeTypeCompilationHelpers
     /// MVID (content-exact for a dirty working tree). A mismatch against a NodeType's
     /// <c>CompiledFrameworkVersion</c> means "recompile". Computed once per process.
     /// </summary>
-    internal static string FrameworkVersion => _frameworkVersion.Value;
+    internal static string FrameworkVersion => _frameworkVersion.Value.Identity;
+
+    /// <summary>Degradation warning from the identity resolution (a torn/unusable surface
+    /// manifest fell back to the stamp/MVID layer), or null on the happy path — cached with the
+    /// identity itself so the pre-warmer can log it beside the identity it announces.</summary>
+    internal static string? FrameworkVersionWarning => _frameworkVersion.Value.Warning;
 
     // Resolution once per process, through the ONE chain (FrameworkBuildIdentity
-    // .ResolveProcessIdentity): surface manifest → commit stamp → Graph MVID. The MVID fallback
+    // .ResolveProcessIdentityWithDiagnostics): surface manifest → commit stamp → Graph MVID. The MVID fallback
     // rationale (local builds): the MVID is part of the compiled module, so it is STABLE whenever
     // the DLL bytes are identical and CHANGES whenever Graph is rebuilt with different content.
     // The surface identity supersedes both where a manifest ships because the commit key
@@ -1015,8 +1020,8 @@ internal static class NodeTypeCompilationHelpers
     // framework). The ref-assembly-based surface hash sits exactly between: it moves when — and
     // only when — the API surface content compiles against changes (plus the Graph-impl
     // exception for the compile pipeline's own emitters).
-    private static readonly Lazy<string> _frameworkVersion = new(() =>
-        FrameworkBuildIdentity.ResolveProcessIdentity(
+    private static readonly Lazy<(string Identity, string? Warning)> _frameworkVersion = new(() =>
+        FrameworkBuildIdentity.ResolveProcessIdentityWithDiagnostics(
             AppContext.BaseDirectory,
             typeof(NodeTypeCompilationHelpers).Assembly));
 

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -62,6 +62,15 @@ public static class PrebuiltAssemblySeeder
     public static string LiveFrameworkMvid => NodeTypeCompilationHelpers.FrameworkVersion;
 
     /// <summary>
+    /// Degradation warning from the live identity's resolution (a torn or unusable surface
+    /// manifest fell back to the stamp/MVID layer — see
+    /// <see cref="FrameworkBuildIdentity.ResolveProcessIdentityWithDiagnostics"/>), or null on
+    /// the happy path. Public beside <see cref="LiveFrameworkMvid"/> so the process that
+    /// announces the identity (the pre-warmer) can announce the degradation with it.
+    /// </summary>
+    public static string? LiveFrameworkIdentityWarning => NodeTypeCompilationHelpers.FrameworkVersionWarning;
+
+    /// <summary>
     /// Seeds <paramref name="assemblyBytes"/> as the build for <paramref name="nodeTypePath"/>.
     ///
     /// <para>Cold: the write runs on Subscribe. Emits <c>true</c> when the assembly was adopted and

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -283,7 +283,16 @@ public sealed class DynamicTypePreWarmerHostedService(
         // that from a container gauge. See MemoryDelta.
         var sweepMemory = MemoryDelta.Start();
 
-        logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
+        // Name the identity the whole sweep keys on, WITH its commit provenance (#1660 WS3): the
+        // staleness key is the API-surface hash (stable across internal-only merges), so "which
+        // commit built this process" is no longer derivable from the key — the g<sha> stamp is,
+        // and this is the one line that ties the two together for an operator reading a roll.
+        logger.LogInformation(
+            "DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs "
+            + "(framework identity {FrameworkIdentity}, build {Provenance})",
+            Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid,
+            Graph.Configuration.FrameworkBuildIdentity.StampedIdentityOf(
+                typeof(Graph.Configuration.FrameworkBuildIdentity).Assembly) ?? "(unstamped)");
         // Shipped prebuilt bundles seed BEFORE the sweep decides what to build (#1660 WS1): a
         // NodeType whose CI-baked bytes match this image's framework identity is stamped +
         // uploaded to the assembly store here, so the sweep's store probe reports it AlreadyBaked

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -293,6 +293,14 @@ public sealed class DynamicTypePreWarmerHostedService(
             Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid,
             Graph.Configuration.FrameworkBuildIdentity.StampedIdentityOf(
                 typeof(Graph.Configuration.FrameworkBuildIdentity).Assembly) ?? "(unstamped)");
+        // A degraded identity resolution (torn/unusable surface manifest → stamp/MVID fallback)
+        // is safe — conservative key, everything rebakes under it — but it silently costs the
+        // whole CI-bake benefit, so it must be SAID where the identity is announced.
+        if (Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkIdentityWarning is { } identityWarning)
+            logger.LogWarning(
+                "DynamicTypePreWarmer: framework identity resolution DEGRADED: {Warning} — "
+                + "CI-published bakes will decline against the fallback identity and this pod "
+                + "compiles its content itself", identityWarning);
         // Shipped prebuilt bundles seed BEFORE the sweep decides what to build (#1660 WS1): a
         // NodeType whose CI-baked bytes match this image's framework identity is stamped +
         // uploaded to the assembly store here, so the sweep's store probe reports it AlreadyBaked

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -55,6 +55,17 @@ public static class ShippedPrebuiltBundles
     /// </summary>
     public const string PublishedRootConfigKey = "PreWarm:PrebuiltBundleRoot";
 
+    /// <summary>
+    /// 🚨 The completeness sentinel of a published source directory (must match the
+    /// <c>SENTINEL</c> in <c>.github/scripts/publish-bake-bundles.sh</c>): the publisher writes it
+    /// strictly LAST, after every bundle uploaded, so its presence is the atomic "this publication
+    /// is whole" fact. The reader honours the same contract — a source directory without it (a
+    /// publish that died mid-way) is never seeded: adopting a PARTIAL bake would stamp types as
+    /// built from a set that is missing members, and the pre-warmer would trust it. Its content
+    /// lists the bundle file names, so a listed-but-missing bundle also reads as torn.
+    /// </summary>
+    public const string CompletionSentinelFileName = "_complete";
+
     /// <summary>The conventional location — <c>prebuilt/</c> beside the app binaries, which is
     /// where the publish lays <c>$(PrebuiltBakeDir)</c> bundles into the image.</summary>
     public static string DefaultDirectory => Path.Combine(AppContext.BaseDirectory, "prebuilt");
@@ -81,17 +92,25 @@ public static class ShippedPrebuiltBundles
         => Observable.Defer(() =>
         {
             var dir = string.IsNullOrWhiteSpace(directory) ? DefaultDirectory : directory;
-            return SeedDirectory(mesh, dir, SearchOption.TopDirectoryOnly, logger);
+            return SeedBundles(mesh, dir,
+                () => Directory
+                    .EnumerateFiles(dir, "*.zip", SearchOption.TopDirectoryOnly)
+                    .OrderBy(f => f, StringComparer.Ordinal)
+                    .ToList(),
+                logger);
         });
 
     /// <summary>
     /// Seeds the CI-published bundles for THIS process's framework identity from the configured
     /// published root (<see cref="PublishedRootConfigKey"/>): the pod resolves its own
-    /// <c>FrameworkVersion</c> and seeds <c>&lt;root&gt;/&lt;identity&gt;/**/*.zip</c> — the
-    /// layout CI's publish step writes, one <c>&lt;source&gt;</c> subdirectory per producing repo.
-    /// Emits the number of assemblies adopted; inert (0, debug-logged) when the root is not
-    /// configured, and loud-but-degrading like <see cref="SeedAll"/> everywhere else — a missing
-    /// or partial publication only ever costs what today costs, a compile.
+    /// <c>FrameworkVersion</c> and seeds
+    /// <c>&lt;root&gt;/&lt;identity&gt;/&lt;source&gt;/*.zip</c> — the layout CI's publish step
+    /// writes, one <c>&lt;source&gt;</c> subdirectory per producing repo — honouring the
+    /// completeness contract: only source directories sealed by
+    /// <see cref="CompletionSentinelFileName"/> are read, and only the bundles the sentinel
+    /// LISTS. Emits the number of assemblies adopted; inert (0, debug-logged) when the root is
+    /// not configured, and loud-but-degrading like <see cref="SeedAll"/> everywhere else — a
+    /// missing, torn, or partial publication only ever costs what today costs, a compile.
     /// </summary>
     /// <param name="mesh">The mesh hub (supplies the workspace, the I/O pool and the services).</param>
     /// <param name="publishedRoot">The published bundle root, or null/blank when the deployment
@@ -116,13 +135,58 @@ public static class ShippedPrebuiltBundles
                     "ShippedPrebuiltBundles: no CI-published bundles for framework identity "
                     + "{Identity} under {Root} — the sweep compiles instead",
                     identity, publishedRoot);
-            return SeedDirectory(mesh, dir, SearchOption.AllDirectories, logger);
+            return SeedBundles(mesh, dir, () => CompletePublishedBundlesOf(dir, logger), logger);
         });
 
-    /// <summary>The shared seeding core: every <c>*.zip</c> under <paramref name="dir"/>
-    /// (recursively for the published-root lane), through the one bundle pipeline.</summary>
-    private static IObservable<int> SeedDirectory(
-        IMessageHub mesh, string dir, SearchOption searchOption, ILogger? logger)
+    /// <summary>
+    /// The sentinel-gated bundle set of a published identity directory: for each
+    /// <c>&lt;source&gt;</c> subdirectory, exactly the bundles its
+    /// <see cref="CompletionSentinelFileName"/> lists — an unsealed directory (publish died
+    /// before the sentinel) or a listed-but-missing bundle (torn beyond the seal) skips that
+    /// WHOLE source, loudly, and the sweep compiles instead. Runs inside the seeding pool's
+    /// blocking leg.
+    /// </summary>
+    private static List<string> CompletePublishedBundlesOf(string identityDirectory, ILogger? logger)
+    {
+        var bundles = new List<string>();
+        foreach (var sourceDir in Directory
+                     .EnumerateDirectories(identityDirectory)
+                     .OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var sentinel = Path.Combine(sourceDir, CompletionSentinelFileName);
+            if (!File.Exists(sentinel))
+            {
+                logger?.LogWarning(
+                    "ShippedPrebuiltBundles: {SourceDirectory} carries no {Sentinel} — the "
+                    + "publication is incomplete (it died before the seal); NOT seeding it, the "
+                    + "sweep compiles instead and the next CI publish re-publishes the source",
+                    sourceDir, CompletionSentinelFileName);
+                continue;
+            }
+            var listed = File.ReadAllLines(sentinel)
+                .Select(l => l.Trim())
+                .Where(l => l.Length > 0)
+                .OrderBy(l => l, StringComparer.Ordinal)
+                .Select(name => Path.Combine(sourceDir, name))
+                .ToList();
+            var missing = listed.Where(p => !File.Exists(p)).ToList();
+            if (missing.Count > 0)
+            {
+                logger?.LogWarning(
+                    "ShippedPrebuiltBundles: {SourceDirectory} is sealed but {Missing} listed "
+                    + "bundle(s) are absent (torn publication) — NOT seeding it, the sweep "
+                    + "compiles instead", sourceDir, missing.Count);
+                continue;
+            }
+            bundles.AddRange(listed);
+        }
+        return bundles;
+    }
+
+    /// <summary>The shared seeding core: the bundle files <paramref name="enumerateBundles"/>
+    /// resolves (on the pool's blocking leg), through the one bundle pipeline.</summary>
+    private static IObservable<int> SeedBundles(
+        IMessageHub mesh, string dir, Func<List<string>> enumerateBundles, ILogger? logger)
         => Observable.Defer(() =>
         {
             if (!Directory.Exists(dir))
@@ -148,10 +212,7 @@ public static class ShippedPrebuiltBundles
             return Observable.Using(
                     () => AccessContextScope.AsSystem(accessService),
                     _ => pool
-                        .InvokeBlocking(_ => Directory
-                            .EnumerateFiles(dir, "*.zip", searchOption)
-                            .OrderBy(f => f, StringComparer.Ordinal)
-                            .ToList())
+                        .InvokeBlocking(_ => enumerateBundles())
                         .SelectMany(bundles =>
                         {
                             if (bundles.Count == 0)

--- a/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
@@ -179,6 +179,66 @@ public class FrameworkBuildIdentityTest
     }
 
     [Fact]
+    public void ProcessIdentity_DegradesToTheFallback_WhenTheManifestIsUnreadable()
+    {
+        // A torn/unreadable manifest must cost a conservative fallback identity + a warning —
+        // NEVER a throw: the resolution runs on the boot path (Copilot finding, PR #1696).
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("stages unreadability via unix file modes — POSIX hosts only (CI is linux)");
+            return;
+        }
+        var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+        var dir = Path.Combine(Path.GetTempPath(), "mw-torn-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var manifest = Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName);
+        File.WriteAllText(manifest, "MeshWeaver.Data=abc");
+        try
+        {
+            File.SetUnixFileMode(manifest, UnixFileMode.None);
+            // Root (or a non-POSIX host) can still read it — then this scenario cannot be staged.
+            var unreadable = false;
+            try { File.ReadAllText(manifest); } catch { unreadable = true; }
+            Assert.SkipWhen(!unreadable, "cannot stage an unreadable file on this host");
+
+            var (identity, warning) =
+                FrameworkBuildIdentity.ResolveProcessIdentityWithDiagnostics(dir, graph);
+            identity.Should().Be(FrameworkBuildIdentity.Resolve(
+                    FrameworkBuildIdentity.StampedIdentityOf(graph),
+                    graph.ManifestModule.ModuleVersionId.ToString("N")),
+                "an unreadable manifest degrades to the stamp/MVID layer");
+            warning.Should().NotBeNullOrEmpty("the degradation must be sayable where the identity is announced");
+        }
+        finally
+        {
+            File.SetUnixFileMode(manifest, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProcessIdentity_DegradesToTheFallback_WhenTheManifestHoldsNothingUsable()
+    {
+        var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+        var dir = Path.Combine(Path.GetTempPath(), "mw-empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName),
+                "not-a-pair\n\n");
+            var (identity, warning) =
+                FrameworkBuildIdentity.ResolveProcessIdentityWithDiagnostics(dir, graph);
+            identity.Should().NotStartWith("s");
+            warning.Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ProcessIdentity_FallsBackToStampThenMvid_WithoutAManifest()
     {
         var graph = typeof(NodeTypeCompilationHelpers).Assembly;

--- a/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System.Text.RegularExpressions;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Plugin.Build;
 using Xunit;
@@ -7,43 +8,200 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// Pins the ONE framework build identity (#1660 WS3): the pure resolution rule, and — the pin the
-/// whole CI bake stands on — that every reader (the in-process
-/// <c>NodeTypeCompilationHelpers.FrameworkVersion</c>, the loaded-assembly reading, and
-/// <see cref="FrameworkIdentity.ReadIdentity"/>'s metadata-only PE reading a producer uses on a
-/// restored package) resolves the SAME value for the same Graph assembly. These tests run in both
-/// build flavors on purpose: locally the assembly carries no stamp (identity = MVID), on CI it
-/// carries the commit stamp (identity = g&lt;sha&gt;) — the consistency assertions must hold in
-/// BOTH, which is exactly the property that makes the bake adoptable.
+/// Pins the ONE framework build identity (#1660 WS3): the API-surface scheme ("rebuild only when
+/// we need to" — content rebakes exactly when the surface it compiles against changes), its
+/// fallback chain (commit stamp → Graph MVID), and — the pin the whole CI bake stands on — that
+/// every reader resolves the SAME value for the same inputs. The process-level tests run in both
+/// build flavors on purpose: this test host ships no surface manifest, so it exercises the
+/// fallback chain exactly as a manifest-less CI test process does.
 /// </summary>
 public class FrameworkBuildIdentityTest
 {
-    [Fact]
-    public void Resolve_PrefersTheStampedIdentity()
-    {
-        FrameworkBuildIdentity.Resolve("g" + new string('a', 40), "22825f59aaaaaaaaaaaaaaaaaaaaaaaa")
-            .Should().Be("g" + new string('a', 40),
-                "a CI build's commit identity covers the whole tree — it wins over the MVID");
-    }
+    private static readonly IReadOnlyDictionary<string, string> BaselinePairs =
+        FrameworkBuildIdentity.ContentSurfaceAssemblies
+            .ToDictionary(n => n, n => "hash-of-" + n, StringComparer.Ordinal);
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void Resolve_FallsBackToTheContentIdentity(string? stamped)
-    {
-        FrameworkBuildIdentity.Resolve(stamped, "22825f59aaaaaaaaaaaaaaaaaaaaaaaa")
-            .Should().Be("22825f59aaaaaaaaaaaaaaaaaaaaaaaa",
-                "a local build carries no stamp and keeps the content-exact MVID scheme");
-    }
+    private static string? NoMvid(string _) => null;
+
+    // ---- the surface computation (pure) --------------------------------------------------------
 
     [Fact]
-    public void FrameworkVersion_IsTheResolvedIdentityOfTheGraphAssembly()
+    public void SurfaceIdentity_IsStableForIdenticalInputs()
+    {
+        var a = FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, NoMvid);
+        var b = FrameworkBuildIdentity.ComputeSurfaceIdentity(
+            new Dictionary<string, string>(BaselinePairs, StringComparer.Ordinal), NoMvid);
+        a.Should().Be(b);
+        a.Should().MatchRegex("^s[0-9a-f]{32}$",
+            "the identity shape is 's' + hex — the store tag takes its first 8 chars");
+    }
+
+    [Fact]
+    public void SurfaceIdentity_ChangesWhenAListedAssemblysSurfaceChanges()
+    {
+        var changed = new Dictionary<string, string>(BaselinePairs, StringComparer.Ordinal)
+        {
+            ["MeshWeaver.Layout"] = "a-public-member-was-added",
+        };
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(changed, NoMvid)
+            .Should().NotBe(FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, NoMvid),
+                "a surface change in a content-facing assembly must rebake");
+    }
+
+    [Fact]
+    public void SurfaceIdentity_IgnoresAssembliesOutsideTheCanonicalList()
+    {
+        // The portal's closure carries Blazor/Orleans/host assemblies the bake host never loads —
+        // they are OUTSIDE the content surface, so their presence (or change) must not fork the
+        // identity between the two hosts.
+        var withHostExtras = new Dictionary<string, string>(BaselinePairs, StringComparer.Ordinal)
+        {
+            ["MeshWeaver.Blazor"] = "portal-only",
+            ["MeshWeaver.Hosting.Orleans"] = "portal-only",
+        };
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(withHostExtras, NoMvid)
+            .Should().Be(FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, NoMvid));
+    }
+
+    [Fact]
+    public void SurfaceIdentity_UsesTheFullImplMvidForGeneratorAssemblies()
+    {
+        // MeshWeaver.Graph carries the NodeType compile pipeline's emitters: a BODY-ONLY change
+        // there alters the GENERATED input of every compile without any API change, so its full
+        // implementation MVID — not its reference-assembly hash — joins the identity.
+        string? MvidV1(string name) => name == "MeshWeaver.Graph" ? "impl-mvid-1" : null;
+        string? MvidV2(string name) => name == "MeshWeaver.Graph" ? "impl-mvid-2" : null;
+
+        var v1 = FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, MvidV1);
+        var v2 = FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, MvidV2);
+        v1.Should().NotBe(v2,
+            "an emitter change must rebake even though the surface pairs are identical");
+
+        // …and with the impl MVID pinned, Graph's REF-ASM hash no longer participates: its
+        // surface entry may change without moving the identity (the impl MVID already covers it).
+        var graphSurfaceChanged = new Dictionary<string, string>(BaselinePairs, StringComparer.Ordinal)
+        {
+            ["MeshWeaver.Graph"] = "different-surface",
+        };
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(graphSurfaceChanged, MvidV1)
+            .Should().Be(v1);
+    }
+
+    [Fact]
+    public void SurfaceIdentity_RecordsAbsence()
+    {
+        // A host missing a canonical assembly is a DIFFERENT surface reality — it must never
+        // share an identity with a host that has it.
+        var missing = new Dictionary<string, string>(BaselinePairs, StringComparer.Ordinal);
+        missing.Remove("MeshWeaver.Maps");
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(missing, NoMvid)
+            .Should().NotBe(FrameworkBuildIdentity.ComputeSurfaceIdentity(BaselinePairs, NoMvid));
+    }
+
+    [Fact]
+    public void ManifestParsing_RoundTrips()
+    {
+        var parsed = FrameworkBuildIdentity.ParseSurfaceManifest(
+            "MeshWeaver.Data=ABC123\n\nnot-a-pair\nMeshWeaver.Layout=DEF456\n=orphan\ntrailing=\n");
+        parsed.Should().HaveCount(2);
+        parsed["MeshWeaver.Data"].Should().Be("ABC123");
+        parsed["MeshWeaver.Layout"].Should().Be("DEF456");
+    }
+
+    // ---- the canonical list --------------------------------------------------------------------
+
+    [Fact]
+    public void CanonicalList_IsSortedAndDistinct_AndContainsTheExceptions()
+    {
+        var list = FrameworkBuildIdentity.ContentSurfaceAssemblies.ToList();
+        list.Should().Equal(list.OrderBy(n => n, StringComparer.Ordinal),
+            "the hash text is built in list order — an unsorted list would make it depend on "
+            + "edit history");
+        list.Should().OnlyHaveUniqueItems();
+        foreach (var exception in FrameworkBuildIdentity.FullMvidAssemblies)
+            list.Should().Contain(exception,
+                "a full-MVID exception outside the canonical set would never be hashed at all");
+    }
+
+    [Fact]
+    public void CanonicalList_MatchesTheTesterClosure()
+    {
+        // The list IS the bake host's framework closure minus its two host assemblies — the
+        // surface shipped content can compile against, enforced by the gate itself. This test
+        // recomputes that closure from the csproj graph so the list cannot silently drift when
+        // the tester gains or loses a framework reference.
+        var root = FindRepositoryRoot();
+        Assert.SkipWhen(root is null,
+            "repository tree not reachable from the test bin — closure pin runs in-repo only");
+
+        var closure = ProjectClosure(Path.Combine(
+            root!, "tools", "MeshWeaver.PluginTester", "MeshWeaver.PluginTester.csproj"));
+        var expected = closure
+            .Where(n => n.StartsWith("MeshWeaver.", StringComparison.Ordinal))
+            .Where(n => n is not "MeshWeaver.PluginTester" and not "MeshWeaver.Hosting.Monolith")
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        FrameworkBuildIdentity.ContentSurfaceAssemblies.ToList().Should().Equal(expected,
+            "the canonical content-surface list must follow the bake host's closure — update "
+            + "FrameworkBuildIdentity.ContentSurfaceAssemblies to match");
+    }
+
+    // ---- the process resolution chain ----------------------------------------------------------
+
+    [Fact]
+    public void ProcessIdentity_UsesTheManifestWhenPresent()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-surface-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+            File.WriteAllText(
+                Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName),
+                string.Join('\n', FrameworkBuildIdentity.ContentSurfaceAssemblies.Select(n => $"{n}=stub")));
+
+            var identity = FrameworkBuildIdentity.ResolveProcessIdentity(dir, graph);
+            identity.Should().StartWith("s");
+            // Graph is a full-MVID exception and IS loaded, so its live MVID joins the hash — the
+            // rest resolve their manifest stubs.
+            var expected = FrameworkBuildIdentity.ComputeSurfaceIdentity(
+                FrameworkBuildIdentity.ContentSurfaceAssemblies.ToDictionary(n => n, _ => "stub"),
+                n => n == "MeshWeaver.Graph"
+                    ? graph.ManifestModule.ModuleVersionId.ToString("N")
+                    : LoadedMvidOf(n));
+            identity.Should().Be(expected);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProcessIdentity_FallsBackToStampThenMvid_WithoutAManifest()
     {
         var graph = typeof(NodeTypeCompilationHelpers).Assembly;
-        var expected = FrameworkBuildIdentity.Resolve(
-            FrameworkBuildIdentity.StampedIdentityOf(graph),
-            graph.ManifestModule.ModuleVersionId.ToString("N"));
+        var dir = Path.Combine(Path.GetTempPath(), "mw-nomanifest-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            FrameworkBuildIdentity.ResolveProcessIdentity(dir, graph)
+                .Should().Be(FrameworkBuildIdentity.Resolve(
+                    FrameworkBuildIdentity.StampedIdentityOf(graph),
+                    graph.ManifestModule.ModuleVersionId.ToString("N")));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FrameworkVersion_IsTheProcessIdentityOfTheGraphAssembly()
+    {
+        var graph = typeof(NodeTypeCompilationHelpers).Assembly;
+        var expected = FrameworkBuildIdentity.ResolveProcessIdentity(AppContext.BaseDirectory, graph);
 
         NodeTypeCompilationHelpers.FrameworkVersion.Should().Be(expected,
             "there is exactly one identity resolution; every consumer flows from it");
@@ -52,13 +210,12 @@ public class FrameworkBuildIdentityTest
     }
 
     [Fact]
-    public void PeRead_AgreesWithTheLoadedAssembly()
+    public void PeRead_AgreesWithTheLoadedAssembly_OnTheFallbackLayer()
     {
-        // The producer side (mw-plugin-test's bake, the plugin packer) reads the identity off the
-        // assembly FILE without loading it; the consumer gate reads it off the LOADED assembly.
-        // If these ever disagree, every bake declines wholesale — silently. This assertion holds
-        // in both build flavors: unstamped (both resolve the MVID) and CI-stamped (both resolve
-        // the commit identity).
+        // The PE-level reading (a producer inspecting a restored Graph.dll) covers the FALLBACK
+        // layer — stamp-or-MVID. In this manifest-less test host that IS the live identity, so
+        // the two must agree; in a manifest-shipping host the surface identity supersedes both
+        // and the PE reading serves as provenance only.
         var graph = typeof(NodeTypeCompilationHelpers).Assembly;
         graph.Location.Should().NotBeNullOrEmpty();
 
@@ -72,9 +229,53 @@ public class FrameworkBuildIdentityTest
         // FileSystemAssemblyStore's filename tag is FrameworkVersion[..8]; the retention sweep
         // only ever deletes files whose tag it can attribute (AssemblyCacheGenerations.TagOf).
         // Whatever flavor built this test run, the live tag must round-trip — otherwise every
-        // generation this build writes would be unreclaimable.
+        // generation this build writes would be unreclaimable. The surface shape ('s' + 7 hex)
+        // is pinned explicitly because no local test run produces it live.
         var tag = NodeTypeCompilationHelpers.FrameworkVersion[..8];
         AssemblyCacheGenerations.TagOf($"v7-{tag}-9f4455cd1122.dll")
             .Should().Be(tag.ToLowerInvariant());
+        AssemblyCacheGenerations.TagOf("v7-s22825f5-9f4455cd1122.dll")
+            .Should().Be("s22825f5");
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------
+
+    private static string? LoadedMvidOf(string simpleName) =>
+        AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => !a.IsDynamic
+                && string.Equals(a.GetName().Name, simpleName, StringComparison.Ordinal))
+            ?.ManifestModule.ModuleVersionId.ToString("N");
+
+    private static string? FindRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static HashSet<string> ProjectClosure(string startProject)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+        stack.Push(Path.GetFullPath(startProject));
+        while (stack.Count > 0)
+        {
+            var project = stack.Pop();
+            if (!seen.Add(project) || !File.Exists(project))
+                continue;
+            names.Add(Path.GetFileNameWithoutExtension(project));
+            var directory = Path.GetDirectoryName(project)!;
+            foreach (Match m in Regex.Matches(
+                File.ReadAllText(project), "ProjectReference Include=\"([^\"]+)\""))
+                stack.Push(Path.GetFullPath(
+                    Path.Combine(directory, m.Groups[1].Value.Replace('\\', '/'))));
+        }
+        return names;
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -146,6 +146,7 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
                 Path.Combine(mine, "shipped.zip"),
                 PrebuiltAssemblySeeder.LiveFrameworkMvid,
                 new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 9, 9, 9 })));
+            Seal(mine, "shipped.zip");
 
             // Another commit's publication beside it — same node path, must be invisible.
             var other = Path.Combine(root, "gdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "meshweaver-content");
@@ -154,12 +155,13 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
                 Path.Combine(other, "shipped.zip"),
                 "gdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
                 new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 1 })));
+            Seal(other, "shipped.zip");
 
             var adopted = await ShippedPrebuiltBundles.SeedPublishedRoot(Mesh, root, null)
                 .FirstAsync()
                 .ToTask(TestContext.Current.CancellationToken);
             adopted.Should().Be(1,
-                "the pod seeds its own identity's directory (recursively, one source subdir), "
+                "the pod seeds its own identity's directory (sealed source subdirs only), "
                 + "and never another identity's");
 
             var node = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
@@ -193,6 +195,56 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
             .ToTask(TestContext.Current.CancellationToken);
         adopted.Should().Be(0, "a deployment that does not consume CI bakes seeds nothing");
     }
+
+    [Fact(Timeout = 120_000)]
+    public async Task PublishedRoot_RefusesUnsealedAndTornPublications()
+    {
+        // The completeness contract (Copilot finding, PR #1696): the publisher writes the
+        // _complete sentinel strictly LAST, so a source directory without it is a publish that
+        // died mid-way — seeding it would adopt a PARTIAL bake the pre-warmer then trusts. A
+        // sealed directory whose sentinel lists a bundle that is ABSENT is torn beyond the seal
+        // and equally refused. Both cost exactly what today costs — a compile.
+        var typePath = $"{TestPartition}/TornThing";
+        await CreateNodeType("TornThing");
+
+        var root = CreateBundleDirectory();
+        try
+        {
+            // Unsealed: bundle present, no sentinel.
+            var unsealed = Path.Combine(root, PrebuiltAssemblySeeder.LiveFrameworkMvid, "unsealed-source");
+            Directory.CreateDirectory(unsealed);
+            WriteBundle(
+                Path.Combine(unsealed, "shipped.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 7 })));
+
+            // Torn: sealed, but the sentinel names a bundle that does not exist.
+            var torn = Path.Combine(root, PrebuiltAssemblySeeder.LiveFrameworkMvid, "torn-source");
+            Directory.CreateDirectory(torn);
+            WriteBundle(
+                Path.Combine(torn, "present.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream(new byte[] { 8 })));
+            Seal(torn, "present.zip", "vanished.zip");
+
+            var adopted = await ShippedPrebuiltBundles.SeedPublishedRoot(Mesh, root, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            adopted.Should().Be(0,
+                "neither an unsealed nor a torn publication may seed anything");
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    /// <summary>Writes the completeness sentinel exactly as the publish script does — bundle
+    /// file names, one per line, written after the bundles.</summary>
+    private static void Seal(string sourceDirectory, params string[] bundleNames) =>
+        File.WriteAllLines(
+            Path.Combine(sourceDirectory, ShippedPrebuiltBundles.CompletionSentinelFileName),
+            bundleNames.OrderBy(n => n, StringComparer.Ordinal));
 
     /// <summary>A durable NodeType node nested under the base's test partition — the shape the
     /// static repo import produces for shipped content, created under the platform identity.</summary>

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -6,8 +6,13 @@
     <RootNamespace>MeshWeaver.PluginTester</RootNamespace>
     <IsPackable>false</IsPackable>
     <!-- Multi-arch container publish (same pair as memex-portal-ai / memex-migration);
-         Directory.Build.props' ProduceReferenceAssembly gate handles the RID-leg race. -->
+         Directory.Build.props' per-leg bin/obj isolation handles the RID-leg race (ref
+         assemblies stay ON — the surface manifest below is hashed from them). -->
     <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
+    <!-- The API-surface manifest (#1660 WS3): this is the CI bake host, so its framework build
+         identity MUST resolve the same s<hash> the portals resolve — the manifest beside the
+         binaries is what makes that possible (see Directory.Build.props). -->
+    <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
   </PropertyGroup>
 
   <!-- 🚨 NO ContainerEnvironmentVariable PATH override. The one that used to sit here (added for

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -63,10 +63,25 @@ for (var i = 0; i < args.Length; i++)
             or "--bake-output" or "--source-sha":
             Console.Error.WriteLine($"Option '{args[i]}' requires a value. Try --help.");
             return 2;
+        // Diagnostic: print the framework build identity this process resolves — the exact value
+        // the bake keys bundles to and the seeder gates on (#1660 WS3). One line, `identity=<id>
+        // provenance=<g<sha> | (unstamped)>`, then exit 0. Lets CI steps and operators verify
+        // "would this build's bake be adoptable by that image?" without standing up a mesh, and
+        // is what the surface-identity proof script drives.
+        case "--print-framework-identity":
+        {
+            var provenance = MeshWeaver.Graph.Configuration.FrameworkBuildIdentity
+                .StampedIdentityOf(typeof(MeshWeaver.Graph.Configuration.FrameworkBuildIdentity).Assembly);
+            Console.WriteLine(
+                $"identity={MeshWeaver.Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid} "
+                + $"provenance={provenance ?? "(unstamped)"}");
+            return 0;
+        }
         case "--help" or "-h":
             Console.WriteLine(
                 "usage: mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>] "
-                + "[--allow <file>] [--report <file>] [--bake-output <dir>] [--source-sha <sha>]");
+                + "[--allow <file>] [--report <file>] [--bake-output <dir>] [--source-sha <sha>] "
+                + "[--print-framework-identity]");
             return 0;
         default:
             if (args[i].StartsWith('-') || root is not null)


### PR DESCRIPTION
## #1660 WS3 refinement — rebuild only when we need to: the API-surface identity

Rides on #1687 (commit-deterministic identity). The commit key made the CI bake adoptable but
OVER-invalidated: every platform merge — internal-only included — minted a new identity and
rebaked all content (measured: `pending=82` on the routine ci.3979 roll). Content must rebake only
when the API SURFACE it compiles against changed — a breaking change.

### The identity (one property, new resolution — `FrameworkBuildIdentity`)

1. **API-surface identity `s<hash>`** — hosts that ship a `meshweaver-surface.manifest`
   (portals + the CI bake host, opt-in `<MeshWeaverSurfaceManifest>true</>`): the manifest records,
   per MeshWeaver compile reference, the SHA-256 of its **reference assembly** — the compiler's own
   surface oracle (byte-stable under body-only/private edits; flips on any public/protected — and,
   for IVT'd assemblies, internal — surface change; a hand-rolled API walk would miss the IVT
   subtlety, which is why the ref-asm is the oracle). The identity hashes the sorted
   `(name, surface-id)` pairs of a **canonical content-surface set** — the bake gate's own
   framework closure (36 assemblies; content referencing anything outside it cannot pass the gate),
   which is what makes the hash EQUAL across the bake host and the portals despite their different
   TPAs (the portal carries 26 more MeshWeaver assemblies — Blazor/Orleans/hosting — deliberately
   outside the content-staleness key). 🚨 **Generator exception**: `MeshWeaver.Graph` contributes
   its FULL implementation MVID — its code (DynamicMeshNodeAttributeGenerator, the skeleton/
   aggregation/`@@`-include/NuGet-directive pipeline in MeshNodeCompilationService +
   CodeQueryResolver) shapes the GENERATED INPUT of every NodeType compile, so a body-only change
   there must rebake without any API change. (Swept: the only other generator, SkeletonGenerator,
   lives in MeshWeaver.Plugin.Build — plugin build tooling, not in the portal compile path.)
2. **Commit identity `g<sha>`** — fallback for manifest-less CI processes (test hosts), and
   retained everywhere as DIAGNOSTIC PROVENANCE (logged at warm-up start:
   `framework identity {id}, build {g<sha>}`).
3. **Graph MVID** — local builds, unchanged.

All consumers follow the ONE property exactly as wired in #1687 (store tag, `HasUsableBuild` /
`CompiledFrameworkVersion`, bake report, build-claim fingerprint, seeder gate, artifact key);
`AssemblyCacheGenerations.TagOf` learns the `s`+7-hex tag shape.

### Build plumbing

- `Directory.Build.props`: `_MeshWeaverWriteSurfaceManifest` (built-in `GetFileHash` over
  `@(ReferencePathWithRefAssemblies)` filtered to `MeshWeaver.*`) + publish hookup. 🚨 The
  multi-arch container publish's `ProduceReferenceAssembly=false` optimization is REMOVED — ref
  assemblies are load-bearing now (no ref-asms ⇒ impl hashes ⇒ forked identity ⇒ every bake
  declines); the PR #552 race stays killed by the per-leg bin/obj isolation.
- `mw-plugin-test --print-framework-identity` — one-line diagnostic (identity + provenance); the
  proof scripts drive the REAL resolution path through it.
- Publish skip: `publish-bake-bundles.sh` skips-with-notice when
  `prebuilt-bundles/<identity>/<source>/` already holds files — an internal-only merge is a no-op
  publish ("rebuild only when we need to" applies to the publish too).
- `notify-dependents` payload drops the (now wrong) `identity` field — receivers resolve their
  own.

### Proof (measured through the real binary, `mw-plugin-test --print-framework-identity`)

- Ref-asm oracle: byte-identical under method-body-only edits, changed by a public const add
  (sha256 of `obj/ref/MeshWeaver.Data.dll` across from-clean rebuilds); internal-member adds flip
  it for IVT'd assemblies — correct conservatism, documented.
- Live identity (all via the real binary): baseline `s9f38b6456177317dd2c6389469811f6b`;
  - internal body-only edit in MeshWeaver.Data ⇒ identity UNCHANGED
    (`s5cfe9fff…` == `s5cfe9fff…`, and reproducible across independent runs);
  - public member added to MeshWeaver.Layout ⇒ identity CHANGED (`s6adbb981…`);
  - body-only edit in MeshWeaver.Graph, ref-asm CONFIRMED byte-stable across the edit ⇒ identity
    CHANGED (`se1518a33…` → `sfbfd8b4d…`) — the emitter full-MVID rule, isolated;
  - revert ⇒ baseline `s9f38b645…` restored — **after merging #1691/#1694/#1695 mid-proof**:
    three real merged commits (CD workflow + ContentCollections internals) moved the identity
    NOT AT ALL, live evidence that routine merges now cause zero rebakes.
- Unit pins: surface computation (stability, listed-assembly change, host-extra invisibility,
  emitter rule, absence marker), manifest parsing, canonical-list invariants, a closure pin test
  that recomputes the tester's csproj closure and fails naming the drift, the process resolution
  chain, tag attributability.
- Full solution `-c Release -warnaserror --no-incremental` green; affected test projects green.

### Ops notes

- First roll after this merges bakes once under the new `s<hash>` identity (a one-time full bake —
  the key scheme changed); after that, internal-only merges keep `pending≈0` end to end and skip
  the publish.
- `BAKE_PUBLISH_TARGETS` + storage role are already provisioned (see #1687).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
