### PR TITLE
fix(#1701): GetMeshNode rides out a recycling address — paced re-probes within the caller's budget

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-reads-ride-out-a-recycling-hub.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-reads-ride-out-a-recycling-hub.md
@@ -1,0 +1,27 @@
+---
+Name: Node reads ride out a recycling hub instead of failing
+Category: Fix
+Description: A node read that landed in a hub's recycle window burned its single re-probe within milliseconds and failed terminally with almost its whole budget unused — every NodeType compile reading its package root during an install-recycle settled as a phantom compile error. Reads now re-probe throughout their budget and deliver the node once the address reactivates.
+Icon: ArrowSync
+Order: -20260817
+---
+
+# Node reads ride out a recycling hub instead of failing
+
+A mesh hub that is recycling — restarting after a package install, a recompile, a config
+change — answers reads with an explicit "I am shutting down, ask again" verdict rather than
+pretending the node is gone. The read primitive honoured only the first half of that contract:
+it re-probed exactly once, immediately, so both probes landed within milliseconds of each other,
+and any recycle longer than a beat became a terminal error with almost the caller's entire
+budget unused.
+
+The visible symptom was phantom compile failures. When installing a package recycles its root
+hub, every one of the package's NodeType compiles reads that root; each read that landed in the
+recycle window failed, and each failure was stamped as a compile error — parking whole modules
+on the compilation-error overlay in the portal, and turning satellite-repo CI gates red on
+types whose code was perfectly fine, on a different module every run.
+
+Reads now keep re-probing on a paced schedule for as long as their own budget allows, and
+deliver the node as soon as the address reactivates. A hub that recycles for the entire budget
+surfaces a dedicated recycling verdict — which the compile pipeline files as "availability
+unknown, retry", never as a verdict about the code.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1317,8 +1317,11 @@ internal static class NodeTypeCompilationHelpers
     ///
     /// <para>🚨 The status is <see cref="CompilationStatus.Error"/> — Roslyn's verdict — EXCEPT
     /// when the compile never ran because its SOURCE SET could not be established
-    /// (<see cref="SourceDiscoveryUnavailableException"/>). That is an availability failure, so it
-    /// stamps <see cref="CompilationStatus.Unavailable"/>: "the compile state could not be
+    /// (<see cref="SourceDiscoveryUnavailableException"/>) or because a mesh address it had to
+    /// read was RECYCLING for the reader's whole budget
+    /// (<see cref="AddressRecyclingException"/> — a package-root hub's install-recycle wedging
+    /// dispose is MeshWeaver#1701's trigger). Those are availability failures, so they stamp
+    /// <see cref="CompilationStatus.Unavailable"/>: "the compile state could not be
     /// determined; nothing is known to be wrong with the source". Everything downstream already
     /// reads the two apart — the instance overlay drops "please correct the code",
     /// <c>EnsureCompileDispatched</c> re-dispatches on the next request, and the bake gate files it
@@ -1331,7 +1334,7 @@ internal static class NodeTypeCompilationHelpers
         string? activityPath)
         => def with
         {
-            CompilationStatus = error is SourceDiscoveryUnavailableException
+            CompilationStatus = error is SourceDiscoveryUnavailableException or AddressRecyclingException
                 ? CompilationStatus.Unavailable
                 : CompilationStatus.Error,
             CompilationError = SummarizeCompileError(result, error),
@@ -1727,9 +1730,15 @@ internal static class NodeTypeCompilationHelpers
                         // snapshot that never answered is the log-line version of the #1218 bug:
                         // Roslyn was never invoked, so a reader (or an operator reading a stalled
                         // rollout's activity log) must not be told it rejected anything.
-                        var failureLead = outcome.Error is SourceDiscoveryUnavailableException
-                            ? "Compile NOT ATTEMPTED — source set could not be established"
-                            : "Roslyn failed";
+                        var failureLead = outcome.Error switch
+                        {
+                            SourceDiscoveryUnavailableException =>
+                                "Compile NOT ATTEMPTED — source set could not be established",
+                            AddressRecyclingException =>
+                                "Compile NOT SETTLED — a mesh address it reads was recycling "
+                                + "for the reader's whole budget",
+                            _ => "Roslyn failed"
+                        };
                         activityMessages.Add(new LogMessage(
                             $"{failureLead}: {outcome.Error?.Message ?? (outcome.Result?.Log?.Errors() is { Count: > 0 } errs ? string.Join("; ", errs.Select(m => m.Message)) : "Compilation produced no assembly")}",
                             LogLevel.Error));

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1832,8 +1832,9 @@ public static class MeshNodeStreamExtensions
     ///     <see cref="ReadTimeoutBehavior.EmitNull"/>.</item>
     /// </list>
     /// Errors that <see cref="GetMeshNode"/> already surfaces still surface here as
-    /// <c>OnError</c>: <see cref="ErrorType.Unauthorized"/>, a second consecutive
-    /// <see cref="ErrorType.ShuttingDown"/>, and a timeout under
+    /// <c>OnError</c>: <see cref="ErrorType.Unauthorized"/>, an
+    /// <see cref="ErrorType.ShuttingDown"/> that persists past the whole budget (the paced
+    /// re-probe loop exhausted — <see cref="AddressRecyclingException"/>), and a timeout under
     /// <see cref="ReadTimeoutBehavior.Throw"/>.</para>
     /// </summary>
     /// <param name="hub">The hub the caller holds (see <see cref="GetMeshNode"/>).</param>
@@ -1866,8 +1867,25 @@ public static class MeshNodeStreamExtensions
             // path emits null and the outer observer disposes, but the inner
             // Subscribe keeps the hub-level callback registered, surfacing as
             // a "pending callback at dispose" Quiescing-watchdog failure.
-            // One re-probe only: a ShuttingDown answered twice is surfaced, never collapsed to null.
-            var reProbed = 0;
+            // ♻️ Recycling (ShuttingDown) is re-probed WITHIN the caller's budget, not a fixed
+            // number of times. ErrorType.ShuttingDown's own contract (Events.cs) is "retry-worthy,
+            // never terminal … the sender must read this as 'ask again', not 'gone'" — and the
+            // previous one-immediate-re-probe cap violated it under any recycle longer than a few
+            // milliseconds: a package-root hub whose dispose wedges for the 8s force-teardown
+            // watchdog window (MeshWeaver#1701) NACKed BOTH probes within ~1s, and a 15s-budget
+            // compile-path read settled terminally failed with 14s of its budget unused — every
+            // NodeType compile reading the root in that window went CompilationStatus=Error and
+            // the satellite gate reported phantom, module-varying "compile failures". The first
+            // NACK still earns an IMMEDIATE re-probe (a normal recycle completes in well under a
+            // second, so the healthy path stays zero-latency); every further NACK re-probes on the
+            // pacing timer until the budget CTS fires. Termination is unchanged — the budget is
+            // the caller's own, never raised here — and a recycler that outlasts it surfaces the
+            // typed AddressRecyclingException (never null for Throw callers; Unavailable — the
+            // timeout-shaped indeterminate — for EmitNull callers, whose documented contract is
+            // "indeterminate ⇒ treat as absent").
+            var shuttingDownNacks = 0;
+            Exception? lastRecyclingNack = null;
+            var reProbePacing = new SerialDisposable();
             // SerialDisposable, not a bare IDisposable: the ShuttingDown re-probe below REPLACES this
             // subscription, and assigning into a SerialDisposable that has already been disposed
             // disposes the newcomer immediately — so a teardown racing the re-probe cannot leak the
@@ -1891,6 +1909,38 @@ public static class MeshNodeStreamExtensions
                 observer.OnError(error);
             }
 
