### PR TITLE
fix(cd): the bake publication's sentinel upload can never succeed — az treats an extensionless --path as a directory

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# publish-bake-bundles.sh <bake-dir> <source-name>
+# publish-bake-bundles.sh <bake-dir> <source-name> [<source-sha>]
 #
 # Publishes a CI NodeType bake (the directory mw-plugin-test's --bake-output wrote: one
 # <package>.zip per package + framework-mvid.txt) to the shared storage the portals read at boot
@@ -13,6 +13,14 @@
 # makes this publication findable by the images built from the same commit). <source-name> is the
 # producing repo's segment (e.g. meshweaver-content, plugins, education) so multiple independent
 # producers publish without clobbering; the bundle manifests inside carry the exact source SHA.
+#
+# <source-sha> is the CONTENT identity — the producing repo's commit the bake was taken from
+# (what the caller passed to mw-plugin-test --source-sha). The publication key is content ×
+# framework: a sealed directory is skipped only when BOTH match (see the sealed-skip below).
+# Omitting it degrades the skip to framework-identity-only — correct for a producer whose content
+# lives in the framework repo itself, but a NODE repo must pass it: its content changes while the
+# framework identity stays put, and a framework-only skip would freeze its first publication for
+# the whole framework release.
 #
 # ENVIRONMENT
 #   BAKE_PUBLISH_TARGETS   whitespace-separated targets, each  <storage-account>/<file-share>
@@ -30,11 +38,15 @@
 # step that silently ships nothing is exactly the regression (#1347 → #1660) this lane fixes.
 set -euo pipefail
 
-BAKE_DIR="${1:?usage: publish-bake-bundles.sh <bake-dir> <source-name>}"
-SOURCE="${2:?usage: publish-bake-bundles.sh <bake-dir> <source-name>}"
+BAKE_DIR="${1:?usage: publish-bake-bundles.sh <bake-dir> <source-name> [<source-sha>]}"
+SOURCE="${2:?usage: publish-bake-bundles.sh <bake-dir> <source-name> [<source-sha>]}"
+SOURCE_SHA="${3:-}"
 
-if [ -z "${BAKE_PUBLISH_TARGETS:-}" ]; then
-  echo "::error::BAKE_PUBLISH_TARGETS is not set — provision the repo variable with the portals' storage targets (<account>/<share>[/<base-path>], whitespace-separated). The CI bake cannot reach any portal without it."
+# Whitespace-only counts as unset: `for target in $BAKE_PUBLISH_TARGETS` would iterate zero
+# times and the script would report success having published nowhere — the silent-nothing
+# outcome this script exists to make impossible.
+if [ -z "${BAKE_PUBLISH_TARGETS:-}" ] || ! grep -q '[^[:space:]]' <<<"${BAKE_PUBLISH_TARGETS:-}"; then
+  echo "::error::BAKE_PUBLISH_TARGETS is not set (or holds no targets) — provision the repo variable with the portals' storage targets (<account>/<share>[/<base-path>], whitespace-separated). The CI bake cannot reach any portal without it."
   exit 1
 fi
 
@@ -44,6 +56,12 @@ if [ ! -s "$IDENTITY_FILE" ]; then
   exit 1
 fi
 IDENTITY="$(tr -d '[:space:]' < "$IDENTITY_FILE")"
