### PR TITLE
fix(#1716): anchored edit_content verifies the anchor inside the owning hub's write turn

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1847,16 +1847,22 @@ public class MeshOperations
 
                 var versionBefore = existing.Version;
                 var appliedCount = 0;
+                string? expectedText = null;
                 return hub.GetWorkspace().GetMeshNodeStream(resolvedPath)
                     // The anchored check-and-replace runs against the LIVE node the framework
                     // hands the lambda (the CollaborationPlugin.SuggestEdit shape). On a
                     // Conflict NACK the re-enqueued lambda re-counts against fresh state, so
                     // the uniqueness check and the replacement always see the same text the
-                    // write applies to.
+                    // write applies to. The lambda records the EXACT post-edit text it
+                    // produced (a re-run overwrites it) — the landed-write gate below compares
+                    // against that, never against bare newText presence: newText can occur
+                    // elsewhere in the document BEFORE the edit, which would satisfy a
+                    // presence check even for a write that never applied.
                     .Update(live =>
                     {
                         var updated = ApplyAnchoredEdit(live, oldText, newText, replaceAll, out var count);
                         appliedCount = count;
+                        expectedText = ExtractEditableText(updated);
                         return updated;
                     })
                     .Take(1)
@@ -1866,9 +1872,11 @@ public class MeshOperations
                     // 🚨 Gate the success string on the edit provably landing (#1716):
                     // UpdateRemote emits OPTIMISTICALLY after its short owner-response bound,
                     // and an exhausted late-NACK retry only logs LATE_NACK_TERMINAL. Wait
-                    // (bounded) until the live mirror actually contains the edit; name the
-                    // conflict when it never does, instead of lying "Edited:".
-                    .SelectMany(_ => WaitForEditApplied(resolvedPath, oldText, newText))
+                    // (bounded) until the live mirror provably reflects OUR edit; name the
+                    // conflict when it never does, instead of lying "Edited:". The expected
+                    // text is read per emission (Func) so a Conflict re-enqueue's re-run —
+                    // which rewrites expectedText — is picked up by the live predicate.
+                    .SelectMany(_ => WaitForEditApplied(resolvedPath, oldText, newText, () => expectedText))
                     .Select(after =>
                     {
                         if (after is null)
@@ -1917,33 +1925,47 @@ public class MeshOperations
 
     /// <summary>
     /// Bounded wait for the anchored edit to be OBSERVABLE in the live mirror: emits the
-    /// first node state that provably contains the edit, or <c>null</c> when it never
-    /// appears within the budget (the write was NACKed away or lost). Subscribes the
-    /// cache mirror's READ stream — same non-deadlocking shape as
-    /// <see cref="WaitForReadYourWrites"/>.
+    /// first node state that provably reflects the edit (see <see cref="IsEditApplied"/>),
+    /// or <c>null</c> when it never appears within the budget (the write was NACKed away
+    /// or lost). <paramref name="expectedText"/> is a live read of the post-edit text the
+    /// update lambda produced — a Func, not a snapshot, because a Conflict re-enqueue
+    /// re-runs the lambda and rewrites the expectation. Subscribes the cache mirror's
+    /// READ stream — same non-deadlocking shape as <see cref="WaitForReadYourWrites"/>.
     /// </summary>
-    private IObservable<MeshNode?> WaitForEditApplied(string path, string oldText, string newText) =>
+    private IObservable<MeshNode?> WaitForEditApplied(
+        string path, string oldText, string newText, Func<string?> expectedText) =>
         hub.GetWorkspace().GetMeshNodeStream(path)
-            .Where(n => n is not null && IsEditApplied(n, oldText, newText))
+            .Where(n => n is not null
+                && expectedText() is { } expected
+                && IsEditApplied(n, oldText, newText, expected))
             .Take(1)
             .Select(n => (MeshNode?)n)
             .Timeout(TimeSpan.FromSeconds(5))
             .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null));
 
     /// <summary>
-    /// Whether <paramref name="node"/>'s text provably contains the applied edit. A successful
-    /// single replace covers the ONLY occurrence and <c>replaceAll</c> covers all of them, so a
-    /// landed deletion (empty <paramref name="newText"/>) means the anchor is gone; otherwise
-    /// the replacement text must be present.
+    /// Whether <paramref name="node"/>'s text provably reflects the applied edit, given
+    /// <paramref name="expectedText"/> — the EXACT post-edit text the update lambda produced.
+    /// 🚨 STRUCTURAL, never a bare "contains newText" probe: <paramref name="newText"/> can
+    /// occur elsewhere in the document BEFORE the edit, so presence alone would report a lost
+    /// write as landed. Exact equality with the expectation is the primary check; the fallback
+    /// tolerates a concurrent writer landing AFTER our edit (so the mirror never shows exactly
+    /// our expected text) by requiring the occurrence structure the edit produced: at least the
+    /// expectation's count of <paramref name="newText"/>, and no more than the expectation's
+    /// count of <paramref name="oldText"/> (0 unless <paramref name="newText"/> re-contains it).
+    /// For a deletion (empty <paramref name="newText"/>) only the anchor-count bound applies.
     /// </summary>
-    internal static bool IsEditApplied(MeshNode node, string oldText, string newText)
+    internal static bool IsEditApplied(MeshNode node, string oldText, string newText, string expectedText)
     {
         var text = ExtractEditableText(node);
         if (text is null)
             return false;
+        if (string.Equals(text, expectedText, StringComparison.Ordinal))
+            return true;
+        var anchorGone = CountOccurrences(text, oldText) <= CountOccurrences(expectedText, oldText);
         return newText.Length > 0
-            ? text.Contains(newText, StringComparison.Ordinal)
-            : !text.Contains(oldText, StringComparison.Ordinal);
+            ? anchorGone && CountOccurrences(text, newText) >= CountOccurrences(expectedText, newText)
+            : anchorGone;
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1799,6 +1799,13 @@ public class MeshOperations
     /// document through Patch (token cost + truncation corruption on long files).
     /// Same read-your-writes semantics as Patch. Every failure mode returns a descriptive
     /// error telling the agent how to recover.
+    /// <para>🚨 ATOMIC (#1716): the anchor check-and-replace runs INSIDE
+    /// <c>GetMeshNodeStream(path).Update(...)</c> against the LIVE node — not against a
+    /// pre-read snapshot. A content-only edit ships as a base-fingerprinted splice the
+    /// owner applies only when its live text provably matches the base; a Conflict NACK
+    /// re-enqueues the lambda, which re-verifies the anchor against fresh state. The
+    /// success string is additionally gated on the edit provably landing in the live
+    /// mirror, so an exhausted late-NACK retry surfaces as an error, never "Edited:".</para>
     /// </summary>
     public IObservable<string> EditContent(string path, string oldText, string newText, bool replaceAll = false)
     {
@@ -1828,60 +1835,60 @@ public class MeshOperations
                         $"Error: node not found at {resolvedPath}. The path must be the node's exact 'path' property — " +
                         "locate it with Search and retry with the 'path' value from the match.");
 
-                var text = existing.Content switch
-                {
-                    MarkdownContent md => md.Content,
-                    CodeConfiguration code => code.Code,
-                    string s => s,
-                    _ => null
-                };
-
-                if (text == null)
+                // Pre-flight ONLY (#1716): this snapshot supplies the friendly not-text error
+                // and the pre-write version for the read-your-writes barrier. The authoritative
+                // anchor check runs inside the write lambda below — a snapshot-verified anchor
+                // can be gone by the time the write applies.
+                if (ExtractEditableText(existing) is null)
                     return Observable.Return(
                         $"Error: cannot edit {resolvedPath}: its content is " +
                         $"{existing.Content?.GetType().Name ?? "empty"}, not editable text. EditContent works on " +
                         "Markdown and Code nodes; for structured content use Patch with the full 'content' object.");
 
-                var count = CountOccurrences(text, oldText);
-                if (count == 0)
-                    return Observable.Return(
-                        $"Error: the text to replace was not found in {resolvedPath}. Get the node and copy the " +
-                        "exact text — including whitespace and line breaks — then retry. " +
-                        $"(Current content is {text.Length} chars.)");
-                if (count > 1 && !replaceAll)
-                    return Observable.Return(
-                        $"Error: the text to replace occurs {count} times in {resolvedPath}. Include more " +
-                        "surrounding context to make the match unique, or set replaceAll=true to change every occurrence.");
-
-                var newFull = text.Replace(oldText, newText, StringComparison.Ordinal);
-                var merged = existing.Content switch
-                {
-                    MarkdownContent md => WithRerenderedMarkdown(existing, md, newFull),
-                    CodeConfiguration code => existing with { Content = code with { Code = newFull } },
-                    _ => existing with { Content = newFull },
-                };
-
                 var versionBefore = existing.Version;
-                return mesh.UpdateNode(merged)
+                var appliedCount = 0;
+                return hub.GetWorkspace().GetMeshNodeStream(resolvedPath)
+                    // The anchored check-and-replace runs against the LIVE node the framework
+                    // hands the lambda (the CollaborationPlugin.SuggestEdit shape). On a
+                    // Conflict NACK the re-enqueued lambda re-counts against fresh state, so
+                    // the uniqueness check and the replacement always see the same text the
+                    // write applies to.
+                    .Update(live =>
+                    {
+                        var updated = ApplyAnchoredEdit(live, oldText, newText, replaceAll, out var count);
+                        appliedCount = count;
+                        return updated;
+                    })
+                    .Take(1)
+                    .DefaultIfEmpty()
                     // Same read-your-writes barrier as Patch — see comment there.
-                    .SelectMany(updated => WaitForReadYourWrites(resolvedPath, versionBefore)
-                        .Select(confirmed =>
+                    .SelectMany(_ => WaitForReadYourWrites(resolvedPath, versionBefore))
+                    // 🚨 Gate the success string on the edit provably landing (#1716):
+                    // UpdateRemote emits OPTIMISTICALLY after its short owner-response bound,
+                    // and an exhausted late-NACK retry only logs LATE_NACK_TERMINAL. Wait
+                    // (bounded) until the live mirror actually contains the edit; name the
+                    // conflict when it never does, instead of lying "Edited:".
+                    .SelectMany(_ => WaitForEditApplied(resolvedPath, oldText, newText))
+                    .Select(after =>
+                    {
+                        if (after is null)
+                            return $"Error: the edit did not land on {resolvedPath} — a concurrent " +
+                                   "change conflicted with it. Get the node to see its current " +
+                                   "content and retry with a fresh oldText.";
+                        OnNodeChange?.Invoke(new NodeChangeEntry
                         {
-                            var after = confirmed ?? updated;
-                            OnNodeChange?.Invoke(new NodeChangeEntry
-                            {
-                                Path = after.Path,
-                                Operation = "Updated",
-                                VersionBefore = versionBefore,
-                                VersionAfter = after.Version,
-                                NodeType = after.NodeType,
-                                NodeName = after.Name
-                            });
-                            var plural = count == 1 ? "" : "s";
-                            return $"Edited: {after.Path} ({count} replacement{plural})";
-                        }))
+                            Path = after.Path,
+                            Operation = "Updated",
+                            VersionBefore = versionBefore,
+                            VersionAfter = after.Version,
+                            NodeType = after.NodeType,
+                            NodeName = after.Name
+                        });
+                        var plural = appliedCount == 1 ? "" : "s";
+                        return $"Edited: {after.Path} ({appliedCount} replacement{plural})";
+                    })
                     .Catch((Exception ex) =>
-                        Observable.Return($"Error editing {resolvedPath}: {ex.Message}"));
+                        Observable.Return(TranslateAnchoredEditError(ex, resolvedPath)));
             })
             .Catch((Exception ex) =>
             {
@@ -1889,6 +1896,54 @@ public class MeshOperations
                 return Observable.Return($"Error: {ex.Message}");
             });
         });
