### PR TITLE
docs: satellite bake-publish credentials are provisioned; dispatch still dormant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,17 @@ summarize step is the real gate; a GitHub-API 429 must not fail the run) and the
 push/prune (losing a marker costs a redundant run, never correctness). The test is *what does a
 failure here hide?* — nothing, for a reporter; everything, for a gate.
 
+### Satellite CI = thin callers of THIS repo's reusable workflows
+
+**Never hand-roll (or copy-paste) a node repo's CI.** The shared jobs live here as `workflow_call`
+workflows — `.github/workflows/node-repo-{validate,compile-check,gate,tag-modules,publish-bake}.yml`
+— and MeshWeaver.Plugins / .Education / .Reinsurance / .SocialMedia call them, keeping only
+repo-specific policy (digest pin, gating, `repository_dispatch` receiver, their own `scripts/`).
+Adopting one renames that repo's required-status-check contexts to `<caller job> / <name>` — do it
+in the same change. Full contract: [CiContentBake.md](src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md)
+and [ContinuousDeliveryContract.md](src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md)
+(which also carries the GitHub OIDC subject-format rule: register BOTH subject formats per repo).
+
 ## 🚨 Postgres: One Schema Per Partition
 
 **`public.mesh_nodes` is empty by design.** Data lives in per-partition schemas (`acme.mesh_nodes`, `rbuergi.mesh_nodes`, etc.).

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -157,14 +157,30 @@ The design rules the extraction preserves:
   the per-repo vendored copies. This repo is public, so private satellites call the workflows
   and read the script with their default token.
 - **Repo-specific policy stays in the caller**: the digest pin (`MW_IMAGE_DIGEST`) and its bump
-  cadence, gating (`if:`/`needs:` on the `uses:` job), the `repository_dispatch` receiver, the
+  cadence — an unpinned image is an explicit `allow-unpinned` opt-in, never a silent fallback —
+  gating (`if:`/`needs:` on the `uses:` job), the `repository_dispatch` receiver, the
   module-bundle job of mixed packages, and each repo's `scripts/` (validate / compile-check /
   affected-modules / tag-modules stay caller-side — they encode the repo's own layout).
+- **Adoption renames the required checks**: a reusable-called workflow's check runs report as
+  `<caller job> / <name>`, so each repo's required-status-check contexts are renamed in the same
+  change that adopts a workflow — a context left at the old name would wait forever.
 - **Staged cross-repo modules are excluded from publication** (e.g. Store is staged so
   `requires` resolve but is owned and published by MeshWeaver.Plugins) — each source directory
   seals independently, which is also why no cross-repo bake ORDERING is needed: a dependent
   repo's publication never contains its dependency's bundles, so there is nothing to wait for.
   The framework-release dispatch fans out to all satellites concurrently.
+
+The satellites' OIDC publish is **provisioned** (2026-08-17): the Azure managed identity
+`github-actions-bake` (RG `memex-aks-rg`) holds *Storage File Data Privileged Contributor* on the
+portals' storage account, with one federated credential per satellite `main` ref
+(`repo:Systemorph/<repo>:ref:refs/heads/main`), and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` /
+`AZURE_SUBSCRIPTION_ID` secrets are set on all four repos. **A red publish-bake was designed debt
+until 2026-08-17 and is a real failure after it** — treat any surviving allowlist or
+"credentials pending" reference to a satellite's publish lane as historical. The
+framework-release dispatch that fans a platform release out to the satellites is still dormant
+(`BAKE_SUBSCRIBER_REPOS` / `DEPENDENT_DISPATCH_TOKEN` unprovisioned — see
+[The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)); until it is
+armed, a satellite re-bakes on its own `main` pushes only.
 
 ## What this step does not do yet
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -184,16 +184,23 @@ portals' storage account and carries 8 federated credentials — the four satell
 GitHub subject formats (classic and immutable; **register both, always** — see
 [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)) — with the
 `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets set on all four repos.
-**A red publish-bake was designed debt until 2026-08-17 and is a real failure after it** — treat
-any surviving allowlist or "credentials pending" reference to a satellite's publish lane as
-historical. The framework-release dispatch that fans a platform release out to the satellites is
+**A red publish-bake was designed debt until 2026-08-17 and is a real failure after it** —
+treat any surviving allowlist or "credentials pending" reference to a satellite's publish lane
+as historical. The framework-release dispatch that fans a platform release out to the satellites is
 still dormant (`BAKE_SUBSCRIBER_REPOS` / `DEPENDENT_DISPATCH_TOKEN` unprovisioned); until it is
 armed, a satellite re-bakes on its own `main` pushes only.
 