+            // ♻️ The recycler outlasted the caller's whole budget. Truthful and typed — the
+            // caller learns the address was RECYCLING (never "not found", never a bare stall)
+            // and can classify it as an availability fact (ApplyCompileFailure stamps
+            // CompilationStatus.Unavailable on it, exactly like SourceDiscoveryUnavailable).
+            // Routed by onTimeout the same way the plain timeout is: EmitNull callers opted
+            // into "indeterminate ⇒ absent" and get the Unavailable outcome (null via
+            // GetMeshNode); Throw callers get the error surfaced.
+            void EmitRecyclingExhausted()
+            {
+                var error = new AddressRecyclingException(
+                    $"GetMeshNode('{path}'): the owning hub was still recycling (ShuttingDown) after "
+                    + $"{Volatile.Read(ref shuttingDownNacks)} probe(s) over {started.Elapsed.TotalSeconds:F1}s "
+                    + $"(budget {budget.TotalSeconds:F0}s) — the address is recycling, NOT absent. "
+                    + "Surfacing rather than returning null, which the caller cannot tell apart from "
+                    + "'node not found'. Retry the read once the address has reactivated.",
+                    lastRecyclingNack);
+                try
+                {
+                    hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
+                        ?.LogWarning("{Message}", error.Message);
+                }
+                catch
+                {
+                    // Logging must never mask the verdict it is reporting.
+                }
+                if (onTimeout == ReadTimeoutBehavior.EmitNull)
+                    EmitOnce(NodeReadOutcome.Unavailable(error));
+                else
+                    EmitError(error);
+            }
+
             // ⏱️ TIMEOUT IS NOT "NOT FOUND". A read that gave up knows nothing about the node;
             // collapsing that into the same `null` the not-found path emits made every caller
             // silently substitute "missing" for "the mesh stalled" — and made the stall itself