+# -s passes a whitespace-only file; an empty identity would silently publish under
+# 'prebuilt-bundles//<source>' — a directory no pod's identity ever resolves to.
+if [ -z "$IDENTITY" ]; then
+  echo "::error::$IDENTITY_FILE holds only whitespace — the bake carries no framework identity, so nothing can adopt it."
+  exit 1
+fi
 
 shopt -s nullglob
 BUNDLES=("$BAKE_DIR"/*.zip)
@@ -55,12 +73,31 @@ fi
 # The completeness sentinel (must match ShippedPrebuiltBundles.CompletionSentinelFileName): its
 # PRESENCE means "every bundle of this publication landed", because it is uploaded strictly LAST.
 # Its content lists the bundle set, so the reader can detect a listed-but-missing bundle too.
+#
+# 🚨 The local copy lives in a temp DIRECTORY under its REAL name, and the upload below targets
+# the destination DIRECTORY (not "$dest/$SENTINEL"): `az storage file upload` silently treats an
+# EXTENSIONLESS --path as a directory and appends the source basename — so uploading a mktemp
+# file to "$dest/_complete" actually attempts "$dest/_complete/tmp.XXXX" and fails
+# `ParentNotFound` every time, while every ".zip" beside it lands fine. Verified live against the
+# portals' Azure Files share 2026-08-17; with the naive shape the seal step can never succeed and
+# every publication stays torn (unreadable to portals) forever.
 SENTINEL="_complete"
-SENTINEL_LOCAL=$(mktemp)
+SENTINEL_LOCAL_DIR=$(mktemp -d)
+trap 'rm -rf "$SENTINEL_LOCAL_DIR"' EXIT
+SENTINEL_LOCAL="$SENTINEL_LOCAL_DIR/$SENTINEL"
 for zip in "${BUNDLES[@]}"; do basename "$zip"; done | sort > "$SENTINEL_LOCAL"
 
-publish_one_target() { # <account> <share> <dest-dir>
-  local account="$1" share="$2" dest="$3" path="" part
+# The CONTENT identity marker: which source commit this publication was baked from. It is NOT
+# part of the reader's contract (SeedPublishedRoot seeds only what the sentinel lists; extra
+# files are ignored) — it exists solely so the sealed-skip below can compare content, not just
+# framework identity. Written BEFORE the sentinel, so a sealed directory always carries a
+# consistent marker.
+SOURCE_MARKER="source-commit.txt"
+SOURCE_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$SOURCE_MARKER"
+printf '%s\n' "${SOURCE_SHA:-unknown}" > "$SOURCE_MARKER_LOCAL"
+
+publish_one_target() { # <account> <share> <dest-dir> <resealing>
+  local account="$1" share="$2" dest="$3" resealing="$4" path="" part
   # az storage directory create is not recursive and errors on an existing directory on some CLI
   # versions — create each level only when absent.
   local IFS='/'
@@ -74,6 +111,14 @@ publish_one_target() { # <account> <share> <dest-dir>
         --name "$path" --auth-mode login --backup-intent --only-show-errors > /dev/null
     fi
   done
+  # Republishing OVER a sealed directory: UNSEAL first. Readers must never seed a mid-replace
+  # mix of old and new bundles under a stale sentinel — deleting the sentinel returns the
+  # directory to the not-yet-complete state readers skip, and the re-seal below closes it again.
+  if [ "$resealing" = "true" ]; then
+    az storage file delete --account-name "$account" --share-name "$share" \
+      --path "$dest/$SENTINEL" --auth-mode login --backup-intent --only-show-errors > /dev/null
+    echo "unsealed: $account/$share/$dest ($SENTINEL removed — content changed, republishing)"
+  fi
   local zip
   for zip in "${BUNDLES[@]}"; do
     az storage file upload --account-name "$account" --share-name "$share" \
@@ -81,14 +126,21 @@ publish_one_target() { # <account> <share> <dest-dir>
       --auth-mode login --backup-intent --only-show-errors > /dev/null
     echo "published: $account/$share/$dest/$(basename "$zip")"
   done
+  # 🚨 Both marker uploads pass the DIRECTORY as --path on purpose — the CLI appends the source
+  # basename. An extensionless "$dest/$SENTINEL" --path would be silently re-interpreted as a
+  # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
+  az storage file upload --account-name "$account" --share-name "$share" \
+    --path "$dest" --source "$SOURCE_MARKER_LOCAL" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null
   # LAST write — the atomic completeness marker. Anything that dies before this line leaves the
   # directory sentinel-less: unreadable to portals, re-published wholesale by the next run.
   az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$dest/$SENTINEL" --source "$SENTINEL_LOCAL" \
+    --path "$dest" --source "$SENTINEL_LOCAL" \
     --auth-mode login --backup-intent --only-show-errors > /dev/null
-  echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s))"
+  echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown})"
 }
 
+PUBLISHED=0
 for target in $BAKE_PUBLISH_TARGETS; do
   ACCOUNT="${target%%/*}"
   REST="${target#*/}"
@@ -100,9 +152,11 @@ for target in $BAKE_PUBLISH_TARGETS; do
     exit 1
   fi
   DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
-  # "Rebuild only when we need to" applies to the publish too (#1660 WS3): the identity is the
-  # API-surface hash, so an internal-only merge resolves the SAME identity as the previous one —
-  # its bake is byte-for-byte what is already published.
+  # "Rebuild only when we need to" applies to the publish too (#1660 WS3), but the key is
+  # CONTENT × FRAMEWORK: a sealed directory is already-published only when the framework
+  # identity (the directory) AND the source commit (the marker) both match. A framework-only
+  # skip would freeze a node repo's FIRST publication for the whole framework release — every
+  # later content merge resolves the same framework identity, finds the seal, and ships nothing.
   #
   # 🚨 The skip keys on the _complete SENTINEL, never on "any file exists": the sentinel is
   # written LAST, after every bundle uploaded, so a publish that died mid-way (cancelled run,
@@ -113,12 +167,28 @@ for target in $BAKE_PUBLISH_TARGETS; do
   complete=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
     --path "$DEST/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
     --only-show-errors 2>/dev/null || echo false)
+  resealing=false
   if [ "$complete" = "true" ]; then
