### PR TITLE
chore: prebump rc4 — v3.0.0-rc3 shipped

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,10 +64,10 @@
          never roll forward again. Keep a pre-release label on the core until 3.0.0 ships clean.
 
          It also has to RESOLVE by the time anything pins content-sync to it: data-sync pulls
-         content from the tag v$(PlatformVersion). v3.0.0-rc2 shipped 2026-08-14; v3.0.0-rc3 is
-         the line NOW BUILDING and its tag is created only when rc3 is released — never tag it
+         content from the tag v$(PlatformVersion). v3.0.0-rc3 shipped 2026-08-16; v3.0.0-rc4 is
+         the line NOW BUILDING and its tag is created only when rc4 is released — never tag it
          early, the v*.*.* tag IS the trigger for the NuGet + image publish. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc3</PlatformVersion>
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc4</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers


### PR DESCRIPTION
v3.0.0-rc3 released 2026-08-16 (NuGet publish green — 3.0.0-rc3 live for the full package set including the new MeshWeaver.Hosting.AspNetCore and MeshWeaver.Approvals; images leg completing). Continuous builds move to the 3.0.0-rc4 line per the release skill's post-release step; the pre-release label stays on the core per the SemVer-precedence note in the props.

No What's New — release bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)