-🚨 A satellite's publication is adoptable at boot; **the platform's own is not, today** — issue
-#1725: the platform bakes from CI build output while the pod resolves its identity inside the
-shipped image, so the identities differ and every boot recompiles the shipped types. The
-satellites escape it precisely because they bake INSIDE the image.
+**Measured in production, 2026-08-17** — for satellite content the lane is not a design any more,
+it is observed behaviour. On `memex` running `3.0.0-rc4.ci.4049` (identity
+`s377941f549f721e01ac764e0fb8db84a`), boot
+**adopted 68 prebuilt assemblies from 31 sealed bundles in 18.9 s**
+and Roslyn-compiled **zero** healthy types (warm-up 32.1 s, `compiled=0`, `alreadyBaked=84`).
+The comparable boot before any satellite bake existed did **80 compiles in 64.8 s**.
+
+🚨 That measurement is **satellite content only**. The platform's own publication is NOT adoptable
+today — issue #1725: the platform bakes from CI build output while the pod resolves its identity
+inside the shipped image, so the identities differ and every boot recompiles the platform's shipped
+types. The satellites escape it precisely because they bake INSIDE the image.
 
 ## What this step does not do yet
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -132,10 +132,14 @@ for the job's preflight discipline and the dependent-repo dispatch.
 Every satellite content repo (MeshWeaver.Plugins, MeshWeaver.Education, MeshWeaver.Reinsurance,
 MeshWeaver.SocialMedia) bakes and publishes its own content through the SAME contract, and since
 #1707 the jobs live HERE, as reusable `workflow_call` workflows the satellites call instead of
-vendoring. Adoption is per job: every repo calls `node-repo-publish-bake` (the lane whose script
-contract must not drift), while a repo whose variant of a gate carries repo-specific machinery
-(Plugins' Tests-area ratchet, Education's course checks) keeps that job vendored until the
-machinery generalizes:
+vendoring. Adoption is **per job and still in progress**: the target is that every repo calls
+`node-repo-publish-bake` (the lane whose script contract must not drift), while a repo whose
+variant of a gate carries repo-specific machinery (Plugins' Tests-area ratchet, Education's
+course checks) keeps that job vendored until the machinery generalizes. As of 2026-08-17
+**MeshWeaver.SocialMedia and MeshWeaver.Plugins are merged and green end-to-end including
+publish-bake** (SocialMedia calls the full set, Plugins calls publish-bake only);
+MeshWeaver.Reinsurance and MeshWeaver.Education are in flight; MeshWeaver.Manufacturing is
+deliberately deferred.
 
 | Workflow | Job it unifies |
 |---|---|
@@ -163,7 +167,11 @@ The design rules the extraction preserves:
   affected-modules / tag-modules stay caller-side — they encode the repo's own layout).
 - **Adoption renames the required checks**: a reusable-called workflow's check runs report as
   `<caller job> / <name>`, so each repo's required-status-check contexts are renamed in the same
-  change that adopts a workflow — a context left at the old name would wait forever.
+  change that adopts a workflow — a context left at the old name would wait forever. On a
+  protected repo this is a required step of the adoption, not an afterthought: SocialMedia's
+  contexts are now `validate / Validate node repos`,
+  `compile-check / Compile every NodeType (vs core)` and
+  `test-repos / Compile + render node repos (MeshWeaver from ACR)`.
 - **Staged cross-repo modules are excluded from publication** (e.g. Store is staged so
   `requires` resolve but is owned and published by MeshWeaver.Plugins) — each source directory
   seals independently, which is also why no cross-repo bake ORDERING is needed: a dependent
@@ -172,15 +180,20 @@ The design rules the extraction preserves:
 
 The satellites' OIDC publish is **provisioned** (2026-08-17): the Azure managed identity
 `github-actions-bake` (RG `memex-aks-rg`) holds *Storage File Data Privileged Contributor* on the