@@ -1904,6 +1954,14 @@ public static class MeshNodeStreamExtensions
             cts.Token.Register(() =>
             {
                 if (Volatile.Read(ref emitted) != 0) return;
+                // ♻️ The budget elapsed while the address was recycling: the paced re-probe loop
+                // above never got a real answer. Say THAT — "the owning per-node hub never
+                // answered" is the wrong diagnosis when it answered ShuttingDown on every probe.
+                if (Volatile.Read(ref shuttingDownNacks) > 0)
+                {
+                    EmitRecyclingExhausted();
+                    return;
+                }
                 var elapsed = started.Elapsed;
                 string diagnostics;
                 // The pending-request snapshot must come from the ISSUING hub — that is where our
@@ -2079,30 +2137,52 @@ public static class MeshNodeStreamExtensions
                                 // NACK existed the same race HUNG for 60s; the symptom migrated from a stall
                                 // to a confident wrong answer.
                                 //
-                                // Re-issue ONCE inside the caller's remaining budget. This is not a
-                                // retry-to-paper-over: the re-probe lands on a FRESH activation (a
+                                // Re-issue inside the caller's remaining budget. This is not a
+                                // retry-to-paper-over: each re-probe lands on a FRESH activation attempt (a
                                 // SubscribeRequest/GetDataRequest creates one on arrival) and terminates
                                 // authoritatively — if the node is genuinely gone, routing answers NotFound and
-                                // we emit null; if it is still shutting down, we surface the error rather than
-                                // lie. Exactly the reasoning MeshNodeStreamCache.IsTransientOwnerFailure already
-                                // applies on the live-stream path, where "is shutting down" is classified
-                                // transient for this same reason.
+                                // we emit null; if it recycles for the ENTIRE budget, we surface the typed
+                                // recycling verdict rather than lie. Exactly the reasoning
+                                // MeshNodeStreamCache.IsTransientOwnerFailure already applies on the
+                                // live-stream path, where "is shutting down" is classified transient for this
+                                // same reason. The first NACK re-probes immediately (zero latency for the
+                                // sub-second recycle); later NACKs ride the pacing timer so a wedged dispose
+                                // (the 8s force-teardown window, MeshWeaver#1701) is polled, not hammered.
                                 if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
                                 {
-                                    if (Interlocked.Exchange(ref reProbed, 1) == 0
-                                        && !cts.IsCancellationRequested)
+                                    lastRecyclingNack = ex;
+                                    var probes = Interlocked.Increment(ref shuttingDownNacks);
+                                    if (!cts.IsCancellationRequested && Volatile.Read(ref emitted) == 0)
                                     {
-                                        logger?.LogDebug(
-                                            "GetMeshNode: {Path} NACKed ShuttingDown — the address is recycling, "
-                                            + "not absent. Re-probing once within the remaining budget.", path);
-                                        Issue();
+                                        if (probes == 1)
+                                        {
+                                            logger?.LogDebug(
+                                                "GetMeshNode: {Path} NACKed ShuttingDown — the address is recycling, "
+                                                + "not absent. Re-probing immediately within the remaining budget.",
+                                                path);
+                                            Issue();
+                                        }
+                                        else
+                                        {
+                                            logger?.LogDebug(
+                                                "GetMeshNode: {Path} is still recycling after {Probes} probe(s) — "
+                                                + "re-probing on the pacing timer within the remaining budget.",
+                                                path, probes);
+                                            // Observable.Timer runs on the DefaultScheduler — OFF any hub action
+                                            // block. SerialDisposable: teardown (or a superseding NACK) disposes
+                                            // the pending tick, so no timer outlives the read.
+                                            reProbePacing.Disposable = Observable
+                                                .Timer(RecyclingReProbePace)
+                                                .Subscribe(_ =>
+                                                {
+                                                    if (!cts.IsCancellationRequested
+                                                        && Volatile.Read(ref emitted) == 0)
+                                                        Issue();
+                                                });
+                                        }
                                         return;
                                     }
-                                    EmitError(new InvalidOperationException(
-                                        $"GetMeshNode('{path}'): the owning hub answered ShuttingDown twice — "
-                                        + "the address is recycling, NOT absent. Surfacing rather than "
-                                        + "returning null, which the caller cannot tell apart from "
-                                        + "'node not found'. Retry the read.", ex));
+                                    EmitRecyclingExhausted();
                                     return;
                                 }
 
@@ -2131,8 +2211,31 @@ public static class MeshNodeStreamExtensions
 
             return Disposable.Create(() =>
             {
+                reProbePacing.Dispose();
                 innerSubscription.Dispose();
                 cts.Dispose();
             });
         });
