### PR TITLE
chore(deps): react-native rides the Expo SDK — hold its majors back in dependabot, not by hand

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,14 +22,15 @@ updates:
         applies-to: version-updates
         update-types: [minor, patch]
 
-  # JS clients — one update config over all workspaces; grouped the same way.
+  # JS clients — one update config over the web workspaces; grouped the same way.
+  # 🚨 /clients/react-native is NOT here: it rides the Expo SDK and needs holdbacks that must not
+  # suppress the same packages everywhere else. It has its own config below.
   - package-ecosystem: npm
     directories:
       - "/clients/react"
       - "/clients/grpc-web"
       - "/clients/typescript"
       - "/clients/portal-next"
-      - "/clients/react-native"
       - "/clients/portal"
     schedule:
       interval: weekly
@@ -47,12 +48,71 @@ updates:
       npm-major:
         applies-to: version-updates
         update-types: [major]
+
+  # React Native / Expo — its OWN config, because this package upgrades as ONE coordinated Expo SDK
+  # jump, never as a sweep. It is the only npm directory whose peer graph is pinned from outside:
+  # react-native hard-peers a react major, and @expo/cli reads tsconfig through the TypeScript
+  # compiler API. So a group PR that moves any ONE of those without the others cannot even install.
+  #
+  # 🚨 Why a SEPARATE config and not an `ignore:` on the block above: `ignore` applies to the whole
+  # update config, so holding react/typescript majors back for RN would also hold them back for
+  # /clients/react, /clients/portal-next and /clients/portal — which take them fine. Splitting the
+  # directory out is what makes the holdback surgical.
+  #
+  # This exact PR has now been opened and rejected twice (most recently #1704, 2026-08-17), each
+  # time dying in `npm ci` before a single check ran, and each time costing a full CI cycle + a
+  # Copilot review. The reasoning is recorded in clients/react-native/package.json's
+  # `_npm_major_holdback_note`; the forward path is issue #1584 (Expo SDK 52→57, RN ~0.82,
+  # expo-av → expo-audio/expo-video). Delete these holdbacks as PART of that migration, not before.
+  - package-ecosystem: npm
+    directory: "/clients/react-native"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: [minor, patch]
+      npm-major:
+        applies-to: version-updates
+        update-types: [major]
     ignore:
       # react-native's 0.x "minors" are breaking platform jumps coupled to the Expo SDK
       # (0.76→0.86 requires React 19): the first wave's group PR broke npm ci on exactly this.
       # RN (and react-native-web, which tracks it) upgrade DELIBERATELY with the Expo SDK.
       - dependency-name: react-native
       - dependency-name: react-native-web
+      # The Expo SDK moves as one unit with react-native — bumping expo 52→57 against RN 0.76.5
+      # is unresolvable. expo-av in particular is REMOVED in SDK 57 (expo-audio/expo-video), so
+      # this is a port, not a version bump.
+      - dependency-name: expo
+        update-types: [version-update:semver-major]
+      - dependency-name: "expo-*"
+        update-types: [version-update:semver-major]
+      - dependency-name: "@expo/*"
+        update-types: [version-update:semver-major]
+      # react-native@0.76.5 hard-peers react ^18.2.0, so a react 19 major fails `npm ci` outright.
+      # Probed directly: pinning @types/react back does NOT help — the blocker is the hard `react`
+      # peer, not the peerOptional @types/react one the CI log happens to surface first.
+      - dependency-name: react
+        update-types: [version-update:semver-major]
+      - dependency-name: react-dom
+        update-types: [version-update:semver-major]
+      - dependency-name: react-test-renderer
+        update-types: [version-update:semver-major]
+      - dependency-name: "@types/react"
+        update-types: [version-update:semver-major]
+      - dependency-name: "@types/react-test-renderer"
+        update-types: [version-update:semver-major]
+      # TypeScript 7 deleted the classic compiler API (and transpileModule) that @expo/cli SDK 52
+      # uses to read tsconfig, so `expo export` dies with
+      #   TypeError: Cannot read properties of undefined (reading 'getCurrentDirectory')
+      # Same removal that forced clients/typescript off transpileModule onto amaro.
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
 
   # Python SDK.
   - package-ecosystem: pip

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -79,6 +79,12 @@
     "   that forced clients/typescript off transpileModule onto amaro.",
     "",
     "Moving forward is issue #1584: react-native 0.82 peers are exactly react ^19.1.1 — the Expo",
