### PR TITLE
fix: the surface manifest never survived publish — images now carry it, portals adopt the CI bake at boot (#1699)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -334,8 +334,19 @@
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
   </Target>
+  <!-- 🚨 AfterTargets="ComputeFilesToPublish" — NOT BeforeTargets="CopyFilesToPublishDirectory".
+       The copy is performed by CopyFilesToPublishDirectory's DEPENDENCIES
+       (_ComputeResolvedFilesToPublishTypes splits @(ResolvedFileToPublish) into the
+       Always/PreserveNewest copy lists, then _CopyResolvedFilesToPublish* copy them), and a
+       BeforeTargets hook on the orchestrator runs AFTER its dependencies — so the previous shape
+       added the item once every copy had already happened. The result (#1699): every published
+       output — plain publish AND -t:PublishContainer, i.e. EVERY SHIPPED IMAGE — silently lacked
+       the manifest, portals fell back to the commit identity g<sha>, and the s<hash>-keyed CI
+       bake publication was never adopted: pods recompiled all shipped content at boot. This hook
+       point (the documented publish extension point) runs after the list is computed and before
+       it is split, and PublishContainer consumes the same list. -->
   <Target Name="_MeshWeaverAddSurfaceManifestToPublish"
-          BeforeTargets="CopyFilesToPublishDirectory"
+          AfterTargets="ComputeFilesToPublish"
           DependsOnTargets="_MeshWeaverWriteSurfaceManifest"
           Condition="'$(MeshWeaverSurfaceManifest)' == 'true'">
     <ItemGroup>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-startup-in-minutes-not-hours.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-startup-in-minutes-not-hours.md
@@ -1,0 +1,20 @@
+---
+Name: Portals start in minutes, adopting the CI-compiled content
+Category: Fix
+Description: Shipped images silently lacked the API-surface manifest, so every booting portal fell back to recompiling all shipped content instead of adopting the CI-published build — startup took as long as a full recompile. The manifest now ships in every image and boot adopts the published bake.
+Icon: Rocket
+Order: -20260817
+---
+
+# Portals start in minutes, adopting the CI-compiled content
+
+The whole bake-on-CI lane exists so that a booting portal loads content compiled once on CI
+instead of recompiling everything itself. The key that connects the two — the API-surface
+manifest the portal derives its identity from — was written at build time but silently dropped
+from every published output, images included: the publish hook added it after the copy had
+already happened. Portals therefore resolved a per-commit identity, never matched the published
+bake, and every pod rebuilt all shipped content at boot.
+
+The manifest now ships in every image (verified inside a locally published container). What you
+notice: after a platform update, pods seed the CI-published bundles at boot and compile only what
+CI did not bake — startup becomes a matter of minutes, not the length of a full content rebuild.


### PR DESCRIPTION
Fixes #1699 — the missing piece between the CI bake publication and minutes-level portal startup.

## Defect
`_MeshWeaverAddSurfaceManifestToPublish` hooked `BeforeTargets="CopyFilesToPublishDirectory"`, but
the copying is performed by that target's **dependencies** (`_ComputeResolvedFilesToPublishTypes`
splits `@(ResolvedFileToPublish)` into the Always/PreserveNewest lists, then
`_CopyResolvedFilesToPublish*` copy them) — and a `BeforeTargets` hook on the orchestrator runs
**after** its dependencies. Traced in a detailed publish log (copy targets at 157345/158114, the
hook at 158126): the item was added after every copy, on every publish shape. So **every shipped
image lacked `meshweaver-surface.manifest`**, portals resolved `g<sha>` while the CI bake is
`s<hash>`-keyed, `SeedPublishedRoot` never matched, and each pod recompiled all shipped content
at boot.

## Fix + proof
`AfterTargets="ComputeFilesToPublish"` (the documented publish extension point — after the list
is computed, before it is split; `PublishContainer` consumes the same list). Verified locally:

```
plain publish → /tmp/pub/meshweaver-surface.manifest        ✓ (3346 bytes)
-t:PublishContainer → docker run … ls /app/meshweaver-surface.manifest  ✓ same bytes, correct hashes
```

With this, the first post-merge release ships manifest-bearing images: portal + mw-plugin-test
resolve the same `s<hash>` as the Build-and-Test bake artifact and the (now-sealing, #1702)
publication — pods seed the published bundles at boot and compile only what CI did not bake.
Startup becomes minutes, and stays warm across internal-only merges by construction.

Related: #1700, #1702 (merged), task #74 (satellite publications — consistent on the same key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)