### PR TITLE
ci: unify node-repo CI as reusable workflows + version-matched compiler tool publish

### DIFF
--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -1,0 +1,115 @@
+name: Node repo compile-check (reusable)
+
+# ♻️ REUSABLE (workflow_call) — 🧱 THE COMPILE GATE for MeshWeaver.* content repos (unified per
+# #1707). validate-repos.py checks JSON shape only — it does NOT compile. This gate compiles
+# every NodeType's resolved Source against the framework assemblies exactly as the mesh does
+# (concatenated sources, hoisted usings), so async-broken / API-drifted Source can no longer
+# merge "green" and PARK on a live mesh at the next pod restart (the 2026-07-21 UWDeepfield
+# outage in MeshWeaver.Plugins). The reference set is taken FROM the digest-pinned platform
+# image — the same assemblies the mesh loads at run time — instead of building the core repo
+# from source (~10 minutes per run for a dependency that changes far less often than the repo).
+#
+# The caller's `scripts/compile-check.py` does the work; `scripts/compile-check.allow`
+# grandfathers known debt with a one-way ratchet: a NEW non-allowlisted failure fails the PR;
+# a fixed allowlisted type must be removed from the file.
+#
+# NOT gated on the image inputs being set: the compile gate is unconditional. If the image
+# reference or the registry credentials are missing, the login/pull steps fail LOUDLY — a
+# silently skipped compile gate is exactly how the 2026-07-21 outage shipped.
+#
+# Caller contract:
+#
+#   compile-check:
+#     needs: validate
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-compile-check.yml@main
+#     with:
+#       test-image: ${{ vars.MW_TEST_IMAGE }}
+#       image-digest: ${{ vars.MW_IMAGE_DIGEST }}
+#     secrets:
+#       acr-username: ${{ secrets.ACR_USERNAME }}
+#       acr-password: ${{ secrets.ACR_PASSWORD }}
+
+on:
+  workflow_call:
+    inputs:
+      test-image:
+        description: The platform image whose /app assemblies are the reference set.
+        required: true
+        type: string
+      image-digest:
+        description: >-
+          Digest pin (tag@digest). Leaving it empty is an ERROR unless allow-unpinned is set.
+        required: false
+        type: string
+        default: ''
+      allow-unpinned:
+        description: >-
+          Explicitly accept an empty image-digest and take the reference assemblies from the
+          tag verbatim. Never a silent fallback.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      acr-username:
+        description: Registry user able to pull the image.
+        required: true
+      acr-password:
+        description: Registry password for that user.
+        required: true
+
+jobs:
+  compile-check:
+    name: Compile every NodeType (vs core)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the node repo
+        uses: actions/checkout@v7
+        with:
+          path: repo
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # compile-check.py shells out to `dotnet build` on a generated net10.0 check.csproj — pin
+      # the SDK rather than depend on whatever the runner image happens to preinstall.
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+      - name: Log in to the image registry
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+        run: >
+          echo "${{ secrets.acr-password }}" |
+          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+      - name: Take the framework assemblies from the platform image
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
+        # The image already CONTAINS the built framework — the same assemblies the mesh loads at
+        # run time. Copying them out costs seconds, and checking Source against what actually
+        # ships is the question this gate exists to answer.
+        run: |
+          set -euo pipefail
+          if [ -n "${IMAGE_DIGEST:-}" ]; then
+            IMAGE="${TEST_IMAGE%%:*}@${IMAGE_DIGEST}"
+          elif [ "${{ inputs.allow-unpinned }}" = "true" ]; then
+            IMAGE="$TEST_IMAGE"
+            echo "checking against ${TEST_IMAGE} verbatim (allow-unpinned — runs are not reproducible)"
+          else
+            echo "::error::image-digest is empty and allow-unpinned is not set — pin a digest (reproducible) or opt in to following the tag."
+            exit 1
+          fi
+          docker pull -q "$IMAGE"
+          id=$(docker create "$IMAGE")
+          mkdir -p refs
+          docker cp "$id:/app/." refs/ >/dev/null
+          docker rm -v "$id" >/dev/null
+          echo "framework assemblies: $(find refs -name 'MeshWeaver.*.dll' | wc -l)"
+      - name: Compile-check every NodeType
+        working-directory: repo
+        # --refs points at the assemblies unpacked from the platform image — a FLAT directory;
+        # compile-check.py globs it recursively, dedupes by filename, and compiles each
+        # NodeType's resolved source-set.
+        run: python3 scripts/compile-check.py --refs ../refs

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -81,6 +81,13 @@ on:
         required: false
         type: boolean
         default: true
+      capture-coredumps:
+        description: >-
+          Run the tester with minidump-on-crash enabled and upload any dumps as a run artifact
+          — for a repo whose gate has crashed in ways a log cannot explain.
+        required: false
+        type: boolean
+        default: false
     secrets:
       acr-username:
         description: Registry user able to pull the test image.
@@ -195,6 +202,24 @@ jobs:
           fi
           ALLOW_ARGS=()
           [ -n "${ALLOW_PATH:-}" ] && ALLOW_ARGS=(--allow "$ALLOW_PATH")
-          docker run --rm -v "$REPO_MOUNT:/repo" \
+          DUMP_ARGS=()
+          if [ "${{ inputs.capture-coredumps }}" = "true" ]; then
+            mkdir -p "${RUNNER_TEMP:-/tmp}/coredumps"
+            chmod 0777 "${RUNNER_TEMP:-/tmp}/coredumps"
+            DUMP_ARGS=(-v "${RUNNER_TEMP:-/tmp}/coredumps:/coredumps"
+              --cap-add=SYS_PTRACE
+              -e DOTNET_DbgEnableMiniDump=1
+              -e DOTNET_DbgMiniDumpType=2
+              -e DOTNET_DbgMiniDumpName=/coredumps/%e-%p.dmp)
+          fi
+          docker run --rm -v "$REPO_MOUNT:/repo" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
             "${ALLOW_ARGS[@]}"