-portals' storage account, with one federated credential per satellite `main` ref
-(`repo:Systemorph/<repo>:ref:refs/heads/main`), and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` /
-`AZURE_SUBSCRIPTION_ID` secrets are set on all four repos. **A red publish-bake was designed debt
-until 2026-08-17 and is a real failure after it** — treat any surviving allowlist or
-"credentials pending" reference to a satellite's publish lane as historical. The
-framework-release dispatch that fans a platform release out to the satellites is still dormant
-(`BAKE_SUBSCRIBER_REPOS` / `DEPENDENT_DISPATCH_TOKEN` unprovisioned — see
-[The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)); until it is
+portals' storage account and carries 8 federated credentials — the four satellite repos × the two
+GitHub subject formats (classic and immutable; **register both, always** — see
+[The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)) — with the
+`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets set on all four repos.
+**A red publish-bake was designed debt until 2026-08-17 and is a real failure after it** — treat
+any surviving allowlist or "credentials pending" reference to a satellite's publish lane as
+historical. The framework-release dispatch that fans a platform release out to the satellites is
+still dormant (`BAKE_SUBSCRIBER_REPOS` / `DEPENDENT_DISPATCH_TOKEN` unprovisioned); until it is
 armed, a satellite re-bakes on its own `main` pushes only.
+
+🚨 A satellite's publication is adoptable at boot; **the platform's own is not, today** — issue
+#1725: the platform bakes from CI build output while the pod resolves its identity inside the
+shipped image, so the identities differ and every boot recompiles the shipped types. The
+satellites escape it precisely because they bake INSIDE the image.
 
 ## What this step does not do yet
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -196,13 +196,15 @@ mid-way leaves no sentinel — the next run re-publishes wholesale, and the port
 unsealed or torn directories, so a partial publication can neither freeze nor be seeded.
 Each booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
 `ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
-did not bake. 🚨 **For the platform's OWN content that is currently aspiration, not fact** — issue
-#1725: CI bakes platform content from the Build-and-Test *build output*, while the pod resolves
-its identity inside the *shipped image*, so the two identities differ and no pod can adopt the
-platform bake (every boot Roslyn-compiles the shipped types anyway). The satellites are unaffected
-because they bake INSIDE the shipped image, which is why only their publications match today. Read
-the paragraph above as the contract the fix restores, not as current behaviour. Its configuration
-is **preflighted red, never skipped**: repo variable
+did not bake. **For satellite content this is measured, not aspirational**: on 2026-08-17 `memex`
+(`3.0.0-rc4.ci.4049`, identity `s377941f549f721e01ac764e0fb8db84a`) adopted 68 prebuilt assemblies
+from 31 sealed bundles in 18.9 s and compiled zero healthy types (`compiled=0`, `alreadyBaked=84`),
+against 80 compiles / 64.8 s on the comparable boot before the satellite bakes existed.
+🚨 **For the platform's OWN content it is still aspiration** — issue #1725: CI bakes it from the
+Build-and-Test *build output*, while the pod resolves its identity inside the *shipped image*, so
+the two identities differ and no pod can adopt the platform bake. The satellites are unaffected
+because they bake INSIDE the shipped image, which is why only their publications match today. Its
+configuration is **preflighted red, never skipped**: repo variable
 `BAKE_PUBLISH_TARGETS` names the Azure Files targets (`<account>/<share>[/<base-path>]`,
 whitespace-separated), and a missing value fails the job naming exactly that — a grey skip here
 would silently restore the every-pod-rebakes-everything regression (#1347). A missing bake
@@ -234,9 +236,9 @@ Provisioning state (2026-08-17): the two halves of this cascade are in different
   portals' storage account, carries **8 federated credentials — the four satellite repos
   (`MeshWeaver.Plugins`, `MeshWeaver.Education`, `MeshWeaver.Reinsurance`, `MeshWeaver.SocialMedia`)
   × two subject formats** (below) — and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` /
-  `AZURE_SUBSCRIPTION_ID` secrets are set on all four repos. **A red publish-bake was designed debt
-  until 2026-08-17 and is a real failure after it** — read any older "credentials pending" or
-  known-red allowlist reference as historical.
+  `AZURE_SUBSCRIPTION_ID` secrets are set on all four repos.
+  **A red publish-bake was designed debt until 2026-08-17 and is a real failure after it** —
+  read any older "credentials pending" or known-red allowlist reference as historical.
 - **The dispatch itself remains dormant.** `BAKE_SUBSCRIBER_REPOS` (platform repo variable) and
   `DEPENDENT_DISPATCH_TOKEN` (a human-minted PAT with `repo` scope on the four satellites) are
   still unset, so `notify-dependents` exits with its loud not-configured notice. Until they are