+    }
+
+    /// <summary>
+    /// Maps the anchored-edit exception types thrown inside the write lambda back to the
+    /// tool's contract error strings — byte-identical to the messages the pre-#1716
+    /// snapshot check produced, so agents see an unchanged contract.
+    /// </summary>
+    private static string TranslateAnchoredEditError(Exception ex, string resolvedPath) => ex switch
+    {
+        AnchorNotFoundException notFound =>
+            $"Error: the text to replace was not found in {resolvedPath}. Get the node and copy the " +
+            "exact text — including whitespace and line breaks — then retry. " +
+            $"(Current content is {notFound.ContentLength} chars.)",
+        AmbiguousAnchorException ambiguous =>
+            $"Error: the text to replace occurs {ambiguous.OccurrenceCount} times in {resolvedPath}. Include more " +
+            "surrounding context to make the match unique, or set replaceAll=true to change every occurrence.",
+        _ => $"Error editing {resolvedPath}: {ex.Message}"
+    };
+
+    /// <summary>
+    /// Bounded wait for the anchored edit to be OBSERVABLE in the live mirror: emits the
+    /// first node state that provably contains the edit, or <c>null</c> when it never
+    /// appears within the budget (the write was NACKed away or lost). Subscribes the
+    /// cache mirror's READ stream — same non-deadlocking shape as
+    /// <see cref="WaitForReadYourWrites"/>.
+    /// </summary>
+    private IObservable<MeshNode?> WaitForEditApplied(string path, string oldText, string newText) =>
+        hub.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null && IsEditApplied(n, oldText, newText))
+            .Take(1)
+            .Select(n => (MeshNode?)n)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null));
+
+    /// <summary>
+    /// Whether <paramref name="node"/>'s text provably contains the applied edit. A successful
+    /// single replace covers the ONLY occurrence and <c>replaceAll</c> covers all of them, so a
+    /// landed deletion (empty <paramref name="newText"/>) means the anchor is gone; otherwise
+    /// the replacement text must be present.
+    /// </summary>
+    internal static bool IsEditApplied(MeshNode node, string oldText, string newText)
+    {
+        var text = ExtractEditableText(node);
+        if (text is null)
+            return false;
+        return newText.Length > 0
+            ? text.Contains(newText, StringComparison.Ordinal)
+            : !text.Contains(oldText, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -1921,6 +1976,69 @@ public class MeshOperations
             i += needle.Length;
         }
         return count;
+    }
+
+    /// <summary>
+    /// Extracts the node's primary editable text — the Markdown body, the Code source, or a raw
+    /// string — or <c>null</c> when the content is not editable text (structured content, a
+    /// degraded <c>JsonElement</c>, empty).
+    /// </summary>
+    internal static string? ExtractEditableText(MeshNode node) => node.Content switch
+    {
+        MarkdownContent md => md.Content,
+        CodeConfiguration code => code.Code,
+        string s => s,
+        _ => null
+    };
+
+    /// <summary>
+    /// The pure anchored-edit transition (#1716): extracts the text from the LIVE node, verifies
+    /// the anchor there (0 matches ⇒ <see cref="AnchorNotFoundException"/>; several without
+    /// <paramref name="replaceAll"/> ⇒ <see cref="AmbiguousAnchorException"/>), replaces
+    /// (ordinal), and rebuilds the node — re-rendering the derived markdown artefacts exactly as
+    /// before. Designed to run INSIDE <c>GetMeshNodeStream(path).Update(...)</c> so the check and
+    /// the replacement see the same state the write applies to; a Conflict re-enqueue re-runs it
+    /// against fresh state.
+    /// </summary>
+    internal static MeshNode ApplyAnchoredEdit(MeshNode live, string oldText, string newText, bool replaceAll)
+        => ApplyAnchoredEdit(live, oldText, newText, replaceAll, out _);
+
+    /// <summary>
+    /// <see cref="ApplyAnchoredEdit(MeshNode, string, string, bool)"/> with the number of
+    /// replacements made, for the caller's success message.
+    /// </summary>
+    internal static MeshNode ApplyAnchoredEdit(
+        MeshNode live, string oldText, string newText, bool replaceAll, out int replacements)
+    {
+        var text = ExtractEditableText(live)
+            ?? throw new InvalidOperationException(
+                $"content is {live.Content?.GetType().Name ?? "empty"}, not editable text");
+        var newFull = AnchoredReplace(text, oldText, newText, replaceAll, out replacements);
+        return live.Content switch
+        {
+            MarkdownContent md => WithRerenderedMarkdown(live, md, newFull),
+            CodeConfiguration code => live with { Content = code with { Code = newFull } },
+            _ => live with { Content = newFull },
+        };
+    }
+
+    /// <summary>
+    /// The ONE anchored text replace (#1716) — shared by <see cref="ApplyAnchoredEdit(MeshNode,
+    /// string, string, bool)"/> and <c>CollaborationPlugin.Splice</c> so the uniqueness contract
+    /// cannot drift between the two edit surfaces. Throws <see cref="AnchorNotFoundException"/>
+    /// on 0 matches and <see cref="AmbiguousAnchorException"/> on an ambiguous match without
+    /// <paramref name="replaceAll"/>.
+    /// </summary>
+    internal static string AnchoredReplace(
+        string text, string oldText, string newText, bool replaceAll, out int replacements)
+    {
+        var count = CountOccurrences(text, oldText);
+        if (count == 0)
+            throw new AnchorNotFoundException(text.Length);
+        if (count > 1 && !replaceAll)
+            throw new AmbiguousAnchorException(count);
+        replacements = count;
+        return text.Replace(oldText, newText, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -4145,4 +4263,37 @@ public class MeshOperations
                 });
         });
     }
