### PR TITLE
fix: ship the Cosmos and Snowflake storage backends so they can be selected

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -78,6 +78,28 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.ClaudeCode/MeshWeaver.AI.ClaudeCode.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.Copilot/MeshWeaver.AI.Copilot.csproj" />
+
+    <!-- Alternative storage backends. These were BORN flipped: no host has ever referenced them
+         (only their own test projects do), and both attributes state the intent verbatim —
+         "everything a deployment needs for Graph:Storage:Type = Cosmos to resolve, with no
+         compiled reference from the portal". What was missing is this lane, so the DLLs reached
+         no image and the documented `Graph:Storage:Type` Cosmos/Snowflake selection could not be
+         turned on in a shipped deployment at all.
+
+         🚨 CLOSURE, never thin. The thin lane copies a module's OWN dll/pdb/xml and relies on the
+         app closure carrying its dependencies — true only while a ships-the-bits ProjectReference
+         stands. These two have none, so their private package closures (Microsoft.Azure.Cosmos,
+         Snowflake.Data) exist nowhere in the app output; a thin-lane row would land an assembly
+         that fails to load its own driver at first use. The closure publish brings the driver and
+         prunes what the app and the shared framework already provide.
+
+         Storage providers ship in the IMAGE rather than as Store bundles on purpose: a module
+         installed from the Store needs storage to already work, and persistence selection reads
+         Graph:Storage during boot. Shipping the bits costs image size in every deployment;
+         ACTIVATION stays the deployment's Modules:Assemblies choice, and no memex portal lists
+         them (they all run PostgreSQL). -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Cosmos/MeshWeaver.Hosting.Cosmos.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Snowflake/MeshWeaver.Hosting.Snowflake.csproj" />
   </ItemGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -117,6 +117,8 @@ The current first-party inventory and each module's configuration section:
 | `MeshWeaver.Notifications.Channels.dll` | Notification delivery channels (rule/channel node types + AI triage escalation) | `Email` (triage self-skips unless `Email:Enabled`) |
 | `MeshWeaver.Social.dll` | LinkedIn publishing: connect/publish/page-sync endpoints + node-menu actions | `Social:LinkedIn` |
 | `MeshWeaver.Hosting.Grpc.dll` | The mesh gRPC transport: `meshweaver.v1.Mesh` + gRPC-web, `py`/`node` foreign participants AND the React GUI's browser data plane | `Grpc` (`TrustedPort`) |
+| `MeshWeaver.Hosting.Cosmos.dll` | Cosmos DB storage backend (keyed adapter factory + native query) | selected by `Graph:Storage:Type` = `Cosmos` |
+| `MeshWeaver.Hosting.Snowflake.dll` | Snowflake storage backend (persistence, change feed, cross-schema query, access projection) | selected by `Graph:Storage:Type` = `Snowflake` |
 
 🚨 **`MeshWeaver.Hosting.Grpc` is DEFAULT-ON in every deployment.** Its endpoint is not just the
 foreign-participant (`py/*`, `node/*`) transport — the React GUI connects over the very same