@@ -262,16 +264,22 @@ each still precisely scoped to repo + branch (no wildcard subject, no org-wide c
 costs nothing, and it survives a repo flipping format under you:
 
 ```bash
-REPO=MeshWeaver.Plugins
+REPO=MeshWeaver.Plugins           # the repo you are wiring
+SHORT=plugins                     # its short name, used only in the credential's --name
 REPO_ID=$(gh api repos/Systemorph/$REPO --jq .id)
+ORG_ID=$(gh api orgs/Systemorph --jq .id)
 ISSUER=https://token.actions.githubusercontent.com
 # BOTH of the following, never just one:
 az identity federated-credential create -g memex-aks-rg --identity-name github-actions-bake \
-  --name "gh-${REPO,,}-main-classic" --issuer "$ISSUER" \
+  --name "gh-$SHORT-main-classic" --issuer "$ISSUER" \
   --subject "repo:Systemorph/$REPO:ref:refs/heads/main" --audience api://AzureADTokenExchange
 az identity federated-credential create -g memex-aks-rg --identity-name github-actions-bake \
-  --name "gh-${REPO,,}-main" --issuer "$ISSUER" \
-  --subject "repo:Systemorph@77832550/$REPO@$REPO_ID:ref:refs/heads/main" --audience api://AzureADTokenExchange
+  --name "gh-meshweaver-$SHORT-main" --issuer "$ISSUER" \
+  --subject "repo:Systemorph@$ORG_ID/$REPO@$REPO_ID:ref:refs/heads/main" --audience api://AzureADTokenExchange
+
+# What is registered today (expect 2 rows per repo, 8 in total):
+az identity federated-credential list --identity-name github-actions-bake -g memex-aks-rg \
+  --query "[].{name:name,subject:subject}" -o tsv
 ```
 
 When `AADSTS700213` appears, **copy the presented subject verbatim out of the error message and add

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -196,7 +196,13 @@ mid-way leaves no sentinel — the next run re-publishes wholesale, and the port
 unsealed or torn directories, so a partial publication can neither freeze nor be seeded.
 Each booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
 `ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
-did not bake. Its configuration is **preflighted red, never skipped**: repo variable
+did not bake. 🚨 **For the platform's OWN content that is currently aspiration, not fact** — issue
+#1725: CI bakes platform content from the Build-and-Test *build output*, while the pod resolves
+its identity inside the *shipped image*, so the two identities differ and no pod can adopt the
+platform bake (every boot Roslyn-compiles the shipped types anyway). The satellites are unaffected
+because they bake INSIDE the shipped image, which is why only their publications match today. Read
+the paragraph above as the contract the fix restores, not as current behaviour. Its configuration
+is **preflighted red, never skipped**: repo variable
 `BAKE_PUBLISH_TARGETS` names the Azure Files targets (`<account>/<share>[/<base-path>]`,
 whitespace-separated), and a missing value fails the job naming exactly that — a grey skip here
 would silently restore the every-pod-rebakes-everything regression (#1347). A missing bake
@@ -225,17 +231,52 @@ Provisioning state (2026-08-17): the two halves of this cascade are in different
 
 - **The satellites' publish credentials ARE provisioned.** The Azure managed identity
   `github-actions-bake` (RG `memex-aks-rg`) holds *Storage File Data Privileged Contributor* on the
-  portals' storage account, with one federated credential per satellite `main` ref
-  (`repo:Systemorph/{MeshWeaver.Plugins,MeshWeaver.Education,MeshWeaver.Reinsurance,MeshWeaver.SocialMedia}:ref:refs/heads/main`),
-  and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets are set on all
-  four repos. **A red publish-bake was designed debt until 2026-08-17 and is a real failure after
-  it** — read any older "credentials pending" or known-red allowlist reference as historical.
+  portals' storage account, carries **8 federated credentials — the four satellite repos
+  (`MeshWeaver.Plugins`, `MeshWeaver.Education`, `MeshWeaver.Reinsurance`, `MeshWeaver.SocialMedia`)
+  × two subject formats** (below) — and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` /
+  `AZURE_SUBSCRIPTION_ID` secrets are set on all four repos. **A red publish-bake was designed debt
+  until 2026-08-17 and is a real failure after it** — read any older "credentials pending" or
+  known-red allowlist reference as historical.
 - **The dispatch itself remains dormant.** `BAKE_SUBSCRIBER_REPOS` (platform repo variable) and
   `DEPENDENT_DISPATCH_TOKEN` (a human-minted PAT with `repo` scope on the four satellites) are
   still unset, so `notify-dependents` exits with its loud not-configured notice. Until they are
   provisioned, satellites re-bake only on their own `main` pushes, and a release-triggered rebuild
   can be hand-fired by anyone with `repo` scope:
   `gh api repos/Systemorph/<repo>/dispatches -f event_type=meshweaver-framework-released`.
+
+### 🚨 Register BOTH OIDC subject formats — the classic one AND the immutable one
+
+GitHub is rolling out **immutable** OIDC subjects that embed numeric ids
+(`repo:Systemorph@77832550/<Repo>@<repoId>:ref:refs/heads/main`) alongside the classic name-based
+form (`repo:Systemorph/<Repo>:ref:refs/heads/main`) — and **which one a repo presents varies per
+repo inside the same org at the same moment.** Measured 2026-08-17: Education and SocialMedia
+presented the immutable form while MeshWeaver.Plugins presented the classic one, so "tidying" all
+four to immutable broke Plugins with
+
+```
+AADSTS700213: No matching federated identity record found for presented assertion subject '<…>'
+```
+
+**The durable arrangement is two federated credentials per repo — one classic, one immutable** —
+each still precisely scoped to repo + branch (no wildcard subject, no org-wide credential). It
+costs nothing, and it survives a repo flipping format under you:
+
+```bash
+REPO=MeshWeaver.Plugins
+REPO_ID=$(gh api repos/Systemorph/$REPO --jq .id)
+ISSUER=https://token.actions.githubusercontent.com
+# BOTH of the following, never just one:
+az identity federated-credential create -g memex-aks-rg --identity-name github-actions-bake \
+  --name "gh-${REPO,,}-main-classic" --issuer "$ISSUER" \
+  --subject "repo:Systemorph/$REPO:ref:refs/heads/main" --audience api://AzureADTokenExchange
+az identity federated-credential create -g memex-aks-rg --identity-name github-actions-bake \
+  --name "gh-${REPO,,}-main" --issuer "$ISSUER" \
+  --subject "repo:Systemorph@77832550/$REPO@$REPO_ID:ref:refs/heads/main" --audience api://AzureADTokenExchange
+```
+
+When `AADSTS700213` appears, **copy the presented subject verbatim out of the error message and add
+a credential for it, KEEPING the existing one.** Deleting the other format is what turns one repo's
+green lane red.
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -221,6 +221,22 @@ identity, so the next CI run re-bakes by construction.) Reporter-class like the 
 webhook: an unconfigured or lost dispatch is a loud notice, never a red — the next release
 re-notifies, and nothing downstream certifies anything on it.
 