+
+    /// <summary>
+    /// How long a recycling (ShuttingDown-NACKing) address rests between re-probes after the
+    /// first immediate one. Short enough that a read resumes well within a normal read budget
+    /// once the address reactivates; long enough that a wedged dispose (the 8s force-teardown
+    /// watchdog window) is polled a handful of times, not hammered. The caller's own budget —
+    /// never this constant — bounds the loop.
+    /// </summary>
+    private static readonly TimeSpan RecyclingReProbePace = TimeSpan.FromMilliseconds(500);
 }
+
+/// <summary>
+/// The owning hub of a read address answered <see cref="ErrorType.ShuttingDown"/> on every probe
+/// for the reader's ENTIRE budget — the address is RECYCLING, not absent (routing mints
+/// ShuttingDown deliberately instead of NotFound for a live-but-recycling address). An
+/// availability fact, never a verdict about the node or about code that reads it: compile
+/// pipelines classify it like <c>SourceDiscoveryUnavailableException</c>
+/// (<c>CompilationStatus.Unavailable</c>), and callers retry once the address has reactivated.
+/// Minted only by <see cref="MeshNodeStreamExtensions.GetMeshNodeOutcome"/> after its
+/// budget-bounded, paced re-probe loop (MeshWeaver#1701) is exhausted.
+/// </summary>
+public sealed class AddressRecyclingException(string message, Exception? inner)
+    : InvalidOperationException(message, inner);

--- a/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeShuttingDownIsNotAbsentTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeShuttingDownIsNotAbsentTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace MeshWeaver.Hosting.Monolith.Test;
 
 /// <summary>
-/// 🚨 A RECYCLING NODE IS NOT A MISSING NODE.
+/// 🚨 A RECYCLING NODE IS NOT A MISSING NODE — AND A RECYCLE IS RIDDEN OUT, NOT SURFACED EARLY.
 ///
 /// <para><see cref="ErrorType.ShuttingDown"/> has an explicit contract (Events.cs): "retry-worthy,
 /// never terminal … the sender must read this as 'ask again', not 'gone'". Routing mints it
@@ -21,16 +21,24 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// and the live-stream path honours that — <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>
 /// classifies "is shutting down" as transient.</para>
 ///