+}
+
+/// <summary>
+/// Thrown by the anchored-edit primitive (<see cref="MeshOperations.AnchoredReplace"/>) when the
+/// text to replace has 0 occurrences in the LIVE content — the anchor was edited away between the
+/// caller's read and the write turn (or never existed). Carries the live content's length so the
+/// tool error can tell the agent what it was checked against.
+/// </summary>
+internal sealed class AnchorNotFoundException : InvalidOperationException
+{
+    /// <summary>Creates the exception, recording the live content's length.</summary>
+    public AnchorNotFoundException(int contentLength)
+        : base("the text to replace was not found — it may have been edited since you read it")
+        => ContentLength = contentLength;
+
+    /// <summary>Length (chars) of the live content the anchor was checked against.</summary>
+    public int ContentLength { get; }
+}
+
+/// <summary>
+/// Thrown by the anchored-edit primitive (<see cref="MeshOperations.AnchoredReplace"/>) when the
+/// text to replace occurs more than once in the LIVE content and <c>replaceAll</c> was not set —
+/// replacing an arbitrary occurrence would corrupt the document.
+/// </summary>
+internal sealed class AmbiguousAnchorException : InvalidOperationException
+{
+    /// <summary>Creates the exception, recording how many occurrences were found.</summary>
+    public AmbiguousAnchorException(int occurrenceCount)
+        : base($"the text to replace occurs {occurrenceCount} times — include more surrounding context to make the match unique")
+        => OccurrenceCount = occurrenceCount;
+
+    /// <summary>Number of occurrences found in the live content.</summary>
+    public int OccurrenceCount { get; }
 }

