### PR TITLE
fix(test): the usage-satellite wait point-read an absent node — use the children query

### DIFF
--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -3,11 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -107,6 +109,16 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
 
         var threadPath = await SeedThread();
         var client = GetClient();
+
+        // Open the usage observation BEFORE the round runs — at this point the thread has no
+        // _Usage namespace at all. RecordUsage is subscribed as an INDEPENDENT side effect,
+        // deliberately NOT chained before the terminal status write, so "the round finished" never
+        // implies "the satellite exists"; a consumer (ThreadTokenChip, this test) is routinely
+        // already watching while it does not. Waiting first makes that the DETERMINISTIC ordering
+        // instead of the one CI loses at random.
+        var watchingUsage = WaitForUsage(threadPath, HealthyUsageKey,
+            u => u.InputTokens == InTokens && u.OutputTokens == OutTokens, 30_000);
+
         client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
 
         var thread = await WaitForThread(threadPath,
@@ -125,8 +137,7 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
 
         // …and the same truth flows into token accounting: the per-model satellite is keyed by the
         // model that answered, so its cost is attributed to the right model.
-        var usage = await WaitForUsage(threadPath, HealthyUsageKey,
-            u => u.InputTokens == InTokens && u.OutputTokens == OutTokens, 30_000);
+        var usage = await watchingUsage;
         usage.Model.Should().Be(HealthyModel);
     }
 
@@ -278,13 +289,40 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
             .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
             .Match(m => predicate(m!)))!;
 
+    /// <summary>
+    /// Watches the per-model <see cref="TokenUsage"/> satellite at
+    /// <c>{threadPath}/_Usage/{modelKey}</c> until it matches <paramref name="predicate"/>.
+    ///
+    /// <para>🚨 Through the LIVE CHILDREN QUERY of <c>{threadPath}/_Usage</c> — byte for byte the
+    /// primitive <c>ThreadTokenChip</c> binds to in the portal, and the same helper
+    /// <c>ThreadTokenUsageTest</c> and <c>DelegationSubThreadUsageTest</c> already use — never a
+    /// point <c>GetMeshNodeStream({threadPath}/_Usage/{modelKey})</c> read. A point read of an
+    /// ABSENT node answers with an authoritative routing NotFound and TERMINATES the stream with an
+    /// error; it cannot wait for a node to appear. The children query starts from the (possibly
+    /// empty) collection and re-emits when the node lands, which is the only shape that serves this
+    /// ordering — and <c>TokenUsageNodeType.RecordUsage</c> is subscribed as an INDEPENDENT side
+    /// effect, deliberately NOT chained before the round's terminal status write, so "the round
+    /// finished" never implies "the satellite exists".</para>
+    ///
+    /// <para>This class was the last straggler on the point read. It cost a red shard on an
+    /// unrelated PR (#1703, 2026-08-17): the round lost the race and the read errored inside a
+    /// second with <c>No node found at …/_Usage/…</c> — an error, not a timeout, so no amount of
+    /// waiting could have saved it. Same defect #1040 fixed in <c>ThreadTokenUsageTest</c>.</para>
+    /// </summary>
     private async Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
-        => (await Mesh.GetWorkspace()
-            .GetMeshNodeStream($"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}")
-            .Select(n => n?.Content as TokenUsage)
+    {
+        var usagePath = $"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}";
+        return (await Mesh.GetQuery(
+                $"usage:{threadPath}",
+                $"path:{threadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
+                + $"nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
+            .Select(nodes => nodes
+                .FirstOrDefault(n => string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase))
+                .ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
             .Where(u => u is not null)
             .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
             .Match(u => predicate(u!)))!;
+    }
 
     // ─── Scripted chat client ───
 


### PR DESCRIPTION
## The red

Dependabot **#1703** — a dependency bump touching nothing but `package-lock.json` and `package.json` — failed **shard 3** on a .NET test it cannot possibly influence:

```
MeshWeaver.AI.Test.ModelSubstitutionTest.UnusableRequestedModel_RoundRecordsAnsweringModel_AndCarriesRequestedMarker

Expected the observable to emit a value matching the predicate within 30s, but it errored:
No node found at 'TestData/_Thread/…/_Usage/subst_healthy_model'.
Closest ancestor is 'TestData/_Thread/…' (remainder='_Usage/subst_healthy_model').
```

Note *errored*, not *timed out* — it failed inside a second. #1704, on the identical base commit, passed shard 3. So: a race, not a regression.

## Root cause

`ModelSubstitutionTest.WaitForUsage` read the per-model `TokenUsage` satellite through a **point** `GetMeshNodeStream({threadPath}/_Usage/{modelKey})`. That primitive cannot serve this read: a point read of an **absent** node answers with an authoritative routing `NotFound` and **terminates the stream with an error**. It can never wait for a node to appear, so no timeout is long enough.

And the node is routinely absent at subscribe time **by design**. `TokenUsageNodeType.RecordUsage` is subscribed as an *independent* side effect, deliberately **not** chained before the round's terminal status write — chaining it delayed the terminal write and gated round-completion on a slow satellite write. Its own doc comment says so, and names this exact failure mode. So "the round reached a terminal state" does not imply "the satellite exists"; waiting for the terminal state first, as this test did, only samples the **lucky** ordering.

## Deterministic repro, before any code changed

Opening the usage watch **before** the submit — the ordering production always has, since `ThreadTokenChip` opens its query the moment the chip is parameterised — reproduces the CI error locally in **2 s, 100% of the time**:

```
[Warning] RouteMessage: NotFound for RawJson → TestData/_Thread/…/_Usage/subst_healthy_model
[Warning] [SYNC_STREAM] OnError for … Owner=TestData/_Thread/…/_Usage/subst_healthy_model
=== TEST FAILED: … it errored: No node found at …
Failed!  -  Failed: 1, Passed: 0  — Duration: 2 s
```

The test now **keeps** that ordering, so the unlucky race is what it asserts rather than what it occasionally loses to.

## The fix

Use the primitive the rest of the codebase already uses for this exact read: the **live children query** of `{threadPath}/_Usage` — byte for byte what `ThreadTokenChip` binds to in the portal, and what `ThreadTokenUsageTest` and `DelegationSubThreadUsageTest` already do. It starts from the (possibly empty) collection and re-emits when the node lands, which is the only shape that serves this ordering.

`ModelSubstitutionTest` was the **last straggler** on the point read — #1040 fixed the same defect in `ThreadTokenUsageTest` and left this class behind. A repo-wide grep confirms no other reader remains.

**No production code changes.** The platform contract is correct and documented; this test was reading against it.

## Verification

| check | result |
|---|---|
| `ModelSubstitutionTest` (both tests) | 2/2 pass |
| full `MeshWeaver.AI.Test` project | **1150 passed, 0 failed**, 5 skipped (1 m 57 s) |
| `dotnet build -c Release -warnaserror` | 0 warnings, 0 errors |
| pre-fix, same repro | fails 100%, in 2 s, with the exact CI error |

Fresh `.trx` on every run — no `--no-build` no-op.

## What's New

Skipped deliberately — test-only, no user-visible change.