-/// <para><b>The read primitive did not.</b> <c>GetMeshNode</c>'s OnError arm surfaced only
-/// <see cref="ErrorType.Unauthorized"/> and collapsed everything else — ShuttingDown included — into
-/// the same <c>null</c> a genuine not-found emits. So a caller was told the node does not exist while
-/// it was merely recycling, with no way to tell the two apart.</para>
+/// <para><b>The read primitive's history, in two defects.</b> First it collapsed ShuttingDown into
+/// the same <c>null</c> a genuine not-found emits — a caller was told the node does not exist while
+/// it was merely recycling (the <c>ThreadAgentIntegrationTest</c> CI failure: "ACME/ProductLaunch
+/// node should exist" 6.4 s into a 60 s budget). Then it surfaced the transient after exactly ONE
+/// immediate re-probe — both probes landed within milliseconds of each other, so ANY recycle longer
+/// than a beat (the 8 s force-teardown watchdog window of a wedged package-root dispose,
+/// MeshWeaver#1701) turned into a terminal error with almost the caller's entire budget unused.
+/// Every NodeType compile reading the root in that window settled
+/// <c>CompilationStatus=Error</c> and the satellite gates reported phantom, module-varying
+/// "compile failures" (Reinsurance run 31992742420: 2 types; the same tree an hour later: 17).</para>
 ///
-/// <para><b>Field evidence.</b> <c>ThreadAgentIntegrationTest</c> on CI: the <c>ACME/ProductLaunch</c>
-/// instance hub self-recycled via the overlay self-heal watcher, its parked <c>GetDataRequest</c> was
-/// NACKed ShuttingDown, and the test failed on "ACME/ProductLaunch node should exist" 6.4 s into a
-/// 60 s budget. Before that NACK existed (9d8880c68) the same race HUNG for the full 60 s — the
-/// symptom migrated from a stall into a confident wrong answer, which is worse.</para>
+/// <para><b>The contract now:</b> re-probe WITHIN the caller's budget — first NACK immediately (the
+/// healthy sub-second recycle stays zero-latency), later NACKs on the pacing timer — and terminate
+/// authoritatively at the budget: a recycler that outlasts it surfaces the typed
+/// <see cref="AddressRecyclingException"/> (Throw callers) or the Unavailable outcome (EmitNull
+/// callers, whose documented contract is "indeterminate ⇒ treat as absent"). Bounded means
+/// BOUNDED BY THE CALLER'S BUDGET — never by a probe count that discards it, and never a loop that
+/// outlives it.</para>
 ///
 /// <para>The sibling <c>DeferredDeliveryNackedOnDisposeTest</c> pins that the NACK is produced and
 /// carries ShuttingDown. This pins what the READER does with it.</para>