@@ -129,6 +131,15 @@ Boot packs select by OTHER configuration too: `Graph:Storage:Type` `Cosmos`/`Sno
 the matching `MeshWeaver.Hosting.Cosmos`/`.Snowflake` DLL in this list — installation runs before
 storage selection, so ordering is safe. Delisting a UI module removes its areas mesh-wide;
 embeds of a removed area render the standard area-not-found placeholder (documented per module).
+
+Both storage backends **ship in the image but are listed by nobody** — every memex portal runs
+PostgreSQL — so selecting one is purely an appsettings edit in the deployment that wants it.
+They ride the closure lane rather than the Store bundle lane on purpose: persistence selection
+reads `Graph:Storage` during boot, so a storage backend cannot be something the mesh installs
+for itself once it is already running. The bits cost ~25 MB of publish output (Cosmos ~15 MB with
+the Direct/ServiceInterop client, Snowflake ~10 MB — its driver carries Arrow plus the AWS and
+GCS SDKs for stage transfer); `-p:PublishMeshModules=false` skips the whole layout for a host
+that wants none of it.
 
 Entries resolve through `MeshBuilder.ResolveModulePath`: a rooted path passes through; a bare
 DLL name probes **`modules/<name>/<name>.dll`** beside the app first (the publish layout below),

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-cosmos-and-snowflake-can-actually-be-selected.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-cosmos-and-snowflake-can-actually-be-selected.md
@@ -1,0 +1,23 @@
+---
+Name: Cosmos and Snowflake can actually be selected
+Category: Fix
+Description: The Cosmos and Snowflake storage backends now ship with the image, so a deployment that sets Graph:Storage:Type to either one can actually start on it.
+Icon: Database
+Order: -20260817
+---
+
+# Cosmos and Snowflake can actually be selected
+
+Both alternative storage backends were fully built, tested and documented as selectable through
+`Graph:Storage:Type` — and neither one reached a shipped deployment. Nothing referenced them
+except their own test projects, and they were absent from the module publish layout, so the
+assemblies existed on no image and the documented selection could not be turned on at all.
+
+They now ship under `modules/`, exactly as the AI provider packs and the other backends-by-listing
+do. Selecting one is an appsettings edit in the deployment that wants it: add the DLL to
+`Modules:Assemblies` and set `Graph:Storage:Type`. Nothing changes for anyone else — no portal
+lists them, and a module that is present but unlisted is never loaded.
+
+They ship with the image rather than as an installable Store package on purpose: persistence
+selection happens during boot, so a storage backend is not something a running mesh can install
+for itself.


### PR DESCRIPTION
Tier 1 of the modular factor-out (item 2 of 4). Independent of the other three.

## The defect

`MeshWeaver.Hosting.Cosmos` and `MeshWeaver.Hosting.Snowflake` are fully built, tested and documented as selectable via `Graph:Storage:Type` — and neither has ever reached a shipped image. Nothing referenced them except their own test projects, and they were absent from `MeshModulesPublish.targets`, so their assemblies existed on no image and `Modules.md`'s documented selection could not be turned on in a shipped deployment at all.

Both attributes already state the intended shipping model verbatim: *"everything a deployment needs for `Graph:Storage:Type = Cosmos` to resolve, **with no compiled reference from the portal**"*. The lane that realises that sentence was simply never wired.

## The fix

Two `MeshModuleClosure` rows.

**Closure, never thin.** The thin lane copies a module's own `dll`/`pdb`/`xml` and leans on the app closure for its dependencies — true only while a ships-the-bits `ProjectReference` stands. These two have none, so a thin-lane row would land an assembly that cannot load its own driver at first use. The closure publish brings the driver and prunes what the app and the shared framework already provide.

**In the image, not the Store bundle lane.** Persistence selection reads `Graph:Storage` during boot, so a storage backend is not something a running mesh can install for itself.

## Verification

- `dotnet build memex/Memex.Portal.Monolith -c Release -p:CIRun=true -warnaserror` → `Build succeeded. 0 Warning(s) 0 Error(s)`.
- `LayoutMeshModuleClosures: 11 closure module(s)` — both new folders carry the module assembly plus its true private closure (`Microsoft.Azure.Cosmos.*`, `Snowflake.Data` + Arrow/AWS/GCS), pruned against the app output and the targeting packs.
- `MeshWeaver.Documentation.Test` 21/21 green (fresh `.trx`).

## Cost, measured

`modules/` grows ~13 MB → ~38 MB (Cosmos ~15 MB, Snowflake ~10 MB) against ~306 MB of app output. Stated in `Modules.md` alongside the `-p:PublishMeshModules=false` escape hatch.

Cosmos's closure includes ~800 KB of Windows CRT DLLs (`msvcp140`, `vcruntime140*`, `Cosmos.CRTCompat`) that its package lays flat rather than under `runtimes/`, so prune (0) does not see them. Left in place deliberately: a special-case prune would break a Windows dev host's Cosmos run for under 1 MB.

## Blast radius

None at runtime. **Nothing is listed** — every memex portal runs PostgreSQL — and a module present but unlisted is never loaded, so `InstalledModulesFingerprint` and every baked NodeType are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjujCq1BsJkNKuZ4wXodo1