--- a/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
@@ -216,9 +216,12 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
     }
 
     /// <summary>
-    /// The pure edit transition: replaces the first occurrence of <paramref name="originalText"/>
-    /// with <paramref name="newText"/> (empty original ⇒ prepend). Throws when the text is no longer
-    /// there — silently splicing at offset 0 would corrupt the document.
+    /// The pure edit transition: replaces the single occurrence of <paramref name="originalText"/>
+    /// with <paramref name="newText"/> (empty original ⇒ prepend). Delegates to the ONE anchored
+    /// replace (<see cref="MeshOperations.AnchoredReplace"/>, #1716) with <c>replaceAll:false</c>,
+    /// so it keeps its single-replace semantics but gains the uniqueness check: it throws when the
+    /// text is no longer there (silently splicing at offset 0 would corrupt the document) AND when
+    /// the anchor is ambiguous (splicing an arbitrary one of several would too).
     /// </summary>
     internal static string Splice(string? content, string originalText, string newText)
     {
@@ -226,11 +229,20 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
         if (string.IsNullOrEmpty(originalText))
             return newText + text;
 
-        var start = text.IndexOf(originalText, StringComparison.Ordinal);
-        if (start < 0)
+        try
+        {
+            return MeshOperations.AnchoredReplace(text, originalText, newText ?? "", replaceAll: false, out _);
+        }
+        catch (AnchorNotFoundException)
+        {
             throw new InvalidOperationException(
                 $"Text '{Truncate(originalText)}' is not present in the document — it may have been edited since you read it.");
-        return text.Remove(start, originalText.Length).Insert(start, newText ?? "");
+        }
+        catch (AmbiguousAnchorException ex)
+        {
+            throw new InvalidOperationException(
+                $"Text '{Truncate(originalText)}' occurs {ex.OccurrenceCount} times in the document — include more surrounding context to make the match unique.");
+        }
     }
 
     private static string Describe(string documentPath, string originalText, string newText)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-atomic-edit-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-atomic-edit-content.md