+      - name: Upload core dumps (if the gate crashed)
+        if: always() && inputs.capture-coredumps
+        uses: actions/upload-artifact@v7
+        with:
+          name: gate-coredumps
+          path: ${{ runner.temp }}/coredumps
+          if-no-files-found: ignore
+          retention-days: 15

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -1,0 +1,200 @@
+name: Node repo gate (reusable)
+
+# ♻️ REUSABLE (workflow_call) — the heavy tester gate every MeshWeaver.* content repo runs
+# (unified per #1707): install each package into a real MeshWeaver mesh (in-process,
+# SQLite/filesystem persistence) and assert code packages compile live, render, AND that each
+# type's `Tests` layout area runs green — tests are EXECUTED, not just compiled; a red test
+# fails the PR. The tester ships in the mw-plugin-test image; contract is `docker run` with the
+# checkout mounted (NOT a `container:` job — see MeshWeaver.Plugins ci.yml history).
+#
+# NO input-shaped `if:` anywhere in here, deliberately (AGENTS.md: a gate never tests its own
+# inputs). The caller's `preflight` job asserts the image/registry inputs red-fail-naming-them,
+# the fork exemption lives there too, and this gate runs unconditionally behind
+# `needs: [preflight, ...]`.
+#
+# Caller contract:
+#
+#   test-repos:
+#     needs: [validate, preflight]
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-gate.yml@main
+#     with:
+#       test-image: ${{ vars.MW_TEST_IMAGE }}
+#       image-digest: ${{ vars.MW_IMAGE_DIGEST }}
+#       stage-repo: Systemorph/MeshWeaver.Plugins
+#       stage-modules: Store
+#     secrets:
+#       acr-username: ${{ secrets.ACR_USERNAME }}
+#       acr-password: ${{ secrets.ACR_PASSWORD }}
+#       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
+
+on:
+  workflow_call:
+    inputs:
+      test-image:
+        description: The mw-plugin-test image reference (the caller's vars.MW_TEST_IMAGE).
+        required: true
+        type: string
+      image-digest:
+        description: >-
+          Digest pin (tag@digest — reproducible; an image regression lands on the commit that
+          bumps the pin, and a pin that lags the platform by days is a gate reporting on a
+          framework nobody runs, so bump it routinely). Leaving it empty is an ERROR unless
+          allow-unpinned is set.
+        required: false
+        type: string
+        default: ''
+      allow-unpinned:
+        description: >-
+          Explicitly accept an empty image-digest and gate against the tag verbatim. Never a
+          silent fallback: an empty digest WITHOUT this flag fails red.
+        required: false
+        type: boolean
+        default: false
+      stage-repo:
+        description: Repository to stage cross-repo modules from. Empty = no staging.
+        required: false
+        type: string
+        default: ''
+      stage-modules:
+        description: >-
+          Module directories to sparse-checkout from stage-repo and copy into the gate mount
+          (newline-separated for several) so the caller's packages' `requires` resolve. Without
+          them the package roots land on the unresolvable-NodeType error overlay — an
+          arrangement production never runs (MeshWeaver#1701).
+        required: false
+        type: string
+        default: ''
+      allow-file:
+        description: >-
+          Known-debt ratchet file passed as --allow (repo-relative; one-way — a NEW
+          non-allowlisted failure fails the PR, a fixed allowlisted type must be removed).
+          Empty = none.
+        required: false
+        type: string
+        default: 'plugin-gate.allow'
+      affected-narrowing:
+        description: >-
+          On pull_request diffs, gate only the affected module closure computed by the caller's
+          scripts/affected-modules.py (mirrors the runtime's edge semantics; full-run fallbacks
+          are built into the script's classification). Main pushes / dispatches never narrow.
+          Set false for a repo without that script — every event then gates the full set.
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      acr-username:
+        description: Registry user able to pull the test image.
+        required: true
+      acr-password:
+        description: Registry password for that user.
+        required: true
+      stage-repo-token:
+        description: Token able to read stage-repo (needed only when stage-modules is set).
+        required: false
+
+jobs:
+  test-repos:
+    name: Compile + render node repos (MeshWeaver from ACR)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The affected computation diffs against the PR base — it needs the base commits.
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Compute the affected module closure
+        id: affected
+        env:
+          NARROWING: ${{ inputs.affected-narrowing }}
+        # 🎯 PRs gate only the AFFECTED dependency closure — changed modules, plus every
+        # transitive DEPENDENT, plus the affected set's own dependencies (the fresh gate mesh
+        # needs them present to install and to resolve `shared=@…`).
+        # 🚨 FAIL LOUD: `set -euo pipefail` — an errored computation fails the job; the script
+        # itself refuses an empty diff, so a wrong empty set can never pass as "nothing to test".
+        run: |
+          set -euo pipefail
+          if [ "$NARROWING" = "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+            python3 scripts/affected-modules.py \
+              --range "origin/${{ github.base_ref }}...HEAD" --json > affected.json
+          else
+            echo "${{ github.event_name }} on ${{ github.ref_name }} — full run (narrowing applies only to PR diffs)"
+            echo '{"mount": [], "runAll": true}' > affected.json
+          fi
+          {
+            echo "mount=$(jq -r '.mount | join(" ")' affected.json)"
+            echo "run_all=$(jq -r '.runAll' affected.json)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Log in to the image registry
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+        run: >
+          echo "${{ secrets.acr-password }}" |
+          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+      # Cross-repo `requires` must resolve for the package roots to bind — the tester installs
+      # whatever the mount holds, so the required modules are STAGED into it, exactly like
+      # production resolves the requires from the store's package sources.
+      - name: Stage cross-repo modules
+        if: inputs.stage-modules != ''
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.stage-repo }}
+          token: ${{ secrets.stage-repo-token }}
+          path: cross-repo-stage
+          sparse-checkout: ${{ inputs.stage-modules }}
+      - name: Import + compile + render + run tests for each node repo
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
+          STAGE_MODULES: ${{ inputs.stage-modules }}
+          ALLOW_FILE: ${{ inputs.allow-file }}
+          AFFECTED_MOUNT: ${{ steps.affected.outputs.mount }}
+          AFFECTED_RUN_ALL: ${{ steps.affected.outputs.run_all }}
+        # Allow entries whose module is not mounted on a narrowed run are "unverifiable" —
+        # warned, never failed — so narrowing cannot trip the ratchet. On a narrowed run the
+        # affected closure is STAGED into its own tree and mounted as /repo — the tester gates
+        # every package it discovers, so the mount IS the filter.
+        run: |
+          set -euo pipefail
+          if [ "$AFFECTED_RUN_ALL" = "true" ]; then
+            REPO_MOUNT="$GITHUB_WORKSPACE"
+            ALLOW_PATH="${ALLOW_FILE:+/repo/$ALLOW_FILE}"
+            echo "full run: gating every module"
+          elif [ -z "$AFFECTED_MOUNT" ]; then
+            echo "no module content affected (see the affected computation above) — nothing for the gate to test"
+            exit 0
+          else
+            REPO_MOUNT="${RUNNER_TEMP:-/tmp}/gate-stage"
+            mkdir "$REPO_MOUNT"
+            for m in $AFFECTED_MOUNT; do cp -R "$GITHUB_WORKSPACE/$m" "$REPO_MOUNT/"; done
+            ALLOW_PATH=""
+            if [ -n "${ALLOW_FILE:-}" ]; then
+              cp "$GITHUB_WORKSPACE/$ALLOW_FILE" "$REPO_MOUNT/"
+              ALLOW_PATH="/repo/$(basename "$ALLOW_FILE")"
+            fi
+            echo "narrowed run: gating $AFFECTED_MOUNT"
+          fi
+          # Staged modules join the mount so every package's requires resolve. On the full-run
+          # path the workspace IS the mount — cross-repo-stage/ itself has no root index.json,
+          # so the tester never treats it as a module; only the copied module dirs count.
+          for m in ${STAGE_MODULES:-}; do
+            cp -R "$GITHUB_WORKSPACE/cross-repo-stage/$m" "$REPO_MOUNT/"
+          done
+          if [ -n "${IMAGE_DIGEST:-}" ]; then
+            IMAGE="${TEST_IMAGE%%:*}@${IMAGE_DIGEST}"
+          elif [ "${{ inputs.allow-unpinned }}" = "true" ]; then
+            IMAGE="$TEST_IMAGE"
+            echo "gating against ${TEST_IMAGE} verbatim (allow-unpinned — runs are not reproducible)"
+          else
+            echo "::error::image-digest is empty and allow-unpinned is not set — pin a digest (reproducible) or opt in to following the tag."
+            exit 1
+          fi
+          ALLOW_ARGS=()
+          [ -n "${ALLOW_PATH:-}" ] && ALLOW_ARGS=(--allow "$ALLOW_PATH")
+          docker run --rm -v "$REPO_MOUNT:/repo" \
+            --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
+            "${ALLOW_ARGS[@]}"

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1,0 +1,335 @@
+name: Node repo publish-bake (reusable)
+
+# ♻️ REUSABLE (workflow_call) — the ONE bake-and-publish lane for every MeshWeaver.* content repo
+# (#1660 WS3, unified per #1707). Each node repo used to vendor a near-identical `publish-bake`
+# job plus its own copy of `publish-bake-bundles.sh`; five copies of a script whose `_complete`
+# sentinel name must keep matching `ShippedPrebuiltBundles.CompletionSentinelFileName` is five
+# chances for silent drift. This workflow runs the canonical script from THIS repo (checked out
+# by ref), so the sentinel contract has exactly one home next to the C# constant it mirrors.
+#
+# What it does: run the caller repo's full content through mw-plugin-test with `--bake-output`
+# (the run IS a full gate — import + compile + render + Tests areas), then publish the resulting
+# bundles to every portal storage target under
+# `<base>/prebuilt-bundles/<framework-identity>/<bake-source>/`. A portal whose own framework
+# identity matches seeds them at boot and compiles nothing the repo ships.
+#
+# The bake is ALWAYS the FULL repo — never a PR-style affected narrowing. The publication is
+# atomic per identity: the `_complete` sentinel (written LAST) lists the whole bundle set and the
+# portal seeds only what the sentinel lists, so a partial publish would SHRINK what portals
+# adopt. Callers gate this job to main pushes + `repository_dispatch` (framework releases) via
+# the job-level `if:`/`needs:` on the `uses:` job.
+#
+# Caller contract (see the SocialMedia/Plugins ci.yml for a worked example):
+#
+#   publish-bake:
+#     if: >
+#       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+#       github.event_name == 'repository_dispatch'
+#     needs: [preflight, validate, compile-check, test-repos]
+#     permissions: { contents: read, id-token: write }   # OIDC — must be granted BY the caller
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-publish-bake.yml@main
+#     with:
+#       bake-source: socialmedia
+#       test-image: ${{ vars.MW_TEST_IMAGE }}
+#       image-digest: ${{ vars.MW_IMAGE_DIGEST }}     # or a workflow env / literal pin
+#       bake-publish-targets: ${{ vars.BAKE_PUBLISH_TARGETS }}
+#       stage-repo: Systemorph/MeshWeaver.Plugins
+#       stage-modules: Store
+#     secrets:
+#       acr-username: ${{ secrets.ACR_USERNAME }}
+#       acr-password: ${{ secrets.ACR_PASSWORD }}
+#       azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+#       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+#       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+#       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
+#
+# Every externally-provisioned value is an EXPLICIT input/secret — nothing is read from the
+# caller's `vars`/`env` implicitly — so the preflight step below can assert the complete set and
+# fail RED naming exactly what to provision (AGENTS.md: a gate never tests its own inputs, and a
+# grey skip is indistinguishable from a pass).
+
+on:
+  workflow_call:
+    inputs:
+      bake-source:
+        description: >-
+          The producing repo's source segment in the publication layout
+          (prebuilt-bundles/<identity>/<bake-source>/...), e.g. plugins, education,
+          reinsurance, socialmedia. Multiple producers publish without clobbering.
+        required: true
+        type: string
+      test-image:
+        description: The mw-plugin-test image reference (the caller's vars.MW_TEST_IMAGE).
+        required: true
+        type: string
+      image-digest:
+        description: >-
+          Digest pin for push-triggered bakes (tag@digest — reproducible, bump deliberately).
+          Ignored for repository_dispatch, which always bakes against the released version tag
+          from the payload. Leaving it empty is an ERROR unless allow-unpinned is set.
+        required: false
+        type: string
+        default: ''
+      allow-unpinned:
+        description: >-
+          Explicitly accept an empty image-digest and bake against the tag verbatim (a repo
+          that tracks :main accepts that its runs are not reproducible). Never a silent
+          fallback: an empty digest WITHOUT this flag fails red.
+        required: false
+        type: boolean
+        default: false
+      bake-publish-targets:
+        description: >-
+          Whitespace-separated portal storage targets, <account>/<share>[/<base-path>]
+          (the caller's vars.BAKE_PUBLISH_TARGETS — same value the platform repo carries).
+        required: true
+        type: string
+      stage-repo:
+        description: >-
+          Repository to stage cross-repo modules from (e.g. Systemorph/MeshWeaver.Plugins),
+          so the caller's packages' `requires` resolve. Empty = no staging.
+        required: false
+        type: string
+        default: ''
+      stage-modules:
+        description: >-
+          Module directories to sparse-checkout from stage-repo and copy into the bake mount
+          (newline-separated for several). Staged modules are OWNED by stage-repo: their bundles
+          are excluded from this repo's publication so no package is ever seeded from two
+          sources.
+        required: false
+        type: string
+        default: ''
+      pre-bake-script:
+        description: >-
+          Optional shell run in the caller checkout after staging, before the bake — e.g. a
+          package-snapshot filter. Keep it minimal; anything load-bearing belongs in the repo.
+          A script that builds its own bake mount (Education's snapshot) writes
+          `BAKE_MOUNT_DIR=<path>` to $GITHUB_ENV; the bake then mounts THAT as /repo instead of
+          the checkout, and staged modules are NOT auto-copied (the script owns the mount's
+          composition — the staged checkout is available at cross-repo-stage/).
+        required: false
+        type: string
+        default: ''
+      node-version:
+        description: Set to install Node (actions/setup-node) before the pre-bake script. Empty = skip.
+        required: false
+        type: string
+        default: ''
+      timeout-minutes:
+        description: Job timeout.
+        required: false
+        type: number
+        default: 40
+      allow-file:
+        description: Known-debt ratchet file passed as --allow (repo-relative). Empty = none.
+        required: false
+        type: string
+        default: 'plugin-gate.allow'
+      platform-ref:
+        description: >-
+          Ref of Systemorph/MeshWeaver to take the canonical publish script from. Default main;
+          pin only to bisect a script regression.
+        required: false
+        type: string
+        default: 'main'
+    secrets:
+      acr-username:
+        description: Registry user able to pull the test image.
+        required: true
+      acr-password:
+        description: Registry password for that user.
+        required: true
+      azure-client-id:
+        description: >-
+          Client id of an Azure identity holding "Storage File Data Privileged Contributor" on
+          the portals' storage accounts, with a federated credential for the caller repo's main.
+        required: true
+      azure-tenant-id:
+        description: Tenant of that identity.
+        required: true
+      azure-subscription-id:
+        description: Subscription of the storage accounts.
+        required: true
+      stage-repo-token:
+        description: Token able to read stage-repo (needed only when stage-modules is set).
+        required: false
+
+jobs:
+  publish-bake:
+    name: Bake + publish NodeType assemblies to portal storage
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      id-token: write     # azure/login OIDC — no long-lived storage secret in any node repo
+    steps:
+      # 🚨 NO SKIP-TRAPDOOR: the publish credentials are asserted RED here, naming exactly what
+      # to provision — never `continue-on-error`, never an if-secret-set skip. A grey skip would
+      # silently restore the every-pod-rebakes-everything regression this lane closes.
+      - name: "Preflight: the publish credentials must be provisioned"
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.azure-client-id }}
+          AZURE_TENANT_ID: ${{ secrets.azure-tenant-id }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
+          ACR_USERNAME: ${{ secrets.acr-username }}
+          ACR_PASSWORD: ${{ secrets.acr-password }}
+          STAGE_TOKEN: ${{ secrets.stage-repo-token }}
+          BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
+          STAGE_MODULES: ${{ inputs.stage-modules }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AZURE_CLIENT_ID:-}" ]        || missing+=("azure-client-id (secret) — client id of an Azure identity holding 'Storage File Data Privileged Contributor' on the portals' storage account, with a federated credential for repo:${GITHUB_REPOSITORY}:ref:refs/heads/main")
+          [ -n "${AZURE_TENANT_ID:-}" ]        || missing+=("azure-tenant-id (secret) — tenant of that identity")
+          [ -n "${AZURE_SUBSCRIPTION_ID:-}" ]  || missing+=("azure-subscription-id (secret) — subscription of the storage account")
+          [ -n "${ACR_USERNAME:-}" ]           || missing+=("acr-username (secret) — registry user able to pull the test image")
+          [ -n "${ACR_PASSWORD:-}" ]           || missing+=("acr-password (secret) — registry password for that user")
+          [ -n "${BAKE_PUBLISH_TARGETS:-}" ]   || missing+=("bake-publish-targets (input, from the caller's repo VARIABLE) — the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>]")
+          if [ -n "${STAGE_MODULES:-}" ] && [ -z "${STAGE_TOKEN:-}" ]; then
+            missing+=("stage-repo-token (secret) — token able to read the stage repo (stage-modules is set)")
+          fi
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::The bake publication cannot reach any portal — required credentials are not provisioned. This job fails RED rather than skipping: a grey skip is indistinguishable from a pass and would silently leave every portal re-compiling this repo's content at boot."
+            for m in "${missing[@]}"; do echo "::error::missing: ${m}"; done
+            exit 1
+          fi
+          echo "All publish credentials are provisioned."
+      - uses: actions/checkout@v7
+        with: { fetch-depth: 1 }
+      - name: Resolve the bake image
+        id: image
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
+          RELEASED_VERSION: ${{ github.event.client_payload.version }}
+          RELEASED_SHA: ${{ github.event.client_payload.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            # The release's own identity tag (main-cd promote, phase A). A dispatch without a
+            # resolvable image is a platform CD contract break — fail loudly, never fall back to
+            # the pinned digest (that would publish the OLD identity and call it a re-bake).
+            if [ -z "${RELEASED_VERSION:-}" ]; then
+              echo "::error::repository_dispatch payload carries no client_payload.version — cannot resolve the released image."
+              exit 1
+            fi
+            echo "ref=${TEST_IMAGE%%:*}:${RELEASED_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "baking against released ${RELEASED_VERSION} (${RELEASED_SHA:-sha unknown})"
+          elif [ -n "${IMAGE_DIGEST:-}" ]; then
+            # tag@digest: the tag names the image, the digest pins the build (reproducible runs;
+            # an image regression lands on the commit that bumps the pin).
+            echo "ref=${TEST_IMAGE%%:*}@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "baking against the pinned digest ${IMAGE_DIGEST}"
+          elif [ "${{ inputs.allow-unpinned }}" = "true" ]; then
+            echo "ref=${TEST_IMAGE}" >> "$GITHUB_OUTPUT"
+            echo "baking against ${TEST_IMAGE} verbatim (allow-unpinned — runs are not reproducible; pin a digest to change that)"
+          else
+            # Never a silent fallback: an unset pin without the explicit opt-in is a
+            # provisioning error, not a mode.
+            echo "::error::image-digest is empty and allow-unpinned is not set — pin a digest (reproducible) or opt in to following the tag."
+            exit 1
+          fi
+      - name: Log in to the image registry
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+        run: >
+          echo "${{ secrets.acr-password }}" |
+          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+      # Same staging the caller's gate does, for the same reason: cross-repo `requires` must
+      # resolve for the package roots to bind.
+      - name: Stage cross-repo modules
+        if: inputs.stage-modules != ''
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.stage-repo }}
+          token: ${{ secrets.stage-repo-token }}
+          path: cross-repo-stage
+          sparse-checkout: ${{ inputs.stage-modules }}
+      - name: Set up Node for the pre-bake hook
+        if: inputs.node-version != ''
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Pre-bake hook
+        if: inputs.pre-bake-script != ''
+        run: ${{ inputs.pre-bake-script }}
+      - name: Bake the full repo (import + compile + render + tests, --bake-output)
+        env:
+          STAGE_MODULES: ${{ inputs.stage-modules }}
+          ALLOW_FILE: ${{ inputs.allow-file }}
+        run: |
+          set -euo pipefail
+          # The mount the tester sees: the checkout, unless the pre-bake hook built its own
+          # (BAKE_MOUNT_DIR via $GITHUB_ENV — Education's package snapshot). When the hook owns
+          # the mount it owns its composition too, so staged modules are only auto-copied into
+          # the plain checkout (cross-repo-stage/ itself has no root index.json, so the tester
+          # never treats it as a module; only the copied module dirs count).
+          REPO_MOUNT="${BAKE_MOUNT_DIR:-$GITHUB_WORKSPACE}"
+          if [ -z "${BAKE_MOUNT_DIR:-}" ]; then
+            for m in ${STAGE_MODULES:-}; do
+              cp -R "$GITHUB_WORKSPACE/cross-repo-stage/$m" "$GITHUB_WORKSPACE/"
+            done
+          fi
+          BAKE="${RUNNER_TEMP:-/tmp}/bake"
+          mkdir -p "$BAKE"
+          # The image's tester runs as a non-root user; the bind-mounted bake dir must be
+          # writable for it.
+          chmod 777 "$BAKE"
+          ALLOW_ARGS=()
+          [ -n "${ALLOW_FILE:-}" ] && ALLOW_ARGS=(--allow "/repo/${ALLOW_FILE}")
+          docker run --rm -v "$REPO_MOUNT:/repo" -v "$BAKE:/bake" \
+            --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" /repo \
+            "${ALLOW_ARGS[@]}" \
+            --bake-output /bake --source-sha "$GITHUB_SHA"
+          # Postcondition, not a hope: a green tester that wrote no identity is a bake-stage
+          # regression (or an image predating --bake-output support).
+          if [ ! -s "$BAKE/framework-mvid.txt" ]; then
+            echo "::error::the tester ran green but wrote no bake identity ($BAKE/framework-mvid.txt) — the bake stage regressed (or the image predates --bake-output support)."
+            exit 1
+          fi
+          # 🚨 LOUD, never silent: staged modules were brought in only so the requires resolve —
+          # they are OWNED and published by the stage repo. Publishing them from here too would
+          # seed the same package from two sources.
+          for m in ${STAGE_MODULES:-}; do
+            name=$(basename "$m")
+            if [ -f "$BAKE/$name.zip" ]; then
+              rm "$BAKE/$name.zip"
+              echo "excluded from publication: $name.zip (owned by ${{ inputs.stage-repo }} — staged here only to resolve the packages' requires)"
+            fi
+          done
+          echo "BAKE_DIR=$BAKE" >> "$GITHUB_ENV"
+          echo "baked identity: $(cat "$BAKE/framework-mvid.txt")"
+          echo "baked bundles:"; ls -l "$BAKE"/*.zip
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      # The CANONICAL script — one home, next to the ShippedPrebuiltBundles constants its
+      # `_complete` sentinel must keep matching. Checked out after the bake so it never sits in
+      # the tester's /repo mount. Public repo: the default token reads it from any caller.
+      - name: Fetch the canonical publish script (platform repo)
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: mw-platform
+          sparse-checkout: .github/scripts
+      - name: Publish bundles to every portal target
+        env:
+          BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
+        # Contract: layout <base>/prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip,
+        # every bundle first, the `_complete` sentinel strictly LAST; an already-sealed identity
+        # with the same source sha skips (the surface identity is breaking-change-keyed, so
+        # internal platform merges re-resolve the SAME identity and the re-publish is a no-op by
+        # design).
+        run: |
+          set -euo pipefail
+          mw-platform/.github/scripts/publish-bake-bundles.sh "$BAKE_DIR" "${{ inputs.bake-source }}" "$GITHUB_SHA"
+          {
+            echo "### 📦 CI bake published"
+            echo "- identity: \`$(cat "$BAKE_DIR/framework-mvid.txt")\`"
+            echo "- source: \`${{ inputs.bake-source }}\`  targets: \`${BAKE_PUBLISH_TARGETS}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/node-repo-tag-modules.yml
+++ b/.github/workflows/node-repo-tag-modules.yml
@@ -1,0 +1,45 @@
+name: Node repo tag-modules (reusable)
+
+# ♻️ REUSABLE (workflow_call) — publishes the git LABEL for each module's released version:
+# `<Module>/vMAJOR.MINOR.PATCH` (unified per #1707). The caller gates it to main after its
+# whole gate suite (`if:` + `needs:` on the `uses:` job), so a tag never names a tree that
+# failed.
+#
+# 🚨 The tag is the contract a dependent's pin resolves against, so the one thing this must
+# never do is let two different trees ship under one version. The caller's scripts/tag-modules.py
+# enforces that: if the tag already exists, its recorded content hash has to match what is in
+# the tree now; a mismatch fails the job loudly rather than silently moving the tag under
+# everyone who pinned it.
+#
+# Caller contract:
+#
+#   tag-modules:
+#     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#     needs: [validate, compile-check, test-repos]
+#     permissions: { contents: write }     # tag push — must be granted BY the caller
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-tag-modules.yml@main
+
+on:
+  workflow_call: {}
+
+jobs:
+  tag-modules:
+    name: Tag module versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0          # tags are the version history — a shallow clone has none
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Tag every module whose version is not yet released
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: python3 scripts/tag-modules.py

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -11,7 +11,18 @@ name: Node repo validate (reusable)
 #     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-validate.yml@main
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      check-versions-always:
+        description: >-
+          Run the derived-version check on EVERY event instead of main-only. Correct for a repo
+          whose PRs are expected to regenerate manifests and which has no settle-versions job to
+          repair a miss on main (a miss would otherwise surface as a red MAIN push). A repo with
+          higher PR traffic keeps the default: the derived patch races the moving trunk baseline,
+          so PR-gating it fails PRs for OTHER people's merges.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   validate:
@@ -41,6 +52,8 @@ jobs:
       # people's merges. What a BRANCH can be held to is `--check` above: your lock describes
       # YOUR tree — content hashes, entirely local. What only MAIN can settle is the derived
       # number, so this runs as that step's POST-condition rather than as a gate.
-      - name: Every module's version matches its content (main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Every module's version matches its content
+        if: >
+          inputs.check-versions-always ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: python3 scripts/gen-manifests.py --check-versions

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -1,0 +1,46 @@
+name: Node repo validate (reusable)
+
+# ♻️ REUSABLE (workflow_call) — the cheap shape gate for MeshWeaver.* content repos (unified per
+# #1707): every node JSON validates, every manifest.lock is current, and — on main only — every
+# module's derived version matches its content. The caller's `scripts/` do the work
+# (validate-repos.py, gen-manifests.py); this workflow is only the unified harness around them.
+#
+# Caller contract:
+#
+#   validate:
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-validate.yml@main
+
+on:
+  workflow_call: {}
+
+jobs:
+  validate:
+    name: Validate node repos
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0          # tags are the version history — --check-versions needs them
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Validate every node JSON (+ NodeType Source)
+        run: python3 scripts/validate-repos.py
+      # manifest.lock calls itself CI-verified; this is what verifies it. A stale lock means a
+      # module's recorded content hash — and the version derived from it — describes a tree that
+      # no longer exists, which is exactly what a dependent's pin would be trusting.
+      - name: Every manifest.lock is current (and carries a version)
+        run: python3 scripts/gen-manifests.py --check
+      # 🚨 …and the version is the RIGHT one — but ONLY on main, and that restriction is the
+      # point. The patch is derived from a baseline that MOVES (the highest published tag plus
+      # the trunk's committed lock), so a branch is correct the moment it is pushed and wrong as
+      # soon as anyone else merges. Run as a PR gate it spends its time failing PRs for OTHER
+      # people's merges. What a BRANCH can be held to is `--check` above: your lock describes
+      # YOUR tree — content hashes, entirely local. What only MAIN can settle is the derived
+      # number, so this runs as that step's POST-condition rather than as a gate.
+      - name: Every module's version matches its content (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: python3 scripts/gen-manifests.py --check-versions

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -43,3 +43,27 @@ jobs:
     # on the first 409 for one already published.
     - name: publish to nuget.org
       run: dotnet nuget push ./nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PAT }} --skip-duplicate
+
+    # The compiler tool ships VERSION-MATCHED with every official release (#1707 S1b): content
+    # repos run `dotnet tool install MeshWeaver.Compiler.Cli --version <platform version>` and
+    # bake with the exact binary this release's portals adopt from. The out-of-band lane stays
+    # publish-compiler-tool.yml (workflow_dispatch / compiler-tool-v* tags). Packed here, not in
+    # the solution-wide pack above: the tool is the mw-plugin-test EXE behind the explicit
+    # -p:PackCompilerTool=true opt-in, so the ordinary pack can never ship it by accident.
+    - name: Pack compiler tool
+      run: |
+        dotnet pack tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj \
+          --configuration Release --output ./tool-nupkgs \
+          -p:PackCompilerTool=true -p:CIRun=true \
+          -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}
+
+    # Positive assertion, not a formality: without the surface manifest inside the package the
+    # installed tool resolves a FORKED framework identity and every bundle it bakes is declined.
+    - name: Verify tool package carries the surface manifest
+      run: |
+        pkg=$(ls ./tool-nupkgs/MeshWeaver.Compiler.Cli.*.nupkg)
+        unzip -l "$pkg" | grep -F "meshweaver-surface.manifest" \
+          || { echo "::error::$pkg does not contain meshweaver-surface.manifest — the installed tool would resolve a forked framework identity"; exit 1; }
+
+    - name: Publish compiler tool to nuget.org
+      run: dotnet nuget push ./tool-nupkgs/MeshWeaver.Compiler.Cli.*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PAT }} --skip-duplicate

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -130,7 +130,10 @@ for the job's preflight discipline and the dependent-repo dispatch.
 Every satellite content repo (MeshWeaver.Plugins, MeshWeaver.Education, MeshWeaver.Reinsurance,
 MeshWeaver.SocialMedia) bakes and publishes its own content through the SAME contract, and since
 #1707 the jobs live HERE, as reusable `workflow_call` workflows the satellites call instead of
-vendoring:
+vendoring. Adoption is per job: every repo calls `node-repo-publish-bake` (the lane whose script
+contract must not drift), while a repo whose variant of a gate carries repo-specific machinery
+(Plugins' Tests-area ratchet, Education's course checks) keeps that job vendored until the
+machinery generalizes:
 
 | Workflow | Job it unifies |
 |---|---|

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -125,6 +125,42 @@ identity as its predecessor — the script skips with a notice instead of re-upl
 [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
 for the job's preflight discipline and the dependent-repo dispatch.
 
+## Node repos run the same lane — as reusable workflows
+
+Every satellite content repo (MeshWeaver.Plugins, MeshWeaver.Education, MeshWeaver.Reinsurance,
+MeshWeaver.SocialMedia) bakes and publishes its own content through the SAME contract, and since
+#1707 the jobs live HERE, as reusable `workflow_call` workflows the satellites call instead of
+vendoring:
+
+| Workflow | Job it unifies |
+|---|---|
+| `.github/workflows/node-repo-validate.yml` | JSON/manifest shape gate (`scripts/validate-repos.py`, `gen-manifests.py --check`, main-only `--check-versions`) |
+| `.github/workflows/node-repo-compile-check.yml` | the compile gate — every NodeType's resolved Source vs the assemblies of the digest-pinned platform image |
+| `.github/workflows/node-repo-gate.yml` | the tester gate — `mw-plugin-test` over the (optionally affected-narrowed) mount, cross-repo `requires` staged in |
+| `.github/workflows/node-repo-publish-bake.yml` | the main-only bake + publication — full-repo `--bake-output`, staged-module exclusion, OIDC publish via the canonical `publish-bake-bundles.sh` |
+| `.github/workflows/node-repo-tag-modules.yml` | the `<Module>/vX.Y.Z` tag publisher (`scripts/tag-modules.py`) |
+
+The design rules the extraction preserves:
+
+- **Every externally-provisioned value is an explicit input/secret** — nothing implicit, so the
+  publish-bake preflight can assert the full set and fail RED naming what to provision. The
+  caller keeps its own `preflight` job (and the fork exemption) for the gate lane, and gates run
+  unconditionally behind `needs:` — no input-shaped `if:` anywhere (no skip-trapdoors).
+- **The publish script has one home** — `publish-bake-bundles.sh` in this repo, next to the
+  `ShippedPrebuiltBundles` constants its `_complete` sentinel must keep matching. The reusable
+  publish-bake checks this repo out (by `platform-ref`, default `main`) and runs it, retiring
+  the per-repo vendored copies. This repo is public, so private satellites call the workflows
+  and read the script with their default token.
+- **Repo-specific policy stays in the caller**: the digest pin (`MW_IMAGE_DIGEST`) and its bump
+  cadence, gating (`if:`/`needs:` on the `uses:` job), the `repository_dispatch` receiver, the
+  module-bundle job of mixed packages, and each repo's `scripts/` (validate / compile-check /
+  affected-modules / tag-modules stay caller-side — they encode the repo's own layout).
+- **Staged cross-repo modules are excluded from publication** (e.g. Store is staged so
+  `requires` resolve but is owned and published by MeshWeaver.Plugins) — each source directory
+  seals independently, which is also why no cross-repo bake ORDERING is needed: a dependent
+  repo's publication never contains its dependency's bundles, so there is nothing to wait for.
+  The framework-release dispatch fans out to all satellites concurrently.
+
 ## What this step does not do yet
 
 - **DB-resident types** (user/partition content CI cannot see) stay on the runtime bake.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -12,9 +12,14 @@ C# stored in mesh nodes compiles **at runtime, in the portal** — see
 [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation). This page is about compiling the same
 source **outside** it: in CI, ahead of time, so the bytes can be shipped rather than recomputed.
 
-`MeshWeaver.Plugin.Build` is the tool that does it. Everything below is what it has to get right to
-produce an assembly the portal would accept — each item established by a build that failed in a way
-that read as author error rather than harness error.
+The compile toolchain itself is **`MeshWeaver.Compiler`** (#1707) — the same code path whether the
+portal compiles at runtime, CI gates and bakes, or you run it by hand — and it is distributed
+three ways: in every portal image, as the **`MeshWeaver.Compiler.Cli` dotnet tool** (command
+`mw-compiler`; version-matched with each platform release, published by the release lane and the
+out-of-band `publish-compiler-tool` workflow), and as the `mw-plugin-test` container image.
+`MeshWeaver.Plugin.Build` is the packaging tool on top. Everything below is what the pipeline has
+to get right to produce an assembly the portal would accept — each item established by a build
+that failed in a way that read as author error rather than harness error.
 
 ---
 
@@ -70,9 +75,11 @@ Two consequences:
   `PostsHub` each still called it from that field — CI green, then all three production portals hit
   `REFUSING READINESS` on the next framework bump.
 
-The tool calls the framework's own `DynamicMeshNodeAttributeGenerator` rather than reproducing it. A
-second implementation is free to drift, and a skeleton that differs from the runtime's is worse than
-none: it compiles, packs, installs, and then behaves differently from everything that was tested.
+The tool calls the framework's own `DynamicMeshNodeAttributeGenerator` (in `MeshWeaver.Compiler`
+since #1707 — the toolchain assembly whose dependency closure keys the framework identity) rather
+than reproducing it. A second implementation is free to drift, and a skeleton that differs from
+the runtime's is worse than none: it compiles, packs, installs, and then behaves differently from
+everything that was tested.
 
 ## The ambient environment is not implicit
 
@@ -95,13 +102,16 @@ environment, is narrower, and reintroduces the `CS0616` above.
 `HasUsableBuild` skips a compile only when `CompiledFrameworkVersion` equals the live
 `NodeTypeCompilationHelpers.FrameworkVersion` — never a semver. Since
 [#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 that value has three shapes, one
-resolution (`FrameworkBuildIdentity`): hosts shipping a `meshweaver-surface.manifest` — the
-portals and the CI bake host — resolve the **API-surface identity** `s<hash>` (reference-assembly
-hashes over the canonical content-surface set, full impl MVID for the generator-bearing
-`MeshWeaver.Graph`; stable across internal-only merges, moved by breaking changes); manifest-less
-CI processes resolve the **commit identity** `g<sha>` (stamped as
-`AssemblyMetadata("MeshWeaverFrameworkIdentity")`, also everyone's logged provenance); a **local
-build** resolves the **Module Version Id of the MeshWeaver.Graph assembly** — a content identity.
+resolution (`FrameworkBuildIdentity`, in `MeshWeaver.Compiler`): hosts shipping a
+`meshweaver-surface.manifest` — the portals and the CI bake host — resolve the **API-surface
+identity** `s<hash>` (reference-assembly hashes over the canonical content-surface set; full impl
+MVIDs for the TOOLCHAIN — `MeshWeaver.Compiler`, `MeshWeaver.NuGet`, and their computed MeshWeaver
+dependency closure, since their code shapes every compile's generated input; stable across
+internal-only merges, moved by breaking changes and toolchain changes); manifest-less CI processes
+resolve the **commit identity** `g<sha>` (stamped as
+`AssemblyMetadata("MeshWeaverFrameworkIdentity")`, also everyone's logged provenance); a
+**manifest-less local build** resolves the **Module Version Id of the MeshWeaver.Compiler
+assembly** — the toolchain anchor, single-file attributable.
 
 None is derived from `AssemblyInformationalVersion`, on purpose. Deriving identity from the
 version string once forced `Directory.Build.props` to stamp a fresh version into every build,
@@ -147,7 +157,9 @@ runtime will look up, with an MVID that matches. The load side already exists
 ```
 MeshWeaver.Plugin.<Name>.<Version>.nupkg
 ├── MeshWeaver.Plugin.<Name>.nuspec
-├── meshweaver/manifest.json          plugin, version, frameworkVersion, frameworkMvid, assemblies[]
+├── meshweaver/manifest.json          plugin, version, frameworkVersion, frameworkMvid,
+│                                     assemblies[] (each with sourceVersions provenance and its
+│                                     per-type DEPENDENCY RECORD — #1707 slice 2)
 ├── meshweaver/assemblies/<Unit>.dll  one per compilation unit, embedded PDB
 └── meshweaver/content/**             the plugin's node files, verbatim
 ```
@@ -253,7 +265,16 @@ carries content — it is a full install artifact, not an increment.)
 `PluginBundleClient` (in `MeshWeaver.PluginCatalog`) reads the index once per client — a
 `PromiseSlot`, so concurrent callers share one run and a fault evicts rather than replaying forever —
 compares the framework MVID **once, before any download**, then fetches and seeds each assembly
-through `PrebuiltAssemblySeeder`.
+through `PrebuiltAssemblySeeder` — which additionally validates each assembly's per-type
+DEPENDENCY RECORD against this environment (a build binding a module this deployment does not run
+declines) and stamps the record on adopt, so an adopted build is judged by the ongoing validity
+checks exactly like a locally compiled one (#1707 slice 2).
+
+Consumption is no longer boot-only (#1707 slice 3): every package INSTALL and every git-sync PUSH
+runs its written/affected types through the bundle sources first
+(`IPrebuiltAssemblyConsumer.SeedForTypes`), and the release-request watcher satisfies a request
+that arrives on an already-valid current build — see
+[NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) → "Adopt-before-compile".
 
 Two ordering rules, both of which fail silently when broken:
 


### PR DESCRIPTION
## What

**Reusable `workflow_call` workflows for every MeshWeaver.\* content repo** (per the CI-unification directive under #1707):

| Workflow | Unifies |
|---|---|
| `node-repo-validate.yml` | JSON/manifest shape gate (`validate-repos.py`, `gen-manifests.py --check`, main-only `--check-versions`) |
| `node-repo-compile-check.yml` | the compile gate vs the digest-pinned platform image's assemblies |
| `node-repo-gate.yml` | the `mw-plugin-test` tester gate (optional affected-narrowing, cross-repo staging) |
| `node-repo-publish-bake.yml` | the main-only full-repo bake + OIDC publication via the **canonical** `publish-bake-bundles.sh` |
| `node-repo-tag-modules.yml` | the `<Module>/vX.Y.Z` tag publisher |

Design rules preserved from the vendored originals: explicit inputs/secrets only (preflights fail RED naming what to provision — no skip-trapdoors), unpinned images are an explicit `allow-unpinned` opt-in (never a silent fallback), staged cross-repo modules are excluded from publication, and the publish script keeps one home next to `ShippedPrebuiltBundles.CompletionSentinelFileName`. Education's snapshot-mount / follow-tag shape is covered (`pre-bake-script` + `BAKE_MOUNT_DIR` + `node-version`); repo policy (digest pins, gating, dispatch receivers, `scripts/`) stays caller-side.

**`release-packages.yml`**: packs + publishes `MeshWeaver.Compiler.Cli` version-matched with every `v*` release (#1707 S1b), asserting `meshweaver-surface.manifest` is inside the package before pushing (without it the installed tool resolves a forked framework identity). The out-of-band lane stays `publish-compiler-tool.yml`.

**Docs**: `CiContentBake.md` — the unified node-repo lane + why no cross-repo bake ordering is needed; `PluginPackaging.md` — `MeshWeaver.Compiler` toolchain, 3-way tool distribution, toolchain-closure identity, per-type dependency records, install/push-time adoption.

## Verification

- All five workflows YAML-parse with the full `workflow_call` input/secret contract.
- Faithfully generalized from all four satellites' current `ci.yml` (fetched + diffed: Plugins / Education / Reinsurance / SocialMedia).
- `MeshWeaver.Documentation.Test` built Release `-warnaserror` (0 warnings/errors); `DocumentationLinkIntegrityTest` green.
- Satellite thin-caller PRs follow after this merges (the `uses:` references need these on `main`).

No What's New entry: CI/docs only, no user-visible change.

Part of #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)