### PR TITLE
fix: satellite data-source registration is idempotent — stable ids + marker guards (#1700-adjacent, unblocks task #74)

### DIFF
--- a/src/MeshWeaver.Approvals/ApprovalExtensions.cs
+++ b/src/MeshWeaver.Approvals/ApprovalExtensions.cs
@@ -42,14 +42,32 @@ public static class ApprovalExtensions
     /// The per-node-hub half of the registration: type + data source + menu entry + the
     /// RequestApproval/Approvals layout areas + the <see cref="ApprovalsEnabled"/> marker.
     /// ONE code path shared by the module attribute and <see cref="AddApprovals"/>.
+    ///
+    /// <para>🚨 Idempotent BY CONSTRUCTION, twice over (#1700). This chain reaches a hub through
+    /// several independent doors — the module attribute's <c>ConfigureDefaultNodeHub</c>, the
+    /// <see cref="AddApprovals"/> builder extension, and the legacy per-lambda
+    /// <c>MeshWeaver.Graph.ApprovalExtensions.AddApprovals()</c> that content configuration
+    /// lambdas call — and a re-applied default-node chain (the error-overlay path) can run it
+    /// twice on ONE hub. (1) The <see cref="ApprovalsEnabled"/> marker short-circuits a second
+    /// application on the same chain. (2) The data source carries a STABLE id (the partition
+    /// name): when two applications land anyway (marker-invisible composition),
+    /// <c>DataContext.Initialize</c>'s documented keep-last-by-id dedupe collapses them. With
+    /// the previous <c>Guid.NewGuid()</c> id, that dedupe could never fire, so a double
+    /// application built two type sources for the <c>Approval</c> collection and hub CREATION
+    /// threw <c>ArgumentException: An item with the same key has already been added. Key:
+    /// Approval</c> — the hub never came up, and every delivery to it parked forever behind its
+    /// init gates (observed as the LinkedIn/Post Tests-area timeout in the SocialMedia gate on
+    /// every post-extraction image).</para>
     /// </summary>
     internal static MessageHubConfiguration ConfigureHub(MessageHubConfiguration configuration)
     {
+        if (configuration.HasApprovals())
+            return configuration;
         return configuration
             .WithType<Approval>(nameof(Approval))
             .Set(new ApprovalsEnabled())
             .AddData(data => data.WithDataSource(_ =>
-                new MeshDataSource(Guid.NewGuid().AsString(), data.Workspace)
+                new MeshDataSource(ApprovalPartition, data.Workspace)
                     .WithType<Approval>(ApprovalPartition, nameof(Approval))))
             .AddNodeMenuItems(ApprovalMenuProvider)
             .AddLayout(layout => layout

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-comment-approval-pages-stay-reachable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-comment-approval-pages-stay-reachable.md
@@ -1,0 +1,20 @@
+---
+Name: Pages with comments and approvals stay reachable after updates
+Category: Fix
+Description: A page whose configuration enabled comments or approvals could become permanently unreachable after a platform update — its hub failed to start and every request to it timed out. Registration is now idempotent, so the page always comes up.
+Icon: CheckmarkCircle
+Order: -20260817
+---
+
+# Pages with comments and approvals stay reachable after updates
+
+Some pages enable comments and approvals in their own configuration while the platform also
+enables them by default. After the approvals module was extracted, that double registration could
+make the page's hub fail to start — the page never loaded, and everything sent to it (including
+its tests) waited forever instead of failing with an error.
+
+The registration is now idempotent: enabling comments or approvals a second time is recognized
+and collapsed, and even when two registrations land through different doors they merge instead of
+colliding. What you notice: pages that request approvals or carry comment threads keep loading
+normally through platform updates, and gate runs against such content finish instead of timing
+out.

--- a/src/MeshWeaver.Graph/CommentsExtensions.cs
+++ b/src/MeshWeaver.Graph/CommentsExtensions.cs
@@ -40,13 +40,23 @@ public static class CommentsExtensions
     /// </summary>
     public static MessageHubConfiguration AddComments(this MessageHubConfiguration configuration)
     {
+        // 🚨 Idempotent BY CONSTRUCTION, twice over — same defect class as Approvals (#1700).
+        // Content configuration lambdas call AddComments() and a re-applied default-node chain
+        // can run the same registration twice on ONE hub: (1) the CommentsEnabled marker
+        // short-circuits a second application on the same chain; (2) the data source carries a
+        // STABLE id (the partition name), so even when two applications land anyway,
+        // DataContext.Initialize's documented keep-last-by-id dedupe collapses them instead of
+        // throwing 'duplicate key: Comment' at hub creation. A Guid.NewGuid() id defeats that
+        // dedupe by definition — never use one for a role-shaped data source.
+        if (configuration.HasComments())
+            return configuration;
         return configuration
             .WithType<CreateCommentRequest>(nameof(CreateCommentRequest))
             .WithType<CreateCommentResponse>(nameof(CreateCommentResponse))
             .Set(new CommentsEnabled())
             .WithHandler<CreateCommentRequest>(HandleCreateCommentRequest)
             .AddData(data => data.WithDataSource(_ =>
-                new MeshDataSource(Guid.NewGuid().AsString(), data.Workspace)
+                new MeshDataSource(CommentPartition, data.Workspace)
                     .WithType<Comment>(CommentPartition, nameof(Comment))))
             .AddLayout(layout => layout
                 .WithView(MeshNodeLayoutAreas.CommentsArea, CommentsView.Comments));

--- a/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainIdempotenceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainIdempotenceTest.cs
@@ -1,0 +1,60 @@
+using System;
+using MeshWeaver.Approvals;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins that the default-node-hub configuration chain is IDEMPOTENT — applying it twice to one
+/// hub must be harmless (#1700).
+///
+/// <para>Twice is not hypothetical: <c>NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay</c>
+/// composes <c>MeshConfiguration.DefaultNodeHubConfiguration</c> INTO the instance's hub
+/// configuration (<c>config =&gt; overlay(baseConfig(config))</c>), on top of whatever default
+/// application the hub creation path already performs — so every package-root node that lands on
+/// the unresolvable-NodeType overlay (e.g. a <c>Store/Plugin</c>-typed root in a gate mesh that
+/// does not mount Store) runs the chain twice.</para>
+///
+/// <para>Before the fix, the Approvals module's per-node registration added a
+/// <c>MeshDataSource</c> whose id was <c>Guid.NewGuid()</c> on EVERY application, defeating
+/// <c>DataContext.Initialize</c>'s documented keep-last-by-id dedupe: the second application
+/// produced a second type source for the <c>Approval</c> collection, workspace activation threw
+/// <c>ArgumentException: An item with the same key has already been added. Key: Approval</c>,
+/// hub creation failed, and every delivery to the hub parked forever behind its init gates —
+/// observed as the LinkedIn/Post Tests-area timeout in the MeshWeaver.SocialMedia gate on every
+/// post-extraction image. Comments had the identical latent defect.</para>
+/// </summary>
+public class DefaultNodeChainIdempotenceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The production arrangement: the Approvals module registered on the mesh (every portal
+    /// lists it under <c>Modules:Assemblies</c>; the plugin-gate tester calls the same builder
+    /// extension), so its per-node-hub registration rides the default node chain.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddApprovals();
+
+    [Fact(Timeout = 30_000)]
+    public void DefaultNodeChain_AppliedTwice_StillActivatesTheWorkspace()
+    {
+        var meshConfiguration = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>();
+        var defaultChain = meshConfiguration.DefaultNodeHubConfiguration;
+        defaultChain.Should().NotBeNull(
+            "the mesh registers the Approvals module, whose per-node-hub half rides the default node chain");
+
+        // The overlay's exact composition shape: the default chain applied on top of itself.
+        var hub = Mesh.GetHostedHub(
+            new Address("double-default-chain", "1"),
+            config => defaultChain!(defaultChain(config)));
+        hub.Should().NotBeNull();
+
+        // Resolving IWorkspace forces DataContext.Initialize — the duplicate-registration
+        // defect threw right here ('duplicate key: Approval') and left the hub uncreatable.
+        hub.ServiceProvider.GetRequiredService<IWorkspace>().Should().NotBeNull();
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -52,6 +52,7 @@
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+        <ProjectReference Include="..\..\src\MeshWeaver.Approvals\MeshWeaver.Approvals.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Documentation\MeshWeaver.Documentation.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Mcp\MeshWeaver.Mcp.csproj" />


### PR DESCRIPTION
## The defect

Since the Approvals extraction (#1654 line), **hub creation fails with `ArgumentException: An item
with the same key has already been added. Key: Approval`** whenever the default-node-hub chain is
applied twice to one hub — which the unresolvable-NodeType overlay path does by construction
(`WithCompilationErrorOverlay` composes `MeshConfiguration.DefaultNodeHubConfiguration` into the
instance's hub configuration, on top of the ambient default application). A failed hub creation
does not fail its callers: every delivery to the address parks forever behind init gates.

**Deterministic repro** (found wiring task #74): `mw-plugin-test` over the MeshWeaver.SocialMedia
tree — its package roots are `Store/Plugin`-typed with Store not mounted, so they land on the
overlay:

| image | verdict |
|---|---|
| `3.0.0-rc1.ci.2524` (pre-extraction) | all 4 modules PASS, 15 s |
| `3.0.0-rc3.ci.3982` / `.3994` (shipped) | `GATE FAILED — tests: LinkedIn/Post` after a 30 s `DataContextInit` deferral |
| this branch (local tester build) | all 4 modules PASS, 7 s, full bake produced |

## The root cause, and why this fix is not a band-aid

`DataContext.Initialize` explicitly handles double-registered data sources — "duplicates happen
when multiple configurations add the same data source; keep the last one with each ID". The
Approvals module's per-node registration defeated that defense by minting a **`Guid.NewGuid()` id
on every application**, so two applications produced two distinct sources whose `Approval`
type-source collection names then collided in `ToDictionary`. Comments carried the identical
latent defect.

Fix at the registration layer, twice over:
1. `ConfigureHub` / `AddComments` short-circuit on their own markers (`ApprovalsEnabled` /
   `CommentsEnabled`) — a second application on the same chain is a no-op;
2. the data sources carry **stable ids** (their partition names `_Approval` / `_Comment`), so
   even marker-invisible double applications collapse under `Initialize`'s documented dedupe.

`DefaultNodeChainIdempotenceTest` pins the overlay's exact composition shape (default chain
applied twice → workspace activation). Proven both directions: fails on current main with the
exact production exception, passes here.

## Why now

This blocks task #74 (satellite repos bake-on-CI): every satellite pin bump to a bake-capable
image (`--bake-output` shipped 2026-08-16, same day as the extraction) hits this wedge in its
required `test-repos` gate. It is also live exposure for any production partition whose package
roots can land on the overlay during a roll.

Related: #1699 (surface-manifest missing from shipped images — separate defect, same lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)