### PR TITLE
feat(#1707 S1b): MeshWeaver.Compiler.Cli dotnet tool + its own publish pipeline

### DIFF
--- a/.claude/skills/pullrequest/SKILL.md
+++ b/.claude/skills/pullrequest/SKILL.md
@@ -126,10 +126,19 @@ gh pr create --base main --head "$(git branch --show-current)" --title "…" --b
 #    suite finishes only when every shard job does, so there's no late-shard race — then read its
 #    conclusion. Merge ONLY on SUCCESS.
 #
-#    🔔 RUN THIS BLOCK IN THE BACKGROUND (harness: run_in_background: true) so you get ONE completion
-#    NOTIFICATION and keep working meanwhile — the background task IS your "CI finished" event. The
-#    loop exits 0 iff green, so the notification's exit code tells you whether to merge. (This is the
-#    push-style event a local session can have; GitHub can't webhook a CLI directly — see below.)
+#    🔔 PREFERRED SHAPE: a PERSISTENT harness `Monitor` armed at PR-open, subscribed to EVERY
+#    transition you'd act on — suite COMPLETED/SUCCESS, suite COMPLETED/<anything else> (red /
+#    cancelled / timed-out), a NEW unresolved review thread (the automatic Copilot review gates the
+#    merge and lands minutes after open), mergeStateStatus=DIRTY (a dirty PR runs ZERO CI), and
+#    MERGED/CLOSED (the monitor's exit). 🚨 Never a success-only watch: silence looks identical to
+#    "still running" while the thing you needed to react to already happened — and one-shot
+#    background loops die at their timeout cap and leave dead air until someone re-arms them
+#    (maintainer, 2026-08-17). See AGENTS.md → "SUBSCRIBE to a PR". One monitor can cover several
+#    open PRs and re-armed pushes (it keys on the LATEST commit each poll).
+#
+#    The single-shot fallback below (harness Bash, run_in_background: true) is acceptable when no
+#    Monitor is available: it exits 0 iff green, so the notification's exit code is the merge
+#    signal — but it fires ONCE, covers no review threads, and dies at the bash timeout cap.
 PR=<PR>
 Q='query($o:String!,$r:String!,$p:Int!){repository(owner:$o,name:$r){pullRequest(number:$p){commits(last:1){nodes{commit{checkSuites(first:20){nodes{status conclusion workflowRun{workflow{name}}}}}}}}}}'
 suite(){ gh api graphql -f query="$Q" -f o=Systemorph -f r=MeshWeaver -F p=$PR \

--- a/.github/workflows/publish-compiler-tool.yml
+++ b/.github/workflows/publish-compiler-tool.yml
@@ -1,0 +1,107 @@
+name: Publish Compiler Tool
+
+# The dotnet-tool distribution of the compiler (#1707 S1b): packs tools/MeshWeaver.PluginTester —
+# the SAME binary the platform CI runs to gate and bake content — as the MeshWeaver.Compiler.Cli
+# dotnet tool (command: mw-compiler) and publishes it to nuget.org. Deliberately a SEPARATE lane
+# from the platform package release (release-packages.yml): the tool ships on its own cadence
+# (maintainer, 2026-08-17: "you can publish tool nuget separately"). The docker distribution of
+# the same binary is the existing mw-plugin-test container image.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tool package version to publish (e.g. 3.0.0-rc4)"
+        required: true
+        type: string
+  push:
+    tags:
+      - 'compiler-tool-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  # A gate never tests its own inputs (AGENTS.md): the secret is asserted here, RED, naming what
+  # to provision — never an if:-shaped skip on the publish step.
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert publish inputs are provisioned
+        env:
+          NUGET_PAT: ${{ secrets.NUGET_PAT }}
+        run: |
+          missing=()
+          [ -n "$NUGET_PAT" ] || missing+=("secrets.NUGET_PAT (nuget.org API key — same secret release-packages.yml uses)")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::publish-compiler-tool cannot run — missing: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [preflight]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.x'
+
+      - name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/compiler-tool-v}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Restore
+        run: dotnet restore tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+
+      - name: Pack the tool
+        run: |
+          dotnet pack tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj \
+            --configuration Release --no-restore --output ./nupkgs \
+            -p:PackCompilerTool=true -p:CIRun=true \
+            -p:Version="$VERSION" -p:PackageVersion="$VERSION"
+
+      # Positive assertions — a pack that "succeeded" without these is a broken tool, not a pass:
+      #  • the surface manifest must be INSIDE the package, or the installed tool resolves a
+      #    forked framework identity and every bundle it produces is declined;
+      #  • the installed tool must actually run and resolve the s<hash> identity.
+      - name: Verify the package carries the surface manifest
+        run: |
+          pkg=$(ls ./nupkgs/MeshWeaver.Compiler.Cli.*.nupkg)
+          unzip -l "$pkg" | grep -F "meshweaver-surface.manifest" \
+            || { echo "::error::$pkg does not contain meshweaver-surface.manifest — the installed tool would resolve a forked framework identity"; exit 1; }
+
+      # An ISOLATED NuGet config: the repo's NuGet.config carries packageSourceMapping (pins
+      # MeshWeaver.* to a source), and `dotnet tool install --add-source` refuses to combine with
+      # mapping — verified locally 2026-08-17.
+      - name: Smoke-install and resolve the framework identity
+        run: |
+          cat > tool-smoke.nuget.config <<'EOF'
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="./nupkgs" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+          </configuration>
+          EOF
+          dotnet tool install MeshWeaver.Compiler.Cli --version "$VERSION" \
+            --tool-path ./toolbin --configfile tool-smoke.nuget.config
+          ./toolbin/mw-compiler --print-framework-identity | tee identity.txt
+          grep -Eq 's[0-9a-f]{7}' identity.txt \
+            || { echo "::error::mw-compiler did not resolve an s<hash> surface identity"; exit 1; }
+
+      # --skip-duplicate makes a re-run idempotent (same rationale as release-packages.yml).
+      - name: Publish to nuget.org
+        run: |
+          dotnet nuget push ./nupkgs/MeshWeaver.Compiler.Cli.*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_PAT }} --skip-duplicate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,30 @@ Merge only on `COMPLETED/SUCCESS` for that suite. Two further gotchas:
   token budget into 403s that masquerade as CI-red. Use the GraphQL query above, or a `Monitor` that
   filters on the workflow name.
 