+Provisioning state (2026-08-17): the two halves of this cascade are in different states.
+
+- **The satellites' publish credentials ARE provisioned.** The Azure managed identity
+  `github-actions-bake` (RG `memex-aks-rg`) holds *Storage File Data Privileged Contributor* on the
+  portals' storage account, with one federated credential per satellite `main` ref
+  (`repo:Systemorph/{MeshWeaver.Plugins,MeshWeaver.Education,MeshWeaver.Reinsurance,MeshWeaver.SocialMedia}:ref:refs/heads/main`),
+  and the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets are set on all
+  four repos. **A red publish-bake was designed debt until 2026-08-17 and is a real failure after
+  it** — read any older "credentials pending" or known-red allowlist reference as historical.
+- **The dispatch itself remains dormant.** `BAKE_SUBSCRIBER_REPOS` (platform repo variable) and
+  `DEPENDENT_DISPATCH_TOKEN` (a human-minted PAT with `repo` scope on the four satellites) are
+  still unset, so `notify-dependents` exits with its loud not-configured notice. Until they are
+  provisioned, satellites re-bake only on their own `main` pushes, and a release-triggered rebuild
+  can be hand-fired by anyone with `repo` scope:
+  `gh api repos/Systemorph/<repo>/dispatches -f event_type=meshweaver-framework-released`.
+
 ## See also
 
 - [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy) — the two channels, the update policy node, and how each install applies an update.