@@ -1,0 +1,11 @@
+---
+Name: Anchored edits are now atomic
+Category: Fix
+Description: edit_content verifies its anchor against the live document at write time, so concurrent edits no longer clobber each other and a lost write reports an error instead of success.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Anchored edits are now atomic
+
+The `edit_content` tool used to check its text anchor against a snapshot read before the write, so an edit landing in between could be silently overwritten — and a write that never applied could still report "Edited". The check-and-replace now runs against the live document inside the owning hub's write turn: two people (or agents) editing different parts of the same document at once both keep their changes, an anchor that was edited away is refused with a clear message, and the success message is only reported once the edit has provably landed.

--- a/test/MeshWeaver.AI.Test/AnchoredEditContentTest.cs
+++ b/test/MeshWeaver.AI.Test/AnchoredEditContentTest.cs
@@ -181,18 +181,47 @@ public class AnchoredEditContentTest(ITestOutputHelper output) : MonolithMeshTes
     // ── IsEditApplied: the landed-write verification predicate ───────────────────────────────
 
     [Fact]
-    public void IsEditApplied_ReplacementPresent_IsTrue()
-        => MeshOperations.IsEditApplied(Markdown("v1", "abc NEW def"), "OLD", "NEW").Should().BeTrue();
+    public void IsEditApplied_LiveMatchesExpectedText_IsTrue()
+        => MeshOperations.IsEditApplied(Markdown("v1", "abc NEW def"), "OLD", "NEW", "abc NEW def")
+            .Should().BeTrue();
 
     [Fact]
     public void IsEditApplied_ReplacementAbsent_IsFalse()
-        => MeshOperations.IsEditApplied(Markdown("v2", "abc OLD def"), "OLD", "NEW").Should().BeFalse();
+        => MeshOperations.IsEditApplied(Markdown("v2", "abc OLD def"), "OLD", "NEW", "abc NEW def")
+            .Should().BeFalse();
+
+    /// <summary>
+    /// Regression pin for the Copilot finding on #1717: when newText ALREADY occurred elsewhere
+    /// in the document before the edit, a bare "contains newText" probe reports a LOST write as
+    /// landed. The structural predicate must refuse: the live text still holds the anchor and
+    /// only the pre-existing newText occurrence, not the occurrence the edit would have added.
+    /// </summary>
+    [Fact]
+    public void IsEditApplied_NewTextPreexistingElsewhere_LostWrite_IsFalse()
+        => MeshOperations.IsEditApplied(
+                Markdown("v3", "x NEW y OLD z"), "OLD", "NEW", expectedText: "x NEW y NEW z")
+            .Should().BeFalse("a pre-existing newText occurrence must not satisfy the gate for a write that never landed");
+
+    [Fact]
+    public void IsEditApplied_ConcurrentLaterEdit_StillRecognizesOurLandedEdit()
+        // Our edit (OLD→NEW) landed, then a concurrent writer appended text — the mirror never
+        // shows exactly our expected text, but the occurrence structure proves the edit is in.
+        => MeshOperations.IsEditApplied(
+                Markdown("v4", "x NEW y NEW z PLUS"), "OLD", "NEW", expectedText: "x NEW y NEW z")
+            .Should().BeTrue("a later concurrent edit on top of ours must not read as a conflict");
+
+    [Fact]
+    public void IsEditApplied_ShrinkingReplace_LostWrite_IsFalse()
+        // newText is a substring of oldText ("cats"→"cat"): the live text trivially contains
+        // newText, so only the anchor-count bound can tell a lost write from a landed one.
+        => MeshOperations.IsEditApplied(Markdown("v5", "cats"), "cats", "cat", expectedText: "cat")
+            .Should().BeFalse("the anchor still being present proves the write did not land");
 
     [Fact]
     public void IsEditApplied_Deletion_TrueOnlyWhenAnchorGone()
     {
-        MeshOperations.IsEditApplied(Markdown("v3", "abc def"), "OLD", "").Should().BeTrue();
-        MeshOperations.IsEditApplied(Markdown("v4", "abc OLD def"), "OLD", "").Should().BeFalse();
+        MeshOperations.IsEditApplied(Markdown("v6", "abc def"), "OLD", "", "abc def").Should().BeTrue();
+        MeshOperations.IsEditApplied(Markdown("v7", "abc OLD def"), "OLD", "", "abc def").Should().BeFalse();
     }
 
     // ── Integration: the tool contract through the real write pipeline ───────────────────────