-    "SDK 52->57 upgrade, which also has to port expo-av. Do that deliberately, not by sweep."
+    "SDK 52->57 upgrade, which also has to port expo-av. Do that deliberately, not by sweep.",
+    "",
+    "This note is now ENFORCED, not just documented: .github/dependabot.yml gives this directory",
+    "its own npm update config whose `ignore` holds back exactly the majors listed above (expo*,",
+    "@expo/*, react, react-dom, react-test-renderer, @types/react*, typescript). Before that split",
+    "the sweep re-opened the same unmergeable PR every Monday (#1704 was the second). Lift those",
+    "holdbacks as PART of the #1584 migration — they and this note retire together."
   ]
 }


### PR DESCRIPTION
## The recurring failure

The weekly `npm-major` sweep has opened the same unmergeable PR twice now — most recently **#1704** — and both times it died in `npm ci` **before a single check ran**:

```
npm error code ERESOLVE
npm error While resolving: react-native@0.76.5
npm error Could not resolve dependency:
npm error peerOptional @types/react@"^18.2.6" from react-native@0.76.5
```

Each occurrence costs a full CI cycle plus a Copilot review, and produces nothing.

## Why it can never succeed

`react-native` is *already* in dependabot's ignore list — deliberately, because its 0.x "minors" are breaking platform jumps coupled to the Expo SDK. So the sweep bumps everything *around* it and pins RN at 0.76.5. Two independent blockers result, both previously observed on CI rather than reasoned about:

1. **react 19 cannot install.** `react-native@0.76.5` hard-peers `react ^18.2.0`. (Probed directly: pinning `@types/react` back to 18 does *not* help — the blocker is the hard `react` peer, not the `peerOptional @types/react` one the CI log surfaces first.)
2. **typescript 7 breaks the web export.** `@expo/cli` (SDK 52) reads tsconfig through the classic TypeScript compiler API, which TS 7 deleted along with `transpileModule`. `expo export` dies with `TypeError: Cannot read properties of undefined (reading 'getCurrentDirectory')` — the same removal that forced `clients/typescript` off `transpileModule` onto amaro.

All of this was already written down in `clients/react-native/package.json`'s `_npm_major_holdback_note`. Prose does not stop a bot.

## The change

Give `/clients/react-native` its **own** npm update config, whose `ignore` holds back exactly the majors it cannot take — scoped to `version-update:semver-major`, so minor/patch bumps still flow:

`expo`, `expo-*`, `@expo/*`, `react`, `react-dom`, `react-test-renderer`, `@types/react`, `@types/react-test-renderer`, `typescript` — plus the existing unconditional `react-native` / `react-native-web` holds, which move here with it.

**Why a separate config rather than an `ignore:` on the shared block:** `ignore` applies to the whole update config. Holding react/typescript majors back for RN would also hold them back for `/clients/react`, `/clients/portal-next` and `/clients/portal` — which take them fine. Splitting the directory out is what makes the holdback surgical; the web clients keep receiving major bumps exactly as before.

`_npm_major_holdback_note` gains a pointer saying the holdback is now enforced in config, and that both retire together with the migration.

## Not a permanent freeze

The forward path is unchanged and unblocked: **#1584** — Expo SDK 52→57, RN ~0.82 (whose peers are exactly `react ^19.1.1`), and porting `expo-av` → `expo-audio`/`expo-video`. These `ignore` entries are meant to be deleted as *part* of that migration.

Closes the loop on #1704.

## Verification

`.github/dependabot.yml` parses; 6 update configs, npm split into the 5-directory web block (no ignores, unchanged grouping) and the react-native block (11 ignores). `clients/react-native/package.json` still parses as valid JSON.

## What's New

Skipped deliberately — dependency-maintenance config, no user-visible change.