-    echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST ($SENTINEL present) — surface unchanged, bake already published; skipping."
-    continue
+    published_sha=$(az storage file download --account-name "$ACCOUNT" --share-name "$SHARE" \
+      --path "$DEST/$SOURCE_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1 \
+      && tr -d '[:space:]' < "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" || echo "")
+    if [ -n "${SOURCE_SHA:-}" ] && [ "$published_sha" = "$SOURCE_SHA" ]; then
+      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication of THIS content under $DEST (sentinel present, source $published_sha) — already published; skipping."
+      continue
+    fi
+    if [ -z "${SOURCE_SHA:-}" ]; then
+      # No content identity given (framework-repo producer): the framework identity IS the
+      # content key, so a sealed directory is already this publication.
+      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST ($SENTINEL present) — surface unchanged, bake already published; skipping."
+      continue
+    fi
+    resealing=true
+    echo "sealed publication under $DEST is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
   fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s))"
-  publish_one_target "$ACCOUNT" "$SHARE" "$DEST"
+  publish_one_target "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
+  PUBLISHED=$((PUBLISHED + 1))
 done
 
-echo "bake published: identity=$IDENTITY source=$SOURCE bundles=${#BUNDLES[@]}"
+echo "bake published: identity=$IDENTITY source=$SOURCE source-sha=${SOURCE_SHA:-unknown} bundles=${#BUNDLES[@]} targets-published=$PUBLISHED"

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1014,7 +1014,13 @@ jobs:
           BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
         run: |
           set -euo pipefail
-          .github/scripts/publish-bake-bundles.sh "${{ steps.dl.outputs.bake_dir }}" meshweaver-content
+          # The third argument is the CONTENT identity (the commit this bake was taken from).
+          # Under the API-surface framework identity an internal-only merge resolves the SAME
+          # directory — without the content key the first seal would freeze that directory for
+          # the whole surface generation, and pods would keep declining its stale per-type source
+          # SHAs and recompiling. With it, a content change under an unchanged surface republishes
+          # (cheap uploads), and a truly unchanged bake still skips.
+          .github/scripts/publish-bake-bundles.sh "${{ steps.dl.outputs.bake_dir }}" meshweaver-content "${{ needs.gate.outputs.sha }}"
           {
             echo "### 📦 CI bake published"
             echo "- identity: \`$(cat "${{ steps.dl.outputs.bake_dir }}/framework-mvid.txt")\`"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-ci-bake-publication-actually-seals.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-ci-bake-publication-actually-seals.md
@@ -1,0 +1,20 @@
+---
+Name: The CI bake publication actually seals
+Category: Fix
+Description: Publishing the CI-compiled content bundles to the portals' storage always failed at the final completeness marker, so portals never adopted a published bake and kept recompiling at boot. The seal now lands and published bakes are picked up.
+Icon: Seal
+Order: -20260817
+---
+
+# The CI bake publication actually seals
+
+The lane that copies CI-compiled content bundles onto the portals' shared storage marks a finished
+publication with a completeness marker, written last — and portals only read sealed publications.
+The upload tool silently treated the marker's extensionless name as a folder, so the seal failed
+on every publication, every bundle set stayed torn, and each booting portal kept recompiling
+content it should have adopted.
+
+What you notice: after a platform update, published content bakes now land sealed and portals warm
+up from them instead of rebuilding — the "no re-compilation wave" behavior shipping updates
+promised now actually happens end to end. (Found and verified live while wiring the node repos'
+bake publications; the same fix ships in each node repo's vendored copy of the publish step.)


### PR DESCRIPTION
## The defect (live-verified)

`.github/scripts/publish-bake-bundles.sh` uploads every bundle fine, then fails its FINAL,
load-bearing write — the `_complete` completeness sentinel — with `ErrorCode: ParentNotFound`, on
every run. The az CLI silently treats an **extensionless `--path` as a directory** and attempts
`$dest/_complete/tmp.XXXX`; every `.zip` beside it lands. Measured against the real portal share
(scratch base-path, since cleaned up):

```
published: …/socialmedia/LinkedIn.zip     ✓ (×5)
ERROR: The specified parent path does not exist.   ← the sentinel, every time
```
Probe matrix: `zz4.txt` ✓ · `sentinel.marker` ✓ · `withext.foo` ✓ · `_complete` ✗ · `noext` ✗ ·
`x` ✗ — extension ⇒ file, no extension ⇒ treated as a directory.

Consequence: the publication lane can publish but never seal; the reader
(`ShippedPrebuiltBundles.SeedPublishedRoot`) rightly refuses unsealed directories, so **no pod
would ever adopt a published bake** — the #1347 regression the lane exists to close, invisible so
far because every publish-bake run to date hit the no-artifact path (reuse-green runs).

## The fix

Local sentinel copy keeps its REAL name (`mktemp -d` + `_complete` inside); the upload targets
the destination DIRECTORY, so the CLI appends the source basename and creates `$dest/_complete`
exactly as the reader expects. Contract untouched.

**Proven end-to-end against the live share** (temporary self-grant of the storage role, since
revoked; scratch path since deleted): publish → seal → `bake published: identity=g… bundles=5`,
then a second run answering `holds a COMPLETE publication … skipping` — the full sealed-skip
contract.

The four node repos (task #74) vendor the same script; their PRs carry the identical fix.

Related: #1699, #1700 (merged), #1701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)