+### 🚨 SUBSCRIBE to a PR — one persistent Monitor over EVERY event you'd act on, never a success-only watch
+
+**Waiting on a PR is event-driven work: arm ONE persistent `Monitor` (the harness tool) when you
+open the PR, and let it wake you.** Hand-re-armed one-shot polls die at their timeout cap and leave
+dead air between "CI finished" and "you noticed" — and a watch that only fires on the happy path is
+the same defect as a gate that skips on missing input: **silence looks identical to
+"still running" while the thing you needed to react to already happened** (maintainer, 2026-08-17:
+"we keep losing time because of such problems"). The monitor's poll loop (GraphQL, ~45s) must emit
+a line on EACH of these transitions, not just green:
+
+- **suite `COMPLETED/SUCCESS`** — the merge signal;
+- **suite `COMPLETED/<anything else>`** (FAILURE / CANCELLED / TIMED_OUT / STALE) — go read the
+  failing job log NOW, not at the next manual check;
+- **a NEW unresolved review thread** (the ruleset's Copilot review lands minutes after open —
+  unwatched, it silently gates the merge);
+- **`mergeStateStatus = DIRTY`** — a dirty PR runs ZERO CI, so with a success-only watch it waits
+  forever;
+- **`MERGED` / `CLOSED`** — the monitor's own exit condition.
+
+One monitor can cover several open PRs (loop over them; emit per-PR lines; exit when all are
+terminal). The same rule applies to any long-running external wait — a deploy, a bake, a
+reconciler: enumerate the terminal states first, subscribe to all of them, and treat "my filter
+only matches success" as a bug to fix before arming.
+
 **Also check the clock before declaring a job stuck.** GitHub timestamps are UTC; a local-time
 comparison makes a healthy 7-minute build look like a 33-minute hang. `date -u` first.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-the-content-compiler-as-a-dotnet-tool.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-the-content-compiler-as-a-dotnet-tool.md