@@ -38,23 +46,20 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 public class GetMeshNodeShuttingDownIsNotAbsentTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
 {
-    private static readonly Address RecyclingAddress = new("recycling", "node");
-
     /// <summary>
-    /// Counts how many <c>GetDataRequest</c>s reach the address, so the re-probe is not merely
-    /// inferred from the outcome — the count IS the assertion that it happened exactly once.
+    /// Counts how many <c>GetDataRequest</c>s reach the address, so the re-probing is not merely
+    /// inferred from the outcome — the count IS the assertion that it happened.
     /// </summary>
     private int _reads;
 
     [Fact(Timeout = 120_000)]
-    public async Task ShuttingDownNack_IsSurfaced_NeverCollapsedToNull()
+    public async Task ShuttingDownNack_PersistingPastTheBudget_IsSurfaced_NeverCollapsedToNull()
     {
-        // A hub that ALWAYS answers as one caught mid-recycle — the exact DeliveryFailure shape
-        // routing mints for a shutting-down address (MonolithRoutingService:
-        // `isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound`). Always, so the test is
-        // deterministic: there is no millisecond window to lose, unlike the production race.
+        var address = new Address("recycling", "forever");
+        // A hub that ALWAYS answers as one caught mid-recycle — deterministic: there is no
+        // millisecond window to lose, unlike the production race.
         var recycling = Mesh.GetHostedHub(
-            RecyclingAddress,
+            address,
             c => c.WithHandler<GetDataRequest>((hub, delivery) =>
             {
                 Interlocked.Increment(ref _reads);
@@ -62,7 +67,7 @@ public class GetMeshNodeShuttingDownIsNotAbsentTest(ITestOutputHelper output)
                     new DeliveryFailure(delivery)
                     {
                         ErrorType = ErrorType.ShuttingDown,
-                        Message = $"Hub {RecyclingAddress} is shutting down — cannot read. "
+                        Message = $"Hub {address} is shutting down — cannot read. "
                                   + "The address may reactivate (recycle / restart); retry to get "
                                   + "the authoritative answer."
                     },
@@ -72,27 +77,131 @@ public class GetMeshNodeShuttingDownIsNotAbsentTest(ITestOutputHelper output)
         recycling.Should().NotBeNull();
 
         var read = Mesh
-            .GetMeshNode(RecyclingAddress.ToString(), TimeSpan.FromSeconds(30))
+            .GetMeshNode(address.ToString(), TimeSpan.FromSeconds(3))
             .FirstAsync()
             .ToTask(TestContext.Current.CancellationToken);
 
-        // The whole point: a caller must NOT be handed null. Null is what "node not found" means, and
-        // a recycling node is present — that conflation is what made the CI failure claim a node in
-        // the test's own fixture did not exist.
+        // The whole point: a Throw-mode caller must NOT be handed null. Null is what "node not
+        // found" means, and a recycling node is present — that conflation is what made the CI
+        // failure claim a node in the test's own fixture did not exist.
         var failure = await Assert.ThrowsAnyAsync<Exception>(() => read);
 
         Output.WriteLine($"surfaced: {failure.GetType().Name}: {failure.Message}");
+        failure.Should().BeOfType<AddressRecyclingException>(
+            "the verdict is TYPED so downstream classifiers (ApplyCompileFailure → "
+            + "CompilationStatus.Unavailable) can file it as availability, never as a code verdict");
         failure.Message.Should().Contain("ShuttingDown",
             "the error must name the classification, so the next reader knows to retry rather than "
             + "concluding the node is gone");
         failure.Message.Should().Contain("NOT absent",
             "…and must say explicitly that this is not absence — the misreading this exists to stop");
 
-        // Exactly TWO reads: the original plus ONE re-probe. Not one (that would mean the transient
-        // was surfaced without giving the address its documented chance to reactivate) and not three
-        // or more (that would be a retry loop, which this repo bans — the re-probe is bounded and
-        // terminates on the second answer, whatever it is).
-        Volatile.Read(ref _reads).Should().Be(2,
-            "ShuttingDown earns exactly one re-probe against a fresh activation — bounded, not a loop");
+        // The re-probing is bounded by the BUDGET, not by a probe count: the original read, the
+        // immediate re-probe, and then paced probes until the 3 s budget elapsed. Fewer than
+        // three total would mean the budget was discarded again (the #1701 defect: both probes
+        // burned within milliseconds, 14 s of a 15 s budget unused); the pacing keeps the count
+        // small (~½ s apart), so this can never be a hot loop.
+        Volatile.Read(ref _reads).Should().BeGreaterThanOrEqualTo(3,
+            "a persistent recycler is probed throughout the budget — immediately once, then paced");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ShuttingDownNack_RecyclingCompletesWithinBudget_YieldsTheNode()
+    {
+        // The MeshWeaver#1701 shape: the owner is mid-recycle when the read starts and answers
+        // ShuttingDown for a while (the wedged-dispose window), then reactivates and serves the
+        // node. The read must RIDE THE RECYCLE OUT and emit the node — the previous
+        // one-immediate-re-probe cap settled this exact sequence as a terminal error, which is
+        // how every NodeType compile reading its package root during an install-recycle went
+        // CompilationStatus=Error and the satellite compile gates failed nondeterministically.
+        var address = new Address("recycling", "recovers");
+        var node = new MeshNode(
+            MeshNode.FromPath(address.Path).Id, MeshNode.FromPath(address.Path).Namespace)
+        {
+            Name = "Recovered",
+            State = MeshNodeState.Active
+        };
+        var recycling = Mesh.GetHostedHub(
+            address,
+            c => c.WithHandler<GetDataRequest>((hub, delivery) =>
+            {
+                var read = Interlocked.Increment(ref _reads);
+                if (read <= 3)
+                {
+                    hub.Post(
+                        new DeliveryFailure(delivery)
+                        {
+                            ErrorType = ErrorType.ShuttingDown,
+                            Message = $"Hub {address} is shutting down — cannot read. "
+                                      + "The address may reactivate (recycle / restart); retry to get "
+                                      + "the authoritative answer."
+                        },
+                        o => o.ResponseFor(delivery));
+                }
+                else
+                {
+                    hub.Post(new GetDataResponse(node, 1), o => o.ResponseFor(delivery));
+                }
+                return delivery.Processed();
+            }));
+        recycling.Should().NotBeNull();
+
+        var result = await Mesh
+            .GetMeshNode(address.ToString(), TimeSpan.FromSeconds(10))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull(
+            "the recycle completed well inside the budget, so the read must deliver the node "
+            + "instead of surfacing a transient that had already healed");
+        result!.Name.Should().Be("Recovered");
+
+        // Deterministic probe ledger: the original read (NACK), the immediate re-probe (NACK),
+        // one paced probe (NACK), one more paced probe (the answer). Exactly four — the pacing
+        // is a schedule, not a storm.
+        Volatile.Read(ref _reads).Should().Be(4,
+            "three NACKs then the answer: original + immediate re-probe + two paced probes");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ShuttingDownNack_PersistingPastTheBudget_EmitNullCaller_DegradesOpen()
+    {
+        // EmitNull callers opted into "indeterminate ⇒ treat as absent" (a cosmetic fallback, an
+        // idempotent existence probe, the cell-surface single-home gate's fail-OPEN owner read).
+        // A recycler that outlasts the whole budget is exactly a timeout-shaped indeterminate for
+        // them: the read emits null instead of erroring — which is what lets
+        // ValidateCellSurfaceSingleHome keep its documented "a transient mesh blip can never turn
+        // into a hard compile failure here" contract even for a pathological recycle. Callers for
+        // which absent ≠ unavailable matters read GetMeshNodeOutcome, where this arrives as
+        // Unavailable (carrying the AddressRecyclingException), never as Absent.
+        var address = new Address("recycling", "emitnull");
+        var recycling = Mesh.GetHostedHub(
+            address,
+            c => c.WithHandler<GetDataRequest>((hub, delivery) =>
+            {
+                Interlocked.Increment(ref _reads);
+                hub.Post(
+                    new DeliveryFailure(delivery)
+                    {
+                        ErrorType = ErrorType.ShuttingDown,
+                        Message = $"Hub {address} is shutting down — cannot read."
+                    },
+                    o => o.ResponseFor(delivery));
+                return delivery.Processed();
+            }));
+        recycling.Should().NotBeNull();
+
+        var outcome = await Mesh
+            .GetMeshNodeOutcome(address.ToString(), TimeSpan.FromSeconds(2),
+                ReadTimeoutBehavior.EmitNull)
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        outcome.Status.Should().Be(NodeReadStatus.Unavailable,
+            "a full-budget recycle is indeterminate — NEVER Absent (recycling ≠ gone), and for an "
+            + "EmitNull caller never an error either");
+        outcome.Failure.Should().BeOfType<AddressRecyclingException>(
+            "the outcome still says WHY, so a caller that asked for the distinction learns the "
+            + "address was recycling");
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SilentReadNackTest.cs
@@ -176,15 +176,18 @@ public class SilentReadNackTest(ITestOutputHelper output) : MonolithMeshTestBase
     ///
     /// <para>This is what the fix is FOR. Before it the same sequence produced
     /// <c>GetMeshNode('…') timed out after 60.0s … Target: NO LOCAL HUB</c> — a minute of stall
-    /// ending in a wrong explanation. Now the NACK arrives, <c>GetMeshNode</c> re-probes ONCE
-    /// against the fresh activation, and the read resolves.</para>
+    /// ending in a wrong explanation. Now the NACK arrives, <c>GetMeshNode</c> re-probes the
+    /// fresh activation immediately, and the read resolves.</para>
     ///
     /// <para>🚨 It also bounds the re-probe by demonstration rather than by assertion, which
     /// matters because a transient NACK a consumer answers by asking again is the shape behind the
-    /// 2026-06-08 resubscribe-storm outage. The claim is <c>Interlocked.Exchange(ref reProbed, 1)</c>
-    /// on a local declared INSIDE <c>GetMeshNode</c>'s <c>Observable.Create</c> — one per
-    /// subscription, no timer, no <c>Retry</c> operator, no shared counter. A loop would never
-    /// settle on a value; this settles on the real node, far inside the budget.</para>
+    /// 2026-06-08 resubscribe-storm outage. The re-probing is per-subscription state declared
+    /// INSIDE <c>GetMeshNode</c>'s <c>Observable.Create</c> — first NACK immediately, later NACKs
+    /// on a half-second pacing timer, everything disposed with the read and terminated by the
+    /// caller's own budget CTS (see <c>GetMeshNodeShuttingDownIsNotAbsentTest</c> for the paced
+    /// bound). No <c>Retry</c> operator, no shared counter, no re-arm outside the read's
+    /// lifetime — a storm has nothing to ride. Here the FIRST re-probe already lands on a healthy
+    /// activation, so the read settles on the real node far inside the budget.</para>
     /// </summary>
     [Fact(Timeout = 60000)]
     public async Task GetMeshNode_WhenOwnerIsDisposedMidRead_RecoversOnTheReProbe()


### PR DESCRIPTION
Fixes the reader half of #1701 — the half that turns a package-root hub's install-time recycle into phantom, module-varying compile failures in every satellite repo's gate and on portals.

## The defect

`ErrorType.ShuttingDown`'s contract (Events.cs) is *"retry-worthy, never terminal … the sender must read this as 'ask again', not 'gone'"* — routing mints it deliberately instead of NotFound for a live-but-recycling address. `GetMeshNode` honored it with exactly **one immediate re-probe**: both probes landed within milliseconds of each other, so any recycle longer than a beat surfaced the terminal *"answered ShuttingDown twice"* error with almost the caller's entire budget unused. A wedged package-root dispose (`DISPOSAL DEADLOCK … RunLevel=DisposeHostedHubs`, the 8 s force-teardown watchdog window) made that deterministic: a 15 s-budget read failed ~1 s in, 14 s early.

**The field chain** (pinned by temporary call-site instrumentation on the deterministic repro): install recycles the package-root hub → every NodeType compile's cell-surface single-home gate reads that root (`ValidateCellSurfaceSingleHome` → `ReadCompileSourceNode(owner, EmitNull)` → `GetMeshNode('<packageRoot>')`) → the ShuttingDown-twice error escapes the gate's documented degrade-open (`EmitNull` only covers the *timeout* path) → `ApplyCompileFailure` stamps `CompilationStatus.Error`. Whole modules park on the compile-error overlay; satellite gates go red on a different module every run — MeshWeaver.Reinsurance run 31992742420 (2 phantom failures) vs. 32018139148 (17, on Ifrs17), same tree, same pinned image digest.

## The fix — in the read primitive, where the contract lives

- **First ShuttingDown NACK re-probes immediately** (the healthy sub-second recycle stays zero-latency); **every further NACK re-probes on a 500 ms pacing timer** — per-subscription state inside `Observable.Create`, disposed with the read, terminated by the caller's **own** budget CTS (never raised here). No `Retry` operator, no shared counter, nothing a storm can ride.
- A recycler that outlasts the **whole budget** surfaces the new typed **`AddressRecyclingException`** (Throw callers) or the `Unavailable` outcome (EmitNull callers — a full-budget recycle is a timeout-shaped indeterminate, which also restores the single-home gate's fail-open; `GetMeshNodeOutcome` callers still see `Unavailable` carrying the exception, never `Absent`).
- **`ApplyCompileFailure` classifies `AddressRecyclingException` like `SourceDiscoveryUnavailableException`**: `CompilationStatus.Unavailable` — an availability fact, never a verdict about the code (the second-layer guard for recycles outlasting a read budget).

## Proof

- Deterministic repro (per #1701: `mw-plugin-test` over the MeshWeaver.Reinsurance tree): **before** — `GATE FAILED … 36 new failure(s)` incl. all 33 Ifrs17 types `compile=FAILED(Error)`, 99 ShuttingDown-twice reads; **after** — zero recycling read failures, `[PASS] Ifrs17 (339 node(s), 33 type(s))`, and with Edu+Store staged (the exact CI arrangement) **exit 0, every module PASS**. The two 8 s disposal deadlocks still occur and the reads ride them out — the dispose wedge is #1701's remaining half and stays open.
- `GetMeshNodeShuttingDownIsNotAbsentTest` pins the new contract: paced probes throughout the budget (never a hot loop), the node once the address reactivates (deterministic 4-probe ledger), typed exhaustion, EmitNull degrade-open. `SilentReadNackTest` (recover-on-first-re-probe, regression guards) and the `WorkspaceCacheEviction`/`UpsertInnerCreateObservation` neighbors stay green.
- `dotnet build -c Release -warnaserror` clean on the touched closure.

Part of #1701 (the disposal-deadlock half remains open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
