### PR TITLE
fix(clients): Vitest loaded tabster's CJS bundle as ESM — alias the real ESM build

### DIFF
--- a/clients/portal-next/vitest.config.ts
+++ b/clients/portal-next/vitest.config.ts
@@ -25,11 +25,22 @@ export default defineConfig({
       // cookies()/headers() only exist inside Next's server runtime — stub so the page's async
       // server component (AreaSnapshot) can be driven directly and its round-trips counted.
       "next/headers": path.resolve(here, "test/stubs/next-headers.ts"),
+      // tabster ships "type": "module" but points `main` at a CommonJS bundle and publishes NO
+      // `exports` map, so Node's ESM resolver lands on dist/cjs/index.cjs and cannot see the named
+      // exports @fluentui/react-tabster imports (`createTabster`, `getMover`, …). Point at the real
+      // ESM build — the same entry every bundler picks up via the `module` field.
+      tabster: "tabster/dist/esm/index.js",
     },
   },
   test: {
     environment: "node", // per-file overrides via "@vitest-environment jsdom" docblocks
     globals: true,
     include: ["test/**/*.test.{ts,tsx}"],
+    server: {
+      // Fluent 9.74.6 dropped the `node` export condition that used to make Vitest load the whole
+      // Fluent tree as CommonJS. It now resolves as ESM, so the tabster mis-packaging above became
+      // load-fatal. Run Fluent through Vite (rather than Node's ESM loader) so the alias applies.
+      deps: { inline: [/@fluentui\//] },
+    },
   },
 });

--- a/clients/react/vitest.config.ts
+++ b/clients/react/vitest.config.ts
@@ -3,9 +3,22 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    // tabster ships "type": "module" but points `main` at a CommonJS bundle and publishes NO
+    // `exports` map, so Node's ESM resolver lands on dist/cjs/index.cjs and cannot see the named
+    // exports @fluentui/react-tabster imports (`createTabster`, `getMover`, …). Point at the real
+    // ESM build — the same entry every bundler picks up via the `module` field.
+    alias: { tabster: "tabster/dist/esm/index.js" },
+  },
   test: {
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],
+    server: {
+      // Fluent 9.74.6 dropped the `node` export condition that used to make Vitest load the whole
+      // Fluent tree as CommonJS. It now resolves as ESM, so the tabster mis-packaging above became
+      // load-fatal. Run Fluent through Vite (rather than Node's ESM loader) so the alias applies.
+      deps: { inline: [/@fluentui\//] },
+    },
   },
 });


### PR DESCRIPTION
## What was red

Dependabot #1703 (`npm-minor-patch`, 5 updates across 4 directories) failed two Clients jobs:

- **`@meshweaver/react`** — 24 of 35 suites failed to import
- **`Portal-next`** — 7 of 12 suites failed to import

both with the same load-time error:

```
SyntaxError: The requested module 'tabster' does not provide an export named 'createTabster'
```

## Root cause

`tabster@8.8.0` is mis-packaged: `"type": "module"` **and** `main: ./dist/cjs/index.cjs` **and** no `exports` map. Node's ESM resolver therefore lands on the CommonJS bundle, whose named exports it cannot statically detect — so `@fluentui/react-tabster`'s `import { createTabster } from "tabster"` is fatal.

That has been latent for a while. `@fluentui/react-components@9.74.5` shipped a **`node` export condition** pointing at `lib-commonjs/`, so Vitest loaded the entire Fluent tree as CommonJS and tabster was `require`d, never `import`ed:

```jsonc
// 9.74.5 — the `node` condition hid the bug
"." : { "types": "…", "node": "./lib-commonjs/index.js", "import": "./lib/index.js", "require": "./lib-commonjs/index.js" }

// 9.74.6 — no `node` condition; Vitest now takes `import` → ESM → tabster breaks
"." : { "import": { "types": "…", "default": "./lib/index.js" }, "require": { "types": "…", "default": "./lib-commonjs/index.cjs" } }
```

The 9.74.5 → 9.74.6 bump in #1703 is the trigger, not the defect. Nothing in the repo changed.

## The fix

Fix at the resolution layer, in both vitest configs:

1. Alias `tabster` → `tabster/dist/esm/index.js` — the real ESM build, the same entry every bundler already picks up via the package's `module` field.
2. `server.deps.inline: [/@fluentui\//]` so Fluent runs through Vite rather than Node's ESM loader — otherwise Node resolves `tabster` itself and the alias never applies.

## Verification

Run locally in isolated worktrees, both dependency trees:

| tree | package | result |
|---|---|---|
| Fluent **9.74.6** (dependabot #1703) | `clients/react` | 35/35 files, 261 tests pass |
| Fluent **9.74.6** | `clients/portal-next` | 12/12 files, 98 tests pass |
| Fluent **9.74.5** (current `main`) | `clients/react` | 35/35 files, 261 tests pass |

`npm run typecheck` and `npm run build` clean in both packages (portal-next's Next build included). Because it is verified against **both** versions, this lands independently of the bump and unblocks #1703 on its next rebase.

## What's New

Skipped deliberately — internal test infrastructure, no user-visible change.