@@ -12,7 +12,7 @@ The compiler that CI uses to gate and bake mesh content — the same code path t
 with at runtime — can now be installed directly:
 
 ```
-dotnet tool install MeshWeaver.Compiler.Cli
+dotnet tool install -g MeshWeaver.Compiler.Cli
 mw-compiler <checkout-root> --bake-output <dir>
 mw-compiler --print-framework-identity
 ```

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-the-content-compiler-as-a-dotnet-tool.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-the-content-compiler-as-a-dotnet-tool.md
@@ -1,0 +1,24 @@
+---
+Name: Install the content compiler as a dotnet tool
+Category: Feature
+Description: The content compiler that gates and bakes mesh content in CI is now installable as the MeshWeaver.Compiler.Cli dotnet tool (command mw-compiler) — content repos run the exact binary the platform runs, with no platform-repo download.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Install the content compiler as a dotnet tool
+
+The compiler that CI uses to gate and bake mesh content — the same code path the portals compile
+with at runtime — can now be installed directly:
+
+```
+dotnet tool install MeshWeaver.Compiler.Cli
+mw-compiler <checkout-root> --bake-output <dir>
+mw-compiler --print-framework-identity
+```
+
+A content repository's CI installs the tool version matching its platform, compiles its node
+trees, and publishes prebuilt-assembly bundles the portals adopt at boot instead of recompiling.
+The framework build identity resolves from the manifest packed inside the tool, so what the tool
+bakes and what a portal would accept can never disagree. The same binary also ships as the
+existing `mw-plugin-test` container image for docker-based pipelines.

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <!-- The dotnet-tool distribution of the compiler (#1707 S1b): the SAME binary CI's bake/gate
-       runs, installable via `dotnet tool install MeshWeaver.Compiler.Cli` so satellite repos need
-       no platform-repo artifact download. OPT-IN via -p:PackCompilerTool=true (the
+       runs, installable via `dotnet tool install -g MeshWeaver.Compiler.Cli` so satellite repos
+       need no platform-repo artifact download. OPT-IN via -p:PackCompilerTool=true (the
        publish-compiler-tool workflow) — IsPackable stays false for the platform release pack, so
        `dotnet pack` over the solution never ships this exe as an ordinary library package. The
        docker distribution of the same binary is the existing mw-plugin-test container image. -->

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -15,6 +15,24 @@
     <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
   </PropertyGroup>
 
+  <!-- The dotnet-tool distribution of the compiler (#1707 S1b): the SAME binary CI's bake/gate
+       runs, installable via `dotnet tool install MeshWeaver.Compiler.Cli` so satellite repos need
+       no platform-repo artifact download. OPT-IN via -p:PackCompilerTool=true (the
+       publish-compiler-tool workflow) — IsPackable stays false for the platform release pack, so
+       `dotnet pack` over the solution never ships this exe as an ordinary library package. The
+       docker distribution of the same binary is the existing mw-plugin-test container image. -->
+  <PropertyGroup Condition="'$(PackCompilerTool)' == 'true'">
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>mw-compiler</ToolCommandName>
+    <PackageId>MeshWeaver.Compiler.Cli</PackageId>
+    <!-- ONE portable, framework-dependent tool package. With the container RID list left in
+         place, PackAsTool splits into linux-only RID packages — uninstallable on a macOS/Windows
+         CI host. The tool is RID-agnostic IL, exactly like the module bundles. -->
+    <RuntimeIdentifiers></RuntimeIdentifiers>
+    <Description>The MeshWeaver content compiler CLI — the same binary the platform CI runs to gate and bake mesh content: stages content from a git checkout, compiles NodeTypes with the MeshWeaver.Compiler toolchain, and (with --bake-output) emits prebuilt-assembly bundles keyed by the framework build identity.</Description>
+  </PropertyGroup>
+
   <!-- 🚨 NO ContainerEnvironmentVariable PATH override. The one that used to sit here (added for
        GitHub Actions `container:` jobs, which run steps through `sh -c` and need the apphost on
        PATH) BROKE the image twice over, and its reason no longer exists:

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -1,0 +1,26 @@
+# MeshWeaver.Compiler.Cli (`mw-compiler` / `mw-plugin-test`)
+
+The MeshWeaver content compiler CLI — the same binary the platform CI runs to gate and bake mesh
+content (#1707). It stages content from a git checkout, compiles NodeTypes with the
+`MeshWeaver.Compiler` toolchain (the identical code path the portals use at runtime), and — with
+`--bake-output` — emits prebuilt-assembly bundles keyed by the framework build identity, so
+portals adopt instead of recompiling.
+
+Distributed two ways, same binary:
+
+- **dotnet tool** — `dotnet tool install MeshWeaver.Compiler.Cli` (command: `mw-compiler`), for
+  satellite content repos' CI lanes: install the version matching your platform, run the bake, no
+  platform-repo artifact download.
+- **container image** — the `mw-plugin-test` image the plugin gates run.
+
+Useful entry points:
+
+```
+mw-compiler <checkout-root>                 # the content gate: compile the repo's node trees
+mw-compiler <root> --bake-output <dir>      # …and persist bundles + framework-mvid.txt
+mw-compiler --print-framework-identity      # one-line identity + provenance diagnostic
+```
+
+The framework build identity resolves from the `meshweaver-surface.manifest` packed beside the
+binaries — equal by construction with the portals' identity (see
+`Doc/Architecture/CiContentBake`), which is what makes the bundles this tool produces adoptable.

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -8,9 +8,9 @@ portals adopt instead of recompiling.
 
 Distributed two ways, same binary:
 
-- **dotnet tool** — `dotnet tool install MeshWeaver.Compiler.Cli` (command: `mw-compiler`), for
-  satellite content repos' CI lanes: install the version matching your platform, run the bake, no
-  platform-repo artifact download.
+- **dotnet tool** — `dotnet tool install -g MeshWeaver.Compiler.Cli` (command: `mw-compiler`; use
+  `--tool-path`/`--local` for CI-scoped installs), for satellite content repos' CI lanes: install
+  the version matching your platform, run the bake, no platform-repo artifact download.
 - **container image** — the `mw-plugin-test` image the plugin gates run.
 
 Useful entry points:


### PR DESCRIPTION
## #1707 S1b — the compiler installs via `dotnet tool install`, published separately

- `tools/MeshWeaver.PluginTester` — the SAME binary CI's gate/bake runs — packs as the portable dotnet tool **`MeshWeaver.Compiler.Cli`** (command: `mw-compiler`) behind an explicit `-p:PackCompilerTool=true` (repo default stays `IsPackable=false`, so the platform release pack never ships the exe). The container RID list is cleared under the flag — PackAsTool otherwise splits into linux-only RID packages uninstallable on macOS/Windows hosts.
- **`publish-compiler-tool.yml`** — a separate lane from `release-packages.yml` (maintainer: "you can publish tool nuget separately"): `workflow_dispatch` (version input) + `compiler-tool-v*` tags; preflight asserts `NUGET_PAT` RED (no skip-trapdoors); two positive assertions gate the push: the **surface manifest must be inside the package** (else the installed tool resolves a forked framework identity and every bundle it produces is declined) and a **smoke install must resolve an `s<hash>` identity**. The smoke install uses an isolated NuGet config — the repo's `NuGet.config` packageSourceMapping refuses `--add-source` (verified locally).
- What's New entry included. The docker distribution of the same binary is the existing `mw-plugin-test` container image.

**Verified locally**: one portable package; `meshweaver-surface.manifest` inside; smoke install runs and resolves `identity=sd8055c7…` — identical to the repo-built binary on the same tree.

After merge: dispatch the workflow with the platform version (3.0.0-rc4) to publish — ideally after #1712 lands so the published tool carries the Compiler-anchored identity.

Part of #1707; under #1660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)