--- a/test/MeshWeaver.AI.Test/AnchoredEditContentTest.cs
+++ b/test/MeshWeaver.AI.Test/AnchoredEditContentTest.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Coverage for the ATOMIC anchored edit (#1716): <c>edit_content</c>'s check-and-replace runs
+/// INSIDE <c>GetMeshNodeStream(path).Update(...)</c> against the LIVE node, not against a
+/// pre-read snapshot, and its success string is gated on the edit provably landing.
+///
+/// <para>Unit half: pins the pure primitive <see cref="MeshOperations.ApplyAnchoredEdit(MeshNode,
+/// string, string, bool)"/> — text extraction per content shape (Markdown / Code / raw string),
+/// the distinct 0-match and ambiguous-match exception types, replaceAll semantics, and the
+/// markdown re-render — plus <c>CollaborationPlugin.Splice</c>'s delegation to the same
+/// primitive.</para>
+///
+/// <para>Integration half: the tool contract strings are unchanged (the exceptions thrown inside
+/// the write lambda map back to the exact pre-#1716 error messages), and two CONCURRENT
+/// non-overlapping edits both land — the clobber case the snapshot-based implementation risked.
+/// A true mid-flight interleaving (pausing EditContent between its pre-flight fetch and its
+/// write) has no deterministic seam in the harness; the concurrency property is pinned via the
+/// serialised per-path write queue instead.</para>
+/// </summary>
+public class AnchoredEditContentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override bool ShareMeshAcrossTests => true;
+
+    private static CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+    private MeshOperations Ops => new(Mesh);
+    private string Json(MeshNode node) => JsonSerializer.Serialize(node, Mesh.JsonSerializerOptions);
+
+    private Task<string> Run(IObservable<string> op) =>
+        op.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+    private static string Unique(string prefix) => prefix + Guid.NewGuid().ToString("N")[..8];
+
+    private static MeshNode Markdown(string id, string content, string ns = TestPartition) =>
+        new(id, ns) { Name = id, NodeType = "Markdown", Content = new MarkdownContent { Content = content } };
+
+    // ── ApplyAnchoredEdit: the pure primitive ────────────────────────────────────────────────
+
+    [Fact]
+    public void ApplyAnchoredEdit_Markdown_ReplacesAndRerenders_PreservingMetadata()
+    {
+        var node = Markdown("m1", "# Title\n\nalpha beta") with
+        {
+            Content = new MarkdownContent
+            {
+                Content = "# Title\n\nalpha beta",
+                Abstract = "keep-me",
+                Authors = new[] { "author-1" }
+            }
+        };
+
+        var result = MeshOperations.ApplyAnchoredEdit(node, "beta", "gamma", replaceAll: false, out var count);
+
+        count.Should().Be(1);
+        var md = result.Content.Should().BeOfType<MarkdownContent>().Subject;
+        md.Content.Should().Be("# Title\n\nalpha gamma");
+        md.Abstract.Should().Be("keep-me", "the rebuild must preserve front-matter metadata");
+        md.Authors.Should().ContainSingle().Which.Should().Be("author-1");
+        md.PrerenderedHtml.Should().NotBeNullOrEmpty("the markdown re-render must run on edit")
+            .And.Contain("gamma", "the re-rendered HTML must reflect the NEW text");
+        result.PreRenderedHtml.Should().Be(md.PrerenderedHtml,
+            "the node-level prerendered HTML must be rebuilt alongside the content's");
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_Code_ReplacesCode_PreservingConfiguration()
+    {
+        var node = new MeshNode("c1", TestPartition)
+        {
+            Name = "c1",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "var x = 1;", IsExecutable = true }
+        };
+
+        var result = MeshOperations.ApplyAnchoredEdit(node, "1", "2", replaceAll: false, out var count);
+
+        count.Should().Be(1);
+        var code = result.Content.Should().BeOfType<CodeConfiguration>().Subject;
+        code.Code.Should().Be("var x = 2;");
+        code.IsExecutable.Should().BeTrue("the rebuild must not reset the configuration's other fields");
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_RawString_Replaces()
+    {
+        var node = new MeshNode("s1", TestPartition) { Name = "s1", NodeType = "Markdown", Content = "hello world" };
+
+        var result = MeshOperations.ApplyAnchoredEdit(node, "world", "mesh", replaceAll: false, out var count);
+
+        count.Should().Be(1);
+        result.Content.Should().Be("hello mesh");
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_ZeroMatches_ThrowsAnchorNotFound_WithContentLength()
+    {
+        var node = Markdown("m2", "alpha beta");
+
+        Action act = () => MeshOperations.ApplyAnchoredEdit(node, "GONE", "x", replaceAll: false);
+
+        act.Should().Throw<AnchorNotFoundException>()
+            .Which.ContentLength.Should().Be("alpha beta".Length,
+                "the error must name the live content's length so the agent knows what was checked");
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_AmbiguousMatch_ThrowsAmbiguousAnchor_WithOccurrenceCount()
+    {
+        var node = Markdown("m3", "dup one dup two dup");
+
+        Action act = () => MeshOperations.ApplyAnchoredEdit(node, "dup", "x", replaceAll: false);
+
+        act.Should().Throw<AmbiguousAnchorException>()
+            .Which.OccurrenceCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        var node = Markdown("m4", "dup one dup two dup");
+
+        var result = MeshOperations.ApplyAnchoredEdit(node, "dup", "DUP", replaceAll: true, out var count);
+
+        count.Should().Be(3);
+        ((MarkdownContent)result.Content!).Content.Should().Be("DUP one DUP two DUP");
+    }
+
+    [Fact]
+    public void ApplyAnchoredEdit_NonTextContent_ThrowsInvalidOperation()
+    {
+        var node = new MeshNode("n1", TestPartition) { Name = "n1", NodeType = "Markdown", Content = 42 };
+
+        Action act = () => MeshOperations.ApplyAnchoredEdit(node, "a", "b", replaceAll: false);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not editable text*");
+    }
+
+    // ── Splice delegates to the same primitive ───────────────────────────────────────────────
+
+    [Fact]
+    public void Splice_SingleOccurrence_Replaces()
+        => CollaborationPlugin.Splice("alpha beta gamma", "beta", "BETA")
+            .Should().Be("alpha BETA gamma");
+
+    [Fact]
+    public void Splice_EmptyOriginal_Prepends()
+        => CollaborationPlugin.Splice("body", "", "head ")
+            .Should().Be("head body");
+
+    [Fact]
+    public void Splice_MissingText_ThrowsWithLegacyMessage()
+    {
+        Action act = () => CollaborationPlugin.Splice("alpha", "GONE", "x");
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*is not present in the document*",
+                "SuggestEdit's user-visible not-found message must not change");
+    }
+
+    [Fact]
+    public void Splice_AmbiguousText_RefusesInsteadOfSplicingFirst()
+    {
+        Action act = () => CollaborationPlugin.Splice("dup and dup", "dup", "x");
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*occurs 2 times*",
+                "an ambiguous anchor must refuse — splicing an arbitrary occurrence corrupts the document");
+    }
+
+    // ── IsEditApplied: the landed-write verification predicate ───────────────────────────────
+
+    [Fact]
+    public void IsEditApplied_ReplacementPresent_IsTrue()
+        => MeshOperations.IsEditApplied(Markdown("v1", "abc NEW def"), "OLD", "NEW").Should().BeTrue();
+
+    [Fact]
+    public void IsEditApplied_ReplacementAbsent_IsFalse()
+        => MeshOperations.IsEditApplied(Markdown("v2", "abc OLD def"), "OLD", "NEW").Should().BeFalse();
+
+    [Fact]
+    public void IsEditApplied_Deletion_TrueOnlyWhenAnchorGone()
+    {
+        MeshOperations.IsEditApplied(Markdown("v3", "abc def"), "OLD", "").Should().BeTrue();
+        MeshOperations.IsEditApplied(Markdown("v4", "abc OLD def"), "OLD", "").Should().BeFalse();
+    }
+
+    // ── Integration: the tool contract through the real write pipeline ───────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_ReplacesAnchoredText_AndReadBackSeesIt()
+    {
+        var id = Unique("edit");
+        var path = $"{TestPartition}/{id}";
+        (await Run(Ops.Create(Json(Markdown(id, "# Doc\n\nalpha beta gamma"))))).Should().StartWith("Created");
+
+        var result = await Run(Ops.EditContent(path, "beta", "BETA"));
+
+        result.Should().Be($"Edited: {path} (1 replacement)");
+        (await Run(Ops.Get(path))).Should().Contain("alpha BETA gamma",
+            because: "the read after the gated success must see the applied edit");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_AnchorMissing_ReturnsContractErrorString()
+    {
+        var id = Unique("miss");
+        var path = $"{TestPartition}/{id}";
+        var content = "# Doc\n\nalpha";
+        await Run(Ops.Create(Json(Markdown(id, content))));
+
+        var result = await Run(Ops.EditContent(path, "NOTTHERE", "x"));
+
+        // The exact pre-#1716 contract string, now produced from the exception thrown
+        // inside the write lambda.
+        result.Should().Be(
+            $"Error: the text to replace was not found in {path}. Get the node and copy the " +
+            "exact text — including whitespace and line breaks — then retry. " +
+            $"(Current content is {content.Length} chars.)");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_AmbiguousAnchor_ReturnsContractErrorString()
+    {
+        var id = Unique("ambi");
+        var path = $"{TestPartition}/{id}";
+        await Run(Ops.Create(Json(Markdown(id, "dup and dup"))));
+
+        var result = await Run(Ops.EditContent(path, "dup", "x"));
+
+        result.Should().Be(
+            $"Error: the text to replace occurs 2 times in {path}. Include more " +
+            "surrounding context to make the match unique, or set replaceAll=true to change every occurrence.");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        var id = Unique("rall");
+        var path = $"{TestPartition}/{id}";
+        await Run(Ops.Create(Json(Markdown(id, "dup and dup"))));
+
+        var result = await Run(Ops.EditContent(path, "dup", "DUP", replaceAll: true));
+
+        result.Should().Be($"Edited: {path} (2 replacements)");
+        (await Run(Ops.Get(path))).Should().Contain("DUP and DUP");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_Deletion_RemovesAnchor()
+    {
+        var id = Unique("del");
+        var path = $"{TestPartition}/{id}";
+        await Run(Ops.Create(Json(Markdown(id, "keep REMOVE keep"))));
+
+        var result = await Run(Ops.EditContent(path, " REMOVE", ""));
+
+        result.Should().Be($"Edited: {path} (1 replacement)");
+        (await Run(Ops.Get(path))).Should().NotContain("REMOVE");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_CodeNode_ReplacesSource()
+    {
+        var id = Unique("code");
+        var path = $"{TestPartition}/{id}";
+        var node = new MeshNode(id, TestPartition)
+        {
+            Name = id,
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "Console.WriteLine(\"before\");" }
+        };
+        (await Run(Ops.Create(Json(node)))).Should().StartWith("Created");
+
+        var result = await Run(Ops.EditContent(path, "before", "after"));
+
+        result.Should().Be($"Edited: {path} (1 replacement)");
+        (await Run(Ops.Get(path))).Should().Contain("after");
+    }
+
+    /// <summary>
+    /// The clobber case #1716 exists for: two writers edit DIFFERENT parts of the same document
+    /// concurrently. The snapshot-based implementation computed both whole contents off the same
+    /// base, so the second write could silently revert the first edit. With the check-and-replace
+    /// inside the write lambda, the per-path serial write queue runs the second lambda against
+    /// the state the first already produced — BOTH edits must always land.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task EditContent_ConcurrentNonOverlappingEdits_BothLand()
+    {
+        var id = Unique("race");
+        var path = $"{TestPartition}/{id}";
+        await Run(Ops.Create(Json(Markdown(id, "alpha beta gamma"))));
+
+        var first = Run(Ops.EditContent(path, "alpha", "ALPHA"));
+        var second = Run(Ops.EditContent(path, "gamma", "GAMMA"));
+        var results = await Task.WhenAll(first, second);
+
+        results.Should().OnlyContain(r => r.StartsWith("Edited:"),
+            "both anchors stay present regardless of apply order, so neither edit may fail: {0}",
+            string.Join(" | ", results));
+        var got = await Run(Ops.Get(path));
+        got.Should().Contain("ALPHA", because: "the first edit must not be clobbered by the second");
+        got.Should().Contain("GAMMA", because: "the second edit must land too");
+    }
+}


### PR DESCRIPTION
Implements #1716: `edit_content` is anchor-based but was not ATOMIC — the anchor was verified against a snapshot read outside the owning hub's write turn, and the write shipped a whole precomputed node. Two racing editors got whole-content last-write-wins, and an optimistically-acked write that never landed still reported `Edited:`.

## What changed

- **Pure primitive** `MeshOperations.ApplyAnchoredEdit(live, oldText, newText, replaceAll)` (next to `WithRerenderedMarkdown` / `CountOccurrences`): extracts the text from the LIVE node (`MarkdownContent.Content` / `CodeConfiguration.Code` / raw string), counts occurrences, throws the distinct `AnchorNotFoundException` (carrying the live content length) on 0 matches and `AmbiguousAnchorException` (carrying the count) on an ambiguous match without `replaceAll`, replaces (Ordinal), and rebuilds the node with the markdown re-render preserved exactly as before.
- **`MeshOperations.EditContent`** keeps `FetchNode` only as pre-flight for the friendly not-found / not-text error strings, then performs the edit via `hub.GetWorkspace().GetMeshNodeStream(resolvedPath).Update(live => ApplyAnchoredEdit(live, …))` — the `CollaborationPlugin.SuggestEdit` shape. The content-only diff ships as a base-fingerprinted splice; on a Conflict NACK the re-enqueued lambda re-verifies the anchor against fresh state. The `.Catch` maps the two exception types back to the **byte-identical** pre-existing error strings (pinned by tests), so the tool contract is unchanged. `WaitForReadYourWrites` is kept.
- **Follow-up from the issue — fail loudly:** the success string is gated on the write provably landing. After `WaitForReadYourWrites`, a bounded wait (`WaitForEditApplied`) requires the live mirror to actually contain the edit (replacement text present; for a deletion, anchor gone); if it never does, the tool returns a conflict error naming the situation instead of `Edited:` (previously an exhausted late-NACK retry only logged `LATE_NACK_TERMINAL`).
- **`CollaborationPlugin.Splice`** delegates to the same primitive (`MeshOperations.AnchoredReplace`, `replaceAll:false`) — ONE anchored-replace implementation remains. Splice keeps its single-replace semantics, its empty-original prepend, and its legacy not-found message; it gains the uniqueness refusal for ambiguous anchors (sanctioned by the issue: SuggestEdit's behavior changes only by gaining the uniqueness check; no existing test pinned first-of-several splicing).

## Tests (`test/MeshWeaver.AI.Test/AnchoredEditContentTest.cs`, 21 tests, all green)

- Unit-pins for `ApplyAnchoredEdit`: markdown (re-render happens, front-matter metadata preserved), code (`IsExecutable` preserved), raw string; 0-match throws with content length; ambiguous throws with occurrence count; `replaceAll` replaces all; non-text content throws.
- `Splice` delegation: single-occurrence replace, empty-original prepend, legacy not-found message preserved, ambiguous refusal.
- `IsEditApplied` (the landed-write predicate): replacement and deletion cases.
- Integration (MonolithMeshTestBase, real write pipeline): happy path with read-back, exact contract error strings for 0-match and ambiguous (now produced from exceptions thrown inside the write lambda), `replaceAll`, deletion, Code node, and **two concurrent non-overlapping edits both landing** — the clobber case #1716 exists for (the per-path serial write queue runs the second lambda against the state the first produced).

## Deviation note

A true mid-flight interleaving test (pausing `EditContent` between its pre-flight fetch and its write, injecting a racing write, then resuming) cannot be staged deterministically — there is no seam in `EditContent`'s pipeline to park it at, and a sleep-based stage is forbidden. The concurrent-edits integration test pins the user-visible non-clobber property instead; the lambda re-evaluation on Conflict NACK is framework machinery covered by the stream-cache/splice tests.

Also ran: `CollaborationPluginGrainFailureTest`, `McpNegativeOperationsTest`, `McpFailureSurfacingTest`, `McpReadYourWritesTest` (34 tests, green) and `DocumentationLinkIntegrityTest` (What's New note). `MeshWeaver.AI`, `MeshWeaver.Mcp`, and the test project build clean with `-c Release -warnaserror`.

Closes #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