--- a/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
@@ -120,6 +120,16 @@ environment, in this order:
    `Admin/UpdatePolicy` node. Recommended: **Continuous for dev/test** (always rolls to the newest
    build-numbered image), **Stable for prod** (rolls only to the newest clean release). See
    [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy).
+5. **Add the env's Azure Files share to the CI bake targets** — otherwise no published bundle ever
+   reaches the new portal and its pods Roslyn-compile every shipped NodeType at boot. Append its
+   `<account>/<share>[/<base-path>]` (the account/share behind the namespace's `memex-data` PVC) to
+   the `BAKE_PUBLISH_TARGETS` repo variable on the platform repo and on each satellite content
+   repo, and make sure the `github-actions-bake` identity holds *Storage File Data Privileged
+   Contributor* on that storage account. The publishing jobs preflight this **red, never skipped**
+   — see [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract), which
+   also carries the GitHub OIDC subject-format rule (register BOTH the classic and the immutable
+   subject per repo). Note that identity's federated subjects come from GitHub's issuer and are
+   unrelated to the cluster-issuer `system:serviceaccount:` subjects in steps 1–3.
 
 ## Plugins — wire the environment to a registry
 


### PR DESCRIPTION
Docs-only update recording verified 2026-08-17 state across the bake/publish lane.

### What is now stated as fact

1. **Satellite bake-publish credentials are PROVISIONED.** Managed identity `github-actions-bake` (RG `memex-aks-rg`) holds *Storage File Data Privileged Contributor* on the portals' storage account, with **8 federated credentials — four satellite repos × two subject formats** — and `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` set on all four repos. **A red publish-bake was designed debt until 2026-08-17 and is a real failure after it.**
2. **Register BOTH OIDC subject formats per repo.** GitHub's immutable subjects embed numeric ids and the format **varies per repo inside the org**, so normalising to one broke a satellite with `AADSTS700213`. Adds the provisioning commands, the list command that shows the expected 8 rows, and the copy-the-presented-subject remedy.
3. **The dispatch cascade is still dormant** (`BAKE_SUBSCRIBER_REPOS` / `DEPENDENT_DISPATCH_TOKEN`) — satellites re-bake on their own main pushes; a release-triggered rebuild can be hand-fired via `repository_dispatch`.
4. **Reusable-workflow adoption (#1721) is per job and in progress** — SocialMedia + Plugins merged and green; Reinsurance and Education in flight; Manufacturing deferred. Also: unpinned images are an explicit `allow-unpinned` opt-in, and adoption renames required contexts to `<caller job> / <name>` (SocialMedia's are recorded as the concrete example).
5. **The adopt path is measured in prod for satellite content** — memex on `3.0.0-rc4.ci.4049` adopted 68 prebuilt assemblies from 31 sealed bundles in 18.9 s and compiled zero healthy types (`compiled=0`, `alreadyBaked=84`), against 80 compiles / 64.8 s before the satellite bakes existed.
6. **#1725 is flagged wherever the docs claim boot adopts the platform's OWN bake** — CI bakes platform content from build output while the pod resolves its identity inside the image, so no pod can adopt it today. Satellites are unaffected (they bake inside the image).

### Files

- `ContinuousDeliveryContract.md` — notify-dependents provisioning state, the OIDC subject-format section, the #1725 caveat, the prod measurement.
- `CiContentBake.md` — node-repo section only (adoption state, context rename, credentials, measurement, #1725). **The delivery-lane section is untouched** — it is owned by a concurrent change.
- `OnboardingNewEnvironment.md` — a new env's Azure Files share must reach `BAKE_PUBLISH_TARGETS`, else its pods compile every shipped NodeType at boot.
- `AGENTS.md` — satellite CI = thin callers of this repo's reusable workflows.

### Verification

`MeshWeaver.Documentation.Test` built `-c Release -warnaserror` (0 errors, 0 warnings) and `DocumentationLinkIntegrityTest` passed after each edit round. Copilot review addressed (bold spans kept on one line) and threads resolved.

No What's New entry — internal docs change, no user-visible product effect.

The first run's shard-4 red is the open **#890** (Roslyn emit NRE, canary `BELOW-ROSLYN`), not this diff — see the attribution comment below.

Companion PR: Systemorph/MeshWeaver.Plugins#504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)